### PR TITLE
Search: Fix various React warnings shown for Customberg

### DIFF
--- a/projects/packages/search/changelog/fix-customberg-notices
+++ b/projects/packages/search/changelog/fix-customberg-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix various notices shown for Customberg

--- a/projects/packages/search/src/customberg/components/sidebar/index.jsx
+++ b/projects/packages/search/src/customberg/components/sidebar/index.jsx
@@ -28,7 +28,7 @@ export default function Sidebar( props ) {
 		<div className="interface-complementary-area jp-search-configure-sidebar">
 			<div
 				className="components-panel__header interface-complementary-area-header jp-search-configure-sidebar__panel-tabs"
-				tabindex="-1"
+				tabIndex="-1"
 			>
 				<Tabs enabledSidebarName={ enabledSidebarName } enableSidebar={ enableSidebar } />
 				<SaveButton />

--- a/projects/packages/search/src/customberg/components/sidebar/sidebar-options.jsx
+++ b/projects/packages/search/src/customberg/components/sidebar/sidebar-options.jsx
@@ -33,10 +33,12 @@ import ThemeControl from './theme-control';
  * @returns {Element} component instance
  */
 export default function SidebarOptions() {
+	// Initializes default values used for FormToggle in order to avoid changing
+	// the toggles from uncontrolled (upon mounting) to controlled (after the settings request finishes).
 	const {
 		color,
 		excludedPostTypes,
-		infiniteScroll,
+		infiniteScroll = true,
 		resultFormat,
 		setColor,
 		setExcludedPostTypes,
@@ -47,9 +49,9 @@ export default function SidebarOptions() {
 		setSortEnabled,
 		setTheme,
 		setTrigger,
-		showLogo,
+		showLogo = true,
 		sort,
-		sortEnabled,
+		sortEnabled = true,
 		theme,
 		trigger,
 	} = useSearchOptions();

--- a/projects/packages/search/src/instant-search/components/path-breadcrumbs.jsx
+++ b/projects/packages/search/src/instant-search/components/path-breadcrumbs.jsx
@@ -32,7 +32,7 @@ const PathBreadcrumbs = ( { className, onClick, url } ) => {
 				onClick={ onClick }
 			>
 				{ breadcrumbPieces.map( ( piece, index, pieces ) => (
-					<span className="jetpack-instant-search__path-breadcrumb-piece">
+					<span className="jetpack-instant-search__path-breadcrumb-piece" key={ piece }>
 						{ decodeURIComponent( piece ) }
 						{ index !== pieces.length - 1 ? ' › ' : '' }
 					</span>

--- a/projects/packages/search/src/instant-search/components/search-results.jsx
+++ b/projects/packages/search/src/instant-search/components/search-results.jsx
@@ -169,6 +169,7 @@ class SearchResults extends Component {
 						{ results.map( ( result, index ) => (
 							<SearchResult
 								index={ index }
+								key={ index }
 								staticFilters={ this.props.staticFilters }
 								isPhotonEnabled={ this.props.isPhotonEnabled }
 								locale={ this.props.locale }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes various React notices shown while smoke testing #22910.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a [key property](https://reactjs.org/docs/lists-and-keys.html) to various components being rendered in a list. 
* Fixes typos.
* Adds default values for boolean configuration values to avoid switching toggles between controlled and uncontrolled.

<!-- #### Jetpack product discussion -->
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this change to your site with a Search subscription.
* Ensure that the (instant) site search experience works as expected.
* Ensure that the live configuration experience (Customberg) also works as expected. 
* (Ensure that there are no browser console warnings for both of the above.)
