### PR TITLE
Actions: try adding the pdo_mysql extension to the action build

### DIFF
--- a/.github/actions/tool-setup/action.yml
+++ b/.github/actions/tool-setup/action.yml
@@ -61,7 +61,8 @@ runs:
         php-version: ${{ steps.versions.outputs.php-version }}
         ini-values: error_reporting=E_ALL, display_errors=On, zend.assertions=1
         tools: composer:${{ steps.versions.outputs.composer-version }}
-        extensions: mysql, imagick, pdo_mysql
+        extensions: mysql, imagick
+        extension-csv: pdo, sqlite, mysql
         coverage: ${{ inputs.coverage }}
 
     - run: printf "\n\e[1mSetup Node\e[0m\n"

--- a/.github/actions/tool-setup/action.yml
+++ b/.github/actions/tool-setup/action.yml
@@ -61,7 +61,7 @@ runs:
         php-version: ${{ steps.versions.outputs.php-version }}
         ini-values: error_reporting=E_ALL, display_errors=On, zend.assertions=1
         tools: composer:${{ steps.versions.outputs.composer-version }}
-        extensions: mysql, imagick
+        extensions: mysql, imagick, pdo_mysql
         coverage: ${{ inputs.coverage }}
 
     - run: printf "\n\e[1mSetup Node\e[0m\n"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

﻿This may fix issues with older PHP builds (PHP 5.6) now getting the following error:

```
PHP Startup: Unable to load dynamic library 'sqlsrv.so'
```

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Is CI happy, especially with PHP 5.6?
