### PR TITLE
actions: Fix branch detection in slack notification workflow

### DIFF
--- a/.github/workflows/slack-workflow-failed.yml
+++ b/.github/workflows/slack-workflow-failed.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Send message to alerts channel
         uses: slackapi/slack-github-action@v1.18.0
-        if: github.ref == 'refs/heads/master'
+        if: github.event.workflow_run.head_branch == 'master'
         with:
           channel-id: ${{ secrets.SLACK_JP_ALERTS_CHANNEL }}
           payload: ${{ steps.message.outputs.message }}
@@ -95,7 +95,7 @@ jobs:
 
       - name: Send message to releases channel
         uses: slackapi/slack-github-action@v1.18.0
-        if: contains( github.ref, '/branch-' )
+        if: contains( github.event.workflow_run.head_branch, '/branch-' )
         with:
           channel-id: ${{ secrets.SLACK_RELEASES_CHANNEL }}
           payload: ${{ steps.message.outputs.message }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
`github.ref` will always be master, because that's where `workflow_run`
runs the workflow from. The branch with the failing workflow that
triggered the `workflow_run` event is available as
`github.event.workflow_run.head_branch`.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1646070824573589/1646069834.054499-slack-C034JEXD1RD

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Merge and wait for another notification.