### PR TITLE
My Jetpack: Update automattic logo href in the footer

### DIFF
--- a/projects/packages/my-jetpack/_inc/admin.jsx
+++ b/projects/packages/my-jetpack/_inc/admin.jsx
@@ -59,7 +59,7 @@ function Layout( { nav = false, children, slug } ) {
 			</Container>
 			<Container horizontalSpacing={ 5 }>
 				<Col>
-					<JetpackFooter />
+					<JetpackFooter a8cLogoHref="https://automattic.com" />
 				</Col>
 			</Container>
 		</div>

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -66,7 +66,7 @@ export default function MyJetpackScreen() {
 	}
 
 	return (
-		<AdminPage>
+		<AdminPage a8cLogoHref="https://automattic.com">
 			<AdminSectionHero>
 				<Container horizontalSpacing={ 5 } horizontalGap={ message ? 3 : 6 }>
 					<Col sm={ 4 } md={ 7 } lg={ 6 }>

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-footer-automattic-logo
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-footer-automattic-logo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Update automattic logo href in the footer


### PR DESCRIPTION
Fixes #23109

Should be followed up by a PR that addresses #23112
![image](https://user-images.githubusercontent.com/746152/155706252-f8e42bf6-df07-4b78-bf20-4814968cedac.png)

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Passes down `a8cLogoHref ` prop set to `https://automattic.com

#### Jetpack product discussion

p8oabR-Oy-p2#comment-6033

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Checkout this branch
* Visit My Jetpack
* Hover on the Automattic logo at the footer
* Confirm it links to automattic.com
* Click an "Add..." link on a card
* Hover on the Automattic logo at the footer
* Confirm it links to automattic.com