### PR TITLE
My Jetpack: Set properly the checkout link for Products

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -97,9 +97,9 @@ const ProductDetail = ( { slug, onClick, trackButtonClick } ) => {
 	const needsPurchase = ! isFree && ! hasRequiredPlan;
 
 	const addProductUrl =
-		! needsPurchase || ! wpcomProductSlug
-			? null
-			: getProductCheckoutUrl( wpcomProductSlug, isUserConnected ); // @ToDo: Remove this when we have a new product structure.
+		needsPurchase && wpcomProductSlug
+			? getProductCheckoutUrl( wpcomProductSlug, isUserConnected ) // @ToDo: Remove this when we have a new product structure.
+			: null;
 
 	// Suppported products icons.
 	const icons = isBundle

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -86,7 +86,7 @@ const ProductDetail = ( { slug, onClick, trackButtonClick } ) => {
 		hasRequiredPlan,
 	} = detail;
 
-	const { isFree, fullPrice, currencyCode, discountedPrice } = pricingForUi;
+	const { isFree, fullPrice, currencyCode, discountedPrice, wpcomProductSlug } = pricingForUi;
 	const { isUserConnected } = useMyJetpackConnection();
 
 	/*
@@ -96,9 +96,10 @@ const ProductDetail = ( { slug, onClick, trackButtonClick } ) => {
 	 */
 	const needsPurchase = ! isFree && ! hasRequiredPlan;
 
-	const addProductUrl = ! needsPurchase
-		? null
-		: getProductCheckoutUrl( `jetpack_${ slug }`, isUserConnected ); // @ToDo: Remove this when we have a new product structure.
+	const addProductUrl =
+		! needsPurchase || ! wpcomProductSlug
+			? null
+			: getProductCheckoutUrl( wpcomProductSlug, isUserConnected ); // @ToDo: Remove this when we have a new product structure.
 
 	// Suppported products icons.
 	const icons = isBundle

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -60,22 +60,18 @@ export default function ProductInterstitial( { installsPlugin = false, slug, chi
 
 	const navigateToMyJetpackOverviewPage = useMyJetpackNavigate( '/' );
 	const navigateToCheckoutPage = useCallback( () => {
-		if ( ! addProductUrl ) {
-			return navigateToMyJetpackOverviewPage();
-		}
-
 		window.location.href = addProductUrl;
-	}, [ addProductUrl, navigateToMyJetpackOverviewPage ] );
+	}, [ addProductUrl ] );
 
 	const afterInstallation = useCallback(
 		free => {
-			if ( free ) {
+			if ( free || ! addProductUrl ) {
 				navigateToMyJetpackOverviewPage();
 			} else {
 				navigateToCheckoutPage();
 			}
 		},
-		[ navigateToMyJetpackOverviewPage, navigateToCheckoutPage ]
+		[ navigateToMyJetpackOverviewPage, navigateToCheckoutPage, addProductUrl ]
 	);
 
 	const clickHandler = useCallback( () => {

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -32,7 +32,8 @@ export default function ProductInterstitial( { installsPlugin = false, slug, chi
 	const { activate, detail } = useProduct( slug );
 	const {
 		isUpgradableByBundle,
-		pricingForUi: { isFree },
+		pricingForUi: { isFree, wpcomProductSlug },
+		hasRequiredPlan,
 	} = detail;
 
 	const {
@@ -50,9 +51,12 @@ export default function ProductInterstitial( { installsPlugin = false, slug, chi
 	const Product = isUpgradableByBundle ? ProductDetailCard : ProductDetail;
 	const { isUserConnected } = useMyJetpackConnection();
 
-	const addProductUrl = isFree
-		? null
-		: getProductCheckoutUrl( `jetpack_${ slug }`, isUserConnected ); // @ToDo: Remove this when we have a new product structure.
+	const needsPurchase = ! isFree && ! hasRequiredPlan;
+
+	const addProductUrl =
+		! needsPurchase || ! wpcomProductSlug
+			? null
+			: getProductCheckoutUrl( wpcomProductSlug, isUserConnected ); // @ToDo: Remove this when we have a new product structure.
 
 	const navigateToMyJetpackOverviewPage = useMyJetpackNavigate( '/' );
 	const navigateToCheckoutPage = useCallback( () => {

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -60,6 +60,10 @@ export default function ProductInterstitial( { installsPlugin = false, slug, chi
 
 	const navigateToMyJetpackOverviewPage = useMyJetpackNavigate( '/' );
 	const navigateToCheckoutPage = useCallback( () => {
+		if ( ! addProductUrl ) {
+			return;
+		}
+
 		window.location.href = addProductUrl;
 	}, [ addProductUrl ] );
 

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -54,9 +54,9 @@ export default function ProductInterstitial( { installsPlugin = false, slug, chi
 	const needsPurchase = ! isFree && ! hasRequiredPlan;
 
 	const addProductUrl =
-		! needsPurchase || ! wpcomProductSlug
-			? null
-			: getProductCheckoutUrl( wpcomProductSlug, isUserConnected );
+		needsPurchase && wpcomProductSlug
+			? getProductCheckoutUrl( wpcomProductSlug, isUserConnected )
+			: null;
 
 	const navigateToMyJetpackOverviewPage = useMyJetpackNavigate( '/' );
 	const navigateToCheckoutPage = useCallback( () => {

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -61,11 +61,11 @@ export default function ProductInterstitial( { installsPlugin = false, slug, chi
 	const navigateToMyJetpackOverviewPage = useMyJetpackNavigate( '/' );
 	const navigateToCheckoutPage = useCallback( () => {
 		if ( ! addProductUrl ) {
-			return;
+			return navigateToMyJetpackOverviewPage();
 		}
 
 		window.location.href = addProductUrl;
-	}, [ addProductUrl ] );
+	}, [ addProductUrl, navigateToMyJetpackOverviewPage ] );
 
 	const afterInstallation = useCallback(
 		free => {

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -56,7 +56,7 @@ export default function ProductInterstitial( { installsPlugin = false, slug, chi
 	const addProductUrl =
 		! needsPurchase || ! wpcomProductSlug
 			? null
-			: getProductCheckoutUrl( wpcomProductSlug, isUserConnected ); // @ToDo: Remove this when we have a new product structure.
+			: getProductCheckoutUrl( wpcomProductSlug, isUserConnected );
 
 	const navigateToMyJetpackOverviewPage = useMyJetpackNavigate( '/' );
 	const navigateToCheckoutPage = useCallback( () => {

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-set-checkout-url-properly
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-set-checkout-url-properly
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Set properly the checkout link for Products

--- a/projects/packages/my-jetpack/src/products/class-anti-spam.php
+++ b/projects/packages/my-jetpack/src/products/class-anti-spam.php
@@ -101,8 +101,9 @@ class Anti_Spam extends Product {
 	public static function get_pricing_for_ui() {
 		return array_merge(
 			array(
-				'available' => true,
-				'discount'  => 60, // hardcoded - it could be overwritten by the wpcom product.
+				'available'          => true,
+				'wpcom_product_slug' => static::get_wpcom_product_slug(),
+				'discount'           => 60, // hardcoded - it could be overwritten by the wpcom product.
 			),
 			Wpcom_Products::get_product_pricing( static::get_wpcom_product_slug() )
 		);

--- a/projects/packages/my-jetpack/src/products/class-backup.php
+++ b/projects/packages/my-jetpack/src/products/class-backup.php
@@ -111,8 +111,9 @@ class Backup extends Hybrid_Product {
 	public static function get_pricing_for_ui() {
 		return array_merge(
 			array(
-				'available' => true,
-				'discount'  => 60, // hardcoded - it could be overwritten by the wpcom product.
+				'available'          => true,
+				'wpcom_product_slug' => static::get_wpcom_product_slug(),
+				'discount'           => 60, // hardcoded - it could be overwritten by the wpcom product.
 			),
 			Wpcom_Products::get_product_pricing( static::get_wpcom_product_slug() )
 		);

--- a/projects/packages/my-jetpack/src/products/class-scan.php
+++ b/projects/packages/my-jetpack/src/products/class-scan.php
@@ -90,8 +90,9 @@ class Scan extends Module_Product {
 	public static function get_pricing_for_ui() {
 		return array_merge(
 			array(
-				'available' => true,
-				'discount'  => 60, // hardcoded - it could be overwritten by the wpcom product.
+				'available'          => true,
+				'wpcom_product_slug' => static::get_wpcom_product_slug(),
+				'discount'           => 60, // hardcoded - it could be overwritten by the wpcom product.
 			),
 			Wpcom_Products::get_product_pricing( static::get_wpcom_product_slug() )
 		);

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -90,8 +90,9 @@ class Search extends Module_Product {
 	public static function get_pricing_for_ui() {
 		return array_merge(
 			array(
-				'available' => true,
-				'discount'  => 60, // hardcoded - it could be overwritten by the wpcom product.
+				'available'          => true,
+				'wpcom_product_slug' => static::get_wpcom_product_slug(),
+				'discount'           => 60, // hardcoded - it could be overwritten by the wpcom product.
 			),
 			Wpcom_Products::get_product_pricing( static::get_wpcom_product_slug() )
 		);

--- a/projects/packages/my-jetpack/src/products/class-security.php
+++ b/projects/packages/my-jetpack/src/products/class-security.php
@@ -90,8 +90,9 @@ class Security extends Module_Product {
 	public static function get_pricing_for_ui() {
 		return array_merge(
 			array(
-				'available' => true,
-				'discount'  => 60, // hardcoded - it could be overwritten by the wpcom product.
+				'available'          => true,
+				'wpcom_product_slug' => static::get_wpcom_product_slug(),
+				'discount'           => 60, // hardcoded - it could be overwritten by the wpcom product.
 			),
 			Wpcom_Products::get_product_pricing( static::get_wpcom_product_slug() )
 		);

--- a/projects/packages/my-jetpack/src/products/class-videopress.php
+++ b/projects/packages/my-jetpack/src/products/class-videopress.php
@@ -87,8 +87,9 @@ class Videopress extends Module_Product {
 	public static function get_pricing_for_ui() {
 		return array_merge(
 			array(
-				'available' => true,
-				'discount'  => 60, // hardcoded - it could be overwritten by the wpcom product.
+				'available'          => true,
+				'wpcom_product_slug' => static::get_wpcom_product_slug(),
+				'discount'           => 60, // hardcoded - it could be overwritten by the wpcom product.
 			),
 			Wpcom_Products::get_product_pricing( static::get_wpcom_product_slug() )
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR exposes the wpcom product slug to be used to build the checkout product URL. 

<img width="996" alt="image" src="https://user-images.githubusercontent.com/77539/154139225-453df4a2-b2d6-4ae4-92f6-c4b189689a98.png">

(1) Disclaimer: it started to duplicated code so let's address it in a follow-up PR. Probably it's time to add `useCheckoutUrl()` hook \m/

(2) Disclaimer: we have some issues with the user currency. Something that we need to address, in a follow-up PR.

Fixes https://github.com/Automattic/jetpack/issues/22901

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: Set properly the checkout link for Products

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack dashboard
* Test with a site with a free plan
* When installing a new paid product, confirm that the error shown above doesn't appear
* Confirm that the product on the checkout page matches the product in My Jetpack, for instance testing with `Backup` product:

My Jetpack | Checkout
------|------
<img width="479" alt="image" src="https://user-images.githubusercontent.com/77539/154139834-64bf275d-e431-4fe4-96d3-b9625a800c97.png"> | <img width="580" alt="image" src="https://user-images.githubusercontent.com/77539/154139856-05b8987c-ff4c-4adb-ad4d-3c939ae4b4c1.png">

