### PR TITLE
My Jetpack: Make click on Fix connection show connection route

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { __, sprintf } from '@wordpress/i18n';
 import { ButtonGroup, Button, DropdownMenu } from '@wordpress/components';
+import { useNavigate } from 'react-router-dom';
 
 /**
  * Internal dependencies
@@ -137,6 +138,7 @@ const ProductCard = props => {
 		tracks: { recordEvent },
 	} = useAnalytics();
 
+	const navigate = useNavigate();
 	/**
 	 * Calls the passed function onDeactivate after firing Tracks event
 	 */
@@ -177,6 +179,16 @@ const ProductCard = props => {
 		onManage();
 	}, [ slug, onManage, recordEvent ] );
 
+	/**
+	 * Calls the passed function onManage after firing Tracks event
+	 */
+	const fixConnectionHandler = useCallback( () => {
+		recordEvent( 'jetpack_myjetpack_product_card_fixconnection_click', {
+			product: slug,
+		} );
+		navigate( '/connection' );
+	}, [ slug, navigate, recordEvent ] );
+
 	return (
 		<div className={ containerClassName }>
 			<div className={ styles.name }>
@@ -187,7 +199,12 @@ const ProductCard = props => {
 			<div className={ styles.actions }>
 				{ canDeactivate ? (
 					<ButtonGroup className={ styles.group }>
-						<ActionButton { ...props } onActivate={ activateHandler } onManage={ manageHandler } />
+						<ActionButton
+							{ ...props }
+							onActivate={ activateHandler }
+							onFixConnection={ fixConnectionHandler }
+							onManage={ manageHandler }
+						/>
 						<DropdownMenu
 							className={ styles.dropdown }
 							toggleProps={ { isPressed: true, disabled: isFetching } }
@@ -204,7 +221,12 @@ const ProductCard = props => {
 						/>
 					</ButtonGroup>
 				) : (
-					<ActionButton { ...props } onActivate={ activateHandler } onAdd={ addHandler } />
+					<ActionButton
+						{ ...props }
+						onFixConnection={ fixConnectionHandler }
+						onActivate={ activateHandler }
+						onAdd={ addHandler }
+					/>
 				) }
 				{ ! isAbsent && <div className={ statusClassName }>{ flagLabel }</div> }
 			</div>

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { __, sprintf } from '@wordpress/i18n';
 import { ButtonGroup, Button, DropdownMenu } from '@wordpress/components';
-import { useNavigate } from 'react-router-dom';
 
 /**
  * Internal dependencies
@@ -109,6 +108,7 @@ const ProductCard = props => {
 		onActivate,
 		onAdd,
 		onDeactivate,
+		onFixConnection,
 		onManage,
 		isFetching,
 		slug,
@@ -138,7 +138,6 @@ const ProductCard = props => {
 		tracks: { recordEvent },
 	} = useAnalytics();
 
-	const navigate = useNavigate();
 	/**
 	 * Calls the passed function onDeactivate after firing Tracks event
 	 */
@@ -186,8 +185,8 @@ const ProductCard = props => {
 		recordEvent( 'jetpack_myjetpack_product_card_fixconnection_click', {
 			product: slug,
 		} );
-		navigate( '/connection' );
-	}, [ slug, navigate, recordEvent ] );
+		onFixConnection();
+	}, [ slug, onFixConnection, recordEvent ] );
 
 	return (
 		<div className={ containerClassName }>

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/anti-spam-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/anti-spam-card.jsx
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 import ProductCard from '../product-card';
 import { useProduct } from '../../hooks/use-product';
 import { AntiSpamIcon } from '../icons';
+import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const AntiSpamCard = ( { admin } ) => {
 	const { status, activate, deactivate, detail, isFetching } = useProduct( 'anti-spam' );
@@ -26,6 +27,7 @@ const AntiSpamCard = ( { admin } ) => {
 			onDeactivate={ deactivate }
 			slug={ slug }
 			onActivate={ activate }
+			onFixConnection={ useMyJetpackNavigate( '/connection' ) }
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card.jsx
@@ -29,6 +29,7 @@ const BackupCard = ( { admin } ) => {
 			onActivate={ activate }
 			showDeactivate={ false }
 			onAdd={ useMyJetpackNavigate( '/add-backup' ) }
+			onFixConnection={ useMyJetpackNavigate( '/connection' ) }
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card.jsx
@@ -11,6 +11,7 @@ import { useNavigate } from 'react-router-dom';
 import ProductCard from '../product-card';
 import { useProduct } from '../../hooks/use-product';
 import { BoostIcon } from '../icons';
+import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const BoostCard = ( { admin } ) => {
 	const { status, activate, deactivate, detail, isFetching } = useProduct( 'boost' );
@@ -33,6 +34,7 @@ const BoostCard = ( { admin } ) => {
 			onActivate={ activate }
 			slug={ slug }
 			onAdd={ onAddHandler }
+			onFixConnection={ useMyJetpackNavigate( '/connection' ) }
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/crm-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/crm-card.jsx
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 import ProductCard from '../product-card';
 import { useProduct } from '../../hooks/use-product';
 import { CrmIcon } from '../icons';
+import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const CrmCard = ( { admin } ) => {
 	const { status, activate, deactivate, detail, isFetching } = useProduct( 'crm' );
@@ -26,6 +27,7 @@ const CrmCard = ( { admin } ) => {
 			onDeactivate={ deactivate }
 			onActivate={ activate }
 			slug={ slug }
+			onFixConnection={ useMyJetpackNavigate( '/connection' ) }
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/extras-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/extras-card.jsx
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 import ProductCard from '../product-card';
 import { useProduct } from '../../hooks/use-product';
 import { ExtrasIcon } from '../icons';
+import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const ExtrasCard = ( { admin } ) => {
 	const { status, activate, deactivate, detail, isFetching } = useProduct( 'extras' );
@@ -27,6 +28,7 @@ const ExtrasCard = ( { admin } ) => {
 			slug={ slug }
 			onActivate={ activate }
 			showDeactivate={ false }
+			onFixConnection={ useMyJetpackNavigate( '/connection' ) }
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/scan-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/scan-card.jsx
@@ -11,6 +11,7 @@ import { useNavigate } from 'react-router-dom';
 import ProductCard from '../product-card';
 import { useProduct } from '../../hooks/use-product';
 import { ScanIcon } from '../icons';
+import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const ScanCard = ( { admin } ) => {
 	const { status, activate, deactivate, detail, isFetching } = useProduct( 'scan' );
@@ -34,6 +35,7 @@ const ScanCard = ( { admin } ) => {
 			onActivate={ activate }
 			onAdd={ onAddHandler }
 			showDeactivate={ false }
+			onFixConnection={ useMyJetpackNavigate( '/connection' ) }
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/search-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/search-card.jsx
@@ -27,6 +27,7 @@ const SearchCard = ( { admin } ) => {
 			onDeactivate={ deactivate }
 			onActivate={ activate }
 			onAdd={ useMyJetpackNavigate( '/add-search' ) }
+			onFixConnection={ useMyJetpackNavigate( '/connection' ) }
 			slug={ slug }
 		/>
 	);

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card.jsx
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 import ProductCard from '../product-card';
 import { useProduct } from '../../hooks/use-product';
 import { VideopressIcon } from '../icons';
+import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const VideopressCard = ( { admin } ) => {
 	const { status, activate, deactivate, detail, isFetching } = useProduct( 'videopress' );
@@ -26,6 +27,7 @@ const VideopressCard = ( { admin } ) => {
 			onDeactivate={ deactivate }
 			onActivate={ activate }
 			slug={ slug }
+			onFixConnection={ useMyJetpackNavigate( '/connection' ) }
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/changelog/add-fix-connection-error-link-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/add-fix-connection-error-link-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Make click on Fix connection show connection route


### PR DESCRIPTION
Makes the fix connection button redirect to the connection screen (`/connection` route).

Fixes #22865


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Makes the ProductCard fix connection button always navigate to `/connection` route.
* Adds firing of Tracks event `jetpack_myjetpack_product_card_fixconnection_click`


#### Does this pull request change what data or activity we track or use?
yes. 
* Add the `jetpack_myjetpack_product_card_fixconnection_click` event

#### Testing instructions:

**Option a**

* Checkout this branch
* Open My Jetpack
* With the React Dev tools, edit a component like Search and set its prop `status` to `error`
* Expect to be shown the "Fix connection" button on that Card
* Click it and confirm you're taken to the connection screen

  ![image](https://user-images.githubusercontent.com/746152/153941421-ff744c5f-6720-40c8-ad35-ed9fed284876.png)



**Option b**

* Install Backup, connect and activate the product
* Confirm the product shows as active
* Use the broken token tool and "clear user tokens"
* Go back to My Jetpack
* Confirm Backup card shows "Error" and clicking the Fix connection button leads to /connection route