### PR TITLE
Search: add babel/runtime to dev dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -738,6 +738,7 @@ importers:
       '@babel/preset-env': 7.16.4
       '@babel/preset-react': 7.16.0
       '@babel/preset-typescript': 7.16.0
+      '@babel/runtime': 7.16.3
       '@size-limit/preset-app': 6.0.3
       '@testing-library/jest-dom': 5.14.1
       '@testing-library/preact': 2.0.1
@@ -809,6 +810,7 @@ importers:
       '@babel/preset-env': 7.16.4_@babel+core@7.16.0
       '@babel/preset-react': 7.16.0_@babel+core@7.16.0
       '@babel/preset-typescript': 7.16.0_@babel+core@7.16.0
+      '@babel/runtime': 7.16.3
       '@size-limit/preset-app': 6.0.3_size-limit@6.0.3
       '@testing-library/jest-dom': 5.14.1
       '@testing-library/preact': 2.0.1_preact@10.5.15
@@ -3750,6 +3752,7 @@ packages:
 
   /@emotion/is-prop-valid/0.8.8:
     resolution: {integrity: sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==}
+    requiresBuild: true
     dependencies:
       '@emotion/memoize': 0.7.4
 
@@ -6734,7 +6737,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       '@babel/code-frame': 7.16.7
-      '@babel/runtime': 7.16.3
+      '@babel/runtime': 7.17.2
       '@types/aria-query': 4.2.2
       aria-query: 4.2.2
       chalk: 4.1.2
@@ -7669,7 +7672,7 @@ packages:
     resolution: {integrity: sha512-pSfqdzaOO7/SrIDkFJDhVDs0DLy1WmrtIxz4rTub+H538MolyHmUh9xs1aIyakgC9PH7DrkzVmj00d8QXBcVcw==}
     engines: {node: '>=12'}
     dependencies:
-      '@babel/runtime': 7.16.3
+      '@babel/runtime': 7.17.2
       '@wordpress/i18n': 4.3.0
       '@wordpress/url': 3.4.0
 
@@ -7880,7 +7883,7 @@ packages:
     resolution: {integrity: sha512-8/ES5wm38/Ydo7Zol4lZT4xlLxE05fLrgjysE14hMBZUYUivqJFRhYxoSrMHW03LBmUUi2fYcdrCh+JRLGbLuw==}
     engines: {node: '>=12'}
     dependencies:
-      '@babel/runtime': 7.16.3
+      '@babel/runtime': 7.17.2
       '@wordpress/autop': 3.3.0
       '@wordpress/blob': 3.3.0
       '@wordpress/block-serialization-default-parser': 4.3.0
@@ -8516,7 +8519,7 @@ packages:
     resolution: {integrity: sha512-RSOZS5cr9h830VHE7XQ/NbgIfQQXtuSWrb2mX+4uN4qK6ua2hUfZS/twW4af2H2beistK/rUDPpUVO9x7XSQ5w==}
     engines: {node: '>=12'}
     dependencies:
-      '@babel/runtime': 7.16.3
+      '@babel/runtime': 7.17.2
 
   /@wordpress/html-entities/3.3.0:
     resolution: {integrity: sha512-KyzQTP+tPyIHUQKaRV8FXUTtIf4pyOSFSnhYA9UZtTa+797B+zSzkj+NCObnxcwbfCqajxlAwxvqKa2OISr74A==}
@@ -20444,7 +20447,7 @@ packages:
     dependencies:
       array.prototype.flat: 1.2.5
       global-cache: 1.2.1
-      react-with-styles: 3.2.3
+      react-with-styles: 3.2.3_react-dom@17.0.2+react@17.0.2
 
   /react-with-styles/3.2.3:
     resolution: {integrity: sha512-MTI1UOvMHABRLj5M4WpODfwnveHaip6X7QUMI2x6zovinJiBXxzhA9AJP7MZNaKqg1JRFtHPXZdroUC8KcXwlQ==}

--- a/projects/packages/search/changelog/add-search-babel-runtime
+++ b/projects/packages/search/changelog/add-search-babel-runtime
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Search: add babel/runtime to dev dependencies

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -71,6 +71,7 @@
 		"@babel/preset-env": "7.16.4",
 		"@babel/preset-react": "7.16.0",
 		"@babel/preset-typescript": "7.16.0",
+		"@babel/runtime": "7.16.3",
 		"@size-limit/preset-app": "6.0.3",
 		"@testing-library/jest-dom": "5.14.1",
 		"@testing-library/preact": "2.0.1",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
When running pre-commit linting for the search package, I was running into the following:

<img width="948" alt="Screen Shot 2022-02-09 at 16 52 31" src="https://user-images.githubusercontent.com/17325/153782926-31f94a6d-0935-4c7f-820c-73905d9de269.png">

@kraftbj discovered that `pnpm add -D @babel/runtime` resolved it. This PR adds babel/runtime to the search package as a dev dependency.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Make a change to one of the files in `projects/packages/search` and try to commit it. Ensure that you don't see linting errors as shown in the screenshot above.