### PR TITLE
My Jetpack: Correct style for `<ProductDetailCard />` button

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -109,8 +109,7 @@ const ProductDetail = ( { slug, trackButtonClick } ) => {
 
 			<Button
 				onClick={ trackButtonClick }
-				isLink
-				isPrimary
+				isPressed
 				href={ addProductUrl }
 				className={ styles[ 'checkout-button' ] }
 			>

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-cta-button
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-cta-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Apply correct style for CTA buttons on Interstitial


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #22704 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add `isPressed` prop into `Button` for `ProductDetailCard`.



#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Build `My Jetpack`(`jetpack build packages/my-jetpack`)
* Navigate to `add-bost` and `add-search` routes.
* You should see black button.

#### Demo

![image](https://user-images.githubusercontent.com/1663717/153300530-ad9bae96-87ce-4d71-8794-d604fcbed738.png)

