### PR TITLE
My Jetpack: Improve Product detail layout - Add Active in your site 

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/icons/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/icons/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { Path, SVG, Circle, Rect } from '@wordpress/components';
+import { Path, SVG, Circle, Rect, G } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -122,6 +122,14 @@ export const VideopressIcon = ( { size } ) => (
 export const StarIcon = ( { size, className = styles[ 'star-icon' ] } ) => (
 	<IconWrapper className={ className } size={ size } viewBox="0 0 24 24">
 		<Path d="M12 2l2.582 6.953L22 9.257l-5.822 4.602L18.18 21 12 16.89 5.82 21l2.002-7.14L2 9.256l7.418-.304" />
+	</IconWrapper>
+);
+
+export const CheckmarkIcon = ( { size, className = styles[ 'checkmark-icon' ] } ) => (
+	<IconWrapper className={ className } size={ size } viewBox="0 0 24 24">
+		<G>
+			<Path d="M11 17.768l-4.884-4.884 1.768-1.768L11 14.232l8.658-8.658C17.823 3.39 15.075 2 12 2 6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10c0-1.528-.353-2.97-.966-4.266L11 17.768z" />
+		</G>
 	</IconWrapper>
 );
 

--- a/projects/packages/my-jetpack/_inc/components/icons/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/icons/style.module.scss
@@ -2,3 +2,7 @@
 	fill: black;
 }
 
+.checkmark-icon {
+	---jp-green-primary: #069e08;
+	fill: var(---jp-green-primary);
+}

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -167,22 +167,25 @@ const ProductDetail = ( { slug, onClick, trackButtonClick } ) => {
 				{ isFree && (
 					<h3 className={ styles[ 'product-free' ] }>{ __( 'Free', 'jetpack-my-jetpack' ) }</h3>
 				) }
-				<ProductDetailButton
-					onClick={ clickHandler }
-					isLink
-					isLoading={ isFetching }
-					isPrimary={ ! isBundle }
-					isSecondary={ isBundle }
-					href={ onClick ? undefined : addProductUrl }
-					className={ `${ styles[ 'checkout-button' ] } ${
-						isBundle ? styles[ 'is-bundle' ] : ''
-					}` }
-				>
-					{
-						/* translators: placeholder is product name. */
-						sprintf( __( 'Add %s', 'jetpack-my-jetpack' ), title )
-					}
-				</ProductDetailButton>
+
+				{ ( ! isBundle || ( isBundle && ! hasRequiredPlan ) ) && (
+					<ProductDetailButton
+						onClick={ clickHandler }
+						isLink
+						isLoading={ isFetching }
+						isPrimary={ ! isBundle }
+						isSecondary={ isBundle }
+						href={ onClick ? undefined : addProductUrl }
+						className={ `${ styles[ 'checkout-button' ] } ${
+							isBundle ? styles[ 'is-bundle' ] : ''
+						}` }
+					>
+						{
+							/* translators: placeholder is product name. */
+							sprintf( __( 'Add %s', 'jetpack-my-jetpack' ), title )
+						}
+					</ProductDetailButton>
+				) }
 			</div>
 		</>
 	);
@@ -197,15 +200,13 @@ export { ProductDetail };
 /**
  * ProductDetailCard component.
  *
- * @param {object}   props                - Component props.
- * @param {string}   props.slug           - Product slug
- * @param {Function} props.onClick        - Product CTA button handler
- * @returns {object}                       ProductDetailCard react component.
+ * @param {object}   props - Component props.
+ * @returns {object}         ProductDetailCard react component.
  */
-export default function ProductDetailCard( { onClick, slug } ) {
+export default function ProductDetailCard( props ) {
 	return (
 		<div className={ styles.card }>
-			<ProductDetail onClick={ onClick } slug={ slug } />
+			<ProductDetail { ...props } />
 		</div>
 	);
 }

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -14,7 +14,14 @@ import styles from './style.module.scss';
 import getProductCheckoutUrl from '../../utils/get-product-checkout-url';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import { useProduct } from '../../hooks/use-product';
-import { BackupIcon, ScanIcon, StarIcon, getIconBySlug, AntiSpamIcon } from '../icons';
+import {
+	BackupIcon,
+	ScanIcon,
+	StarIcon,
+	getIconBySlug,
+	AntiSpamIcon,
+	CheckmarkIcon,
+} from '../icons';
 import ProductDetailButton from './button';
 
 /**
@@ -185,6 +192,13 @@ const ProductDetail = ( { slug, onClick, trackButtonClick } ) => {
 							sprintf( __( 'Add %s', 'jetpack-my-jetpack' ), title )
 						}
 					</ProductDetailButton>
+				) }
+
+				{ isBundle && hasRequiredPlan && (
+					<div className={ styles[ 'product-has-required-plan' ] }>
+						<CheckmarkIcon size={ 36 } />
+						{ __( 'Active on your site', 'jetpack-my-jetpack' ) }
+					</div>
 				) }
 			</div>
 		</>

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -175,31 +175,33 @@ const ProductDetail = ( { slug, onClick, trackButtonClick } ) => {
 					<h3 className={ styles[ 'product-free' ] }>{ __( 'Free', 'jetpack-my-jetpack' ) }</h3>
 				) }
 
-				{ ( ! isBundle || ( isBundle && ! hasRequiredPlan ) ) && (
-					<ProductDetailButton
-						onClick={ clickHandler }
-						isLink
-						isLoading={ isFetching }
-						isPrimary={ ! isBundle }
-						isSecondary={ isBundle }
-						href={ onClick ? undefined : addProductUrl }
-						className={ `${ styles[ 'checkout-button' ] } ${
-							isBundle ? styles[ 'is-bundle' ] : ''
-						}` }
-					>
-						{
-							/* translators: placeholder is product name. */
-							sprintf( __( 'Add %s', 'jetpack-my-jetpack' ), title )
-						}
-					</ProductDetailButton>
-				) }
+				<div className={ styles[ 'cta-container' ] }>
+					{ ( ! isBundle || ( isBundle && ! hasRequiredPlan ) ) && (
+						<ProductDetailButton
+							onClick={ clickHandler }
+							isLink
+							isLoading={ isFetching }
+							isPrimary={ ! isBundle }
+							isSecondary={ isBundle }
+							href={ onClick ? undefined : addProductUrl }
+							className={ `${ styles[ 'checkout-button' ] } ${
+								isBundle ? styles[ 'is-bundle' ] : ''
+							}` }
+						>
+							{
+								/* translators: placeholder is product name. */
+								sprintf( __( 'Add %s', 'jetpack-my-jetpack' ), title )
+							}
+						</ProductDetailButton>
+					) }
 
-				{ isBundle && hasRequiredPlan && (
-					<div className={ styles[ 'product-has-required-plan' ] }>
-						<CheckmarkIcon size={ 36 } />
-						{ __( 'Active on your site', 'jetpack-my-jetpack' ) }
-					</div>
-				) }
+					{ isBundle && hasRequiredPlan && (
+						<div className={ styles[ 'product-has-required-plan' ] }>
+							<CheckmarkIcon size={ 36 } />
+							{ __( 'Active on your site', 'jetpack-my-jetpack' ) }
+						</div>
+					) }
+				</div>
 			</div>
 		</>
 	);

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/style.module.scss
@@ -105,6 +105,16 @@
 	& > svg {
 		margin-bottom: 24px;
 	}
+
+	.product-has-required-plan {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		font-size: 18px;
+		svg {
+			margin-right: 5px;
+		}
+	}
 }
 
 .name {

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/style.module.scss
@@ -108,19 +108,21 @@
 		}
 	}
 
-	// Product Icon
-	& > svg {
-		margin-bottom: 24px;
-	}
-
 	.product-has-required-plan {
 		display: flex;
 		justify-content: center;
 		align-items: center;
 		font-size: 18px;
+		align-self: flex-end;
+		margin: 0 auto;
 		svg {
 			margin-right: 5px;
 		}
+	}
+
+	// Product Icon
+	& > svg {
+		margin-bottom: 24px;
 	}
 }
 

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/style.module.scss
@@ -66,6 +66,7 @@
 	flex-direction: column;
 	justify-content: space-between;
 	max-width: 600px;
+	height: 100%;
 	padding: 60px 40px;
 
 	.product-icons {
@@ -87,11 +88,17 @@
 		margin: 18px 0;
 	}
 
+	.cta-container {
+		flex-grow: 2;
+		display: flex;
+		min-height: 60px;
+	}
+
 	.checkout-button {
-		margin: 40px 0 20px;
 		white-space: pre-line;
 		height: auto;
 		line-height: 26px;
+		align-self: flex-end;
 
 		&.is-bundle {
 			&:hover {

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-improve-product-card-layout
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-improve-product-card-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Improve Product detail layout


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR:
* improves the Product detail component to align the buttons when they are next to next (upgradable suggestion)
* Add `Active in your site` message to Security product bundle when the site already has it.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Improve Product detail layout

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to a product that is upgradable by the Security bundle: `anti-spam`, `backup`, `scan`
* Confirm visually that buttons are aligned in the interstitial page

before | after
-----|-----
<img width="1005" alt="Screen Shot 2022-02-15 at 5 09 47 PM" src="https://user-images.githubusercontent.com/77539/154141031-0b6ca1ec-b314-427c-8543-e54ed5c03cd8.png"> | <img width="998" alt="image" src="https://user-images.githubusercontent.com/77539/154141122-44056dc9-6209-4048-a713-5f4016bda8ed.png">

Check the `Active in your site` message:

* Buy the Security bundle
* Go to a product that is upgradable by the Security bundle: `anti-spam`, `backup`, `scan`
* Confirm you see the `Active in your site` instead of the CTA button.

before | after
-----|-----
<img width="950" alt="image" src="https://user-images.githubusercontent.com/77539/154142959-70a922a8-2caa-483b-8d95-ead4b7093309.png"> | <img width="956" alt="image" src="https://user-images.githubusercontent.com/77539/154142843-a387a87c-1b2d-4acb-984b-0ed2f73976b0.png">

