### PR TITLE
Removed prefix from is_allowed_mode() function since we are in the waf namespace anyway.

### DIFF
--- a/projects/packages/waf/actions.php
+++ b/projects/packages/waf/actions.php
@@ -18,7 +18,7 @@ if ( ! function_exists( 'add_action' ) ) {
  * @param  string $option The mode option.
  * @return bool
  */
-function jpwaf_is_allowed_mode( $option ) {
+function is_allowed_mode( $option ) {
 	$allowed_modes = array(
 		'normal',
 		'silent',
@@ -39,14 +39,14 @@ add_action(
 		if ( ! defined( 'JETPACK_WAF_MODE' ) ) {
 			$mode_option = get_option( 'jetpack_waf_mode' );
 
-			if ( ! jpwaf_is_allowed_mode( $mode_option ) ) {
+			if ( ! is_allowed_mode( $mode_option ) ) {
 				return;
 			}
 
 			define( 'JETPACK_WAF_MODE', $mode_option );
 		}
 
-		if ( ! jpwaf_is_allowed_mode( JETPACK_WAF_MODE ) ) {
+		if ( ! is_allowed_mode( JETPACK_WAF_MODE ) ) {
 			return;
 		}
 

--- a/projects/packages/waf/changelog/enhancement-rename_waf_allow_function
+++ b/projects/packages/waf/changelog/enhancement-rename_waf_allow_function
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Only renamed the is_allowed_mode() function within the waf namespace.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up for a review nitpick in #22816. More details in [this comment](https://github.com/Automattic/jetpack/pull/22816#discussion_r807049405).

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* See linked PR above.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The change is trivial, but if you really want to test it:
* Go to the original PR linked above and follow its testing instructions.
