### PR TITLE
actions: Work around branch matching bug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,10 @@
 name: Build
 on:
   push:
-    branches: [ 'master', '**/branch-**' ]
+    branches:
+      - 'master'
+      # The `**/*/` works around the fact that GitHub considers a leading `**/` as meaning "zero or more path components" where we want "one or more".
+      - '**/*/branch-**'
   pull_request:
 concurrency:
   # Cancel concurrent jobs on pull_request but not push, by including the run_id in the concurrency group for the latter.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We noticed the other day that GitHub incorrectly ran the workflow on a
push to a branch named "fix/slack-workflow-branch-detection".

This turned out to be due to a bug in GitHub's pattern matching code.
They intended for a pattern like `**/foo/bar` to act like .gitignore in
that the `**/` would match zero or more path components and therefore
match "foo/bar" at the repo root. But what they actually do is have it
make the pattern be completely unanchored, so it'll also incorrectly
match something like "notfoo/bar".

Since we want to match "one or more path-like components" anyway, we can
work around that bug by using a pattern like `**/*/branch-**`, meaning
"zero or more path-like components, followed by exactly one path-like
component, followed by `branch-**`".

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1646071764075929-slack-C01U2KGS2PQ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* There should have been no run of the Build workflow for the push creating this PR's branch.
* Merge this. There should be a run of the Build workflow for the resulting push to master.
* Next time we create a release branch, verify that there is a run of the Build workflow for that push too.