### PR TITLE
Subscribe block: Fix icon display color

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribe-block-icon-display
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-block-icon-display
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscribe block: Fix icon display

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/index.js
@@ -23,13 +23,13 @@ export const icon = (
 			width="14.5"
 			height="10.5"
 			rx="1.25"
-			stroke={ getIconColor() }
+			stroke={ 'currentColor' }
 			strokeWidth="1.5"
 			fill="none"
 		/>
 		<Path
 			d="M19 7L13.3609 12.2363C12.5935 12.9489 11.4065 12.9489 10.6391 12.2363L5 7"
-			stroke={ getIconColor() }
+			stroke={ 'currentColor' }
 			strokeWidth="1.5"
 			strokeLinejoin="bevel"
 			fill="none"


### PR DESCRIPTION
Work in progress.

Addresses: #22973.

`getIconColor()` returns either Jetpack color (`Jetpack Green 40`) or `null` depending on whether the site is self-hosted or Simple/Atomic.

Currently, SVG elemnts `<Rect>` and `<Path>` that are essential for the block icon, have attribute `stroke={ getIconColor() }`.

When `getIconColor()` returns `null`, stroke attribute is omitted in the HTML output altogether - making the icon disappear.

This commit replaces `getIconColor()` with `currentColor`. The current color then comes from `foreground: getIconColor()` defined later in the code and fixes the issue #22973.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


#### Changes proposed in this Pull Request:
To be added.

#### Jetpack product discussion
- GH: https://github.com/Automattic/jetpack/issues/22973
- Slack: p1645178788688219-slack-C02TCEHP3HA

#### Does this pull request change what data or activity we track or use?
No, it does not.

#### Testing instructions:
To be added.