### PR TITLE
My Jetpack: Pass slug prop to ProductCard

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -211,6 +211,7 @@ ProductCard.propTypes = {
 	onActivate: PropTypes.func,
 	onAdd: PropTypes.func,
 	onLearn: PropTypes.func,
+	slug: PropTypes.string.isRequired,
 	status: PropTypes.oneOf( [
 		PRODUCT_STATUSES.ACTIVE,
 		PRODUCT_STATUSES.INACTIVE,

--- a/projects/packages/my-jetpack/_inc/components/product-card/stories/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/stories/index.jsx
@@ -54,6 +54,7 @@ const DefaultArgs = {
 	icon: <BackupIcon />,
 	status: PRODUCT_STATUSES.ACTIVE,
 	admin: true,
+	slug: 'backup',
 };
 
 export const Default = Template.bind( {} );

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/anti-spam-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/anti-spam-card.jsx
@@ -22,7 +22,7 @@ export const AntiSpamIcon = () => (
 );
 
 const AntiSpamCard = ( { admin } ) => {
-	const { status, activate, deactivate, detail, isFetching } = useProduct( 'anti-spam' );
+	const { slug, status, activate, deactivate, detail, isFetching } = useProduct( 'anti-spam' );
 	const { name, description } = detail;
 
 	return (
@@ -34,6 +34,7 @@ const AntiSpamCard = ( { admin } ) => {
 			admin={ admin }
 			isFetching={ isFetching }
 			onDeactivate={ deactivate }
+			slug={ slug }
 			onActivate={ activate }
 		/>
 	);

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/anti-spam-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/anti-spam-card.jsx
@@ -22,8 +22,8 @@ export const AntiSpamIcon = () => (
 );
 
 const AntiSpamCard = ( { admin } ) => {
-	const { slug, status, activate, deactivate, detail, isFetching } = useProduct( 'anti-spam' );
-	const { name, description } = detail;
+	const { status, activate, deactivate, detail, isFetching } = useProduct( 'anti-spam' );
+	const { name, description, slug } = detail;
 
 	return (
 		<ProductCard

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card.jsx
@@ -22,8 +22,8 @@ export const BackupIcon = () => (
 );
 
 const BackupCard = ( { admin } ) => {
-	const { slug, status, activate, deactivate, detail, isFetching } = useProduct( 'backup' );
-	const { name, description } = detail;
+	const { status, activate, deactivate, detail, isFetching } = useProduct( 'backup' );
+	const { name, description, slug } = detail;
 
 	return (
 		<ProductCard

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card.jsx
@@ -22,7 +22,7 @@ export const BackupIcon = () => (
 );
 
 const BackupCard = ( { admin } ) => {
-	const { status, activate, deactivate, detail, isFetching } = useProduct( 'backup' );
+	const { slug, status, activate, deactivate, detail, isFetching } = useProduct( 'backup' );
 	const { name, description } = detail;
 
 	return (
@@ -34,6 +34,7 @@ const BackupCard = ( { admin } ) => {
 			isFetching={ isFetching }
 			admin={ admin }
 			onDeactivate={ deactivate }
+			slug={ slug }
 			onActivate={ activate }
 		/>
 	);

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card.jsx
@@ -18,8 +18,8 @@ export const BoostIcon = () => (
 );
 
 const BoostCard = ( { admin } ) => {
-	const { slug, status, activate, deactivate, detail, isFetching } = useProduct( 'boost' );
-	const { name, description } = detail;
+	const { status, activate, deactivate, detail, isFetching } = useProduct( 'boost' );
+	const { name, description, slug } = detail;
 	const navigate = useNavigate();
 
 	const onAddHandler = useCallback( () => {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card.jsx
@@ -18,7 +18,7 @@ export const BoostIcon = () => (
 );
 
 const BoostCard = ( { admin } ) => {
-	const { status, activate, deactivate, detail, isFetching } = useProduct( 'boost' );
+	const { slug, status, activate, deactivate, detail, isFetching } = useProduct( 'boost' );
 	const { name, description } = detail;
 	const navigate = useNavigate();
 
@@ -36,6 +36,7 @@ const BoostCard = ( { admin } ) => {
 			isFetching={ isFetching }
 			onDeactivate={ deactivate }
 			onActivate={ activate }
+			slug={ slug }
 			onAdd={ onAddHandler }
 		/>
 	);

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/crm-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/crm-card.jsx
@@ -24,8 +24,8 @@ export const CrmIcon = () => (
 );
 
 const CrmCard = ( { admin } ) => {
-	const { slug, status, activate, deactivate, detail, isFetching } = useProduct( 'crm' );
-	const { name, description } = detail;
+	const { status, activate, deactivate, detail, isFetching } = useProduct( 'crm' );
+	const { name, description, slug } = detail;
 
 	return (
 		<ProductCard

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/crm-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/crm-card.jsx
@@ -24,7 +24,7 @@ export const CrmIcon = () => (
 );
 
 const CrmCard = ( { admin } ) => {
-	const { status, activate, deactivate, detail, isFetching } = useProduct( 'crm' );
+	const { slug, status, activate, deactivate, detail, isFetching } = useProduct( 'crm' );
 	const { name, description } = detail;
 
 	return (
@@ -37,6 +37,7 @@ const CrmCard = ( { admin } ) => {
 			admin={ admin }
 			onDeactivate={ deactivate }
 			onActivate={ activate }
+			slug={ slug }
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/extras-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/extras-card.jsx
@@ -22,7 +22,7 @@ export const ExtrasIcon = () => (
 );
 
 const ExtrasCard = ( { admin } ) => {
-	const { status, activate, deactivate, detail, isFetching } = useProduct( 'extras' );
+	const { slug, status, activate, deactivate, detail, isFetching } = useProduct( 'extras' );
 	const { name, description } = detail;
 
 	return (
@@ -34,6 +34,7 @@ const ExtrasCard = ( { admin } ) => {
 			admin={ admin }
 			isFetching={ isFetching }
 			onDeactivate={ deactivate }
+			slug={ slug }
 			onActivate={ activate }
 		/>
 	);

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/extras-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/extras-card.jsx
@@ -22,8 +22,8 @@ export const ExtrasIcon = () => (
 );
 
 const ExtrasCard = ( { admin } ) => {
-	const { slug, status, activate, deactivate, detail, isFetching } = useProduct( 'extras' );
-	const { name, description } = detail;
+	const { status, activate, deactivate, detail, isFetching } = useProduct( 'extras' );
+	const { name, description, slug } = detail;
 
 	return (
 		<ProductCard

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/scan-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/scan-card.jsx
@@ -22,7 +22,7 @@ export const ScanIcon = () => (
 );
 
 const ScanCard = ( { admin } ) => {
-	const { status, activate, deactivate, detail, isFetching } = useProduct( 'scan' );
+	const { slug, status, activate, deactivate, detail, isFetching } = useProduct( 'scan' );
 	const { name, description } = detail;
 
 	return (
@@ -34,6 +34,7 @@ const ScanCard = ( { admin } ) => {
 			admin={ admin }
 			isFetching={ isFetching }
 			onDeactivate={ deactivate }
+			slug={ slug }
 			onActivate={ activate }
 		/>
 	);

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/scan-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/scan-card.jsx
@@ -22,8 +22,8 @@ export const ScanIcon = () => (
 );
 
 const ScanCard = ( { admin } ) => {
-	const { slug, status, activate, deactivate, detail, isFetching } = useProduct( 'scan' );
-	const { name, description } = detail;
+	const { status, activate, deactivate, detail, isFetching } = useProduct( 'scan' );
+	const { name, description, slug } = detail;
 
 	return (
 		<ProductCard

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/search-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/search-card.jsx
@@ -19,8 +19,8 @@ export const SearchIcon = () => (
 );
 
 const SearchCard = ( { admin } ) => {
-	const { slug, status, activate, deactivate, detail, isFetching } = useProduct( 'search' );
-	const { name, description } = detail;
+	const { status, activate, deactivate, detail, isFetching } = useProduct( 'search' );
+	const { name, description, slug } = detail;
 
 	const navigate = useNavigate();
 	const onAddHandler = useCallback( () => navigate( '/add-search' ), [ navigate ] );

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/search-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/search-card.jsx
@@ -19,7 +19,7 @@ export const SearchIcon = () => (
 );
 
 const SearchCard = ( { admin } ) => {
-	const { status, activate, deactivate, detail, isFetching } = useProduct( 'search' );
+	const { slug, status, activate, deactivate, detail, isFetching } = useProduct( 'search' );
 	const { name, description } = detail;
 
 	const navigate = useNavigate();
@@ -36,6 +36,7 @@ const SearchCard = ( { admin } ) => {
 			onDeactivate={ deactivate }
 			onActivate={ activate }
 			onAdd={ onAddHandler }
+			slug={ slug }
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card.jsx
@@ -26,8 +26,8 @@ export const VideopressIcon = () => (
 );
 
 const VideopressCard = ( { admin } ) => {
-	const { slug, status, activate, deactivate, detail, isFetching } = useProduct( 'videopress' );
-	const { name, description } = detail;
+	const { status, activate, deactivate, detail, isFetching } = useProduct( 'videopress' );
+	const { name, description, slug } = detail;
 
 	return (
 		<ProductCard

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card.jsx
@@ -26,7 +26,7 @@ export const VideopressIcon = () => (
 );
 
 const VideopressCard = ( { admin } ) => {
-	const { status, activate, deactivate, detail, isFetching } = useProduct( 'videopress' );
+	const { slug, status, activate, deactivate, detail, isFetching } = useProduct( 'videopress' );
 	const { name, description } = detail;
 
 	return (
@@ -39,6 +39,7 @@ const VideopressCard = ( { admin } ) => {
 			isFetching={ isFetching }
 			onDeactivate={ deactivate }
 			onActivate={ activate }
+			slug={ slug }
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/hooks/use-product/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-product/index.js
@@ -33,7 +33,6 @@ export function useProduct( productId ) {
 		detail,
 		isActive: detail.status === 'active',
 		isFetching: useSelect( select => select( STORE_ID ).isFetching( productId ) ),
-		slug: productId,
 		status: detail.status, // shorthand. Consider to remove.
 	};
 }

--- a/projects/packages/my-jetpack/_inc/hooks/use-product/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-product/index.js
@@ -33,6 +33,7 @@ export function useProduct( productId ) {
 		detail,
 		isActive: detail.status === 'active',
 		isFetching: useSelect( select => select( STORE_ID ).isFetching( productId ) ),
+		slug: productId,
 		status: detail.status, // shorthand. Consider to remove.
 	};
 }

--- a/projects/packages/my-jetpack/changelog/update-pass-slug-to-product-card
+++ b/projects/packages/my-jetpack/changelog/update-pass-slug-to-product-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Pass slug prop to ProductCard'


### PR DESCRIPTION
Needed for #22755

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Makes `slug` be a required Prop in ProductCard
* Makes the `useProduct` hook return `slug`
* Makes the specific product components pass slug on <ProductCard/> usage.



#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:

* Visit My Jetpack.
* Confirm you see no errors in the console (Due to slug now being a reuquired prop)