### PR TITLE
My Jetpack: switch product endpoint depending on user is connected or not

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-change-wpcom-product-endpoint
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-change-wpcom-product-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Hit the wpcom product endpoint depending on whether the user is connected or not

--- a/projects/packages/my-jetpack/src/class-wpcom-products.php
+++ b/projects/packages/my-jetpack/src/class-wpcom-products.php
@@ -47,22 +47,22 @@ class Wpcom_Products {
 			),
 		);
 
-		$endpoint = sprintf( '/sites/%d/products/?_locale=%s&type=jetpack', \Jetpack_Options::get_option( 'id' ), get_user_locale() );
-		$version  = '1.1';
+		$endpoint = sprintf( '/products/?_locale=%s&type=jetpack', get_user_locale() );
+		$version  = '2';
 
 		// Hit the endpoint depending on the user's connection status.
 		$wpcom_request = $is_user_connected
 			? Client::wpcom_json_api_request_as_user(
 				$endpoint,
 				$version,
-				$params,
-				null,
-				'rest'
+				$params
 			)
 			: Client::wpcom_json_api_request_as_blog(
 				$endpoint,
 				$version,
-				$params
+				$params,
+				null,
+				'wpcom'
 			);
 
 		$response_code = wp_remote_retrieve_response_code( $wpcom_request );

--- a/projects/packages/my-jetpack/src/class-wpcom-products.php
+++ b/projects/packages/my-jetpack/src/class-wpcom-products.php
@@ -47,16 +47,21 @@ class Wpcom_Products {
 			),
 		);
 
+		$endpoint = sprintf( '/sites/%d/products/?_locale=%s&type=jetpack', \Jetpack_Options::get_option( 'id' ), get_user_locale() );
+		$version  = '1.1';
+
 		// Hit the endpoint depending on the user's connection status.
 		$wpcom_request = $is_user_connected
 			? Client::wpcom_json_api_request_as_user(
-				'/products?_locale=' . get_user_locale() . '&type=jetpack',
-				'2',
-				$params
+				$endpoint,
+				$version,
+				$params,
+				null,
+				'rest'
 			)
 			: Client::wpcom_json_api_request_as_blog(
-				sprintf( '/sites/%d/products/?_locale=%s&type=jetpack', \Jetpack_Options::get_option( 'id' ), get_user_locale() ),
-				'1.1',
+				$endpoint,
+				$version,
 				$params
 			);
 
@@ -128,7 +133,7 @@ class Wpcom_Products {
 		if ( is_wp_error( $products ) ) {
 			// Let's see if we have it cached.
 			$cached = self::get_products_from_cache();
-			if ( ! empty( $cached ) ) {
+			if ( ! $skip_cache && ! empty( $cached ) ) {
 				return $cached;
 			} else {
 				return $products;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR switches the wpcom endpoint to hit when requesting products depending on whether the user is connected, or not.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: switch product endpoint depending on user is connected or not

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Testing from CLI

* Connect a site and its user
* `wp shell`
* wp_set_current_user(1);
* Automattic\Jetpack\My_Jetpack\Wpcom_Products::get_products( true );

### Testing in the UI

* Disconnect the user. You should see something like below in My Jetpack dashboard
* <img width="532" alt="image" src="https://user-images.githubusercontent.com/77539/154288003-226742b1-47eb-42bd-912f-49ffe9cd6ab9.png">

* Disable the cache. Hardcoding t[his line](https://github.com/Automattic/jetpack/blob/update/my-jetpack-change-wpcom-product-endpoint/projects/packages/my-jetpack/src/class-wpcom-products.php/#L123):

```php
if ( ! self::is_cache_old() && ! $skip_cache && false ) {
```

* Test with a Free plan
* Add a paid product, for instance, Backup, by clicking on `Add Backup` link
* Confirm you see the price, probably in USD beyond what's your user setting.
* Connect the user
* Confirm you see the prices according to your account. In my case, the currency is EUR


User connected | User disconnected
-------|-------
User token | Blog ser token
currency: USD | currency: EUR
<img width="469" alt="image" src="https://user-images.githubusercontent.com/77539/154287656-5305cb3c-da51-48e4-b428-42b1d1a91615.png"> | <img width="471" alt="image" src="https://user-images.githubusercontent.com/77539/154288080-34123717-0f18-4f74-a174-f3b2e3eae7b4.png">

