### PR TITLE
tools: Allow `$$next-version$$` in deprecation functions

### DIFF
--- a/projects/packages/README.md
+++ b/projects/packages/README.md
@@ -111,5 +111,6 @@ When needing to add a package version number inside a DocBlock, please use `$$ne
 - `@since $$next-version$$`
 - `@deprecated $$next-version$$`
 - `@deprecated since $$next-version$$`
+- `_deprecated_function( __METHOD__, 'package-$$next-version$$' );` (other WordPress deprecation functions also work, but note it must be all on one line).
 
 The `$$next-version$$` specifier will be automatically replaced with the correct package version number the next time a new version of that package is released.

--- a/tools/replace-next-version-tag.sh
+++ b/tools/replace-next-version-tag.sh
@@ -19,7 +19,8 @@ function usage {
 		 - `@deprecated since $$next-version$$`
 		 - `_deprecated_function( ..., 'prefix-$$next-version$$' )`
 		   Other WordPress deprecation functions also work. The call must be on one
-		   line, and the '$$next-version$$' token must be in a single-quoted string.
+		   line, indented with tabs, and the '$$next-version$$' token must be in a
+		   single-quoted string.
 	EOH
 	exit 1
 }

--- a/tools/replace-next-version-tag.sh
+++ b/tools/replace-next-version-tag.sh
@@ -81,6 +81,8 @@ for FILE in $(git ls-files "projects/$SLUG/"); do
 
 	sed -i.bak -E -e 's!(@since|@deprecated( +[sS]ince)?)( +)\$\$next-version\$\$!\1\3'"$VE"'!g' "$FILE"
 	rm "$FILE.bak" # We need a backup file because macOS requires it.
+	sed -i.bak -E -e $'s!(^\t*_deprecated_(function|constructor|file|argument|hook)\\( .*, \'[^\']*)\\$\\$next-version\\$\\$\'!\\1'"$VE"$'\'!g' "$FILE"
+	rm "$FILE.bak" # We need a backup file because macOS requires it.
 
 	if grep -F -q '$$next-version$$' "$FILE"; then
 		EXIT=1

--- a/tools/replace-next-version-tag.sh
+++ b/tools/replace-next-version-tag.sh
@@ -17,6 +17,9 @@ function usage {
 		 - `@since $$next-version$$`
 		 - `@deprecated $$next-version$$`
 		 - `@deprecated since $$next-version$$`
+		 - `_deprecated_function( ..., 'prefix-$$next-version$$' )`
+		   Other WordPress deprecation functions also work. The call must be on one
+		   line, and the '$$next-version$$' token must be in a single-quoted string.
 	EOH
 	exit 1
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Allow the `$$next-version$$` token to be passed to the WordPress
deprecation notice functions too. Note the token must be inside
single-quotes and the call must be all on one line and indented with
tabs.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Nothing I recall to link to. I think it has been mentioned once or twice.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a deprecation like `_deprecated_function( __METHOD__, 'jetpack-$$next-version$$' )` somewhere in a project. Then run the script for that project and see that it's updated correctly.