### PR TITLE
My Jetpack: Avoid fetch all products on initial render

### DIFF
--- a/projects/packages/my-jetpack/_inc/state/constants.js
+++ b/projects/packages/my-jetpack/_inc/state/constants.js
@@ -1,4 +1,4 @@
 const REST_API_NAMESPACE = 'my-jetpack/v1';
 export const REST_API_SITE_PURCHASES_ENDPOINT = `${ REST_API_NAMESPACE }/site/purchases`;
 export const REST_API_SITE_PRODUCTS_ENDPOINT = `${ REST_API_NAMESPACE }/site/products`;
-export const PRODUCTS_THAT_NEEDS_INITIAL_FETCH = [ 'search' ];
+export const PRODUCTS_THAT_NEEDS_INITIAL_FETCH = [ 'scan' ];

--- a/projects/packages/my-jetpack/_inc/state/constants.js
+++ b/projects/packages/my-jetpack/_inc/state/constants.js
@@ -1,3 +1,4 @@
 const REST_API_NAMESPACE = 'my-jetpack/v1';
 export const REST_API_SITE_PURCHASES_ENDPOINT = `${ REST_API_NAMESPACE }/site/purchases`;
 export const REST_API_SITE_PRODUCTS_ENDPOINT = `${ REST_API_NAMESPACE }/site/products`;
+export const PRODUCTS_THAT_NEEDS_INITIAL_FETCH = [ 'search' ];

--- a/projects/packages/my-jetpack/_inc/state/resolvers.js
+++ b/projects/packages/my-jetpack/_inc/state/resolvers.js
@@ -6,24 +6,41 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import { REST_API_SITE_PURCHASES_ENDPOINT, REST_API_SITE_PRODUCTS_ENDPOINT } from './constants';
+import {
+	REST_API_SITE_PURCHASES_ENDPOINT,
+	REST_API_SITE_PRODUCTS_ENDPOINT,
+	PRODUCTS_THAT_NEEDS_INITIAL_FETCH,
+} from './constants';
 
 const myJetpackResolvers = {
-	getProduct: ( productId ) => async ( { dispatch } ) => {
-		try {
-			dispatch.setProduct(
-				await apiFetch( {
-					path: `${ REST_API_SITE_PRODUCTS_ENDPOINT }/${ productId }`,
-				} )
+	getProduct: {
+		isFulfilled: ( state, productId ) => {
+			const items = state?.products?.items || {};
+			return (
+				items.hasOwnProperty( productId ) &&
+				! PRODUCTS_THAT_NEEDS_INITIAL_FETCH.includes( productId )
 			);
-		} catch ( error ) {
-			// Pick error from the response body.
-			if ( error?.code && error?.message ) {
-				dispatch.setRequestProductError( productId, error );
-			} else {
+		},
+		fulfill: productId => async ( { dispatch } ) => {
+			try {
+				dispatch.setIsFetchingProduct( productId, true );
+				const response = await apiFetch( {
+					path: `${ REST_API_SITE_PRODUCTS_ENDPOINT }/${ productId }`,
+				} );
+				dispatch.setProduct( response );
+				dispatch.setIsFetchingProduct( productId, false );
+				return Promise.resolve();
+			} catch ( error ) {
+				dispatch.setIsFetchingProduct( productId, false );
+
+				// Pick error from the response body.
+				if ( error?.code && error?.message ) {
+					dispatch.setRequestProductError( productId, error );
+					return Promise.reject( error );
+				}
 				throw new Error( error );
 			}
-		}
+		},
 	},
 
 	getPurchases: () => async ( { dispatch } ) => {

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-initial-state
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-initial-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Implement is fulfilled handler for product resolver


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Avoid fetching all products data on the initial render, since most of them come from the backend already populated.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Include `isFulfilled` into `getProduct` resolver, which looks for the initial state and list of products that need initial fetch.
* Dispatch `isFetching` in `getProduct` resolver, to avoid user interact with product before initial fetch.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Build `My Jetpack`(`jetpack build packages/my-jetpack`)
* Open the initial page.
* Inspect the request, you should see only `scan` being fetched.

#### Demo


https://user-images.githubusercontent.com/1663717/153309190-4ea8e82b-b09b-44db-bd9d-43463dcd9009.mp4


