### PR TITLE
My Jetpack: Fix Add click for Scan and Search product cards

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -165,7 +165,7 @@ export function CRMInterstitial() {
  */
 export function ScanInterstitial() {
 	return (
-		<ProductInterstitial slug="scan">
+		<ProductInterstitial slug="scan" installsPlugin={ true }>
 			<ProductDetailCard slug="security" />
 		</ProductInterstitial>
 	);
@@ -178,7 +178,7 @@ export function ScanInterstitial() {
  */
 export function SearchInterstitial() {
 	return (
-		<ProductInterstitial slug="search">
+		<ProductInterstitial slug="search" installsPlugin={ true }>
 			<img src={ searchImage } alt="Search" />
 		</ProductInterstitial>
 	);

--- a/projects/packages/my-jetpack/changelog/fix-click-on-scan-and-search-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/fix-click-on-scan-and-search-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Make Scan and Search interstitials install the plugin


### PR DESCRIPTION
Fixes clicks not working on Scan and Search  cards

Closes #22927 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds installer prop to interstitials


#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

* Checkout this branch
* Visit My Jetpack
* Rmove the Jetpack plugin 
* Confirm clickin Add on Scan or Search installs the Jetpack plugin


