### PR TITLE
Search: fetch the site stats endpoint from wp-admin dashboard

### DIFF
--- a/projects/packages/search/changelog/add-jp-search-dashboard-stats-endpoint
+++ b/projects/packages/search/changelog/add-jp-search-dashboard-stats-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search: fetch search stats endpoint in wp-admin dashboard

--- a/projects/packages/search/changelog/add-jp-search-dashboard-stats-endpoint
+++ b/projects/packages/search/changelog/add-jp-search-dashboard-stats-endpoint
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: added
 
 Search: fetch search stats endpoint in wp-admin dashboard

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.9.0",
+	"version": "0.9.1-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/search.php
+++ b/projects/packages/search/search.php
@@ -7,7 +7,7 @@
 
 namespace Automattic\Jetpack\Search;
 
-define( 'JETPACK_SEARCH_PKG__VERSION', '0.9.0' );
+define( 'JETPACK_SEARCH_PKG__VERSION', '0.9.1-alpha' );
 define( 'JETPACK_SEARCH_PKG__DIR', __DIR__ . '/' );
 define( 'JETPACK_SEARCH_PKG__SLUG', 'search' );
 

--- a/projects/packages/search/src/dashboard/components/dashboard/index.jsx
+++ b/projects/packages/search/src/dashboard/components/dashboard/index.jsx
@@ -32,6 +32,7 @@ import './style.scss';
 export default function SearchDashboard() {
 	useSelect( select => select( STORE_ID ).getSearchPlanInfo(), [] );
 	useSelect( select => select( STORE_ID ).getSearchModuleStatus(), [] );
+	useSelect( select => select( STORE_ID ).getSearchStats(), [] );
 
 	const siteAdminUrl = useSelect( select => select( STORE_ID ).getSiteAdminUrl() );
 	const aboutPageUrl = siteAdminUrl + 'admin.php?page=jetpack_about';
@@ -59,12 +60,19 @@ export default function SearchDashboard() {
 		select( STORE_ID ).isTogglingInstantSearch()
 	);
 
+	// Record Meter data
+	const tierMaximumRecords = useSelect( select => select( STORE_ID ).getTierMaximumRecords() );
+	const postCount = useSelect( select => select( STORE_ID ).getPostCount() );
+	const postTypeBreakdown = useSelect( select => select( STORE_ID ).getPostTypeBreakdown() );
+
 	const isLoading = useSelect(
 		select =>
 			select( STORE_ID ).isResolving( 'getSearchPlanInfo' ) ||
 			! select( STORE_ID ).hasStartedResolution( 'getSearchPlanInfo' ) ||
 			select( STORE_ID ).isResolving( 'getSearchModuleStatus' ) ||
-			! select( STORE_ID ).hasStartedResolution( 'getSearchModuleStatus' )
+			! select( STORE_ID ).hasStartedResolution( 'getSearchModuleStatus' ) ||
+			select( STORE_ID ).isResolving( 'getSearchStats' ) ||
+			! select( STORE_ID ).hasStartedResolution( 'getSearchStats' )
 	);
 
 	const handleLocalNoticeDismissClick = useDispatch( STORE_ID ).removeNotice;
@@ -184,7 +192,13 @@ export default function SearchDashboard() {
 					{ renderHeader() }
 					{ renderMockedSearchInterface() }
 					{ renderModuleControl() }
-					{ isRecordMeterEnabled && <RecordMeter /> }
+					{ isRecordMeterEnabled && (
+						<RecordMeter
+							postCount={ postCount }
+							postTypeBreakdown={ postTypeBreakdown }
+							tierMaximumRecords={ tierMaximumRecords }
+						/>
+					) }
 					{ renderFooter() }
 				</Fragment>
 			) }

--- a/projects/packages/search/src/dashboard/components/record-meter/index.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/index.jsx
@@ -4,26 +4,18 @@
 import React from 'react';
 import { __ } from '@wordpress/i18n';
 
-/**
- * WordPress dependencies
- */
-import { useSelect } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
-import { STORE_ID } from 'store';
-
 import './style.scss';
 
 /**
  * Generate Record Meter showing how many records the user has indexed
  *
+ * @param {object} props - Props
+ * @param {number} props.postCount - Post count
+ * @param {object} props.postTypeBreakdown - Post type breakdown (post type => number of posts)
+ * @param {number} props.tierMaximumRecords - Max number of records allowed in user's current tier
  * @returns {React.Component} RecordMeter React component
  */
-export default function RecordMeter() {
-	const tierMaximumRecords = useSelect( select => select( STORE_ID ).getTierMaximumRecords() );
-
+export default function RecordMeter( { postCount, postTypeBreakdown, tierMaximumRecords } ) {
 	return (
 		<div className="jp-search-record-meter jp-search-dashboard-wrap">
 			<div className="jp-search-dashboard-row">
@@ -32,6 +24,26 @@ export default function RecordMeter() {
 					{ tierMaximumRecords && (
 						<p>
 							Tier maximum records: <strong>{ tierMaximumRecords }</strong>
+						</p>
+					) }
+					{ postCount && (
+						<p>
+							Post count: <strong>{ postCount }</strong>
+						</p>
+					) }
+					{ postTypeBreakdown && (
+						<p>
+							Post type breakdown:
+							<table>
+								{ Object.entries( postTypeBreakdown ).map( postType => (
+									<tr>
+										<td>{ postType[ 0 ] }</td>
+										<td>
+											<strong>{ postType[ 1 ] }</strong>
+										</td>
+									</tr>
+								) ) }
+							</table>
 						</p>
 					) }
 				</div>

--- a/projects/packages/search/src/dashboard/store/actions/index.js
+++ b/projects/packages/search/src/dashboard/store/actions/index.js
@@ -3,11 +3,13 @@
  */
 import siteSettingActions from './jetpack-settings';
 import sitePlanActions from './site-plan';
+import siteStatsActions from './site-stats';
 import noticeActions from 'components/global-notices/store/actions';
 
 const actions = {
 	...siteSettingActions,
 	...sitePlanActions,
+	...siteStatsActions,
 	...noticeActions,
 };
 

--- a/projects/packages/search/src/dashboard/store/actions/site-stats.js
+++ b/projects/packages/search/src/dashboard/store/actions/site-stats.js
@@ -1,0 +1,16 @@
+export const SET_SEARCH_STATS = 'SET_SEARCH_STATS';
+
+/**
+ * Action to set site stats (e.g. record usage)
+ *
+ * @param {*} options - stats.
+ * @returns {object} - an action object.
+ */
+export function setSearchStats( options ) {
+	return {
+		type: 'SET_SEARCH_STATS',
+		options,
+	};
+}
+
+export default { setSearchStats };

--- a/projects/packages/search/src/dashboard/store/controls.js
+++ b/projects/packages/search/src/dashboard/store/controls.js
@@ -64,7 +64,7 @@ export default {
 	[ FETCH_SEARCH_PLAN_INFO ]: function () {
 		return restApi.fetchSearchPlanInfo();
 	},
-	// [ FETCH_SEARCH_STATS ]: function () {
-	// 	return restApi.fetchSearchStats();
-	// },
+	[ FETCH_SEARCH_STATS ]: function () {
+		return restApi.fetchSearchStats();
+	},
 };

--- a/projects/packages/search/src/dashboard/store/controls.js
+++ b/projects/packages/search/src/dashboard/store/controls.js
@@ -6,6 +6,7 @@ import restApi from '@automattic/jetpack-api';
 export const FETCH_JETPACK_SETTINGS = 'FETCH_JETPACK_SETTINGS';
 export const UPDATE_JETPACK_SETTINGS = 'UPDATE_JETPACK_SETTINGS';
 export const FETCH_SEARCH_PLAN_INFO = 'FETCH_SEARCH_PLAN_INFO';
+export const FETCH_SEARCH_STATS = 'FETCH_SEARCH_STATS';
 
 /**
  * fetchJetpackSettings action
@@ -42,6 +43,17 @@ export const fetchSearchPlanInfo = () => {
 	};
 };
 
+/**
+ * fetchSearchStats action
+ *
+ * @returns {object} - an action object.
+ */
+export const fetchSearchStats = () => {
+	return {
+		type: FETCH_SEARCH_STATS,
+	};
+};
+
 export default {
 	[ FETCH_JETPACK_SETTINGS ]: function () {
 		return restApi.fetchSearchSettings();
@@ -52,4 +64,7 @@ export default {
 	[ FETCH_SEARCH_PLAN_INFO ]: function () {
 		return restApi.fetchSearchPlanInfo();
 	},
+	// [ FETCH_SEARCH_STATS ]: function () {
+	// 	return restApi.fetchSearchStats();
+	// },
 };

--- a/projects/packages/search/src/dashboard/store/reducer/index.js
+++ b/projects/packages/search/src/dashboard/store/reducer/index.js
@@ -10,6 +10,7 @@ import siteData from './site-data';
 import userData from './user-data';
 import jetpackSettings from './jetpack-settings';
 import sitePlan from './site-plan';
+import siteStats from './site-stats';
 import features from './feature';
 import notices from 'components/global-notices/store/reducer';
 
@@ -17,6 +18,7 @@ const reducer = combineReducers( {
 	siteData,
 	jetpackSettings,
 	sitePlan,
+	siteStats,
 	userData,
 	features,
 	notices,

--- a/projects/packages/search/src/dashboard/store/reducer/site-stats.js
+++ b/projects/packages/search/src/dashboard/store/reducer/site-stats.js
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import { SET_SEARCH_STATS } from '../actions/site-stats';
+
+const siteStats = ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SET_SEARCH_STATS:
+			return {
+				...state,
+				...action.options,
+			};
+	}
+
+	return state;
+};
+
+export default siteStats;

--- a/projects/packages/search/src/dashboard/store/reducer/test/site-plan.test.js
+++ b/projects/packages/search/src/dashboard/store/reducer/test/site-plan.test.js
@@ -4,7 +4,7 @@
 import { setSearchPlanInfo } from '../../actions/site-plan';
 import reducer from '../site-plan';
 
-describe( 'Jetpack Settings Reducer', () => {
+describe( 'Site plan reducer', () => {
 	const initState = {
 		supports_search: false,
 	};
@@ -16,7 +16,8 @@ describe( 'Jetpack Settings Reducer', () => {
 		const state = reducer( undefined, setSearchPlanInfo( { supports_search: true } ) );
 		expect( state ).toEqual( { supports_search: true } );
 	} );
-	test( 'can update site plan', () => {} );
-	const state = reducer( initState, setSearchPlanInfo( { supports_search: true } ) );
-	expect( state ).toEqual( { supports_search: true } );
+	test( 'can update site plan', () => {
+		const state = reducer( initState, setSearchPlanInfo( { supports_search: true } ) );
+		expect( state ).toEqual( { supports_search: true } );
+	} );
 } );

--- a/projects/packages/search/src/dashboard/store/reducer/test/site-stats.test.js
+++ b/projects/packages/search/src/dashboard/store/reducer/test/site-stats.test.js
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+import { setSearchStats } from '../../actions/site-stats';
+import reducer from '../site-stats';
+
+describe( 'Site stats reducer', () => {
+	const initState = {
+		post_count: 9,
+		post_type_breakdown: [ { post: 1 } ],
+	};
+	test( 'should default to empty', () => {
+		const state = reducer( undefined, {} );
+		expect( state ).toEqual( {} );
+	} );
+	test( 'can init site stats', () => {
+		const state = reducer( undefined, setSearchStats( { post_count: 123 } ) );
+		expect( state ).toEqual( { post_count: 123 } );
+	} );
+	test( 'can update site stats', () => {
+		const state = reducer(
+			initState,
+			setSearchStats( { post_count: 123, post_type_breakdown: [ { banana: 2 } ] } )
+		);
+		expect( state ).toEqual( { post_count: 123, post_type_breakdown: [ { banana: 2 } ] } );
+	} );
+} );

--- a/projects/packages/search/src/dashboard/store/resolvers.js
+++ b/projects/packages/search/src/dashboard/store/resolvers.js
@@ -6,9 +6,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { fetchJetpackSettings, fetchSearchPlanInfo } from './controls';
+import { fetchJetpackSettings, fetchSearchPlanInfo, fetchSearchStats } from './controls';
 import { setJetpackSettings } from './actions/jetpack-settings';
 import { setSearchPlanInfo } from './actions/site-plan';
+import { setSearchStats } from './actions/site-stats';
 import { errorNotice } from '../components/global-notices/store/actions';
 
 /**
@@ -45,4 +46,21 @@ export function* getSearchPlanInfo() {
 	}
 }
 
-export default { getSearchModuleStatus, getSearchPlanInfo };
+/**
+ * Yield actions to get search stats
+ *
+ * @yields {object} - an action object.
+ * @returns {object} - an action object.
+ */
+export function* getSearchStats() {
+	try {
+		const stats = yield fetchSearchStats();
+		if ( stats ) {
+			return setSearchStats( stats );
+		}
+	} catch ( e ) {
+		return errorNotice( __( 'Error fetching search stats', 'jetpack-search-pkg' ) );
+	}
+}
+
+export default { getSearchModuleStatus, getSearchPlanInfo, getSearchStats };

--- a/projects/packages/search/src/dashboard/store/selectors/index.js
+++ b/projects/packages/search/src/dashboard/store/selectors/index.js
@@ -7,6 +7,7 @@ import sitePlanSelectors from './site-plan';
 import userDataSelectors from './user-data';
 import noticeSelectors from 'components/global-notices/store/selectors';
 import featureSelectors from './feature';
+import siteStatsSelectors from './site-stats';
 
 const selectors = {
 	...siteDataSelectors,
@@ -15,6 +16,7 @@ const selectors = {
 	...userDataSelectors,
 	...noticeSelectors,
 	...featureSelectors,
+	...siteStatsSelectors,
 };
 
 export default selectors;

--- a/projects/packages/search/src/dashboard/store/selectors/site-stats.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-stats.js
@@ -1,0 +1,7 @@
+const siteStatsSelectors = {
+	getSearchStats: state => state.siteStats,
+	getPostCount: state => state.siteStats?.post_count,
+	getPostTypeBreakdown: state => state.siteStats?.post_type_breakdown,
+};
+
+export default siteStatsSelectors;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The new Record Meter needs the data from the search stats endpoint to show record usage.

This PR adds the necessary plumbing to fetch, store and request this information.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

Visit `/wp-admin/admin.php?page=jetpack-search&features=record-meter` and make sure the post count and post type breakdown are output in the page:

<img width="315" alt="Screen Shot 2022-02-23 at 15 10 51" src="https://user-images.githubusercontent.com/17325/155250935-53a92147-86fb-4124-9913-7627b052cc19.png">

You can also run the reducer tests with `(cd projects/packages/search && pnpm test)`.
