### PR TITLE
Blocks: Remove cron check from `jetpack_is_frontend`

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-is-frontend-cron-check
+++ b/projects/plugins/jetpack/changelog/remove-is-frontend-cron-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Blocks: Cron requests are now considered frontend requests, so blocks will no longer be rendered as fallbacks on those.

--- a/projects/plugins/jetpack/functions.global.php
+++ b/projects/plugins/jetpack/functions.global.php
@@ -466,7 +466,6 @@ function jetpack_is_frontend() {
 	if (
 		is_admin() ||
 		wp_doing_ajax() ||
-		wp_doing_cron() ||
 		wp_is_json_request() ||
 		wp_is_jsonp_request() ||
 		wp_is_xml_request() ||


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/22410

#### Changes proposed in this Pull Request:
Removes the `wp_doing_cron` check from the `jetpack_is_frontend` function, since it seems that some cron requests may result on frontend requests (e.g. when using the Super Cache plugin). That way, blocks will no longer be rendered as fallbacks on these requests.

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- Go to `wp-admin/post-new.php`.
- Insert a Contact Form block.
- Publish the post.
- Add the following code to a mu-plugin: `add_filter( 'wp_doing_cron', '__return_true' );`
- Visit the published post.
- Make sure the contact form is displayed correctly.
