### PR TITLE
i18n-check-webpack-plugin: Add timing to debug output

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -474,7 +474,7 @@ importers:
     specifiers:
       '@automattic/babel-plugin-preserve-i18n': 1.0.0
       '@automattic/babel-plugin-replace-textdomain': workspace:^1.0.2
-      '@automattic/i18n-check-webpack-plugin': workspace:^1.0.4
+      '@automattic/i18n-check-webpack-plugin': workspace:^1.0.5-alpha
       '@automattic/i18n-loader-webpack-plugin': workspace:^2.0.1
       '@automattic/webpack-rtl-plugin': 5.1.0
       '@babel/compat-data': 7.16.4
@@ -534,7 +534,7 @@ importers:
 
   projects/packages/assets:
     specifiers:
-      '@automattic/jetpack-webpack-config': workspace:^1.1.2
+      '@automattic/jetpack-webpack-config': workspace:^1.1.3-alpha
       jest: 27.3.1
       md5-es: 1.8.2
       webpack: 5.65.0
@@ -548,7 +548,7 @@ importers:
     specifiers:
       '@automattic/jetpack-api': workspace:^0.8.4
       '@automattic/jetpack-connection': workspace:^0.15.1
-      '@automattic/jetpack-webpack-config': workspace:^1.1.2
+      '@automattic/jetpack-webpack-config': workspace:^1.1.3-alpha
       '@babel/core': 7.16.0
       '@babel/preset-env': 7.16.4
       '@babel/register': 7.16.0
@@ -588,7 +588,7 @@ importers:
   projects/packages/identity-crisis:
     specifiers:
       '@automattic/jetpack-idc': workspace:^0.9.2
-      '@automattic/jetpack-webpack-config': workspace:^1.1.2
+      '@automattic/jetpack-webpack-config': workspace:^1.1.3-alpha
       '@babel/core': 7.16.0
       '@babel/preset-env': 7.16.4
       '@babel/register': 7.16.0
@@ -620,7 +620,7 @@ importers:
 
   projects/packages/jitm:
     specifiers:
-      '@automattic/jetpack-webpack-config': workspace:^1.1.2
+      '@automattic/jetpack-webpack-config': workspace:^1.1.3-alpha
       '@wordpress/browserslist-config': 4.1.0
       sass: 1.43.3
       sass-loader: 12.4.0
@@ -636,7 +636,7 @@ importers:
 
   projects/packages/lazy-images:
     specifiers:
-      '@automattic/jetpack-webpack-config': workspace:^1.1.2
+      '@automattic/jetpack-webpack-config': workspace:^1.1.3-alpha
       copy-webpack-plugin: 10.2.0
       intersection-observer: 0.12.0
       webpack: 5.65.0
@@ -653,7 +653,7 @@ importers:
       '@automattic/jetpack-base-styles': workspace:^0.1.8
       '@automattic/jetpack-components': workspace:^0.10.5
       '@automattic/jetpack-connection': workspace:^0.15.1
-      '@automattic/jetpack-webpack-config': workspace:^1.1.2
+      '@automattic/jetpack-webpack-config': workspace:^1.1.3-alpha
       '@babel/core': 7.16.0
       '@babel/preset-env': 7.16.4
       '@babel/register': 7.16.0
@@ -730,7 +730,7 @@ importers:
       '@automattic/jetpack-analytics': workspace:^0.1.7
       '@automattic/jetpack-api': workspace:^0.8.4
       '@automattic/jetpack-components': workspace:^0.10.5
-      '@automattic/jetpack-webpack-config': workspace:^1.1.2
+      '@automattic/jetpack-webpack-config': workspace:^1.1.3-alpha
       '@babel/core': 7.16.0
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.16.0
       '@babel/preset-env': 7.16.4
@@ -828,7 +828,7 @@ importers:
       '@automattic/jetpack-base-styles': workspace:^0.1.8
       '@automattic/jetpack-components': workspace:^0.10.5
       '@automattic/jetpack-connection': workspace:^0.15.1
-      '@automattic/jetpack-webpack-config': workspace:^1.1.2
+      '@automattic/jetpack-webpack-config': workspace:^1.1.3-alpha
       '@babel/core': 7.16.0
       '@babel/preset-env': 7.16.4
       '@babel/register': 7.16.0
@@ -968,7 +968,7 @@ importers:
       '@automattic/jetpack-licensing': workspace:^0.4.6
       '@automattic/jetpack-partner-coupon': workspace:^0.1.8
       '@automattic/jetpack-shared-extension-utils': workspace:^0.1.0
-      '@automattic/jetpack-webpack-config': workspace:^1.1.2
+      '@automattic/jetpack-webpack-config': workspace:^1.1.3-alpha
       '@automattic/popup-monitor': 1.0.0
       '@automattic/remove-asset-webpack-plugin': workspace:^1.0.3
       '@automattic/request-external-access': 1.0.0

--- a/projects/js-packages/i18n-check-webpack-plugin/changelog/add-i18n-check-debug-timing
+++ b/projects/js-packages/i18n-check-webpack-plugin/changelog/add-i18n-check-debug-timing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add timing info to debug output.

--- a/projects/js-packages/i18n-check-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-check-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-check-webpack-plugin",
-	"version": "1.0.4",
+	"version": "1.0.5-alpha",
 	"description": "A Webpack plugin to check that WordPress i18n hasn't been mangled by Webpack optimizations.",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/js-packages/webpack-config/changelog/add-i18n-check-debug-timing
+++ b/projects/js-packages/webpack-config/changelog/add-i18n-check-debug-timing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "1.1.2",
+	"version": "1.1.3-alpha",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://jetpack.com",
 	"bugs": {
@@ -19,7 +19,7 @@
 	"dependencies": {
 		"@automattic/babel-plugin-preserve-i18n": "1.0.0",
 		"@automattic/babel-plugin-replace-textdomain": "workspace:^1.0.2",
-		"@automattic/i18n-check-webpack-plugin": "workspace:^1.0.4",
+		"@automattic/i18n-check-webpack-plugin": "workspace:^1.0.5-alpha",
 		"@automattic/i18n-loader-webpack-plugin": "workspace:^2.0.1",
 		"@automattic/webpack-rtl-plugin": "5.1.0",
 		"@babel/compat-data": "7.16.4",

--- a/projects/packages/assets/changelog/add-i18n-check-debug-timing
+++ b/projects/packages/assets/changelog/add-i18n-check-debug-timing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/assets/package.json
+++ b/projects/packages/assets/package.json
@@ -12,7 +12,7 @@
 		"validate": "pnpm exec validate-es build/"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-webpack-config": "workspace:^1.1.2",
+		"@automattic/jetpack-webpack-config": "workspace:^1.1.3-alpha",
 		"md5-es": "1.8.2",
 		"jest": "27.3.1",
 		"webpack": "5.65.0"

--- a/projects/packages/connection-ui/changelog/add-i18n-check-debug-timing
+++ b/projects/packages/connection-ui/changelog/add-i18n-check-debug-timing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/connection-ui/package.json
+++ b/projects/packages/connection-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-connection-manager-ui",
-	"version": "2.3.5",
+	"version": "2.3.6-alpha",
 	"description": "Jetpack Connection Manager UI",
 	"main": "_inc/admin.jsx",
 	"repository": "https://github.com/Automattic/jetpack-connection-ui",
@@ -20,7 +20,7 @@
 		"@wordpress/data": "6.2.0"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-webpack-config": "workspace:^1.1.2",
+		"@automattic/jetpack-webpack-config": "workspace:^1.1.3-alpha",
 		"@babel/core": "7.16.0",
 		"@babel/preset-env": "7.16.4",
 		"@babel/register": "7.16.0",

--- a/projects/packages/identity-crisis/changelog/add-i18n-check-debug-timing
+++ b/projects/packages/identity-crisis/changelog/add-i18n-check-debug-timing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.7.2",
+	"version": "0.7.3-alpha",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": "https://github.com/Automattic/jetpack-identity-crisis",
@@ -19,7 +19,7 @@
 		"@wordpress/data": "6.2.0"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-webpack-config": "workspace:^1.1.2",
+		"@automattic/jetpack-webpack-config": "workspace:^1.1.3-alpha",
 		"@babel/core": "7.16.0",
 		"@babel/preset-env": "7.16.4",
 		"@babel/register": "7.16.0",

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -28,7 +28,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.7.2';
+	const PACKAGE_VERSION = '0.7.3-alpha';
 
 	/**
 	 * Instance of the object.

--- a/projects/packages/jitm/changelog/add-i18n-check-debug-timing
+++ b/projects/packages/jitm/changelog/add-i18n-check-debug-timing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/jitm/package.json
+++ b/projects/packages/jitm/package.json
@@ -22,7 +22,7 @@
 	},
 	"browserslist": "extends @wordpress/browserslist-config",
 	"devDependencies": {
-		"@automattic/jetpack-webpack-config": "workspace:^1.1.2",
+		"@automattic/jetpack-webpack-config": "workspace:^1.1.3-alpha",
 		"@wordpress/browserslist-config": "4.1.0",
 		"sass": "1.43.3",
 		"sass-loader": "12.4.0",

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '2.2.5';
+	const PACKAGE_VERSION = '2.2.6-alpha';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/lazy-images/changelog/add-i18n-check-debug-timing
+++ b/projects/packages/lazy-images/changelog/add-i18n-check-debug-timing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/lazy-images/package.json
+++ b/projects/packages/lazy-images/package.json
@@ -23,7 +23,7 @@
 		"validate": "pnpm exec validate-es dist/"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-webpack-config": "workspace:^1.1.2",
+		"@automattic/jetpack-webpack-config": "workspace:^1.1.3-alpha",
 		"copy-webpack-plugin": "10.2.0",
 		"intersection-observer": "0.12.0",
 		"webpack": "5.65.0"

--- a/projects/packages/my-jetpack/changelog/add-i18n-check-debug-timing
+++ b/projects/packages/my-jetpack/changelog/add-i18n-check-debug-timing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -40,7 +40,7 @@
 	],
 	"devDependencies": {
 		"@automattic/jetpack-base-styles": "workspace:^0.1.8",
-		"@automattic/jetpack-webpack-config": "workspace:^1.1.2",
+		"@automattic/jetpack-webpack-config": "workspace:^1.1.3-alpha",
 		"@babel/core": "7.16.0",
 		"@babel/preset-env": "7.16.4",
 		"@babel/register": "7.16.0",

--- a/projects/packages/search/changelog/add-i18n-check-debug-timing
+++ b/projects/packages/search/changelog/add-i18n-check-debug-timing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -65,7 +65,7 @@
 		"tiny-lru": "7.0.6"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-webpack-config": "workspace:^1.1.2",
+		"@automattic/jetpack-webpack-config": "workspace:^1.1.3-alpha",
 		"@babel/core": "7.16.0",
 		"@babel/plugin-proposal-nullish-coalescing-operator": "7.16.0",
 		"@babel/preset-env": "7.16.4",

--- a/projects/plugins/backup/changelog/add-i18n-check-debug-timing
+++ b/projects/plugins/backup/changelog/add-i18n-check-debug-timing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/backup/package.json
+++ b/projects/plugins/backup/package.json
@@ -37,7 +37,7 @@
 	},
 	"devDependencies": {
 		"@automattic/jetpack-base-styles": "workspace:^0.1.8",
-		"@automattic/jetpack-webpack-config": "workspace:^1.1.2",
+		"@automattic/jetpack-webpack-config": "workspace:^1.1.3-alpha",
 		"@babel/core": "7.16.0",
 		"@babel/preset-env": "7.16.4",
 		"@babel/register": "7.16.0",

--- a/projects/plugins/jetpack/changelog/add-i18n-check-debug-timing
+++ b/projects/plugins/jetpack/changelog/add-i18n-check-debug-timing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -137,7 +137,7 @@
 	"devDependencies": {
 		"@automattic/color-studio": "2.5.0",
 		"@automattic/jetpack-base-styles": "workspace:^0.1.8",
-		"@automattic/jetpack-webpack-config": "workspace:^1.1.2",
+		"@automattic/jetpack-webpack-config": "workspace:^1.1.3-alpha",
 		"@automattic/remove-asset-webpack-plugin": "workspace:^1.0.3",
 		"@babel/core": "7.16.0",
 		"@babel/plugin-proposal-nullish-coalescing-operator": "7.16.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Allows for more directly seeing how long exactly the i18n check is
taking.

Also, while I was looking at it, I cleaned up the async handling
somewhat. Now the source files for each resource can in theory be
processed in parallel. Although in practice it probably doesn't make
much difference since the @babel/traverse part is not async anyway.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Vaguely related to p9dueE-4dJ-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try setting `DEBUG=@automattic/i18n-check-webpack-plugin:timing` then doing a production build of Jetpack or something. Look for the appropriate lines in the output.