### PR TITLE
My Jetpack Make Go Back link fire Tracks event

### DIFF
--- a/projects/packages/my-jetpack/_inc/admin.jsx
+++ b/projects/packages/my-jetpack/_inc/admin.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import ReactDOM from 'react-dom';
-import React from 'react';
+import React, { useCallback } from 'react';
 import { HashRouter, Routes, Route } from 'react-router-dom';
 import { Container, Col, JetpackFooter } from '@automattic/jetpack-components';
 
@@ -19,6 +19,7 @@ import {
 } from './components/product-interstitial';
 import GoBackLink from './components/go-back-link';
 import styles from './style.module.scss';
+import useAnalytics from './hooks/use-analytics';
 
 initStore();
 
@@ -30,9 +31,19 @@ initStore();
  * @param {object} props          - Component props.
  * @param {boolean} props.nav     - Header navigation.
  * @param {object} props.children - Child components.
+ * @param {string} props.slug     - A product slug or undefined. Will Fire Tracks event with product:slug if not undefined
  * @returns {object}                Layout react component.
  */
-function Layout( { nav = false, children } ) {
+function Layout( { nav = false, children, slug } ) {
+	const {
+		tracks: { recordEvent },
+	} = useAnalytics();
+	const onClick = useCallback( () => {
+		if ( slug ) {
+			recordEvent( 'jetpack_myjetpack_product_interstitial_back_link_click', { product: slug } );
+		}
+	}, [ recordEvent, slug ] );
+
 	if ( ! nav ) {
 		return children;
 	}
@@ -41,7 +52,7 @@ function Layout( { nav = false, children } ) {
 		<div className={ styles.layout }>
 			<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 				<Col>
-					<GoBackLink />
+					<GoBackLink onClick={ onClick } />
 				</Col>
 				<Col>{ children }</Col>
 			</Container>
@@ -64,11 +75,11 @@ const MyJetpack = () => (
 			/>
 			<Route
 				path="/add-boost"
-				element={ <Layout nav={ true } children={ <BoostInterstitial /> } /> }
+				element={ <Layout nav={ true } children={ <BoostInterstitial /> } slug={ 'boost' } /> }
 			/>
 			<Route
 				path="/add-scan"
-				element={ <Layout nav={ true } children={ <ScanInterstitial /> } /> }
+				element={ <Layout nav={ true } children={ <ScanInterstitial /> } slug={ 'scan' } /> }
 			/>
 			<Route
 				path="/add-search"

--- a/projects/packages/my-jetpack/_inc/components/go-back-link/index.js
+++ b/projects/packages/my-jetpack/_inc/components/go-back-link/index.js
@@ -14,13 +14,21 @@ import styles from './styles.module.scss';
 /**
  * Simple component that renders a go back link
  *
- * @returns {object} GoBackLink component.
+ * @param {object} props           - Component props.
+ * @param {Function} props.onClick - A callback to execute on click
+ * @returns {object}                 GoBackLink component.
  */
-export default function GoBackLink() {
+function GoBackLink( { onClick } ) {
 	return (
-		<Link to="/" className={ styles.link }>
+		<Link to="/" className={ styles.link } onClick={ onClick }>
 			<Icon icon={ arrowLeft } className={ styles.icon } />
 			{ __( 'Go back', 'jetpack-my-jetpack' ) }
 		</Link>
 	);
 }
+
+GoBackLink.defaultProps = {
+	onClick: () => {},
+};
+
+export default GoBackLink;

--- a/projects/packages/my-jetpack/changelog/add-tracks-event-interstitial-back
+++ b/projects/packages/my-jetpack/changelog/add-tracks-event-interstitial-back
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Fire Tracks Event when user clicks on Product Interstitial Back link


### PR DESCRIPTION
Adds tracking for click on product interstitial back buttons

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Introduces firing of  `jetpack_myjetpack_product_interstitial_back_link_click`.
* Refactors <GoBackLink /> component to accept onClick prop.
* 
#### Jetpack product discussion

#### Does this pull request change what data or activity we track or use?

Introduces 1 new event:
*  `jetpack_myjetpack_product_interstitial_back_link_click` fired when the user clicks on the Go Back link on the interstitial page for a product

#### Testing instructions:
* Checkout this branch on a site with Jetpack connected the Backup plugin active, and the `JETPACK_ENABLE_MY_JETPACK` constant set to `true`.
* Open the browser and visit the site's wp-admin.
* Open the developer console, execute the following code: `localStorage.debug='dops:analyitics*`
* On an missing product card
* Click the _Add_ button (For example Scan, Search, or Boost)
* Expect to see an interstitial .
* Click the Go back link.
* Confirm that the developer console displays the events `jetpack_myjetpack_product_interstitial_back_link_click` 