### PR TITLE
WPCOM API: avoid fatals when editing images from the API.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-media-endpoint-restore-media
+++ b/projects/plugins/jetpack/changelog/fix-media-endpoint-restore-media
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+WordPress.com REST API: avoid errors when restoring the previous version of an image from the WordPress.com dashboard.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-edit-media-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-edit-media-v1-2-endpoint.php
@@ -310,8 +310,12 @@ class WPCOM_JSON_API_Edit_Media_v1_2_Endpoint extends WPCOM_JSON_API_Update_Medi
 			return new WP_Error( 'invalid_url', 'No media provided in url.' );
 		}
 
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$url = wpcom_get_private_file( $url );
+		}
+
 		// save the remote image into a tmp file.
-		$tmp = download_url( wpcom_get_private_file( $url ) );
+		$tmp = download_url( $url );
 		if ( is_wp_error( $tmp ) ) {
 			return $tmp;
 		}


### PR DESCRIPTION
Fixes #22935

#### Changes proposed in this Pull Request:

* WordPress.com has its own media structure; let's limit that implementation to WordPress.com simple sites and use the default behaviour on self-hosted sites.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

1. Start from a site that's connected to WordPress.com, where you've uploaded some images in the past. 
2. Go to `https://wordpress.com/media/yoursite.com`
3. Select an image, and click on Edit (you can also upload a new image and produce the same result)
4. Click on "Edit Image" in the right corner of the image.
5. Save your changes.
6. Go back to edit the same image.
7. A "Restore Image" button now appears next to the "Edit Image" button. Click it
8. When not running this branch, you should get an error, and a Fatal error in your logs.
9. When running this branch, the original version of the image should be restored.
