### PR TITLE
Tracking: add missing jQuery dependency

### DIFF
--- a/projects/packages/tracking/changelog/update-tracking-asset-dep
+++ b/projects/packages/tracking/changelog/update-tracking-asset-dep
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tracking script: add missing jQuery dependency.

--- a/projects/packages/tracking/src/class-tracking.php
+++ b/projects/packages/tracking/src/class-tracking.php
@@ -145,7 +145,7 @@ class Tracking {
 		wp_enqueue_script(
 			'jptracks',
 			Assets::get_file_url_for_environment( 'js/tracks-ajax.js', 'js/tracks-ajax.js', __FILE__ ),
-			array(),
+			array( 'jquery' ),
 			self::ASSETS_VERSION,
 			true
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* The Tracking script relies on jQuery, so we should add it as dependency so it can be loaded by WordPress when loading `jptracks`.
* This was not an issue until today since we've only loaded Tracks in wp-admin, where jQuery is already enqueued. But with #22818, this may change, and thus we'll need to properly declare our dependencies.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* On a brand new site that does not run Jetpack, create a new plugin.
* Add the following dependencies to your plugin:
```
"require": {
    "automattic/jetpack-tracking": "1.14.x-dev",
    "automattic/jetpack-autoloader": "2.10.x-dev",
    "automattic/jetpack-composer-plugin": "1.1.x-dev",
    "automattic/jetpack-connection": "1.36.x-dev"
}
```
* In your plugin, load the autoloader.
* Load Track's script like so:
```
use Automattic\Jetpack\Tracking as Tracks;

add_action( 'wp_enqueue_scripts', array( new Tracks( 'jetpack' ), 'enqueue_tracks_scripts' ) );
```
* On the frontend, you should then see `jetpack_vendor/automattic/jetpack-tracking/src/js/tracks-ajax.js?ver=1.0.0` loaded, and a JavaScript error in the console.
* Edit `jetpack_vendor/automattic/jetpack-tracking/src/class-tracking.php` to apply the changes from this PR; the JavaScript error should disappear.
* Here is [a zip](https://github.com/jeherve/test/archive/refs/heads/master.zip) you can download and then upload to test things easily.