### PR TITLE
My Jetpack: Load My Jetpack by default unless explicitly asked to check for the constant

### DIFF
--- a/projects/packages/my-jetpack/README.md
+++ b/projects/packages/my-jetpack/README.md
@@ -6,18 +6,36 @@ WP Admin page with information and configuration shared among all Jetpack stand-
 
 Every Jetpack plugin must include the My Jetpack package.
 
-Define the `JETPACK_ENABLE_MY_JETPACK` constant as true:
-
-```php
-defined( 'JETPACK_ENABLE_MY_JETPACK' ) || define( 'JETPACK_ENABLE_MY_JETPACK', true );
-```
-
 Require this package and initialize it:
 
 ```PHP
 add_action( 'init', function() {
 	Automattic\Jetpack\My_Jetpack\Initializer::init();
 } );
+```
+
+### Conditionally loading My Jetpack behind a feature flag
+
+Initialize My Jetpack passing `true` to `init()` instead: 
+
+```PHP
+add_action( 'init', function() {
+	Automattic\Jetpack\My_Jetpack\Initializer::init( true );
+} );
+```
+
+Define the `JETPACK_ENABLE_MY_JETPACK` constant as true:
+
+```php
+defined( 'JETPACK_ENABLE_MY_JETPACK' ) || define( 'JETPACK_ENABLE_MY_JETPACK', true );
+```
+
+### Conditionally loading My Jetpack via a filter
+
+Set `jetpack_my_jetpack_should_initialize` to return false for avoiding the initialization of My Jetpack..
+
+```
+add_filter( 'jetpack_my_jetpack_should_initialize', '__return_false' );
 ```
 
 That's all!

--- a/projects/packages/my-jetpack/changelog/update-add-cold-feet-mechanism-for-enabling-my-jetpack-by-default
+++ b/projects/packages/my-jetpack/changelog/update-add-cold-feet-mechanism-for-enabling-my-jetpack-by-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add $check_for_feature_flag argument to My Jetpack init method defaulting to false

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -30,12 +30,17 @@ class Initializer {
 	const PACKAGE_VERSION = '0.6.2-alpha';
 
 	/**
-	 * Initialize My Jetapack
+	 * Initialize My Jetpack
+	 *
+	 * If $check_for_feature_flag is true, My Jetpack will only be loaded if the constant JETPACK_ENABLE_MY_JETPACK is set to true.
+	 * This helps with integration on plugins that just started including the My Jetpack page.
+	 *
+	 * @param boolean $check_for_feature_flag Whether to check for presence of feature flag before deciding to load My Ketpack. Defaults to false.
 	 *
 	 * @return void
 	 */
-	public static function init() {
-		if ( ! self::should_initialize() ) {
+	public static function init( $check_for_feature_flag = false ) {
+		if ( ! self::should_initialize( $check_for_feature_flag ) ) {
 			return;
 		}
 
@@ -183,8 +188,10 @@ class Initializer {
 
 	/**
 	 * Return true if we should initialize the My Jetpack
+	 *
+	 * @param boolean $check_for_feature_flag Whether to check for presence of feature flag before returning true.
 	 */
-	public static function should_initialize() {
+	public static function should_initialize( $check_for_feature_flag ) {
 		if ( did_action( 'my_jetpack_init' ) ) {
 			return false;
 		}
@@ -199,7 +206,7 @@ class Initializer {
 		$should = apply_filters( 'jetpack_my_jetpack_should_initialize', true );
 
 		// Feature flag while we are developing it.
-		if ( ! defined( 'JETPACK_ENABLE_MY_JETPACK' ) || ! JETPACK_ENABLE_MY_JETPACK ) {
+		if ( $check_for_feature_flag && ( ! defined( 'JETPACK_ENABLE_MY_JETPACK' ) || ! JETPACK_ENABLE_MY_JETPACK ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
Sets My Jetpack loading to on by default. 

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Implements initializing by default behaviour
* Implements argument to initializer method to optionally check for feature flag (`JETPACK_ENABLE_MY_JETPACK` constant).
* Updates README.md

#### Jetpack product discussion

p9dueE-4rG-p2

#### Does this pull request change what data or activity we track or use?

no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**On a site with Boost bleeding edge and connected.**
* Confirm the My Jetpack page is shown without any constant set


**On a site with Backup bleeding edge and connected.**
* Confirm the My Jetpack page is shown without any constant set


**On a site with Jetpack bleeding edge and connected.**
* Confirm the My Jetpack page is shown without any constant set