### PR TITLE
My Jetpack: add VideoPress product data 

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-add-videopress-interstitial
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-add-videopress-interstitial
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add VideoPress data

--- a/projects/packages/my-jetpack/src/products/class-videopress.php
+++ b/projects/packages/my-jetpack/src/products/class-videopress.php
@@ -44,7 +44,7 @@ class Videopress extends Module_Product {
 	 * @return string
 	 */
 	public static function get_title() {
-		return ''; // @todo title
+		return __( 'Jetpack VideoPress', 'jetpack-my-jetpack' );
 	}
 
 	/**
@@ -62,7 +62,7 @@ class Videopress extends Module_Product {
 	 * @return string
 	 */
 	public static function get_long_description() {
-		return ''; // @todo Add long description
+		return __( 'High-quality, ad-free video built specifically for WordPress.', 'jetpack-my-jetpack' );
 	}
 
 	/**
@@ -71,7 +71,12 @@ class Videopress extends Module_Product {
 	 * @return array Boost features list
 	 */
 	public static function get_features() {
-		return array();
+		return array(
+			_x( '1TB of storage', 'VideoPress Product Feature', 'jetpack-my-jetpack' ),
+			_x( 'Built into WordPress editor', 'VideoPress Product Feature', 'jetpack-my-jetpack' ),
+			_x( 'Ad-free and brandable player', 'VideoPress Product Feature', 'jetpack-my-jetpack' ),
+			_x( 'Unlimited users', 'VideoPress Product Feature', 'jetpack-my-jetpack' ),
+		);
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds VideoPress product data to be used to show them in the UI.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: add VideoPress product data

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack dashboard
* Print the `videopress` field of the `myJetpackInitialState` global var. Confirm you see `title`, `longDescription`, `features`...

<img width="758" alt="image" src="https://user-images.githubusercontent.com/77539/153928790-fc832b2f-d00a-4129-bcf8-4f74e288b8c9.png">
