### PR TITLE
My Jetpack: useMyJetpackNavigate when it's worth it

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card.jsx
@@ -15,7 +15,7 @@ import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 const BoostCard = ( { admin } ) => {
 	const { status, activate, deactivate, detail, isFetching } = useProduct( 'boost' );
 	const { name, description, slug } = detail;
-
+	
 	return (
 		<ProductCard
 			name={ name }

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card.jsx
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import React, { useCallback } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { useNavigate } from 'react-router-dom';
 
 /**
  * Internal dependencies
@@ -16,11 +15,6 @@ import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 const BoostCard = ( { admin } ) => {
 	const { status, activate, deactivate, detail, isFetching } = useProduct( 'boost' );
 	const { name, description, slug } = detail;
-	const navigate = useNavigate();
-
-	const onAddHandler = useCallback( () => {
-		navigate( '/add-boost' );
-	}, [ navigate ] );
 
 	return (
 		<ProductCard
@@ -33,7 +27,7 @@ const BoostCard = ( { admin } ) => {
 			onDeactivate={ deactivate }
 			onActivate={ activate }
 			slug={ slug }
-			onAdd={ onAddHandler }
+			onAdd={ useMyJetpackNavigate( '/add-boost' ) }
 			onFixConnection={ useMyJetpackNavigate( '/connection' ) }
 		/>
 	);

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card.jsx
@@ -15,7 +15,7 @@ import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 const BoostCard = ( { admin } ) => {
 	const { status, activate, deactivate, detail, isFetching } = useProduct( 'boost' );
 	const { name, description, slug } = detail;
-	
+
 	return (
 		<ProductCard
 			name={ name }

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/scan-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/scan-card.jsx
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import React, { useCallback } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { useNavigate } from 'react-router-dom';
 
 /**
  * Internal dependencies
@@ -16,11 +15,6 @@ import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 const ScanCard = ( { admin } ) => {
 	const { status, activate, deactivate, detail, isFetching } = useProduct( 'scan' );
 	const { name, description, slug } = detail;
-	const navigate = useNavigate();
-
-	const onAddHandler = useCallback( () => {
-		navigate( '/add-scan' );
-	}, [ navigate ] );
 
 	return (
 		<ProductCard
@@ -33,7 +27,7 @@ const ScanCard = ( { admin } ) => {
 			onDeactivate={ deactivate }
 			slug={ slug }
 			onActivate={ activate }
-			onAdd={ onAddHandler }
+			onAdd={ useMyJetpackNavigate( '/add-scan' ) }
 			showDeactivate={ false }
 			onFixConnection={ useMyJetpackNavigate( '/connection' ) }
 		/>

--- a/projects/packages/my-jetpack/_inc/hooks/use-connection-watcher/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-connection-watcher/index.js
@@ -4,14 +4,14 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { useEffect, useMemo } from 'react';
 import { useSelect, useDispatch } from '@wordpress/data';
-import useMyJetpackConnection from '../use-my-jetpack-connection';
-import { useNavigate } from 'react-router-dom';
 
 /**
  * Internal dependencies
  */
 import { STORE_ID } from '../../state/store';
 import { PRODUCT_STATUSES } from '../../components/product-card';
+import useMyJetpackConnection from '../use-my-jetpack-connection';
+import useMyJetpackNavigate from '../use-my-jetpack-navigate';
 
 const getProductsWithRequires = products => {
 	return Object.keys( products ).reduce( ( current, product ) => {
@@ -33,7 +33,7 @@ const getProductsWithRequires = products => {
  * the hook dispatches an action to populate the global notice.
  */
 export default function useConnectionWatcher() {
-	const navigate = useNavigate();
+	const navToConnection = useMyJetpackNavigate( '/connection' );
 	const { setGlobalNotice } = useDispatch( STORE_ID );
 	const products = useSelect( select => select( STORE_ID ).getProducts() );
 	const { isSiteConnected, redirectUrl, hasConnectedOwner } = useMyJetpackConnection();
@@ -76,12 +76,12 @@ export default function useConnectionWatcher() {
 				actions: [
 					{
 						label: __( 'Connect your user account to fix this', 'jetpack-my-jetpack' ),
-						onClick: () => navigate( '/connection' ),
+						onClick: navToConnection,
 						variant: 'link',
 						noDefaultClasses: true,
 					},
 				],
 			} );
 		}
-	}, [ productsThatRequiresUserConnection, requiresUserConnection, navigate, setGlobalNotice ] );
+	}, [ productsThatRequiresUserConnection, requiresUserConnection, navToConnection, setGlobalNotice ] );
 }

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-use-nav-custom-hook
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-use-nav-custom-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use useMyJetpackNavigate when it worths it


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR updates when using the navigation with the useMyJetpackNavigate () cusotm hook

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: useMyJetpackNavigate when it's worth it

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack
* Check that all `/add-boost`,  `add-scan`, and the global notices link work as expected
* 
