### PR TITLE
Always use payments intro when selecting a payments block

### DIFF
--- a/projects/plugins/jetpack/changelog/spread-payments-intro
+++ b/projects/plugins/jetpack/changelog/spread-payments-intro
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Payments Block: Use the payments introduction whenever selecting an eligible payments block - payments button and donations

--- a/projects/plugins/jetpack/extensions/blocks/donations/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/index.js
@@ -27,6 +27,7 @@ export const settings = {
 	keywords: [ __( 'Donations', 'jetpack' ) ],
 	supports: {
 		html: false,
+		inserter: false, // Inserted by payments-intro block
 	},
 	edit,
 	save,

--- a/projects/plugins/jetpack/extensions/blocks/payments-intro/variations.js
+++ b/projects/plugins/jetpack/extensions/blocks/payments-intro/variations.js
@@ -32,9 +32,6 @@ const variationDefinitions = variations
 			title: settings.title,
 			description: settings.description,
 			icon: settings.icon.src,
-			// The inner block itself is already listed in the inserter in its own right, so just include in this blocks
-			// unified intro.
-			scope: [ 'block' ],
 		};
 	} )
 	.filter( blockDefinition => Object.entries( blockDefinition ).length > 0 );

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/index.js
@@ -63,6 +63,7 @@ export const settings = {
 	supports: {
 		html: false,
 		align: true,
+		inserter: false, // Inserted by payments-intro block
 	},
 	deprecated: [ deprecatedV1 ],
 	transforms: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes 599-gh-Automattic/dotcom-manage

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Hide the payments blocks from the block selector and use the payments-intro variations to list them in the block selector instead.

For this purpose payments blocks currently means recurring-payments (Payment button) and Donations blocks.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

See paYJgx-1Hh-p2#comment-2119

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Note, this is branched from and builds upon #22491, I've set that as the target branch to make reviewing the code simpler

**Setup**

Jetpack env: Run pnpm build-extensions from projects/plugins/jetpack/extensions

wpcom: Apply phab patch sandbox as usual

Atomic: Use jetpack beta plugin to select this branch

** Test **

 *  Load gutenberg
 * In the block inserter / you should now be able to find 'Payments button', 'Donations form' and 'Payments'
 * Try inserting a 'Payment' block, you'll then be given a choice of payments button or donations form
 * Try the other two blocks, the same should happen
 * Choose blocks from the payments intro choice, see them inserted as if the payments intro block was never there