### PR TITLE
Publicize: Fix post meta not saving properly in Classic Editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-publicize-classic-editor-save-meta
+++ b/projects/plugins/jetpack/changelog/fix-publicize-classic-editor-save-meta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Removed wrong sanitation that was causing some Publicize options to not save in the Classic Editor

--- a/projects/plugins/jetpack/modules/publicize/publicize.php
+++ b/projects/plugins/jetpack/modules/publicize/publicize.php
@@ -1140,8 +1140,8 @@ abstract class Publicize_Base {
 			$submit_post = false;
 		}
 
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$admin_page = isset( $_POST[ $this->ADMIN_PAGE ] ) ? sanitize_text_field( wp_unslash( $_POST[ $this->ADMIN_PAGE ] ) ) : null;
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- We're only checking if a value is set
+		$admin_page = isset( $_POST[ $this->ADMIN_PAGE ] ) ? $_POST[ $this->ADMIN_PAGE ] : null;
 
 		// Did this request happen via wp-admin?
 		$from_web = isset( $_SERVER['REQUEST_METHOD'] )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes a bug in Publicize that caused some post meta in the Classic Editor to not get saved properly.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes the incorrect sanitation that caused an array to get converted to an empty string, causing the following if statement to always return false.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1645738067416259-slack-CBG1CP4EN
p1645728865017369-slack-C02JJ910CNL

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start a new post with Publicize enabled.
* Disable Publicize for a specific connection for that post (e.g. don't post to Facebook or Twitter)
* Save as draft.
* Confirm the connection is still unchecked.