### PR TITLE
Jetpack: Dashboard/Assistant - Add support links

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/support-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/support-card/index.jsx
@@ -67,6 +67,14 @@ class SupportCard extends React.Component {
 		} );
 	};
 
+	trackGettingStartedClick = () => {
+		analytics.tracks.recordJetpackClick( {
+			target: 'support-card',
+			button: 'getting-started',
+			page: this.props.path,
+		} );
+	};
+
 	render() {
 		if (
 			'undefined' === typeof this.props.sitePlan.product_slug &&
@@ -98,6 +106,16 @@ class SupportCard extends React.Component {
 								  ) }
 						</p>
 						<p className="jp-support-card__description">
+							<Button
+								onClick={ this.trackGettingStartedClick }
+								href={
+									this.props.isAtomicSite
+										? getRedirectUrl( 'calypso-help' )
+										: getRedirectUrl( 'jetpack-support-getting-started' )
+								}
+							>
+								{ __( 'Getting started with Jetpack', 'jetpack' ) }
+							</Button>
 							<Button
 								onClick={ this.trackSearchClick }
 								href={

--- a/projects/plugins/jetpack/_inc/client/recommendations/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { connect } from 'react-redux';
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { getRedirectUrl } from '@automattic/jetpack-components';
 
 /**

--- a/projects/plugins/jetpack/_inc/client/recommendations/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/index.jsx
@@ -4,7 +4,8 @@
 import React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { connect } from 'react-redux';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
+import { getRedirectUrl } from '@automattic/jetpack-components';
 
 /**
  * Internal dependencies
@@ -105,6 +106,28 @@ const RecommendationsComponent = props => {
 					</Route>
 				</Switch>
 			) }
+			<div className="jp-footer">
+				<li className="jp-footer__link-item">
+					<a
+						role="button"
+						tabIndex="0"
+						className="jp-footer__link"
+						href={ getRedirectUrl( 'jetpack-support-getting-started' ) }
+					>
+						{ __( 'Learn how to get started with Jetpack', 'jetpack' ) }
+					</a>
+				</li>
+				<li className="jp-footer__link-item">
+					<a
+						role="button"
+						tabIndex="0"
+						className="jp-footer__link"
+						href={ getRedirectUrl( 'jetpack-support' ) }
+					>
+						{ __( 'Search our support site', 'jetpack' ) }
+					</a>
+				</li>
+			</div>
 		</>
 	);
 };

--- a/projects/plugins/jetpack/changelog/add-support-liknks-jetpack
+++ b/projects/plugins/jetpack/changelog/add-support-liknks-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Added support links


### PR DESCRIPTION
Fixes #23266
Fixes #23267

* Introduces a support button on the dashboard linking to the getting started page
* Introduces 2 links at the botton of the recommendatios card linking to the getting started page and the supported page respectively


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* pcKp4R-9E-p2
* Design: p1HpG7-eji-p2 (**check the Accepted answer**)


#### Jetpack product discussion
pcKp4R-9E-p2

#### Does this pull request change what data or activity we track or use?

Yes. Introduces a few events

#### Testing instructions:

1. Checkout this branch
2. Visit the dashboard
  Confirm the first button points to the getting started page
![image](https://user-images.githubusercontent.com/746152/157669751-1207e437-9bc0-45df-b41b-31cac2308497.png)




4. Visit the Recommendations tab
  Confirm the first links points to the getting started page and the second one to the Jetpack support page.
![image](https://user-images.githubusercontent.com/746152/157669884-67bbb744-b449-4cc5-a5a2-48a41fa6dff8.png)



## Designs

![image](https://user-images.githubusercontent.com/746152/155844514-488f4a69-a6d4-45ee-a3c6-e90b7876b7fc.png)
![image](https://user-images.githubusercontent.com/746152/155844534-9c447bc5-13c7-4720-89c9-e15ba72c4685.png)
