### PR TITLE
My Jetpack / Purchases: retrieve localized version of purchases

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-purchases-i18n
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-purchases-i18n
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Purchases: ensure we retrieve translated version of active purchases.

--- a/projects/packages/my-jetpack/src/class-rest-purchases.php
+++ b/projects/packages/my-jetpack/src/class-rest-purchases.php
@@ -61,7 +61,7 @@ class REST_Purchases {
 	 */
 	public static function get_site_current_purchases() {
 		$site_id           = \Jetpack_Options::get_option( 'id' );
-		$wpcom_endpoint    = sprintf( '/sites/%d/purchases', $site_id );
+		$wpcom_endpoint    = sprintf( '/sites/%1$d/purchases?locale=%2$s', $site_id, get_user_locale() );
 		$wpcom_api_version = '1.1';
 		$response          = Client::wpcom_json_api_request_as_blog( $wpcom_endpoint, $wpcom_api_version );
 		$response_code     = wp_remote_retrieve_response_code( $response );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

While testing My Jetpack on a site set to French, I noticed some issues with current plan information.

In the Jetpack client, we have `ProductExpiration` and a hardcoded list of localized product titles based on the active purchases on the site (in `MyPlanBody`). In My Jetpack, however, we pull all the data from the `purchases` endpoint on WordPress.com. As a result, that section of My Jetpack is not translated:

<img width="1168" alt="Screenshot 2022-02-17 at 8 46 50" src="https://user-images.githubusercontent.com/426388/154430760-b91fd719-8f7d-4351-986e-b5641cb8b125.png">

What do you think about retrieving a translated version whenever possible? It's not a perfect solution since the expiration dates won't use the date format set for that site in Settings > General (we'd need to implement something like in the Jetpack plugin to make that happen I think), but at least it will be translated.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start with a site with language set to French, with Jetpack activated, connected to WordPress.com, and where you've purchased one or more products.
* Enable My Jetpack with `JETPACK_ENABLE_MY_JETPACK`
* Go to Jetpack > My Jetpack
* Ensure the list of purchases at the bottom of the page is translated.
