### PR TITLE
Jetpack: Take pre_update_option filter into account when firing active module hooks

### DIFF
--- a/projects/plugins/jetpack/changelog/update-module-activation-hooks
+++ b/projects/plugins/jetpack/changelog/update-module-activation-hooks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Take pre_update_option filter into account when firing active module hooks

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -596,6 +596,18 @@ class Jetpack {
 		$new_current_modules  = array_diff( array_merge( $current_modules, $new_active_modules ), $new_inactive_modules );
 		$reindexed_modules    = array_values( $new_current_modules );
 		$success              = Jetpack_Options::update_option( 'active_modules', array_unique( $reindexed_modules ) );
+		// Let's take `pre_update_option_jetpack_active_modules` filter into account
+		// and actually decide for which modules we need to fire hooks by comparing
+		// the 'active_modules' option before and after the update.
+		$current_modules_post_update = Jetpack_Options::get_option( 'active_modules', array() );
+
+		$new_inactive_modules = array_diff( $current_modules, $current_modules_post_update );
+		$new_inactive_modules = array_unique( $new_inactive_modules );
+		$new_inactive_modules = array_values( $new_inactive_modules );
+
+		$new_active_modules = array_diff( $current_modules_post_update, $current_modules );
+		$new_active_modules = array_unique( $new_active_modules );
+		$new_active_modules = array_values( $new_active_modules );
 
 		foreach ( $new_active_modules as $module ) {
 			/**

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -3035,8 +3035,7 @@ class Jetpack {
 		self::catch_errors( true );
 		ob_start();
 		require self::get_module_path( $module ); // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
-		/** This action is documented in class.jetpack.php */
-		do_action( 'jetpack_activate_module', $module );
+
 		$active[] = $module;
 		self::update_active_modules( $active );
 

--- a/projects/plugins/jetpack/tests/php/general/test_class.jetpack.php
+++ b/projects/plugins/jetpack/tests/php/general/test_class.jetpack.php
@@ -287,6 +287,28 @@ EXPECTED;
 		remove_action( 'jetpack_activate_module_stats', array( __CLASS__, 'track_activated_modules' ) );
 		remove_action( 'jetpack_deactivate_module_stats', array( __CLASS__, 'track_deactivated_modules' ) );
 	}
+	/**
+	 * Test Jetpack::update_active_modules with pre_update_option_jetpack_active_modules filter.
+	 *
+	 * @author fgiannar
+	 */
+	public function test_activating_deactivating_modules_with_pre_update_filter() {
+		self::reset_tracking_of_module_activation();
+
+		add_action( 'jetpack_activate_module', array( __CLASS__, 'track_activated_modules' ) );
+		add_action( 'jetpack_deactivate_module', array( __CLASS__, 'track_deactivated_modules' ) );
+		add_filter( 'pre_update_option_jetpack_active_modules', array( __CLASS__, 'filter_pre_update_option_jetpack_active_modules' ), 10, 2 );
+
+		Jetpack::update_active_modules( array( 'json-api' ) );
+		Jetpack::update_active_modules( array( 'json-api' ) );
+
+		$this->assertEquals( self::$activated_modules, array( 'json-api', 'stats' ) );
+		$this->assertEmpty( self::$deactivated_modules );
+
+		remove_filter( 'pre_update_option_jetpack_active_modules', array( __CLASS__, 'filter_pre_update_option_jetpack_active_modules' ) );
+		remove_action( 'jetpack_activate_module', array( __CLASS__, 'track_activated_modules' ) );
+		remove_action( 'jetpack_deactivate_module', array( __CLASS__, 'track_deactivated_modules' ) );
+	}
 
 	public function test_active_modules_filter_restores_state() {
 		self::reset_tracking_of_module_activation();
@@ -714,6 +736,22 @@ EXPECTED;
 	 */
 	public static function track_deactivated_modules( $module ) {
 		self::$deactivated_modules[] = $module;
+	}
+
+	/**
+	 * Hooks the WP pre_update filter on the jetpack_active_modules option to
+	 * add 'stats' module to the array.
+	 *
+	 * @param array $modules An array of Jetpack module slugs.
+	 *
+	 * @return array An array of Jetpack module slugs
+	 */
+	public static function filter_pre_update_option_jetpack_active_modules( $modules ) {
+		$modules = array_merge( $modules, array( 'stats' ) );
+		$modules = array_unique( $modules );
+		$modules = array_values( $modules );
+
+		return $modules;
 	}
 
 	/**


### PR DESCRIPTION
Enhances `Jetpack::update_active_modules` method by taking the `pre_update_option_jetpack_active_modules` filter into account before firing the corresponding `jetpack_activate_module` and `jetpack_deactivate_module` hooks.

The logic is to compare the `jetpack_active_modules` option value before and after the update and based on the differences decide which modules were **just** activated or deactivated in order to fire the corresponding hooks.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates `Jetpack::update_active_modules` method by relying on the `jetpack_active_modules` option value before and after the update in order to fire the corresponding hooks. This approach ensures that if a consumer uses the `pre_update_option_jetpack_active_modules` filter, it will be respected.
* Removes redundant hook from `Jetpack::activate_module`. This resulted in firing the same action twice.

#### Jetpack product discussion
p9GBOq-37V-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

**Prerequisites**
A fully connected Jetpack site with the Jetpack plugin active.
Initial branch should be master.

**Before**
Add the following snippet to your site (you can use the Code Snippets plugin):

```
// Make sure "Site Stats" are always active and "Notifications" always inactive.
add_filter( 'pre_update_option_jetpack_active_modules', function( $modules ) {
	$modules = array_merge( $modules, array( 'stats' ) );
	$modules = array_diff( $modules, ['notes'] );
	$modules = array_unique( $modules );
	$modules = array_values( $modules );
	error_log( 'Applied pre_update_option_jetpack_active_modules filter. Active modules: ' . json_encode( $modules ) );
	return $modules;
});

add_action( 'jetpack_activate_module', function( $module ) {
	error_log( 'Activated module: ' . $module );
});

add_action( 'jetpack_deactivate_module', function( $module ) {
	error_log( 'Deactivated module: ' . $module );
});
```

- Go to the Modules page (`wp-admin/admin.php?page=jetpack_modules`) and deactivate the Stats module
- You will notice that the Stats module is active but the `jetpack_deactivate_module` hook was fired - "Deactivated module: stats" will be present in the `debug.log`
-  Now deactivate Notifications
-  You will notice that the Notifications module is not active but the `jetpack_activate_module` hook was fired - "Activated module: notes" will be present in the `debug.log`

**After**
- Apply the current branch and repeat the above
- Confirm that when you tried to activate the Stats module the `jetpack_deactivate_module` hook was NOT  fired
- Confirm that when you tried to deactivate the Notifications module the `jetpack_activate_module` hook was NOT  fired