### PR TITLE
Publicize: Fix custom messages in the classic editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-publicize-custom-message
+++ b/projects/plugins/jetpack/changelog/fix-publicize-custom-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Corrected the wpas_title form field name to fix Publicize custom messages in the classic editor.

--- a/projects/plugins/jetpack/modules/publicize/publicize.php
+++ b/projects/plugins/jetpack/modules/publicize/publicize.php
@@ -1151,7 +1151,7 @@ abstract class Publicize_Base {
 			! empty( $admin_page );
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$title = isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : null;
+		$title = isset( $_POST['wpas_title'] ) ? sanitize_text_field( wp_unslash( $_POST['wpas_title'] ) ) : null;
 
 		if ( ( $from_web || defined( 'POST_BY_EMAIL' ) ) && $title ) {
 			if ( empty( $title ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

As reported in https://wordpress.com/forums/topic/custom-twitter-message-broken/?view=all
a bug introduced in #22511 meant that we would not use the supplied
custom message when sharing the post.

This change fixes the bug by correcting the form field name used.

#### Jetpack product discussion

p1645767881753639-slack-C02JJ910CNL

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* With a test site that has a Publicize connection to Twitter
* Create a post in the classic editor, and supply a custom message
* Without this change the default post title will be used in the tweet
* With this change the custom message will be used in the tweet.