### PR TITLE
My Jetpack: prevent calling activation hook when activating backup

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-fix-backup-activation-response
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-fix-backup-activation-response
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+prevent calling activation hook when activating backup

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -330,7 +330,12 @@ abstract class Product {
 			return new WP_Error( 'not_allowed', __( 'You are not allowed to activate plugins on this site.', 'jetpack-my-jetpack' ) );
 		}
 
-		$result = activate_plugin( static::get_installed_plugin_filename() );
+		/*
+		 * Silent mode True.
+		 * > Whether to prevent calling activation hooks.
+		 * > https://developer.wordpress.org/reference/functions/activate_plugin/
+		 */
+		$result = activate_plugin( static::get_installed_plugin_filename(), '', false, true );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

My Jetpack: prevent calling activation hook when activating backup.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: prevent calling activation hook when activating backup

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*
