### PR TITLE
My Jetpack:  Pull product discount from wpcom

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/stories/mock-data.js
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/stories/mock-data.js
@@ -101,7 +101,7 @@ export const scanProductData = {
 		available: true,
 		currency_code: 'USD',
 		full_price: 9.92,
-		promotion_percentage: 50,
+		discount: 60,
 	},
 };
 
@@ -123,7 +123,7 @@ export const searchProductData = {
 		available: true,
 		currency_code: 'EUR',
 		full_price: 4.5,
-		promotion_percentage: 50,
+		discount: 60,
 	},
 };
 
@@ -146,7 +146,7 @@ export const securityProductData = {
 		available: true,
 		show_promotion: true,
 		full_price: 24.92,
-		promotion_percentage: 50,
+		discount: 60,
 	},
 };
 

--- a/projects/packages/my-jetpack/_inc/hooks/use-product/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-product/index.js
@@ -35,8 +35,8 @@ export function useProduct( productId ) {
 
 	// Pricinf for UI.
 	detail.pricingForUi = detail.pricingForUi || {};
-	const { fullPrice, promotionPercentage } = detail.pricingForUi;
-	detail.pricingForUi.discountedPrice = ( fullPrice * ( 100 - promotionPercentage ) ) / 100;
+	const { fullPrice, discount } = detail.pricingForUi;
+	detail.pricingForUi.discountedPrice = ( fullPrice * ( 100 - discount ) ) / 100;
 
 	return {
 		activate: () => activateProduct( productId ),

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-check-product-purchase
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-check-product-purchase
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Pull product discount from wpcom

--- a/projects/packages/my-jetpack/src/class-wpcom-products.php
+++ b/projects/packages/my-jetpack/src/class-wpcom-products.php
@@ -151,7 +151,7 @@ class Wpcom_Products {
 	 *
 	 * @return array An array with currency_code and full_price. Empty array if product not found.
 	 */
-	public static function get_product_currency_and_price( $product_slug ) {
+	public static function get_product_pricing( $product_slug ) {
 		$product = self::get_product( $product_slug );
 		if ( empty( $product ) ) {
 			return array();

--- a/projects/packages/my-jetpack/src/class-wpcom-products.php
+++ b/projects/packages/my-jetpack/src/class-wpcom-products.php
@@ -152,14 +152,14 @@ class Wpcom_Products {
 	 * @return array An array with currency_code and full_price. Empty array if product not found.
 	 */
 	public static function get_product_currency_and_price( $product_slug ) {
-		$products = self::get_products();
-		if ( ! empty( $products->$product_slug ) ) {
-			return array(
-				'currency_code' => $products->$product_slug->currency_code,
-				'full_price'    => $products->$product_slug->cost,
-			);
+		$product = self::get_product( $product_slug );
+		if ( empty( $product ) ) {
+			return array();
 		}
-		return array();
-	}
 
+		return array(
+			'currency_code' => $product->currency_code,
+			'full_price'    => $product->cost,
+		);
+	}
 }

--- a/projects/packages/my-jetpack/src/class-wpcom-products.php
+++ b/projects/packages/my-jetpack/src/class-wpcom-products.php
@@ -157,9 +157,26 @@ class Wpcom_Products {
 			return array();
 		}
 
-		return array(
+		$pricing = array(
 			'currency_code' => $product->currency_code,
 			'full_price'    => $product->cost,
 		);
+
+		if ( ! $product->sale_coupon ) {
+			return $pricing;
+		}
+
+		// Check whether the coupon is still valid.
+		$sale            = $product->sale_coupon;
+		$sale_start_date = strtotime( $sale->start_date );
+		$sale_expires    = strtotime( $sale->expires );
+		if ( $sale_start_date > time() || $sale_expires < time() ) {
+			return $pricing;
+		}
+
+		// Populate response with sale discount.
+		$pricing['discount'] = $sale->discount;
+
+		return $pricing;
 	}
 }

--- a/projects/packages/my-jetpack/src/class-wpcom-products.php
+++ b/projects/packages/my-jetpack/src/class-wpcom-products.php
@@ -162,7 +162,7 @@ class Wpcom_Products {
 			'full_price'    => $product->cost,
 		);
 
-		if ( ! $product->sale_coupon ) {
+		if ( ! isset( $product->sale_coupon ) ) {
 			return $pricing;
 		}
 

--- a/projects/packages/my-jetpack/src/products/class-anti-spam.php
+++ b/projects/packages/my-jetpack/src/products/class-anti-spam.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\My_Jetpack\Products;
 
 use Automattic\Jetpack\My_Jetpack\Product;
+use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 
 /**
  * Class responsible for handling the Anti_Spam product
@@ -98,11 +99,11 @@ class Anti_Spam extends Product {
 	 * @return array Pricing details
 	 */
 	public static function get_pricing_for_ui() {
-		return array(
-			'available'            => true,
-			'currency_code'        => 'EUR',
-			'full_price'           => 9.92,
-			'promotion_percentage' => 50,
+		return array_merge(
+			array(
+				'available' => true,
+			),
+			Wpcom_Products::get_product_pricing( static::get_wpcom_product_slug() )
 		);
 	}
 

--- a/projects/packages/my-jetpack/src/products/class-anti-spam.php
+++ b/projects/packages/my-jetpack/src/products/class-anti-spam.php
@@ -102,9 +102,19 @@ class Anti_Spam extends Product {
 		return array_merge(
 			array(
 				'available' => true,
+				'discount'  => 60, // hardcoded - it could be overwritten by the wpcom product.
 			),
 			Wpcom_Products::get_product_pricing( static::get_wpcom_product_slug() )
 		);
+	}
+
+	/**
+	 * Get the WPCOM product slug used to make the purchase
+	 *
+	 * @return ?string
+	 */
+	public static function get_wpcom_product_slug() {
+		return 'jetpack_anti_spam_monthly';
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-backup.php
+++ b/projects/packages/my-jetpack/src/products/class-backup.php
@@ -100,7 +100,7 @@ class Backup extends Hybrid_Product {
 	 * @return ?string
 	 */
 	public static function get_wpcom_product_slug() {
-		return 'jetpack_backup_t1_yearly';
+		return 'jetpack_backup_t1_monthly';
 	}
 
 	/**
@@ -112,6 +112,7 @@ class Backup extends Hybrid_Product {
 		return array_merge(
 			array(
 				'available' => true,
+				'discount'  => 60, // hardcoded - it could be overwritten by the wpcom product.
 			),
 			Wpcom_Products::get_product_pricing( static::get_wpcom_product_slug() )
 		);

--- a/projects/packages/my-jetpack/src/products/class-backup.php
+++ b/projects/packages/my-jetpack/src/products/class-backup.php
@@ -111,8 +111,7 @@ class Backup extends Hybrid_Product {
 	public static function get_pricing_for_ui() {
 		return array_merge(
 			array(
-				'available'            => true,
-				'promotion_percentage' => 50,
+				'available' => true,
 			),
 			Wpcom_Products::get_product_pricing( static::get_wpcom_product_slug() )
 		);

--- a/projects/packages/my-jetpack/src/products/class-backup.php
+++ b/projects/packages/my-jetpack/src/products/class-backup.php
@@ -114,7 +114,7 @@ class Backup extends Hybrid_Product {
 				'available'            => true,
 				'promotion_percentage' => 50,
 			),
-			Wpcom_Products::get_product_currency_and_price( static::get_wpcom_product_slug() )
+			Wpcom_Products::get_product_pricing( static::get_wpcom_product_slug() )
 		);
 	}
 

--- a/projects/packages/my-jetpack/src/products/class-scan.php
+++ b/projects/packages/my-jetpack/src/products/class-scan.php
@@ -93,7 +93,7 @@ class Scan extends Module_Product {
 				'available'            => true,
 				'promotion_percentage' => 50,
 			),
-			Wpcom_Products::get_product_currency_and_price( static::get_wpcom_product_slug() )
+			Wpcom_Products::get_product_pricing( static::get_wpcom_product_slug() )
 		);
 	}
 

--- a/projects/packages/my-jetpack/src/products/class-scan.php
+++ b/projects/packages/my-jetpack/src/products/class-scan.php
@@ -91,6 +91,7 @@ class Scan extends Module_Product {
 		return array_merge(
 			array(
 				'available' => true,
+				'discount'  => 60, // hardcoded - it could be overwritten by the wpcom product.
 			),
 			Wpcom_Products::get_product_pricing( static::get_wpcom_product_slug() )
 		);
@@ -102,7 +103,7 @@ class Scan extends Module_Product {
 	 * @return ?string
 	 */
 	public static function get_wpcom_product_slug() {
-		return 'jetpack_scan';
+		return 'jetpack_scan_monthly';
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-scan.php
+++ b/projects/packages/my-jetpack/src/products/class-scan.php
@@ -90,8 +90,7 @@ class Scan extends Module_Product {
 	public static function get_pricing_for_ui() {
 		return array_merge(
 			array(
-				'available'            => true,
-				'promotion_percentage' => 50,
+				'available' => true,
 			),
 			Wpcom_Products::get_product_pricing( static::get_wpcom_product_slug() )
 		);

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -91,6 +91,7 @@ class Search extends Module_Product {
 		return array_merge(
 			array(
 				'available' => true,
+				'discount'  => 60, // hardcoded - it could be overwritten by the wpcom product.
 			),
 			Wpcom_Products::get_product_pricing( static::get_wpcom_product_slug() )
 		);
@@ -102,7 +103,7 @@ class Search extends Module_Product {
 	 * @return ?string
 	 */
 	public static function get_wpcom_product_slug() {
-		return 'jetpack_search';
+		return 'jetpack_search_monthly';
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -90,8 +90,7 @@ class Search extends Module_Product {
 	public static function get_pricing_for_ui() {
 		return array_merge(
 			array(
-				'available'            => true,
-				'promotion_percentage' => 50,
+				'available' => true,
 			),
 			Wpcom_Products::get_product_pricing( static::get_wpcom_product_slug() )
 		);

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -93,7 +93,7 @@ class Search extends Module_Product {
 				'available'            => true,
 				'promotion_percentage' => 50,
 			),
-			Wpcom_Products::get_product_currency_and_price( static::get_wpcom_product_slug() )
+			Wpcom_Products::get_product_pricing( static::get_wpcom_product_slug() )
 		);
 	}
 

--- a/projects/packages/my-jetpack/src/products/class-security.php
+++ b/projects/packages/my-jetpack/src/products/class-security.php
@@ -88,7 +88,7 @@ class Security extends Module_Product {
 		return array_merge(
 			array(
 				'available' => true,
-				'discount'  => 50,
+				'discount'  => 60, // hardcoded - it could be overwritten by the wpcom product.
 			),
 			Wpcom_Products::get_product_pricing( static::get_wpcom_product_slug() )
 		);

--- a/projects/packages/my-jetpack/src/products/class-security.php
+++ b/projects/packages/my-jetpack/src/products/class-security.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\My_Jetpack\Products;
 
 use Automattic\Jetpack\My_Jetpack\Module_Product;
+use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 
 /**
  * Class responsible for handling the Security product
@@ -86,11 +87,9 @@ class Security extends Module_Product {
 	public static function get_pricing_for_ui() {
 		return array_merge(
 			array(
-				'available'            => true,
-				'show_promotion'       => true,
-				'full_price'           => 24.92,
-				'promotion_percentage' => 50,
-			)
+				'available' => true,
+			),
+			Wpcom_Products::get_product_pricing( static::get_wpcom_product_slug() )
 		);
 	}
 

--- a/projects/packages/my-jetpack/src/products/class-security.php
+++ b/projects/packages/my-jetpack/src/products/class-security.php
@@ -88,6 +88,7 @@ class Security extends Module_Product {
 		return array_merge(
 			array(
 				'available' => true,
+				'discount'  => 50,
 			),
 			Wpcom_Products::get_product_pricing( static::get_wpcom_product_slug() )
 		);
@@ -99,7 +100,7 @@ class Security extends Module_Product {
 	 * @return ?string
 	 */
 	public static function get_wpcom_product_slug() {
-		return 'jetpack_security';
+		return 'jetpack_security_t2_monthly';
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-videopress.php
+++ b/projects/packages/my-jetpack/src/products/class-videopress.php
@@ -90,7 +90,7 @@ class Videopress extends Module_Product {
 				'available'            => true,
 				'promotion_percentage' => 50,
 			),
-			Wpcom_Products::get_product_currency_and_price( static::get_wpcom_product_slug() )
+			Wpcom_Products::get_product_pricing( static::get_wpcom_product_slug() )
 		);
 	}
 

--- a/projects/packages/my-jetpack/src/products/class-videopress.php
+++ b/projects/packages/my-jetpack/src/products/class-videopress.php
@@ -87,8 +87,7 @@ class Videopress extends Module_Product {
 	public static function get_pricing_for_ui() {
 		return array_merge(
 			array(
-				'available'            => true,
-				'promotion_percentage' => 50,
+				'available' => true,
 			),
 			Wpcom_Products::get_product_pricing( static::get_wpcom_product_slug() )
 		);

--- a/projects/packages/my-jetpack/src/products/class-videopress.php
+++ b/projects/packages/my-jetpack/src/products/class-videopress.php
@@ -88,6 +88,7 @@ class Videopress extends Module_Product {
 		return array_merge(
 			array(
 				'available' => true,
+				'discount'  => 60, // hardcoded - it could be overwritten by the wpcom product.
 			),
 			Wpcom_Products::get_product_pricing( static::get_wpcom_product_slug() )
 		);
@@ -99,7 +100,7 @@ class Videopress extends Module_Product {
 	 * @return ?string
 	 */
 	public static function get_wpcom_product_slug() {
-		return 'jetpack_videopress';
+		return 'jetpack_videopress_monthly';
 	}
 
 	/**

--- a/projects/packages/my-jetpack/tests/php/test-wpcom-products.php
+++ b/projects/packages/my-jetpack/tests/php/test-wpcom-products.php
@@ -197,7 +197,7 @@ class Test_Wpcom_Products extends TestCase {
 		$this->create_user_and_login();
 
 		add_filter( 'pre_http_request', array( $this, 'mock_success_response' ) );
-		$product_price = Wpcom_Products::get_product_currency_and_price( 'jetpack_videopress_monthly' );
+		$product_price = Wpcom_Products::get_product_pricing( 'jetpack_videopress_monthly' );
 		remove_filter( 'pre_http_request', array( $this, 'mock_success_response' ) );
 
 		$expected = array(
@@ -216,7 +216,7 @@ class Test_Wpcom_Products extends TestCase {
 		$this->create_user_and_login();
 
 		add_filter( 'pre_http_request', array( $this, 'mock_success_response' ) );
-		$product_price = Wpcom_Products::get_product_currency_and_price( 'invalid' );
+		$product_price = Wpcom_Products::get_product_pricing( 'invalid' );
 		remove_filter( 'pre_http_request', array( $this, 'mock_success_response' ) );
 
 		$this->assertSame( array(), $product_price );

--- a/projects/packages/my-jetpack/tests/php/test-wpcom-products.php
+++ b/projects/packages/my-jetpack/tests/php/test-wpcom-products.php
@@ -107,6 +107,11 @@ class Test_Wpcom_Products extends TestCase {
 				'cost_display'           => 'R$4.90',
 				'cost'                   => 4.9,
 				'currency_code'          => 'BRL',
+				'sale_coupon'            => (object) array(
+					'start_date' => gmdate( 'Y' ) . '-01-01',
+					'expires'    => gmdate( 'Y' ) . '-12-31',
+					'discount'   => 20,
+				),
 			),
 		);
 	}
@@ -203,6 +208,7 @@ class Test_Wpcom_Products extends TestCase {
 		$expected = array(
 			'currency_code' => 'BRL',
 			'full_price'    => 4.9,
+			'discount'      => 20,
 		);
 
 		$this->assertSame( $expected, $product_price );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

On this PR
* Propagate wpcom product name according to what we'd like to show
* try to pull discount value from wpcom side
* Add a discount value fallback when it isn't provided by wpcom 

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack
* Compares Product prices with Jetpack pricing page. For instance, `Search`

My Jetpack | Jetpack Pricinf
-------|------
`https://retrowolf.ngrok.io/wp-admin/admin.php?page=my-jetpack#/add-search` | `https://cloud.jetpack.com/en/pricing/retrowolf.ngrok.io?site=retrowolf.ngrok.io`
<img width="800" alt="image" src="https://user-images.githubusercontent.com/77539/154108333-9aa1cecb-7fb5-43fd-a06c-91d12065bd0d.png"> |  <img width="600px" alt="image" src="https://user-images.githubusercontent.com/77539/154108682-e5c12075-b356-442c-b5f6-5f103d87a8c4.png">



Disclaimer: `Security` bundle shows a different value. Let's address this issue in a follow-up PR
