### PR TITLE
Jetpack Settings Submenu: Hide submenu item from menu on unsupported plan

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-jetpack-menu-item
+++ b/projects/plugins/jetpack/changelog/remove-jetpack-menu-item
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Remove jetpack settings submenu from general settings menu when site doesn't have atomic supported plan.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -429,8 +429,9 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * Check if site has Atomic supported plan. `Atomic_Plan_Manager` lives in wpcomsh
 	 */
 	protected function has_atomic_supported_plan() {
+		// Fallback to default behavior if Atomic_Plan_Manager doesn't exists.
 		if ( ! class_exists( 'Atomic_Plan_Manager' ) ) {
-			return false;
+			return true;
 		}
 
 		return \Atomic_Plan_Manager::has_atomic_supported_plan();

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -118,7 +118,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		global $submenu;
 
 		// Hide Add new plugin and plugin file editor menu.
-		if ( class_exists( 'Atomic_Plan_Manager' ) && ! \Atomic_Plan_Manager::has_atomic_supported_plan() ) {
+		if ( ! $this->has_atomic_supported_plan() ) {
 			parent::add_plugins_menu();
 
 			return;
@@ -351,7 +351,10 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			);
 		}
 		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 11 );
-		add_submenu_page( 'options-general.php', esc_attr__( 'Jetpack', 'jetpack' ), __( 'Jetpack', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/jetpack/' . $this->domain, null, 12 );
+
+		if ( $this->has_atomic_supported_plan() ) {
+			add_submenu_page( 'options-general.php', esc_attr__( 'Jetpack', 'jetpack' ), __( 'Jetpack', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/jetpack/' . $this->domain, null, 12 );
+		}
 
 		// Page Optimize is active by default on all Atomic sites and registers a Settings > Performance submenu which
 		// would conflict with our own Settings > Performance that links to Calypso, so we hide it it since the Calypso
@@ -420,5 +423,12 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 */
 	public function hide_search_menu_for_calypso() {
 		$this->hide_submenu_page( 'jetpack', 'https://wordpress.com/jetpack-search/' . $this->domain );
+	}
+
+	/**
+	 * Check if site has Atomic supported plan. `Atomic_Plan_Manager` lives in wpcomsh
+	 */
+	protected function has_atomic_supported_plan() {
+		return class_exists( 'Atomic_Plan_Manager' ) && \Atomic_Plan_Manager::has_atomic_supported_plan();
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -429,6 +429,10 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * Check if site has Atomic supported plan. `Atomic_Plan_Manager` lives in wpcomsh
 	 */
 	protected function has_atomic_supported_plan() {
-		return class_exists( 'Atomic_Plan_Manager' ) && \Atomic_Plan_Manager::has_atomic_supported_plan();
+		if ( ! class_exists( 'Atomic_Plan_Manager' ) ) {
+			return false;
+		}
+
+		return \Atomic_Plan_Manager::has_atomic_supported_plan();
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/54652

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR removes jetpack submenu item from the settings menu on the unsupported plan.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Copy the changes proposed in this PR to your atomic site.
- visit your site

Free Atomic:
- Verify `Settings` > `jetpack` submenu is not be visible
<img src="https://cloudup.com/crFb2vPtFqX+" width="200" />

Atomic with a higher plan:
- Make sure `Settings` > `jetpack` is visible as usual.
<img src="https://cloudup.com/cM_wpBvX5n0+" width="200" />
