### PR TITLE
Fix jetpack stat screen option checkmark style

### DIFF
--- a/projects/plugins/jetpack/_inc/client/dashboard-widget/style.scss
+++ b/projects/plugins/jetpack/_inc/client/dashboard-widget/style.scss
@@ -265,7 +265,10 @@
 .metabox-prefs {
 	label[for="jetpack_summary_widget-hide"] {
 		span {
- 			display: none;
+ 			svg {
+				 height: 1.2rem;
+				 vertical-align: text-bottom;
+			 }
 		}
 	}
 }

--- a/projects/plugins/jetpack/changelog/fix-jetpack-stats-screen-option
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-stats-screen-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Style jetpack stats Screen Options label to show - currently no label text shows

--- a/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
@@ -48,10 +48,16 @@ class Jetpack_Stats_Dashboard_Widget {
 				$jetpack_logo->get_jp_emblem( true )
 			);
 
+			$aria_label = sprintf(
+				// translators: placeholder is the product name.
+				__( 'Stats by %s', 'jetpack' ),
+				'Jetpack'
+			);
 			// Wrap title in span so Logo can be properly styled.
 			$widget_title = sprintf(
-				'<span>%s</span>',
-				$widget_title
+				'<span aria-label="%2$s">%1$s</span>',
+				$widget_title,
+				$aria_label
 			);
 
 			wp_add_dashboard_widget(


### PR DESCRIPTION
Fixes #22811

#### Changes proposed in this Pull Request:

Style change to display the label text  for the Stats by Jetpack Screen Option checkbox toggle

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
* Checkout this branch and rebuild jetpack plugin and dependencies
* Launch locally e.g. via jurassic tube
* Expand the screen options
* You should now see label text next to the Stats by Jetpack checkbox where before it was 'anonymous' with no label text

Before:
![Screenshot 2022-02-11 at 14 31 20](https://user-images.githubusercontent.com/8742105/153628006-86ef9dee-35d6-4b82-9873-c3e308c4a41f.png)


After:
![Screenshot 2022-02-11 at 14 32 52](https://user-images.githubusercontent.com/8742105/153628017-89abb00c-66f1-4332-81db-a6a236e2ab26.png)

