### PR TITLE
My Jetpack: Fix click tracking on My Jetpack interstitial for Security bundle

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -24,11 +24,17 @@ import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
  *
  * @param {object} props                 - Component props.
  * @param {string} props.slug            - Product slug
+ * @param {string} props.bundle          - Bundle including this product
  * @param {object} props.children        - Product additional content
  * @param {boolean} props.installsPlugin - Whether the interstitial button installs a plugin*
  * @returns {object}                       ProductInterstitial react component.
  */
-export default function ProductInterstitial( { installsPlugin = false, slug, children = null } ) {
+export default function ProductInterstitial( {
+	bundle,
+	installsPlugin = false,
+	slug,
+	children = null,
+} ) {
 	const { activate, detail } = useProduct( slug );
 	const {
 		isUpgradableByBundle,
@@ -47,6 +53,10 @@ export default function ProductInterstitial( { installsPlugin = false, slug, chi
 	const trackProductClick = useCallback( () => {
 		recordEvent( 'jetpack_myjetpack_product_interstitial_add_link_click', { product: slug } );
 	}, [ recordEvent, slug ] );
+
+	const trackBundleClick = useCallback( () => {
+		recordEvent( 'jetpack_myjetpack_product_interstitial_add_link_click', { product: bundle } );
+	}, [ recordEvent, bundle ] );
 
 	const Product = isUpgradableByBundle ? ProductDetailCard : ProductDetail;
 	const { isUserConnected } = useMyJetpackConnection();
@@ -92,7 +102,11 @@ export default function ProductInterstitial( { installsPlugin = false, slug, chi
 				/>
 			</Col>
 			<Col sm={ 4 } md={ 4 } lg={ 5 } className={ styles.imageContainer }>
-				{ children }
+				{ bundle ? (
+					<ProductDetailCard slug="security" trackButtonClick={ trackBundleClick } />
+				) : (
+					children
+				) }
 			</Col>
 		</Container>
 	);
@@ -104,11 +118,7 @@ export default function ProductInterstitial( { installsPlugin = false, slug, chi
  * @returns {object} AntiSpamInterstitial react component.
  */
 export function AntiSpamInterstitial() {
-	return (
-		<ProductInterstitial slug="anti-spam" installsPlugin={ true }>
-			<ProductDetailCard slug="security" />
-		</ProductInterstitial>
-	);
+	return <ProductInterstitial slug="anti-spam" installsPlugin={ true } bundle="security" />;
 }
 
 /**
@@ -117,11 +127,7 @@ export function AntiSpamInterstitial() {
  * @returns {object} BackupInterstitial react component.
  */
 export function BackupInterstitial() {
-	return (
-		<ProductInterstitial slug="backup" installsPlugin={ true }>
-			<ProductDetailCard slug="security" />
-		</ProductInterstitial>
-	);
+	return <ProductInterstitial slug="backup" installsPlugin={ true } bundle="security" />;
 }
 
 /**
@@ -156,11 +162,7 @@ export function CRMInterstitial() {
  * @returns {object} ScanInterstitial react component.
  */
 export function ScanInterstitial() {
-	return (
-		<ProductInterstitial slug="scan" installsPlugin={ true }>
-			<ProductDetailCard slug="security" />
-		</ProductInterstitial>
-	);
+	return <ProductInterstitial slug="scan" installsPlugin={ true } bundle="security" />;
 }
 
 /**

--- a/projects/packages/my-jetpack/changelog/add-tracks-events-my-jetpack-security-product-card
+++ b/projects/packages/my-jetpack/changelog/add-tracks-events-my-jetpack-security-product-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix click on security add click on My Jetpack interstitial


### PR DESCRIPTION

Fixes lack of event tracking when clicking the Add Security button on the product interstitial

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes click tracking on My Jetpack interstitial for Security bundle

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
* Checkout this branch on a site with Jetpack connected the Backup plugin active, and the `JETPACK_ENABLE_MY_JETPACK` constant set to `true`.
* Open the browser and visit the site's wp-admin.
* Open the developer console, execute the following code: `localStorage.debug='dops:analyitics*`
* Go to this patch `wp-admin/admin.php?page=my-jetpack#/add-scan`. 
* Click the Add Security button on the right card
* Confirm that the developer console displays the events `jetpack_myjetpack_product_interstitial_add_link_click` 
