### PR TITLE
Analyzer: Fix bug when getting latest stable version by default.

### DIFF
--- a/projects/packages/analyzer/changelog/fix-analyzer-script-default-from-version
+++ b/projects/packages/analyzer/changelog/fix-analyzer-script-default-from-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix jetpack-svn.php script getting latest stable Jetpack version by default

--- a/projects/packages/analyzer/scripts/jetpack-svn.php
+++ b/projects/packages/analyzer/scripts/jetpack-svn.php
@@ -47,12 +47,7 @@ if ( empty( $from_version ) ) {
 	// Get latest stable version in svn.
 	$jetpack_info = json_decode( file_get_contents( 'https://api.wordpress.org/plugins/info/1.0/jetpack.json' ) );
 	$org_versions = array_reverse( (array) $jetpack_info->versions );
-	foreach ( $org_versions as $version => $zip_path ) {
-		if ( ! preg_match( '/[a-z]/i', $version ) ) {
-			$from_version = $version;
-			break;
-		}
-	}
+	$from_version = $jetpack_info->version;
 }
 
 // Download and unzip "from" version.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes a bug in the jetpack-svn.php script when using default "jetpack from" parameter. The loop is unnecessary and was returning `9.9.1` version. Get the latest tagged version directly from the response object instead. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Gets the latest tagged version directly from the response object instead of trying to loop through them all. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

You could error_log the `$from_version` before and after the patch is applied. 
