### PR TITLE
VideoPress: Fix missing block attributes when using resumable uploads

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-videopress-set-core-video-attributes
+++ b/projects/plugins/jetpack/changelog/fix-videopress-set-core-video-attributes
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Fixing feature that is not in production yet.
+
+

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
@@ -606,18 +606,35 @@ const VideoPressEdit = CoreVideoEdit =>
 			};
 
 			// Handle Media Library selection
-			const mediaItemSelected = item => {
-				if ( item && item.videopress_guid ) {
-					this.props.setAttributes( { guid: item.videopress_guid } );
-				} else {
-					this.props.setAttributes( { src: item.url } );
+			// Same as core video block media selection while adding video guid to attributes
+			const mediaItemSelected = media => {
+				if ( ! media || ! media.url ) {
+					// In this case there was an error
+					// previous attributes should be removed
+					// because they may be temporary blob urls.
+					setAttributes( {
+						src: undefined,
+						id: undefined,
+						poster: undefined,
+					} );
+					return;
+				}
+
+				this.props.setAttributes( {
+					src: media.url,
+					id: media.id,
+					poster: media.image?.src !== media.icon ? media.image?.src : undefined,
+				} );
+
+				if ( media.videopress_guid ) {
+					this.props.setAttributes( { guid: media.videopress_guid } );
 				}
 			};
 
-			const uploadFinished = ( videoGuid = null ) => {
+			const uploadFinished = ( { mediaId, guid: videoGuid, src: videoSrc } ) => {
 				this.setState( { fileForUpload: null } );
-				if ( videoGuid ) {
-					setAttributes( { guid: videoGuid } );
+				if ( mediaId && videoGuid && videoSrc ) {
+					setAttributes( { id: mediaId, guid: videoGuid, src: videoSrc } );
 				}
 			};
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/resumable-upload/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/resumable-upload/index.js
@@ -52,8 +52,8 @@ export default function ResumableUpload( { file } ) {
 			setProgress( percentage );
 		};
 
-		const onSuccess = guid => {
-			onUploadFinished( guid );
+		const onSuccess = args => {
+			onUploadFinished( args );
 		};
 
 		const uploader = resumableUploader( {

--- a/projects/plugins/jetpack/extensions/blocks/videopress/resumable-upload/use-uploader.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/resumable-upload/use-uploader.js
@@ -48,9 +48,13 @@ export const resumableUploader = ( { onError, onProgress, onSuccess } ) => {
 				}
 
 				const GUID_HEADER = 'x-videopress-upload-guid';
+				const MEDIA_ID_HEADER = 'x-videopress-upload-media-id';
+				const SRC_URL_HEADER = 'x-videopress-upload-src-url';
 				const guid = res.getHeader( GUID_HEADER );
-				if ( guid ) {
-					onSuccess && onSuccess( guid );
+				const mediaId = res.getHeader( MEDIA_ID_HEADER );
+				const src = res.getHeader( SRC_URL_HEADER );
+				if ( guid && mediaId && src ) {
+					onSuccess && onSuccess( { mediaId, guid, src } );
 					return;
 				}
 


### PR DESCRIPTION
Fixes a bug where resumable video uploads were not properly setting the attachment id and/or src, which the block expects to receive as attributes. We noticed that some block settings were not saving properly, due to the missing `id`.

_Note: This is currently only an issue on wpcom simple sites for Automatticians._

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
* Sets the `id` and `src` attributes when selecting a video from the media library.
* Also sets the `id` and `src` attributes after a resumable upload completes.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pxWta-16I-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* You must test this on your wp.com sandbox on a site that has VideoPress enabled (Premium plan or better)
* Apply D76041-code to your sandbox, and also apply D76039-code ( `arc patch D76039 --nobranch` )
* Create a new post in Gutenberg and add select a video from the media library.
* Open the block settings and toggle the `Allow download` option. It should switch to the new state and save properly if you reload the page.
* Also upload a new video to the post, and perform the same test with the `Allow download` option. You can also change to the `Code editor` setting in Gutenberg and verify that your video blocks all have a `id` and `src` attribute set.
