### PR TITLE
Update/backup deactivation disconnection

### DIFF
--- a/projects/plugins/backup/changelog/update-backup-deactivation-disconnection
+++ b/projects/plugins/backup/changelog/update-backup-deactivation-disconnection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Do not disable plugin connection, and fix DB for those who have done it

--- a/projects/plugins/backup/jetpack-backup.php
+++ b/projects/plugins/backup/jetpack-backup.php
@@ -43,6 +43,7 @@ define( 'JETPACK_BACKUP_PLUGIN_URI', 'https://jetpack.com/jetpack-backup' );
 define( 'JETPACK_BACKUP_REQUIRED_JETPACK_VERSION', '10.0' );
 define( 'JETPACK_BACKUP_PLUGIN_FOLDER', dirname( plugin_basename( __FILE__ ) ) );
 define( 'JETPACK_BACKUP_PROMOTED_PRODUCT', 'jetpack_backup_t1_yearly' );
+define( 'JETPACK_BACKUP_DB_VERSION', '2' );
 
 /**
  * Checks if Jetpack is installed and if yes, require version 10+

--- a/projects/plugins/backup/src/php/class-jetpack-backup-upgrades.php
+++ b/projects/plugins/backup/src/php/class-jetpack-backup-upgrades.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Handle Backup plugin upgrades
+ *
+ * @package automattic/jetpack-backup-plugin
+ */
+
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+
+/**
+ * The Upgrades class.
+ */
+class Jetpack_Backup_Upgrades {
+
+	/**
+	 * Run all methods only once and store an option to make sure it never runs again
+	 */
+	public static function upgrade() {
+
+		$upgrades = get_class_methods( 'Jetpack_Backup_Upgrades' );
+
+		foreach ( $upgrades as $upgrade ) {
+			$option_name = '_upgrade_' . $upgrade;
+			if ( 'upgrade' === $upgrade || get_option( $option_name ) ) {
+				continue;
+			}
+
+			update_option( $option_name, 1 );
+
+			call_user_func( array( 'Jetpack_Backup_Upgrades', $upgrade ) );
+
+		}
+
+	}
+
+	/**
+	 * The plugin is not checking if it was disabled and reactivating it when we reconnect, therefore we need to clear this information from DB so other plugins know we are still using the connection
+	 */
+	public static function clear_disabled_plugin() {
+		$manager = new Connection_Manager( 'jetpack-backup' );
+		$manager->enable_plugin();
+	}
+
+}

--- a/projects/plugins/backup/src/php/class-jetpack-backup.php
+++ b/projects/plugins/backup/src/php/class-jetpack-backup.php
@@ -75,6 +75,8 @@ class Jetpack_Backup {
 			}
 		);
 
+		add_action( 'plugins_loaded', array( $this, 'maybe_upgrade_db' ), 20 );
+
 		My_Jetpack_Initializer::init();
 	}
 
@@ -83,6 +85,17 @@ class Jetpack_Backup {
 	 */
 	public function admin_init() {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
+	}
+
+	/**
+	 * Checks current version against version in code and run upgrades if we are running a new version
+	 */
+	public function maybe_upgrade_db() {
+		$current_db_version = get_option( 'jetpack_backup_db_version' );
+		if ( version_compare( $current_db_version, JETPACK_BACKUP_DB_VERSION, '<' ) ) {
+			update_option( 'jetpack_backup_db_version', JETPACK_BACKUP_DB_VERSION );
+			Jetpack_Backup_Upgrades::upgrade();
+		}
 	}
 
 	/**

--- a/projects/plugins/backup/src/php/class-jetpack-backup.php
+++ b/projects/plugins/backup/src/php/class-jetpack-backup.php
@@ -303,7 +303,8 @@ class Jetpack_Backup {
 	 */
 	public static function plugin_deactivation() {
 		$manager = new Connection_Manager( 'jetpack-backup' );
-		$manager->remove_connection();
+		$manager->disconnect_site_wpcom();
+		$manager->delete_all_connection_tokens();
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Backup plugin is disabling the plugin connection on deactivation but never re-enabling it.

The result is that other plugins might think it is disabled, and disconnect the site, while Backup is actively using the conneciton

This PR will
* Not disable the plugin on deactivation anymore
* clear the disabled information on the sites that might have it (run an upgrade db only once)

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Do not disable plugin connection, and fix DB for those who have done it

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-4n9-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On MASTER or STABLE, activate and connect Backup
* Deactivate the Backup plugin
* Confirm that jetpack-backup is disabled in the connectioni by running `wp option get jetpack_connection_disabled_plugins`
* Checkout this branch
* Activate the plugin and visit Backup page
* Verify that Backup is not disabled anymore `wp option get jetpack_connection_disabled_plugins`
* Connect
* Deactivate the plugin
* Check again that the plugin is not listed as disabled
*
