### PR TITLE
My Jetpack: Memoize RecordEvent from useAnalytics hook

### DIFF
--- a/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import useMyJetpackConnection from '../use-my-jetpack-connection';
 
@@ -37,12 +37,15 @@ const useAnalytics = () => {
 	 * @param {string} event       - event name
 	 * @param {object} properties  - event propeties
 	 */
-	const recordMyJetpackEvent = ( event, properties ) => {
-		tracks.recordEvent( event, {
-			...properties,
-			version: window?.myJetpackInitialState?.myJetpackVersion,
-		} );
-	};
+	const recordMyJetpackEvent = useCallback(
+		( event, properties ) => {
+			tracks.recordEvent( event, {
+				...properties,
+				version: window?.myJetpackInitialState?.myJetpackVersion,
+			} );
+		},
+		[ tracks ]
+	);
 
 	return {
 		clearedIdentity,

--- a/projects/packages/my-jetpack/changelog/fix-recordevent-my-jetpack-memoize
+++ b/projects/packages/my-jetpack/changelog/fix-recordevent-my-jetpack-memoize
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Memoized RecordEvent from usAnalytics hook


### PR DESCRIPTION
Fixes double/triple tracking of events

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Wraps `recordEvent` with `useCallback` hookl

#### Jetpack product discussion

p1645633985514979-slack-C02TQF5VAJD

#### Does this pull request change what data or activity we track or use?
no and yes. Fixes tracking, but nothing new is introduced

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout to this branch 
* Visit My Jetpack
* open the console and run `localStorage.debug='dops:analytics';`
* Refresh the page
*  Confirm that you only see one page view event for `jetpack_myjetpack_product_card_add_click`