### PR TITLE
Enable ajax tracking for guest users

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1087,5 +1087,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/projects/packages/connection/changelog/add-guest-ajax-tracking
+++ b/projects/packages/connection/changelog/add-guest-ajax-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/connection/composer.json
+++ b/projects/packages/connection/composer.json
@@ -11,7 +11,7 @@
 		"automattic/jetpack-roles": "^1.4",
 		"automattic/jetpack-status": "^1.10",
 		"automattic/jetpack-terms-of-service": "^1.9",
-		"automattic/jetpack-tracking": "^1.14",
+		"automattic/jetpack-tracking": "^1.15",
 		"automattic/jetpack-redirect": "^1.7"
 	},
 	"require-dev": {

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.36.2';
+	const PACKAGE_VERSION = '1.36.3-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/identity-crisis/changelog/add-guest-ajax-tracking
+++ b/projects/packages/identity-crisis/changelog/add-guest-ajax-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/identity-crisis/composer.json
+++ b/projects/packages/identity-crisis/composer.json
@@ -8,7 +8,7 @@
 		"automattic/jetpack-constants": "^1.6",
 		"automattic/jetpack-options": "^1.14",
 		"automattic/jetpack-status": "^1.10",
-		"automattic/jetpack-tracking": "^1.14",
+		"automattic/jetpack-tracking": "^1.15",
 		"automattic/jetpack-logo": "^1.5",
 		"automattic/jetpack-assets": "^1.17"
 	},

--- a/projects/packages/jitm/changelog/add-guest-ajax-tracking
+++ b/projects/packages/jitm/changelog/add-guest-ajax-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/jitm/composer.json
+++ b/projects/packages/jitm/composer.json
@@ -13,7 +13,7 @@
 		"automattic/jetpack-partner": "^1.7",
 		"automattic/jetpack-redirect": "^1.7",
 		"automattic/jetpack-status": "^1.10",
-		"automattic/jetpack-tracking": "^1.14"
+		"automattic/jetpack-tracking": "^1.15"
 	},
 	"require-dev": {
 		"brain/monkey": "2.6.1",

--- a/projects/packages/my-jetpack/changelog/add-guest-ajax-tracking
+++ b/projects/packages/my-jetpack/changelog/add-guest-ajax-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -9,7 +9,7 @@
 		"automattic/jetpack-connection": "^1.36",
 		"automattic/jetpack-plugins-installer": "^0.1",
 		"automattic/jetpack-terms-of-service": "^1.9",
-		"automattic/jetpack-tracking": "^1.14",
+		"automattic/jetpack-tracking": "^1.15",
 		"automattic/jetpack-redirect": "^1.7"
 	},
 	"require-dev": {

--- a/projects/packages/search/changelog/add-guest-ajax-tracking
+++ b/projects/packages/search/changelog/add-guest-ajax-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -7,7 +7,7 @@
 		"automattic/jetpack-connection": "^1.36",
 		"automattic/jetpack-assets": "^1.17",
 		"automattic/jetpack-constants": "^1.6",
-		"automattic/jetpack-tracking": "^1.14",
+		"automattic/jetpack-tracking": "^1.15",
 		"automattic/jetpack-options": "^1.14",
 		"automattic/jetpack-status": "^1.10"
 	},

--- a/projects/packages/tracking/changelog/add-guest-ajax-tracking
+++ b/projects/packages/tracking/changelog/add-guest-ajax-tracking
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Enable ajax tracking for guest users

--- a/projects/packages/tracking/composer.json
+++ b/projects/packages/tracking/composer.json
@@ -50,7 +50,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-tracking/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-master": "1.14.x-dev"
+			"dev-master": "1.15.x-dev"
 		}
 	}
 }

--- a/projects/packages/tracking/src/class-tracking.php
+++ b/projects/packages/tracking/src/class-tracking.php
@@ -50,6 +50,7 @@ class Tracking {
 
 		if ( ! did_action( 'jetpack_set_tracks_ajax_hook' ) ) {
 			add_action( 'wp_ajax_jetpack_tracks', array( $this, 'ajax_tracks' ) );
+			add_action( 'wp_ajax_nopriv_jetpack_tracks', array( $this, 'ajax_tracks' ) );
 
 			/**
 			 * Fires when the Tracking::ajax_tracks() callback has been hooked to the

--- a/projects/plugins/backup/changelog/add-guest-ajax-tracking
+++ b/projects/plugins/backup/changelog/add-guest-ajax-tracking
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -392,7 +392,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "5bf3bebadaec57d95df9dc6e01b9d4b7e20a2284"
+                "reference": "3732394e68b49e01fd5e6c73ad0e4c8f08ada84c"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -403,7 +403,7 @@
                 "automattic/jetpack-roles": "^1.4",
                 "automattic/jetpack-status": "^1.10",
                 "automattic/jetpack-terms-of-service": "^1.9",
-                "automattic/jetpack-tracking": "^1.14"
+                "automattic/jetpack-tracking": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.0",
@@ -655,7 +655,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/identity-crisis",
-                "reference": "80cc6904f5337f7cfa194199ad307e054fece278"
+                "reference": "2c6e57561443f31a08d43302e441583ac628c584"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -664,7 +664,7 @@
                 "automattic/jetpack-logo": "^1.5",
                 "automattic/jetpack-options": "^1.14",
                 "automattic/jetpack-status": "^1.10",
-                "automattic/jetpack-tracking": "^1.14"
+                "automattic/jetpack-tracking": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.0",
@@ -778,7 +778,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "d9c67455da0f3210b8aa25ed2a860a568bf03364"
+                "reference": "1ceef893216c851f4a3150872d5cf39461b75e5a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -787,7 +787,7 @@
                 "automattic/jetpack-plugins-installer": "^0.1",
                 "automattic/jetpack-redirect": "^1.7",
                 "automattic/jetpack-terms-of-service": "^1.9",
-                "automattic/jetpack-tracking": "^1.14"
+                "automattic/jetpack-tracking": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.0",
@@ -1281,7 +1281,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/tracking",
-                "reference": "60dd2a4462221bcc460aadf9f86daeb308fd8027"
+                "reference": "ffcfc67d2040d470f5297bfbbd9212e97343432e"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -1303,7 +1303,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-tracking/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.14.x-dev"
+                    "dev-master": "1.15.x-dev"
                 }
             },
             "autoload": {
@@ -4492,5 +4492,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/projects/plugins/beta/changelog/add-guest-ajax-tracking
+++ b/projects/plugins/beta/changelog/add-guest-ajax-tracking
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/beta/composer.lock
+++ b/projects/plugins/beta/composer.lock
@@ -1271,5 +1271,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/projects/plugins/boost/changelog/add-guest-ajax-tracking
+++ b/projects/plugins/boost/changelog/add-guest-ajax-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -23,7 +23,7 @@
 		"automattic/jetpack-device-detection": "1.4.x-dev",
 		"automattic/jetpack-lazy-images": "2.1.x-dev",
 		"automattic/jetpack-terms-of-service": "1.9.x-dev",
-		"automattic/jetpack-tracking": "1.14.x-dev",
+		"automattic/jetpack-tracking": "1.15.x-dev",
 		"tedivm/jshrink": "1.4.0"
 	},
 	"require-dev": {

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf84051ff242fd51a306b1a6eed5ce99",
+    "content-hash": "32c7adb8c54fbd91f745ec022c85cf5b",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -329,7 +329,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "5bf3bebadaec57d95df9dc6e01b9d4b7e20a2284"
+                "reference": "3732394e68b49e01fd5e6c73ad0e4c8f08ada84c"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -340,7 +340,7 @@
                 "automattic/jetpack-roles": "^1.4",
                 "automattic/jetpack-status": "^1.10",
                 "automattic/jetpack-terms-of-service": "^1.9",
-                "automattic/jetpack-tracking": "^1.14"
+                "automattic/jetpack-tracking": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.0",
@@ -845,7 +845,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/tracking",
-                "reference": "60dd2a4462221bcc460aadf9f86daeb308fd8027"
+                "reference": "ffcfc67d2040d470f5297bfbbd9212e97343432e"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -867,7 +867,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-tracking/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.14.x-dev"
+                    "dev-master": "1.15.x-dev"
                 }
             },
             "autoload": {
@@ -4528,5 +4528,5 @@
     "platform-overrides": {
         "ext-intl": "0.0.0"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/projects/plugins/debug-helper/changelog/add-guest-ajax-tracking
+++ b/projects/plugins/debug-helper/changelog/add-guest-ajax-tracking
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/debug-helper/composer.lock
+++ b/projects/plugins/debug-helper/composer.lock
@@ -1082,5 +1082,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/projects/plugins/jetpack/changelog/add-guest-ajax-tracking
+++ b/projects/plugins/jetpack/changelog/add-guest-ajax-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -41,7 +41,7 @@
 		"automattic/jetpack-status": "1.10.x-dev",
 		"automattic/jetpack-sync": "1.29.x-dev",
 		"automattic/jetpack-terms-of-service": "1.9.x-dev",
-		"automattic/jetpack-tracking": "1.14.x-dev",
+		"automattic/jetpack-tracking": "1.15.x-dev",
 		"automattic/jetpack-waf": "0.1.x-dev",
 		"nojimage/twitter-text-php": "3.1.2"
 	},

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "81e4f6fdc653109cf322c4bd8069f919",
+    "content-hash": "599ef09cd3e644fc9b3babadcb8b2df1",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -540,7 +540,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "5bf3bebadaec57d95df9dc6e01b9d4b7e20a2284"
+                "reference": "3732394e68b49e01fd5e6c73ad0e4c8f08ada84c"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -551,7 +551,7 @@
                 "automattic/jetpack-roles": "^1.4",
                 "automattic/jetpack-status": "^1.10",
                 "automattic/jetpack-terms-of-service": "^1.9",
-                "automattic/jetpack-tracking": "^1.14"
+                "automattic/jetpack-tracking": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.0",
@@ -851,7 +851,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/identity-crisis",
-                "reference": "80cc6904f5337f7cfa194199ad307e054fece278"
+                "reference": "2c6e57561443f31a08d43302e441583ac628c584"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -860,7 +860,7 @@
                 "automattic/jetpack-logo": "^1.5",
                 "automattic/jetpack-options": "^1.14",
                 "automattic/jetpack-status": "^1.10",
-                "automattic/jetpack-tracking": "^1.14"
+                "automattic/jetpack-tracking": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.0",
@@ -926,7 +926,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "4f5248371ee496e39e648de3de062466c71807be"
+                "reference": "9e9e0b9fff88d16ea406f032992e6cb611b8fe1c"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -938,7 +938,7 @@
                 "automattic/jetpack-partner": "^1.7",
                 "automattic/jetpack-redirect": "^1.7",
                 "automattic/jetpack-status": "^1.10",
-                "automattic/jetpack-tracking": "^1.14"
+                "automattic/jetpack-tracking": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.0",
@@ -1165,7 +1165,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "d9c67455da0f3210b8aa25ed2a860a568bf03364"
+                "reference": "1ceef893216c851f4a3150872d5cf39461b75e5a"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -1174,7 +1174,7 @@
                 "automattic/jetpack-plugins-installer": "^0.1",
                 "automattic/jetpack-redirect": "^1.7",
                 "automattic/jetpack-terms-of-service": "^1.9",
-                "automattic/jetpack-tracking": "^1.14"
+                "automattic/jetpack-tracking": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.0",
@@ -1555,7 +1555,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "a89165a040679943b525f8983b78b7f097a87dfd"
+                "reference": "9edb6e4ca9515e02047560d13fd0a69233103e23"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -1563,7 +1563,7 @@
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-options": "^1.14",
                 "automattic/jetpack-status": "^1.10",
-                "automattic/jetpack-tracking": "^1.14"
+                "automattic/jetpack-tracking": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.0",
@@ -1810,7 +1810,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/tracking",
-                "reference": "60dd2a4462221bcc460aadf9f86daeb308fd8027"
+                "reference": "ffcfc67d2040d470f5297bfbbd9212e97343432e"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -1832,7 +1832,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-tracking/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.14.x-dev"
+                    "dev-master": "1.15.x-dev"
                 }
             },
             "autoload": {
@@ -5324,5 +5324,5 @@
     "platform-overrides": {
         "ext-intl": "0.0.0"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "599ef09cd3e644fc9b3babadcb8b2df1",
+    "content-hash": "6dcc04c266fee404bce15bcde3dbc656",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -926,7 +926,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "9e9e0b9fff88d16ea406f032992e6cb611b8fe1c"
+                "reference": "3fb4d043601c8e2c7cee720a0450c39489d787b7"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -1165,7 +1165,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "1ceef893216c851f4a3150872d5cf39461b75e5a"
+                "reference": "ad5dcad9251133851378b3e66f4e25646909c748"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",

--- a/projects/plugins/search/changelog/add-guest-ajax-tracking
+++ b/projects/plugins/search/changelog/add-guest-ajax-tracking
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -3152,5 +3152,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/projects/plugins/vaultpress/changelog/add-guest-ajax-tracking
+++ b/projects/plugins/vaultpress/changelog/add-guest-ajax-tracking
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/vaultpress/composer.lock
+++ b/projects/plugins/vaultpress/composer.lock
@@ -3260,5 +3260,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
Jetpack-tracking package is being explored for the tracking needs of WooCommerce Platform Checkout. One of the limitations we've noticed in using jetpack-tracking is that `record_ajax_event` does not capture ajax events if the user is not logged in. This change uses `wp_ajax_nopriv_jetpack_tracks` action so that ajax calls from guest users also call `ajax_tracks` function. 


<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Capture ajax events from guest users to track guest user events

#### Relevant P2 thread
pdpOw2-mz-p2#comment-270

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Yes

**Concerns**
I am not sure whether guest user tracking is intentionally omitted, but because this is already possible from other tracking methods (Tracking pixel, `record_user_event` in PHP) in this package, I am guessing that's not the case. 


#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure tracking scripts are [enabled](https://github.com/Automattic/jetpack/tree/master/projects/packages/tracking#1-enqueue-script) in the test site
* Add a break point inside [ajax-tracks ](https://github.com/Automattic/jetpack-tracking/blob/master/src/class-tracking.php#L73)
* Log out from the site and visit the site frontend 
* In browser's dev tools make an [ajax tracking request](https://github.com/Automattic/jetpack/tree/master/projects/packages/tracking#4-making-your-own-ajax-calls)
* Ensure that the above ajax requests hits the break point