### PR TITLE
My Jetpack: Install products from interstitial page

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/button.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/button.jsx
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { Button } from '@wordpress/components';
+import { Spinner } from '@automattic/jetpack-components';
+
+const ProductDetailButton = ( {
+	children,
+	className,
+	href,
+	isLink,
+	isLoading,
+	onClick,
+	isPrimary,
+	isSecondary,
+} ) => {
+	return (
+		<Button
+			onClick={ onClick }
+			isLink={ isLink }
+			isPrimary={ isPrimary }
+			isSecondary={ isSecondary }
+			className={ className }
+			href={ href }
+		>
+			{ isLoading ? <Spinner /> : children }
+		</Button>
+	);
+};
+
+ProductDetailButton.defaultProps = {
+	isLink: true,
+	isLoading: false,
+	isPrimary: false,
+	isSecondary: false,
+};
+
+export default ProductDetailButton;

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -181,14 +181,15 @@ export { ProductDetail };
 /**
  * ProductDetailCard component.
  *
- * @param {object}  props                - Component props.
- * @param {string}  props.slug           - Product slug
+ * @param {object}   props                - Component props.
+ * @param {string}   props.slug           - Product slug
+ * @param {Function} props.onClick        - Product CTA button handler
  * @returns {object}                       ProductDetailCard react component.
  */
-export default function ProductDetailCard( { slug } ) {
+export default function ProductDetailCard( { onClick, slug } ) {
 	return (
 		<div className={ styles.card }>
-			<ProductDetail slug={ slug } />
+			<ProductDetail onClick={ onClick } slug={ slug } />
 		</div>
 	);
 }

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useCallback } from 'react';
 import classnames from 'classnames';
-import { Button } from '@wordpress/components';
 import { Icon, check, plus } from '@wordpress/icons';
 import { getCurrencyObject } from '@automattic/format-currency';
 import { __, sprintf } from '@wordpress/i18n';
@@ -16,6 +15,7 @@ import getProductCheckoutUrl from '../../utils/get-product-checkout-url';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import { useProduct } from '../../hooks/use-product';
 import { BackupIcon, ScanIcon, StarIcon, getIconBySlug, AntiSpamIcon } from '../icons';
+import ProductDetailButton from './button';
 
 /**
  * Simple react component to render the product icon,
@@ -70,11 +70,12 @@ function Price( { value, currency, isOld } ) {
  *
  * @param {object} props                    - Component props.
  * @param {string} props.slug               - Product slug
+ * @param {Function} props.onClick          - Callback for Call To Action button click
  * @param {Function} props.trackButtonClick - Function to call for tracking clicks on Call To Action button
  * @returns {object}                          ProductDetailCard react component.
  */
-const ProductDetail = ( { slug, trackButtonClick } ) => {
-	const { detail } = useProduct( slug );
+const ProductDetail = ( { slug, onClick, trackButtonClick } ) => {
+	const { detail, isFetching } = useProduct( slug );
 	const { title, longDescription, features, pricingForUi, isBundle, supportedProducts } = detail;
 
 	const { isFree, fullPrice, currencyCode, discountedPrice } = pricingForUi;
@@ -106,6 +107,12 @@ const ProductDetail = ( { slug, trackButtonClick } ) => {
 				} )
 		: null;
 
+	const clickHandler = useCallback( () => {
+		trackButtonClick();
+		if ( onClick ) {
+			onClick();
+		}
+	}, [ onClick, trackButtonClick ] );
 	return (
 		<>
 			{ isBundle && (
@@ -144,13 +151,13 @@ const ProductDetail = ( { slug, trackButtonClick } ) => {
 				{ isFree && (
 					<h3 className={ styles[ 'product-free' ] }>{ __( 'Free', 'jetpack-my-jetpack' ) }</h3>
 				) }
-
-				<Button
-					onClick={ trackButtonClick }
+				<ProductDetailButton
+					onClick={ clickHandler }
 					isLink
+					isLoading={ isFetching }
 					isPrimary={ ! isBundle }
 					isSecondary={ isBundle }
-					href={ addProductUrl }
+					href={ onClick ? undefined : addProductUrl }
 					className={ `${ styles[ 'checkout-button' ] } ${
 						isBundle ? styles[ 'is-bundle' ] : ''
 					}` }
@@ -159,7 +166,7 @@ const ProductDetail = ( { slug, trackButtonClick } ) => {
 						/* translators: placeholder is product name. */
 						sprintf( __( 'Add %s', 'jetpack-my-jetpack' ), title )
 					}
-				</Button>
+				</ProductDetailButton>
 			</div>
 		</>
 	);
@@ -174,9 +181,9 @@ export { ProductDetail };
 /**
  * ProductDetailCard component.
  *
- * @param {object} props          - Component props.
- * @param {string} props.slug     - Product slug
- * @returns {object}                ProductDetailCard react component.
+ * @param {object}  props                - Component props.
+ * @param {string}  props.slug           - Product slug
+ * @returns {object}                       ProductDetailCard react component.
  */
 export default function ProductDetailCard( { slug } ) {
 	return (

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -14,18 +14,24 @@ import boostImage from './boost.png';
 import searchImage from './search.png';
 import videoPressImage from './videopress.png';
 import { useProduct } from '../../hooks/use-product';
-
+import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
+import getProductCheckoutUrl from '../../utils/get-product-checkout-url';
+import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 /**
  * Product Interstitial component.
  *
- * @param {object} props          - Component props.
- * @param {string} props.slug     - Product slug
- * @param {object} props.children - Product additional content
- * @returns {object}                ProductInterstitial react component.
+ * @param {object} props                 - Component props.
+ * @param {string} props.slug            - Product slug
+ * @param {object} props.children        - Product additional content
+ * @param {boolean} props.installsPlugin - Whether the interstitial button installs a plugin*
+ * @returns {object}                       ProductInterstitial react component.
  */
-export default function ProductInterstitial( { slug, children = null } ) {
-	const { detail } = useProduct( slug );
-	const { isUpgradableByBundle } = detail;
+export default function ProductInterstitial( { installsPlugin = false, slug, children = null } ) {
+	const { activate, detail } = useProduct( slug );
+	const {
+		isUpgradableByBundle,
+		pricingForUi: { isFree },
+	} = detail;
 
 	const {
 		tracks: { recordEvent },
@@ -40,7 +46,39 @@ export default function ProductInterstitial( { slug, children = null } ) {
 	}, [ recordEvent, slug ] );
 
 	const Product = isUpgradableByBundle ? ProductDetailCard : ProductDetail;
+	const { isUserConnected } = useMyJetpackConnection();
 
+	const addProductUrl = isFree
+		? null
+		: getProductCheckoutUrl( `jetpack_${ slug }`, isUserConnected ); // @ToDo: Remove this when we have a new product structure.
+
+	const navigateToMyJetpackOverviewPage = useMyJetpackNavigate( '/' );
+	const navigateToCheckoutPage = useCallback( () => {
+		window.location.href = addProductUrl;
+	}, [ addProductUrl ] );
+
+	const afterInstallation = useCallback(
+		free => {
+			if ( free ) {
+				navigateToMyJetpackOverviewPage();
+			} else {
+				navigateToCheckoutPage();
+			}
+		},
+		[ navigateToMyJetpackOverviewPage, navigateToCheckoutPage ]
+	);
+
+	const clickHandler = useCallback( () => {
+		if ( installsPlugin ) {
+			activate()
+				.then( () => {
+					afterInstallation( isFree );
+				} )
+				.catch( () => {
+					afterInstallation( isFree );
+				} );
+		}
+	}, [ activate, isFree, installsPlugin, afterInstallation ] );
 	return (
 		<Container
 			className={ ! isUpgradableByBundle ? styles.container : null }
@@ -49,7 +87,11 @@ export default function ProductInterstitial( { slug, children = null } ) {
 			fluid
 		>
 			<Col sm={ 4 } md={ 4 } lg={ 5 }>
-				<Product slug={ slug } trackButtonClick={ trackProductClick } />
+				<Product
+					slug={ slug }
+					trackButtonClick={ trackProductClick }
+					onClick={ installsPlugin ? clickHandler : undefined }
+				/>
 			</Col>
 			<Col sm={ 4 } md={ 4 } lg={ 7 } className={ styles.imageContainer }>
 				{ children }
@@ -78,7 +120,7 @@ export function AntiSpamInterstitial() {
  */
 export function BackupInterstitial() {
 	return (
-		<ProductInterstitial slug="backup">
+		<ProductInterstitial slug="backup" installsPlugin={ true }>
 			<ProductDetailCard slug="security" />
 		</ProductInterstitial>
 	);
@@ -91,7 +133,7 @@ export function BackupInterstitial() {
  */
 export function BoostInterstitial() {
 	return (
-		<ProductInterstitial slug="boost">
+		<ProductInterstitial slug="boost" installsPlugin={ true }>
 			<img src={ boostImage } alt="Boost" />
 		</ProductInterstitial>
 	);

--- a/projects/packages/my-jetpack/changelog/add-install-on-interstitial
+++ b/projects/packages/my-jetpack/changelog/add-install-on-interstitial
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Install proudcts from interstitial pages

--- a/projects/packages/my-jetpack/src/class-rest-products.php
+++ b/projects/packages/my-jetpack/src/class-rest-products.php
@@ -178,7 +178,7 @@ class REST_Products {
 	}
 
 	/**
-	 * Callback for activating a product
+	 * Callback for deactivating a product
 	 *
 	 * @param \WP_REST_Request $request The request object.
 	 * @return \WP_REST_Response


### PR DESCRIPTION
Adds mechanism for sideloading product plugins when clicking the _Add Product_ button on interstitial pages.

**I am not so sure I like this flow now that I've seen it working here.**

* Makes Boost and Backup be installed from the interstitial pages.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds button component with spinner next to product-detail-card component. Jetpack's ActionButton is not styled properly as to be useful here rapidly
* Replaces usage of regular Button for this new ProductDetailButton




#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

#### Test Scan acquisition flow
1. Test that the scan interstitial leads directly to the checkout page for the Scan and Security products.

#### Testing Boost sideloading

2. Remove the boost plugin
3. Visit My Jetpack.
4. Click Add Boost link. Expect to see the interstitial page for Boost
5. Click Add boost button on the interstitial. Expect to see a spinner
6. Expect to get reidrected to the My Jetpack page again

https://user-images.githubusercontent.com/746152/153989964-d2d8c7d1-7f02-4a34-aef4-c7b7e97bf961.mov


#### Testing Backup sideloading

2. Remove the Backup plugin
3. Temporarily edit line 27 of file `/projects/packages/my-jetpack/src/products/class-hybrid-product.php` to be
  ```
  return static::is_plugin_active();// || static::is_jetpack_plugin_active();

  ```
3. Visit My Jetpack.
4. Click Add Backup link. Expect to see the interstitial page for Backup
5. Click Add Backup button on the interstitial. Expect to see a spinner
6. Expect to get redrected to the Checkout page. The current flow for Backup is failing so expect to see a failure there on Calypso

https://user-images.githubusercontent.com/746152/153991065-a5000d11-5af1-4653-b7a9-3295941a253e.mov


