### PR TITLE
actions: Direct CI Slack notifications to different channels

### DIFF
--- a/.github/workflows/slack-workflow-failed.yml
+++ b/.github/workflows/slack-workflow-failed.yml
@@ -84,10 +84,20 @@ jobs:
             ]
           }'
 
-      - name: Send message
+      - name: Send message to alerts channel
         uses: slackapi/slack-github-action@v1.18.0
+        if: github.ref == 'refs/heads/master'
         with:
-          channel-id: ${{ secrets.SLACK_CI_CHANNEL }}
+          channel-id: ${{ secrets.SLACK_JP_ALERTS_CHANNEL }}
+          payload: ${{ steps.message.outputs.message }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }}
+
+      - name: Send message to releases channel
+        uses: slackapi/slack-github-action@v1.18.0
+        if: contains( github.ref, '/branch-' )
+        with:
+          channel-id: ${{ secrets.SLACK_RELEASES_CHANNEL }}
           payload: ${{ steps.message.outputs.message }}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We've decided to split the notifications, with master going to one
channel and release branches going to another.

There are two ways this could have been done: have a step determine the
channel as an output to feed to the send-message step, or have
send-message steps per channel with `if` used to enable the appropriate
steps. I decided to go with the latter, since it's more straightforward
that way if at some point in the future we decide messages might want to
go to more than one channel (e.g. say Boost wanted notifications about
their release branch to go to their channel too).

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-4wL-p2#comment-7473

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Hard to directly test this, mostly we'll have to merge then wait for things to fail.