### PR TITLE
Improve fetching a11n data on About page

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-about-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-about-page.php
@@ -539,7 +539,7 @@ class Jetpack_About_Page extends Jetpack_Admin_Page {
 				true
 			);
 			if ( ! empty( $data ) && is_array( $data ) ) {
-				set_transient( 'jetpack_a8c_data', $data, DAY_IN_SECONDS );
+				set_transient( 'jetpack_a8c_data', $data, WEEK_IN_SECONDS );
 			} else {
 				// Fallback if everything fails.
 				$data = array(

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-about-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-about-page.php
@@ -53,10 +53,12 @@ class Jetpack_About_Page extends Jetpack_Admin_Page {
 	/**
 	 * Add page action
 	 *
-	 * @param string $hook Hook of current page, unused.
+	 * @param string $hook Hook of current page.
 	 */
-	public function add_page_actions( $hook ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$this->a8c_data = $this->fetch_a8c_data();
+	public function add_page_actions( $hook ) {
+		if ( 'admin_page_jetpack_about' === $hook ) {
+			$this->a8c_data = $this->fetch_a8c_data();
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -19,7 +19,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	}
 
 	function add_page_actions( $hook ) {
-		/** This action is documented in class.jetpack.php */
+		/** This action is documented in class.jetpack-admin.php */
 		do_action( 'jetpack_admin_menu', $hook );
 
 		if ( ! isset( $_GET['page'] ) || 'jetpack' !== $_GET['page'] ) {

--- a/projects/plugins/jetpack/changelog/fix-A11n_data_load
+++ b/projects/plugins/jetpack/changelog/fix-A11n_data_load
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Limited fetching a11n data to Jetpack About page.

--- a/projects/plugins/jetpack/changelog/fix-A11n_data_load
+++ b/projects/plugins/jetpack/changelog/fix-A11n_data_load
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Limited fetching a11n data to Jetpack About page.
+About page: only fetch a11n data when page is active.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #22666

The fetch_a8c_data() is being loaded on each WP-Admin page although it's only relevant to the Jetpack About page.


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Added a condition that loads data only on a page that has the current page hook set to 'admin_page_jetpack_about'.
* Changed the expiry of the `jetpack_a8c_data` transient to one week. Internal reference: p1644577543217449-slack-C0D96691V

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Find and delete the `jetpack_a8c_data` transient.
* Load any WP-Admin page (except the about page) and check if the transient is created. It shouldn't be.
* Go to Jetpack About page and check if the transient is created and the about page is showing correct data (number of people, languages...).