### PR TITLE
Fix potential fatal error on speed scores

### DIFF
--- a/projects/plugins/boost/app/features/speed-score/Speed_Score.php
+++ b/projects/plugins/boost/app/features/speed-score/Speed_Score.php
@@ -94,11 +94,7 @@ class Speed_Score {
 			$score_request->store( 1800 ); // Keep the request for 30 minutes even if no one access the results.
 
 			// Send the request.
-			$response = $score_request->execute();
-
-			if ( is_wp_error( $response ) ) {
-				return $response;
-			}
+			$score_request->execute();
 		}
 
 		$score_request_no_boost = $this->maybe_dispatch_no_boost_score_request( $url );
@@ -196,11 +192,7 @@ class Speed_Score {
 			$score_request->store( 3600 ); // Keep the request for 1 hour even if no one access the results. The value is persisted for 1 hour in wp.com from initial request.
 
 			// Send the request.
-			$response = $score_request->execute();
-
-			if ( is_wp_error( $response ) ) {
-				return $response;
-			}
+			$score_request->execute();
 		}
 		remove_filter( 'jetpack_boost_excluded_query_parameters', array( $this, 'allow_jb_disable_module' ) );
 

--- a/projects/plugins/boost/app/features/speed-score/Speed_Score_Request.php
+++ b/projects/plugins/boost/app/features/speed-score/Speed_Score_Request.php
@@ -167,6 +167,10 @@ class Speed_Score_Request extends Cacheable {
 		);
 
 		if ( is_wp_error( $response ) ) {
+			$this->status = 'error';
+			$this->error  = $response->get_error_message();
+			$this->store();
+
 			return $response;
 		}
 

--- a/projects/plugins/boost/app/features/speed-score/Speed_Score_Request.php
+++ b/projects/plugins/boost/app/features/speed-score/Speed_Score_Request.php
@@ -226,7 +226,7 @@ class Speed_Score_Request extends Cacheable {
 
 		switch ( $response->status ) {
 			case 'pending':
-				// The initial job probalby failed, dispatch again if so.
+				// The initial job probably failed, dispatch again if so.
 				if ( $this->created <= strtotime( '-15 mins' ) ) {
 					return $this->restart();
 				}

--- a/projects/plugins/boost/changelog/fix-no-boost-score-error
+++ b/projects/plugins/boost/changelog/fix-no-boost-score-error
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix minor bug on AT
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #22773

#### Changes proposed in this Pull Request:
* Make sure `Speed_Score::prepare_speed_score_response()` Always receives `Speed_Score_Request` and not `WP_Error`

#### Jetpack product discussion
p1644432595899629-slack-C3GP81E05

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Create an AT site
* Set the site to "Private" from __Settings -> General > Privacy__
* Install Boost, if it was already installed deactivate and activate to get rid of stale data.
* Go to __Jetpack -> Boost__ and request a speed score.
* The request should fail as the site is private.
* Open `_cli` and run `wp php-errors` command to see if the fatal error appears.