### PR TITLE
Search: Move record meter component location on dashboard above ModuleControl

### DIFF
--- a/projects/packages/search/changelog/update-search-move-record-meter
+++ b/projects/packages/search/changelog/update-search-move-record-meter
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: changed
 
 search: move record meter location on dashboard

--- a/projects/packages/search/changelog/update-search-move-record-meter
+++ b/projects/packages/search/changelog/update-search-move-record-meter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+search: move record meter location on dashboard

--- a/projects/packages/search/src/dashboard/components/dashboard/index.jsx
+++ b/projects/packages/search/src/dashboard/components/dashboard/index.jsx
@@ -191,7 +191,6 @@ export default function SearchDashboard() {
 				<Fragment>
 					{ renderHeader() }
 					{ renderMockedSearchInterface() }
-					{ renderModuleControl() }
 					{ isRecordMeterEnabled && (
 						<RecordMeter
 							postCount={ postCount }
@@ -199,6 +198,7 @@ export default function SearchDashboard() {
 							tierMaximumRecords={ tierMaximumRecords }
 						/>
 					) }
+					{ renderModuleControl() }
 					{ renderFooter() }
 				</Fragment>
 			) }

--- a/projects/packages/search/src/dashboard/components/record-meter/index.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/index.jsx
@@ -19,6 +19,7 @@ export default function RecordMeter( { postCount, postTypeBreakdown, tierMaximum
 	return (
 		<div className="jp-search-record-meter jp-search-dashboard-wrap">
 			<div className="jp-search-dashboard-row">
+				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
 				<div className="jp-search-record-meter__title lg-col-span-8 md-col-span-6 sm-col-span-4">
 					<h2>{ __( 'Your search records', 'jetpack-search-pkg' ) }</h2>
 					{ tierMaximumRecords && (


### PR DESCRIPTION
This PR moves the location of the RecordMeter component on the search dashboard to above the ModuleControls 

#### Does this pull request change what data or activity we track or use?

no

#### Testing instructions:

Visit `/wp-admin/admin.php?page=jetpack-search&features=record-meter` and make sure the 'Your search records' heading and post count are output in the page above the `enable Jetpack Search` toggle and below the mock search image; and that it is aligned correctly with the elements below it:

![image](https://user-images.githubusercontent.com/30754158/156621709-f59f76c0-e543-43f4-84e1-e853cc32d49a.png)
