### PR TITLE
Search package: add i18n support for auto added search block

### DIFF
--- a/projects/packages/search/changelog/fix-auto-added-search-block-i18n
+++ b/projects/packages/search/changelog/fix-auto-added-search-block-i18n
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search package: i18n support for auto added search block label and button

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.9.0",
+	"version": "0.9.1-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/search.php
+++ b/projects/packages/search/search.php
@@ -7,7 +7,7 @@
 
 namespace Automattic\Jetpack\Search;
 
-define( 'JETPACK_SEARCH_PKG__VERSION', '0.9.0' );
+define( 'JETPACK_SEARCH_PKG__VERSION', '0.9.1-alpha' );
 define( 'JETPACK_SEARCH_PKG__DIR', __DIR__ . '/' );
 define( 'JETPACK_SEARCH_PKG__SLUG', 'search' );
 

--- a/projects/packages/search/src/instant-search/class-instant-search.php
+++ b/projects/packages/search/src/instant-search/class-instant-search.php
@@ -620,7 +620,11 @@ class Instant_Search extends Classic_Search {
 	 * @param {string} $block_content - the content to append the search block.
 	 */
 	public static function inject_search_widget_to_block( $block_content ) {
-		$search_block = '<!-- wp:search {"label":"Jetpack Search","buttonText":"Search"} /-->';
+		$search_block = sprintf(
+			'<!-- wp:search {"label":"%s","buttonText":"%s"} /-->',
+			__( 'Search', 'jetpack-search-pkg' ),
+			__( 'Search', 'jetpack-search-pkg' )
+		);
 
 		// Place the search block on bottom of the first column if there's any.
 		$column_end_pattern = '/(<\s*\/div[^>]*>\s*<!--\s*\/wp:column\s+[^>]*-->)/';

--- a/projects/packages/search/src/instant-search/class-instant-search.php
+++ b/projects/packages/search/src/instant-search/class-instant-search.php
@@ -621,8 +621,7 @@ class Instant_Search extends Classic_Search {
 	 */
 	public static function inject_search_widget_to_block( $block_content ) {
 		$search_block = sprintf(
-			'<!-- wp:search {"label":"%s","buttonText":"%s"} /-->',
-			__( 'Search', 'jetpack-search-pkg' ),
+			'<!-- wp:search {"label":"","buttonText":"%s"} /-->',
 			__( 'Search', 'jetpack-search-pkg' )
 		);
 

--- a/projects/packages/search/tests/php/test-instant-search-add-search-block.php
+++ b/projects/packages/search/tests/php/test-instant-search-add-search-block.php
@@ -33,7 +33,7 @@ EOT;
 <!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignwide" style="padding-top:4rem;padding-bottom:4rem">
 
-<!-- wp:search {"label":"Jetpack Search","buttonText":"Search"} /-->
+<!-- wp:search {"label":"","buttonText":"Search"} /-->
 <!-- wp:site-title {"level":0} /-->
 <!-- wp:paragraph {"align":"right"} -->
 <p class="has-text-align-right">Proudly powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
@@ -65,7 +65,7 @@ EOT;
 <!-- wp:group -->
 <div class="wp-block-group">
 
-<!-- wp:search {"label":"Jetpack Search","buttonText":"Search"} /-->
+<!-- wp:search {"label":"","buttonText":"Search"} /-->
 <!-- wp:site-title {"level":0} /-->
 <!-- wp:paragraph {"align":"right"} -->
 <p class="has-text-align-right">Proudly powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
@@ -170,7 +170,7 @@ EOT;
 <p class="has-small-font-size">We provide excellent services and products that help you provide the best for your customers.</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:search {"label":"Jetpack Search","buttonText":"Search"} /-->
+<!-- wp:search {"label":"","buttonText":"Search"} /-->
 </div>
 <!-- /wp:column -->
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The PR adds i18n support for auto added Search input, and is a followup for #22613.

#### Jetpack product discussion
https://github.com/Automattic/jetpack/pull/22613#discussion_r809930841

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Go to a site with Search subscription
* Change theme to a FSE theme (e.g. 2020), remove search input in the footer if any
* Change the language of the site to non-English
* Update translations if any (Dashboard -> Updates)
* Run `jetpack docker wp jetpack-search auto_config wordpress` <- replace wordpress to a local user name or ID
* Ensure Search input is added in footer, label and button text translated

![image](https://user-images.githubusercontent.com/1425433/155223676-373a912c-1380-44c7-9857-9c09cfc394a3.png)

