### PR TITLE
My Jetpack: Check if product is active before checking if it requires plan

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-check-forpurchase-after-check-for-active
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-check-forpurchase-after-check-for-active
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Check if product is active before checking if requires plan

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -250,13 +250,13 @@ abstract class Product {
 
 		if ( ! static::is_plugin_installed() ) {
 			$status = 'plugin_absent';
-		} elseif ( ! static::has_required_plan() ) {
-			$status = 'needs_purchase';
 		} elseif ( static::is_active() ) {
 			$status = 'active';
 			// We only consider missing user connection an error when the Product is active.
 			if ( static::$requires_user_connection && ! ( new Connection_Manager() )->has_connected_owner() ) {
 				$status = 'error';
+			} elseif ( ! static::has_required_plan() ) {
+				$status = 'needs_purchase';
 			}
 		} else {
 			$status = 'inactive';


### PR DESCRIPTION
Fixes lack of connection error status in Product cards when they had been active prior to visiting My Jetpack

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Moves the check for purchase inside the check for active.

#### Jetpack product discussion

p1645195048392569/1645194604.515169-slack-C02TQF5VAJD

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

1. On a site with just Boost active and My Jetpack enabled. 
2. Connect with boost. 
3. Add Jetpack Backup from the plugin repository
4. Visit My jetpack
5. Confirm you see the "requires user connection" message and the "Fix connection" button on the card

![image](https://user-images.githubusercontent.com/746152/154708841-0b659ade-5684-4c9f-9225-f9136c66aea3.png)
