### PR TITLE
actions: Maintain per-project pr-update-to tags

### DIFF
--- a/.github/files/pr-update-to.sh
+++ b/.github/files/pr-update-to.sh
@@ -10,15 +10,18 @@ function die {
 [[ "$GITHUB_EVENT_NAME" == "push" ]] || die "Must be a push event"
 [[ "$GITHUB_REF" == "refs/heads/master" ]] || die "Must be a push to master"
 
+export GIT_AUTHOR_NAME=matticbot
+export GIT_AUTHOR_EMAIL=matticbot@users.noreply.github.com
+export GIT_COMMITTER_NAME=matticbot
+export GIT_COMMITTER_EMAIL=matticbot@users.noreply.github.com
+
+declare -A TAGS
 function update_tag {
-	echo 'Updating tag!'
-	export GIT_AUTHOR_NAME=matticbot
-	export GIT_AUTHOR_EMAIL=matticbot@users.noreply.github.com
-	export GIT_COMMITTER_NAME=matticbot
-	export GIT_COMMITTER_EMAIL=matticbot@users.noreply.github.com
-	git tag --force pr-update-to HEAD
-	git push --force origin pr-update-to
-	exit 0
+	if [[ -z "${TAGS[$1]}" ]]; then
+		echo "Updating tag $1!"
+		git tag --force "$1" HEAD
+		TAGS[$1]=1
+	fi
 }
 
 cd $(dirname "${BASH_SOURCE[0]}")/../..
@@ -33,10 +36,21 @@ for FILE in projects/*/*/composer.json; do
 	FILES+=( "$(realpath -m --relative-to="$BASE" "$(jq -r '.extra.changelogger.changelog // "CHANGELOG.md"' composer.json)")" )
 done
 cd "$BASE"
-git diff --exit-code --name-only HEAD^..HEAD "${FILES[@]}" || update_tag
+for F in $(git diff --name-only HEAD^..HEAD "${FILES[@]}"); do
+	update_tag "pr-update-to-${F%/*}"
+	# TODO: Remove this once the action uses the above tags.
+	update_tag "pr-update-to"
+done
 
 # If this commit changed tool versions, update the tag so PRs get rechecked with the new versions.
 echo "Checking for changes to .github/versions.sh..."
-git diff --exit-code --name-only HEAD^..HEAD .github/versions.sh || update_tag
+git diff --exit-code --name-only HEAD^..HEAD .github/versions.sh || update_tag "pr-update-to"
 
-echo 'Done, no tag update needed.'
+if [[ ${#TAGS[*]} -le 0 ]]; then
+	echo 'Done, no tag updates needed.'
+	exit 0
+fi
+
+echo "Pushing tag updates..."
+git push --force origin "${!TAGS[@]}"
+echo 'Done!'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We're going to start using per-project pr-update-to tags to avoid e.g. a
release of Jetpack from invalidating PRs touching only Boost. Part of
that is that we'll need to create all those tags; that will be done
manually. But then we also need to keep those tags up to date as things
are released, which is what this PR is for.

Actually using the tags will come later. For now this also updates the
global pr-update-to tag whenever a per-project tag is updated.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
none to link

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You could try running the script locally, with the `git push` at the end commented out, see if it reports no tag updates needed.
* Then copy the script into a checkout of something like e56542cd09e1c6a509faf42e3e49fee81a3b5dd2 and do the same. Since that commit has various changes, it should report tag updates.
* Merge this, then release something. See if it updated the right per-project tags.