### PR TITLE
My Jetpack: set status and manage link of Extras card

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-fix-extras-manage-link
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-fix-extras-manage-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add Extras class

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -145,12 +145,7 @@ class Products {
 	 * @return array Object with infromation about the product.
 	 */
 	public static function get_extras_data() {
-		return array(
-			'slug'        => 'extras',
-			'description' => __( 'Basic tools for a successful site', 'jetpack-my-jetpack' ),
-			'name'        => __( 'Extras', 'jetpack-my-jetpack' ),
-			'status'      => 'active',
-		);
+		return Products\Extras::get_info();
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-extras.php
+++ b/projects/packages/my-jetpack/src/products/class-extras.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Extras product
+ *
+ * @package my-jetpack
+ */
+
+namespace Automattic\Jetpack\My_Jetpack\Products;
+
+use Automattic\Jetpack\My_Jetpack\Product;
+
+/**
+ * Class responsible for handling the Extras product.
+ * Extras, so far, could be considered as Jetpack plugin bridge.
+ */
+class Extras extends Product {
+
+	/**
+	 * The product slug
+	 *
+	 * @var string
+	 */
+	public static $slug = 'extras';
+
+	/**
+	 * Whether this product requires a user connection
+	 *
+	 * @var string
+	 */
+	public static $requires_user_connection = false;
+
+	/**
+	 * Get the internationalized product name
+	 *
+	 * @return string
+	 */
+	public static function get_name() {
+		return __( 'Extras', 'jetpack-my-jetpack' );
+	}
+
+	/**
+	 * Get the internationalized product title
+	 *
+	 * @return string
+	 */
+	public static function get_title() {
+		return __( 'Jetpack Extras', 'jetpack-my-jetpack' );
+	}
+
+	/**
+	 * Get the internationalized product description
+	 *
+	 * @return string
+	 */
+	public static function get_description() {
+		return __( 'Basic tools for a successful site', 'jetpack-my-jetpack' );
+	}
+
+	/**
+	 * Get the internationalized product long description
+	 *
+	 * @return string
+	 */
+	public static function get_long_description() {
+		return '';
+	}
+
+	/**
+	 * Get the internationalized features list
+	 *
+	 * @return array Boost features list
+	 */
+	public static function get_features() {
+		return array();
+	}
+
+	/**
+	 * Get the product princing details
+	 *
+	 * @return array Pricing details
+	 */
+	public static function get_pricing_for_ui() {
+		return array(
+			'available' => true,
+			'is_free'   => true,
+		);
+	}
+
+	/**
+	 * Checks whether the Product is active.
+	 * If Jetpack plugin is active, then Extras will be inactive.
+	 *
+	 * @return boolean
+	 */
+	public static function is_active() {
+		return static::is_jetpack_plugin_active();
+	}
+
+	/**
+	 * Checks whether the plugin is installed
+	 * If Jetpack plugin is installed, then Extras will be inactive.
+	 *
+	 * @return boolean
+	 */
+	public static function is_plugin_installed() {
+		return static::is_jetpack_plugin_installed();
+	}
+
+	/**
+	 * Get the URL where the user manages the product
+	 *
+	 * @return ?string
+	 */
+	public static function get_manage_url() {
+		return admin_url( 'admin.php?page=jetpack' );
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR sets the status of the `Extras` card according to the Jetpack plugin.

Fixes https://github.com/Automattic/jetpack/issues/23019

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: My Jetpack: set status and manage link of Extras card

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Check `Extras` is not available/active le when Jetpack plugin is not available/active**

* Active `Boost` plugin, for instance

<img width="338" alt="image" src="https://user-images.githubusercontent.com/77539/155148658-86166e0d-881e-45c7-8ff9-12d1a541f76d.png">

* Go to My Jetpack overview
* Confirm the `Extras` is available/active

<img width="391" alt="image" src="https://user-images.githubusercontent.com/77539/155150383-061bb9fd-e191-41d0-b92c-c46cbeb4171f.png">

* Clicking on `Active` triggers an error (going to be handled in a follow-up PR)

**Check `Extras` is active when Jetpack plugin is active**

* Confirm that when the Jetpack plugin is active, `Extras` is active too.

<img width="393" alt="image" src="https://user-images.githubusercontent.com/77539/155150939-38cf28b8-655a-4514-9a5e-4cdab1b3b63e.png">

* Confirm that, when it's active, the Manage link leads to the Jetpack plugin dashboard.

