### PR TITLE
Memoize site specific features

### DIFF
--- a/projects/plugins/jetpack/changelog/memoize-site-specific-features
+++ b/projects/plugins/jetpack/changelog/memoize-site-specific-features
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Change is relatively small
+
+

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -1074,7 +1074,7 @@ class Jetpack_Gutenberg {
 		$current_blog_id = get_current_blog_id();
 
 		// keep track of specific features data per blog between calls.
-		static $site_specific_features = [];
+		static $site_specific_features = array();
 
 		// Check feature availability for Simple and Atomic sites.
 		if ( $is_simple_site || $is_atomic_site ) {
@@ -1086,7 +1086,7 @@ class Jetpack_Gutenberg {
 				}
 
 				// memoize site specific features data to avoid excessive queries.
-				if ( empty( $site_specific_features_data[ $current_blog_id ] ) ) {
+				if ( empty( $site_specific_features[ $current_blog_id ] ) ) {
 					$site_specific_features[ $current_blog_id ] = Store_Product_List::get_site_specific_features_data( $current_blog_id );
 				}
 				$features_data = $site_specific_features[ $current_blog_id ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
We've noticed on P2 sites that we are doing quite a lot of queries to the `store_subscriptions` table, more context about the investigation can be found at p4jECJ-1FH-p2#comment-4841.

This PR adds some memoization to the `set_availability_for_plan` function to avoid querying the same uncached data for the current site for each Jetpack Gutenberg block. This has reduced quite a lot the number of queries we do on each page load.

I've picked the reviewers based on previous authors of these parts of the code.

**Before**
![Markup on 2022-02-11 at 6:28:02 PM](https://user-images.githubusercontent.com/2129455/153645294-9e042823-6f04-4946-92d1-7d3864bfc61f.png)

**After**
![Markup on 2022-02-11 at 6:27:08 PM](https://user-images.githubusercontent.com/2129455/153645317-df8e30b5-f065-47d4-bfd3-f577232b9ff1.png)

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
- Jetpack blocks are still working in P2 sites
- I have no idea how to test other use cases, please advise