### PR TITLE
Premium content: avoid deprecation warning.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-warning-premium-content
+++ b/projects/plugins/jetpack/changelog/fix-warning-premium-content
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Blocks: avoid deprecation warning.
+
+

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/remove-block-keep-content.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/remove-block-keep-content.js
@@ -12,7 +12,7 @@ import { transformToCoreGroup } from './transform-to-core-group';
 import { name } from '../index';
 
 function replaceBlockAndKeepContent() {
-	const block = select( 'core/editor' ).getSelectedBlock();
+	const block = select( 'core/block-editor' ).getSelectedBlock();
 	dispatch( 'core/block-editor' ).replaceBlock(
 		block.clientId,
 		transformToCoreGroup( block.innerBlocks )


### PR DESCRIPTION
Follow-up to #22691

#### Changes proposed in this Pull Request:

* Avoid warnings such as
```
wp.data.select( 'core/editor' ).getSelectedBlock` is deprecated since version 5.3 and will be removed in version 6.2. Please use `wp.data.select( 'core/block-editor' ).getSelectedBlock` instead.
```

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* On a WoA site, try to use the Premium content block; it should still work, especially the feature highlighted in #22691. You can follow the testing instructions there.
