### PR TITLE
Analyzer: Change minimum PHP version to 7.4

### DIFF
--- a/projects/packages/analyzer/changelog/update-analyzer-required-php-version
+++ b/projects/packages/analyzer/changelog/update-analyzer-required-php-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Analyzer: Change minimum PHP version to 7.4.

--- a/projects/packages/analyzer/composer.json
+++ b/projects/packages/analyzer/composer.json
@@ -7,7 +7,7 @@
 		"nikic/php-parser": "4.13.2"
 	},
 	"require-dev": {
-		"php": "^7.4",
+		"php": "^7.4 || ^8.0",
 		"automattic/jetpack-changelogger": "^3.0"
 	},
 	"autoload": {

--- a/projects/packages/analyzer/composer.json
+++ b/projects/packages/analyzer/composer.json
@@ -7,7 +7,7 @@
 		"nikic/php-parser": "4.13.2"
 	},
 	"require-dev": {
-		"php": "^8.0",
+		"php": "^7.4",
 		"automattic/jetpack-changelogger": "^3.0"
 	},
 	"autoload": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Updates the PHP requirement to allow using PHP 7.4. 

This allows us to run it in our wpcom sandboxes. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Changes minimum PHP version to 7.4

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
@brbrr said it's probably fine p1645624757709889/1645621224.278529-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Not really sure. Testing in a PHP 7.4* environment (wpcom) WFM. 