### PR TITLE
Media Button: Fix the external medial modal cannot be closed

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-external-media-modal-cannot-close
+++ b/projects/plugins/jetpack/changelog/fix-external-media-modal-cannot-close
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Media Buttons: Fix external medial modal cannot be closed

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-button/index.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-button/index.js
@@ -30,6 +30,7 @@ function MediaButton( props ) {
 		}
 
 		setSelectedSource( null );
+		mediaProps.onClose?.();
 	};
 
 	return (
@@ -44,7 +45,7 @@ function MediaButton( props ) {
 				hasImage={ mediaProps.value > 0 }
 			/>
 
-			{ ExternalLibrary && <ExternalLibrary onClose={ closeLibrary } { ...mediaProps } /> }
+			{ ExternalLibrary && <ExternalLibrary { ...mediaProps } onClose={ closeLibrary } /> }
 		</div>
 	);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/59985

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* As `mediaProps` has `onClose` property, spreading it after the customized `onClose` function overwrites the customized one so that the external media modal cannot be closed. So I reorder the spreading `mediaProps` and call the `mediaProps.onClose` function inside customized `onClose` function if it is existed.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* apply soon-to-be-generated Diff to your WPCom sandbox
* Open an existing post (or create a new one)
* Insert an image block
* Select Image > Google Photos or Pexels Free Photos
* Close the modal

https://user-images.githubusercontent.com/13596067/153846267-c24d50b0-816e-48f8-a953-848ec67cf0ca.mov



