### PR TITLE
Photon: ensure fallback when 3rd-parties empty array of sources

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-photon-srcset-svg
+++ b/projects/plugins/jetpack/changelog/fix-photon-srcset-svg
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Image CDN: ensure that SVG images added to posts thanks to the SVG Support plugin can be displayed even when Jetpack's Image CDN is active.

--- a/projects/plugins/jetpack/class.photon.php
+++ b/projects/plugins/jetpack/class.photon.php
@@ -896,7 +896,7 @@ class Jetpack_Photon {
 	 * @return array An array of Photon image urls and widths.
 	 */
 	public function filter_srcset_array( $sources = array(), $size_array = array(), $image_src = array(), $image_meta = array(), $attachment_id = 0 ) {
-		if ( ! is_array( $sources ) ) {
+		if ( ! is_array( $sources ) || empty( $sources ) ) {
 			return $sources;
 		}
 		$upload_dir = wp_get_upload_dir();

--- a/projects/plugins/jetpack/class.photon.php
+++ b/projects/plugins/jetpack/class.photon.php
@@ -896,7 +896,7 @@ class Jetpack_Photon {
 	 * @return array An array of Photon image urls and widths.
 	 */
 	public function filter_srcset_array( $sources = array(), $size_array = array(), $image_src = array(), $image_meta = array(), $attachment_id = 0 ) {
-		if ( ! is_array( $sources ) || empty( $sources ) ) {
+		if ( ! is_array( $sources ) || $sources === array() ) {
 			return $sources;
 		}
 		$upload_dir = wp_get_upload_dir();

--- a/projects/plugins/jetpack/class.photon.php
+++ b/projects/plugins/jetpack/class.photon.php
@@ -896,7 +896,7 @@ class Jetpack_Photon {
 	 * @return array An array of Photon image urls and widths.
 	 */
 	public function filter_srcset_array( $sources = array(), $size_array = array(), $image_src = array(), $image_meta = array(), $attachment_id = 0 ) {
-		if ( ! is_array( $sources ) || $sources === array() ) {
+		if ( ! is_array( $sources ) || array() === $sources ) {
 			return $sources;
 		}
 		$upload_dir = wp_get_upload_dir();


### PR DESCRIPTION
Fixes #22692

#### Changes proposed in this Pull Request:

Photon hooks into the `wp_calculate_image_srcset` filter to add Photon domain and parameters to srcset image URLs generated for each image in a post. However, other plugins can also hook into that same filter, and some empty the array of images available for srcset. Let's support that use-case by checking not only for an array of images, but for an array that is not empty.

This PR particularly aims to solve a conflict with [the SVG Support plugin](https://wordpress.org/plugins/svg-support/). [Here](https://plugins.trac.wordpress.org/browser/svg-support/trunk/functions/attachment.php?rev=2672900#L263) is where that plugin hooks into `wp_calculate_image_srcset`.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

* Start with a site that's connected to WordPress.com, and where you've activated Jetpack's Site accelerator feature under Jetpack > Settings > Performance.
* Before you switch to this branch, let's test the breakage:
    * Go to Plugins > Add New, and install / activate the SVG Support plugin by Benbodhi.
    * Go to Media > Library, and upload an SVG file. You can find some in this very repo if you need something to upload. e.g. `projects/plugins/jetpack/_inc/client/at-a-glance/boost/boost.svg`.
    * Go to Posts > Add New, and add a new image block with this SVG.
    * Upon publishing the post, you'll see that the image is broken in the post.
* Now switch to this branch; the problem should disappear.
