### PR TITLE
Various: Ensure WP CLI is defined before extending

### DIFF
--- a/projects/packages/search/changelog/update-cli-classes
+++ b/projects/packages/search/changelog/update-cli-classes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensure that WP CLI is present before extending the class.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.10.0",
+	"version": "0.10.1-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/search.php
+++ b/projects/packages/search/search.php
@@ -7,7 +7,7 @@
 
 namespace Automattic\Jetpack\Search;
 
-define( 'JETPACK_SEARCH_PKG__VERSION', '0.10.0' );
+define( 'JETPACK_SEARCH_PKG__VERSION', '0.10.1-alpha' );
 define( 'JETPACK_SEARCH_PKG__DIR', __DIR__ . '/' );
 define( 'JETPACK_SEARCH_PKG__SLUG', 'search' );
 

--- a/projects/packages/search/src/class-cli.php
+++ b/projects/packages/search/src/class-cli.php
@@ -11,6 +11,10 @@ use \WP_CLI;
 use \WP_CLI_Command;
 use \WP_Error;
 
+if ( ! class_exists( 'WP_CLI_Command' ) ) {
+	return;
+}
+
 /**
  * Provide functionality by WPCLI.
  */

--- a/projects/plugins/beta/changelog/update-cli-classes
+++ b/projects/plugins/beta/changelog/update-cli-classes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensure that WP CLI is present before extending the class.

--- a/projects/plugins/beta/src/class-clicommand.php
+++ b/projects/plugins/beta/src/class-clicommand.php
@@ -10,6 +10,10 @@ namespace Automattic\JetpackBeta;
 use WP_CLI;
 use WP_CLI_Command;
 
+if ( ! class_exists( 'WP_CLI_Command' ) ) {
+	return;
+}
+
 /**
  * Control your local Jetpack Beta Tester plugin.
  */

--- a/projects/plugins/jetpack/changelog/update-cli-classes
+++ b/projects/plugins/jetpack/changelog/update-cli-classes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Ensure WP CLI is present before extending the class.

--- a/projects/plugins/jetpack/class.jetpack-cli.php
+++ b/projects/plugins/jetpack/class.jetpack-cli.php
@@ -16,6 +16,10 @@ use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Queue;
 use Automattic\Jetpack\Sync\Settings;
 
+if ( ! class_exists( 'WP_CLI_Command' ) ) {
+	return;
+}
+
 WP_CLI::add_command( 'jetpack', 'Jetpack_CLI' );
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

After https://github.com/Automattic/jetpack/pull/23039 we are attempting to load all autoloaded files upon upgrade to we don't have mid-deploy fatals like we've had in the past. But, this is creating an issue since the Search package's CLI class is now being loaded without WP CLI being present.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Ensures WP CLI is present before extending the class. This is helpful in situations where a class is autoloaded without a gate.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1646255328527279-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Not real sure. Install this on a test site, then have an upgrade routiene to a newer version than what is produced by this patch I suppose.