### PR TITLE
Search package: should include widget js

### DIFF
--- a/projects/packages/search/.gitattributes
+++ b/projects/packages/search/.gitattributes
@@ -3,10 +3,6 @@
 .github/                                                 export-ignore
 package.json                                             export-ignore
 
-# Files to include in production build.
-/build/**                                                production-include
-/src/widgets/**                                          production-include
-
 # Files not needed in the production build.
 /changelog/**                                            production-exclude
 /.gitignore                                              production-exclude
@@ -26,3 +22,7 @@ package.json                                             export-ignore
 /src/**/*.jsx                                            production-exclude
 /src/**/*.ts                                             production-exclude
 .phpcs.dir.xml                                           production-exclude
+
+# Files to include in production build.
+/build/**                                                production-include
+/src/widgets/**                                          production-include

--- a/projects/packages/search/.gitattributes
+++ b/projects/packages/search/.gitattributes
@@ -3,6 +3,9 @@
 .github/                                                 export-ignore
 package.json                                             export-ignore
 
+# Files to include in production build.
+/build/**                                                production-include
+
 # Files not needed in the production build.
 /changelog/**                                            production-exclude
 /.gitignore                                              production-exclude
@@ -18,11 +21,7 @@ package.json                                             export-ignore
 /src/**/test/**                                          production-exclude
 /src/**/*.scss                                           production-exclude
 # JS scripts to integrate with customizer and wigets might need to be explicitly included.
-/src/**/*.js                                             production-exclude
-/src/**/*.jsx                                            production-exclude
-/src/**/*.ts                                             production-exclude
+/src/customberg/*.{js,jsx,ts,scss}                       production-exclude
+/src/dashboard/*.{js,jsx,ts,scss}                        production-exclude
+/src/instant-search/*.{js,jsx,ts,scss}                   production-exclude
 .phpcs.dir.xml                                           production-exclude
-
-# Files to include in production build.
-/build/**                                                production-include
-/src/widgets/**                                          production-include

--- a/projects/packages/search/.gitattributes
+++ b/projects/packages/search/.gitattributes
@@ -19,8 +19,13 @@ package.json                                             export-ignore
 /phpunit.xml.dist                                        production-exclude
 /tests/**                                                production-exclude
 /src/**/test/**                                          production-exclude
-# JS scripts to integrate with customizer and wigets might need to be explicitly included.
-/src/customberg/**/*.{js,jsx,ts,tsx,scss}                production-exclude
-/src/dashboard/**/*.{js,jsx,ts,tsx,scss}                 production-exclude
-/src/instant-search/**/*.{js,jsx,ts,tsx,scss}            production-exclude
 .phpcs.dir.xml                                           production-exclude
+/src/customberg/**/*.js                                  production-exclude
+/src/customberg/**/*.jsx                                 production-exclude
+/src/customberg/**/*.scss                                production-exclude
+/src/dashboard/**/*.js                                   production-exclude
+/src/dashboard/**/*.jsx                                  production-exclude
+/src/dashboard/**/*.scss                                 production-exclude
+/src/instant-search/**/*.js                              production-exclude
+/src/instant-search/**/*.jsx                             production-exclude
+/src/instant-search/**/*.scss                            production-exclude

--- a/projects/packages/search/.gitattributes
+++ b/projects/packages/search/.gitattributes
@@ -19,7 +19,6 @@ package.json                                             export-ignore
 /phpunit.xml.dist                                        production-exclude
 /tests/**                                                production-exclude
 /src/**/test/**                                          production-exclude
-/src/**/*.scss                                           production-exclude
 # JS scripts to integrate with customizer and wigets might need to be explicitly included.
 /src/customberg/*.{js,jsx,ts,scss}                       production-exclude
 /src/dashboard/*.{js,jsx,ts,scss}                        production-exclude

--- a/projects/packages/search/.gitattributes
+++ b/projects/packages/search/.gitattributes
@@ -5,7 +5,7 @@ package.json                                             export-ignore
 
 # Files to include in production build.
 /build/**                                                production-include
-/src/widgets/**/*.js                                     production-include
+/src/widgets/**                                          production-include
 
 # Files not needed in the production build.
 /changelog/**                                            production-exclude

--- a/projects/packages/search/.gitattributes
+++ b/projects/packages/search/.gitattributes
@@ -5,6 +5,7 @@ package.json                                             export-ignore
 
 # Files to include in production build.
 /build/**                                                production-include
+/src/widgets/**/*.js                                     production-include
 
 # Files not needed in the production build.
 /changelog/**                                            production-exclude

--- a/projects/packages/search/.gitattributes
+++ b/projects/packages/search/.gitattributes
@@ -20,7 +20,7 @@ package.json                                             export-ignore
 /tests/**                                                production-exclude
 /src/**/test/**                                          production-exclude
 # JS scripts to integrate with customizer and wigets might need to be explicitly included.
-/src/customberg/*.{js,jsx,ts,scss}                       production-exclude
-/src/dashboard/*.{js,jsx,ts,scss}                        production-exclude
-/src/instant-search/*.{js,jsx,ts,scss}                   production-exclude
+/src/customberg/**/*.{js,jsx,ts,tsx,scss}                production-exclude
+/src/dashboard/**/*.{js,jsx,ts,tsx,scss}                 production-exclude
+/src/instant-search/**/*.{js,jsx,ts,tsx,scss}            production-exclude
 .phpcs.dir.xml                                           production-exclude

--- a/projects/packages/search/changelog/fix-should-include-widget-js-explicitly
+++ b/projects/packages/search/changelog/fix-should-include-widget-js-explicitly
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search package: should include widget js in package distribution explicitly

--- a/projects/packages/search/changelog/fix-should-include-widget-js-explicitly
+++ b/projects/packages/search/changelog/fix-should-include-widget-js-explicitly
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Search package: should include widget js in package distribution explicitly
+Search package: should not exclude widget js in package distribution


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This is a follow up PR for #22364 which doesn't include widget js in production. Reported by @jeherve [here](https://github.com/Automattic/jetpack/pull/22364#pullrequestreview-866058171).

#### Jetpack product discussion
https://github.com/Automattic/jetpack/pull/22364#pullrequestreview-866058171

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Create a JN site with current branch, connect, purchase search etc
* Open `/wp-admin/widgets.php`
* Ensure JP Search widget filter adding/deleting works - there are a couple of warning which doesn't fall in the scope of the PR
* Enure search widgets could be rendered correctly on the frontend

