### PR TITLE
Instant Search: avoid React warning

### DIFF
--- a/projects/packages/search/changelog/fix-search-warning
+++ b/projects/packages/search/changelog/fix-search-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Form: avoid React warning.

--- a/projects/packages/search/src/instant-search/components/search-form.jsx
+++ b/projects/packages/search/src/instant-search/components/search-form.jsx
@@ -16,7 +16,7 @@ class SearchForm extends Component {
 
 	render() {
 		return (
-			<form autocomplete="off" onSubmit={ noop } role="search" className={ this.props.className }>
+			<form autoComplete="off" onSubmit={ noop } role="search" className={ this.props.className }>
 				<div className="jetpack-instant-search__search-form">
 					<SearchBox
 						isVisible={ this.props.isVisible }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* This tiny change avoids a React warning when viewing the Instant Search form.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Not much to test here.
* On a site with an active Search plan, go to `wp-admin/admin.php?page=jetpack-search-configure`
* You should not see any `Warning: Invalid DOM property `autocomplete`. Did you mean `autoComplete`?` warning anymore.
