### PR TITLE
API: Only count VideoPress files if that module is active

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -237,17 +237,19 @@ class Jetpack_Core_API_Site_Endpoint {
 		}
 
 		// Number of VideoPress videos on the site.
-		$videopress_attachments = wp_count_attachments( 'video/videopress' );
-		if (
-			isset( $videopress_attachments->{'video/videopress'} )
-			&& $videopress_attachments->{'video/videopress'} > 0
-		) {
-			$benefits[] = array(
-				'name'        => 'video-hosting',
-				'title'       => esc_html__( 'Video Hosting', 'jetpack' ),
-				'description' => esc_html__( 'Ad-free, lightning-fast videos delivered by Jetpack', 'jetpack' ),
-				'value'       => absint( $videopress_attachments->{'video/videopress'} ),
-			);
+		if ( Jetpack::is_module_active( 'videopress' ) ) {
+			$videopress_attachments = wp_count_attachments( 'video/videopress' );
+			if (
+				isset( $videopress_attachments->{'video/videopress'} )
+				&& $videopress_attachments->{'video/videopress'} > 0
+			) {
+				$benefits[] = array(
+					'name'        => 'video-hosting',
+					'title'       => esc_html__( 'Video Hosting', 'jetpack' ),
+					'description' => esc_html__( 'Ad-free, lightning-fast videos delivered by Jetpack', 'jetpack' ),
+					'value'       => absint( $videopress_attachments->{'video/videopress'} ),
+				);
+			}
 		}
 
 		// Number of active Publicize connections.

--- a/projects/plugins/jetpack/changelog/add-gate-for-videopress-active
+++ b/projects/plugins/jetpack/changelog/add-gate-for-videopress-active
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Performance: improve performance for sites without VideoPress enabled.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Improves the performance of the API to only count VideoPress videos if that module is active.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a module check.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1645543635194369-slack-CDLH4C1UZ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a connected Jetpack site with a lot of attachments, check the performance of the API before or after.