### PR TITLE
Publicize: Remove can_connect_service unused method

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-publicize-unused-method
+++ b/projects/plugins/jetpack/changelog/remove-publicize-unused-method
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Removed the unused can_connect_service method

--- a/projects/plugins/jetpack/modules/publicize/publicize.php
+++ b/projects/plugins/jetpack/modules/publicize/publicize.php
@@ -159,10 +159,6 @@ abstract class Publicize_Base {
 	 */
 	abstract function get_services( $filter = 'all', $_blog_id = false, $_user_id = false );
 
-	function can_connect_service( $service_name ) {
-		return true;
-	}
-
 	/**
 	 * Does the given user have a connection to the service on the given blog?
 	 *


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The `can_connect_service` method used to be overridden in some contexts,
but is no longer used and is out of sync with the WPCOM codebase. This
PR removes it.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
TBC, but probably need to check this doesn't break Publicize!
