### PR TITLE
My Jetpack update interstitial page when it has an upgradable bundle

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -92,14 +92,14 @@ export default function ProductInterstitial( { installsPlugin = false, slug, chi
 			horizontalGap={ 0 }
 			fluid
 		>
-			<Col sm={ 4 } md={ 4 } lg={ 5 }>
+			<Col sm={ 4 } md={ 4 } lg={ 7 }>
 				<Product
 					slug={ slug }
 					trackButtonClick={ trackProductClick }
 					onClick={ installsPlugin ? clickHandler : undefined }
 				/>
 			</Col>
-			<Col sm={ 4 } md={ 4 } lg={ 7 } className={ styles.imageContainer }>
+			<Col sm={ 4 } md={ 4 } lg={ 5 } className={ styles.imageContainer }>
 				{ children }
 			</Col>
 		</Container>

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-tweak-interstitial-upgradable-layout
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-tweak-interstitial-upgradable-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update the layout of interstitial page when it has an upgradable bundle


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR updates the layout of the interstitial page when it has an upgradable bundle making it more similar to the design.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack update interstitial page when it has an upgradable bundle

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to an interstitial page that has the upgradable option
* Confirm visually the changes in the widths of both cards

before | after
-----|------
<img width="976" alt="image" src="https://user-images.githubusercontent.com/77539/154563946-79bd3fde-3380-4e15-b8d4-d8f3a7e75822.png"> | <img width="976" alt="image" src="https://user-images.githubusercontent.com/77539/154563890-b03459e2-8f95-45c2-b4b9-455484adaeaa.png">

