### PR TITLE
Related Posts: Remove duplicated filter

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-duplicate-related-posts-filter
+++ b/projects/plugins/jetpack/changelog/remove-duplicate-related-posts-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Remove the duplicated jetpack_relatedposts_returned_results filter

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -1217,8 +1217,8 @@ EOT;
 	 * @return array
 	 */
 	public function get_related_post_data_for_post( $post_id, $position, $origin ) {
-		$post          = get_post( $post_id );
-		$related_posts = array(
+		$post = get_post( $post_id );
+		return array(
 			'id'       => $post->ID,
 			'url'      => get_permalink( $post->ID ),
 			'url_meta' => array(
@@ -1273,9 +1273,6 @@ EOT;
 				$post->ID
 			),
 		);
-
-		/** This filter is already documented in modules/related-posts/jetpack-related-posts.php */
-		return apply_filters( 'jetpack_relatedposts_returned_results', $related_posts, $post_id );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
In #22270 we added a second call to the
`jetpack_relatedposts_returned_results`, so the output could be
modified, but it was passed a single related post rather than an array
of results.

Because of this, any existing code hooked into the filter caused a fatal
error as it tried to process a scalar as an array.

This PR reverts the change. It looks like the output can still be
modified in the same way as the testing instructions for #22270 without
it.

#### Jetpack product discussion
p1646335055245699-slack-CDD9LQRSN

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the instructions for 'Related Posts injected at the bottom of each post via JS' in #22270
* Without this change you should see errors in the logs similar to: `Uncaught Error: Cannot use a scalar value as an array in ...`
* With this change it should work as described.
