### PR TITLE
Add filter for optional blocking of file uploads in upload_handler()

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-upload-handler-can-upload-filter
+++ b/projects/plugins/jetpack/changelog/add-jetpack-upload-handler-can-upload-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Added jetpack_upload_handler_can_upload filter for blocking specific file uploads

--- a/projects/plugins/jetpack/changelog/add-upload-block-filter
+++ b/projects/plugins/jetpack/changelog/add-upload-block-filter
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Added jetpack_upload_handler_block filter for blocking certain file uploads

--- a/projects/plugins/jetpack/changelog/add-upload-block-filter
+++ b/projects/plugins/jetpack/changelog/add-upload-block-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Added jetpack_upload_handler_block filter for blocking certain file uploads

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -3917,7 +3917,7 @@ p {
 		 * Optionally block uploads processed through Jetpack's upload_handler().
 		 * The filter may return false or WP_Error to block this particular upload.
 		 *
-		 * @since 10.8
+		 * @since $$next-version$$
 		 *
 		 * @param bool|WP_Error $allowed If false or WP_Error, block the upload. If true, allow the upload.
 		 * @param mixed $_FILES The $_FILES attempting to be uploaded.
@@ -3927,7 +3927,7 @@ p {
 			if ( is_wp_error( $can_upload ) ) {
 				return $can_upload;
 			}
-			return new WP_Error( 'handler_cannot_upload', 'The upload handler cannot upload files', 400 );
+			return new WP_Error( 'handler_cannot_upload', __( 'The upload handler cannot upload files', 'jetpack' ), 400 );
 		}
 
 		$uploaded_files = array();

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -3914,7 +3914,7 @@ p {
 		}
 
 		/**
-		 * Optionally block uploads processed through jetpack's upload_handler().
+		 * Optionally block uploads processed through Jetpack's upload_handler().
 		 * The filter may return false or WP_Error to block this particular upload.
 		 *
 		 * @since 10.8

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -3913,9 +3913,21 @@ p {
 			return new WP_Error( 'unknown_token', 'Unknown Jetpack token', 403 );
 		}
 
-		$upload_blocked = apply_filters( 'jetpack_upload_handler_block', false, $_FILES );
-		if ( is_wp_error( $upload_blocked ) ) {
-				return $upload_blocked;
+		/**
+		 * Optionally block uploads processed through jetpack's upload_handler().
+		 * The filter may return false or WP_Error to block this particular upload.
+		 *
+		 * @since 10.8
+		 *
+		 * @param bool|WP_Error $allowed If false or WP_Error, block the upload. If true, allow the upload.
+		 * @param mixed $_FILES The $_FILES attempting to be uploaded.
+		 */
+		$can_upload = apply_filters( 'jetpack_upload_handler_can_upload', true, $_FILES );
+		if ( ! $can_upload || is_wp_error( $can_upload ) ) {
+			if ( is_wp_error( $can_upload ) ) {
+				return $can_upload;
+			}
+			return new WP_Error( 'handler_cannot_upload', 'The upload handler cannot upload files', 400 );
 		}
 
 		$uploaded_files = array();

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -3913,6 +3913,11 @@ p {
 			return new WP_Error( 'unknown_token', 'Unknown Jetpack token', 403 );
 		}
 
+		$upload_blocked = apply_filters( 'jetpack_upload_handler_block', false, $_FILES );
+		if ( is_wp_error( $upload_blocked ) ) {
+				return $upload_blocked;
+		}
+
 		$uploaded_files = array();
 		$global_post    = isset( $GLOBALS['post'] ) ? $GLOBALS['post'] : null;
 		unset( $GLOBALS['post'] );


### PR DESCRIPTION
Related to #https://github.com/Automattic/wp-calypso/issues/51594

#### Changes proposed in this Pull Request:
* Add a new filter which can be used to block uploads processed by remote_request_handlers() -> upload_handler() 
  *  For example, a WP.com user using calypso to upload to a Jetpack or Atomic site

An example use of the filter is 832-gh-Automattic/wpcomsh . This prevents WoA users from using `https://wordpress.com/media/<site>` to upload files to their site, if that upload would take them over disk quota. Currently, this upload path goes through  `(wpcom) upload_jetpack_files() -> Jetpack_Client::upload_files() --> curl` `--http-->` `(jetpack) do_action 'wp_ajax_nopriv_jetpack_upload_file' -> remote_request_handlers() -> upload_handler()`. No file upload size checking is done in this path, as far as I can tell.  Adding the filter allows WoA to do their own checking of file sizes.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:
* Create a Jetpack site running this branch
* Connect to WP.com
* Add this code somewhere
```
function test_jetpack_upload_handler_can_upload( $value, $files ) {
        $upload_size = 0;
        if ( ! empty( $files['media']['size'] ) ) {
                $upload_size = array_sum( $files['media']['size'] );
                if ( $upload_size > 50000 ) {
                        return new WP_Error( 'insufficient_space_available', 'Uploaded file is too large.' );
                }
        }

        return $value;
}
add_filter( 'jetpack_upload_handler_can_upload', 'test_jetpack_upload_handler_can_upload', 10, 2 );
```
* Visit `https://wordpress.com/media/<sitename>`
* You should be able to upload a very small image (below 50kb), but a large image (above 50kb) should return an error and not write a file to disk

![2022-03-03_16-41](https://user-images.githubusercontent.com/937354/156665106-7148a724-c1df-4940-9fd4-f141ef4b1078.png)
