### PR TITLE
repo-gardening: Cache results from the milestones endpoint

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/fix-gardening-cache-milestones
+++ b/projects/github-actions/repo-gardening/changelog/fix-gardening-cache-milestones
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Only hit the milestones endpoint once per run.

--- a/projects/github-actions/repo-gardening/src/get-next-valid-milestone.js
+++ b/projects/github-actions/repo-gardening/src/get-next-valid-milestone.js
@@ -6,6 +6,41 @@ const compareVersions = require( 'compare-versions' );
 
 /* global GitHub, OktokitIssuesListMilestonesForRepoResponseItem */
 
+// Cache for getOpenMilestones.
+const cache = {};
+
+/**
+ * Fetch all open milestones.
+ *
+ * @param {GitHub} octokit - Initialized Octokit REST client.
+ * @param {string} owner   - Repository owner.
+ * @param {string} repo    - Repository name.
+ * @returns {Promise<Array>} Promise resolving to an array of all open milestones.
+ */
+async function getOpenMilestones( octokit, owner, repo ) {
+	const milestones = [];
+	const cacheKey = `${ owner }/${ repo }`;
+	if ( cache[ cacheKey ] ) {
+		return cache[ cacheKey ];
+	}
+
+	for await ( const response of octokit.paginate.iterator( octokit.rest.issues.listMilestones, {
+		owner,
+		repo,
+		state: 'open',
+		sort: 'due_on',
+		direction: 'asc',
+		per_page: 100,
+	} ) ) {
+		for ( const milestone of response.data ) {
+			milestones.push( milestone );
+		}
+	}
+
+	cache[ cacheKey ] = milestones;
+	return milestones;
+}
+
 /**
  * Returns a promise resolving to the next valid milestone, if exists.
  *
@@ -16,32 +51,20 @@ const compareVersions = require( 'compare-versions' );
  * @returns {Promise<OktokitIssuesListMilestonesForRepoResponseItem|void>} Promise resolving to milestone, if exists.
  */
 async function getNextValidMilestone( octokit, owner, repo, plugin = 'jetpack' ) {
-	const options = octokit.rest.issues.listMilestones.endpoint.merge( {
-		owner,
-		repo,
-		state: 'open',
-		sort: 'due_on',
-		direction: 'asc',
-	} );
-
-	const responses = octokit.paginate.iterator( options );
-
-	for await ( const response of responses ) {
-		// Find all valid milestones for the specified plugin.
-		const reg = new RegExp( '^' + plugin + '\\/\\d+\\.\\d' );
-		const milestones = response.data
-			.filter( m => m.title.match( reg ) )
-			.sort( ( m1, m2 ) =>
-				compareVersions( m1.title.split( '/' )[ 1 ], m2.title.split( '/' )[ 1 ] )
-			);
-
-		// Return the first milestone with a future due date,
-		// or failing that the first milestone with no due date.
-		return (
-			milestones.find( milestone => milestone.due_on && moment( milestone.due_on ) > moment() ) ||
-			milestones.find( milestone => ! milestone.due_on )
+	// Find all valid milestones for the specified plugin.
+	const reg = new RegExp( '^' + plugin + '\\/\\d+\\.\\d' );
+	const milestones = ( await getOpenMilestones( octokit, owner, repo ) )
+		.filter( m => m.title.match( reg ) )
+		.sort( ( m1, m2 ) =>
+			compareVersions( m1.title.split( '/' )[ 1 ], m2.title.split( '/' )[ 1 ] )
 		);
-	}
+
+	// Return the first milestone with a future due date,
+	// or failing that the first milestone with no due date.
+	return (
+		milestones.find( milestone => milestone.due_on && moment( milestone.due_on ) > moment() ) ||
+		milestones.find( milestone => ! milestone.due_on )
+	);
 }
 
 module.exports = getNextValidMilestone;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
When multiple plugins are touched, it was hitting the milestones
endpoint for each one. We can reduce API calls slightly by caching the
results.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* ???