### PR TITLE
My Jetpack: Improve global notice style

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
@@ -10,21 +10,34 @@
 	margin: 0;
 	font-size: 16px;
 
+	// notice itself on error status
 	&:global(.is-error) {
 		background-color: var(--jp-red-0);
 	}
 
-	& > *:first-child {
+	// notice content
+	& :global(.components-notice__content) {
 		display: flex;
 		align-items: center;
 		margin: 0;
 		padding: 12px 4px;
+
+		// left icon
+		& > svg {
+			fill: var(--jp-red-60);
+		}
 	}
 
+	// action button
 	& :global(.is-link) {
 		color: var( --jp-black );
 		font-size: 16px;
 		font-weight: 600;
+	}
+
+	// X close button
+	& :global(.components-notice__dismiss) {
+		align-self: center;
 	}
 }
 

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-global-notice-style
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-global-notice-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Improve global notice layout


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #22843 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix notice dismiss button alignment.
* Update notice error icon color.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `state/actions.js`
* Simulate an error throw on `requestProductStatus` method (line 33)
* Try to activate or deactivate one module.
* It should show the notice with improved styles.

#### Demo

![Screen Shot 2022-02-14 at 15 55 26](https://user-images.githubusercontent.com/1663717/153928873-d73fdf85-77a2-4092-a355-66bb7756dfa9.png)


