### PR TITLE
beta: Download from correct URL for a tag like "v3.1.1"

### DIFF
--- a/projects/plugins/beta/changelog/fix-beta-download-with-v
+++ b/projects/plugins/beta/changelog/fix-beta-download-with-v
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Download from the correct URL when updating to a version tagged like "v3.1.1" rather than "3.1.1".

--- a/projects/plugins/beta/composer.json
+++ b/projects/plugins/beta/composer.json
@@ -34,7 +34,7 @@
 	"prefer-stable": true,
 	"config": {
 		"sort-packages": true,
-		"autoloader-suffix": "567fa3f555de8fd218dfdc1688bb97b5_betaⓥ3_1_1",
+		"autoloader-suffix": "567fa3f555de8fd218dfdc1688bb97b5_betaⓥ3_1_2_alpha",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true
 		}

--- a/projects/plugins/beta/jetpack-beta.php
+++ b/projects/plugins/beta/jetpack-beta.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack Beta Tester
  * Plugin URI: https://jetpack.com/beta/
  * Description: Use the Beta plugin to get a sneak peek at new features and test them on your site.
- * Version: 3.1.1
+ * Version: 3.1.2-alpha
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later
@@ -34,7 +34,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'JPBETA__PLUGIN_FOLDER', dirname( plugin_basename( __FILE__ ) ) );
-define( 'JPBETA_VERSION', '3.1.1' );
+define( 'JPBETA_VERSION', '3.1.2-alpha' );
 
 define( 'JETPACK_BETA_PLUGINS_URL', 'https://betadownload.jetpack.me/plugins.json' );
 

--- a/projects/plugins/beta/src/class-autoupdateself.php
+++ b/projects/plugins/beta/src/class-autoupdateself.php
@@ -67,17 +67,18 @@ class AutoupdateSelf {
 	 * Set update arguments in `$this->config`.
 	 */
 	private function set_update_args() {
-		$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/' . $this->config['plugin_file'] );
-		$github_data = $this->get_github_data();
+		$plugin_data    = get_plugin_data( WP_PLUGIN_DIR . '/' . $this->config['plugin_file'] );
+		$github_data    = $this->get_github_data();
+		$tagged_version = $this->get_latest_prerelease();
 
 		$this->config['plugin_name']  = $plugin_data['Name'];
 		$this->config['version']      = $plugin_data['Version'];
 		$this->config['author']       = $plugin_data['Author'];
 		$this->config['homepage']     = $plugin_data['PluginURI'];
-		$this->config['new_version']  = $this->get_latest_prerelease();
+		$this->config['new_version']  = ltrim( $tagged_version, 'v' );
 		$this->config['last_updated'] = empty( $github_data->updated_at ) ? false : gmdate( 'Y-m-d', strtotime( $github_data->updated_at ) );
 		$this->config['description']  = empty( $github_data->description ) ? false : $github_data->description;
-		$this->config['zip_url']      = 'https://github.com/Automattic/jetpack-beta/zipball/' . $this->config['new_version'];
+		$this->config['zip_url']      = 'https://github.com/Automattic/jetpack-beta/zipball/' . $tagged_version;
 	}
 
 	/**
@@ -98,7 +99,7 @@ class AutoupdateSelf {
 				foreach ( $releases as $release ) {
 					// Since 2.2, so that we don't have to maker the Jetpack Beta 2.0.3 as prerelease.
 					if ( ! $release->prerelease ) {
-						$tagged_version = ltrim( $release->tag_name, 'v' );
+						$tagged_version = $release->tag_name;
 						break;
 					}
 				}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Back in #20385, we fixed it to recognize versions like "v3.1.1". But we
left it downloading from the URL based on the version number without the
"v".

Fixes #23184

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1646171473021239-slack-C01U2KGS2PQ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Testing the update logic is a little tricky.

* Install the release version of Jetpack Beta 3.1.1.
* `cd wp-content/plugins/jetpack-beta`
* Apply the patch from this PR: `curl -L https://github.com/Automattic/jetpack/pull/23185.diff | patch -p4`
* Point the self-update at a fork I've prepared: `sed -E -i 's!Automattic([-/]jetpack-beta)!anomiex\1!' src/class-autoupdateself.php`
* It should offer an update to a version 3.1.2. Updating to that should work.