### PR TITLE
Fix fatal "Uncaught Error: Call to a member function get_last_query_info() on null

### DIFF
--- a/projects/plugins/jetpack/3rd-party/debug-bar/class-jetpack-search-debug-bar.php
+++ b/projects/plugins/jetpack/3rd-party/debug-bar/class-jetpack-search-debug-bar.php
@@ -93,7 +93,7 @@ class Jetpack_Search_Debug_Bar extends Debug_Bar_Panel {
 	 * @return void
 	 */
 	public function render() {
-		$jetpack_search  = (
+		$jetpack_search = (
 			Jetpack_Search\Options::is_instant_enabled() ?
 			Jetpack_Search\Instant_Search::instance() :
 			Jetpack_Search\Classic_Search::instance()
@@ -102,7 +102,6 @@ class Jetpack_Search_Debug_Bar extends Debug_Bar_Panel {
 		if ( ! $jetpack_search ) {
 			return;
 		}
-		
 		$last_query_info = $jetpack_search->get_last_query_info();
 
 		// If not empty, let's reshuffle the order of some things.

--- a/projects/plugins/jetpack/3rd-party/debug-bar/class-jetpack-search-debug-bar.php
+++ b/projects/plugins/jetpack/3rd-party/debug-bar/class-jetpack-search-debug-bar.php
@@ -98,6 +98,11 @@ class Jetpack_Search_Debug_Bar extends Debug_Bar_Panel {
 			Jetpack_Search\Instant_Search::instance() :
 			Jetpack_Search\Classic_Search::instance()
 		);
+
+		if ( ! $jetpack_search ) {
+			return;
+		}
+		
 		$last_query_info = $jetpack_search->get_last_query_info();
 
 		// If not empty, let's reshuffle the order of some things.

--- a/projects/plugins/jetpack/changelog/fix-fatal-error-null_get_last_query_info
+++ b/projects/plugins/jetpack/changelog/fix-fatal-error-null_get_last_query_info
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: Fix fatal "Uncaught Error: Call to a member function get_last_query_info() on null"


### PR DESCRIPTION
This error occurs after Jetpack 10.6 update.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Checks that the $jetpack_search instance is not null

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
1) Enable Debug bar
2) Enable Jetpack Search
3) Go to wp-admin and see:

<img width="745" alt="Screen Shot 2022-02-14 at 11 16 41 AM" src="https://user-images.githubusercontent.com/16962021/153922626-33e70558-a175-4313-8159-2a98f913f7ec.png">
