### PR TITLE
My Jetpack: Send My Jetpack version with fired events

### DIFF
--- a/projects/packages/my-jetpack/_inc/admin.jsx
+++ b/projects/packages/my-jetpack/_inc/admin.jsx
@@ -39,9 +39,7 @@ initStore();
  * @returns {object}                Layout react component.
  */
 function Layout( { nav = false, children, slug } ) {
-	const {
-		tracks: { recordEvent },
-	} = useAnalytics();
+	const { recordEvent } = useAnalytics();
 	const onClick = useCallback( () => {
 		if ( slug ) {
 			recordEvent( 'jetpack_myjetpack_product_interstitial_back_link_click', { product: slug } );

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -52,9 +52,7 @@ export default function MyJetpackScreen() {
 	useConnectionWatcher();
 	const { message, options, clean } = useGlobalNotice();
 
-	const {
-		tracks: { recordEvent },
-	} = useAnalytics();
+	const { recordEvent } = useAnalytics();
 
 	useEffect( () => {
 		recordEvent( 'jetpack_myjetpack_page_view' );

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -134,9 +134,7 @@ const ProductCard = props => {
 		[ styles[ 'is-fetching' ] ]: isFetching,
 	} );
 
-	const {
-		tracks: { recordEvent },
-	} = useAnalytics();
+	const { recordEvent } = useAnalytics();
 
 	/**
 	 * Calls the passed function onDeactivate after firing Tracks event

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -42,9 +42,7 @@ export default function ProductInterstitial( {
 		hasRequiredPlan,
 	} = detail;
 
-	const {
-		tracks: { recordEvent },
-	} = useAnalytics();
+	const { recordEvent } = useAnalytics();
 
 	useEffect( () => {
 		recordEvent( 'jetpack_myjetpack_product_interstitial_view', { product: slug } );

--- a/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.js
@@ -30,12 +30,27 @@ const useAnalytics = () => {
 		setProperties,
 		tracks,
 	} = jetpackAnalytics;
+
+	/**
+	 * Like tracks.recordEvent but provides specifics to My Jetpack
+	 *
+	 * @param {string} event       - event name
+	 * @param {object} properties  - event propeties
+	 */
+	const recordMyJetpackEvent = ( event, properties ) => {
+		tracks.recordEvent( event, {
+			...properties,
+			version: window?.myJetpackInitialState?.myJetpackVersion,
+		} );
+	};
+
 	return {
 		clearedIdentity,
 		ga,
 		mc,
 		pageView,
 		purchase,
+		recordEvent: recordMyJetpackEvent,
 		setGoogleAnalyticsEnabled,
 		setMcAnalyticsEnabled,
 		setProperties,

--- a/projects/packages/my-jetpack/changelog/add-version-tracks-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/add-version-tracks-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Send My Jetpack version with fired events

--- a/projects/packages/my-jetpack/changelog/add-version-tracks-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/add-version-tracks-my-jetpack
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Send My Jetpack version with fired events
+Send My Jetpack version with fired events.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -118,6 +118,7 @@ class Initializer {
 				'topJetpackMenuItemUrl' => Admin_Menu::get_top_level_menu_item_url(),
 				'siteSuffix'            => ( new Status() )->get_site_suffix(),
 				'myJetpackVersion'      => self::PACKAGE_VERSION,
+				'MyJetpackPlugin'       => get_plugin_data( __FILE__ ),
 				'fileSystemWriteAccess' => self::has_file_system_write_access(),
 			)
 		);


### PR DESCRIPTION

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Introduces a bare recordEvent function exported from `useAnalytics` that can be used instead of `tracks.recordEvents`
* Makes every event fired carry the My Jetpack version from where it was firedf

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?

* We update every event from My Jetpack to carry a `version` property.

#### Testing instructions:

* Checkout this branch on a site with Jetpack connected the Backup plugin active
* Go to this path `wp-admin/admin.php?page=my-jetpac`. 
* Open the developer console, execute the following code: `localStorage.debug='dops:analyitics*`
* Click the Add Security button on the right card, active buttons, manage, etc. Confirm you see the version on each event


