### PR TITLE
Payment Button Block: InnerBlocks have the ability to connect Stripe

### DIFF
--- a/projects/plugins/jetpack/changelog/add-stripe-connect-to-payment-button-blocks
+++ b/projects/plugins/jetpack/changelog/add-stripe-connect-to-payment-button-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+We now share the Payment Button block controls with it's InnerBlocks so that we can connect Stripe from any InnerBlock within the Payment Button block.

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/edit.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/edit.jsx
@@ -478,7 +478,7 @@ export class MembershipsButtonEdit extends Component {
 		);
 
 		const blockControls = (
-			<BlockControls>
+			<BlockControls __experimentalShareWithChildBlocks>
 				<ToolbarControls
 					connected={ connected !== API_STATE_NOTCONNECTED }
 					connectURL={ getConnectUrl( this.props.postId, connectURL ) }

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/index.js
@@ -63,6 +63,7 @@ export const settings = {
 	supports: {
 		html: false,
 		align: true,
+		__experimentalExposeControlsToChildren: true,
 	},
 	deprecated: [ deprecatedV1 ],
 	transforms: {

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/index.js
@@ -62,7 +62,6 @@ export const settings = {
 	),
 	supports: {
 		html: false,
-		align: true,
 		__experimentalExposeControlsToChildren: true,
 	},
 	deprecated: [ deprecatedV1 ],

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/test/fixtures/jetpack__recurring-payments--with-color-attrs__deprecated-1.serialized.html
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/test/fixtures/jetpack__recurring-payments--with-color-attrs__deprecated-1.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:jetpack/recurring-payments {"planId":228,"align":"center"} -->
-<div class="wp-block-jetpack-recurring-payments aligncenter"><!-- wp:jetpack/button {"element":"a","uniqueId":"recurring-payments-id","text":"$0.50 Contribution","textColor":"green","backgroundColor":"purple"} /--></div>
+<div class="wp-block-jetpack-recurring-payments"><!-- wp:jetpack/button {"element":"a","uniqueId":"recurring-payments-id","text":"$0.50 Contribution","textColor":"green","backgroundColor":"purple"} /--></div>
 <!-- /wp:jetpack/recurring-payments -->

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/test/fixtures/jetpack__recurring-payments--with-custom-color-attrs__deprecated-1.serialized.html
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/test/fixtures/jetpack__recurring-payments--with-custom-color-attrs__deprecated-1.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:jetpack/recurring-payments {"planId":228,"align":"center"} -->
-<div class="wp-block-jetpack-recurring-payments aligncenter"><!-- wp:jetpack/button {"element":"a","uniqueId":"recurring-payments-id","text":"$0.50 Contribution","customTextColor":"#1010d0","customBackgroundColor":"#1f97c3"} /--></div>
+<div class="wp-block-jetpack-recurring-payments"><!-- wp:jetpack/button {"element":"a","uniqueId":"recurring-payments-id","text":"$0.50 Contribution","customTextColor":"#1010d0","customBackgroundColor":"#1f97c3"} /--></div>
 <!-- /wp:jetpack/recurring-payments -->

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/test/fixtures/jetpack__recurring-payments.html
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/test/fixtures/jetpack__recurring-payments.html
@@ -1,3 +1,3 @@
 <!-- wp:jetpack/recurring-payments {"planId":12,"align":"right"} -->
-<div class="wp-block-jetpack-recurring-payments alignright"><!-- wp:jetpack/button {"element":"a","uniqueId":"recurring-payments-id","text":"Payment","borderRadius":0} /--></div>
+<div class="wp-block-jetpack-recurring-payments"><!-- wp:jetpack/button {"element":"a","uniqueId":"recurring-payments-id","text":"Payment","borderRadius":0} /--></div>
 <!-- /wp:jetpack/recurring-payments -->

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/test/fixtures/jetpack__recurring-payments.json
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/test/fixtures/jetpack__recurring-payments.json
@@ -1,28 +1,28 @@
 [
-    {
-        "clientId": "_clientId_0",
-        "name": "jetpack/recurring-payments",
-        "isValid": true,
-        "attributes": {
-            "planId": 12,
-            "align": "right"
-        },
-        "innerBlocks": [
-            {
-                "clientId": "_clientId_0",
-                "name": "jetpack/button",
-                "isValid": true,
-                "attributes": {
-                    "element": "a",
-                    "saveInPostContent": false,
-                    "uniqueId": "recurring-payments-id",
-                    "text": "Payment",
-                    "borderRadius": 0
-                },
-                "innerBlocks": [],
-                "originalContent": ""
-            }
-        ],
-        "originalContent": "<div class=\"wp-block-jetpack-recurring-payments alignright\"></div>"
-    }
+	{
+		"clientId": "_clientId_0",
+		"name": "jetpack/recurring-payments",
+		"isValid": true,
+		"attributes": {
+			"planId": 12,
+			"align": "right"
+		},
+		"innerBlocks": [
+			{
+				"clientId": "_clientId_0",
+				"name": "jetpack/button",
+				"isValid": true,
+				"attributes": {
+					"element": "a",
+					"saveInPostContent": false,
+					"uniqueId": "recurring-payments-id",
+					"text": "Payment",
+					"borderRadius": 0
+				},
+				"innerBlocks": [],
+				"originalContent": ""
+			}
+		],
+		"originalContent": "<div class=\"wp-block-jetpack-recurring-payments\"></div>"
+	}
 ]

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/test/fixtures/jetpack__recurring-payments.parsed.json
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/test/fixtures/jetpack__recurring-payments.parsed.json
@@ -1,29 +1,25 @@
 [
-    {
-        "blockName": "jetpack/recurring-payments",
-        "attrs": {
-            "planId": 12,
-            "align": "right"
-        },
-        "innerBlocks": [
-            {
-                "blockName": "jetpack/button",
-                "attrs": {
-                    "element": "a",
-                    "uniqueId": "recurring-payments-id",
-                    "text": "Payment",
-                    "borderRadius": 0
-                },
-                "innerBlocks": [],
-                "innerHTML": "",
-                "innerContent": []
-            }
-        ],
-        "innerHTML": "\n<div class=\"wp-block-jetpack-recurring-payments alignright\"></div>\n",
-        "innerContent": [
-            "\n<div class=\"wp-block-jetpack-recurring-payments alignright\">",
-            null,
-            "</div>\n"
-        ]
-    }
+	{
+		"blockName": "jetpack/recurring-payments",
+		"attrs": {
+			"planId": 12,
+			"align": "right"
+		},
+		"innerBlocks": [
+			{
+				"blockName": "jetpack/button",
+				"attrs": {
+					"element": "a",
+					"uniqueId": "recurring-payments-id",
+					"text": "Payment",
+					"borderRadius": 0
+				},
+				"innerBlocks": [],
+				"innerHTML": "",
+				"innerContent": []
+			}
+		],
+		"innerHTML": "\n<div class=\"wp-block-jetpack-recurring-payments\"></div>\n",
+		"innerContent": [ "\n<div class=\"wp-block-jetpack-recurring-payments\">", null, "</div>\n" ]
+	}
 ]

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/test/fixtures/jetpack__recurring-payments.serialized.html
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/test/fixtures/jetpack__recurring-payments.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:jetpack/recurring-payments {"planId":12,"align":"right"} -->
-<div class="wp-block-jetpack-recurring-payments alignright"><!-- wp:jetpack/button {"element":"a","uniqueId":"recurring-payments-id","text":"Payment","borderRadius":0} /--></div>
+<div class="wp-block-jetpack-recurring-payments"><!-- wp:jetpack/button {"element":"a","uniqueId":"recurring-payments-id","text":"Payment","borderRadius":0} /--></div>
 <!-- /wp:jetpack/recurring-payments -->


### PR DESCRIPTION
Now the InnerBlocks of the Payment Button block is able to connect Stripe.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [#61422](https://github.com/Automattic/wp-calypso/issues/61422)

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Propagated the block controls to it's children using the `__experimentalExposeControlsToChildren` Gutenberg supports attribute.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Known issues
The `__experimentalExposeControlsToChildren` does not support choosing a subset of controls to inherit. In order to avoid having alignment controls twice on the child blocks, I've removed support for aligning on the Payment Button block. We can still align the buttons as we did before, the only difference will be that the main block won't have this option. I don't anticipate this being a blocker since the component maintains all its previous functionality. If someone has a strong opinion, we should tackle it on a separate issue.

I found a bug that is also present in the previous version. When working with the block, if you set an alignment you can then bypass the template locking and insert blocks in the button row. I've created an [issue to address this problem](https://github.com/Automattic/jetpack/issues/23204).

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Edit or create a new Post.
* Add a Payment Button block.
* Make sure you have Stripe disconnected.
* Click on the block, you should see the `Connect Stripe` option in the toolbar.
* Click on the button inside the block, you should see the `Connect Stripe` option in the toolbar.

#### Test evidence

https://user-images.githubusercontent.com/1989914/156445501-b38edb0a-abf6-4f04-aca7-2e712fe64cad.mp4


