### PR TITLE
My Jetpack: Return needs purchase status for Module Products

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-product-needs-purchase-status
+++ b/projects/packages/my-jetpack/changelog/update-product-needs-purchase-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Return needs purchase status for Module Products

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -256,8 +256,10 @@ abstract class Product {
 			if ( static::$requires_user_connection && ! ( new Connection_Manager() )->has_connected_owner() ) {
 				$status = 'error';
 			} elseif ( ! static::has_required_plan() ) {
-				$status = 'needs_purchase';
+				$status = 'needs_purchase'; // We need needs_purchase here as well because some products we consider active without the required plan.
 			}
+		} elseif ( ! static::has_required_plan() ) {
+			$status = 'needs_purchase';
 		} else {
 			$status = 'inactive';
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes situation where `needs_purchase` status was not being returned.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Return needs purchase status for Module Products

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1645472714319129-C02TQF5VAJD-slack

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Backup with active plugin but without a plan should return `needs_purchase` - but should return an error if user is not connected
* Scan and Search should return `needs_purchase` if plugin is active but plan is missing
