### PR TITLE
My Jetpack: Add beta badge

### DIFF
--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-beta-badge
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-beta-badge
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add Beta badge for My Jetpack

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -40,7 +40,11 @@ class Initializer {
 
 		$page_suffix = Admin_Menu::add_menu(
 			__( 'My Jetpack', 'jetpack-my-jetpack' ),
-			__( 'My Jetpack', 'jetpack-my-jetpack' ),
+			sprintf(
+			/* translators: %s: "beta" label on Menu item for My Jetpack. */
+				__( 'My Jetpack %s', 'jetpack-my-jetpack' ),
+				'<span style="margin: 8px; color: #bbb;">' . __( 'beta', 'jetpack-my-jetpack' ) . '</span>'
+			),
 			'manage_options',
 			'my-jetpack',
 			array( __CLASS__, 'admin_page' ),


### PR DESCRIPTION
Based on accepted answer here: p1HpG7-egt-p2#comment-51829
Following the recommendation from p1HpG7-egt-p2#comment-52146 by @retrofox 

![image](https://user-images.githubusercontent.com/746152/153202534-28eb4b27-ab8f-4d80-9c77-50f7cb76092b.png)

Fixes #22377

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update the menu item to include a beta indictaor... Taken from implementation in https://github.com/WordPress/gutenberg/blob/596afccfe1396584f11e7c5b7cc22bf1b24e4ced/lib/init.php#L84-L88
#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?

no

#### Testing instructions:

* Checkout this page
* On a connected Jetpack site, confirm the My Jetpack menu shows a beta indicator

* Go to '..'
*