### PR TITLE
Improve tests workflow for PHP 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,6 +90,7 @@ jobs:
         run: .github/files/setup-wordpress-env.sh
 
       - name: Run project tests
+        continue-on-error: ${{ matrix.experimental }}
         env:
           EXPERIMENTAL: ${{ matrix.experimental && 'true' || 'false' }}
           CHANGED: ${{ steps.changed.outputs.projects }}


### PR DESCRIPTION
Since Tests using PHP 8.1 are not marked as Required but they fail and mark every PR to have failed tests, this doesn't look nice

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Mark the "Run project tests" test step to `continue-on-error` for experimental (PHP 8.1) Matrix values
* This way the step and thus the job will be marked as green on error

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

Testing instructions

* Just check the PR checks for this PR and see that PHP 8.1 tests are green

Link to PHP 8.1 tests: https://github.com/Automattic/jetpack/runs/5124274495?check_suite_focus=true
