### PR TITLE
Premium Content Block: User can't access premium content on renewal date.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-premium-content-no-access-on-renewal-date
+++ b/projects/plugins/jetpack/changelog/fix-premium-content-no-access-on-renewal-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+The user can now visualize the premium content during a 1 day grace period to take into account possiible delays between the actual renewal and the subscription expiry date.

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
@@ -218,7 +218,7 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 		foreach ( $token_subscriptions as $product_id => $token_subscription ) {
 			if ( in_array( $product_id, $product_ids, true ) ) {
 				$end = is_int( $token_subscription->end_date ) ? $token_subscription->end_date : strtotime( $token_subscription->end_date );
-				if ( $end > time() ) {
+				if ( ( $end + 24 * 3600 ) > time() ) {
 					return true;
 				}
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [#46242](https://github.com/Automattic/wp-calypso/issues/46242)

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Since we can't guarantee that the subscription renewal will happen exactly at the time of the expiry of the subscription, we now add a one-day grace period to the check that determines if the user can or can't view the premium content. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open a post that has premium content.
* Create a token with a subscription that expires today.
* Append the token to the URL.
* You should see the content.

#### Test evidence:

https://user-images.githubusercontent.com/1989914/153202351-56337c4d-425e-4140-b039-33d7dfc49562.mp4

