### PR TITLE
My Jetpack: add Icons to Search and Scan interstitial components

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -11,12 +11,14 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { useProduct } from '../../hooks/use-product';
-import { BackupIcon } from '../product-cards-section/backup-card';
 import styles from './style.module.scss';
 import { BoostIcon } from '../product-cards-section/boost-card';
 import getProductCheckoutUrl from '../../utils/get-product-checkout-url';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
+import { useProduct } from '../../hooks/use-product';
+import { BackupIcon } from '../product-cards-section/backup-card';
+import { SearchIcon } from '../product-cards-section/search-card';
+import { ScanIcon } from '../product-cards-section/scan-card';
 
 /**
  * Simple react component to render the product icon,
@@ -32,6 +34,13 @@ function ProductIcon( { slug } ) {
 
 		case 'boost':
 			return <BoostIcon />;
+
+		case 'search':
+			return <SearchIcon />;
+
+		case 'scan':
+			return <ScanIcon />;
+
 		default:
 			return null;
 	}

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-fix-product-detail-icons
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-fix-product-detail-icons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+my-jetpack: add Icons to Search and Scan interstitials


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds the Icons to Search and Scan interstitial components.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: add Icons to Search and Scan interstitial components

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack
* Confirm you see the icons in the `Search` and `Scan` interstitial pages.

**Search**
`https://your-testing-site/wp-admin/admin.php?page=my-jetpack#/add-search`
<img width="800" alt="image" src="https://user-images.githubusercontent.com/77539/153298486-0f03d6f3-ed74-44e3-b8ed-af8497f07d32.png">

**Scan**
`https://your-testing-site/wp-admin/admin.php?page=my-jetpack#/add-scan`
<img width="800" alt="image" src="https://user-images.githubusercontent.com/77539/153298451-b5f0e197-a053-47f5-80fc-f9592783f7d0.png">

