### PR TITLE
Search: Add record count component to Record Meter

### DIFF
--- a/projects/packages/search/changelog/record meter: add record-count
+++ b/projects/packages/search/changelog/record meter: add record-count
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+adds a record count above the record meter chart

--- a/projects/packages/search/changelog/record meter: add record-count
+++ b/projects/packages/search/changelog/record meter: add record-count
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-adds a record count above the record meter chart
+Search: adds a record count above the record meter chart

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.11.2",
+	"version": "0.11.3-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.11.2';
+	const VERSION = '0.11.3-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/dashboard/components/record-meter/index.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/index.jsx
@@ -1,5 +1,4 @@
-/**
- * External dependencies
+/* * External dependencies
  */
 import React, { useState } from 'react';
 import { __ } from '@wordpress/i18n';
@@ -8,6 +7,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { BarChart } from './bar-chart';
+import { RecordCount } from './record-count';
 import getRecordInfo from './lib/record-info';
 import createData from './lib/create-data';
 
@@ -37,12 +37,15 @@ export default function RecordMeter( { postCount, postTypeBreakdown, tierMaximum
 					<h2>{ __( 'Your search records', 'jetpack-search-pkg' ) }</h2>
 					{ tierMaximumRecords && (
 						<div>
+							<RecordCount
+								recordCount={ recordInfo.recordCount }
+								planRecordLimit={ tierMaximumRecords }
+							/>
 							<BarChart
 								data={ recordInfo.data }
 								isValid={ recordInfo.isValid }
 								postTypeBreakdown={ postTypeBreakdown }
 							/>
-							Tier maximum records: <strong>{ tierMaximumRecords }</strong>
 						</div>
 					) }
 					{ postCount && (

--- a/projects/packages/search/src/dashboard/components/record-meter/record-count.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/record-count.jsx
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Returns record count component showing curent records indexed and max records available for tier
+ *
+ * @param {object} props - current record count and plan record limit.
+ * @returns {React.Component} record count component.
+ */
+export function RecordCount( props ) {
+	if ( ! props.recordCount || ! props.planRecordLimit ) {
+		return null;
+	}
+
+	return (
+		<div data-testid="record-count" className="record-count">
+			{ props.recordCount && props.planRecordLimit && (
+				<p>
+					{ sprintf(
+						// translators: %1$d: site's current record count, %2$d: record limit of the curren plan
+						__(
+							'%1$d records indexed out of the %2$d alloted for your current plan',
+							'jetpack-search-pkg'
+						),
+						props.recordCount,
+						props.planRecordLimit
+					) }
+				</p>
+			) }
+		</div>
+	);
+}

--- a/projects/packages/search/src/dashboard/components/record-meter/record-count.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/record-count.jsx
@@ -17,19 +17,17 @@ export function RecordCount( props ) {
 
 	return (
 		<div data-testid="record-count" className="jp-search-record-count">
-			{ props.recordCount && props.planRecordLimit && (
-				<p>
-					{ sprintf(
-						// translators: %1$d: site's current record count, %2$d: record limit of the current plan
-						__(
-							'%1$d records indexed out of the %2$d allotted for your current plan',
-							'jetpack-search-pkg'
-						),
-						props.recordCount,
-						props.planRecordLimit
-					) }
-				</p>
-			) }
+			<p>
+				{ sprintf(
+					// translators: %1$d: site's current record count, %2$d: record limit of the current plan
+					__(
+						'%1$d records indexed out of the %2$d allotted for your current plan',
+						'jetpack-search-pkg'
+					),
+					props.recordCount,
+					props.planRecordLimit
+				) }
+			</p>
 		</div>
 	);
 }

--- a/projects/packages/search/src/dashboard/components/record-meter/record-count.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/record-count.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
- * Returns record count component showing curent records indexed and max records available for tier
+ * Returns record count component showing current records indexed and max records available for tier.
  *
  * @param {object} props - current record count and plan record limit.
  * @returns {React.Component} record count component.
@@ -16,13 +16,13 @@ export function RecordCount( props ) {
 	}
 
 	return (
-		<div data-testid="record-count" className="record-count">
+		<div data-testid="record-count" className="jp-search-record-count">
 			{ props.recordCount && props.planRecordLimit && (
 				<p>
 					{ sprintf(
-						// translators: %1$d: site's current record count, %2$d: record limit of the curren plan
+						// translators: %1$d: site's current record count, %2$d: record limit of the current plan
 						__(
-							'%1$d records indexed out of the %2$d alloted for your current plan',
+							'%1$d records indexed out of the %2$d allotted for your current plan',
 							'jetpack-search-pkg'
 						),
 						props.recordCount,

--- a/projects/packages/search/src/dashboard/components/record-meter/test/record-count.test.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/test/record-count.test.jsx
@@ -15,12 +15,12 @@ import '@testing-library/jest-dom/extend-expect';
 import { RecordCount } from 'components/record-meter/record-count';
 
 describe( 'record count', () => {
-	test( 'outputs correct text', () => {
+	test( 'outputs correct record counts', () => {
 		render( <RecordCount recordCount={ 20 } planRecordLimit={ 100 } /> );
 
-		expect(
-			screen.getByText( '20 records indexed out of the 100 allotted for your current plan' )
-		).toBeInTheDocument();
+		expect( screen.getByText( /20 records indexed/i ) ).toBeInTheDocument();
+
+		expect( screen.getByText( /100 allotted/i ) ).toBeInTheDocument();
 	} );
 
 	test( "doesn't output if there are no records", () => {

--- a/projects/packages/search/src/dashboard/components/record-meter/test/record-count.test.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/test/record-count.test.jsx
@@ -1,0 +1,32 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+/**
+ * Internal dependencies
+ */
+import { RecordCount } from 'components/record-meter/record-count';
+
+describe( 'record count', () => {
+	test( 'outputs correct text', () => {
+		render( <RecordCount recordCount={ 20 } planRecordLimit={ 100 } /> );
+
+		expect(
+			screen.getByText( '20 records indexed out of the 100 allotted for your current plan' )
+		).toBeInTheDocument();
+	} );
+
+	test( "doesn't output if there are no records", () => {
+		render( <RecordCount /> );
+
+		const recordCount = screen.queryByTestId( 'record-count' );
+		expect( recordCount ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/search/src/dashboard/components/record-meter/test/record-info.test.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/test/record-info.test.jsx
@@ -75,9 +75,9 @@ describe( 'API data is converted into record info ', () => {
 
 	test( 'first letter of string is capitalized', () => {
 		const stringToTest = 'i am a string';
-		const capializedString = capitalizeFirstLetter( stringToTest );
+		const capitalizedString = capitalizeFirstLetter( stringToTest );
 
-		expect( capializedString ).toBe( 'I am a string' );
+		expect( capitalizedString ).toBe( 'I am a string' );
 	} );
 
 	test( 'combine count of remaining items sums', () => {


### PR DESCRIPTION
This PR builds upon https://github.com/Automattic/jetpack/pull/23221 to add the a record count component to the record meter. 

#### Changes proposed in this Pull Request:

* Adds a record count component _(record-count.jsx)_ to display the indexed record count above the record meter chart. 

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

Visit `/wp-admin/admin.php?page=jetpack-search&features=record-meter` and check the record count is displaying immediately above the chart. The current notice should say `249 records indexed out of the 100 alloted for your current plan` but should respond correctly to any changes made in `lib/create-data.js` or if plan is upgraded to a higher tier. 

![image](https://user-images.githubusercontent.com/30754158/156664877-6e440874-deea-42b8-8275-650050451f80.png)
