### PR TITLE
Publicize: Fix double escaping in Classic Editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-publicize-double-escaping
+++ b/projects/plugins/jetpack/changelog/fix-publicize-double-escaping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix double escaping of connections in Classic Editor

--- a/projects/plugins/jetpack/modules/publicize/ui.php
+++ b/projects/plugins/jetpack/modules/publicize/ui.php
@@ -542,7 +542,8 @@ jQuery( function($) {
 				}
 
 				?>
-					<span id="publicize-defaults"><?php echo esc_html( join( ', ', $labels ) ); ?></span>
+					<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- labels are already escaped above ?>
+					<span id="publicize-defaults"><?php echo join( ', ', $labels ); ?></span>
 					<a href="#" id="publicize-form-edit"><?php esc_html_e( 'Edit', 'jetpack' ); ?></a>&nbsp;<a href="<?php echo esc_url( $this->publicize_settings_url ); ?>" rel="noopener noreferrer" target="_blank"><?php esc_html_e( 'Settings', 'jetpack' ); ?></a><br />
 				<?php
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes a minor bug introduced in #22511.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes a minor regression causing the connections info in the Publicize metabox in the Classic Editor to be double escaped.

<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
* Open a new Classic Editor post window.
* Ensure the connections in the Publicize metabox are displayed properly.