### PR TITLE
autoloader: Fix coverage generation for upstream change

### DIFF
--- a/projects/packages/autoloader/changelog/fix-autoloader-coverage-for-upstream-change
+++ b/projects/packages/autoloader/changelog/fix-autoloader-coverage-for-upstream-change
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix tests for upstream phpunit change.

--- a/projects/packages/autoloader/tests/php/bin/test-coverage.php
+++ b/projects/packages/autoloader/tests/php/bin/test-coverage.php
@@ -164,7 +164,8 @@ function get_path_transformation_map( $report_file_paths ) {
  * @return SebastianBergmann\CodeCoverage\CodeCoverage The processed report.
  */
 function process_coverage_9( $report ) {
-	$data = $report->getData( true );
+	$data      = $report->getData( true );
+	$classname = get_class( $data );
 
 	// We're going to merge the line coverage from compiled files into the src files.
 	$line_coverage   = $data->lineCoverage();
@@ -187,7 +188,7 @@ function process_coverage_9( $report ) {
 		}
 
 		// Merge the coverage since multiple compiled files may map to a single src file.
-		$merge = new SebastianBergmann\CodeCoverage\ProcessedCodeCoverageData();
+		$merge = new $classname();
 		$merge->setLineCoverage( $new_coverage );
 		$data->merge( $merge );
 

--- a/projects/packages/autoloader/tests/php/lib/class-test-plugin-factory.php
+++ b/projects/packages/autoloader/tests/php/lib/class-test-plugin-factory.php
@@ -409,7 +409,8 @@ class Test_Plugin_Factory {
 		}
 
 		// We can finally execute Composer now that we're ready.
-		exec( 'php ' . escapeshellarg( $composer_bin ) . ' install -d ' . escapeshellarg( $plugin_dir ) . ' 2>&1' );
+		putenv( 'COMPOSER_HOME=' . TEST_TEMP_BIN_DIR ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_putenv
+		exec( 'php ' . escapeshellarg( $composer_bin ) . ' install -q -d ' . escapeshellarg( $plugin_dir ) );
 		if ( ! is_file( $plugin_dir . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php' ) ) {
 			throw new \RuntimeException( 'Unable to execute the `' . $composer_bin . '` archive for tests.' );
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
sebastianbergmann/php-code-coverage@0f89e2c renamed some internal
classes, one of which we were using to munge line numbers for the
autoloader coverage report.

Unfortunately there doesn't really seem to be any cleaner way to do
this. At the least we can read the class name with `get_class()`
instead of hard coding it.

Also, since it came up while trying to test this locally, set
`COMPOSER_HOME` when trying to run old versions of composer that don't
recognize new-format GitHub OAuth tokens so it doesn't complain about
the one that's probably in the local config.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None really

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Does the coverage test pass again?