### PR TITLE
My Jetpack: Notices for request errors

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -36,7 +36,7 @@ const GlobalNotice = ( { message, options, clean } ) => {
 	};
 
 	return (
-		<Notice { ...options } onRemove={ clean } className={ styles.notice } isDismissible={ false }>
+		<Notice isDismissible={ false } { ...options } onRemove={ clean } className={ styles.notice }>
 			{ iconMap?.[ options.status ] && <Icon icon={ iconMap[ options.status ] } /> }
 			<div className={ styles.message }>{ message }</div>
 		</Notice>

--- a/projects/packages/my-jetpack/_inc/state/actions.js
+++ b/projects/packages/my-jetpack/_inc/state/actions.js
@@ -114,12 +114,18 @@ function requestProductStatus( productId, data, { select, dispatch } ) {
 				resolve( freshProduct?.status );
 			} )
 			.catch( error => {
-				const message = sprintf(
-					// translators: %$1s: Type of action, %$2s Product
-					__( 'Failed to %1$s jetpack %2$s. Please try again', 'jetpack-my-jetpack' ),
-					data.activate ? 'activate' : 'deactivate',
-					productId
-				);
+				const { name } = select.getProduct( productId );
+				const message = data.activate
+					? sprintf(
+							// translators: %$1s: Jetpack Product name
+							__( 'Failed to activate %1$s. Please try again', 'jetpack-my-jetpack' ),
+							name
+					  )
+					: sprintf(
+							// translators: %$1s: Jetpack Product name
+							__( 'Failed to deactivate %1$s. Please try again', 'jetpack-my-jetpack' ),
+							name
+					  );
 
 				dispatch( setIsFetchingProduct( productId, false ) );
 				dispatch( setRequestProductError( productId, error ) );

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-request-error-notice
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-request-error-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Add global notices for activate/deactivate failures


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #22627 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Calls `setGlobalNotice` on product request failures.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Build `My Jetpack` (`jetpack build jetpack/my-jetpack`)
* Disconnect your user from wordpress.com
* Try to activate some product that requires a connection (like Scan).
* You should see a message saying that activation failed.

#### Demo


https://user-images.githubusercontent.com/1663717/153298963-a7d18666-e0cc-403a-ba69-9809aba439d3.mp4


