### PR TITLE
pr-is-up-to-date: Allow checking multiple tags

### DIFF
--- a/.github/files/pr-update-to.sh
+++ b/.github/files/pr-update-to.sh
@@ -36,10 +36,8 @@ for FILE in projects/*/*/composer.json; do
 	FILES+=( "$(realpath -m --relative-to="$BASE" "$(jq -r '.extra.changelogger.changelog // "CHANGELOG.md"' composer.json)")" )
 done
 cd "$BASE"
-for F in $(git diff --name-only HEAD^..HEAD "${FILES[@]}"); do
+for F in $(git -c core.quotepath=off diff --name-only HEAD^..HEAD "${FILES[@]}"); do
 	update_tag "pr-update-to-${F%/*}"
-	# TODO: Remove this once the action uses the above tags.
-	update_tag "pr-update-to"
 done
 
 # If this commit changed tool versions, update the tag so PRs get rechecked with the new versions.

--- a/.github/workflows/pr-is-up-to-date.yml
+++ b/.github/workflows/pr-is-up-to-date.yml
@@ -4,7 +4,9 @@ on:
     branches: [ master ]
   push:
     branches: [ master ]
-    tags: [ pr-update-to ]
+    tags:
+      - pr-update-to
+      - pr-update-to-projects/**
 
 jobs:
   check:
@@ -19,11 +21,40 @@ jobs:
           fetch-depth: 2
           token: ${{ secrets.API_TOKEN_GITHUB }}
 
+      - name: Deepen to merge base
+        if: github.event_name != 'push'
+        uses: ./.github/actions/deepen-to-merge-base
+        with:
+          checkout: false
+
+      - name: Determine tags for PR or tag and paths for tag push
+        id: determine
+        if: github.event_name != 'push' || github.ref != 'refs/heads/master'
+        run: |
+          TAGS=()
+          TAG=
+          PATHS=
+          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+            if [[ "$TAG" == pr-update-to-* ]]; then
+              PATHS="${TAG#pr-update-to-}"
+            fi
+          else
+            TMP="$(git -c core.quotepath=off diff --name-only origin/master...HEAD projects/*/*/ | sed -nE 's!^(projects/[^/]+/[^/]+)/.*!pr-update-to-\1!p' | sort -u)"
+            mapfile -t TAGS <<<"$TMP"
+            TAGS+=( pr-update-to )
+          fi
+          echo "::set-output name=pr-tags::${TAGS[*]}"
+          echo "::set-output name=push-tag::$TAG"
+          echo "::set-output name=push-paths::$PATHS"
+
       - name: Check PR or tag push
         if: github.event_name != 'push' || github.ref != 'refs/heads/master'
         uses: ./projects/github-actions/pr-is-up-to-date
         with:
-          tag: pr-update-to
+          tags: ${{ steps.determine.outputs.pr-tags }}
+          tag: ${{ steps.determine.outputs.push-tag }}
+          paths: ${{ steps.determine.outputs.push-paths }}
           token: ${{ secrets.API_TOKEN_GITHUB }}
           status: PR is up to date
 

--- a/projects/github-actions/pr-is-up-to-date/.gitattributes
+++ b/projects/github-actions/pr-is-up-to-date/.gitattributes
@@ -1,2 +1,3 @@
 # Files to exclude from the mirror repo, but included in the monorepo.
 changelog/**      production-exclude
+tests/**          production-exclude

--- a/projects/github-actions/pr-is-up-to-date/README.md
+++ b/projects/github-actions/pr-is-up-to-date/README.md
@@ -4,7 +4,7 @@ This [Github Action](https://github.com/features/actions) will check that PRs in
 are up to date with respect to a tag.
 
 The idea is to work like GitHub's "Require branches to be up to date before merging" setting,
-but using a tag rather than the HEAD of the target branch.
+but using one or more tags rather than the HEAD of the target branch.
 
 ## Example
 
@@ -21,7 +21,16 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: Automattic/action-pr-is-up-to-date@v1
+      - name: Handle pull request
+        if: github.event_name != 'push'
+        uses: Automattic/action-pr-is-up-to-date@v2
+        with:
+          token: ${{ secrets.API_TOKEN_GITHUB }}
+          tags: latest
+
+      - name: Handle tag push
+        if: github.event_name == 'push'
+        uses: Automattic/action-pr-is-up-to-date@v2
         with:
           token: ${{ secrets.API_TOKEN_GITHUB }}
           tag: latest
@@ -29,17 +38,19 @@ jobs:
 
 ## Usage
 
-This action is intended to be triggered by `pull_request_target` or `pull_request` targeting the specified branch, and by a `push` to the specified tag.
+This action is intended to be triggered by `pull_request_target` or `pull_request` targeting the specified branch, and by a `push` to the specified tags.
 It will not work for pushes to anything else.
 
+### On pull request
+
 ```yaml
-- uses: Automattic/action-pr-is-up-to-date@v1
+- uses: Automattic/action-pr-is-up-to-date@v2
   with:
     # Branch to use. Defaults to the repository's default branch.
     branch:
 
     # Specify the "context" for the status to set. This is what shows up in the
-    # PR's checks list. The default is "PR is up to date with ${{ inputs.tag }}".
+    # PR's checks list. The default is "PR is up to date".
     status:
 
     # Specify the "description" when the PR is out of date.
@@ -49,19 +60,85 @@ It will not work for pushes to anything else.
     # Specify the "description" when the PR is up to date. The default is empty.
     description-ok:
 
-    # Specify the tag that is used for the check. The tag must point to a commit that
-    # is reachable from the input branch.
-    tag:
+    # Specify the tags that are used for the check, separated by whitespace.
+    # The tags must point to commits that are reachable from the input branch.
+    # For backwards compatibility, if `tags` is not set but `tag` is, the single tag in `tag` will be used here.
+    tags:
 
     # GitHub Access Token. The user associated with this token will show up
     # as the "creator" of the status check.
     token:
 ```
 
-The specified tag must, of course, exist. You may update it manually, for example from the command line with
+The current pull request will be checked for being up to date with the specified tags. The status check will be set accordingly.
+
+### On tag push
+
+```yaml
+- uses: Automattic/action-pr-is-up-to-date@v2
+  with:
+    # Branch to use. Defaults to the repository's default branch.
+    branch:
+
+    # Specify the "context" for the status to set. This is what shows up in the
+    # PR's checks list. The default is "PR is up to date".
+    status:
+
+    # Specify the "description" when the PR is out of date.
+    # The default is "This PR needs a ${{ inputs.branch }} merge or rebase.".
+    description-fail:
+
+    # Specify the tag that is used for the check. The tag must point to a commit that
+    # is reachable from the input branch.
+    tag:
+
+    # Only process PRs that touch a file matching one of these paths (one path per line).
+    # Any path format accepted by `git diff` may be used.
+    paths:
+
+    # GitHub Access Token. The user associated with this token will show up
+    # as the "creator" of the status check.
+    token:
+```
+
+All open pull requests targeting the specified branch will be checked for being up to date with the specified tag.
+Any that are not will have the status check set to a failing status.
+
+Pull requests to process may be filtered by setting `paths`. In that case, only PRs that affect the specified paths will be processed.
+
+### Updating tags
+
+You may update tags manually, for example from the command line with
 ```
 git tag --force $TAG $COMMIT
 git push --force origin $TAG
 ```
-Or you might use another action to examine pushes to your branch and update the tag accordingly.
-Either way, the push of the tag will update the status on all open PRs targeting the branch.
+
+Or you might use another action to examine pushes to your branch and update the tags accordingly.
+In that case, you'd want to make sure to use a custom access tokan as [events triggered by the stock `GITHUB_TOKEN` will not trigger workflows](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) and you'll want this workflow to be triggered by the the tag push.
+
+### Multiple tags
+
+As of v2, this action supports use of multiple tags. The intended use is for a monorepo where you want separate tags per project.
+
+* On pull request, you'd analyze the paths affected by the PR to determine which tags apply and pass all relevant tags as `tags`.
+* On push to any of the tags, you'd pass that tag as `tag` and set `paths` to the paths that tag applies to.
+
+Perhaps something like this:
+
+```yaml
+- name: Determine tags for PR or paths for pull request
+  id: determine
+  run: some-script.sh
+- name: Check PR
+  if: github.event_name == 'pull_request'
+  uses: Automattic/action-pr-is-up-to-date@v2
+  with:
+    tags: steps.determine.outputs.pr-tags
+- name: Check tag push
+  if: github.event_name == 'push'
+  uses: Automattic/action-pr-is-up-to-date@v2
+  with:
+    tag: steps.determine.outputs.push-tag
+    paths: steps.determine.outputs.push-paths
+```

--- a/projects/github-actions/pr-is-up-to-date/README.md
+++ b/projects/github-actions/pr-is-up-to-date/README.md
@@ -115,7 +115,7 @@ git push --force origin $TAG
 ```
 
 Or you might use another action to examine pushes to your branch and update the tags accordingly.
-In that case, you'd want to make sure to use a custom access tokan as [events triggered by the stock `GITHUB_TOKEN` will not trigger workflows](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) and you'll want this workflow to be triggered by the the tag push.
+In that case, you'd want to make sure to use a custom access token as [events triggered by the stock `GITHUB_TOKEN` will not trigger workflows](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) and you'll want this workflow to be triggered by the tag push.
 
 ### Multiple tags
 

--- a/projects/github-actions/pr-is-up-to-date/action.yml
+++ b/projects/github-actions/pr-is-up-to-date/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: false
     default: ${{ github.event.repository.default_branch }}
   status:
-    description: Status context for the status check. Default is "PR is up to date with $TAG".
+    description: Status context for the status check. Default is "PR is up to date".
     required: false
   description-fail:
     description: Description field for the status check when the PR is out of date. Default is "This PR needs a $BRANCH merge or rebase."
@@ -17,13 +17,17 @@ inputs:
   description-ok:
     description: Description field for the status check when the PR is up to date. Default is empty.
     required: false
+  tags:
+    description: Whitespace-separated list of tags that the PR must be up to date with. Required when called on pull_request, but currently defaults to `input.tag` if that is set for back compat.
+    required: false
   tag:
-    description: Tag that PRs must be up to date with.
-    required: true
+    description: Tag that PRs must be up to date with. Required when called on push.
+    required: false
+  paths:
+    description: When called on push, only process PRs that touch a file matching one of these paths (one path per line). Any path format accepted by `git diff` may be used.
+    required: false
   token:
-    description: >
-      GitHub Access Token. The user associated with this token will show up
-      as the "creator" of the status check.
+    description: GitHub Access Token. The user associated with this token will show up as the "creator" of the status check.
     required: false
     default: ${{ github.token }}
 runs:
@@ -36,5 +40,7 @@ runs:
         CONTEXT: ${{ inputs.status }}
         DESCRIPTION_FAIL: ${{ inputs.description-fail }}
         DESCRIPTION_OK: ${{ inputs.description-ok }}
+        PATHS: ${{ inputs.paths }}
         TAG: ${{ inputs.tag }}
+        TAGS: ${{ inputs.tags }}
       run: $GITHUB_ACTION_PATH/run.sh

--- a/projects/github-actions/pr-is-up-to-date/changelog/update-pr-is-up-to-date-multiple-tags
+++ b/projects/github-actions/pr-is-up-to-date/changelog/update-pr-is-up-to-date-multiple-tags
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added the ability to check against multiple tags.

--- a/projects/github-actions/pr-is-up-to-date/changelog/update-pr-is-up-to-date-multiple-tags#2
+++ b/projects/github-actions/pr-is-up-to-date/changelog/update-pr-is-up-to-date-multiple-tags#2
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+BREAKING: Changed the default value for the `status` input.

--- a/projects/github-actions/pr-is-up-to-date/composer.json
+++ b/projects/github-actions/pr-is-up-to-date/composer.json
@@ -7,6 +7,9 @@
 	"require-dev": {
 		"automattic/jetpack-changelogger": "3.0.x-dev"
 	},
+	"scripts": {
+		"test-js": "tests/run-tests.sh"
+	},
 	"repositories": [
 		{
 			"type": "path",

--- a/projects/github-actions/pr-is-up-to-date/funcs.sh
+++ b/projects/github-actions/pr-is-up-to-date/funcs.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# Execute `git` with logging of commands.
+#
+# Inputs:
+#  $*: Git command and options.
+function git {
+	printf "\e[32m%s\e[0m\n" "/usr/bin/git $*" >&2
+	/usr/bin/git "$@"
+}
+
+# Initialize the repo in the current directory.
+#
+# Inputs:
+#  $BRANCH: Base branch, e.g. master.
+#  $GITHUB_SERVER_URL: GitHub server URL.
+#  $GITHUB_REPOSITORY: GitHub repository slug.
+#  ${TAGS[@]}: Tags to check against.
+# Outputs:
+#  ${TAGS[@]}: Sorted list of tags.
+function init_repo {
+	echo "::group::Initializing repo"
+	git init -q .
+	git remote add origin "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+	echo "::endgroup::"
+
+	echo "::group::Fetching tags"
+	gitfetch --depth=1 origin tag "${TAGS[@]}" || die "Failed to fetch specified tags"
+	mapfile -t TAGS < <(git tag --list --sort=committerdate "${TAGS[@]}")
+	echo "Tags, in order:"
+	local TAG
+	for TAG in "${TAGS[@]}"; do
+		printf " - %s: %s\n" "$TAG" "$(/usr/bin/git rev-parse --verify "$TAG")"
+	done
+	echo "::endgroup::"
+
+	echo "::group::Fetching $BRANCH"
+	echo "Fetching first commit"
+	gitfetch --depth=1 origin "$BRANCH"
+	local TAG
+	for TAG in "${TAGS[@]}"; do
+		if ! git merge-base --is-ancestor "$TAG" "origin/$BRANCH"; then
+			echo "Fetching commits to $TAG"
+			gitfetch --shallow-exclude="$TAG" origin "$BRANCH"
+			if ! git merge-base --is-ancestor "$TAG" "origin/$BRANCH"; then
+				die "Tag $TAG is not an ancestor of $BRANCH! Aborting."
+			fi
+		else
+			echo "Already have commits to $TAG"
+		fi
+	done
+	echo "::endgroup::"
+}
+
+# Execute `git fetch`, with logging and some cleanup.
+#
+# Note: I've tried including `--filter=tree:0` or `--filter=blob:none`, but git tends to try to
+# implicitly fetch later (including blobs and trees) when commits are missing which defeats the purpose.
+#
+# Inputs:
+#  $*: Git fetch options.
+function gitfetch {
+	git fetch "$@" && git_clean_shallow
+}
+
+# Clean up .git/shallow after a shallow fetch.
+#
+# A shallow fetch will add a graft point to .git/shallow, even if the parent of the graft point exists locally.
+# This makes sense for git's specific intention, but it's not what we want.
+#
+# This function updates .git/shallow to remove any revision where its parent revs exist, and fetches parent
+# revs for merge commits where some but not all parent revs exist.
+function git_clean_shallow {
+	local REV REVS P PP PPM TOFETCH
+
+	[[ -f .git/shallow ]] || return 0
+
+	TOFETCH=()
+	mapfile -t REVS < .git/shallow
+	rm .git/shallow
+	for REV in "${REVS[@]}"; do
+		# Read parents. If any are missing, put the rev back in .git/shallow. If not all are missing, queue the missing ones to be fetched.
+		mapfile -t PP < <(/usr/bin/git cat-file commit "$REV" 2>/dev/null | sed -n 's/^parent //p')
+		PPM=()
+		for P in "${PP[@]}"; do
+			if ! /usr/bin/git cat-file -e "$P" &>/dev/null; then
+				PPM+=( "$P" )
+			fi
+		done
+		if [[ ${#PPM[@]} -gt 0 ]]; then
+			echo "$REV" >> .git/shallow
+			if [[ ${#PP[@]} -ne ${#PPM[@]} ]]; then
+				TOFETCH+=( "${PPM[@]}" )
+			fi
+		fi
+	done
+
+	# If we queued any revs for fetching, fetch them now. Note that'll in turn re-run git_clean_shallow, which should now be able to remove the revs that had them as parents.
+	if [[ ${#TOFETCH[@]} -gt 0 ]]; then
+		gitfetch --depth=1 origin "${TOFETCH[@]}"
+	fi
+}
+
+# Print a GitHub error message and exit.
+#
+# Inputs:
+#  $*: Error message.
+function die {
+	echo "::error::$*"
+	exit 1
+}
+
+# Fetch one or more PRs.
+#
+# Inputs:
+#  $*: PR numbers to fetch.
+#  $BRANCH: Base branch, e.g. master.
+function fetch_prs {
+	local PR REFS=()
+	for PR in "$@"; do
+		REFS+=( "+refs/pull/$PR/head:refs/remotes/pulls/$PR" )
+	done
+
+	gitfetch --shallow-exclude="$BRANCH" origin "${REFS[@]}"
+}
+
+# Test if a PR should be processed.
+#
+# Inputs:
+#  $1: PR number to test.
+#  $BRANCH: Base branch, e.g. master.
+#  ${PATHS[@]}: Paths that must be touched.
+# Returns: 0 if the PR should be processed, non-zero otherwise.
+function should_process_pr {
+	local MB, PR=$1
+	if [[ ${#PATHS[@]} -gt 0 ]]; then
+		git rev-parse --verify "pulls/$PR" &>/dev/null || die "PR #$PR has not been fetched"
+		MB="$(git merge-base "pulls/$PR" "origin/$BRANCH")"
+		# We need to find the merge base in order to diff. If there wasn't one, fetch the needed revs and try again.
+		if [[ -z "$MB" ]]; then
+			# We need to fetch $BRANCH down to the PR, and then deepen the PR by 1 to get the actual merge base.
+			gitfetch --shallow-exclude="refs/pull/$PR/head" origin "$BRANCH" || die "should_process_pr: Failed to fetch $BRANCH to PR #$PR"
+			gitfetch --deepen=1 origin "+refs/pull/$PR/head:refs/remotes/pulls/$PR" || die "should_process_pr: Failed to fetch next revision for PR #$PR"
+			MB="$(git merge-base "pulls/$PR" "origin/$BRANCH")"
+			[[ -z "$MB" ]] && die "Failed to determine merge base for pulls/$PR and origin/$BRANCH"
+		fi
+		! git diff --name-only --exit-code "$MB..pulls/$PR" -- "${PATHS[@]}"
+		return
+	fi
+
+	return 0
+}
+
+# Update status on GitHub.
+#
+# Inputs:
+#  $1: Commit hash being updated.
+#  $2: JSON data for the status update.
+#  $API_TOKEN: GitHub API token for updates.
+#  $CI: Does nothing unless this is non-empty.
+#  $GITHUB_API_URL: GitHub API URL for updates.
+#  $GITHUB_REPOSITORY: GitHub repository for updates.
+function update_github_status {
+	if [[ -n "$CI" ]]; then
+		echo "::group::Setting GitHub status"
+		curl -v \
+			--url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/statuses/${1}" \
+			--header "authorization: Bearer $API_TOKEN" \
+			--header 'content-type: application/json' \
+			--data "$2"
+		local R=$?
+		echo "::endgroup::"
+		return $R
+	fi
+}
+
+# Process a PR.
+#
+# Inputs:
+#  $1: PR numbers to process.
+#  $DATA_FAIL: JSON string to send to GitHub on failure.
+#  $DATA_OK: JSON string to send to GitHub on success.
+#  $NOTIFY_SUCCESS: `true` or `false`, whether to update the GitHub status on success.
+#  ${TAGS[@]}: Tags to check against.
+#  (and anything used by update_github_status)
+function process_pr {
+	local TAG COMMIT PR=$1
+	COMMIT="$(git rev-parse --verify "pulls/$PR")"
+	[[ -z "$COMMIT" ]] && die "PR #$PR has not been fetched"
+	for TAG in "${TAGS[@]}"; do
+		if ! git merge-base --is-ancestor "$TAG" "$COMMIT"; then
+			printf "\e[1;31mPR #%d is outdated\e[0m\n" "$PR"
+			update_github_status "$COMMIT" "$DATA_FAIL"
+			return
+		fi
+	done
+	printf "\e[1;32mPR #%d is up to date\e[0m\n" "$PR"
+	if $NOTIFY_SUCCESS; then
+		update_github_status "$COMMIT" "$DATA_OK"
+	fi
+}
+

--- a/projects/github-actions/pr-is-up-to-date/run.sh
+++ b/projects/github-actions/pr-is-up-to-date/run.sh
@@ -2,23 +2,14 @@
 
 set -eo pipefail
 
-function git {
-	printf "\e[32m%s\e[0m\n" "/usr/bin/git $*" >&2
-	/usr/bin/git "$@"
-}
-
-function die {
-	echo "::error::$*"
-	exit 1
-}
+source ./funcs.sh
 
 GITHUB_API_URL="${GITHUB_API_URL:-https://api.github.com}"
 GITHUB_SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
 [[ -n "$API_TOKEN" ]] || die "API_TOKEN must be set"
 [[ -n "$GITHUB_REPOSITORY" ]] || die "GITHUB_REPOSITORY must be set"
-[[ -n "$TAG" ]] || die "TAG must be set"
 [[ -n "$BRANCH" ]] || die "BRANCH must be set"
-CONTEXT="${CONTEXT:-PR is up to date with $TAG}"
+CONTEXT="${CONTEXT:-PR is up to date}"
 DESCRIPTION_FAIL="${DESCRIPTION_FAIL:-This PR needs a $BRANCH merge or rebase.}"
 DESCRIPTION_OK="${DESCRIPTION_OK:-}"
 
@@ -26,25 +17,35 @@ DATA_FAIL="$(jq --arg url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$G
 DATA_OK="$(jq --arg url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" --arg context "$CONTEXT" --arg desc "$DESCRIPTION_OK" -n '{ "state": "success", "target_url": $url, "context": $context, "description": $desc }')"
 
 case "$GITHUB_EVENT_NAME" in
-	pull_request)
-		if [[ "$GITHUB_REF" =~ ^refs/pull/[0-9]+/merge ]]; then
-			PR="${GITHUB_REF#refs/pull/}"
-			PR="${PR%/merge}"
+	pull_request|pull_request_target)
+		if [[ -n "$TAGS" ]]; then
+			IFS=$' \t\r\n' read -d '' -ra TAGS <<<"$TAGS" || true
+		elif [[ -n "$TAG" ]]; then
+			# Back compat.
+			echo "Deprecation: TAGS should be set instead of TAG on $GITHUB_EVENT_NAME"
+			TAGS=( "$TAG" )
 		else
-			die "Could not determine PR number from GITHUB_REF $GITHUB_REF"
+			die "TAGS (or TAG) must be set on $GITHUB_EVENT_NAME"
 		fi
-		;;
-	pull_request_target)
+
 		PR="$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")"
 		if [[ -z "$PR" ]]; then
 			echo "::error::Could not determine PR number from event data"
-			cat $GITHUB_EVENT_PATH
+			cat "$GITHUB_EVENT_PATH"
 			exit 1
 		fi
 		;;
 	push)
+		[[ -n "$TAG" ]] || die "TAG must be set on $GITHUB_EVENT_NAME"
 		if [[ "$GITHUB_REF" != "refs/tags/$TAG" ]]; then
 			die "Push event for incorrect tag, $GITHUB_REF != refs/tags/$TAG"
+		fi
+		TAGS=( "$TAG" )
+
+		if [[ -n "$PATHS" ]]; then
+			mapfile -t PATHS <<<"$PATHS"
+		else
+			PATHS=()
 		fi
 		;;
 	*)
@@ -53,82 +54,20 @@ case "$GITHUB_EVENT_NAME" in
 esac
 
 TMPDIR="${TMPDIR:-/tmp}"
-DIR=$(mktemp -d "${TMPDIR%/}/check-prs-are-up-to-date.XXXXXXXX")
-trap "rm -rf $DIR" EXIT
-cd $DIR
+DIR="$(mktemp -d "${TMPDIR%/}/pr-is-up-to-date.XXXXXXXX")"
+trap 'rm -rf $DIR' EXIT
+cd "$DIR"
 
-echo "::group::Initializing repo"
-git init -q .
-git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-git fetch --depth=1 origin "$TAG"
-TAG_COMMIT="$(git rev-parse FETCH_HEAD)"
-git repack -d  # Work around a git bug
-echo "::endgroup::"
-echo "Tag $TAG points to $TAG_COMMIT"
-
-echo "::group::Sanity check"
-git fetch --depth=1 origin "$BRANCH"
-git repack -d  # Work around a git bug
-if ! git merge-base --is-ancestor "$TAG_COMMIT" "origin/$BRANCH"; then
-	git fetch --shallow-exclude="$TAG" origin "$BRANCH"
-	git repack -d  # Work around a git bug
-	git fetch --deepen=1 origin "$BRANCH"
-	if ! git merge-base --is-ancestor "$TAG_COMMIT" "origin/$BRANCH"; then
-		echo "::endgroup::"
-		die "Tag $TAG is not an ancestor of $BRANCH! Aborting."
-	fi
-fi
-echo "::endgroup::"
-
-function do_fetch {
-	local PR REFS=()
-	for PR in "$@"; do
-		REFS+=( "+refs/pull/$PR/head:refs/remotes/pulls/$PR" )
-	done
-
-	git fetch --shallow-exclude="$TAG" origin "${REFS[@]}"
-	git repack -d  # Work around a git bug
-	git fetch --deepen=1 origin "${REFS[@]}"
-}
-
-function process_prs {
-	local PR COMMIT
-	for PR in "$@"; do
-		COMMIT="$(git rev-parse "pulls/$PR")"
-		if git merge-base --is-ancestor "$TAG_COMMIT" "$COMMIT"; then
-			printf "\e[1;32mPR $PR is up to date\e[0m\n"
-			if $NOTIFY_SUCCESS && [[ -n "$CI" ]]; then
-				echo "::group::Setting successful status check"
-				curl -v \
-					--url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/statuses/${COMMIT}" \
-					--header "authorization: Bearer $API_TOKEN" \
-					--header 'content-type: application/json' \
-					--data "$DATA_OK"
-				echo "::endgroup::"
-			fi
-		else
-			printf "\e[1;31mPR $PR is outdated\e[0m\n"
-			if [[ -n "$CI" ]]; then
-				echo "::group::Setting failed status check"
-				curl -v \
-					--url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/statuses/${COMMIT}" \
-					--header "authorization: Bearer $API_TOKEN" \
-					--header 'content-type: application/json' \
-					--data "$DATA_FAIL"
-				echo "::endgroup::"
-			fi
-		fi
-	done
-}
+init_repo
 
 NOTIFY_SUCCESS=false
 case "$GITHUB_EVENT_NAME" in
 	pull_request|pull_request_target)
 		NOTIFY_SUCCESS=true
 		echo "::group::Fetching PR $PR"
-		do_fetch "$PR"
+		fetch_prs "$PR"
 		echo "::endgroup::"
-		process_prs "$PR"
+		process_pr "$PR"
 		;;
 	push)
 		declare -i PAGE=1
@@ -139,11 +78,17 @@ case "$GITHUB_EVENT_NAME" in
 			PRS=()
 			mapfile -t PRS < <( jq -r '.[].number' <<<"$JSON" )
 			[[ ${#PRS[@]} != 0 ]] || break
-			do_fetch "${PRS[@]}"
+			fetch_prs "${PRS[@]}"
 
 			echo "::endgroup::"
 
-			process_prs "${PRS[@]}"
+			for PR in "${PRS[@]}"; do
+				if should_process_pr "$PR"; then
+					process_pr "$PR"
+				else
+					printf "\e[1;34mPR #%d does not touch the specified paths\e[0m\n" "$PR"
+				fi
+			done
 
 			jq -e 'length == 100' <<<"$JSON" >/dev/null || break
 			PAGE+=1

--- a/projects/github-actions/pr-is-up-to-date/tests/funcs.sh
+++ b/projects/github-actions/pr-is-up-to-date/tests/funcs.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+
+set -eo pipefail
+
+: "${TESTDIR:?}"
+BASE=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+source "$BASE/funcs.sh"
+
+# Variables expected in the environment.
+GITHUB_SERVER_URL="file://$TESTDIR"
+GITHUB_REPOSITORY=repo
+BRANCH=master
+DATA_FAIL='"FAIL"'
+DATA_OK='"OK"'
+CI=true
+
+# Git needs these
+export GIT_AUTHOR_DATE="1640995200 +0000"
+export GIT_AUTHOR_NAME=Test
+export GIT_AUTHOR_EMAIL=test@example.com
+export GIT_COMMITTER_DATE
+
+# Variable mapping symbolic names to git hashes
+declare -A TEST_COMMITS
+
+# Variable holding GitHub statuses by commit hash.
+declare -A TEST_STATUSES
+
+# Override this to do nothing during tests.
+function update_github_status {
+	TEST_STATUSES[$1]="$2"
+	echo "Set GitHub status for $1: $2"
+}
+
+# Print an error an exit.
+function testfail {
+	printf "\e[31mFAIL: %s\e[0m\n" "$*"
+	exit 1
+}
+
+# Fake the git commit date.
+#
+# Increments GIT_AUTHOR_DATE and GIT_COMMITTER_DATE so each commit can have a separate timestamp.
+# This avoids certain confusion when commits are ordered.
+function test_inc_git_date {
+	GIT_AUTHOR_DATE="$(( ${GIT_AUTHOR_DATE% +0000} + 1 )) +0000"
+	GIT_COMMITTER_DATE="$GIT_AUTHOR_DATE"
+}
+test_inc_git_date
+
+# Initialize a repository for testing.
+#
+# Changes the current directory to the new repo.
+# Creates a "ROOT" entry in $TEST_COMMITS.
+function test_init_repo {
+	mkdir "$TESTDIR/repo"
+	cd "$TESTDIR/repo"
+	git init -b xxx -q .
+	git commit --allow-empty -m 'ROOT'
+	test_inc_git_date
+	TEST_COMMITS[ROOT]="$(git rev-parse HEAD)"
+	git checkout -q "${TEST_COMMITS[ROOT]}"
+	git branch -D xxx
+}
+
+# Create a tree of commits in the test repo
+#
+# Inputs:
+#  $1: Base commit symbol in TEST_COMMITS. Pass the empty string to create a new root.
+#  $*: Commit symbols to create, in order.
+function test_make_commits {
+	[[ "$PWD" == "$TESTDIR/repo" ]] || testfail "test_make_commits: cwd is not $TESTDIR/repo (it's $PWD)"
+
+	if [[ "$1" == "" ]]; then
+		shift
+		git checkout -q --orphan xxx
+		git commit --allow-empty -m "$1"
+		test_inc_git_date
+		TEST_COMMITS[$1]="$(git rev-parse HEAD)"
+		git checkout -q "${TEST_COMMITS[$1]}"
+		git branch -D xxx
+	else
+		[[ -n "${TEST_COMMITS[$1]}" ]] || testfail "test_make_commits: root commit $1 not found"
+		git checkout -q "${TEST_COMMITS[$1]}"
+	fi
+	shift
+	while [[ $# -gt 0 ]]; do
+		[[ -z "${TEST_COMMITS[$1]}" ]] || testfail "test_make_commits: commit $1 already exists"
+		git commit --allow-empty -m "$1" || testfail "test_make_commits: Failed to create commit"
+		test_inc_git_date
+		TEST_COMMITS[$1]="$(git rev-parse HEAD)"
+		shift
+	done
+}
+
+# Create a merge commit in the repo.
+#
+# Inputs:
+#  $1: Symbol for the merge commit.
+#  $*: Commit symbols for the parent commits.
+function test_make_merge {
+	[[ "$PWD" == "$TESTDIR/repo" ]] || testfail "test_make_merge: cwd is not $TESTDIR/repo (it's $PWD)"
+
+	[[ -z "${TEST_COMMITS[$1]}" ]] || testfail "test_make_merge: commit $1 already exists"
+	local NEW=$1
+	shift
+
+	[[ -n "${TEST_COMMITS[$1]}" ]] || testfail "test_make_merge: parent commit $2 not found"
+	git checkout -q "${TEST_COMMITS[$1]}"
+	shift
+
+	local PARENTS=()
+	while [[ $# -gt 0 ]]; do
+		[[ -n "${TEST_COMMITS[$1]}" ]] || testfail "test_make_merge: parent commit $1 not found"
+		PARENTS+=( "${TEST_COMMITS[$1]}" )
+		shift
+	done
+
+	git merge --no-ff -m "$NEW" "${PARENTS[@]}" || testfail "test_make_merge: failed to create commit"
+	test_inc_git_date
+	TEST_COMMITS[$NEW]="$(git rev-parse HEAD)"
+}
+
+# Create a branch in the test repo
+#
+# Inputs:
+#  $1: Branch name.
+#  $2: Commit symbol in TEST_COMMITS.
+function test_make_branch {
+	[[ "$PWD" == "$TESTDIR/repo" ]] || testfail "test_make_branch: cwd is not $TESTDIR/repo (it's $PWD)"
+	[[ -n "${TEST_COMMITS[$2]}" ]] || testfail "test_make_branch: commit $2 not found"
+	git branch "$1" "${TEST_COMMITS[$2]}" || testfail "test_make_branch: failed to create branch"
+}
+
+# Create a tag in the test repo
+#
+# Inputs:
+#  $1: Tag name.
+#  $2: Commit symbol in TEST_COMMITS.
+function test_make_tag {
+	[[ "$PWD" == "$TESTDIR/repo" ]] || testfail "test_make_tag: cwd is not $TESTDIR/repo (it's $PWD)"
+	[[ -n "${TEST_COMMITS[$2]}" ]] || testfail "test_make_tag: commit $2 not found"
+	git tag "$1" "${TEST_COMMITS[$2]}" || testfail "test_make_tag: failed to create tag"
+}
+
+# Create a PR in the test repo
+#
+# Inputs:
+#  $1: PR number.
+#  $2: Commit symbol in TEST_COMMITS.
+function test_make_pr {
+	[[ "$PWD" == "$TESTDIR/repo" ]] || testfail "test_make_pr: cwd is not $TESTDIR/repo (it's $PWD)"
+	[[ -n "${TEST_COMMITS[$2]}" ]] || testfail "test_make_pr: commit $2 not found"
+	git update-ref "refs/pull/$1/head" "${TEST_COMMITS[$2]}" || testfail "test_make_pr: failed to create PR ref"
+}
+
+# Change to a mirror directory to start actual testing
+function test_begin {
+	printf "\n\e[1mTEST: %s\e[0m\n" "$*"
+	rm -rf "$TESTDIR/ci"
+	mkdir "$TESTDIR/ci"
+	cd "$TESTDIR/ci"
+	reset_statuses
+}
+
+# Assert that a status was "set" to GitHub.
+#
+# Inputs:
+#  $1: Commit symbol in TEST_COMMITS.
+#  $2: Status. Pass "$DATA_FAIL" or "$DATA_OK" or the empty string.
+function assert_status {
+	[[ -n "${TEST_COMMITS[$1]}" ]] || testfail "assert_status: commit $1 not found"
+	local C="${TEST_COMMITS[$1]}"
+	local S="${TEST_STATUSES[$C]}"
+	[[ "$S" == "$2" ]] || testfail "assert_status: For $1, expected ${2:-unset} but got ${S:-unset}"
+}
+
+# Assert that a given ref corresponds to exactly the specified commits.
+#
+# Inputs:
+#  $1: Git ref.
+#  $*: Commit symbol in TEST_COMMITS.
+function assert_commits {
+	local REF=$1
+	shift
+	local S EXPECT='' ACTUAL
+	for S in "$@"; do
+		[[ -n "${TEST_COMMITS[$S]}" ]] || testfail "assert_status: commit $S not found"
+		EXPECT+="${TEST_COMMITS[$S]} $S"$'\n'
+	done
+
+	ACTUAL="$(git log --topo-order --format='%H %s' "$REF")"$'\n'
+	diff -u /dev/fd/3 --label expected /dev/fd/4 --label actual 3<<<"$EXPECT" 4<<<"$ACTUAL"
+}
+
+# Reset the statuses array.
+function reset_statuses {
+	TEST_STATUSES=()
+}

--- a/projects/github-actions/pr-is-up-to-date/tests/funcs.sh
+++ b/projects/github-actions/pr-is-up-to-date/tests/funcs.sh
@@ -19,6 +19,8 @@ export GIT_AUTHOR_DATE="1640995200 +0000"
 export GIT_AUTHOR_NAME=Test
 export GIT_AUTHOR_EMAIL=test@example.com
 export GIT_COMMITTER_DATE
+export GIT_COMMITTER_NAME=Test
+export GIT_COMMITTER_EMAIL=test@example.com
 
 # Variable mapping symbolic names to git hashes
 declare -A TEST_COMMITS

--- a/projects/github-actions/pr-is-up-to-date/tests/run-tests.sh
+++ b/projects/github-actions/pr-is-up-to-date/tests/run-tests.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -eo pipefail
+
+BASE=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+TMPDIR="${TMPDIR:-/tmp}"
+DIR=$(mktemp -d "${TMPDIR%/}/pr-is-up-to-date.XXXXXXXX")
+trap 'rm -rf $DIR' EXIT
+
+cd "$BASE/tests"
+EXIT=0
+for TEST in test-*.sh; do
+	DESC="$(sed -E 's/^test-(.*)\.sh$/\1/; s/-/ /g' <<<"$TEST")"
+	printf " -- Running test %s..." "$DESC"
+	mkdir "$DIR/test"
+	if TESTDIR="$DIR/test" "$BASE/tests/$TEST" &>"$DIR/out.txt"; then
+		printf "\r\e[K ✅ \e[32mTest %s passed!\e[0m\n" "$DESC"
+	else
+		printf "\r\e[K ❌ \e[31mTest %s failed!\e[0m\n\n" "$DESC"
+		sed 's/^/      /' < "$DIR/out.txt"
+		printf "\n\n"
+		EXIT=1
+	fi
+	rm -rf "$DIR/test" "$DIR/out.txt"
+done
+
+exit $EXIT

--- a/projects/github-actions/pr-is-up-to-date/tests/test-010-init_repo.sh
+++ b/projects/github-actions/pr-is-up-to-date/tests/test-010-init_repo.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+set -eo pipefail
+
+BASE=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+source "$BASE/tests/funcs.sh"
+
+test_init_repo
+test_make_commits ROOT X1 X2 X3 X4 A B1 C1 D1
+test_make_commits A B2 C2 D2
+test_make_commits A B3 C3 D3
+test_make_merge E D1 D2
+test_make_merge F E D3
+test_make_commits F G H I
+test_make_commits '' O1 O2 O3
+test_make_branch master I
+test_make_tag tagA A
+test_make_tag tagB1 B1
+test_make_tag tagB2 B2
+test_make_tag tagB3 B3
+test_make_tag tagD1 D1
+test_make_tag tagD2 D2
+test_make_tag tagD3 D3
+test_make_tag tagE E
+test_make_tag tagF F
+test_make_tag tagG G
+test_make_tag tagI I
+test_make_tag tagO O3
+
+TAGS=( tagA tagE tagG )
+test_begin "Tags A, E, G"
+init_repo
+assert_commits origin/master I H G F D3 C3 B3 E D2 C2 B2 D1 C1 B1 A
+
+TAGS=( tagI )
+test_begin "Tag I"
+init_repo
+assert_commits origin/master I
+
+TAGS=( tagD1 tagD3 )
+test_begin "Tags D1, D3"
+init_repo
+assert_commits origin/master I H G F D3 C3 B3 E D2 D1
+
+TAGS=( tagD2 tagD3 )
+test_begin "Tags D2, D3"
+init_repo
+assert_commits origin/master I H G F D3 C3 B3 E D2 D1
+
+TAGS=( tagD1 tagD2 )
+test_begin "Tags D1, D2"
+init_repo
+assert_commits origin/master I H G F D3 C3 B3 E D2 C2 B2 D1
+
+TAGS=( tagD1 tagD2 tagD3 )
+test_begin "Tags D1, D2, D3"
+init_repo
+assert_commits origin/master I H G F D3 C3 B3 E D2 C2 B2 D1
+
+TAGS=( tagB1 tagB2 tagB3 )
+test_begin "Tags B1, B2, B3"
+init_repo
+assert_commits origin/master I H G F D3 C3 B3 E D2 C2 B2 D1 C1 B1
+
+TAGS=( tagO )
+test_begin "Tag O"
+if ( init_repo || true ); then
+	testfail 'Expected `init_repo` to exit'
+fi
+
+cd "$TESTDIR/repo"
+git checkout -q master
+git reset --hard tagF
+
+TAGS=( tagA tagI )
+test_begin "Tag I with old master"
+if ( init_repo || true ); then
+	testfail 'Expected `init_repo` to exit'
+fi
+
+TAGS=( tagD1 )
+test_begin "Tag D1 with old master"
+init_repo
+assert_commits origin/master F D3 C3 B3 E D2 D1
+
+TAGS=( tagE )
+test_begin "Tag E with old master"
+init_repo
+assert_commits origin/master F D3 E
+
+TAGS=( tagD3 )
+test_begin "Tag D3 with old master"
+init_repo
+assert_commits origin/master F D3 E
+
+TAGS=( tagB1 tagB2 tagB3 )
+test_begin "Tags B1, B2, B3 with old master"
+init_repo
+assert_commits origin/master F D3 C3 B3 E D2 C2 B2 D1 C1 B1

--- a/projects/github-actions/pr-is-up-to-date/tests/test-020-fetch_prs.sh
+++ b/projects/github-actions/pr-is-up-to-date/tests/test-020-fetch_prs.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -eo pipefail
+
+BASE=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+source "$BASE/tests/funcs.sh"
+
+test_init_repo
+test_make_commits ROOT X1 X2 X3 X4 A B C PR1
+test_make_commits B PR2.1 PR2
+test_make_commits X3 PR3.1 PR3
+test_make_commits X3 PR4.1 PR4.2
+test_make_merge PR4.3 PR4.2 C
+test_make_commits PR4.3 PR4
+test_make_commits X3 PR5.1 PR5.2
+test_make_merge PR5 PR5.2 C
+test_make_branch master C
+test_make_pr 1 PR1
+test_make_pr 2 PR2
+test_make_pr 3 PR3
+test_make_pr 4 PR4
+test_make_pr 5 PR5
+test_make_tag tagB B
+
+TAGS=( tagB )
+
+test_begin "Fetching PR descended from master"
+init_repo
+fetch_prs 1
+assert_commits pulls/1 PR1 C B
+
+test_begin "Fetching PR descended from the tag"
+init_repo
+fetch_prs 2
+assert_commits pulls/2 PR2 PR2.1 B
+
+test_begin "Fetching PR descended from an ancestor"
+init_repo
+fetch_prs 3
+assert_commits pulls/3 PR3 PR3.1
+
+test_begin "Fetching a PR merged with master plus more commits"
+init_repo
+fetch_prs 4
+assert_commits pulls/4 PR4 PR4.3 C B PR4.2
+
+test_begin "Fetching a PR merged with master"
+init_repo
+fetch_prs 5
+assert_commits pulls/5 PR5 C B PR5.2
+
+test_begin "Fetching PR that doesn't exist"
+init_repo
+if fetch_prs 999; then
+	testfail 'Expected `fetch_prs 999` to fail'
+fi

--- a/projects/github-actions/pr-is-up-to-date/tests/test-030-should_process_pr.sh
+++ b/projects/github-actions/pr-is-up-to-date/tests/test-030-should_process_pr.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+set -eo pipefail
+
+BASE=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+source "$BASE/tests/funcs.sh"
+
+function test_make_files {
+	mkdir -p a/b/c
+	touch a/b/c/bar.txt
+	git add a
+}
+
+test_init_repo
+test_make_commits ROOT X1 X2 X3 X4 X5 A B C PR1
+test_make_files
+test_make_commits A PR2
+test_make_commits X3 PR3.1
+test_make_files
+test_make_commits PR3.1 PR3
+test_make_commits X3 PR4.1
+test_make_files
+test_make_commits PR4.1 PR4.2
+test_make_merge PR4 PR4.2 C
+test_make_branch master C
+test_make_pr 1 PR1
+test_make_pr 2 PR2
+test_make_pr 3 PR3
+test_make_pr 4 PR4
+test_make_tag tagA A
+
+TAGS=( tagA )
+
+test_begin "No paths set"
+init_repo
+fetch_prs 1 2 3 4
+if ! should_process_pr 1; then
+	testfail 'Expected `should_process_pr 1` to pass'
+fi
+if ! should_process_pr 2; then
+	testfail 'Expected `should_process_pr 2` to pass'
+fi
+if ! should_process_pr 3; then
+	testfail 'Expected `should_process_pr 3` to pass'
+fi
+if ! should_process_pr 4; then
+	testfail 'Expected `should_process_pr 4` to pass'
+fi
+
+PATHS=( xxx 'a/b/c/*.txt' xyz )
+test_begin "Paths set"
+init_repo
+fetch_prs 1 2
+if should_process_pr 1; then
+	testfail 'Expected `should_process_pr 1` to fail'
+fi
+if ! should_process_pr 2; then
+	testfail 'Expected `should_process_pr 2` to pass'
+fi
+
+PATHS=( xxx bar.txt a/b/c/foo.txt xyz )
+test_begin "Paths set, but not including the touched path"
+init_repo
+fetch_prs 1 2
+if should_process_pr 1; then
+	testfail 'Expected `should_process_pr 1` to fail'
+fi
+if should_process_pr 2; then
+	testfail 'Expected `should_process_pr 2` to fail'
+fi
+
+PATHS=( xxx 'a/b/c/*.txt' xyz )
+test_begin "Forgot to fetch PR"
+init_repo
+if ( should_process_pr 1 || true ); then
+	testfail 'Expected `should_process_pr 1` to exit'
+fi
+if ( should_process_pr 2 || true ); then
+	testfail 'Expected `should_process_pr 2` to exit'
+fi
+
+PATHS=( xxx 'a/b/c/*.txt' xyz )
+test_begin "Paths set, outdated PR"
+init_repo
+fetch_prs 3
+if ! should_process_pr 3; then
+	testfail 'Expected `should_process_pr 3` to pass'
+fi
+
+PATHS=( xxx bar.txt a/b/c/foo.txt xyz )
+test_begin "Paths set but not including the touched path, outdated PR"
+init_repo
+fetch_prs 3
+if should_process_pr 3; then
+	testfail 'Expected `should_process_pr 3` to fail'
+fi
+
+PATHS=( xxx 'a/b/c/*.txt' xyz )
+test_begin "Paths set, master-merged PR"
+init_repo
+fetch_prs 4
+if ! should_process_pr 4; then
+	testfail 'Expected `should_process_pr 4` to pass'
+fi
+
+PATHS=( xxx bar.txt a/b/c/foo.txt xyz )
+test_begin "Paths set but not including the touched path, master-merged PR"
+init_repo
+fetch_prs 4
+if should_process_pr 4; then
+	testfail 'Expected `should_process_pr 4` to fail'
+fi

--- a/projects/github-actions/pr-is-up-to-date/tests/test-040-process_pr.sh
+++ b/projects/github-actions/pr-is-up-to-date/tests/test-040-process_pr.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -eo pipefail
+
+BASE=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+source "$BASE/tests/funcs.sh"
+
+test_init_repo
+test_make_commits ROOT A B C PR1
+test_make_commits A PR2
+test_make_branch master C
+test_make_pr 1 PR1
+test_make_pr 2 PR2
+test_make_tag tagA A
+test_make_tag tagB B
+
+NOTIFY_SUCCESS=true
+TAGS=( tagB )
+test_begin "Tag B, NOTIFY_SUCCESS"
+init_repo
+fetch_prs 1 2
+process_pr 1
+assert_status PR1 "$DATA_OK"
+process_pr 2
+assert_status PR2 "$DATA_FAIL"
+
+NOTIFY_SUCCESS=false
+TAGS=( tagB )
+test_begin "Tag B, no NOTIFY_SUCCESS"
+init_repo
+fetch_prs 1 2
+process_pr 1
+assert_status PR1 ""
+process_pr 2
+assert_status PR2 "$DATA_FAIL"
+
+NOTIFY_SUCCESS=true
+TAGS=( tagA )
+test_begin "Tag A"
+init_repo
+fetch_prs 1 2
+process_pr 1
+assert_status PR1 "$DATA_OK"
+process_pr 2
+assert_status PR2 "$DATA_OK"
+
+NOTIFY_SUCCESS=true
+TAGS=( tagA tagB )
+test_begin "Tags A and B"
+init_repo
+fetch_prs 1 2
+process_pr 1
+assert_status PR1 "$DATA_OK"
+process_pr 2
+assert_status PR2 "$DATA_FAIL"
+
+NOTIFY_SUCCESS=true
+TAGS=( tagB )
+test_begin "Forgot to fetch the PR"
+init_repo
+fetch_prs 2
+if ( process_pr 1 || true ); then
+	testfail 'Expected `process_pr 1` to exit'
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
In our monorepo, we don't want releases of one project to make PRs
against another out of date. The solution is to have one tag per project
(plus the global tag for situations when CI infrastructure changes) and
only check the PR against the relevant project.
    
This needs two changes in the action:
    
1. When called on PR, allow specifying multiple tags.
2. When called on tag push, allow specifying the paths the pushed tag
    affects.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None to link

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You could merge this into master on a fork, then try merging things and updating tags and seeing if it works right. Or you could run the script locally with the proper environment variables set (just don't set `CI` and it won't try to update GitHub).
* Also, proofread the updated docs.