### PR TITLE
Jetpack: Circumvent CRM Wizard behaviour when activating the plugin

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -3845,6 +3845,11 @@ class Jetpack_Core_Json_Api_Endpoints {
 			);
 		}
 
+		// Exception to circumvent the Jetpack CRM Wizard.
+		if ( 'zero-bs-crm' === $plugin ) {
+			update_option( 'jpcrm_skip_wizard', 1 );
+		}
+
 		// Now try to activate the plugin.
 		$activated = activate_plugin( $plugin );
 

--- a/projects/plugins/jetpack/changelog/update-my-jetpack-circumvent-crm-redirect
+++ b/projects/plugins/jetpack/changelog/update-my-jetpack-circumvent-crm-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Circumvent CRM Wizard when activating the plugin from the Jetpack dashboard


### PR DESCRIPTION
Follow-up to #22957

Fixes https://github.com/Automattic/jetpack/pull/22957#issuecomment-1043300546

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates the install plugin endpoint to  Set an option that will avoid CRM showing the wizard 

cc @jeherve @leogermani @kbrown9 @cleacos 

#### Jetpack product discussion

p1645124760638949-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?

no

#### Testing instructions:

1. On the docker environment, with Jetpack connected with the CRM plugin uninstalled
2. Run from the command line `jetpack docker wp option delete zbs_wizard_run`
3. Visit the Jetpack dashbaord
4. Find the CRM card and click  Install CRM
5. Wait until the spinner finishes loading 6. **Refresh the page immediately**
7. Confirm you don't see the CRM Wizard