### PR TITLE
My Jetpack: Remove unnecessary payload from request to activate or deactivate a product

### DIFF
--- a/projects/packages/my-jetpack/_inc/state/actions.js
+++ b/projects/packages/my-jetpack/_inc/state/actions.js
@@ -106,7 +106,6 @@ function requestProductStatus( productId, data, { select, dispatch } ) {
 		return apiFetch( {
 			path: `${ REST_API_SITE_PRODUCTS_ENDPOINT }/${ productId }`,
 			method,
-			data,
 		} )
 			.then( freshProduct => {
 				dispatch( setIsFetchingProduct( productId, false ) );

--- a/projects/packages/my-jetpack/changelog/remove-unnecessary-body-activate-request-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/remove-unnecessary-body-activate-request-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove unnecessary payload from  request to activate or deactivate a product


### PR DESCRIPTION
We're sending a JSON body on the POST and DELETE requests but we don't actually use them on the backend

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes unnecessary paylod from request to activate or deactivate a product
[
#### Jetpack product discussion
(p1644867361608179/1644860476.341909-slack-C02TQF5VAJD)

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Visit the My Jetpack page
* Click on activate or deactivate on any given product
* Confirm your action worked by refreshing the page and seeing if the product remains on the intended state