### PR TITLE
Premium Content block: Disallow markup blocks to be transformed to Premium Content block

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-premium-content-transformation-disallowlist
+++ b/projects/plugins/jetpack/changelog/fix-premium-content-transformation-disallowlist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Don't allow core markup blocks to be transformed to Premium Content block (e.g. core/nextpage, core/spacer)

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/index.js
@@ -14,17 +14,15 @@ import { blockContainsPremiumBlock, blockHasParentPremiumBlock } from './_inc/pr
 
 /**
  * A list of blocks that should be disallowed to be transformed to Premium content block since they are mostly markup blocks.
- *
- * @type {{"core/loginout": boolean, "core/nextpage": boolean, "core/more": boolean, "core/separator": boolean, "core/spacer": boolean, "core/post-navigation-link": boolean}}
  */
-const disallowFromTransformations = {
-	'core/nextpage': true,
-	'core/spacer': true,
-	'core/separator': true,
-	'core/more': true,
-	'core/loginout': true,
-	'core/post-navigation-link': true,
-};
+const disallowFromTransformations = [
+	'core/nextpage',
+	'core/spacer',
+	'core/separator',
+	'core/more',
+	'core/loginout',
+	'core/post-navigation-link',
+];
 
 /**
  * Check if the given blocks are transformable to premium-content block
@@ -52,7 +50,7 @@ const blocksCanBeTransformed = blocks => {
 	// Check if the blocks selected are all in the disallowFromTransformations.
 	// If  they are, they don't have any value in allowing them to be transformed to Premium Content.
 	const isInDisallowList = blocks.every( block =>
-		disallowFromTransformations.hasOwnProperty( block.name )
+		disallowFromTransformations.includes( block.name )
 	);
 
 	return ! isInDisallowList;

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/index.js
@@ -13,10 +13,26 @@ import icon from './_inc/icon';
 import { blockContainsPremiumBlock, blockHasParentPremiumBlock } from './_inc/premium';
 
 /**
+ * A list of blocks that should be disallowed to be transformed to Premium content block since they are mostly markup blocks.
+ *
+ * @type {{"core/loginout": boolean, "core/nextpage": boolean, "core/more": boolean, "core/separator": boolean, "core/spacer": boolean, "core/post-navigation-link": boolean}}
+ */
+const disallowFromTransformations = {
+	'core/nextpage': true,
+	'core/spacer': true,
+	'core/separator': true,
+	'core/more': true,
+	'core/loginout': true,
+	'core/post-navigation-link': true,
+};
+
+/**
  * Check if the given blocks are transformable to premium-content block
  *
  * This is because transforming blocks that are already premium content blocks, or have one as a descendant or ancestor
  * doesn't make sense and is likely to lead to confusion.
+ *
+ * We also filter the blocks that don't bring any value in transforming them to Premium Content block.
  *
  * @param {Array} blocks - The blocks that could be transformed
  * @returns {boolean} Whether the blocks should be allowed to be transformed to a premium content block
@@ -33,7 +49,13 @@ const blocksCanBeTransformed = blocks => {
 		return false;
 	}
 
-	return true;
+	// Check if the blocks selected are all in the disallowFromTransformations.
+	// If  they are, they don't have any value in allowing them to be transformed to Premium Content.
+	const isInDisallowList = blocks.every( block =>
+		disallowFromTransformations.hasOwnProperty( block.name )
+	);
+
+	return ! isInDisallowList;
 };
 
 export const name = 'premium-content/container';


### PR DESCRIPTION
Since there's no reason to allow transforming markup blocks to Premium Content block, let's not allow the user to transform them to Premium Content.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #22422 (Partially).

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Disallows the following blocks to be transformed to Premium Content block:
* core/nextpage
* core/spacer
* core/separator
* core/more
* core/loginout
* core/post-navigation-link

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* WPCOM: Apply D74740-code on your sandbox
* Atomic: Use Jetpack Beta plugin and switch to this branch
* Go to a new post and add one of the above mentioned blocks (e.g. core/spacer).
* Open the transforms dropdown and make sure that "Premium Content" block is no longer available.
* Try various variations (e.g. multiple block select blocks, multiple blocks that have at least one paragraph block)
