### PR TITLE
SEO Tools: fix filter priority in Jetpack_Twitter_Cards

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-twitter-og-tags-filter-priority
+++ b/projects/plugins/jetpack/changelog/fix-twitter-og-tags-filter-priority
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+SEO Tools: ensure Twitter cards get correct description when a site has a blank tagline.

--- a/projects/plugins/jetpack/class.jetpack-twitter-cards.php
+++ b/projects/plugins/jetpack/class.jetpack-twitter-cards.php
@@ -339,7 +339,7 @@ class Jetpack_Twitter_Cards {
 	 * Initiates the class.
 	 */
 	public static function init() {
-		add_filter( 'jetpack_open_graph_tags', array( __CLASS__, 'twitter_cards_tags' ) );
+		add_filter( 'jetpack_open_graph_tags', array( __CLASS__, 'twitter_cards_tags' ), 11 ); // $priority=11: this should hook into jetpack_open_graph_tags after 'class.jetpack-seo.php' has done so.
 		add_filter( 'jetpack_open_graph_output', array( __CLASS__, 'twitter_cards_output' ) );
 		add_filter( 'jetpack_twitter_cards_site_tag', array( __CLASS__, 'site_tag' ), -99 );
 		add_filter( 'jetpack_twitter_cards_site_tag', array( __CLASS__, 'prioritize_creator_over_default_site' ), 99, 2 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

In `Jetpack_Twitter_Cards`, adjust the `jetpack_open_graph_tags` filter priority so that Jetpack SEO tools has a chance to create its tags before the Twitter specific ones are created.

#### Jetpack product discussion

Fixes #23182

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

- Before patching, on a Jetpack connected site, make sure your site has a blank Site Tagline set in `General > Settings`
- In `Jetpack > Settings > Sharing` turn on Publicize (so JP OpenGraph tags are being added).
- In `Jetpack > Settings > Traffic` turn on the `Customize your SEO settings`, then set a custom Front Page Meta description.
- Set a static homepage page. In a theme like Twenty Twenty this can be done in `Appearance > Customize > Homepage Settings`.
- Inspect the homepage source which will look similar to:

```html
<!-- Jetpack Open Graph Tags -->
<meta property="og:type" content="website" />
<meta property="og:title" content="Example Test Site" />
<meta property="og:description" content="Custom front page meta desc. via JP SEO Tools." />
. . . 
<meta name="twitter:description" content="Visit the post for more." />
<!-- End Jetpack Open Graph Tags -->
```

- After patching, the erroneous `twitter:description` tag should not be added to the page source.