### PR TITLE
Janitorial: add missing @since version numbers

### DIFF
--- a/projects/packages/connection/changelog/fix-next-version-references
+++ b/projects/packages/connection/changelog/fix-next-version-references
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Janitorial: update docblock version numbers.
+
+

--- a/projects/packages/connection/src/class-package-version-tracker.php
+++ b/projects/packages/connection/src/class-package-version-tracker.php
@@ -38,7 +38,7 @@ class Package_Version_Tracker {
 		/**
 		 * Obtains the package versions.
 		 *
-		 * @since $$next_version$$
+		 * @since 1.30.2
 		 *
 		 * @param array An associative array of Jetpack package slugs and their corresponding versions as key/value pairs.
 		 */

--- a/projects/packages/connection/src/class-plugin-storage.php
+++ b/projects/packages/connection/src/class-plugin-storage.php
@@ -239,7 +239,7 @@ class Plugin_Storage {
 	 * This is a fallback to ensure this option is always up to date on WPCOM in case
 	 * Sync is not present or disabled.
 	 *
-	 * @since $$next_version$$
+	 * @since 1.34.0
 	 */
 	private static function update_active_plugins_wpcom_no_sync_fallback() {
 		$connection = new Manager();

--- a/projects/packages/connection/src/class-server-sandbox.php
+++ b/projects/packages/connection/src/class-server-sandbox.php
@@ -33,7 +33,7 @@ class Server_Sandbox {
 		 * Fires when the server sandbox is initialized. This action is used to ensure that
 		 * the server sandbox action hooks are set up only once.
 		 *
-		 * @since $$next_version$$
+		 * @since 1.30.7
 		 */
 		do_action( 'jetpack_server_sandbox_init' );
 	}

--- a/projects/packages/my-jetpack/changelog/fix-next-version-references
+++ b/projects/packages/my-jetpack/changelog/fix-next-version-references
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Janitorial: update docblock version numbers.
+
+

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -59,7 +59,7 @@ class Initializer {
 		/**
 		 * Fires after the My Jetpack package is initialized
 		 *
-		 * @since $$next_version$$
+		 * @since 0.1.0
 		 */
 		do_action( 'my_jetpack_init' );
 	}

--- a/projects/packages/partner/changelog/fix-next-version-references
+++ b/projects/packages/partner/changelog/fix-next-version-references
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Janitorial: update docblock version numbers.
+
+

--- a/projects/packages/partner/src/class-partner-coupon.php
+++ b/projects/packages/partner/src/class-partner-coupon.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Class Jetpack_Partner_Coupon
  *
- * @since $$next_version$$
+ * @since 1.6.0
  */
 class Partner_Coupon {
 
@@ -367,7 +367,7 @@ class Partner_Coupon {
 		/**
 		 * Allow for plugins to register supported products.
 		 *
-		 * @since $$next_version$$
+		 * @since 1.6.0
 		 *
 		 * @param array A list of product details.
 		 * @return array
@@ -436,7 +436,7 @@ class Partner_Coupon {
 		/**
 		 * Allow external code to add additional supported partners.
 		 *
-		 * @since $$next_version$$
+		 * @since 1.6.0
 		 *
 		 * @param array $supported_partners A list of supported partners.
 		 * @return array
@@ -453,7 +453,7 @@ class Partner_Coupon {
 		/**
 		 * Allow external code to add additional supported presets.
 		 *
-		 * @since $$next_version$$
+		 * @since 1.6.0
 		 *
 		 * @param array $supported_presets A list of supported presets.
 		 * @return array

--- a/projects/packages/status/changelog/fix-next-version-references
+++ b/projects/packages/status/changelog/fix-next-version-references
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Janitorial: update docblock version numbers.
+
+

--- a/projects/packages/status/src/class-host.php
+++ b/projects/packages/status/src/class-host.php
@@ -17,7 +17,7 @@ class Host {
 	 * Determine if this site is an WordPress.com on Atomic site or not looking first at the 'at_options' option.
 	 * As a fallback, check for presence of wpcomsh plugin to determine if a current site has undergone AT.
 	 *
-	 * @since $$next_version$$
+	 * @since 1.9.0
 	 *
 	 * @return bool
 	 */
@@ -29,7 +29,7 @@ class Host {
 	/**
 	 * Determine if site is hosted on the Atomic hosting platform.
 	 *
-	 * @since $$next_version$$
+	 * @since 1.9.0
 	 *
 	 * @return bool;
 	 */

--- a/projects/plugins/jetpack/3rd-party/class.jetpack-amp-support.php
+++ b/projects/plugins/jetpack/3rd-party/class.jetpack-amp-support.php
@@ -126,7 +126,7 @@ class Jetpack_AMP_Support {
 	/**
 	 * Determines whether the legacy AMP post templates are being used.
 	 *
-	 * @since $$next_version$$
+	 * @since 10.6.0
 	 *
 	 * @return bool
 	 */

--- a/projects/plugins/jetpack/changelog/fix-next-version-references
+++ b/projects/plugins/jetpack/changelog/fix-next-version-references
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Janitorial: update docblocks' version numbers.
+
+

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -7239,7 +7239,7 @@ endif;
 	/**
 	 * Register product descriptions for partner coupon usage.
 	 *
-	 * @since $$next_version$$
+	 * @since 10.4.0
 	 *
 	 * @param array $products An array of registered products.
 	 *

--- a/projects/plugins/jetpack/functions.global.php
+++ b/projects/plugins/jetpack/functions.global.php
@@ -148,12 +148,12 @@ function jetpack_get_future_removed_version( $version ) {
  * As a fallback, check for presence of wpcomsh plugin to determine if a current site has undergone AT.
  *
  * @since 4.8.1
- * @deprecated  $$next_version$$
+ * @deprecated 10.3.0
  *
  * @return bool
  */
 function jetpack_is_atomic_site() {
-	jetpack_deprecated_function( __FUNCTION__, 'Automattic/Jetpack/Status/Host::is_woa_site', '$$next_version$$' );
+	jetpack_deprecated_function( __FUNCTION__, 'Automattic/Jetpack/Status/Host::is_woa_site', 'jetpack-10.3.0' );
 	return ( new Host() )->is_woa_site();
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* ﻿We use the `$$next-version$$` reference to automatically update version numbers when a project is released, but those few references used `$$next_version$$` instead.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* You could use `git blame` to go and check when each one of those references was added, and ensure that the version numbers I provided are correct. That's what I did, so maybe that's enough :) 
