### PR TITLE
Connection: remove trailing semicolons from the site suffix

### DIFF
--- a/projects/packages/status/changelog/fix-site-suffix-colon
+++ b/projects/packages/status/changelog/fix-site-suffix-colon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Remove trailing semicolor form site suffix.

--- a/projects/packages/status/src/class-status.php
+++ b/projects/packages/status/src/class-status.php
@@ -322,6 +322,6 @@ class Status {
 		$url = preg_replace( '#^.*?://#', '', $url );
 		$url = str_replace( '/', '::', $url );
 
-		return $url;
+		return rtrim( $url, ':' );
 	}
 }

--- a/projects/packages/status/tests/php/test-status.php
+++ b/projects/packages/status/tests/php/test-status.php
@@ -498,6 +498,10 @@ class Test_Status extends TestCase {
 				'https://example.org/http://example.com',
 				'example.org::http:::::example.com',
 			),
+			'trailing_slash'   => array(
+				'https://example.org/',
+				'example.org',
+			),
 		);
 	}
 


### PR DESCRIPTION
In response to https://github.com/Automattic/wp-calypso/issues/61464

Some plugins add trailing slash to the WP home URL, resulting in the site suffix ending with `::` (e.g. `example.org::`).
That causes issues with Calypso, and this PR removes the trailing `::` it happens to be there.

#### Changes proposed in this Pull Request:
* remove trailing semicolons from the site suffix

#### Jetpack product discussion
https://wp.me/p9F6qB-8EL

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
_Before checking out the PR, please try reproducing the issue:_
1. Connect Jetpack
2. Install and activate the following plugins: Polyland, Elementor, Polylang Connect for Elementor
3. Go to your site's Calypso section (e.g. "Stats") and then click on "Plugins".
4. Confirm that the site suffix in the URL contains the trailing `::` (e.g. `your-site.example.org::`). The plugin page will not load.
5. Checkout the branch, close the browser tab and repeat step 3. The site suffix should no longer contain trailing `::`, the plugins page should work fine.