### PR TITLE
Search: Fix regression preventing clicks from spawning overlay

### DIFF
--- a/projects/packages/search/changelog/fix-instant-search-link-spawner-regression
+++ b/projects/packages/search/changelog/fix-instant-search-link-spawner-regression
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: Fixed a regression that prevented modal from being spawned by link clicks

--- a/projects/packages/search/src/instant-search/components/overlay.jsx
+++ b/projects/packages/search/src/instant-search/components/overlay.jsx
@@ -35,13 +35,21 @@ const Overlay = props => {
 		};
 
 		window.addEventListener( 'keydown', closeWithEscape );
-		window.addEventListener( 'click', closeWithOutsideClick );
+
+		// Ensures that the click closed handler only fires when the overlay is active.
+		// This ensures it doesn't erroneously intercept filter links or overlay spawner buttons.
+		if ( isVisible ) {
+			window.addEventListener( 'click', closeWithOutsideClick );
+		} else {
+			window.removeEventListener( 'click', closeWithOutsideClick );
+		}
+
 		return () => {
 			// Cleanup on component dismount
 			window.removeEventListener( 'keydown', closeWithEscape );
 			window.removeEventListener( 'click', closeWithOutsideClick );
 		};
-	}, [ closeOverlay ] );
+	}, [ closeOverlay, isVisible ] );
 
 	return (
 		<div


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #23091. E2E tests will be added in another PR to ensure this regression will not recur.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Fixes a regression that prevents click events from spawning the search overlay.

<!-- #### Jetpack product discussion -->
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this change to your site with a Jetpack Search subscription.
* Add a `a.jetpack-search-filter__link` and a `button.jetpack-instant-search__open-overlay-button` to a page or a post.
* Open the post and click on the link or the button. 
* Ensure that the modal is spawned as expected.
* Click outside the modal; ensure that the modal closes as expected.
* Repeat the above steps to spawn the modal. 
* Press escape; ensure the modal closes as expected.
