### PR TITLE
Premium Content Block: Fix inverted inner blocks without migration step

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-inverted-premium-content-inner-blocks
+++ b/projects/plugins/jetpack/changelog/fix-inverted-premium-content-inner-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Fix accidental inversion of the Premium Content block tabs

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/blocks.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/blocks.js
@@ -10,8 +10,8 @@ export default function Blocks() {
 				allowedBlocks={ [ 'premium-content/subscriber-view', 'premium-content/logged-out-view' ] }
 				templateLock={ 'all' }
 				template={ [
-					[ 'premium-content/logged-out-view' ],
 					[ 'premium-content/subscriber-view' ],
+					[ 'premium-content/logged-out-view' ],
 				] }
 				__experimentalCaptureToolbars={ true }
 				templateInsertUpdatesSelection={ false }

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/deprecated/v1/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/deprecated/v1/index.js
@@ -9,14 +9,10 @@ import save from '../../save';
 
 export default {
 	isEligible: ( attributes, innerBlocks ) => {
-		console.log( { type: 'copons', innerBlocks } );
-		if ( 'premium-content/logged-out-view' === innerBlocks?.[0]?.name ) {
-			return true
+		if ( 'premium-content/logged-out-view' === innerBlocks?.[ 0 ]?.name ) {
+			return true;
 		}
 	},
-	migrate: ( attributes, innerBlocks ) => [
-		attributes,
-		[ innerBlocks[1], innerBlocks[0] ],
-	],
+	migrate: ( attributes, innerBlocks ) => [ attributes, [ innerBlocks[ 1 ], innerBlocks[ 0 ] ] ],
 	save,
 };

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/deprecated/v1/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/deprecated/v1/index.js
@@ -1,8 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { __, _x } from '@wordpress/i18n';
-/**
  * Internal dependencies
  */
 import save from '../../save';

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/deprecated/v1/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/deprecated/v1/index.js
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import { __, _x } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import save from '../../save';
+
+export default {
+	isEligible: ( attributes, innerBlocks ) => {
+		console.log( { type: 'copons', innerBlocks } );
+		if ( 'premium-content/logged-out-view' === innerBlocks?.[0]?.name ) {
+			return true
+		}
+	},
+	migrate: ( attributes, innerBlocks ) => [
+		attributes,
+		[ innerBlocks[1], innerBlocks[0] ],
+	],
+	save,
+};

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/edit.js
@@ -371,21 +371,21 @@ function Edit( props ) {
 				<ToolbarGroup>
 					<ToolbarButton
 						onClick={ () => {
-							selectTab( tabs[ WALL_TAB ] );
-						} }
-						className="components-tab-button"
-						isPressed={ selectedTab.className === 'wp-premium-content-logged-out-view' }
-					>
-						<span>{ __( 'Guest View', 'jetpack' ) }</span>
-					</ToolbarButton>
-					<ToolbarButton
-						onClick={ () => {
 							selectTab( tabs[ CONTENT_TAB ] );
 						} }
 						className="components-tab-button"
 						isPressed={ selectedTab.className !== 'wp-premium-content-logged-out-view' }
 					>
 						<span>{ __( 'Subscriber View', 'jetpack' ) }</span>
+					</ToolbarButton>
+					<ToolbarButton
+						onClick={ () => {
+							selectTab( tabs[ WALL_TAB ] );
+						} }
+						className="components-tab-button"
+						isPressed={ selectedTab.className === 'wp-premium-content-logged-out-view' }
+					>
+						<span>{ __( 'Guest View', 'jetpack' ) }</span>
 					</ToolbarButton>
 				</ToolbarGroup>
 			</BlockControls>

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/index.js
@@ -145,8 +145,8 @@ export const settings = {
 					} );
 
 					return createBlock( 'premium-content/container', {}, [
-						createBlock( 'premium-content/logged-out-view' ),
 						createBlock( 'premium-content/subscriber-view', {}, innerBlocksSubscribe ),
+						createBlock( 'premium-content/logged-out-view' ),
 					] );
 				},
 			},

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/index.js
@@ -9,6 +9,7 @@ import { createBlock } from '@wordpress/blocks';
  */
 import edit from './edit';
 import save from './save';
+import deprecatedV1 from './deprecated/v1';
 import icon from './_inc/icon';
 import { blockContainsPremiumBlock, blockHasParentPremiumBlock } from './_inc/premium';
 import { transformToCoreGroup } from './_inc/transform-to-core-group';
@@ -161,4 +162,5 @@ export const settings = {
 			},
 		],
 	},
+	deprecated: [ deprecatedV1 ],
 };


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/60871

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes an inversion of the Premium Content inner blocks that was leading to lost content during block parsing.

The regression was accidentally introduced in https://github.com/Automattic/jetpack/pull/22626 when we inverted the order of the Guest and Subscriber views of the Premium Content block for UI consistency reasons.

By inverting the block's InnerBlocks template, all Premium Content blocks using the old template were failing the parsing and reverting to the placeholder content.
This only happened in the editor, while the post content was safely maintained, and the block rendered correctly on the front end.

Even so, users editing a post containing an "old" Premium Content were seeing the placeholder content instead of what they actually wrote.
Multiple users reported this issue on WordPress.com.

The fix involves:

1. Restoring the original order of the InnerBlocks templates.
2. Switching only the tab buttons in the toolbar for UI consistency.
3. Adding a migration step to the block, so that blocks added with the incorrect format will be correctly migrated to the old correct one.

Point 3 is necessary to preserve Premium Content blocks created _after_ the regression was introduced.
Without it, they would suffer the same problem.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

* Pick a WordPress.com site with a paid plan.
* **Before applying any patches**
  * Create a post.
  * Insert the Premium Content block.
  * Edit the content in both Guest and Subscriber views.
  * Note that the order of the two views is `Guest - Subscriber` (look at block toolbar or the editor's List View).
  * Save the post.
* Apply the patch.
  * Reload the post.
  * The Premium Content block shows the expected content.
  * Note that the order of the two views is now `Subscriber - Guest`.