### PR TITLE
Publicize: Sync Publicize_UI with WPCOM

### DIFF
--- a/projects/plugins/jetpack/changelog/update-sync-publicize-ui
+++ b/projects/plugins/jetpack/changelog/update-sync-publicize-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Adding note for translators

--- a/projects/plugins/jetpack/modules/publicize/ui.php
+++ b/projects/plugins/jetpack/modules/publicize/ui.php
@@ -99,6 +99,7 @@ class Publicize_UI {
 		<h4><?php
 			printf(
 				wp_kses(
+					/* translators: %s is the link to the Publicize page in Calypso */
 					__( "We've made some updates to Publicize. Please visit the <a href='%s' class='jptracks' data-jptracks-name='legacy_publicize_settings'>WordPress.com sharing page</a> to manage your publicize connections or use the button below.", 'jetpack' ),
 					array( 'a' => array( 'href' => array(), 'class' => array(), 'data-jptracks-name' => array() ) )
 				),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
In order to land the changes in #22511 we need to make sure that the
files are in sync with WPCOM. The coding standards have changed and so
when we sync'd this UI we had to add a note for translators.

This brings the Jetpack version in line with that change.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
N/A - it only adds a comment.
