### PR TITLE
Search E2E: Add tests for link spawning overlay

### DIFF
--- a/projects/plugins/jetpack/changelog/add-e2e-for-link-spawning-overlay
+++ b/projects/plugins/jetpack/changelog/add-e2e-for-link-spawning-overlay
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+E2E: add tests for clicking link to open overlay

--- a/projects/plugins/jetpack/tests/e2e/specs/post-connection/search.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/post-connection/search.test.js
@@ -168,5 +168,13 @@ test.describe( 'Search', () => {
 		} );
 	} );
 
-	test( 'Can open overly by clicking an item in the page', async () => {} );
+	test( 'Can open overly by clicking an item in the page', async () => {
+		await homepage.goto( `${ siteUrl }?search_link_in_footer=1` );
+		await homepage.waitForPage();
+		await homepage.waitForNetworkIdle();
+
+		expect( await homepage.isOverlayVisible() ).toBeFalsy();
+		await homepage.clickLink();
+		expect( await homepage.isOverlayVisible() ).toBeTruthy();
+	} );
 } );

--- a/projects/plugins/jetpack/tests/e2e/specs/post-connection/search.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/post-connection/search.test.js
@@ -167,4 +167,6 @@ test.describe( 'Search', () => {
 			expect( await homepage.isExpandedImageVisible() ).toBeTruthy();
 		} );
 	} );
+
+	test( 'Can open overly by clicking an item in the page', async () => {} );
 } );

--- a/projects/plugins/jetpack/tests/e2e/specs/post-connection/search.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/post-connection/search.test.js
@@ -168,8 +168,8 @@ test.describe( 'Search', () => {
 		} );
 	} );
 
-	test( 'Can open overly by clicking an item in the page', async () => {
-		await homepage.goto( `${ siteUrl }?search_link_in_footer=1` );
+	test( 'Can open overlay by clicking a link', async () => {
+		await homepage.goto( `${ siteUrl }?jetpack_search_link_in_footer=1` );
 		await homepage.waitForPage();
 		await homepage.waitForNetworkIdle();
 

--- a/tools/docker/jetpack-docker-config-default.yml
+++ b/tools/docker/jetpack-docker-config-default.yml
@@ -57,3 +57,4 @@ e2e:
     tools/e2e-commons/plugins/e2e-plugin-updater.php: /var/www/html/wp-content/plugins/e2e-plugin-updater.php
     tools/e2e-commons/plugins/e2e-plan-data-interceptor.php: /var/www/html/wp-content/plugins/e2e-plan-data-interceptor.php
     projects/plugins/boost/tests/e2e/plugins/e2e-mock-speed-score-api.php: /var/www/html/wp-content/plugins/e2e-mock-speed-score-api.php
+    tools/e2e-commons/plugins/e2e-search-test-helper.php: /var/www/html/wp-content/plugins/e2e-search-test-helper.php

--- a/tools/e2e-commons/bin/e2e-env.sh
+++ b/tools/e2e-commons/bin/e2e-env.sh
@@ -44,6 +44,7 @@ gb_setup() {
 configure_wp_env() {
 	$BASE_CMD wp plugin activate jetpack
 	$BASE_CMD wp plugin activate e2e-plan-data-interceptor
+	$BASE_CMD wp plugin activate e2e-search-test-helper
 	if [ "${1}" == "--activate-plugins" ]; then
 		shift;
 		for var in "$@"

--- a/tools/e2e-commons/pages/search-homepage.js
+++ b/tools/e2e-commons/pages/search-homepage.js
@@ -126,4 +126,9 @@ export default class SearchHomepage extends WpPage {
 		const expandedImageSelector = '.jetpack-instant-search__search-result-expanded__image';
 		return this.isElementVisible( expandedImageSelector );
 	}
+
+	async clickLink() {
+		const linkSelector = '.wp-button.jetpack-search-filter__link';
+		return this.click(linkSelector);
+	}
 }

--- a/tools/e2e-commons/plugins/e2e-plan-data-interceptor.php
+++ b/tools/e2e-commons/plugins/e2e-plan-data-interceptor.php
@@ -54,12 +54,5 @@ function e2e_intercept_plan_data_request( $return, $r, $url ) {
 		);
 	}
 
-	if ( false !== stripos( $url, sprintf( '/sites/%d/jetpack-search/plan', $site_id ) ) ) {
-		return array(
-			'response' => array( 'code' => 200 ),
-			'body'     => sprintf( '{"search_subscriptions":[{"ID":"123","user_id":"456","blog_id":"%d","product_id":"2104","expiry":"2125-05-17","subscribed_date":"2021-05-17 05:34:09","renew":false,"auto_renew":true,"ownership_id":"123","most_recent_renew_date":"","subscription_status":"active","product_name":"Jetpack Search","product_name_en":"Jetpack Search","product_slug":"jetpack_search","product_type":"search","cost":50,"currency":"USD","bill_period":"365","available":"yes","multi":true,"support_document":null,"is_instant_search":true,"tier":"up_to_100_records"}],"supports_instant_search":true,"supports_only_classic_search":false,"supports_search":true,"default_upgrade_bill_period":"yearly"}', $site_id ),
-		);
-	}
-
 	return $return;
 }

--- a/tools/e2e-commons/plugins/e2e-search-test-helper.php
+++ b/tools/e2e-commons/plugins/e2e-search-test-helper.php
@@ -8,6 +8,7 @@
  *
  * @package automattic/jetpack
  */
+
 add_filter( 'pre_http_request', 'e2e_jetpack_search_intercept_plan_data_request', 1, 3 );
 add_action( 'wp_footer', 'e2e_jetpack_search_show_link_in_footer' );
 
@@ -46,6 +47,7 @@ function e2e_intercept_jetpack_search_plan_data_request( $return, $r, $url ) {
  */
 function e2e_jetpack_search_show_link_in_footer() {
 	if ( isset( $_GET['search_link_in_footer'] ) ) {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		echo '<a href="#" class="wp-button jetpack-search-filter__link">Click to search</a>';
 	}
 }

--- a/tools/e2e-commons/plugins/e2e-search-test-helper.php
+++ b/tools/e2e-commons/plugins/e2e-search-test-helper.php
@@ -9,8 +9,8 @@
  * @package automattic/jetpack
  */
 
-add_filter( 'pre_http_request', 'e2e_jetpack_search_intercept_plan_data_request', 1, 3 );
-add_action( 'wp_footer', 'e2e_jetpack_search_show_link_in_footer' );
+add_filter( 'pre_http_request', 'e2e_jetpack_search_intercept_plan_data_request', 3, 3 );
+add_action( 'wp_footer', 'e2e_jetpack_search_maybe_show_link_in_footer' );
 
 /**
  * Intercept WPCOM plan data request and replaces it with mocked data
@@ -19,7 +19,7 @@ add_action( 'wp_footer', 'e2e_jetpack_search_show_link_in_footer' );
  * @param r      $r not used.
  * @param string $url request URL.
  */
-function e2e_intercept_jetpack_search_plan_data_request( $return, $r, $url ) {
+function e2e_jetpack_search_intercept_plan_data_request( $return, $r, $url ) {
 	if ( ! class_exists( 'Jetpack_Options' ) ) {
 		return $return;
 	}
@@ -45,7 +45,7 @@ function e2e_intercept_jetpack_search_plan_data_request( $return, $r, $url ) {
  *
  * @return void
  */
-function e2e_jetpack_search_show_link_in_footer() {
+function e2e_jetpack_search_maybe_show_link_in_footer() {
 	// phpcs:disable WordPress.Security.NonceVerification.Recommended
 	if ( isset( $_GET['search_link_in_footer'] ) ) {
 		echo '<a href="#" class="wp-button jetpack-search-filter__link">Click to search</a>';

--- a/tools/e2e-commons/plugins/e2e-search-test-helper.php
+++ b/tools/e2e-commons/plugins/e2e-search-test-helper.php
@@ -47,7 +47,7 @@ function e2e_jetpack_search_intercept_plan_data_request( $return, $r, $url ) {
  */
 function e2e_jetpack_search_maybe_show_link_in_footer() {
 	// phpcs:disable WordPress.Security.NonceVerification.Recommended
-	if ( isset( $_GET['search_link_in_footer'] ) ) {
+	if ( isset( $_GET['jetpack_search_link_in_footer'] ) ) {
 		echo '<a href="#" class="wp-button jetpack-search-filter__link">Click to search</a>';
 	}
 }

--- a/tools/e2e-commons/plugins/e2e-search-test-helper.php
+++ b/tools/e2e-commons/plugins/e2e-search-test-helper.php
@@ -46,8 +46,8 @@ function e2e_intercept_jetpack_search_plan_data_request( $return, $r, $url ) {
  * @return void
  */
 function e2e_jetpack_search_show_link_in_footer() {
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended
 	if ( isset( $_GET['search_link_in_footer'] ) ) {
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		echo '<a href="#" class="wp-button jetpack-search-filter__link">Click to search</a>';
 	}
 }

--- a/tools/e2e-commons/plugins/e2e-search-test-helper.php
+++ b/tools/e2e-commons/plugins/e2e-search-test-helper.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Plugin Name: Jetpack Search E2E Helper
+ * Plugin URI: https://github.com/automattic/jetpack
+ * Author: Jetpack Team
+ * Version: 1.0.0
+ * Text Domain: jetpack
+ *
+ * @package automattic/jetpack
+ */
+add_filter( 'pre_http_request', 'e2e_jetpack_search_intercept_plan_data_request', 1, 3 );
+add_action( 'wp_footer', 'e2e_jetpack_search_show_link_in_footer' );
+
+/**
+ * Intercept WPCOM plan data request and replaces it with mocked data
+ *
+ * @param result $return result.
+ * @param r      $r not used.
+ * @param string $url request URL.
+ */
+function e2e_intercept_jetpack_search_plan_data_request( $return, $r, $url ) {
+	if ( ! class_exists( 'Jetpack_Options' ) ) {
+		return $return;
+	}
+
+	$site_id = Jetpack_Options::get_option( 'id' );
+
+	if ( empty( $site_id ) ) {
+		return $return;
+	}
+
+	if ( false !== stripos( $url, sprintf( '/sites/%d/jetpack-search/plan', $site_id ) ) ) {
+		return array(
+			'response' => array( 'code' => 200 ),
+			'body'     => sprintf( '{"search_subscriptions":[{"ID":"123","user_id":"456","blog_id":"%d","product_id":"2104","expiry":"2125-05-17","subscribed_date":"2021-05-17 05:34:09","renew":false,"auto_renew":true,"ownership_id":"123","most_recent_renew_date":"","subscription_status":"active","product_name":"Jetpack Search","product_name_en":"Jetpack Search","product_slug":"jetpack_search","product_type":"search","cost":50,"currency":"USD","bill_period":"365","available":"yes","multi":true,"support_document":null,"is_instant_search":true,"tier":"up_to_100_records"}],"supports_instant_search":true,"supports_only_classic_search":false,"supports_search":true,"default_upgrade_bill_period":"yearly"}', $site_id ),
+		);
+	}
+
+	return $return;
+}
+
+/**
+ * Output a link for E2E tests
+ *
+ * @return void
+ */
+function e2e_jetpack_search_show_link_in_footer() {
+	if ( isset( $_GET['search_link_in_footer'] ) ) {
+		echo '<a href="#" class="wp-button jetpack-search-filter__link">Click to search</a>';
+	}
+}


### PR DESCRIPTION
Add E2E test for #23102

#### Changes proposed in this Pull Request:
- Added a plugin to add link in footer when `search_link_in_footer` exists in URL
   - Extracted the logic in `e2e-plan-data-interceptor` to the plugin
   - Future hooks for search E2E should be added to the plugin as well
- Added test to ensure when clicking the link, the overly would be spawned

#### Jetpack product discussion
pcNPJE-I2-p2

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Follow [instructions](https://github.com/Automattic/jetpack/blob/master/projects/plugins/jetpack/tests/e2e/README.md) to set up E2E env
* Ensure all 6 E2E tests pass: `pnpm test-e2e -- search`
* Ensure workflow E2E tests pass
