### PR TITLE
Payments Button Block: Add payments block support reference link

### DIFF
--- a/projects/plugins/jetpack/changelog/add-payments-block-support-reference
+++ b/projects/plugins/jetpack/changelog/add-payments-block-support-reference
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+The Payments Block now has a link to the support reference page on the block configuration panel

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/index.js
@@ -1,13 +1,15 @@
 /**
  * External dependencies
  */
-import { Path, Rect, SVG, G } from '@wordpress/components';
+import { isAtomicSite, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 
 /**
  * WordPress dependencies
  */
 import { InnerBlocks } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
+import { Path, Rect, SVG, G, ExternalLink } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -30,13 +32,23 @@ export const icon = (
 	</SVG>
 );
 
+const supportLink =
+	isSimpleSite() || isAtomicSite()
+		? 'https://wordpress.com/support/video-tutorials-add-payments-features-to-your-site-with-our-guides/#how-to-use-the-payments-block-video'
+		: 'https://jetpack.com/support/jetpack-blocks/payments-block/';
+
 export const settings = {
 	title: __( 'Payment Button', 'jetpack' ),
 	icon: {
 		src: icon,
 		foreground: getIconColor(),
 	},
-	description: __( 'Button allowing you to sell products and subscriptions.', 'jetpack' ),
+	description: (
+		<Fragment>
+			<p>{ __( 'Button allowing you to sell products and subscriptions.', 'jetpack' ) }</p>
+			<ExternalLink href={ supportLink }>{ __( 'Support reference', 'jetpack' ) }</ExternalLink>
+		</Fragment>
+	),
 	category: 'earn',
 	keywords: [
 		_x( 'buy', 'block search term', 'jetpack' ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [#61420](https://github.com/Automattic/wp-calypso/issues/61420)

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Added a link to the block reference/documentation.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

##### Simple and Atomic sites
1. Create or Edit a post.
2. Add a Payments Button block.
3. You should see a link to the support reference.
4. Click on the link
5. WPCom support page should be shown.

##### Standalone sites
1. Create or Edit a post.
2. Add a Payments Button block.
3. You should see a link to the support reference.
4. Click on the link
5. Jetpack support page should be shown.

#### Test evidence

https://user-images.githubusercontent.com/1989914/156579541-09c533da-894f-4d48-ad1a-353443c0a3c7.mp4

