### PR TITLE
My Jetpack: fix products upgradability

### DIFF
--- a/projects/packages/my-jetpack/changelog/my-jetpack-fix-products-upgradibility
+++ b/projects/packages/my-jetpack/changelog/my-jetpack-fix-products-upgradibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix upgradability for anti-spam and backup products

--- a/projects/packages/my-jetpack/src/products/class-anti-spam.php
+++ b/projects/packages/my-jetpack/src/products/class-anti-spam.php
@@ -105,4 +105,14 @@ class Anti_Spam extends Product {
 			'promotion_percentage' => 50,
 		);
 	}
+
+	/**
+	 * Return product bundles list
+	 * that supports the product.
+	 *
+	 * @return boolean|array Products bundle list.
+	 */
+	public static function is_upgradable_by_bundle() {
+		return array( 'security' );
+	}
 }

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -152,14 +152,4 @@ class Search extends Module_Product {
 		$search_state = static::get_state_from_wpcom();
 		return ! empty( $search_state->supports_search ) || ! empty( $search_state->supports_instant_search );
 	}
-
-	/**
-	 * Return product bundles list
-	 * that supports the product.
-	 *
-	 * @return boolean|array Products bundle list.
-	 */
-	public static function is_upgradable_by_bundle() {
-		return array( 'security' );
-	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes the upgradability of `search` and `anti-spam`: Search is not upgradable by the security plan but Anti-Spam is.
It impacts straightly in the UI.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: fix products upgradability

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `#/add-search` page. Confirm you see the background color white.
`https://your-testing-site/wp-admin/admin.php?page=my-jetpack#/add-search`

<img width="1138" alt="image" src="https://user-images.githubusercontent.com/77539/153917148-238aecfc-cbec-4cba-8a44-b59e8566e7cd.png">