### PR TITLE
Search: Improve reliability of search class initialization

### DIFF
--- a/projects/packages/search/changelog/fix-search-debug-bar-init-2
+++ b/projects/packages/search/changelog/fix-search-debug-bar-init-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Change `instance` function for improved compatibility

--- a/projects/packages/search/src/class-cli.php
+++ b/projects/packages/search/src/class-cli.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\Search;
 
-use \Jetpack_Options;
 use \WP_CLI;
 use \WP_CLI_Command;
 
@@ -24,7 +23,7 @@ class CLI extends WP_CLI_Command {
 	 */
 	public function auto_config() {
 		try {
-			$blog_id = ( defined( 'IS_WPCOM' ) && constant( 'IS_WPCOM' ) ) ? get_current_blog_id() : Jetpack_Options::get_option( 'id' );
+			$blog_id = Helper::get_wpcom_site_id();
 			Instant_Search::instance( $blog_id )->auto_config_search();
 			WP_CLI::line( 'Jetpack Search: auto config success!' );
 		} catch ( \Exception $e ) {

--- a/projects/packages/search/src/class-cli.php
+++ b/projects/packages/search/src/class-cli.php
@@ -25,8 +25,7 @@ class CLI extends WP_CLI_Command {
 	public function auto_config() {
 		try {
 			$blog_id = ( defined( 'IS_WPCOM' ) && constant( 'IS_WPCOM' ) ) ? get_current_blog_id() : Jetpack_Options::get_option( 'id' );
-			Instant_Search::initialize( $blog_id );
-			Instant_Search::instance()->auto_config_search();
+			Instant_Search::instance( $blog_id )->auto_config_search();
 			WP_CLI::line( 'Jetpack Search: auto config success!' );
 		} catch ( \Exception $e ) {
 			WP_CLI::error( $e->getMessage() );

--- a/projects/packages/search/src/class-helper.php
+++ b/projects/packages/search/src/class-helper.php
@@ -923,4 +923,19 @@ class Helper {
 		sort( $active_plugins );
 		return array_unique( $active_plugins );
 	}
+
+	/**
+	 * Get the current site's WordPress.com ID.
+	 *
+	 * @return int Blog ID.
+	 */
+	public static function get_wpcom_site_id() {
+		// Returns local blog ID for a multi-site network.
+		if ( defined( 'IS_WPCOM' ) && constant( 'IS_WPCOM' ) ) {
+			return get_current_blog_id();
+		}
+
+		// Returns cache site ID.
+		return Jetpack_Options::get_option( 'id' );
+	}
 }

--- a/projects/packages/search/src/class-helper.php
+++ b/projects/packages/search/src/class-helper.php
@@ -932,10 +932,10 @@ class Helper {
 	public static function get_wpcom_site_id() {
 		// Returns local blog ID for a multi-site network.
 		if ( defined( 'IS_WPCOM' ) && constant( 'IS_WPCOM' ) ) {
-			return get_current_blog_id();
+			return \get_current_blog_id();
 		}
 
 		// Returns cache site ID.
-		return Jetpack_Options::get_option( 'id' );
+		return \Jetpack_Options::get_option( 'id' );
 	}
 }

--- a/projects/packages/search/src/classic-search/class-classic-search.php
+++ b/projects/packages/search/src/classic-search/class-classic-search.php
@@ -101,7 +101,10 @@ class Classic_Search {
 	 * @return static The class singleton.
 	 */
 	public static function instance( $blog_id = null ) {
-		if ( null !== $blog_id && ! isset( self::$instance ) ) {
+		if ( ! isset( self::$instance ) ) {
+			if ( null === $blog_id ) {
+				$blog_id = get_current_blog_id();
+			}
 			self::$instance = new static();
 			self::$instance->setup( $blog_id );
 		}

--- a/projects/packages/search/src/classic-search/class-classic-search.php
+++ b/projects/packages/search/src/classic-search/class-classic-search.php
@@ -95,27 +95,24 @@ class Classic_Search {
 	}
 
 	/**
-	 * Returns the singleton of the class. Does not perform any instantiation.
-	 *
-	 * @return static The class singleton.
-	 */
-	public static function instance() {
-		return self::$instance;
-	}
-
-	/**
-	 * Instantiate and initialize a singleton instance of the class.
+	 * Returns a class singleton. Initializes with first-time setup if given a blog ID parameter.
 	 *
 	 * @param string $blog_id Blog id.
 	 * @return static The class singleton.
 	 */
-	public static function initialize( $blog_id ) {
-		if ( ! isset( self::$instance ) ) {
+	public static function instance( $blog_id = null ) {
+		if ( null !== $blog_id && ! isset( self::$instance ) ) {
 			self::$instance = new static();
 			self::$instance->setup( $blog_id );
 		}
-
 		return self::$instance;
+	}
+
+	/**
+	 * Alias of the instance function.
+	 */
+	public static function initialize() {
+		return call_user_func_array( array( 'self', 'instance' ), func_get_args() );
 	}
 
 	/**

--- a/projects/packages/search/src/classic-search/class-classic-search.php
+++ b/projects/packages/search/src/classic-search/class-classic-search.php
@@ -103,7 +103,7 @@ class Classic_Search {
 	public static function instance( $blog_id = null ) {
 		if ( ! isset( self::$instance ) ) {
 			if ( null === $blog_id ) {
-				$blog_id = get_current_blog_id();
+				$blog_id = Helper::get_wpcom_site_id();
 			}
 			self::$instance = new static();
 			self::$instance->setup( $blog_id );

--- a/projects/plugins/jetpack/3rd-party/debug-bar/class-jetpack-search-debug-bar.php
+++ b/projects/plugins/jetpack/3rd-party/debug-bar/class-jetpack-search-debug-bar.php
@@ -93,11 +93,17 @@ class Jetpack_Search_Debug_Bar extends Debug_Bar_Panel {
 	 * @return void
 	 */
 	public function render() {
-		$jetpack_search  = (
+		$jetpack_search = (
 			Jetpack_Search\Options::is_instant_enabled() ?
 			Jetpack_Search\Instant_Search::instance() :
 			Jetpack_Search\Classic_Search::instance()
 		);
+
+		// Search hasn't been initialized. Exit early and do not display the debug bar.
+		if ( ! method_exists( $jetpack_search, 'get_last_query_info' ) ) {
+			return;
+		}
+
 		$last_query_info = $jetpack_search->get_last_query_info();
 
 		// If not empty, let's reshuffle the order of some things.

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -750,7 +750,8 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 								$updated = new WP_Error( 'instant_search_disabled', 'Instant Search is disabled', array( 'status' => 400 ) );
 								$error   = $updated->get_error_message();
 							} else {
-								$instance = Automattic\Jetpack\Search\Instant_Search::instance( Jetpack_Options::get_option( 'id' ) );
+								$blog_id  = ( defined( 'IS_WPCOM' ) && constant( 'IS_WPCOM' ) ) ? get_current_blog_id() : Jetpack_Options::get_option( 'id' );
+								$instance = Automattic\Jetpack\Search\Instant_Search::instance( $blog_id );
 								$instance->auto_config_search();
 								$updated = true;
 							}

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -750,7 +750,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 								$updated = new WP_Error( 'instant_search_disabled', 'Instant Search is disabled', array( 'status' => 400 ) );
 								$error   = $updated->get_error_message();
 							} else {
-								$blog_id  = ( defined( 'IS_WPCOM' ) && constant( 'IS_WPCOM' ) ) ? get_current_blog_id() : Jetpack_Options::get_option( 'id' );
+								$blog_id  = Automattic\Jetpack\Search\Helper::get_wpcom_site_id();
 								$instance = Automattic\Jetpack\Search\Instant_Search::instance( $blog_id );
 								$instance->auto_config_search();
 								$updated = true;

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -750,15 +750,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 								$updated = new WP_Error( 'instant_search_disabled', 'Instant Search is disabled', array( 'status' => 400 ) );
 								$error   = $updated->get_error_message();
 							} else {
-								$instance = Automattic\Jetpack\Search\Instant_Search::instance();
-
-								// Perform initialization. This should have already been executed in modules/search.php.
-								// In other words: This is a failsafe.
-								if ( ! $instance ) {
-									Automattic\Jetpack\Search\Jetpack_Initializer::initialize();
-									$instance = Automattic\Jetpack\Search\Instant_Search::instance();
-								}
-
+								$instance = Automattic\Jetpack\Search\Instant_Search::instance( Jetpack_Options::get_option( 'id' ) );
 								$instance->auto_config_search();
 								$updated = true;
 							}

--- a/projects/plugins/jetpack/changelog/fix-search-debug-bar-init-2
+++ b/projects/plugins/jetpack/changelog/fix-search-debug-bar-init-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: Make debug bar more reliable

--- a/projects/plugins/jetpack/modules/search.php
+++ b/projects/plugins/jetpack/modules/search.php
@@ -15,6 +15,7 @@
  */
 
 use Automattic\Jetpack\Search\Classic_Search;
+use Automattic\Jetpack\Search\Helper as Search_Helper;
 
 Automattic\Jetpack\Search\Jetpack_Initializer::initialize();
 
@@ -41,10 +42,6 @@ class Jetpack_Search {
 	 */
 	public static function instance() {
 		// Explicitly provide the blog ID, just in case.
-		return Classic_Search::instance(
-			( defined( 'IS_WPCOM' ) && constant( 'IS_WPCOM' ) ) ?
-			get_current_blog_id() :
-			Jetpack_Options::get_option( 'id' )
-		);
+		return Classic_Search::instance( Search_Helper::get_wpcom_site_id() );
 	}
 }

--- a/projects/plugins/jetpack/modules/search.php
+++ b/projects/plugins/jetpack/modules/search.php
@@ -41,6 +41,10 @@ class Jetpack_Search {
 	 */
 	public static function instance() {
 		// Explicitly provide the blog ID, just in case.
-		return Classic_Search::instance( Jetpack_Options::get_option( 'id' ) );
+		return Classic_Search::instance(
+			( defined( 'IS_WPCOM' ) && constant( 'IS_WPCOM' ) ) ?
+			get_current_blog_id() :
+			Jetpack_Options::get_option( 'id' )
+		);
 	}
 }

--- a/projects/plugins/jetpack/modules/search.php
+++ b/projects/plugins/jetpack/modules/search.php
@@ -40,6 +40,7 @@ class Jetpack_Search {
 	 * Return the instance of the new class.
 	 */
 	public static function instance() {
-		return Classic_Search::initialize( get_current_blog_id() );
+		// Explicitly provide the blog ID, just in case.
+		return Classic_Search::instance( Jetpack_Options::get_option( 'id' ) );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/search/test-class-instant-search.php
+++ b/projects/plugins/jetpack/tests/php/modules/search/test-class-instant-search.php
@@ -26,8 +26,7 @@ class WP_Test_Instant_Search extends WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
-		Automattic\Jetpack\Search\Instant_Search::initialize( get_current_blog_id() );
-		static::$instant_search = Automattic\Jetpack\Search\Instant_Search::instance();
+		static::$instant_search = Automattic\Jetpack\Search\Instant_Search::instance( get_current_blog_id() );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #22801.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Change `Classic_Search::instance` and `Instant_Search::instance` functions to accept an optional blog ID parameter.
* Make `Classic_Search::initialize` and `Instant_Search::initialize` to be aliases of the `instance` function.
* Skip rendering the Jetpack Search debug bar if the search instance has not been properly initialized. 

<!--#### Jetpack product discussion -->
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this change to your site **without** a Search subscription. 
(Note: Block-based theme support is still in development and is not included in this PR.)
* Purchase a Jetpack Search subscription for the site.
* Ensure that the auto-configuration works as expected.
* Ensure that Instant Search and Customberg works as expected.
