### PR TITLE
My Jetpack: add connected plugins to Disconnect dialog

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connections-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connections-section/index.jsx
@@ -1,3 +1,4 @@
+/* global myJetpackInitialState */
 /**
  * External dependencies
  */
@@ -18,12 +19,14 @@ import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 export default function ConnectionsSection() {
 	const { apiRoot, apiNonce, redirectUrl } = useMyJetpackConnection();
 	const navigate = useMyJetpackNavigate( '/connection' );
+	const { connectedPlugins } = myJetpackInitialState;
 	return (
 		<ConnectionStatusCard
 			apiRoot={ apiRoot }
 			apiNonce={ apiNonce }
 			redirectUri={ redirectUrl }
 			onConnectUser={ navigate }
+			connectedPlugins={ connectedPlugins }
 		/>
 	);
 }

--- a/projects/packages/my-jetpack/changelog/add-connected-plugins-my-jetpack-disconnect
+++ b/projects/packages/my-jetpack/changelog/add-connected-plugins-my-jetpack-disconnect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added list of connected plugins to Disconnect dialog in My Jetpack

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -119,6 +119,7 @@ class Initializer {
 				'siteSuffix'            => ( new Status() )->get_site_suffix(),
 				'myJetpackVersion'      => self::PACKAGE_VERSION,
 				'fileSystemWriteAccess' => self::has_file_system_write_access(),
+				'connectedPlugins'      => self::get_connected_plugins(),
 			)
 		);
 
@@ -138,6 +139,28 @@ class Initializer {
 		if ( self::can_use_analytics() ) {
 			Tracking::register_tracks_functions_scripts( true );
 		}
+	}
+
+	/**
+	 * Get the list of plugins actively using the Connection
+	 *
+	 * @return array The list of plugins.
+	 */
+	private static function get_connected_plugins() {
+		$plugins = ( new Connection_Manager() )->get_connected_plugins();
+
+		if ( is_wp_error( $plugins ) ) {
+			return array();
+		}
+
+		array_walk(
+			$plugins,
+			function ( &$data, $slug ) {
+				$data['slug'] = $slug;
+			}
+		);
+
+		return $plugins;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Adds the list of connected plugins to the disconnect dialog.

This is a temporary approach while we don't incorporate this into the js connection package.

Known issue: if you activate a plugin and click Disconnect without a page refresh, the activated plugin will not show up in the list

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Added list of connected plugins to Disconnect dialog in My Jetpack

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/issues/23079

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Connect Jetpack
* Activate More than one plugin. e.g. Boost and Jetpack
* Go to My Jetpack
* Click Disconnect
* Confirm that the modal window shows the correct list of active plugins using the conection

![Captura de tela de 2022-02-24 15-56-04](https://user-images.githubusercontent.com/971483/155594566-c06f94b7-383b-4265-8cad-7a82f704d438.png)

