### PR TITLE
Subscribe block: remove from P2 bundle

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-p2-subscribe-block
+++ b/projects/plugins/jetpack/changelog/fix-p2-subscribe-block
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: P2: remove the Subscriptions block from the P2 bundle.
+
+

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -65,7 +65,6 @@
 		"revue",
 		"simple-payments",
 		"slideshow",
-		"subscriptions",
 		"tiled-gallery",
 		"videopress",
 		"wordads"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

#22912 added publish panels, and thus a dependency with `@wordpress/edit-post`, but that is not available on that `no-post-editor` bundle, used on the frontend of P2s.

#### Jetpack product discussion

* p1646062066323259-slack-C010KDAPG49

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* On WordPress.com, apply D75812-code and sandbox a P2.
* See if Jetpack blocks are available in the post editor on the frontend.
