### PR TITLE
Admin Page: avoid React warning triggered by ExternalLink

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/user-license-activation.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/user-license-activation.jsx
@@ -114,7 +114,6 @@ const UserLicenseActivationNotice = props => {
 							href: getRedirectUrl( 'calypso-purchases' ),
 							onClick: trackUserPurchasesClick,
 							target: '_blank',
-							icon: true,
 						} ),
 					}
 				) }

--- a/projects/plugins/jetpack/changelog/update-externallink-warning
+++ b/projects/plugins/jetpack/changelog/update-externallink-warning
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Janitorial: avoid React warning in Jetpack dashboard.
+
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Clear a React warning.

************

react-dom.development.js:61 Warning: Received true for a non-boolean attribute icon.
If you want to write it to the DOM, pass a string instead: icon="true" or icon={value.toString()}.
at a
at wp-content/plugins/gutenberg/build/components/index.min.js?ver=9fa5641bd0d4c655b0f865c04e8ad546:17:1073
at span
at span
at div
at SimpleNotice (wp-content/plugins/jetpack/_inc/build/admin.js?ver=10.8-a.0:65397:5)
at UserLicenseActivationNotice (wp-content/plugins/jetpack/_inc/build/admin.js?ver=10.8-a.0:63416:5)
at Connect (wp-content/plugins/jetpack/_inc/build/admin.js?ver=10.8-a.0:37828:37)
at div
at JetpackNotices (wp-content/plugins/jetpack/_inc/build/admin.js?ver=10.8-a.0:62662:1)

************

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Build that branch.
* Go to Jetpack > Dashboard
* You should not see the warning above.
