### PR TITLE
Search: add stats endpoint to REST controller

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,7 +159,7 @@ importers:
   projects/js-packages/connection:
     specifiers:
       '@automattic/jetpack-analytics': workspace:^0.1.7
-      '@automattic/jetpack-api': workspace:^0.8.5-alpha
+      '@automattic/jetpack-api': workspace:^0.9.0-alpha
       '@automattic/jetpack-base-styles': workspace:^0.1.8
       '@automattic/jetpack-components': workspace:^0.10.5
       '@automattic/jetpack-config': workspace:^0.1.3
@@ -272,7 +272,7 @@ importers:
   projects/js-packages/idc:
     specifiers:
       '@automattic/jetpack-analytics': workspace:^0.1.7
-      '@automattic/jetpack-api': workspace:^0.8.5-alpha
+      '@automattic/jetpack-api': workspace:^0.9.0-alpha
       '@automattic/jetpack-base-styles': workspace:^0.1.8
       '@automattic/jetpack-components': workspace:^0.10.5
       '@babel/core': 7.16.0
@@ -314,7 +314,7 @@ importers:
 
   projects/js-packages/licensing:
     specifiers:
-      '@automattic/jetpack-api': workspace:^0.8.5-alpha
+      '@automattic/jetpack-api': workspace:^0.9.0-alpha
       '@automattic/jetpack-base-styles': workspace:^0.1.8
       '@automattic/jetpack-components': workspace:^0.10.5
       '@babel/core': 7.16.0
@@ -550,7 +550,7 @@ importers:
 
   projects/packages/connection-ui:
     specifiers:
-      '@automattic/jetpack-api': workspace:^0.8.5-alpha
+      '@automattic/jetpack-api': workspace:^0.9.0-alpha
       '@automattic/jetpack-connection': workspace:^0.15.2-alpha
       '@automattic/jetpack-webpack-config': workspace:^1.1.3
       '@babel/core': 7.16.0
@@ -729,7 +729,7 @@ importers:
       '@automattic/calypso-color-schemes': 2.1.1
       '@automattic/color-studio': 2.5.0
       '@automattic/jetpack-analytics': workspace:^0.1.7
-      '@automattic/jetpack-api': workspace:^0.8.5-alpha
+      '@automattic/jetpack-api': workspace:^0.9.0-alpha
       '@automattic/jetpack-components': workspace:^0.10.5
       '@automattic/jetpack-webpack-config': workspace:^1.1.3
       '@babel/core': 7.16.0
@@ -827,7 +827,7 @@ importers:
 
   projects/plugins/backup:
     specifiers:
-      '@automattic/jetpack-api': workspace:^0.8.5-alpha
+      '@automattic/jetpack-api': workspace:^0.9.0-alpha
       '@automattic/jetpack-base-styles': workspace:^0.1.8
       '@automattic/jetpack-components': workspace:^0.10.5
       '@automattic/jetpack-connection': workspace:^0.15.2-alpha
@@ -964,7 +964,7 @@ importers:
       '@automattic/components': 1.0.0-alpha.3
       '@automattic/format-currency': 1.0.0-alpha.0
       '@automattic/jetpack-analytics': workspace:^0.1.7
-      '@automattic/jetpack-api': workspace:^0.8.5-alpha
+      '@automattic/jetpack-api': workspace:^0.9.0-alpha
       '@automattic/jetpack-base-styles': workspace:^0.1.8
       '@automattic/jetpack-components': workspace:^0.10.5
       '@automattic/jetpack-connection': workspace:^0.15.2-alpha

--- a/projects/js-packages/api/changelog/add-jetpack-stats-endpoint
+++ b/projects/js-packages/api/changelog/add-jetpack-stats-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+API: add Jetpack Search stats endpoint

--- a/projects/js-packages/api/index.jsx
+++ b/projects/js-packages/api/index.jsx
@@ -478,6 +478,10 @@ function JetpackRestApiClient( root, nonce ) {
 			} )
 				.then( checkStatus )
 				.then( parseJsonResponse ),
+		fetchSearchStats: () =>
+			getRequest( `${ apiRoot }jetpack/v4/search/stats`, getParams )
+				.then( checkStatus )
+				.then( parseJsonResponse ),
 	};
 
 	/**

--- a/projects/js-packages/api/package.json
+++ b/projects/js-packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-api",
-	"version": "0.8.5-alpha",
+	"version": "0.9.0-alpha",
 	"description": "Jetpack Api Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/changelog/add-jetpack-stats-endpoint
+++ b/projects/js-packages/connection/changelog/add-jetpack-stats-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -8,7 +8,7 @@
 		"@automattic/jetpack-analytics": "workspace:^0.1.7",
 		"@automattic/jetpack-config": "workspace:^0.1.3",
 		"@automattic/jetpack-components": "workspace:^0.10.5",
-		"@automattic/jetpack-api": "workspace:^0.8.5-alpha",
+		"@automattic/jetpack-api": "workspace:^0.9.0-alpha",
 		"@wordpress/base-styles": "4.1.0",
 		"@wordpress/browserslist-config": "4.1.0",
 		"@wordpress/components": "19.3.0",

--- a/projects/js-packages/idc/changelog/add-jetpack-stats-endpoint
+++ b/projects/js-packages/idc/changelog/add-jetpack-stats-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -6,7 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"dependencies": {
 		"@automattic/jetpack-analytics": "workspace:^0.1.7",
-		"@automattic/jetpack-api": "workspace:^0.8.5-alpha",
+		"@automattic/jetpack-api": "workspace:^0.9.0-alpha",
 		"@automattic/jetpack-base-styles": "workspace:^0.1.8",
 		"@automattic/jetpack-components": "workspace:^0.10.5",
 		"@wordpress/base-styles": "4.1.0",

--- a/projects/js-packages/licensing/changelog/add-jetpack-stats-endpoint
+++ b/projects/js-packages/licensing/changelog/add-jetpack-stats-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -36,7 +36,7 @@
 		"./action-types": "./src/state/action-types"
 	},
 	"dependencies": {
-		"@automattic/jetpack-api": "workspace:^0.8.5-alpha",
+		"@automattic/jetpack-api": "workspace:^0.9.0-alpha",
 		"@automattic/jetpack-components": "workspace:^0.10.5",
 		"@wordpress/i18n": "4.3.0",
 		"@wordpress/element": "4.1.0",

--- a/projects/packages/connection-ui/changelog/add-jetpack-stats-endpoint
+++ b/projects/packages/connection-ui/changelog/add-jetpack-stats-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/connection-ui/package.json
+++ b/projects/packages/connection-ui/package.json
@@ -15,7 +15,7 @@
 	},
 	"browserslist": "extends @wordpress/browserslist-config",
 	"dependencies": {
-		"@automattic/jetpack-api": "workspace:^0.8.5-alpha",
+		"@automattic/jetpack-api": "workspace:^0.9.0-alpha",
 		"@automattic/jetpack-connection": "workspace:^0.15.2-alpha",
 		"@wordpress/data": "6.2.0"
 	},

--- a/projects/packages/search/changelog/add-jetpack-stats-endpoint
+++ b/projects/packages/search/changelog/add-jetpack-stats-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search: add stats endpoint to REST controller

--- a/projects/packages/search/changelog/add-jetpack-stats-endpoint#2
+++ b/projects/packages/search/changelog/add-jetpack-stats-endpoint#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -72,7 +72,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-master": "0.8.x-dev"
+			"dev-master": "0.9.x-dev"
 		},
 		"version-constants": {
 			"JETPACK_SEARCH_PKG__VERSION": "search.php"

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.8.1-alpha",
+	"version": "0.9.0-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {
@@ -39,7 +39,7 @@
 		"@automattic/calypso-color-schemes": "2.1.1",
 		"@automattic/color-studio": "2.5.0",
 		"@automattic/jetpack-analytics": "workspace:^0.1.7",
-		"@automattic/jetpack-api": "workspace:^0.8.5-alpha",
+		"@automattic/jetpack-api": "workspace:^0.9.0-alpha",
 		"@automattic/jetpack-components": "workspace:^0.10.5",
 		"@wordpress/base-styles": "4.1.0",
 		"@wordpress/block-editor": "8.1.0",

--- a/projects/packages/search/search.php
+++ b/projects/packages/search/search.php
@@ -7,7 +7,7 @@
 
 namespace Automattic\Jetpack\Search;
 
-define( 'JETPACK_SEARCH_PKG__VERSION', '0.8.1-alpha' );
+define( 'JETPACK_SEARCH_PKG__VERSION', '0.9.0-alpha' );
 define( 'JETPACK_SEARCH_PKG__DIR', __DIR__ . '/' );
 define( 'JETPACK_SEARCH_PKG__SLUG', 'search' );
 

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -81,6 +81,15 @@ class REST_Controller {
 		);
 		register_rest_route(
 			'jetpack/v4',
+			'/search/stats',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_stats' ),
+				'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
+			)
+		);
+		register_rest_route(
+			'jetpack/v4',
 			'/search',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
@@ -221,6 +230,16 @@ class REST_Controller {
 	}
 
 	/**
+	 * Proxy the request to WPCOM and return the response.
+	 *
+	 * GET `jetpack/v4/search/stats`
+	 */
+	public function get_search_stats() {
+		$response = ( new Stats() )->get_stats_from_wpcom();
+		return $this->make_proper_response( $response );
+	}
+
+	/**
 	 * Search Endpoint for private sites.
 	 *
 	 * GET `jetpack/v4/search`
@@ -298,7 +317,7 @@ class REST_Controller {
 	/**
 	 * Forward remote response to client with error handling.
 	 *
-	 * @param array|WP_Error $response - Resopnse from WPCOM.
+	 * @param array|WP_Error $response - Response from WPCOM.
 	 */
 	protected function make_proper_response( $response ) {
 		if ( is_wp_error( $response ) ) {

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -234,7 +234,7 @@ class REST_Controller {
 	 *
 	 * GET `jetpack/v4/search/stats`
 	 */
-	public function get_search_stats() {
+	public function get_stats() {
 		$response = ( new Stats() )->get_stats_from_wpcom();
 		return $this->make_proper_response( $response );
 	}

--- a/projects/packages/search/src/class-stats.php
+++ b/projects/packages/search/src/class-stats.php
@@ -18,9 +18,14 @@ class Stats {
 	 * Get stats from the WordPress.com API for the current blog ID.
 	 */
 	public function get_stats_from_wpcom() {
-		$blog_id  = Jetpack_Options::get_option( 'id' );
+		$blog_id = Jetpack_Options::get_option( 'id' );
+
+		if ( ! is_numeric( $blog_id ) ) {
+			return null;
+		}
+
 		$response = Client::wpcom_json_api_request_as_blog(
-			'/sites/' . $blog_id . '/jetpack-search/stats',
+			'/sites/' . (int) $blog_id . '/jetpack-search/stats',
 			'2',
 			array(),
 			null,

--- a/projects/packages/search/src/class-stats.php
+++ b/projects/packages/search/src/class-stats.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Fetch Search stats from WordPress.com.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+use Automattic\Jetpack\Connection\Client;
+use Jetpack_Options;
+
+/**
+ * Search stats (e.g. post count, post type breakdown)
+ */
+class Stats {
+	/**
+	 * Get stats from the WordPress.com API for the current blog ID.
+	 */
+	public function get_stats_from_wpcom() {
+		$blog_id  = Jetpack_Options::get_option( 'id' );
+		$response = Client::wpcom_json_api_request_as_blog(
+			'/sites/' . $blog_id . '/jetpack-search/stats',
+			'2',
+			array(),
+			null,
+			'wpcom'
+		);
+
+		return $response;
+	}
+}

--- a/projects/plugins/backup/changelog/add-jetpack-stats-endpoint
+++ b/projects/plugins/backup/changelog/add-jetpack-stats-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/backup/package.json
+++ b/projects/plugins/backup/package.json
@@ -24,7 +24,7 @@
 		"extends @wordpress/browserslist-config"
 	],
 	"dependencies": {
-		"@automattic/jetpack-api": "workspace:^0.8.5-alpha",
+		"@automattic/jetpack-api": "workspace:^0.9.0-alpha",
 		"@automattic/jetpack-components": "workspace:^0.10.5",
 		"@automattic/jetpack-connection": "workspace:^0.15.2-alpha",
 		"@wordpress/api-fetch": "6.0.0",

--- a/projects/plugins/jetpack/changelog/add-jetpack-stats-endpoint
+++ b/projects/plugins/jetpack/changelog/add-jetpack-stats-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/add-jetpack-stats-endpoint#2
+++ b/projects/plugins/jetpack/changelog/add-jetpack-stats-endpoint#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -37,7 +37,7 @@
 		"automattic/jetpack-plugins-installer": "0.1.x-dev",
 		"automattic/jetpack-redirect": "1.7.x-dev",
 		"automattic/jetpack-roles": "1.4.x-dev",
-		"automattic/jetpack-search": "0.8.x-dev",
+		"automattic/jetpack-search": "0.9.x-dev",
 		"automattic/jetpack-status": "1.10.x-dev",
 		"automattic/jetpack-sync": "1.30.x-dev",
 		"automattic/jetpack-terms-of-service": "1.9.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e3863a21a058e8dd82fd0b1f4374f71e",
+    "content-hash": "9d2323c6448a1c0ad8cc836bdedd6777",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -290,11 +290,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "e338b717cf1dc78b8b1570b87213fc91e25197ad"
+                "reference": "281aecc8c5f48a483bd931c61d64d50a66f3b741"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.36",
-                "automattic/jetpack-sync": "^1.30"
+                "automattic/jetpack-sync": "^1.29"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.0",
@@ -1527,7 +1527,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "a89165a040679943b525f8983b78b7f097a87dfd"
+                "reference": "ccf6a365abb9291a7b8454908d0f15bf870b5cfb"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -1551,7 +1551,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "0.8.x-dev"
+                    "dev-master": "0.9.x-dev"
                 },
                 "version-constants": {
                     "JETPACK_SEARCH_PKG__VERSION": "search.php"
@@ -1661,7 +1661,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "6a8766c8465af765dc98ce86d454cfafa0bb0009"
+                "reference": "08c63a81a1ac29072c140383f3bf9266a4c3c6be"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.36",
@@ -1690,7 +1690,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.30.x-dev"
+                    "dev-master": "1.29.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9d2323c6448a1c0ad8cc836bdedd6777",
+    "content-hash": "a9beed9119ac1aa6dc35e4f404cf1066",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -290,11 +290,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "281aecc8c5f48a483bd931c61d64d50a66f3b741"
+                "reference": "e338b717cf1dc78b8b1570b87213fc91e25197ad"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.36",
-                "automattic/jetpack-sync": "^1.29"
+                "automattic/jetpack-sync": "^1.30"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.0",
@@ -1661,7 +1661,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "08c63a81a1ac29072c140383f3bf9266a4c3c6be"
+                "reference": "6a8766c8465af765dc98ce86d454cfafa0bb0009"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.36",
@@ -1690,7 +1690,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.29.x-dev"
+                    "dev-master": "1.30.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -49,7 +49,7 @@
 		"@automattic/components": "1.0.0-alpha.3",
 		"@automattic/format-currency": "1.0.0-alpha.0",
 		"@automattic/jetpack-analytics": "workspace:^0.1.7",
-		"@automattic/jetpack-api": "workspace:^0.8.5-alpha",
+		"@automattic/jetpack-api": "workspace:^0.9.0-alpha",
 		"@automattic/jetpack-components": "workspace:^0.10.5",
 		"@automattic/jetpack-connection": "workspace:^0.15.2-alpha",
 		"@automattic/jetpack-licensing": "workspace:^0.4.7-alpha",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Add the stats endpoint to the REST controller for Search, enabling us to fetch information like post count and post type breakdown.
* Add `fetchSearchStats` to the API package so we can use it from the Search package later.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
On your test site with Jetpack Search enabled, open your browser network console and go to `/wp-admin/admin.php?page=jetpack-search`.

Find the API request to `/wp-json/jetpack/v4/search/plan` and choose `Edit and resend`. Amend the API endpoint path to `/wp-json/jetpack/v4/search/stats` and send off the request.

<img width="347" alt="Screen Shot 2022-02-16 at 13 54 44" src="https://user-images.githubusercontent.com/17325/154175699-b40094c7-77be-40eb-a049-4a278bddd696.png">

Ensure the API response looks like this:

<img width="396" alt="Screen Shot 2022-02-16 at 13 55 03" src="https://user-images.githubusercontent.com/17325/154175602-9578e899-7170-497b-8030-c1ba4fb63896.png">
