### PR TITLE
My Jetpack: activate Jetpack plugin from Extras product card

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/extras-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/extras-card.jsx
@@ -33,6 +33,7 @@ const ExtrasCard = ( { admin } ) => {
 			showDeactivate={ false }
 			onFixConnection={ useMyJetpackNavigate( '/connection' ) }
 			onManage={ onManage }
+			onAdd={ activate }
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-handling-extras-product
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-handling-extras-product
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Activate Jetpack plugin from Extras product card

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "0.6.3",
+	"version": "0.6.4-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -27,7 +27,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.6.3';
+	const PACKAGE_VERSION = '0.6.4-alpha';
 
 	/**
 	 * Initialize My Jetapack

--- a/projects/packages/my-jetpack/src/products/class-extras.php
+++ b/projects/packages/my-jetpack/src/products/class-extras.php
@@ -23,6 +23,14 @@ class Extras extends Product {
 	public static $slug = 'extras';
 
 	/**
+	 * The slug of the plugin associated with this product.
+	 * Extras, is in short, Jetpack plugin bridge so far.
+	 *
+	 * @var string
+	 */
+	public static $plugin_slug = 'jetpack';
+
+	/**
 	 * Whether this product requires a user connection
 	 *
 	 * @var string

--- a/projects/packages/my-jetpack/src/products/class-extras.php
+++ b/projects/packages/my-jetpack/src/products/class-extras.php
@@ -114,4 +114,16 @@ class Extras extends Product {
 	public static function get_manage_url() {
 		return admin_url( 'admin.php?page=jetpack' );
 	}
+
+	/**
+	 * Activates the Jetpack plugin
+	 *
+	 * @return null|WP_Error Null on success, WP_Error on invalid file.
+	 */
+	public static function activate_plugin() {
+		/*
+		 * Silent mode True to avoid redirect
+		 */
+		return activate_plugin( static::get_installed_plugin_filename( 'jetpack' ), '', false, true );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Being consistent with the Manage link which leads the user to the Jetpack plugin, this PR activates the Jetpack plugin by clicking on the `Connect` button.

Fixes https://github.com/Automattic/jetpack/issues/22943

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: activate Jetpack plugin from Extras product card

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install a not Jetpack plugin, for instance, Boost
* Connect the site (via Boost)
* Confirm you get access to My Jetpack overview
* Confirm you see `Extras` card with the `Add Extras` or `Activate` option available
* Confirm it gets activated by clicking on it
* Confirm the Manage link leads to the, now activated, Jetpack plugin

https://user-images.githubusercontent.com/77539/155221932-e8519cdb-62f9-4205-85ef-c1a3a79e8425.mov


