### PR TITLE
pr-is-up-to-date: Speed up processing of tag pushes with paths

### DIFF
--- a/projects/github-actions/pr-is-up-to-date/changelog/fix-pr-up-to-date-workflow-timeout
+++ b/projects/github-actions/pr-is-up-to-date/changelog/fix-pr-up-to-date-workflow-timeout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Speed up processing of tag push with paths.

--- a/projects/github-actions/pr-is-up-to-date/run.sh
+++ b/projects/github-actions/pr-is-up-to-date/run.sh
@@ -72,6 +72,7 @@ case "$GITHUB_EVENT_NAME" in
 		;;
 	push)
 		declare -i PAGE=1
+		declare -i DEEPENBY=100
 		while :; do
 			echo "::group::Fetching PRs (page $PAGE)"
 			JSON=$(curl --fail --get --header "authorization: Bearer $API_TOKEN" --data-urlencode "base=${BRANCH}" "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pulls?state=open&per_page=100&page=${PAGE}")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
When processing a tag push and PATHS is set, we need to find the merge
base to get the diff to determine if the paths are touched.

But it's a lot faster to fetch 100 revisions at once than to fetch 10
revisions 10 times. So instead of fetching to each PR's merge base,
which will likely enough fetch a few revisions for every PR beyond a
certain age, fetch arbitrary blocks of revisions.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You could set the relevant environment variables and run the script manually. Or merge then watch the run on the next tag push.
