### PR TITLE
Stats: removed the logo form dashboard widget title

### DIFF
--- a/projects/plugins/jetpack/_inc/client/dashboard-widget/style.scss
+++ b/projects/plugins/jetpack/_inc/client/dashboard-widget/style.scss
@@ -217,10 +217,14 @@
 	}
 
 	footer {
-		background: #f6f7f7;
-		padding: .75em .75em 0 .75em;
 		overflow: hidden;
 		border-top: 1px solid #ccc;
+
+		.blocked-container {
+			background: #f6f7f7;
+			display: flex;
+			padding: .75em .75em 0 .75em;
+		}
 
 		.protect,
 		.akismet {
@@ -242,10 +246,18 @@
 		}
 
 		p.blocked-count {
-			font-size: 1.5em;
-			font-weight: normal;
-			margin: 0;
-			padding: 0;
+			margin-top: 0;
+			margin-bottom: 6px;
+			margin-right: 8px;
+			color: #3582c4;
+			font-weight: 500;
+			font-size: 2rem;
+			display: inline-block;
+			border: 1px solid #c3c4c7;
+			border-radius: 4px;
+			padding: 0 4px;
+			min-width: 36px;
+			text-align: center;
 		}
 
 		p {
@@ -257,6 +269,18 @@
 			margin: 0;
 			padding: 0;
 			text-align: center;
+		}
+
+		.footer-links{
+			padding: 0.75em 0.75em 0.5em 0.75em;
+			border-top: 1px solid #f0f0f1;
+						
+			svg {
+				height: 20px;
+			}
+			span {
+				float: right;
+			}
 		}
 	}
 }

--- a/projects/plugins/jetpack/changelog/fix-remove-duplicate-svg-logo
+++ b/projects/plugins/jetpack/changelog/fix-remove-duplicate-svg-logo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Removed the SVG logo from the dashboard stats widget. Created a new footer section for the widget witlinks

--- a/projects/plugins/jetpack/changelog/fix-remove-duplicate-svg-logo
+++ b/projects/plugins/jetpack/changelog/fix-remove-duplicate-svg-logo
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Removed the SVG logo from the dashboard stats widget. Created a new footer section for the widget witlinks
+Stats: improve accessibility and performance for the admin dashboard widget.

--- a/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
@@ -153,10 +153,10 @@ class Jetpack_Stats_Dashboard_Widget {
 					esc_html_e( 'Configure stats', 'jetpack' );
 					?>
 			</a>
+			|
 					<?php
 					endif;
 				?>
-			|
 			<a href="<?php echo esc_url( Redirect::get_url( 'jetpack-support-wordpress-com-stats' ) ); ?>" target="_blank"><?php esc_html_e( 'Learn more', 'jetpack' ); ?></a>
 			</span>
 

--- a/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
+use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
 
 /**
@@ -41,23 +42,8 @@ class Jetpack_Stats_Dashboard_Widget {
 		}
 
 		if ( has_action( 'jetpack_dashboard_widget' ) ) {
-			$jetpack_logo = new Jetpack_Logo();
 			$widget_title = sprintf(
-				// translators: Placeholder is a Jetpack logo.
-				__( 'Stats by %s', 'jetpack' ),
-				$jetpack_logo->get_jp_emblem( true )
-			);
-
-			$aria_label = sprintf(
-				// translators: placeholder is the product name.
-				__( 'Stats by %s', 'jetpack' ),
-				'Jetpack'
-			);
-			// Wrap title in span so Logo can be properly styled.
-			$widget_title = sprintf(
-				'<span aria-label="%2$s">%1$s</span>',
-				$widget_title,
-				$aria_label
+				__( 'Stats by Jetpack', 'jetpack' )
 			);
 
 			wp_add_dashboard_widget(
@@ -89,69 +75,94 @@ class Jetpack_Stats_Dashboard_Widget {
 	public static function dashboard_widget_footer() {
 		?>
 		<footer>
-
-		<div class="protect">
-			<h3><?php esc_html_e( 'Brute force attack protection', 'jetpack' ); ?></h3>
-			<?php if ( Jetpack::is_module_active( 'protect' ) ) : ?>
-				<p class="blocked-count">
-					<?php echo esc_html( number_format_i18n( get_site_option( 'jetpack_protect_blocked_attempts', 0 ) ) ); ?>
-				</p>
-				<p><?php echo esc_html_x( 'Blocked malicious login attempts', '{#} Blocked malicious login attempts -- number is on a prior line, text is a caption.', 'jetpack' ); ?></p>
-			<?php elseif ( current_user_can( 'jetpack_activate_modules' ) && ! ( new Status() )->is_offline_mode() ) : ?>
-				<a href="
-				<?php
-				echo esc_url(
-					wp_nonce_url(
-						Jetpack::admin_url(
-							array(
-								'action' => 'activate',
-								'module' => 'protect',
-							)
-						),
-						'jetpack_activate-protect'
-					)
-				);
-				?>
-							" class="button button-jetpack" title="<?php esc_attr_e( 'Protect helps to keep you secure from brute-force login attacks.', 'jetpack' ); ?>">
-					<?php esc_html_e( 'Activate brute force attack protection', 'jetpack' ); ?>
-				</a>
-			<?php else : ?>
-				<?php esc_html_e( 'Brute force attack protection is inactive.', 'jetpack' ); ?>
-			<?php endif; ?>
-		</div>
-
-		<div class="akismet">
-			<h3><?php esc_html_e( 'Anti-spam', 'jetpack' ); ?></h3>
-			<?php if ( is_plugin_active( 'akismet/akismet.php' ) ) : ?>
-				<p class="blocked-count">
-					<?php echo esc_html( number_format_i18n( get_option( 'akismet_spam_count', 0 ) ) ); ?>
-				</p>
-				<p><?php echo esc_html_x( 'Blocked spam comments.', '{#} Spam comments blocked by Akismet -- number is on a prior line, text is a caption.', 'jetpack' ); ?></p>
-			<?php elseif ( current_user_can( 'activate_plugins' ) && ! is_wp_error( validate_plugin( 'akismet/akismet.php' ) ) ) : ?>
-				<a href="
-				<?php
-				echo esc_url(
-					wp_nonce_url(
-						add_query_arg(
-							array(
-								'action' => 'activate',
-								'plugin' => 'akismet/akismet.php',
+		<div class="blocked-container">
+			<div class="protect">
+				<h3><?php esc_html_e( 'Brute force attack protection', 'jetpack' ); ?></h3>
+				<?php if ( Jetpack::is_module_active( 'protect' ) ) : ?>
+					<p class="blocked-count">
+						<?php echo esc_html( number_format_i18n( get_site_option( 'jetpack_protect_blocked_attempts', 0 ) ) ); ?>
+					</p>
+					<p><?php echo esc_html_x( 'Blocked malicious login attempts', '{#} Blocked malicious login attempts -- number is on a prior line, text is a caption.', 'jetpack' ); ?></p>
+				<?php elseif ( current_user_can( 'jetpack_activate_modules' ) && ! ( new Status() )->is_offline_mode() ) : ?>
+					<a href="
+					<?php
+					echo esc_url(
+						wp_nonce_url(
+							Jetpack::admin_url(
+								array(
+									'action' => 'activate',
+									'module' => 'protect',
+								)
 							),
-							admin_url( 'plugins.php' )
-						),
-						'activate-plugin_akismet/akismet.php'
-					)
-				);
-				?>
-							" class="button button-jetpack">
-					<?php esc_html_e( 'Activate Anti-spam', 'jetpack' ); ?>
-				</a>
-			<?php else : ?>
-				<p><a href="<?php echo esc_url( 'https://akismet.com/?utm_source=jetpack&utm_medium=link&utm_campaign=Jetpack%20Dashboard%20Widget%20Footer%20Link' ); ?>"><?php esc_html_e( 'Anti-spam can help to keep your blog safe from spam!', 'jetpack' ); ?></a></p>
-			<?php endif; ?>
-		</div>
+							'jetpack_activate-protect'
+						)
+					);
+					?>
+								" class="button button-jetpack" title="<?php esc_attr_e( 'Protect helps to keep you secure from brute-force login attacks.', 'jetpack' ); ?>">
+						<?php esc_html_e( 'Activate brute force attack protection', 'jetpack' ); ?>
+					</a>
+				<?php else : ?>
+					<?php esc_html_e( 'Brute force attack protection is inactive.', 'jetpack' ); ?>
+				<?php endif; ?>
+			</div>
 
+			<div class="akismet">
+				<h3><?php esc_html_e( 'Anti-spam', 'jetpack' ); ?></h3>
+				<?php if ( is_plugin_active( 'akismet/akismet.php' ) ) : ?>
+					<p class="blocked-count">
+						<?php echo esc_html( number_format_i18n( get_option( 'akismet_spam_count', 0 ) ) ); ?>
+					</p>
+					<p><?php echo esc_html_x( 'Blocked spam comments.', '{#} Spam comments blocked by Akismet -- number is on a prior line, text is a caption.', 'jetpack' ); ?></p>
+				<?php elseif ( current_user_can( 'activate_plugins' ) && ! is_wp_error( validate_plugin( 'akismet/akismet.php' ) ) ) : ?>
+					<a href="
+					<?php
+					echo esc_url(
+						wp_nonce_url(
+							add_query_arg(
+								array(
+									'action' => 'activate',
+									'plugin' => 'akismet/akismet.php',
+								),
+								admin_url( 'plugins.php' )
+							),
+							'activate-plugin_akismet/akismet.php'
+						)
+					);
+					?>
+								" class="button button-jetpack">
+						<?php esc_html_e( 'Activate Anti-spam', 'jetpack' ); ?>
+					</a>
+				<?php else : ?>
+					<p><a href="<?php echo esc_url( 'https://akismet.com/?utm_source=jetpack&utm_medium=link&utm_campaign=Jetpack%20Dashboard%20Widget%20Footer%20Link' ); ?>"><?php esc_html_e( 'Anti-spam can help to keep your blog safe from spam!', 'jetpack' ); ?></a></p>
+				<?php endif; ?>
+			</div>
+		</div>
+		<div class="footer-links">
+			<?php
+				$jetpack_logo = new Jetpack_Logo();
+				echo $jetpack_logo->get_jp_emblem( true );// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			?>
+			<span>
+				<?php
+				if ( current_user_can( 'jetpack_manage_modules' ) ) :
+					$i18n_headers = jetpack_get_module_i18n( 'stats' );
+					?>
+			<a href="<?php echo esc_url( admin_url( 'admin.php?page=jetpack#/settings?term=' . rawurlencode( $i18n_headers['name'] ) ) ); ?>"
+				>
+					<?php
+					esc_html_e( 'Configure stats', 'jetpack' );
+					?>
+			</a>
+					<?php
+					endif;
+				?>
+			|
+			<a href="<?php echo esc_url( Redirect::get_url( 'jetpack-support-wordpress-com-stats' ) ); ?>" target="_blank"><?php esc_html_e( 'Learn more', 'jetpack' ); ?></a>
+			</span>
+
+		</div>
 		</footer>
+
 		<?php
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The Jetpack logo that was added to the dashboard stats widget gets loaded several times on the same page, and was causing performance and accessibility issues. The logo gets attached to the move up & down, and toggle widget buttons. 
For that reason, screen readers read buttons as "Move Stats by box up...". 

This issue is also related to the broken Screen options issues mentioned  here: https://github.com/Automattic/jetpack/pull/22812


Fixes #22669

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removed the logo from the dashboard widget title. The title is now plain text "Stats by Jetpack".
* Created a new widget footer section and added the logo there to keep the branding consistency. 
* Added Configure Stats and Learn More links to the new footer section.
* Applied styles from the Jetpack dashboard to the blocked numbers in the widget for better style consistency.

How the widget looked before:

<img width="665" alt="stats_widget_before" src="https://user-images.githubusercontent.com/1242807/155335138-fef9348d-e08d-4883-bff0-0798a07f42cc.png">

How it looks now:

<img width="655" alt="stats_widget_after" src="https://user-images.githubusercontent.com/1242807/155335121-e6def6da-3db2-496f-a877-35b7a9d61e0e.png">


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to WP Admin and see how the widget looks with different screen widths.
* Try disabling, Stats, Protect, and Akismet.
* Check the Screen options.
