### PR TITLE
My Jetpack: My Jetpack: Handle cosmetic tweaks

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
@@ -3,6 +3,7 @@
 .heading {
 	font-size: 36px;
 	line-height: 40px;
+	font-weight: 700;
 	margin: 0;
 }
 

--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { __ } from '@wordpress/i18n';
+import { __, _n } from '@wordpress/i18n';
 import { ExternalLink } from '@wordpress/components';
 
 /**
@@ -37,6 +37,17 @@ function PlanSection( { purchase = {} } ) {
  * @returns {object} PlanSectionHeader react component.
  */
 function PlanSectionHeader( { purchases } ) {
+	let planLinkDescription = __( 'Purchase a plan', 'jetpack-my-jetpack' );
+	if ( purchases.length > 1 ) {
+		/* translators: %d: number of site plans. */
+		planLinkDescription = _n(
+			'Manage your plan.',
+			'Manage your plans',
+			purchases.length,
+			'jetpack-my-jetpack'
+		);
+	}
+
 	return (
 		<>
 			<h3>
@@ -47,9 +58,7 @@ function PlanSectionHeader( { purchases } ) {
 			<p>{ __( 'The extra power you added to your Jetpack.', 'jetpack-my-jetpack' ) }</p>
 			<p>
 				<ExternalLink className={ styles[ 'external-link' ] } href={ getManageYourPlanUrl() }>
-					{ purchases.length <= 1
-						? __( 'Manage your plan', 'jetpack-my-jetpack' )
-						: __( 'Manage your plans', 'jetpack-my-jetpack' ) }
+					{ planLinkDescription }
 				</ExternalLink>
 			</p>
 		</>

--- a/projects/packages/my-jetpack/_inc/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/style.module.scss
@@ -12,6 +12,27 @@
 		.jp-dashboard-footer__jetpack-symbol {
 			height: 16px;
 		}
+		
+		// Buttons
+		// button-group
+		.components-button {
+			border-radius: 4px;
+		}
+
+		.components-button-group {
+			> .components-button:first-child {
+				border-top-right-radius: 0;
+				border-bottom-right-radius: 0;
+			}
+
+			.components-dropdown-menu .components-button,
+			> .components-button:last-child {
+				border-top-left-radius: 0;
+				border-bottom-left-radius: 0;
+			}
+
+			
+		}
 	}
 
 	#wpbody-content {

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-keep-tweaking-styles
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-keep-tweaking-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+My Jetpack: Handle cosmetic tweaks


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

On this PR:
✅ Page heading weight.
✅ Buttons border-radius from 2px to 4px.
✅ My Plan text for no plan and manage plans.

Fix partially https://github.com/Automattic/jetpack/issues/23014

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* My Jetpack
* Confirm the style tweaks 

<img width="1218" alt="Screen Shot 2022-02-25 at 10 46 00 AM" src="https://user-images.githubusercontent.com/77539/155725912-c117817b-7184-48c2-ac38-523d80f94373.png">

