### PR TITLE
My Jetpack: Apply coupon discount to Product price when it exists

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-apply-coupon-when-exists
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-apply-coupon-when-exists
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Apply coupon discount to Product price when it exists

--- a/projects/packages/my-jetpack/src/class-wpcom-products.php
+++ b/projects/packages/my-jetpack/src/class-wpcom-products.php
@@ -157,9 +157,8 @@ class Wpcom_Products {
 			return array();
 		}
 
-		$default_discount = 50;
-		$cost             = $product->cost;
-		$discount_price   = $cost * $default_discount / 100; // default discount.
+		$cost           = $product->cost;
+		$discount_price = $cost;
 
 		// Get/compute the discounted price.
 		if ( isset( $product->introductory_offer->cost_per_interval ) ) {
@@ -177,16 +176,19 @@ class Wpcom_Products {
 			return $pricing;
 		}
 
-		// Check whether the coupon is still valid.
-		$sale            = $product->sale_coupon;
-		$sale_start_date = strtotime( $sale->start_date );
-		$sale_expires    = strtotime( $sale->expires );
-		if ( $sale_start_date > time() || $sale_expires < time() ) {
+		// Check whether it is still valid.
+		$coupon            = $product->sale_coupon;
+		$coupon_start_date = strtotime( $coupon->start_date );
+		$coupon_expires    = strtotime( $coupon->expires );
+		if ( $coupon_start_date > time() || $coupon_expires < time() ) {
 			return $pricing;
 		}
 
-		// Populate response with sale discount.
-		$pricing['discount'] = $sale->discount;
+		// Populate response with coupon discount.
+		$pricing['coupon_discount'] = $coupon->discount;
+
+		// Apply coupon discount to discount price.
+		$pricing['discount_price'] = $discount_price * ( 100 - $coupon->discount ) / 100;
 
 		return $pricing;
 	}

--- a/projects/packages/my-jetpack/tests/php/test-wpcom-products.php
+++ b/projects/packages/my-jetpack/tests/php/test-wpcom-products.php
@@ -206,10 +206,10 @@ class Test_Wpcom_Products extends TestCase {
 		remove_filter( 'pre_http_request', array( $this, 'mock_success_response' ) );
 
 		$expected = array(
-			'currency_code'  => 'BRL',
-			'full_price'     => 4.9,
-			'discount_price' => 2.45,
-			'discount'       => 50,
+			'currency_code'   => 'BRL',
+			'full_price'      => 4.9,
+			'discount_price'  => 2.45,
+			'coupon_discount' => 50,
 		);
 
 		$this->assertSame( $expected, $product_price );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

~# Depends on https://github.com/Automattic/jetpack/pull/22928~

This PR applies the coupon discount to the Product price when it exists.
Currently, some products have a discount (valid until Feb 22). 

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: Apply coupon discount to Product price when it exists

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with a Free site
* Check that all product prices shown on the interstitials page are consistent with what the checkout page shows.
Keep in mind that the price is shown on the interstitial by month.

For instance, with Backup:

Interstitial | Checkout
-----|------
<img width="497" alt="image" src="https://user-images.githubusercontent.com/77539/154367198-ce57f3a1-d746-402c-9971-bdb161a39753.png"> | <img width="584" alt="Screen Shot 2022-02-16 at 7 17 45 PM" src="https://user-images.githubusercontent.com/77539/154366927-0a7e792e-295b-4635-a3f9-2fe5bb27744c.png">
`$9.92`/ `$3.94` | `$119` / `$47.20`
.    | `119 / 12 ~= 9.92` / `47.20 / 12 ~= 3.94`





