### PR TITLE
Fix Fatal error in the customizer while in sandbox mode

### DIFF
--- a/projects/packages/search/changelog/fix-customizer-fatal-error
+++ b/projects/packages/search/changelog/fix-customizer-fatal-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Fatal error in the customizer while in sandbox mode.

--- a/projects/packages/search/changelog/fix-customizer-fatal-error
+++ b/projects/packages/search/changelog/fix-customizer-fatal-error
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix Fatal error in the customizer while in sandbox mode.

--- a/projects/plugins/jetpack/changelog/fix-customizer-fatal-error
+++ b/projects/plugins/jetpack/changelog/fix-customizer-fatal-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix Fatal error in the WP.com customizer while in sandbox mode.

--- a/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
@@ -271,9 +271,10 @@ class Jetpack_Search_Customize {
 	public function customize_controls_enqueue_scripts() {
 		$script_relative_path = 'customize-controls/customize-controls.js';
 		$script_version       = Automattic\Jetpack\Search\Helper::get_asset_version( $script_relative_path );
+		$script_path          = plugins_url( $script_relative_path, __FILE__ );
 		wp_enqueue_script(
 			'jetpack-instant-search-customizer',
-			__DIR__,
+			$script_path,
 			array( 'customize-controls' ),
 			$script_version,
 			true

--- a/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
@@ -37,8 +37,8 @@ class Jetpack_Search_Customize {
 	 * @param WP_Customize_Manager $wp_customize Customizer instance.
 	 */
 	public function customize_register( $wp_customize ) {
-		require_once dirname( __FILE__ ) . '/customize-controls/class-label-control.php';
-		require_once dirname( __FILE__ ) . '/customize-controls/class-excluded-post-types-control.php';
+		require_once __DIR__ . '/customize-controls/class-label-control.php';
+		require_once __DIR__ . '/customize-controls/class-excluded-post-types-control.php';
 		$section_id     = 'jetpack_search';
 		$setting_prefix = Options::OPTION_PREFIX;
 
@@ -271,10 +271,9 @@ class Jetpack_Search_Customize {
 	public function customize_controls_enqueue_scripts() {
 		$script_relative_path = 'customize-controls/customize-controls.js';
 		$script_version       = Automattic\Jetpack\Search\Helper::get_asset_version( $script_relative_path );
-		$script_path          = dirname( __FILE__ );
 		wp_enqueue_script(
 			'jetpack-instant-search-customizer',
-			$script_path,
+			__DIR__,
 			array( 'customize-controls' ),
 			$script_version,
 			true

--- a/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
+++ b/projects/plugins/jetpack/modules/search/class-jetpack-search-customize.php
@@ -37,8 +37,8 @@ class Jetpack_Search_Customize {
 	 * @param WP_Customize_Manager $wp_customize Customizer instance.
 	 */
 	public function customize_register( $wp_customize ) {
-		require_once dirname( JETPACK__PLUGIN_FILE ) . '/modules/search/customize-controls/class-label-control.php';
-		require_once dirname( JETPACK__PLUGIN_FILE ) . '/modules/search/customize-controls/class-excluded-post-types-control.php';
+		require_once dirname( __FILE__ ) . '/customize-controls/class-label-control.php';
+		require_once dirname( __FILE__ ) . '/customize-controls/class-excluded-post-types-control.php';
 		$section_id     = 'jetpack_search';
 		$setting_prefix = Options::OPTION_PREFIX;
 
@@ -269,9 +269,9 @@ class Jetpack_Search_Customize {
 	 * @since 9.6.0
 	 */
 	public function customize_controls_enqueue_scripts() {
-		$script_relative_path = 'modules/search/customize-controls/customize-controls.js';
+		$script_relative_path = 'customize-controls/customize-controls.js';
 		$script_version       = Automattic\Jetpack\Search\Helper::get_asset_version( $script_relative_path );
-		$script_path          = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
+		$script_path          = dirname( __FILE__ );
 		wp_enqueue_script(
 			'jetpack-instant-search-customizer',
 			$script_path,


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

When attempting to access the customizer for any site while in sandbox mode, the following fatal error is triggered:

```PHP Fatal error:  require_once(): Failed opening required '/home/wpcom/public_html/wp-content/mu-plugins/jetpack/modules/search/customize-controls/class-label-control.php' (include_path='.') in /home/wpcom/public_html/wp-content/mu-plugins/site-search/class-jetpack-search-customize.php on line 41```

To solve the problem, the paths for both `class-label-control.php` and `class-excluded-post-types-control.php` were updated here to match the correct ones.

The path to `customize-controls.js` was also updated to mitigate the 404 errors in the console.

To be honest, I'm a bit puzzled because this error is triggered only on the WP.com sandbox and not on production. It might also be the case that this is a consequence of a process failing elsewhere, but I'm not familiar with this project, so any recommendations are very welcome.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:
* Attempt to access the customizer on any site on WP.com while in sandbox mode (e.g. [the Bloganuary](https://wordpress.com/customize/bloganuary.wordpress.com?return=https%3A%2F%2Fbloganuary.wordpress.com)): you should be able to do so without any problems.
