### PR TITLE
Pr-is-up-to-date: Fix run.sh source

### DIFF
--- a/projects/github-actions/pr-is-up-to-date/changelog/update-try-to-fix-run-sh
+++ b/projects/github-actions/pr-is-up-to-date/changelog/update-try-to-fix-run-sh
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Try and fix source file not found error by specifying path.

--- a/projects/github-actions/pr-is-up-to-date/run.sh
+++ b/projects/github-actions/pr-is-up-to-date/run.sh
@@ -2,6 +2,7 @@
 
 set -eo pipefail
 
+BASE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source "$BASE/funcs.sh"
 
 GITHUB_API_URL="${GITHUB_API_URL:-https://api.github.com}"

--- a/projects/github-actions/pr-is-up-to-date/run.sh
+++ b/projects/github-actions/pr-is-up-to-date/run.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-source ./funcs.sh
+source "$BASE/funcs.sh"
 
 GITHUB_API_URL="${GITHUB_API_URL:-https://api.github.com}"
 GITHUB_SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"


### PR DESCRIPTION
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
After #22925 was merged, pr-is-up-to-date started failing with `/home/runner/work/jetpack/jetpack/./projects/github-actions/pr-is-up-to-date/run.sh: line 5: ./funcs.sh: No such file or directory` - this PR tries to specify the source for funcs.sh more specifically to see if that does the trick.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Does the test pass?
*
