### PR TITLE
Search: add chart.js dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -749,7 +749,7 @@ importers:
       '@wordpress/element': 4.1.0
       '@wordpress/i18n': 4.3.0
       '@wordpress/icons': 6.2.0
-      chart.js: 3.7.1
+      chart.js: ^3.7.1
       classnames: 2.3.1
       concurrently: 6.4.0
       fast-json-stable-stringify: 2.1.0
@@ -20446,7 +20446,7 @@ packages:
     dependencies:
       array.prototype.flat: 1.2.5
       global-cache: 1.2.1
-      react-with-styles: 3.2.3_react-dom@17.0.2+react@17.0.2
+      react-with-styles: 3.2.3
 
   /react-with-styles/3.2.3:
     resolution: {integrity: sha512-MTI1UOvMHABRLj5M4WpODfwnveHaip6X7QUMI2x6zovinJiBXxzhA9AJP7MZNaKqg1JRFtHPXZdroUC8KcXwlQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -749,6 +749,7 @@ importers:
       '@wordpress/element': 4.1.0
       '@wordpress/i18n': 4.3.0
       '@wordpress/icons': 6.2.0
+      chart.js: 3.7.1
       classnames: 2.3.1
       concurrently: 6.4.0
       fast-json-stable-stringify: 2.1.0
@@ -786,6 +787,7 @@ importers:
       '@wordpress/element': 4.1.0
       '@wordpress/i18n': 4.3.0
       '@wordpress/icons': 6.2.0
+      chart.js: 3.7.1
       classnames: 2.3.1
       fast-json-stable-stringify: 2.1.0
       gridicons: 3.3.1_react@17.0.2
@@ -10554,6 +10556,10 @@ packages:
   /charm/0.1.2:
     resolution: {integrity: sha1-BsIe7RobBq62dVPNxT4jJ0usIpY=}
     dev: true
+
+  /chart.js/3.7.1:
+    resolution: {integrity: sha512-8knRegQLFnPQAheZV8MjxIXc5gQEfDFD897BJgv/klO/vtIyFFmgMXrNfgrXpbTr/XbTturxRgxIXx/Y+ASJBA==}
+    dev: false
 
   /check-error/1.0.2:
     resolution: {integrity: sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=}
@@ -20440,7 +20446,7 @@ packages:
     dependencies:
       array.prototype.flat: 1.2.5
       global-cache: 1.2.1
-      react-with-styles: 3.2.3
+      react-with-styles: 3.2.3_react-dom@17.0.2+react@17.0.2
 
   /react-with-styles/3.2.3:
     resolution: {integrity: sha512-MTI1UOvMHABRLj5M4WpODfwnveHaip6X7QUMI2x6zovinJiBXxzhA9AJP7MZNaKqg1JRFtHPXZdroUC8KcXwlQ==}

--- a/projects/packages/search/changelog/add-search-chart-js
+++ b/projects/packages/search/changelog/add-search-chart-js
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search: add chart.js package to dependencies

--- a/projects/packages/search/changelog/add-search-chart-js
+++ b/projects/packages/search/changelog/add-search-chart-js
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: added
 
 Search: add chart.js package to dependencies

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.9.0",
+	"version": "0.9.1-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -47,6 +47,7 @@
 		"@wordpress/element": "4.1.0",
 		"@wordpress/i18n": "4.3.0",
 		"@wordpress/icons": "6.2.0",
+		"chart.js": "^3.7.1",
 		"classnames": "2.3.1",
 		"fast-json-stable-stringify": "2.1.0",
 		"gridicons": "3.3.1",

--- a/projects/packages/search/search.php
+++ b/projects/packages/search/search.php
@@ -7,7 +7,7 @@
 
 namespace Automattic\Jetpack\Search;
 
-define( 'JETPACK_SEARCH_PKG__VERSION', '0.9.0' );
+define( 'JETPACK_SEARCH_PKG__VERSION', '0.9.1-alpha' );
 define( 'JETPACK_SEARCH_PKG__DIR', __DIR__ . '/' );
 define( 'JETPACK_SEARCH_PKG__SLUG', 'search' );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Add chart.js dependency to the Search package. This is needed to render the Record Meter.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Do `jetpack install --all` and ensure chart.js is installed.