### PR TITLE
My Jetpack: align CTA buttons of My Jetpack overview

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -193,41 +193,39 @@ const ProductCard = props => {
 				{ icon }
 			</div>
 			<p className={ styles.description }>{ description }</p>
-			<div className={ styles[ 'actions-wrapper' ] }>
-				<div className={ styles.actions }>
-					{ canDeactivate ? (
-						<ButtonGroup className={ styles.group }>
-							<ActionButton
-								{ ...props }
-								onActivate={ activateHandler }
-								onFixConnection={ fixConnectionHandler }
-								onManage={ manageHandler }
-							/>
-							<DropdownMenu
-								className={ styles.dropdown }
-								toggleProps={ { isPrimary: true, disabled: isFetching } }
-								popoverProps={ { noArrow: false } }
-								icon={ DownIcon }
-								disableOpenOnArrowDown={ true }
-								controls={ [
-									{
-										title: __( 'Deactivate', 'jetpack-my-jetpack' ),
-										icon: null,
-										onClick: deactivateHandler,
-									},
-								] }
-							/>
-						</ButtonGroup>
-					) : (
+			<div className={ styles.actions }>
+				{ canDeactivate ? (
+					<ButtonGroup className={ styles.group }>
 						<ActionButton
 							{ ...props }
-							onFixConnection={ fixConnectionHandler }
 							onActivate={ activateHandler }
-							onAdd={ addHandler }
+							onFixConnection={ fixConnectionHandler }
+							onManage={ manageHandler }
 						/>
-					) }
-					{ ! isAbsent && <div className={ statusClassName }>{ flagLabel }</div> }
-				</div>
+						<DropdownMenu
+							className={ styles.dropdown }
+							toggleProps={ { isPrimary: true, disabled: isFetching } }
+							popoverProps={ { noArrow: false } }
+							icon={ DownIcon }
+							disableOpenOnArrowDown={ true }
+							controls={ [
+								{
+									title: __( 'Deactivate', 'jetpack-my-jetpack' ),
+									icon: null,
+									onClick: deactivateHandler,
+								},
+							] }
+						/>
+					</ButtonGroup>
+				) : (
+					<ActionButton
+						{ ...props }
+						onFixConnection={ fixConnectionHandler }
+						onActivate={ activateHandler }
+						onAdd={ addHandler }
+					/>
+				) }
+				{ ! isAbsent && <div className={ statusClassName }>{ flagLabel }</div> }
 			</div>
 		</div>
 	);

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -193,39 +193,41 @@ const ProductCard = props => {
 				{ icon }
 			</div>
 			<p className={ styles.description }>{ description }</p>
-			<div className={ styles.actions }>
-				{ canDeactivate ? (
-					<ButtonGroup className={ styles.group }>
+			<div className={ styles[ 'actions-wrapper' ] }>
+				<div className={ styles.actions }>
+					{ canDeactivate ? (
+						<ButtonGroup className={ styles.group }>
+							<ActionButton
+								{ ...props }
+								onActivate={ activateHandler }
+								onFixConnection={ fixConnectionHandler }
+								onManage={ manageHandler }
+							/>
+							<DropdownMenu
+								className={ styles.dropdown }
+								toggleProps={ { isPrimary: true, disabled: isFetching } }
+								popoverProps={ { noArrow: false } }
+								icon={ DownIcon }
+								disableOpenOnArrowDown={ true }
+								controls={ [
+									{
+										title: __( 'Deactivate', 'jetpack-my-jetpack' ),
+										icon: null,
+										onClick: deactivateHandler,
+									},
+								] }
+							/>
+						</ButtonGroup>
+					) : (
 						<ActionButton
 							{ ...props }
-							onActivate={ activateHandler }
 							onFixConnection={ fixConnectionHandler }
-							onManage={ manageHandler }
+							onActivate={ activateHandler }
+							onAdd={ addHandler }
 						/>
-						<DropdownMenu
-							className={ styles.dropdown }
-							toggleProps={ { isPrimary: true, disabled: isFetching } }
-							popoverProps={ { noArrow: false } }
-							icon={ DownIcon }
-							disableOpenOnArrowDown={ true }
-							controls={ [
-								{
-									title: __( 'Deactivate', 'jetpack-my-jetpack' ),
-									icon: null,
-									onClick: deactivateHandler,
-								},
-							] }
-						/>
-					</ButtonGroup>
-				) : (
-					<ActionButton
-						{ ...props }
-						onFixConnection={ fixConnectionHandler }
-						onActivate={ activateHandler }
-						onAdd={ addHandler }
-					/>
-				) }
-				{ ! isAbsent && <div className={ statusClassName }>{ flagLabel }</div> }
+					) }
+					{ ! isAbsent && <div className={ statusClassName }>{ flagLabel }</div> }
+				</div>
 			</div>
 		</div>
 	);

--- a/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
@@ -46,6 +46,14 @@
 	margin:0;
 }
 
+.actions-wrapper {
+	display: flex;
+    flex-grow: 2;
+    flex-direction: column;
+    justify-content: end;
+	margin-top: calc(var(--product-card-margin-base) * 4); // 16px
+}
+
 .actions {
 	display: flex;
 	align-items: center;

--- a/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
@@ -44,14 +44,7 @@
 .description {
 	font-size: var(--product-card-description-font-size);
 	margin:0;
-}
-
-.actions-wrapper {
-	display: flex;
-	flex-grow: 2;
-	flex-direction: column;
-	justify-content: end;
-	margin-top: calc(var(--product-card-margin-base) * 4); // 16px
+	flex-grow: 1;
 }
 
 .actions {

--- a/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
@@ -48,9 +48,9 @@
 
 .actions-wrapper {
 	display: flex;
-    flex-grow: 2;
-    flex-direction: column;
-    justify-content: end;
+	flex-grow: 2;
+	flex-direction: column;
+	justify-content: end;
 	margin-top: calc(var(--product-card-margin-base) * 4); // 16px
 }
 

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-cta-button-alignments
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-cta-button-alignments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: align CTA buttons of My Jetpack overview

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "0.6.7",
+	"version": "0.6.8-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -27,7 +27,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.6.7';
+	const PACKAGE_VERSION = '0.6.8-alpha';
 
 	/**
 	 * Initialize My Jetapack


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR aligns CTA buttons of the My Jetpack overview taking reference from the card bottom.

Fixes https://github.com/Automattic/jetpack/issues/23190

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: align CTA buttons of My Jetpack overview

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack overview

**before**
<img width="1058" alt="Screen Shot 2022-03-02 at 9 25 55 AM" src="https://user-images.githubusercontent.com/77539/156362370-bae53962-fd03-4cbf-9321-eb543a48cd4c.png">


**after**
<img width="1053" alt="Screen Shot 2022-03-02 at 9 27 26 AM" src="https://user-images.githubusercontent.com/77539/156362362-23182c72-13e6-469c-ac5f-e9f4c850f425.png">