### PR TITLE
My Jetpack: Fix footer layout on interstitial pages

### DIFF
--- a/projects/packages/my-jetpack/_inc/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/style.module.scss
@@ -1,6 +1,12 @@
+:global {
+	#my-jetpack-container {
+		height: 100%;
+	}
+}
+
 .layout {
 	display: flex;
-	height: calc(100vh - 100px); // to neutralize wp-footer (Thank you for creating with WordPress)
+	height: 100%;
 	flex-direction: column;
 	justify-content: space-between;
 	margin-left: -20px; // to neutralize the padding of #wpcontent.

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-footer
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-footer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Avoid usage of 100vh on layout


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Since `wp-admin` has a lot of possibilities on top of `sidebar`, `footer messages`, etc, the usage of `vh` for `height` causes more side-effects than expected, based on that I moved to just use the available `height`.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Move from `100vh` to `100%` in all tree.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open `My Jetpack` page.
* Move to some interstitial pages (`add-boost`, `connection`, ...)
* You should not see the footer as below:
 
![image](https://user-images.githubusercontent.com/1663717/153923888-3a910eb3-27db-4401-9a22-5d74b38b6e65.png)

#### Demo

_Connection Interstitial_

![Screen Shot 2022-02-14 at 15 20 54](https://user-images.githubusercontent.com/1663717/153923966-577fc474-3a01-4381-8141-4126fbe61ba3.png)

