### PR TITLE
jetpack: Include a WAF composer dep in the build

### DIFF
--- a/projects/plugins/jetpack/.gitattributes
+++ b/projects/plugins/jetpack/.gitattributes
@@ -16,6 +16,7 @@
 /vendor/composer/**                                      production-include
 /vendor/jetpack-autoloader/**                            production-include
 /vendor/nojimage/**                                      production-include
+/vendor/wikimedia/aho-corasick/**                        production-include
 
 # Files to exclude from Automattic/jetpack-production.
 # Remember to end all directories with `/**` to properly tag every file.

--- a/projects/plugins/jetpack/changelog/add-jetpack-include-waf-dep-in-build
+++ b/projects/plugins/jetpack/changelog/add-jetpack-include-waf-dep-in-build
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Include the dependency of the WAF package in the plugin zip.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
PR #22816 added packages/waf to Jetpack, and that package has a
(non-dev) Composer dep. If we want the package to work (someday, looks
like there's no UI for enabling or configuring it yet), that dep will
need to be included in the plugin bundle.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1645724524900839/1645722448.473329-slack-C01U2KGS2PQ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the build artifact for the Jetpack plugin. Make sure the aho-corasick library is included in the bundle.