### PR TITLE
My Jetpack: Remove check for feature flag JETPACK_ENABLE_MY_JETPACK

### DIFF
--- a/projects/packages/my-jetpack/README.md
+++ b/projects/packages/my-jetpack/README.md
@@ -6,12 +6,6 @@ WP Admin page with information and configuration shared among all Jetpack stand-
 
 Every Jetpack plugin must include the My Jetpack package.
 
-Define the `JETPACK_ENABLE_MY_JETPACK` constant as true:
-
-```php
-defined( 'JETPACK_ENABLE_MY_JETPACK' ) || define( 'JETPACK_ENABLE_MY_JETPACK', true );
-```
-
 Require this package and initialize it:
 
 ```PHP

--- a/projects/packages/my-jetpack/changelog/remove-feature-flag-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/remove-feature-flag-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove conditional loading depending on constant

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -198,11 +198,6 @@ class Initializer {
 		 */
 		$should = apply_filters( 'jetpack_my_jetpack_should_initialize', true );
 
-		// Feature flag while we are developing it.
-		if ( ! defined( 'JETPACK_ENABLE_MY_JETPACK' ) || ! JETPACK_ENABLE_MY_JETPACK ) {
-			return false;
-		}
-
 		// Do not initialize My Jetpack if site is not connected.
 		if ( ! ( new Connection_Manager() )->is_connected() ) {
 			return false;


### PR DESCRIPTION
Sets My Jetpack loading to on by default. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes check for constant
* Updates README.md

#### Jetpack product discussion

p9dueE-4rG-p2

#### Does this pull request change what data or activity we track or use?

no

#### Testing instructions:


**On a site with Boost bleeding edge and connected.**
* Confirm the My Jetpack page is shown without any constant set


**On a site with Backup bleeding edge and connected.**
* Confirm the My Jetpack page is shown without any constant set


**On a site with Jetpack bleeding edge and connected.**
* Confirm the My Jetpack page is shown without any constant set