### PR TITLE
My Jetpack: tidy Product card component

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -179,6 +179,19 @@ const ProductCard = props => {
 		navigateToConnectionPage();
 	}, [ slug, navigateToConnectionPage, recordEvent ] );
 
+	const ActionButtonInstance = actionButtonProps => (
+		<ActionButton
+			status={ status }
+			isFetching={ isFetching }
+			name={ name }
+			admin={ admin }
+			onActivate={ activateHandler }
+			onFixConnection={ fixConnectionHandler }
+			onManage={ manageHandler }
+			{ ...actionButtonProps }
+		/>
+	);
+
 	return (
 		<div className={ containerClassName }>
 			<div className={ styles.name }>
@@ -189,15 +202,7 @@ const ProductCard = props => {
 			<div className={ styles.actions }>
 				{ canDeactivate ? (
 					<ButtonGroup className={ styles.group }>
-						<ActionButton
-							status={ status }
-							isFetching={ isFetching }
-							name={ name }
-							admin={ admin }
-							onActivate={ activateHandler }
-							onFixConnection={ fixConnectionHandler }
-							onManage={ manageHandler }
-						/>
+						<ActionButtonInstance onManage={ manageHandler } />
 						<DropdownMenu
 							className={ styles.dropdown }
 							toggleProps={ { isPrimary: true, disabled: isFetching } }
@@ -214,15 +219,7 @@ const ProductCard = props => {
 						/>
 					</ButtonGroup>
 				) : (
-					<ActionButton
-						status={ status }
-						isFetching={ isFetching }
-						name={ name }
-						admin={ admin }
-						onFixConnection={ fixConnectionHandler }
-						onActivate={ activateHandler }
-						onAdd={ addHandler }
-					/>
+					<ActionButtonInstance onAdd={ addHandler } />
 				) }
 				{ ! isAbsent && <div className={ statusClassName }>{ flagLabel }</div> }
 			</div>

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -14,6 +14,7 @@ import styles from './style.module.scss';
 import useAnalytics from '../../hooks/use-analytics';
 import { useProduct } from '../../hooks/use-product';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
+import { getIconBySlug } from '../icons';
 
 export const PRODUCT_STATUSES = {
 	ACTIVE: 'active',
@@ -101,7 +102,7 @@ const ActionButton = ( {
 };
 
 const ProductCard = props => {
-	const { admin, icon, onAdd, slug, showDeactivate } = props;
+	const { admin, onAdd, slug, showDeactivate } = props;
 	const { detail, status, activate, deactivate, isFetching } = useProduct( slug );
 	const { name, description, manageUrl } = detail;
 
@@ -192,11 +193,12 @@ const ProductCard = props => {
 		/>
 	);
 
+	const ProductIcon = getIconBySlug( slug );
 	return (
 		<div className={ containerClassName }>
 			<div className={ styles.name }>
 				<span>{ name }</span>
-				{ icon }
+				<ProductIcon />
 			</div>
 			<p className={ styles.description }>{ description }</p>
 			<div className={ styles.actions }>
@@ -228,7 +230,6 @@ const ProductCard = props => {
 };
 
 ProductCard.propTypes = {
-	icon: PropTypes.element,
 	admin: PropTypes.bool.isRequired,
 	onAdd: PropTypes.func,
 	onLearn: PropTypes.func,
@@ -237,7 +238,6 @@ ProductCard.propTypes = {
 };
 
 ProductCard.defaultProps = {
-	icon: null,
 	onAdd: () => {},
 	onLearn: () => {},
 	showDeactivate: true,

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -102,7 +102,7 @@ const ActionButton = ( {
 };
 
 const ProductCard = props => {
-	const { admin, onAdd, slug, showDeactivate } = props;
+	const { admin, slug, showDeactivate } = props;
 	const { detail, status, activate, deactivate, isFetching } = useProduct( slug );
 	const { name, description, manageUrl } = detail;
 
@@ -126,10 +126,13 @@ const ProductCard = props => {
 		[ styles[ 'is-fetching' ] ]: isFetching,
 	} );
 
+	const navigateToConnectionPage = useMyJetpackNavigate( '/connection' );
+	const navigateToAddProductPage = useMyJetpackNavigate( `add-${ slug }` );
+
 	const { recordEvent } = useAnalytics();
 
 	/**
-	 * Redrect to manage URL after firing Tracks event
+	 * Redirect to manage URL after firing Tracks event
 	 */
 	const manageHandler = useCallback( () => {
 		recordEvent( 'jetpack_myjetpack_product_card_manage_click', {
@@ -160,19 +163,18 @@ const ProductCard = props => {
 	}, [ slug, activate, recordEvent ] );
 
 	/**
-	 * Calls the passed function onAdd after firing Tracks event
+	 * Navigate to add product page after firing Tracks event
 	 */
 	const addHandler = useCallback( () => {
 		recordEvent( 'jetpack_myjetpack_product_card_add_click', {
 			product: slug,
 		} );
-		onAdd();
-	}, [ slug, onAdd, recordEvent ] );
+		navigateToAddProductPage();
+	}, [ slug, navigateToAddProductPage, recordEvent ] );
 
 	/**
 	 * Calls the passed function onManage after firing Tracks event
 	 */
-	const navigateToConnectionPage = useMyJetpackNavigate( '/connection' );
 	const fixConnectionHandler = useCallback( () => {
 		recordEvent( 'jetpack_myjetpack_product_card_fixconnection_click', {
 			product: slug,
@@ -231,14 +233,12 @@ const ProductCard = props => {
 
 ProductCard.propTypes = {
 	admin: PropTypes.bool.isRequired,
-	onAdd: PropTypes.func,
 	onLearn: PropTypes.func,
 	slug: PropTypes.string.isRequired,
 	showDeactivate: PropTypes.bool,
 };
 
 ProductCard.defaultProps = {
-	onAdd: () => {},
 	onLearn: () => {},
 	showDeactivate: true,
 };

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/anti-spam-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/anti-spam-card.jsx
@@ -1,38 +1,23 @@
 /**
  * External dependencies
  */
-import React, { useCallback } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
 import ProductCard from '../product-card';
-import { useProduct } from '../../hooks/use-product';
 import { AntiSpamIcon } from '../icons';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const AntiSpamCard = ( { admin } ) => {
-	const { status, activate, deactivate, detail, isFetching } = useProduct( 'anti-spam' );
-	const { name, description, slug, manageUrl } = detail;
-	const onManage = useCallback( () => {
-		window.location = manageUrl;
-	}, [ manageUrl ] );
-
 	return (
 		<ProductCard
-			name={ name }
-			description={ description }
-			status={ status }
-			icon={ <AntiSpamIcon /> }
 			admin={ admin }
-			isFetching={ isFetching }
-			onDeactivate={ deactivate }
-			slug={ slug }
-			onActivate={ activate }
+			icon={ <AntiSpamIcon /> }
 			onAdd={ useMyJetpackNavigate( '/add-anti-spam' ) }
-			onFixConnection={ useMyJetpackNavigate( '/connection' ) }
-			onManage={ onManage }
+			slug="anti-spam"
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/anti-spam-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/anti-spam-card.jsx
@@ -8,16 +8,14 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import ProductCard from '../product-card';
-import { AntiSpamIcon } from '../icons';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const AntiSpamCard = ( { admin } ) => {
 	return (
 		<ProductCard
 			admin={ admin }
-			icon={ <AntiSpamIcon /> }
-			onAdd={ useMyJetpackNavigate( '/add-anti-spam' ) }
 			slug="anti-spam"
+			onAdd={ useMyJetpackNavigate( '/add-anti-spam' ) }
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/anti-spam-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/anti-spam-card.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import ProductCard from '../product-card';
+import ProductCard from './connected-product-card';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const AntiSpamCard = ( { admin } ) => {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import ProductCard from '../product-card';
+import ProductCard from './connected-product-card';
 
 const BackupCard = ( { admin } ) => {
 	return <ProductCard admin={ admin } showDeactivate={ false } slug="backup" />;

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card.jsx
@@ -9,13 +9,11 @@ import PropTypes from 'prop-types';
  */
 import ProductCard from '../product-card';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
-import { BackupIcon } from '../icons';
 
 const BackupCard = ( { admin } ) => {
 	return (
 		<ProductCard
 			admin={ admin }
-			icon={ <BackupIcon /> }
 			onAdd={ useMyJetpackNavigate( '/add-backup' ) }
 			showDeactivate={ false }
 			slug="backup"

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card.jsx
@@ -1,39 +1,24 @@
 /**
  * External dependencies
  */
-import React, { useCallback } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
 import ProductCard from '../product-card';
-import { useProduct } from '../../hooks/use-product';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 import { BackupIcon } from '../icons';
 
 const BackupCard = ( { admin } ) => {
-	const { status, activate, deactivate, detail, isFetching } = useProduct( 'backup' );
-	const { name, description, slug, manageUrl } = detail;
-	const onManage = useCallback( () => {
-		window.location = manageUrl;
-	}, [ manageUrl ] );
-
 	return (
 		<ProductCard
-			name={ name }
-			description={ description }
-			status={ status }
-			icon={ <BackupIcon /> }
-			isFetching={ isFetching }
 			admin={ admin }
-			onDeactivate={ deactivate }
-			slug={ slug }
-			onActivate={ activate }
-			showDeactivate={ false }
+			icon={ <BackupIcon /> }
 			onAdd={ useMyJetpackNavigate( '/add-backup' ) }
-			onFixConnection={ useMyJetpackNavigate( '/connection' ) }
-			onManage={ onManage }
+			showDeactivate={ false }
+			slug="backup"
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card.jsx
@@ -8,17 +8,9 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import ProductCard from '../product-card';
-import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const BackupCard = ( { admin } ) => {
-	return (
-		<ProductCard
-			admin={ admin }
-			onAdd={ useMyJetpackNavigate( '/add-backup' ) }
-			showDeactivate={ false }
-			slug="backup"
-		/>
-	);
+	return <ProductCard admin={ admin } showDeactivate={ false } slug="backup" />;
 };
 
 BackupCard.propTypes = {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import ProductCard from '../product-card';
+import ProductCard from './connected-product-card';
 
 const BoostCard = ( { admin } ) => {
 	return <ProductCard admin={ admin } slug="boost" />;

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card.jsx
@@ -8,12 +8,9 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import ProductCard from '../product-card';
-import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const BoostCard = ( { admin } ) => {
-	return (
-		<ProductCard admin={ admin } onAdd={ useMyJetpackNavigate( '/add-boost' ) } slug="boost" />
-	);
+	return <ProductCard admin={ admin } slug="boost" />;
 };
 
 BoostCard.propTypes = {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card.jsx
@@ -8,17 +8,11 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import ProductCard from '../product-card';
-import { BoostIcon } from '../icons';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const BoostCard = ( { admin } ) => {
 	return (
-		<ProductCard
-			admin={ admin }
-			icon={ <BoostIcon /> }
-			onAdd={ useMyJetpackNavigate( '/add-boost' ) }
-			slug="boost"
-		/>
+		<ProductCard admin={ admin } onAdd={ useMyJetpackNavigate( '/add-boost' ) } slug="boost" />
 	);
 };
 

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card.jsx
@@ -1,38 +1,23 @@
 /**
  * External dependencies
  */
-import React, { useCallback } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
 import ProductCard from '../product-card';
-import { useProduct } from '../../hooks/use-product';
 import { BoostIcon } from '../icons';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const BoostCard = ( { admin } ) => {
-	const { status, activate, deactivate, detail, isFetching } = useProduct( 'boost' );
-	const { name, description, slug, manageUrl } = detail;
-	const onManage = useCallback( () => {
-		window.location = manageUrl;
-	}, [ manageUrl ] );
-
 	return (
 		<ProductCard
-			name={ name }
-			description={ description }
-			status={ status }
-			icon={ <BoostIcon /> }
 			admin={ admin }
-			isFetching={ isFetching }
-			onDeactivate={ deactivate }
-			onActivate={ activate }
-			slug={ slug }
+			icon={ <BoostIcon /> }
 			onAdd={ useMyJetpackNavigate( '/add-boost' ) }
-			onFixConnection={ useMyJetpackNavigate( '/connection' ) }
-			onManage={ onManage }
+			slug="boost"
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/connected-product-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/connected-product-card.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
  */
 import ProductCard from '../product-card';
 import { useProduct } from '../../hooks/use-product';
-import { AntiSpamIcon } from '../icons';
+import { getIconBySlug } from '../icons';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const ConnectedProductCard = ( { admin, slug, showDeactivate } ) => {
@@ -26,12 +26,14 @@ const ConnectedProductCard = ( { admin, slug, showDeactivate } ) => {
 		window.location = manageUrl;
 	}, [ manageUrl ] );
 
+	const Icon = getIconBySlug( slug );
+
 	return (
 		<ProductCard
 			name={ name }
 			description={ description }
 			status={ status }
-			icon={ <AntiSpamIcon /> }
+			icon={ <Icon /> }
 			admin={ admin }
 			isFetching={ isFetching }
 			onDeactivate={ deactivate }

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/connected-product-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/connected-product-card.jsx
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import React, { useCallback } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import ProductCard from '../product-card';
+import { useProduct } from '../../hooks/use-product';
+import { AntiSpamIcon } from '../icons';
+import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
+
+const ConnectedProductCard = ( { admin, slug, showDeactivate } ) => {
+	const { detail, status, activate, deactivate, isFetching } = useProduct( slug );
+	const { name, description, manageUrl } = detail;
+
+	const navigateToConnectionPage = useMyJetpackNavigate( '/connection' );
+	const navigateToAddProductPage = useMyJetpackNavigate( `add-${ slug }` );
+
+	/*
+	 * Redirect to manage URL
+	 */
+	const onManage = useCallback( () => {
+		window.location = manageUrl;
+	}, [ manageUrl ] );
+
+	return (
+		<ProductCard
+			name={ name }
+			description={ description }
+			status={ status }
+			icon={ <AntiSpamIcon /> }
+			admin={ admin }
+			isFetching={ isFetching }
+			onDeactivate={ deactivate }
+			slug={ slug }
+			onActivate={ activate }
+			onAdd={ navigateToAddProductPage }
+			onFixConnection={ navigateToConnectionPage }
+			onManage={ onManage }
+			showDeactivate={ showDeactivate }
+		/>
+	);
+};
+
+ConnectedProductCard.propTypes = {
+	admin: PropTypes.bool.isRequired,
+	onLearn: PropTypes.func,
+	slug: PropTypes.string.isRequired,
+	showDeactivate: PropTypes.bool,
+};
+ConnectedProductCard.defaultProps = {
+	onLearn: () => {},
+	showDeactivate: true,
+};
+
+export default ConnectedProductCard;

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/crm-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/crm-card.jsx
@@ -8,18 +8,10 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import ProductCard from '../product-card';
-import { CrmIcon } from '../icons';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const CrmCard = ( { admin } ) => {
-	return (
-		<ProductCard
-			admin={ admin }
-			icon={ <CrmIcon /> }
-			onAdd={ useMyJetpackNavigate( '/add-crm' ) }
-			slug="crm"
-		/>
-	);
+	return <ProductCard admin={ admin } onAdd={ useMyJetpackNavigate( '/add-crm' ) } slug="crm" />;
 };
 
 CrmCard.propTypes = {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/crm-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/crm-card.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import ProductCard from '../product-card';
+import ProductCard from './connected-product-card';
 
 const CrmCard = ( { admin } ) => {
 	return <ProductCard admin={ admin } slug="crm" />;

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/crm-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/crm-card.jsx
@@ -1,38 +1,23 @@
 /**
  * External dependencies
  */
-import React, { useCallback } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
 import ProductCard from '../product-card';
-import { useProduct } from '../../hooks/use-product';
 import { CrmIcon } from '../icons';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const CrmCard = ( { admin } ) => {
-	const { status, activate, deactivate, detail, isFetching } = useProduct( 'crm' );
-	const { name, description, slug, manageUrl } = detail;
-	const onManage = useCallback( () => {
-		window.location = manageUrl;
-	}, [ manageUrl ] );
-
 	return (
 		<ProductCard
-			name={ name }
-			description={ description }
-			status={ status }
-			icon={ <CrmIcon /> }
-			isFetching={ isFetching }
 			admin={ admin }
-			onDeactivate={ deactivate }
-			onActivate={ activate }
-			slug={ slug }
+			icon={ <CrmIcon /> }
 			onAdd={ useMyJetpackNavigate( '/add-crm' ) }
-			onFixConnection={ useMyJetpackNavigate( '/connection' ) }
-			onManage={ onManage }
+			slug="crm"
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/crm-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/crm-card.jsx
@@ -8,10 +8,9 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import ProductCard from '../product-card';
-import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const CrmCard = ( { admin } ) => {
-	return <ProductCard admin={ admin } onAdd={ useMyJetpackNavigate( '/add-crm' ) } slug="crm" />;
+	return <ProductCard admin={ admin } slug="crm" />;
 };
 
 CrmCard.propTypes = {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/extras-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/extras-card.jsx
@@ -8,14 +8,12 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import ProductCard from '../product-card';
-import { ExtrasIcon } from '../icons';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const ExtrasCard = ( { admin } ) => {
 	return (
 		<ProductCard
 			admin={ admin }
-			icon={ <ExtrasIcon /> }
 			onAdd={ useMyJetpackNavigate( '/add-extras' ) }
 			showDeactivate={ false }
 			slug="extras"

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/extras-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/extras-card.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import ProductCard from '../product-card';
+import ProductCard from './connected-product-card';
 
 const ExtrasCard = ( { admin } ) => {
 	return <ProductCard admin={ admin } showDeactivate={ false } slug="extras" />;

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/extras-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/extras-card.jsx
@@ -1,40 +1,24 @@
 /**
  * External dependencies
  */
-import React, { useCallback } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
 import ProductCard from '../product-card';
-import { useProduct } from '../../hooks/use-product';
 import { ExtrasIcon } from '../icons';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const ExtrasCard = ( { admin } ) => {
-	const { status, activate, deactivate, detail, isFetching } = useProduct( 'extras' );
-	const { name, description, slug, manageUrl } = detail;
-
-	const onManage = useCallback( () => {
-		window.location = manageUrl;
-	}, [ manageUrl ] );
-
 	return (
 		<ProductCard
-			name={ name }
-			description={ description }
-			status={ status }
-			icon={ <ExtrasIcon /> }
 			admin={ admin }
-			isFetching={ isFetching }
-			onDeactivate={ deactivate }
-			slug={ slug }
-			onActivate={ activate }
-			showDeactivate={ false }
-			onFixConnection={ useMyJetpackNavigate( '/connection' ) }
-			onManage={ onManage }
+			icon={ <ExtrasIcon /> }
 			onAdd={ useMyJetpackNavigate( '/add-extras' ) }
+			showDeactivate={ false }
+			slug="extras"
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/extras-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/extras-card.jsx
@@ -8,17 +8,9 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import ProductCard from '../product-card';
-import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const ExtrasCard = ( { admin } ) => {
-	return (
-		<ProductCard
-			admin={ admin }
-			onAdd={ useMyJetpackNavigate( '/add-extras' ) }
-			showDeactivate={ false }
-			slug="extras"
-		/>
-	);
+	return <ProductCard admin={ admin } showDeactivate={ false } slug="extras" />;
 };
 
 ExtrasCard.propTypes = {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/scan-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/scan-card.jsx
@@ -1,39 +1,24 @@
 /**
  * External dependencies
  */
-import React, { useCallback } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
 import ProductCard from '../product-card';
-import { useProduct } from '../../hooks/use-product';
 import { ScanIcon } from '../icons';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const ScanCard = ( { admin } ) => {
-	const { status, activate, deactivate, detail, isFetching } = useProduct( 'scan' );
-	const { name, description, slug, manageUrl } = detail;
-	const onManage = useCallback( () => {
-		window.location = manageUrl;
-	}, [ manageUrl ] );
-
 	return (
 		<ProductCard
-			name={ name }
-			description={ description }
-			status={ status }
-			icon={ <ScanIcon /> }
 			admin={ admin }
-			isFetching={ isFetching }
-			onDeactivate={ deactivate }
-			slug={ slug }
-			onActivate={ activate }
+			icon={ <ScanIcon /> }
 			onAdd={ useMyJetpackNavigate( '/add-scan' ) }
 			showDeactivate={ false }
-			onFixConnection={ useMyJetpackNavigate( '/connection' ) }
-			onManage={ onManage }
+			slug="scan"
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/scan-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/scan-card.jsx
@@ -8,14 +8,12 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import ProductCard from '../product-card';
-import { ScanIcon } from '../icons';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const ScanCard = ( { admin } ) => {
 	return (
 		<ProductCard
 			admin={ admin }
-			icon={ <ScanIcon /> }
 			onAdd={ useMyJetpackNavigate( '/add-scan' ) }
 			showDeactivate={ false }
 			slug="scan"

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/scan-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/scan-card.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import ProductCard from '../product-card';
+import ProductCard from './connected-product-card';
 
 const ScanCard = ( { admin } ) => {
 	return <ProductCard admin={ admin } showDeactivate={ false } slug="scan" />;

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/scan-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/scan-card.jsx
@@ -8,17 +8,9 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import ProductCard from '../product-card';
-import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const ScanCard = ( { admin } ) => {
-	return (
-		<ProductCard
-			admin={ admin }
-			onAdd={ useMyJetpackNavigate( '/add-scan' ) }
-			showDeactivate={ false }
-			slug="scan"
-		/>
-	);
+	return <ProductCard admin={ admin } showDeactivate={ false } slug="scan" />;
 };
 
 ScanCard.propTypes = {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/search-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/search-card.jsx
@@ -1,38 +1,23 @@
 /**
  * External dependencies
  */
-import React, { useCallback } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
 import ProductCard from '../product-card';
-import { useProduct } from '../../hooks/use-product';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 import { SearchIcon } from '../icons';
 
 const SearchCard = ( { admin } ) => {
-	const { status, activate, deactivate, detail, isFetching } = useProduct( 'search' );
-	const { name, description, slug, manageUrl } = detail;
-	const onManage = useCallback( () => {
-		window.location = manageUrl;
-	}, [ manageUrl ] );
-
 	return (
 		<ProductCard
-			name={ name }
-			description={ description }
-			status={ status }
-			icon={ <SearchIcon /> }
 			admin={ admin }
-			isFetching={ isFetching }
-			onDeactivate={ deactivate }
-			onActivate={ activate }
+			icon={ <SearchIcon /> }
 			onAdd={ useMyJetpackNavigate( '/add-search' ) }
-			onFixConnection={ useMyJetpackNavigate( '/connection' ) }
-			onManage={ onManage }
-			slug={ slug }
+			slug="search"
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/search-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/search-card.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import ProductCard from '../product-card';
+import ProductCard from './connected-product-card';
 
 const SearchCard = ( { admin } ) => {
 	return <ProductCard admin={ admin } slug="search" />;

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/search-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/search-card.jsx
@@ -9,16 +9,10 @@ import PropTypes from 'prop-types';
  */
 import ProductCard from '../product-card';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
-import { SearchIcon } from '../icons';
 
 const SearchCard = ( { admin } ) => {
 	return (
-		<ProductCard
-			admin={ admin }
-			icon={ <SearchIcon /> }
-			onAdd={ useMyJetpackNavigate( '/add-search' ) }
-			slug="search"
-		/>
+		<ProductCard admin={ admin } onAdd={ useMyJetpackNavigate( '/add-search' ) } slug="search" />
 	);
 };
 

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/search-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/search-card.jsx
@@ -8,12 +8,9 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import ProductCard from '../product-card';
-import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const SearchCard = ( { admin } ) => {
-	return (
-		<ProductCard admin={ admin } onAdd={ useMyJetpackNavigate( '/add-search' ) } slug="search" />
-	);
+	return <ProductCard admin={ admin } slug="search" />;
 };
 
 SearchCard.propTypes = {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card.jsx
@@ -1,38 +1,23 @@
 /**
  * External dependencies
  */
-import React, { useCallback } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
 import ProductCard from '../product-card';
-import { useProduct } from '../../hooks/use-product';
 import { VideopressIcon } from '../icons';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const VideopressCard = ( { admin } ) => {
-	const { status, activate, deactivate, detail, isFetching } = useProduct( 'videopress' );
-	const { name, description, slug, manageUrl } = detail;
-	const onManage = useCallback( () => {
-		window.location = manageUrl;
-	}, [ manageUrl ] );
-
 	return (
 		<ProductCard
-			name={ name }
-			description={ description }
-			status={ status }
-			icon={ <VideopressIcon /> }
 			admin={ admin }
-			isFetching={ isFetching }
-			onDeactivate={ deactivate }
-			onActivate={ activate }
-			slug={ slug }
+			icon={ <VideopressIcon /> }
 			onAdd={ useMyJetpackNavigate( '/add-videopress' ) }
-			onFixConnection={ useMyJetpackNavigate( '/connection' ) }
-			onManage={ onManage }
+			slug="videopress"
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card.jsx
@@ -8,14 +8,12 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import ProductCard from '../product-card';
-import { VideopressIcon } from '../icons';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const VideopressCard = ( { admin } ) => {
 	return (
 		<ProductCard
 			admin={ admin }
-			icon={ <VideopressIcon /> }
 			onAdd={ useMyJetpackNavigate( '/add-videopress' ) }
 			slug="videopress"
 		/>

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import ProductCard from '../product-card';
+import ProductCard from './connected-product-card';
 
 const VideopressCard = ( { admin } ) => {
 	return <ProductCard admin={ admin } slug="videopress" />;

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card.jsx
@@ -8,16 +8,9 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import ProductCard from '../product-card';
-import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 const VideopressCard = ( { admin } ) => {
-	return (
-		<ProductCard
-			admin={ admin }
-			onAdd={ useMyJetpackNavigate( '/add-videopress' ) }
-			slug="videopress"
-		/>
-	);
+	return <ProductCard admin={ admin } slug="videopress" />;
 };
 
 VideopressCard.propTypes = {

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-product-card-janitorial
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-product-card-janitorial
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+My Jetpack: tidy Product card component


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR iterates over ProductCard components in order to simplify and reduce the code.  There is a bunch of repeated code that can be simplified thanks to the `useProduct()` hook, name conventions, etc. The goal is, again, to make the code more eligible, simpler, but without removing the ability to customize some of them when it's required. `showDeactivate` is an example of it.

<img width="117" alt="image" src="https://user-images.githubusercontent.com/77539/156640190-afdf9ca9-da71-4b96-ac52-db1dd9e148ce.png">

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Introduces <ConnectedProductCard/> component.
* SImplifies code in product cards by using <ConnectedProductCard/> instead of <ProductCard/> directly


#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* Go to My Jetpack dashboard. Confirm everything works as expected:
  *  Activate/Deactivate Product
  * Add Product link leads to the Interstitial page
  * Confirm it triggers events
  * etc
