### PR TITLE
Subscribe block: Fix Border Color Serialization

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribe-block-color-serialization
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-block-color-serialization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscribe block: Fix color serialization

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
@@ -47,6 +47,7 @@ export default function SubscriptionControls( {
 	isGradientAvailable,
 	padding,
 	setAttributes,
+	setBorderColor,
 	setButtonBackgroundColor,
 	setTextColor,
 	showSubscribersTotal,
@@ -94,14 +95,7 @@ export default function SubscriptionControls( {
 						},
 						{
 							colorValue: borderColor.color,
-							onColorChange: newBorderColor => {
-								// Note: setBorderColor from withColors hook does not
-								// work correctly with shortcode border color rendering.
-								setAttributes( {
-									borderColor: newBorderColor,
-									customBorderColor: newBorderColor,
-								} );
-							},
+							onColorChange: setBorderColor,
 							label: __( 'Border', 'jetpack' ),
 						},
 					] }
@@ -135,14 +129,7 @@ export default function SubscriptionControls( {
 						},
 						{
 							value: borderColor.color,
-							onColorChange: newBorderColor => {
-								// Note: setBorderColor from withColors hook does not
-								// work correctly with shortcode border color rendering.
-								setAttributes( {
-									borderColor: newBorderColor,
-									customBorderColor: newBorderColor,
-								} );
-							},
+							onColorChange: setBorderColor,
 							label: __( 'Border Color', 'jetpack' ),
 						},
 					] }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -64,6 +64,7 @@ export function SubscriptionEdit( props ) {
 		fallbackTextColor,
 		setTextColor,
 		borderColor,
+		setBorderColor,
 		fontSize,
 	} = props;
 
@@ -218,6 +219,7 @@ export function SubscriptionEdit( props ) {
 					isGradientAvailable={ isGradientAvailable }
 					padding={ padding }
 					setAttributes={ setAttributes }
+					setBorderColor={ setBorderColor }
 					setButtonBackgroundColor={ setButtonBackgroundColor }
 					setTextColor={ setTextColor }
 					showSubscribersTotal={ showSubscribersTotal }


### PR DESCRIPTION
The proposed changes make sure that when user selects one of the theme-registered palette colors for the block border color:

![Markup on 2022-02-17 at 11:29:16](https://user-images.githubusercontent.com/25105483/154459079-41560c8d-f206-4ca7-b72d-749c985fd2ef.png)

the color will be saved as the palette color (e.g. "primary") instead of the related color code (e.g. `#000000`).

Before:
![Markup on 2022-02-17 at 11:57:21](https://user-images.githubusercontent.com/25105483/154465246-77a43c65-6efe-47a9-8227-2e6efc3248fd.png)

After:
![Markup on 2022-02-17 at 11:49:25](https://user-images.githubusercontent.com/25105483/154465345-0738dee3-442d-4a0a-a156-f2c98b7f9c2e.png)

#### Changes proposed in this Pull Request:
- use `setBorderColor()` instead of `setAttributes()` to handle the Subscribe block border color changes

#### Jetpack product discussion
- p1645006316158349-slack-C02TCEHP3HA

#### Does this pull request change what data or activity we track or use?
No, it does not.

#### Testing instructions:

#### Main test
1. Create a new page or a post and add Subscribe block to it
2. Change the border color block setting. Try the _theme preset colors_ and also _custom ones_:
![Markup on 2022-02-16 at 12:28:32](https://user-images.githubusercontent.com/25105483/154255821-4c62d68c-4a63-46ea-922b-2534341ff179.png)
3. Save the changes
4. Observe the changes on both: block editor and frontend. Color should change correctly
5. If you select one of the preset colors, the color should be applied using a CSS class, not an inline style. This can be checked in the browser inspector
6. We can test the proposed changes with multiple themes

#### Backward compatibility test
1. **Before applying the changes in this PR**, create a new post or a page with the Subscribe block
2. Adjust the block settings, especially the border color. Save the changes
3. Apply this PR and reload the editor. The block settings set previously should stay. There should be no block validation errors
4. Change the block settings again, including the border color. Save the changes
5. Observe the changes on both: block editor and frontend. Color should change correctly