### PR TITLE
My Jetpack: Fix Add click for CRM, VideoPress and Anti-Spam product cards

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/anti-spam-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/anti-spam-card.jsx
@@ -30,6 +30,7 @@ const AntiSpamCard = ( { admin } ) => {
 			onDeactivate={ deactivate }
 			slug={ slug }
 			onActivate={ activate }
+			onAdd={ useMyJetpackNavigate( '/add-anti-spam' ) }
 			onFixConnection={ useMyJetpackNavigate( '/connection' ) }
 			onManage={ onManage }
 		/>

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card.jsx
@@ -30,6 +30,7 @@ const VideopressCard = ( { admin } ) => {
 			onDeactivate={ deactivate }
 			onActivate={ activate }
 			slug={ slug }
+			onAdd={ useMyJetpackNavigate( '/add-videopress' ) }
 			onFixConnection={ useMyJetpackNavigate( '/connection' ) }
 			onManage={ onManage }
 		/>

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -113,7 +113,7 @@ export default function ProductInterstitial( { installsPlugin = false, slug, chi
  */
 export function AntiSpamInterstitial() {
 	return (
-		<ProductInterstitial slug="anti-spam">
+		<ProductInterstitial slug="anti-spam" installsPlugin={ true }>
 			<ProductDetailCard slug="security" />
 		</ProductInterstitial>
 	);

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -191,7 +191,7 @@ export function SearchInterstitial() {
  */
 export function VideoPressInterstitial() {
 	return (
-		<ProductInterstitial slug="videopress">
+		<ProductInterstitial slug="videopress" installsPlugin={ true }>
 			<img src={ videoPressImage } alt="VideoPress" />
 		</ProductInterstitial>
 	);

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -152,7 +152,7 @@ export function BoostInterstitial() {
  */
 export function CRMInterstitial() {
 	return (
-		<ProductInterstitial slug="crm">
+		<ProductInterstitial slug="crm" installsPlugin={ true }>
 			<img src={ crmImage } alt="CRM" />
 		</ProductInterstitial>
 	);

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-videopress-anti-spam-clicks
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-videopress-anti-spam-clicks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix clicks on VideoPress and CRM cards

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "0.6.1",
+	"version": "0.6.2-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -27,7 +27,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.6.1';
+	const PACKAGE_VERSION = '0.6.2-alpha';
 
 	/**
 	 * Initialize My Jetapack


### PR DESCRIPTION
Fixes clicks not working on CRM, VideoPress and Anti-Spam  cards

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds click handler for Add actions on CRM, VideoPress and Anti-Spam cards


#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

* Checkout this branch
* Visit My Jetpack
* With the React Dev Tools (components tab) forge the state of the VideoPress, Anti-Spam and CRM cards to be `"plugin_absent"`.
* Confirm clickin Add on them pops up the interstitial and that you can install the plugins from the individiual price buttons.

![image](https://user-images.githubusercontent.com/746152/154328683-421d9464-9f17-436a-9e77-de47d182f6e9.png)

