### PR TITLE
Fix broken image in plan loading placeholder in "My Plan"

### DIFF
--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-card/index.jsx
@@ -26,7 +26,7 @@ const MyPlanCard = ( { productSlug, action, isError, isPlaceholder, details, tag
 		<div className={ cardClassNames }>
 			<div className="my-plan-card__primary">
 				<div className="my-plan-card__icon">
-					<PlanIcon plan={ productSlug } alt={ title } />
+					{ productSlug && <PlanIcon plan={ productSlug } alt={ title } /> }
 				</div>
 				<div className="my-plan-card__header">
 					{ title && <h2 className="my-plan-card__title">{ title }</h2> }

--- a/projects/plugins/jetpack/changelog/fix-broken-image-in-plan-placeholder
+++ b/projects/plugins/jetpack/changelog/fix-broken-image-in-plan-placeholder
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix broken image in plan loading placeholder in "My Plan"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes 1164141197617539-as-1200760947306498/f

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Display plan icon only if the plan is valid.
* It means that when the plan is being loaded, there will be no plan icon in the loading placeholder

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1164141197617539-as-1200760947306498/f

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Boot up this PR and 🔥 it.
* Go to wp-admin > Jetpack > My Plan
* Reload the. page if you need to
* Confirm that you don't see any broken image in plan loading placeholder

Screenshots
|BEFORE|AFTER|
|-|-|
| <img width="1012" alt="Screenshot 2022-02-09 at 3 52 28 PM" src="https://user-images.githubusercontent.com/18226415/153182470-f461724a-8971-46d3-a439-4a71b27f41c0.png"> | <img width="1007" alt="Screenshot 2022-02-09 at 3 53 16 PM" src="https://user-images.githubusercontent.com/18226415/153182517-7d7d36f6-f520-4611-b9d3-1a5e788a7928.png"> |