### PR TITLE
Boost: Remove conditional loading of My Jetpack

### DIFF
--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -101,6 +101,7 @@ class Jetpack_Boost {
 		// Fired when plugin ready.
 		do_action( 'jetpack_boost_loaded', $this );
 
+		define( 'JETPACK_ENABLE_MY_JETPACK', true );
 		My_Jetpack_Initializer::init();
 	}
 

--- a/projects/plugins/boost/changelog/update-boost-define-my-jetpack-feature-flag
+++ b/projects/plugins/boost/changelog/update-boost-define-my-jetpack-feature-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Remove check for My Jetpack feature flag


### PR DESCRIPTION
Removes the conditional loading of My Jetpack feature flag from the Boost plugin

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Defines `JETPACK_ENABLE_MY_JETPACK`.

#### Jetpack product discussion

p9dueE-4rG-p2

#### Does this pull request change what data or activity we track or use?

It adds to Boost the set of events tracked by My Jetpack introduced in [all these Pull Requests](https://github.com/Automattic/jetpack/pulls?q=is%3Apr+label%3A%22%5BPackage%5D+My+Jetpack%22+label%3ATracks+is%3Amerged)

#### Testing instructions:

* Build the Boost plugin with `jetpack build plugins/boost`
* Connect Boost
* Confirm that the My Jetpack menu item is shown even when only the Boost plugin is enabled