### PR TITLE
My Jetpack: Fix My Jetpack connection notices

### DIFF
--- a/projects/packages/my-jetpack/_inc/hooks/use-connection-watcher/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-connection-watcher/index.js
@@ -2,30 +2,15 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { STORE_ID } from '../../state/store';
-import { PRODUCT_STATUSES } from '../../components/product-card';
 import useMyJetpackConnection from '../use-my-jetpack-connection';
 import useMyJetpackNavigate from '../use-my-jetpack-navigate';
-
-const getProductsWithRequires = products => {
-	return Object.keys( products ).reduce( ( current, product ) => {
-		const currentProduct = products[ product ];
-		const requires =
-			currentProduct?.requiresUserConnection &&
-			( currentProduct?.status === PRODUCT_STATUSES.ACTIVE ||
-				currentProduct?.status === PRODUCT_STATUSES.ERROR );
-		if ( requires ) {
-			current.push( currentProduct?.name );
-		}
-		return current;
-	}, [] );
-};
 
 /**
  * React custom hook to watch connection.
@@ -35,13 +20,30 @@ const getProductsWithRequires = products => {
 export default function useConnectionWatcher() {
 	const navToConnection = useMyJetpackNavigate( '/connection' );
 	const { setGlobalNotice } = useDispatch( STORE_ID );
-	const products = useSelect( select => select( STORE_ID ).getProducts() );
+	const productsThatRequiresUserConnection = useSelect( select =>
+		select( STORE_ID ).getProductsThatRequiresUserConnection()
+	);
 	const { isSiteConnected, redirectUrl, hasConnectedOwner } = useMyJetpackConnection();
-	const productsThatRequiresUserConnection = useMemo( () => getProductsWithRequires( products ), [
-		products,
-	] );
+
 	const requiresUserConnection =
 		! hasConnectedOwner && productsThatRequiresUserConnection.length > 0;
+
+	const oneProductMessage = sprintf(
+		/* translators: placeholder is product name. */
+		__(
+			'Jetpack %s needs a user connection to WordPress.com to be able to work.',
+			'jetpack-my-jetpack'
+		),
+		productsThatRequiresUserConnection[ 0 ]
+	);
+
+	const message =
+		productsThatRequiresUserConnection.length > 1
+			? __(
+					'Some products need a user connection to WordPress.com to be able to work.',
+					'jetpack-my-jetpack'
+			  )
+			: oneProductMessage;
 
 	/*
 	 * When the site is not connect, redirect to the Jetpack dashboard.
@@ -54,23 +56,6 @@ export default function useConnectionWatcher() {
 
 	useEffect( () => {
 		if ( requiresUserConnection ) {
-			const oneProductMessage = sprintf(
-				/* translators: placeholder is product name. */
-				__(
-					'Jetpack %s needs a user connection to WordPress.com to be able to work.',
-					'jetpack-my-jetpack'
-				),
-				productsThatRequiresUserConnection[ 0 ]
-			);
-
-			const message =
-				productsThatRequiresUserConnection.length > 1
-					? __(
-							'Some products need a user connection to WordPress.com to be able to work.',
-							'jetpack-my-jetpack'
-					  )
-					: oneProductMessage;
-
 			setGlobalNotice( message, {
 				status: 'error',
 				actions: [
@@ -83,10 +68,5 @@ export default function useConnectionWatcher() {
 				],
 			} );
 		}
-	}, [
-		productsThatRequiresUserConnection,
-		requiresUserConnection,
-		navToConnection,
-		setGlobalNotice,
-	] );
+	}, [ message, requiresUserConnection, navToConnection, setGlobalNotice ] );
 }

--- a/projects/packages/my-jetpack/_inc/state/selectors.js
+++ b/projects/packages/my-jetpack/_inc/state/selectors.js
@@ -2,9 +2,12 @@
  * Internal dependencies
  */
 import { mapObjectKeysToCamel } from '../utils/to-camel';
+import { PRODUCT_STATUSES } from '../components/product-card';
 
 export const getProducts = state => state.products?.items || {};
+
 export const getProductNames = state => Object.keys( getProducts( state ) );
+
 export const getProduct = ( state, productId ) => {
 	const stateProduct = getProducts( state )?.[ productId ] || {};
 
@@ -21,8 +24,25 @@ export const getProduct = ( state, productId ) => {
 
 	return product;
 };
+
 export const isValidProduct = ( state, productId ) =>
 	getProductNames( state ).includes( productId );
+
+export const getProductsThatRequiresUserConnection = state => {
+	const products = getProducts( state );
+
+	return Object.keys( products ).reduce( ( current, product ) => {
+		const currentProduct = products[ product ];
+		const requires =
+			currentProduct?.requires_user_connection &&
+			( currentProduct?.status === PRODUCT_STATUSES.ACTIVE ||
+				currentProduct?.status === PRODUCT_STATUSES.ERROR );
+		if ( requires ) {
+			current.push( currentProduct?.name );
+		}
+		return current;
+	}, [] );
+};
 
 const productSelectors = {
 	getProducts,
@@ -30,6 +50,7 @@ const productSelectors = {
 	getProduct,
 	isValidProduct,
 	isFetching: ( state, productId ) => state.products?.isFetching?.[ productId ] || false,
+	getProductsThatRequiresUserConnection,
 };
 
 const purchasesSelectors = {

--- a/projects/packages/my-jetpack/changelog/update-fix-my-jetpack-connection-notice
+++ b/projects/packages/my-jetpack/changelog/update-fix-my-jetpack-connection-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Move product list that requires user connection to selector


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes a regression caused by #23073, since all manipulation on the product that was being directly on the original object, the entire data on the store was getting modified for `camelCase`, since it was moved to `selector` and not modified the original object, the connection was using in `camelCase` direct from `getProducts`, because of this it stopped to work.

This already will help on follow-up PRs about `ConnectionStatusCard`.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Move `getProductsThanRequiresUserConnection` to own selector using `snake_case`.
* Use that on `useConnectionWatcher` and move message out of `useEffect` to avoid recalling `useEffect` unnecessary.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Disconnect user from the site.
* Goes to `My Jetpack` page.
* You should see the notice saying about connection.
