### PR TITLE
My Jetpack: Fire Tracks event when clicking Manage button on product card

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -108,6 +108,7 @@ const ProductCard = props => {
 		onActivate,
 		onAdd,
 		onDeactivate,
+		onManage,
 		isFetching,
 	} = props;
 	const isActive = status === PRODUCT_STATUSES.ACTIVE;
@@ -164,6 +165,16 @@ const ProductCard = props => {
 		onAdd();
 	}, [ name, onAdd, recordEvent ] );
 
+	/**
+	 * Calls the passed function onManage after firing Tracks event
+	 */
+	const manageHandler = useCallback( () => {
+		recordEvent( 'jetpack_myjetpack_product_card_manage_click', {
+			product: name,
+		} );
+		onManage();
+	}, [ name, onManage, recordEvent ] );
+
 	return (
 		<div className={ containerClassName }>
 			<div className={ styles.name }>
@@ -174,7 +185,11 @@ const ProductCard = props => {
 			<div className={ styles.actions }>
 				{ canDeactivate ? (
 					<ButtonGroup className={ styles.group }>
-						{ renderActionButton( { ...props, onActivate: activateHandler } ) }
+						{ renderActionButton( {
+							...props,
+							onActivate: activateHandler,
+							onManage: manageHandler,
+						} ) }
 						<DropdownMenu
 							className={ styles.dropdown }
 							toggleProps={ { isPressed: true, disabled: isFetching } }
@@ -191,7 +206,11 @@ const ProductCard = props => {
 						/>
 					</ButtonGroup>
 				) : (
-					renderActionButton( { ...props, onActivate: activateHandler, onAdd: addHandler } )
+					renderActionButton( {
+						...props,
+						onActivate: activateHandler,
+						onAdd: addHandler,
+					} )
 				) }
 				{ ! isAbsent && <div className={ statusClassName }>{ flagLabel }</div> }
 			</div>

--- a/projects/packages/my-jetpack/changelog/add-manage-link-Tracks-event
+++ b/projects/packages/my-jetpack/changelog/add-manage-link-Tracks-event
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Fire Tracks event when clicking Manage button on product card


### PR DESCRIPTION
Adds tracking for click on product card Manage butons

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Introduces firing of  `jetpack_myjetpack_product_card_manage_click`.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?

Introduces 1 new event:
*  `jetpack_myjetpack_product_card_manage_click` fired when the user views the interstitial page

#### Testing instructions:
* Checkout this branch on a site with Jetpack connected the Backup plugin active, and the `JETPACK_ENABLE_MY_JETPACK` constant set to `true`.
* Open the browser and visit the site's wp-admin.
* Open the developer console, execute the following code: `localStorage.debug='dops:analyitics*`
* On an active product card
* Click the Manage... button
* Confirm that the developer console displays the events `jetpack_myjetpack_product_card_manage_click` 