### PR TITLE
SSO: removing wpcom_user_id upon disconnect

### DIFF
--- a/projects/packages/connection/changelog/fix-sso-wpcom-user-id
+++ b/projects/packages/connection/changelog/fix-sso-wpcom-user-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add the 'jetpack_site_before_disconnected' action hook.

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -2004,6 +2004,13 @@ class Manager {
 
 		( new Nonce_Handler() )->clean_all();
 
+		/**
+		 * Fires when a site is disconnected.
+		 *
+		 * @since 1.36.3
+		 */
+		do_action( 'jetpack_site_before_disconnected' );
+
 		// If the site is in an IDC because sync is not allowed,
 		// let's make sure to not disconnect the production site.
 		if ( $disconnect_wpcom ) {

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -2007,7 +2007,7 @@ class Manager {
 		/**
 		 * Fires when a site is disconnected.
 		 *
-		 * @since 1.36.3
+		 * @since $$next-version$$
 		 */
 		do_action( 'jetpack_site_before_disconnected' );
 

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.36.2';
+	const PACKAGE_VERSION = '1.36.3-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/plugins/jetpack/changelog/fix-sso-wpcom-user-id
+++ b/projects/plugins/jetpack/changelog/fix-sso-wpcom-user-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix a bug with SSO not cleaning up wpcom_user_id.

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -653,7 +653,7 @@ class Jetpack_SSO {
 	/**
 	 * Clean up after Jetpack gets disconnected.
 	 *
-	 * @since 10.7.0
+	 * @since $$next-version$$
 	 */
 	public static function disconnect() {
 		if ( Jetpack::connection()->is_user_connected() ) {

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -656,7 +656,9 @@ class Jetpack_SSO {
 	 * @since 10.7.0
 	 */
 	public static function disconnect() {
-		static::delete_connection_for_user( get_current_user_id() );
+		if ( Jetpack::connection()->is_user_connected() ) {
+			static::delete_connection_for_user( get_current_user_id() );
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -50,6 +50,7 @@ class Jetpack_SSO {
 		add_action( 'jetpack_modules_loaded', array( $this, 'module_configure_button' ) );
 		add_action( 'login_form_logout', array( $this, 'store_wpcom_profile_cookies_on_logout' ) );
 		add_action( 'jetpack_unlinked_user', array( $this, 'delete_connection_for_user' ) );
+		add_action( 'jetpack_site_before_disconnected', array( static::class, 'disconnect' ) );
 		add_action( 'wp_login', array( 'Jetpack_SSO', 'clear_cookies_after_login' ) );
 
 		// Adding this action so that on login_init, the action won't be sanitized out of the $action global.
@@ -650,6 +651,15 @@ class Jetpack_SSO {
 	}
 
 	/**
+	 * Clean up after Jetpack gets disconnected.
+	 *
+	 * @since 10.7.0
+	 */
+	public static function disconnect() {
+		static::delete_connection_for_user( get_current_user_id() );
+	}
+
+	/**
 	 * Remove an SSO connection for a user.
 	 *
 	 * @param int $user_id The local user id.
@@ -769,6 +779,13 @@ class Jetpack_SSO {
 				$expected_id = get_user_meta( $user->ID, 'wpcom_user_id', true );
 				if ( $expected_id && $expected_id != $user_data->ID ) { // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison, Universal.Operators.StrictComparisons.LooseNotEqual
 					$error = new WP_Error( 'expected_wpcom_user', __( 'Something got a little mixed up and an unexpected WordPress.com user logged in.', 'jetpack' ) );
+
+					$tracking->record_user_event(
+						'sso_login_failed',
+						array(
+							'error_message' => 'error_unexpected_wpcom_user',
+						)
+					);
 
 					/** This filter is documented in core/src/wp-includes/pluggable.php */
 					do_action( 'wp_login_failed', $user_data->login, $error );


### PR DESCRIPTION
SSO module adds meta key `wpcom_user_id` after first SSO sign in.
During all subsequent sign-ins Jetpack will check if the stored `wpcom_user_id` value matches the ID of the user trying to connect, and block the sign in attempt if it doesn't.

When a secondary user removes their user connection, we remove their `wpcom_user_id` meta value, so they can continue using SSO if they later connect as a different WP.com user.

However, we never do that for the primary user. If the primary user disconnects Jetpack, and connects later using different WP.com account, the `wpcom_user_id` meta value will not be updated, so they will not be able to connect via SSO.
The only way to resolve the issue to remove `wpcom_user_id` from the database manually.

#### Changes proposed in this Pull Request:
* remove the current user's `wpcom_user_id` meta key upon disconnecting Jetpack
* add tracking for the `error_unexpected_wpcom_user` event

#### Discussion
1191179647901802-as-1201828747583004

#### Does this pull request change what data or activity we track or use?
We add new Tracks event `error_unexpected_wpcom_user`, which is tracked if SSO fails because local `wpcom_user_id` does not match the actual WP.com user ID.

#### Testing instructions:
_First, let's reproduce the issue before checking out the branch:_
1. Connect the Jetpack site, enable SSO ("Settings -> Security -> WordPress.com login").
2. If this is not a new site, run the following SQL query to start with the clean state:
`DELETE FROM wp_usermeta WHERE meta_key = 'wpcom_user_id';`
3. Log out of WP-admin, log in using SSO. Run the following DB query to confirm that `wpcom_user_id` meta was saved for your user:
`SELECT * FROM wp_usermeta WHERE meta_key = 'wpcom_user_id';`
4. Disconnect Jetpack, log out of WP.com and login as a different WP.com user (WP user 2).
5. Connect Jetpack using WP.com user 2, and log out of WP-admin.
6. Try to log into WP-admin via SSO using the WP.com user 2. You might need to click "Log in as a different WP.com user" on the login screen.
7. You should see the error:
<img width="355" alt="Screen Shot 2022-02-15 at 3 42 41 PM" src="https://user-images.githubusercontent.com/1341249/154145933-a8948253-1c11-4d18-ae91-b046aaf7910c.png">

_Now checkout this branch and continue:_
8. Disconnect Jetpack, connect it again under WP.com user 2.
9. Log out of WP-admin, and log in again via SSO. You should login successfully.
10. Run the SQL query:
`SELECT * FROM wp_usermeta WHERE meta_key = 'wpcom_user_id';`
Confirm that the saved WP.com user ID belongs to WP.com user 2.