### PR TITLE
actions: Disable experimental PHP 8.1 run

### DIFF
--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -61,7 +61,9 @@ foreach ( array( '5.6', '7.0', '7.2', '7.3', '7.4', '8.0' ) as $php ) {
 		'timeout' => 20, // 2022-01-25: 5.6 tests have started timing out at 15 minutes. Previously: Successful runs seem to take ~8 minutes for PHP 5.6 and for the 7.4 master run, ~5.5-6 for 7.x and 8.0.
 	);
 }
-// Merge this into the above once we decide PHP 8.1 is stable and WP latest works with 8.1.
+// Uncomment this once WP master finally works with 8.1. Then merge into the above once WP latest does and we've cleaned up any problems in our own code.
+// phpcs:ignore Squiz.PHP.CommentedOutCode.Found, Squiz.Commenting.BlockComment.NoEmptyLineBefore
+/*
 $matrix[] = array(
 	'name'         => 'PHP tests: PHP 8.1 WP master',
 	'script'       => 'test-php',
@@ -70,6 +72,7 @@ $matrix[] = array(
 	'timeout'      => 15,
 	'experimental' => true,
 );
+*/
 foreach ( array( 'previous', 'master' ) as $wp ) {
 	$matrix[] = array(
 		'name'    => "PHP tests: PHP {$versions['PHP_VERSION']} WP $wp",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We enabled this back in October 2021 in the hope that WordPress Core
would quickly make progress on their own PHP 8.1 compatibility project.
That has not at all been born out, four months later they still need to
update their copy-pasted version of their own requests library and
still need to fix another random deprecation warning despite [a short
PR][1] existing.

GitHub's handling for expected-failing tests [is lacking][2], so having a
test, even one flagged experimental, failing long term causes some other
issues. At this point, let's just disable the test until one or the
other makes some progress.

[1]: https://github.com/WordPress/wordpress-develop/pull/1801
[2]: https://github.com/actions/runner/issues/2347

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1644842786633359-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* The "PHP tests: PHP 8.1 WP master" job should no longer run.