### PR TITLE
My Jetpack: Fix Scan activation and status

### DIFF
--- a/projects/packages/my-jetpack/changelog/change-my-jetpack-scan-status
+++ b/projects/packages/my-jetpack/changelog/change-my-jetpack-scan-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Adapt Scan actiavtion behavior as it is not a module

--- a/projects/packages/my-jetpack/src/products/class-module-product.php
+++ b/projects/packages/my-jetpack/src/products/class-module-product.php
@@ -86,7 +86,7 @@ abstract class Module_Product extends Product {
 	 */
 	public static function get_status() {
 		$status = parent::get_status();
-		if ( 'active' === $status && ! self::is_module_active() ) {
+		if ( 'active' === $status && ! static::is_module_active() ) {
 			$status = 'module_disabled';
 		}
 		return $status;

--- a/projects/packages/my-jetpack/src/products/class-scan.php
+++ b/projects/packages/my-jetpack/src/products/class-scan.php
@@ -143,4 +143,44 @@ class Scan extends Module_Product {
 		return is_object( $scan_data ) && isset( $scan_data->state ) && 'unavailable' !== $scan_data->state;
 	}
 
+	/**
+	 * Checks whether the Product is active
+	 *
+	 * Scan is not actually a module. Activation takes place on WPCOM. So lets consider it active if jetpack is active and has the plan.
+	 *
+	 * @return boolean
+	 */
+	public static function is_active() {
+		return static::is_jetpack_plugin_active() && static::has_required_plan();
+	}
+
+	/**
+	 * Activates the product by installing and activating its plugin
+	 *
+	 * @return boolean|\WP_Error
+	 */
+	public static function activate() {
+
+		$product_activation = parent::activate();
+
+		if ( is_wp_error( $product_activation ) && 'module_activation_failed' === $product_activation->get_error_code() ) {
+			// Scan is not a module. There's nothing in the plugin to be activated, so it's ok to fail to activate the module.
+			$product_activation = true;
+		}
+
+		return $product_activation;
+
+	}
+
+	/**
+	 * Checks whether the Jetpack module is active
+	 *
+	 * Scan is not a module. Nothing needs to be active. Let's always consider it active.
+	 *
+	 * @return bool
+	 */
+	public static function is_module_active() {
+		return true;
+	}
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Scan looks like a module but it's not. All information about its activation lives in WPCOM.

This PR adapts its behavior to:

* consider itself active if Jetpack plugin is active and the plan was purchased (no need to activate any module)
* When activation is triggered, it does not fail if the scan module can not be found

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix Scan activation status

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
NA

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Launch a new site
* Confirm scan is not active
* Activate Jetpack plugin
* Buy Scan
* Go to My Jetpack and confirm Scan is shown as active
NOTE: we are not covering the activation and purchase flow in this PR
