### PR TITLE
My Jetpack: Only show the deactivate action when it makes sense according to the product

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -111,6 +111,7 @@ const ProductCard = props => {
 		onManage,
 		isFetching,
 		slug,
+		showDeactivate,
 	} = props;
 	const isActive = status === PRODUCT_STATUSES.ACTIVE;
 	const isError = status === PRODUCT_STATUSES.ERROR;
@@ -118,7 +119,7 @@ const ProductCard = props => {
 	const isAbsent = status === PRODUCT_STATUSES.ABSENT || status === PRODUCT_STATUSES.NEEDS_PURCHASE;
 	const isPurchaseRequired = status === PRODUCT_STATUSES.NEEDS_PURCHASE;
 	const flagLabel = PRODUCT_STATUSES_LABELS[ status ];
-	const canDeactivate = ( isActive || isError ) && admin;
+	const canDeactivate = ( isActive || isError ) && admin && showDeactivate;
 
 	const containerClassName = classNames( styles.container, {
 		[ styles.plugin_absent ]: isAbsent,
@@ -232,6 +233,7 @@ ProductCard.propTypes = {
 	onAdd: PropTypes.func,
 	onLearn: PropTypes.func,
 	slug: PropTypes.string.isRequired,
+	showDeactivate: PropTypes.bool,
 	status: PropTypes.oneOf( [
 		PRODUCT_STATUSES.ACTIVE,
 		PRODUCT_STATUSES.INACTIVE,
@@ -250,6 +252,7 @@ ProductCard.defaultProps = {
 	onActivate: () => {},
 	onAdd: () => {},
 	onLearn: () => {},
+	showDeactivate: true,
 };
 
 export default ProductCard;

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card.jsx
@@ -36,6 +36,7 @@ const BackupCard = ( { admin } ) => {
 			onDeactivate={ deactivate }
 			slug={ slug }
 			onActivate={ activate }
+			showDeactivate={ false }
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/extras-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/extras-card.jsx
@@ -36,6 +36,7 @@ const ExtrasCard = ( { admin } ) => {
 			onDeactivate={ deactivate }
 			slug={ slug }
 			onActivate={ activate }
+			showDeactivate={ false }
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/scan-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/scan-card.jsx
@@ -42,6 +42,7 @@ const ScanCard = ( { admin } ) => {
 			slug={ slug }
 			onActivate={ activate }
 			onAdd={ onAddHandler }
+			showDeactivate={ false }
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/changelog/update-show-activate-button-when-it-makes-sense-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/update-show-activate-button-when-it-makes-sense-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Only show the deactivate action when it makes sense


### PR DESCRIPTION
For products like Scan, Backup if it makes sense to allow the user to deactivate them.

This PR conditionally shows the deactivate button
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* adds showDeactivate boolean prop to ProductCard defaulting to true
* Hides deactivate for Scan, Backup and Extras.

#### Jetpack product discussion

p1644526299447199-slack-C02TQF5VAJD

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* Visit my Jetpack on a connected site
* Open the dev console
* For Scan, Backup and Extras card, tamper with the `status` property using the React Dev Tools setting them to active.
* Confirm those cards never show the deactivate button
![image](https://user-images.githubusercontent.com/746152/153495238-606c5e54-6053-42fa-ae44-9b9c31cb7328.png)
