### PR TITLE
jetpack: Improve error handling in mapbox API call

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
@@ -298,9 +298,9 @@ class WPCOM_REST_API_V2_Endpoint_Service_API_Keys extends WP_REST_Controller {
 		$mapbox_geocode_response = wp_safe_remote_get( esc_url_raw( $mapbox_geocode_url ) );
 		$mapbox_geocode_body     = wp_remote_retrieve_body( $mapbox_geocode_response );
 		$mapbox_geocode_json     = json_decode( $mapbox_geocode_body );
-		if ( isset( $mapbox_geocode_json->message ) && ! isset( $mapbox_geocode_json->query ) ) {
+		if ( isset( $mapbox_geocode_json->message ) || ! isset( $mapbox_geocode_json->query ) ) {
 			$status = false;
-			$msg    = $mapbox_geocode_json->message;
+			$msg    = isset( $mapbox_geocode_json->message ) ? $mapbox_geocode_json->message : 'Unknown error';
 		}
 		return array(
 			'status'        => $status,

--- a/projects/plugins/jetpack/changelog/fix-mapbox-api-error-handling
+++ b/projects/plugins/jetpack/changelog/fix-mapbox-api-error-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+If the mapbox API call returns a completely invalid response, treat it as a failure rather than a success.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The mapbox API returns a JSON object with a "query" property on success,
and one with a "message" property on failure. But apparently certain
error cases (some sort of HTTP 5xx maybe?) can have neither. Treat that
as a failure rather than a success.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1646383848458609-slack-C034JEXD1RD

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* I suppose you could try using a hosts file to "sandbox" api.mapbox.com and see if failures are properly detected.