### PR TITLE
VideoPress: avoid PHP warnings when accessing media from API.

### DIFF
--- a/projects/plugins/jetpack/changelog/2022-02-17-11-22-57-699265
+++ b/projects/plugins/jetpack/changelog/2022-02-17-11-22-57-699265
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+WordPress.com REST API: avoid PHP warnings when accessing videos from the WordPress.com dashboard.

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1522,7 +1522,10 @@ abstract class WPCOM_JSON_API_Endpoint {
 				? $attachment_metadata['filesize']
 				: 0;
 		} else {
-			$filesize = filesize( $attachment_file );
+			// For VideoPress videos, $attachment_file is the video URL.
+			$filesize = file_exists( $attachment_file )
+				? filesize( $attachment_file )
+				: 0;
 		}
 
 		$response = array(

--- a/projects/plugins/jetpack/modules/videopress/utility-functions.php
+++ b/projects/plugins/jetpack/modules/videopress/utility-functions.php
@@ -481,9 +481,10 @@ function video_get_info_by_blogpostid( $blog_id, $post_id ) {
 
 	if ( $meta && isset( $meta['videopress'] ) ) {
 		$videopress_meta            = $meta['videopress'];
-		$video_info->rating         = $videopress_meta['rating'];
-		$video_info->allow_download =
-			isset( $videopress_meta['allow_download'] )
+		$video_info->rating         = isset( $videopress_meta['rating'] )
+			? $videopress_meta['rating']
+			: null;
+		$video_info->allow_download = isset( $videopress_meta['allow_download'] )
 			? $videopress_meta['allow_download']
 			: 0;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

﻿* When viewing Media from Calypso, including videos, old and new, you may run into warnings. This should fix that.

```
PHP Warning:  Undefined array key "rating" in /wp-content/plugins/jetpack-dev/modules/videopress/utility-functions.php on line 484
PHP Warning:  filesize(): stat failed for https://videos.files.wordpress.com/vgpx3cCK/screen-recording-2021-10-26-at-9.41.35.mov in /wp-content/plugins/jetpack-dev/class.json-api-endpoints.php on line 1525
```

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start from a site that's connected to WordPress.com, with a Video plan, and where you uploaded videos in the past.
* Tail your site's error log.
* Access `https://wordpress.com/media/yoursite.com`
* Ensure you see no errors in your log.
