### PR TITLE
My Jetpack: Only pass a productUrl if the product is not free on interstitial pages

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -80,7 +80,9 @@ const ProductDetail = ( { slug, trackButtonClick } ) => {
 	const { isFree, fullPrice, currencyCode, discountedPrice } = pricingForUi;
 	const { isUserConnected } = useMyJetpackConnection();
 
-	const addProductUrl = getProductCheckoutUrl( `jetpack_${ slug }`, isUserConnected ); // @ToDo: Remove this when we have a new product structure.
+	const addProductUrl = isFree
+		? null
+		: getProductCheckoutUrl( `jetpack_${ slug }`, isUserConnected ); // @ToDo: Remove this when we have a new product structure.
 
 	// Suppported products icons.
 	const icons = isBundle

--- a/projects/packages/my-jetpack/changelog/fix-boost-checkout-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/fix-boost-checkout-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Only pass a productUrl if the product is not free on interstitial pages


### PR DESCRIPTION

Fixes #22844

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates setting of productUrl to only happen if product is not free


#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:

* Visit `/wp-admin/admin.php?page=my-jetpack#/add-boost`
* Confirm clicking the button does not lead to checkout flow
