### PR TITLE
handle authorize_redirect from connection package

### DIFF
--- a/projects/packages/connection/changelog/add-connection-handle-authorize-redirect
+++ b/projects/packages/connection/changelog/add-connection-handle-authorize-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Handle the Authorization Redirect from the Connection package


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

WORK IN PROGRESS

Proof of concept to fix the checkout flow with `unlinked=1` when Jetpack plugin is not present

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Launch a JN site with only Boost in this branch
* Connect Boost
* Make sure Backup plugin is NOT installed
* Go to My Jetpack
* Click Add Backup
* Add Backup
* You should be redirected to authorize your user
* After authorizing, you should go to Checkout
* After purchasing you should go back to your site with Backup working
* In the Connection Status settings, you should see your user is properly connected to the site

