### PR TITLE
Gutenberg: Cache site-specific features for the request lifetime

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-gutenberg-block-registration-features
+++ b/projects/plugins/jetpack/changelog/fix-gutenberg-block-registration-features
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Gutenberg: Cache site-specific features for the request lifetime


### PR DESCRIPTION
This PR is part of a sprint effort by @Automattic/team-calypso-frameworks to improve the load speed and performance of the editor. This particularly improves the TTFB of the editor on Simple sites.

Currently, we call `Jetpack_Gutenberg::set_availability_for_plan()` for several blocks (14 in my test site) that are under a plan or product feature wall. Internally, each of those calls `Store_Product_List::get_site_specific_features_data()`.

However, `Store_Product_List::get_site_specific_features_data()` is not cached; and its return value is the same for every call. It can only be different if we call it for another blog. In my testing on a sandbox, I've found that every `Store_Product_List::get_site_specific_features_data()` adds between 130 and 200 ms of load time. Consequently, this adds around 2 seconds to the load time of the editor page!

#### Changes proposed in this Pull Request:

* Cache the `Store_Product_List::get_site_specific_features_data()` result in `Jetpack_Gutenberg` for the lifetime of the request. 

This way we ensure that it won't be run more than once per request, and instead of 2000ms of delay, we'll have just ~ 150ms. Here's a screenshot of the slow actions:

Before:
![](https://cldup.com/cd1v4_porg.png)

After:
![](https://cldup.com/1QTdgRnAFG.png)

This also seems to reduce the number of queries on the new post page drastically - according to my testing:

Before:
![](https://cldup.com/V8tvtx25Q4.png)

After:
![](https://cldup.com/FWdh9WCcJV.png)

Total execution time is also improved by quite a bit:

Before:
![](https://cldup.com/XI_A1A5jf3.png)

After:
![](https://cldup.com/hwKVPK2Alf.png)


#### Jetpack product discussion
This affects the performance (TTFB) of Gutenberg on all Simple sites.

#### Does this pull request change what data or activity we track or use?
No privacy changes whatsoever.

#### Testing instructions:

Disclaimer: this is only testable on a WP.com Simple site - use the corresponding WP.com diff.

* Sandbox a WP.com simple site by mapping it to your sandbox in your hosts file.
* Go to `YOURSITE.wordpress.com/wp-admin/post-new.php`
* Expand the debug bar. 
* In the sidebar, click on "Slow Actions".
* View the value of `jetpack_register_gutenberg_extensions` and `enqueue_block_editor_assets`.
* Now apply this diff on your sandbox.
* Refresh the new post page.
* Verify that `jetpack_register_gutenberg_extensions` and `enqueue_block_editor_assets` went down drastically after applying this patch.
* Verify that the number of queries also went down drastically after applying this patch.
* Verify that the same blocks are registered as before.