### PR TITLE
Fix/missing critical css load

### DIFF
--- a/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS_Request.php
+++ b/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS_Request.php
@@ -40,9 +40,6 @@ class Cloud_CSS_Request {
 
 	private function reset_existing_css() {
 		$storage = new Critical_CSS_Storage();
-
-		foreach ( $this->state->get_provider_urls() as $provider => $urls ) {
-			$storage->store_css( $provider, '/* ' . __( 'Jetpack Boost is currently generating critical css for this page', 'jetpack-boost' ) . ' */' );
-		}
+		$storage->clear();
 	}
 }

--- a/projects/plugins/boost/changelog/fix-missing-critical-css-load
+++ b/projects/plugins/boost/changelog/fix-missing-critical-css-load
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Removed Critical CSS loading comment


### PR DESCRIPTION
Fixes https://href.li/?62-gh-Automattic/boost-hydra

When clearing Cloud CSS, a comment indicating it was loading was being translated and stored - so that it appeared in the rendered page source.

That caused problems, because when Critical CSS is available, other CSS files were deferred - causing a huge increase in CLS.

This fix removes the generating comment. I think this is the way to go because Boost is an optimization plugin. Adding extra content to the HTML source which doesn't help the page load speed is counter-productive.

If we decide later that we still want at comment in the source indicating that Critical CSS is pending, we would want to implement it in a different manner - check for a pending CSS request, and render a message at render-time - don't store a translated message in the database.

#### Changes proposed in this Pull Request:
* Don't store a CSS comment indicating Critical CSS is being regenerated.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Turn on Cloud CSS
* Regenerate Critical CSS
* Check that the main CSS files aren't deferred during loading.