### PR TITLE
Payment Block: fix payment block upgrade message obscured

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-payment-block-upgrade-message-obscured
+++ b/projects/plugins/jetpack/changelog/fix-payment-block-upgrade-message-obscured
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed and issue with the upgrade banner being obscured from all payment blocks. Also, now the upgrade lin does not have any text decorations.

--- a/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/editor.scss
+++ b/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/editor.scss
@@ -38,6 +38,7 @@ $icon-background-color: #fff;
 			height: 28px;
 
 			&.is-primary {
+				text-decoration: none;
 				background: $studio-pink-40;
 				color: $studio-white;
 
@@ -76,6 +77,12 @@ $icon-background-color: #fff;
 // Tweak Banner: Inspector Controls.
 .editor-styles-wrapper [data-block].is-upgradable,
 .block-editor-block-list__block.is-upgradable {
+	margin-top: 0;
+	padding-top: $banner-height;
+}
+
+// Tweak Banner: More specific selector needed for Inspector Controls.
+.editor-styles-wrapper .block-editor-block-list__layout.is-root-container .is-upgradable {
 	margin-top: 0;
 	padding-top: $banner-height;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [#61419](https://github.com/Automattic/wp-calypso/issues/61419)

Currently, the upgrade nudge interferes with the block controls, this PR solves the issue.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* The necessary rules were already in place, we just had to create a rule with more specificity so that the default wp-core behavior can be overridden without the need to use `!important`.
* This PR fixes the issue not only for the Payment Block but for all the blocks that require/show the upgrade nudge.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create or Edit a new Post
* Add any/all the blocks that require an upgraded subscription.
* You shall see that the block controls are shown without interfering with the upgrade nudge.

#### Test evidence

https://user-images.githubusercontent.com/1989914/156790069-dbf6c875-e5d9-46a8-8bb6-4974ae0df0e5.mp4

