### PR TITLE
My Jetpack: Fix get_product_names to not make requests

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-get-product-names
+++ b/projects/packages/my-jetpack/changelog/fix-get-product-names
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Products::get_products_names should not load all product information

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -24,17 +24,7 @@ class Products {
 			$products[ $name ] = call_user_func( array( __CLASS__, $method_name ) );
 		}
 
-		return array(
-			'anti-spam'  => self::get_anti_spam_data(),
-			'backup'     => self::get_backup_data(),
-			'boost'      => self::get_boost_data(),
-			'scan'       => self::get_scan_data(),
-			'search'     => self::get_search_data(),
-			'security'   => self::get_security_data(),
-			'videopress' => self::get_videopress_data(),
-			'crm'        => self::get_crm_data(),
-			'extras'     => self::get_extras_data(),
-		);
+		return $products;
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -17,6 +17,13 @@ class Products {
 	 * @return array Jetpack products on the site and their availability.
 	 */
 	public static function get_products() {
+		$names    = self::get_product_names();
+		$products = array();
+		foreach ( $names as $name ) {
+			$method_name       = 'get_' . str_replace( '-', '_', $name ) . '_data';
+			$products[ $name ] = call_user_func( array( __CLASS__, $method_name ) );
+		}
+
 		return array(
 			'anti-spam'  => self::get_anti_spam_data(),
 			'backup'     => self::get_backup_data(),
@@ -51,7 +58,17 @@ class Products {
 	 * @return array Product names array.
 	 */
 	public static function get_product_names() {
-		return array_keys( self::get_products() );
+		return array(
+			'anti-spam',
+			'backup',
+			'boost',
+			'scan',
+			'search',
+			'security',
+			'videopress',
+			'crm',
+			'extras',
+		);
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes `get_product_names` method so it does not load all products information. This avoids the site triggering requests in every page load.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Do not load all data of the products on get_product_names method

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p8oabR-Oy-p2#comment-5997

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Looking at the Query Monitor plugin information, confirm there are no requests being triggered by My Jetpack, outside of the My Jetpack page