### PR TITLE
Sync class.json-api-endpoints.php from wpcom

### DIFF
--- a/projects/plugins/jetpack/changelog/fusion-sync-thedebian-r240611-wpcom-sync
+++ b/projects/plugins/jetpack/changelog/fusion-sync-thedebian-r240611-wpcom-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sync changes added to wpcom to Jetpack

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1644,6 +1644,12 @@ abstract class WPCOM_JSON_API_Endpoint {
 					$response['allow_download'] = (string) (int) $metadata['videopress']['allow_download'];
 				}
 
+				if ( isset( $info->thumbnail_generating ) ) {
+					$response['thumbnail_generating'] = (bool) intval( $info->thumbnail_generating );
+				} elseif ( isset( $metadata['videopress']['thumbnail_generating'] ) ) {
+					$response['thumbnail_generating'] = (bool) intval( $metadata['videopress']['thumbnail_generating'] );
+				}
+
 				// Thumbnails.
 				if ( function_exists( 'video_format_done' ) && function_exists( 'video_image_url_by_guid' ) ) {
 					$response['thumbnails'] = array(
@@ -1834,6 +1840,14 @@ abstract class WPCOM_JSON_API_Endpoint {
 		// VIP context loading is handled elsewhere, so bail to prevent
 		// duplicate loading. See `switch_to_blog_and_validate_user()`.
 		if ( defined( 'WPCOM_IS_VIP_ENV' ) && WPCOM_IS_VIP_ENV ) {
+			return;
+		}
+
+		$do_check_theme =
+			defined( 'REST_API_TEST_REQUEST' ) && REST_API_TEST_REQUEST ||
+			defined( 'IS_WPCOM' ) && IS_WPCOM;
+
+		if ( $do_check_theme && ! wpcom_should_load_theme_files_on_rest_api() ) {
 			return;
 		}
 
@@ -2053,6 +2067,61 @@ abstract class WPCOM_JSON_API_Endpoint {
 	}
 
 	/**
+	 * Mobile apps are allowed free video uploads, but limited to 5 minutes in length.
+	 *
+	 * @param $media_item array the media item to evaluate.
+	 * @return bool true if the media item is a video that was uploaded via the mobile
+	 * app that is longer than 5 minutes.
+	 */
+	public function media_item_is_free_video_mobile_upload_and_too_long( $media_item ) {
+		if ( ! $media_item ) {
+			return false;
+		}
+
+		// Verify file is a video
+		$is_video = preg_match( '@^video/@', $media_item['type'] );
+		if ( ! $is_video ) {
+			return false;
+		}
+
+		// Check if the request is from a mobile app, where we allow free video uploads at limited length
+		if ( ! in_array( $this->api->token_details['client_id'], VIDEOPRESS_ALLOWED_REST_API_CLIENT_IDS ) ) {
+			return false;
+		}
+
+		// We're only worried about free sites
+		require_once WP_CONTENT_DIR . '/admin-plugins/wpcom-billing.php';
+		$current_plan = WPCOM_Store_API::get_current_plan( get_current_blog_id() );
+		if ( ! $current_plan['is_free'] ) {
+			return false;
+		}
+
+		// Check if video is longer than 5 minutes
+		$video_meta = wp_read_video_metadata( $media_item['tmp_name'] );
+		if (
+			false !== $video_meta &&
+			isset( $video_meta['length'] ) &&
+			5 * MINUTE_IN_SECONDS < $video_meta['length']
+		) {
+			videopress_log(
+				'videopress_app_upload_length_block',
+				'Mobile app upload on free site blocked because length was longer than 5 minutes.',
+				null,
+				null,
+				null,
+				null,
+				array(
+					'blog_id' => get_current_blog_id(),
+					'user_id' => get_current_user_id(),
+				)
+			);
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Handle a v1.1 media creation.
 	 *
 	 * Only one of $media_files and $media_urls should be non-empty.
@@ -2079,17 +2148,22 @@ abstract class WPCOM_JSON_API_Endpoint {
 			$this->api->trap_wp_die( 'upload_error' );
 			foreach ( $media_files as $media_item ) {
 				$_FILES['.api.media.item.'] = $media_item;
+
 				if ( ! $user_can_upload_files ) {
 					$media_id = new WP_Error( 'unauthorized', 'User cannot upload media.', 403 );
 				} else {
-					if ( $force_parent_id ) {
-						$parent_id = absint( $force_parent_id );
-					} elseif ( ! empty( $media_attrs[ $i ] ) && ! empty( $media_attrs[ $i ]['parent_id'] ) ) {
-						$parent_id = absint( $media_attrs[ $i ]['parent_id'] );
+					if ( $this->media_item_is_free_video_mobile_upload_and_too_long( $media_item ) ) {
+						$media_id = new WP_Error( 'upload_video_length', 'Video uploads longer than 5 minutes require a paid plan.', 400 );
 					} else {
-						$parent_id = 0;
+						if ( $force_parent_id ) {
+							$parent_id = absint( $force_parent_id );
+						} elseif ( ! empty( $media_attrs[ $i ] ) && ! empty( $media_attrs[ $i ]['parent_id'] ) ) {
+							$parent_id = absint( $media_attrs[ $i ]['parent_id'] );
+						} else {
+							$parent_id = 0;
+						}
+						$media_id = media_handle_upload( '.api.media.item.', $parent_id );
 					}
-					$media_id = media_handle_upload( '.api.media.item.', $parent_id );
 				}
 				if ( is_wp_error( $media_id ) ) {
 					$errors[ $i ]['file']    = $media_item['name'];


### PR DESCRIPTION
Some commits were made directly to `class.json-api-endpoints.php` on wpcom and were not created with a Jetpack PR first. 

#### Changes proposed in this Pull Request:
* This PR catches up with the changes in Jetpack to `class.json-api-endpoints.php`.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* These changes contain code that is only used from wpcom, so just verify that the Jetpack site still operates normally.
