### PR TITLE
Repo Gardening: avoid throwing an error when no valid milestone

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/fix-repo-gardening-milestone-error
+++ b/projects/github-actions/repo-gardening/changelog/fix-repo-gardening-milestone-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Milestone management: avoid throwing an error when a valid milestone cannot be found. Abort task instead.

--- a/projects/github-actions/repo-gardening/package.json
+++ b/projects/github-actions/repo-gardening/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "repo-gardening",
-	"version": "2.0.2",
+	"version": "2.0.3-alpha",
 	"description": "Manage Pull Requests and issues in your Open Source project (automate labelling, milestones, feedback to PR authors, ...)",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/github-actions/repo-gardening/src/tasks/add-milestone/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-milestone/index.js
@@ -58,7 +58,8 @@ async function addMilestone( payload, octokit ) {
 	const nextMilestone = await getNextValidMilestone( octokit, ownerLogin, repo, plugins[ 0 ] );
 
 	if ( ! nextMilestone ) {
-		throw new Error( `Could not find a valid milestone for ${ plugins[ 0 ] }` );
+		debug( `add-milestone: Could not find a valid milestone for ${ plugins[ 0 ] }. Aborting.` );
+		return;
 	}
 
 	debug( `add-milestone: Adding PR #${ prNumber } to milestone #${ nextMilestone.number }` );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Let's avoid having the whole workflow fail when a valid milestone cannot be found. See https://github.com/Automattic/jetpack/actions/runs/1858103640 for example, where it threw an error just because Boost only has an opened milestone with a due date in the past.
* ﻿Instead, just abort the task and display the error in the log.

#### Jetpack product discussion

* p1645094099777259-slack-C02SV8APDTM

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Not much to test here; let's see if the next Boost PR without a milestone attached throws an error when it's merged?
