### PR TITLE
Add Filesystem write access to the initial state

### DIFF
--- a/projects/packages/my-jetpack/changelog/add-write-access-initial-state
+++ b/projects/packages/my-jetpack/changelog/add-write-access-initial-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Filesystem write access to the initial state

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -118,6 +118,7 @@ class Initializer {
 				'topJetpackMenuItemUrl' => Admin_Menu::get_top_level_menu_item_url(),
 				'siteSuffix'            => ( new Status() )->get_site_suffix(),
 				'myJetpackVersion'      => self::PACKAGE_VERSION,
+				'fileSystemWriteAccess' => self::has_file_system_write_access(),
 			)
 		);
 
@@ -228,6 +229,47 @@ class Initializer {
 		}
 
 		return rest_ensure_response( $body, 200 );
+	}
+
+	/**
+	 * Returns true if the site has file write access to the plugins folder, false otherwise.
+	 *
+	 * @return bool
+	 **/
+	public static function has_file_system_write_access() {
+
+		$cache = get_transient( 'my_jetpack_write_access' );
+
+		if ( false !== $cache ) {
+			return $cache;
+		}
+
+		if ( ! function_exists( 'get_filesystem_method' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/template.php';
+
+		$write_access = 'no';
+
+		$filesystem_method = get_filesystem_method( array(), WP_PLUGIN_DIR );
+		if ( 'direct' === $filesystem_method ) {
+			$write_access = 'yes';
+		}
+
+		if ( ! $write_access ) {
+			ob_start();
+			$filesystem_credentials_are_stored = request_filesystem_credentials( self_admin_url() );
+			ob_end_clean();
+
+			if ( $filesystem_credentials_are_stored ) {
+				$write_access = 'yes';
+			}
+		}
+
+		set_transient( 'my_jetpack_write_access', $write_access, 30 * MINUTE_IN_SECONDS );
+
+		return $write_access;
 	}
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We want to correctly inform the user when we are not able to install plugins for them, so we are adding this information on the initial state.

Since the check is made by trying to write a file to the filesystem, I decided to cache this so we don't do it on every request to My Jetpack. By using transients, there could be ambiguity if we stored a boolean (get_transient will return false if the transient does not exist), so I went with `yes` and `no`.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add Filesystem write access to the initial state

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1645191421562159-C02TQF5VAJD-slack

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack page
* inspect the global `myJetpackInitialState` var and verify there's a `fileSystemWriteAccess` var with a value of `yes` or `no`
* On your local dev env, it should probably be "no" (if it's like mine)
* On a JN site it should be "yes"
* On a JN site you can SSH into it and change the file permissions on the plugins folder
* Clear the cache `wp transient delete my_jetpack_write_access`
* It should change to "no"
*
