### PR TITLE
My Jetpack: Fix styles for beta badge on RTL languages

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-beta-badge-style
+++ b/projects/packages/my-jetpack/changelog/update-beta-badge-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix beta badge for RTL languages

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -50,7 +50,7 @@ class Initializer {
 			sprintf(
 			/* translators: %s: "beta" label on Menu item for My Jetpack. */
 				__( 'My Jetpack %s', 'jetpack-my-jetpack' ),
-				'<span style="margin: 8px; color: #bbb;">' . __( 'beta', 'jetpack-my-jetpack' ) . '</span>'
+				'<span style="display:inline-block; margin: 0 8px; color: #bbb;">' . __( 'beta', 'jetpack-my-jetpack' ) . '</span>'
 			),
 			'manage_options',
 			'my-jetpack',


### PR DESCRIPTION
Fixes #22962
#### After


<img width="306" alt="image" src="https://user-images.githubusercontent.com/746152/155525841-15f53900-7dc6-4218-a645-2d990b281403.png">

### Before
<img width="306" alt="image" src="https://user-images.githubusercontent.com/746152/155526272-7fd82c63-c69c-493a-b534-84f176e749be.png">

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates styles on Beta badge


#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Checkout this branch
* Check the beta badge on an RTL language 
* Confirm it looks like in the screenshot
