### PR TITLE
Add missing plugins sidebar menu for Atomic site with unsupported plan

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-add-missing-plugins-menu-woa-site
+++ b/projects/plugins/jetpack/changelog/fix-add-missing-plugins-menu-woa-site
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Add missing plugins sidebar menu for Atomic site with unsupported plan

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -120,7 +120,10 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		// Calypso plugins screens link.
 		$plugins_slug = 'https://wordpress.com/plugins/' . $this->domain;
 
-		// Hide Add new plugin and plugin file editor menu.
+		// `wpcomsh` restricts the plugins capabilities when the site doesn't have a 
+		// supported plan so the Plugins menu it's not registered. We still want the 
+		// menu to be available though, since it offers an opportunity to buy again
+		// the needed plan.
 		if ( ! $this->has_atomic_supported_plan() ) {
 			add_menu_page( 'Plugins', 'Plugins', 'manage_options', $plugins_slug, null, 'dashicons-admin-plugins', '65' );
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -117,6 +117,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	public function add_plugins_menu() {
 		global $submenu;
 
+		// Calypso plugins screens link.
 		$plugins_slug = 'https://wordpress.com/plugins/' . $this->domain;
 
 		// Hide Add new plugin and plugin file editor menu.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -117,9 +117,11 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	public function add_plugins_menu() {
 		global $submenu;
 
+		$plugins_slug = 'https://wordpress.com/plugins/' . $this->domain;
+
 		// Hide Add new plugin and plugin file editor menu.
 		if ( ! $this->has_atomic_supported_plan() ) {
-			parent::add_plugins_menu();
+			add_menu_page( 'Plugins', 'Plugins', 'manage_options', $plugins_slug, null, 'dashicons-admin-plugins', '65' );
 
 			return;
 		}
@@ -138,7 +140,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			}
 		}
 
-		$submenus_to_update = array( 'plugin-install.php' => 'https://wordpress.com/plugins/' . $this->domain );
+		$submenus_to_update = array( 'plugin-install.php' => $plugins_slug );
 
 		$this->update_submenus( 'plugins.php', $submenus_to_update );
 	}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -120,8 +120,8 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		// Calypso plugins screens link.
 		$plugins_slug = 'https://wordpress.com/plugins/' . $this->domain;
 
-		// `wpcomsh` restricts the plugins capabilities when the site doesn't have a 
-		// supported plan so the Plugins menu it's not registered. We still want the 
+		// `wpcomsh` restricts the plugins capabilities when the site doesn't have a
+		// supported plan so the Plugins menu it's not registered. We still want the
 		// menu to be available though, since it offers an opportunity to buy again
 		// the needed plan.
 		if ( ! $this->has_atomic_supported_plan() ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #https://github.com/Automattic/wp-calypso/issues/59734

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This is follow-up PR to fix changes introduces by #22786. Due to the capability being removed the plugins.php menu went missing. This PR re-adds the Plugins menu for the Atomic site with unsupported plans. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a short link to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request to change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- in your atomic dev blog, copy the changes proposed in this PR
- visit your site

##### Free Atomic:

- make sure that Plugins links to Calypso [https://wordpress.com/plugins/[DOMAIN]](https://wordpress.com/plugins/%5BDOMAIN%5D)
- You don't see any submenu under Plugins menu

##### Atomic with a higher plan:

- make sure that Plugins -> Add New still links to Calypso [https://wordpress.com/plugins/[DOMAIN]](https://wordpress.com/plugins/%5BDOMAIN%5D)
- make sure that Plugins links to the default WP admin wp-admin/plugins.php page.
- make sure that Plugins -> Installed Plugins to the default WP admin wp-admin/plugins.php page.
