### PR TITLE
My Jetpack: Move out from `isPressed` props on `Wordpress/Buttons`

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -62,7 +62,7 @@ const ActionButton = ( {
 	}
 
 	const buttonState = {
-		isPressed: ! isFetching,
+		isPrimary: ! isFetching,
 		disabled: isFetching,
 	};
 
@@ -206,7 +206,7 @@ const ProductCard = props => {
 						/>
 						<DropdownMenu
 							className={ styles.dropdown }
-							toggleProps={ { isPressed: true, disabled: isFetching } }
+							toggleProps={ { isPrimary: true, disabled: isFetching } }
 							popoverProps={ { noArrow: false } }
 							icon={ DownIcon }
 							disableOpenOnArrowDown={ true }

--- a/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
@@ -1,7 +1,4 @@
 .container {
-  // @todo find a better way to change link color
-  // since this could affect more places
-  --wp-admin-theme-color: var(--jp-black);
   // all css variables used down in product-card
   --product-card-shadow: rgba(0, 0, 0, 0.08);
   --product-card-shadow-size: 40px;

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/button.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/button.jsx
@@ -11,7 +11,7 @@ const ProductDetailButton = ( {
 	href,
 	isLoading,
 	onClick,
-	isPressed,
+	isPrimary,
 	isSecondary,
 } ) => {
 	return (
@@ -19,7 +19,7 @@ const ProductDetailButton = ( {
 			onClick={ onClick }
 			className={ className }
 			href={ href }
-			isPressed={ isPressed }
+			isPrimary={ isPrimary }
 			isSecondary={ isSecondary }
 		>
 			{ isLoading ? <Spinner /> : children }

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -191,7 +191,7 @@ const ProductDetail = ( { slug, onClick, trackButtonClick } ) => {
 						<ProductDetailButton
 							onClick={ clickHandler }
 							isLoading={ isFetching }
-							isPressed={ ! isBundle }
+							isPrimary={ ! isBundle }
 							isSecondary={ isBundle }
 							href={ onClick ? undefined : addProductUrl }
 							className={ `${ styles[ 'checkout-button' ] } ${

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/style.module.scss
@@ -42,10 +42,6 @@
 }
 
 .container {
-	// @todo find a better way to change link color
-	// since this could affect more places
-	--wp-admin-theme-color: var(--jp-black);
-
 	// all css variables used down in product-detail-card
 
 	// Colors
@@ -58,9 +54,6 @@
 	--product-card-description-line-height: 1.5;
 	--product-card-description-font-size: 16px;
 	--product-card-price-font-size: 4rem;
-
-	--product-card-action-button-color-hover: white;
-	--product-card-action-button-bg-color-hover: black;
 
 	display: flex;
 	flex-direction: column;
@@ -94,21 +87,6 @@
 		min-height: 60px;
 	}
 
-	.checkout-button {
-		white-space: pre-line;
-		height: auto;
-		line-height: 26px;
-		align-self: flex-end;
-
-		&.is-bundle {
-			&:hover {
-				background-color: var(--product-card-action-button-bg-color-hover);
-				color: var(--product-card-action-button-color-hover);
-				box-shadow: none;
-			}
-		}
-	}
-
 	.product-has-required-plan {
 		display: flex;
 		justify-content: center;
@@ -116,8 +94,27 @@
 		font-size: 18px;
 		align-self: flex-end;
 		margin: 0 auto;
+
 		svg {
 			margin-right: 5px;
+		}
+	}
+
+	.checkout-button {
+		min-height: 42px;
+		line-height: 26px;
+		align-self: flex-end;
+		font-size: var(--product-card-description-font-size);
+		padding: 8px 60px;
+		text-align: center;
+		width: 100%;
+		display: inline-block;
+		white-space: pre-line;
+		height: auto;
+
+		&.is-bundle:hover {
+			background: var(--jp-black);
+			color: var(--jp-white);
 		}
 	}
 
@@ -136,6 +133,7 @@
 .features {
 	margin: 0 0 30px;
 	padding: 0;
+
 	li {
 		list-style: none;
 		display: flex;
@@ -161,7 +159,7 @@
 
 .price {
 	font-size: var(--product-card-price-font-size);
-    display: flex;
+	display: flex;
 	margin: 0;
 	position: relative;
 
@@ -189,7 +187,8 @@
 	}
 
 	&.is-old {
-    	color: #a7aaad;
+		color: #a7aaad;
+
 		&:after {
 			content: " ";
 			display: block;
@@ -209,13 +208,4 @@
 	color: #787c82;
 	letter-spacing: 0.2px;
 	flex-grow: 2;
-}
-
-.checkout-button {
-	align-self: flex-start;
-	font-size: 16px;
-	padding: 8px 60px;
-    text-align: center;;
-	width: 100%;
-	display: inline-block;
 }

--- a/projects/packages/my-jetpack/_inc/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/style.module.scss
@@ -1,5 +1,8 @@
 :global {
 	#my-jetpack-container {
+		--wp-admin-theme-color: var(--jp-black);
+		--wp-admin-theme-color-darker-10: var(--jp-black-80);
+		--wp-admin-theme-color-darker-20: var(--jp-black-80);
 		height: 100%;
 	}
 }

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-buttons-links
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-buttons-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Move from isPressed to CSS vars


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related with #22649 and #22647

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add CSS vars from `wp-admin` to override some `wordpress/components`.
* Remove all `isPressed` props.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `My Jetpack` page.
* Navigate and interact with buttons (Home, Interstitials, and Connection).
* You should see all buttons in black style.

#### Demo

![image](https://user-images.githubusercontent.com/1663717/154569049-1824648c-2e6c-42db-8bd5-8c1b727f9a9b.png)

