### PR TITLE
Jetpack: Re-introduce CRM card to At A Glance page 

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
@@ -14,6 +14,7 @@ import { withModuleSettingsFormHelpers } from 'components/module-settings/with-m
 import DashSectionHeader from 'components/dash-section-header';
 import DashActivity from './activity';
 import DashBoost from './boost';
+import DashCRM from './crm';
 import DashStats from './stats/index.jsx';
 import DashProtect from './protect';
 import DashMonitor from './monitor';
@@ -162,7 +163,10 @@ class AtAGlance extends Component {
 			}
 
 			if ( this.props.userCanManagePlugins ) {
-				performanceCards.push( <DashBoost siteAdminUrl={ this.props.siteAdminUrl } /> );
+				performanceCards.push(
+					<DashBoost siteAdminUrl={ this.props.siteAdminUrl } />,
+					<DashCRM siteAdminUrl={ this.props.siteAdminUrl } />
+				);
 			}
 
 			const redeemPartnerCoupon = ! this.props.isOfflineMode && this.props.partnerCoupon && (

--- a/projects/plugins/jetpack/changelog/update-restore-crm-card-aag
+++ b/projects/plugins/jetpack/changelog/update-restore-crm-card-aag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Re-introduce CRM card on At A Glance page for Jetpack


### PR DESCRIPTION

Reverts #22240

Original intention https://github.com/Automattic/jetpack/pull/21866 reverted in #22240


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Re-introduced the CRM card with the upgrade side-loading button now that Jetpack CRM no longer forces the welcome screen on its version 4.9

Solved via  1794-gh-Automattic/zero-bs-crm

#### Jetpack product discussion

p1HpG7-eHP-p2#comment-52374

Original report of problem p8oabR-LV-p2#comment-5778


#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

* Start with a site running this branch, and connected to WordPress.com.
* Build with `jetpack build plugins/myjetpack`
* Go to Jetpack > Dashboard
* You should see a CRM card towards the bottom of the page.