### PR TITLE
My Jetpack: Replace renderActionButton function for ActionButton component

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -39,7 +39,7 @@ const DownIcon = () => (
 	</svg>
 );
 
-const renderActionButton = ( {
+const ActionButton = ( {
 	status,
 	admin,
 	name,
@@ -187,11 +187,7 @@ const ProductCard = props => {
 			<div className={ styles.actions }>
 				{ canDeactivate ? (
 					<ButtonGroup className={ styles.group }>
-						{ renderActionButton( {
-							...props,
-							onActivate: activateHandler,
-							onManage: manageHandler,
-						} ) }
+						<ActionButton { ...props } onActivate={ activateHandler } onManage={ manageHandler } />
 						<DropdownMenu
 							className={ styles.dropdown }
 							toggleProps={ { isPressed: true, disabled: isFetching } }
@@ -208,11 +204,7 @@ const ProductCard = props => {
 						/>
 					</ButtonGroup>
 				) : (
-					renderActionButton( {
-						...props,
-						onActivate: activateHandler,
-						onAdd: addHandler,
-					} )
+					<ActionButton { ...props } onActivate={ activateHandler } onAdd={ addHandler } />
 				) }
 				{ ! isAbsent && <div className={ statusClassName }>{ flagLabel }</div> }
 			</div>

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-product-card-action-button
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-product-card-action-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace renderActionButton function for ActionButton component


### PR DESCRIPTION
Replaces the usage renderActionButton for a component like usage pattern

Fixes inability to tamper with args passed to action button using React Dev Tools

![image](https://user-images.githubusercontent.com/746152/153517652-dc61ab61-0392-464f-adae-0448e88ffcb3.png)


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Renames renderActionButton to ActionButton
* Update usage inside JSX to reflect the fact it's a component now


#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Checkout this branch
* Confirm all buttons render properly and no error is shown on the console.
* Confirm you're able to inspect the Action button as a component with the React Dev Tools
