### PR TITLE
My Jetpack: Declare usage of WP_Error in REST Products class to prevent fatal

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-wp-error-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/fix-wp-error-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use namespace in My Jetpack REST Products class to prevent fatal

--- a/projects/packages/my-jetpack/src/class-rest-products.php
+++ b/projects/packages/my-jetpack/src/class-rest-products.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\My_Jetpack;
 
+use WP_Error;
+
 /**
  * Registers the REST routes for Products.
  */


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*  Adds `use WP_Error` statement.

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
Confirm changes make sense. Line [110](https://github.com/Automattic/jetpack/blob/e1f49a69ab8f90a34aff53f8d9ef13a196b421c4/projects/packages/my-jetpack/src/class-rest-products.php#L110) is using WP_Error but this symbol hasn't been imported nor it's referred to via the global namespace.