### PR TITLE
My Jetpack: Use proper key when looping through product detail icons and rendering the plus icon 

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -89,9 +89,16 @@ const ProductDetail = ( { slug, trackButtonClick } ) => {
 		? supportedProducts
 				.join( '_plus_' )
 				.split( '_' )
-				.map( iconSlug => {
+				.map( ( iconSlug, i ) => {
 					if ( iconSlug === 'plus' ) {
-						return <Icon className={ styles[ 'plus-icon' ] } icon={ plus } size={ 14 } />;
+						return (
+							<Icon
+								className={ styles[ 'plus-icon' ] }
+								key={ `icon-plugs${ i }` }
+								icon={ plus }
+								size={ 14 }
+							/>
+						);
 					}
 
 					const SupportedProductIcon = getIconBySlug( iconSlug );

--- a/projects/packages/my-jetpack/changelog/fix-lack-of-key-in-bundle-icon-loop-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/fix-lack-of-key-in-bundle-icon-loop-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use key when looping through product detail icons


### PR DESCRIPTION

Fixes warning about duplicated key

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->


#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
* Visit `/wp-admin/admin.php?page=my-jetpack#/add-search`.
* Open the console and confirm there's no React warning about duplicate keys
