### PR TITLE
My Jetpack: Circumvent CRM Wizard and goodbye Screen behaviour when activating or deactivating the plugin

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-circumvent-crm-redirect
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-circumvent-crm-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Circumvent CRM page overriding behaviour when activating and deactivating the plugin

--- a/projects/packages/my-jetpack/src/products/class-crm.php
+++ b/projects/packages/my-jetpack/src/products/class-crm.php
@@ -62,6 +62,26 @@ class Crm extends Product {
 	}
 
 	/**
+	 * Dectivates CRM after circumventing its deactivation survey
+	 *
+	 * @return boolean|WP_Error
+	 */
+	public static function deactivate() {
+		self::circumvent_deactivation_survey();
+		return parent::deactivate();
+	}
+
+	/**
+	 * Does what's necessary to avoid CRM hijacking REST requests and page loads
+	 * when being deactivated
+	 *
+	 * @return boolean
+	 */
+	public static function circumvent_deactivation_survey() {
+		return define( 'ZBSPHPVERDEACTIVATE', 1 );
+	}
+
+	/**
 	 * Get the internationalized product name
 	 *
 	 * @return string

--- a/projects/packages/my-jetpack/src/products/class-crm.php
+++ b/projects/packages/my-jetpack/src/products/class-crm.php
@@ -43,6 +43,25 @@ class Crm extends Product {
 	public static $requires_user_connection = false;
 
 	/**
+	 * Activates CRM after circumventing its Wizard Mechanism
+	 *
+	 * @return boolean|WP_Error
+	 */
+	public static function activate() {
+		self::circumvent_wizard();
+		return parent::activate();
+	}
+
+	/**
+	 * Does what's necessary to avoid CRM hijacking REST requests and page loads
+	 *
+	 * @return boolean
+	 */
+	public static function circumvent_wizard() {
+		return update_option( 'jpcrm_skip_wizard', 1 );
+	}
+
+	/**
 	 * Get the internationalized product name
 	 *
 	 * @return string


### PR DESCRIPTION
Fixes #22785

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Sets an option that will avoid CRM showing the welcome Wizard
* Sets a constant that will avoid CRM showing the deactivation dialog.

#### Jetpack product discussion

#### Does this pull request change what data or activity we track or use?
no
#### Testing instructions:

1. On the docker environment, with Jetack connected with the CRM plugin uninstalled
2. Run from the command line `jetpack docker wp option delete zbs_wizard_run`
3. Visit My Jetpack
4. Click Add CRM
5. On the interstitial page, click the other Add CRM   button
5. Wait until the spinner finishes loading and redirects you to the product cards
6. **Refresh the page immediately**
7. Confirm you don't see the CRM Wizard
8. From the CRM Product card, click Deactivate
9. Expect to see no error about CRM failing to deactivate and the product card updating correctly