### PR TITLE
Search: Re-add removes Jetpack_Search class

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-search-class-change
+++ b/projects/plugins/jetpack/changelog/fix-search-class-change
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Search: Add deprecated class to prevent third-party integrations from failing after 10.6 updates.

--- a/projects/plugins/jetpack/modules/search.php
+++ b/projects/plugins/jetpack/modules/search.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 /**
  * Module Name: Search
  * Module Description: Help visitors quickly find answers with highly relevant instant search results and powerful filtering.
@@ -14,4 +14,32 @@
  * @package automattic/jetpack
  */
 
+use Automattic\Jetpack\Search\Classic_Search;
+
 Automattic\Jetpack\Search\Jetpack_Initializer::initialize();
+
+/**
+ * These are old legacy class names that were deprecated due to the move to packages.
+ *
+ * @todo Does this make more sense as a legacy dir in the search package?
+ */
+
+/**
+ * Jetpack Search deprecated class.
+ *
+ * @deprecated 10.6
+ */
+class Jetpack_Search {
+	/**
+	 * Singleton
+	 */
+	protected function __construct() {
+	}
+
+	/**
+	 * Return the instance of the new class.
+	 */
+	public static function instance() {
+		return Classic_Search::initialize( get_current_blog_id() );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/modules/search/test-class-jetpack-search.php
+++ b/projects/plugins/jetpack/tests/php/modules/search/test-class-jetpack-search.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Instant Search test cases
+ *
+ * @package automattic/jetpack
+ */
+
+if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+	require_once WPMU_PLUGIN_DIR . '/jetpack-plugin/vendor/autoload_packages.php';
+}
+
+require_jetpack_file( 'modules/search.php' );
+
+/**
+ * Jetpack_Instant_Search test cases
+ */
+class WP_Test_Jetpack_Search extends WP_UnitTestCase {
+
+	/**
+	 * Verify deprecated classes still exist.
+	 *
+	 * @since 10.6.1
+	 */
+	public function test_deprecated_jetpack_search_class() {
+		$search = Jetpack_Search::instance();
+		self::assertTrue( is_a( $search, 'Automattic\Jetpack\Search\Classic_Search' ) );
+	}
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The Alley Interactive es-wp-query plugin allows Jetpack Search customers to use that functionality to offload WP queries to our ES instance. The recent change to packages broke this by removing the `Jetpack_Search` class.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Readds the Jetpack_Search class.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1644594692698079-slack-C032R1T03DH

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with the alley interactive `es-wp-query` plugin.