### PR TITLE
Update critical CSS generation library to 0.0.4

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -879,7 +879,7 @@ importers:
       '@wordpress/i18n': 4.3.1
       eslint-plugin-import: 2.25.4
       eslint-plugin-svelte3: 3.2.1
-      jetpack-boost-critical-css-gen: github:automattic/jetpack-boost-critical-css-gen#release-0.0.2
+      jetpack-boost-critical-css-gen: github:automattic/jetpack-boost-critical-css-gen#release-0.0.4
       node-wp-i18n: 1.2.6
       npm-run-all: 4.1.5
       prettier-plugin-svelte: 2.4.0
@@ -899,7 +899,7 @@ importers:
     dependencies:
       '@wordpress/components': 19.5.0_@babel+core@7.16.0
       '@wordpress/element': 4.1.1
-      jetpack-boost-critical-css-gen: github.com/automattic/jetpack-boost-critical-css-gen/0232a05d6681315f40365143c7ed93707933f7e3
+      jetpack-boost-critical-css-gen: github.com/automattic/jetpack-boost-critical-css-gen/91e0ed5e0cf6296fd06f525d1fc016d5d46af86f
     devDependencies:
       '@babel/core': 7.16.0
       '@babel/preset-env': 7.16.4_@babel+core@7.16.0
@@ -25470,10 +25470,10 @@ packages:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
     dev: true
 
-  github.com/automattic/jetpack-boost-critical-css-gen/0232a05d6681315f40365143c7ed93707933f7e3:
-    resolution: {tarball: https://codeload.github.com/automattic/jetpack-boost-critical-css-gen/tar.gz/0232a05d6681315f40365143c7ed93707933f7e3}
+  github.com/automattic/jetpack-boost-critical-css-gen/91e0ed5e0cf6296fd06f525d1fc016d5d46af86f:
+    resolution: {tarball: https://codeload.github.com/automattic/jetpack-boost-critical-css-gen/tar.gz/91e0ed5e0cf6296fd06f525d1fc016d5d46af86f}
     name: jetpack-boost-critical-css-gen
-    version: 0.0.1
+    version: 0.0.4
     prepare: true
     requiresBuild: true
     dependencies:

--- a/projects/plugins/boost/changelog/update-critical-css-lib
+++ b/projects/plugins/boost/changelog/update-critical-css-lib
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use latest release of critical-css-gen library

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -8,7 +8,7 @@
 	"dependencies": {
 		"@wordpress/components": "19.5.0",
 		"@wordpress/element": "4.1.1",
-		"jetpack-boost-critical-css-gen": "github:automattic/jetpack-boost-critical-css-gen#release-0.0.2"
+		"jetpack-boost-critical-css-gen": "github:automattic/jetpack-boost-critical-css-gen#release-0.0.4"
 	},
 	"devDependencies": {
 		"@babel/core": "7.16.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Taking in https://github.com/Automattic/jetpack-boost-critical-css-gen/issues/26

#### Changes proposed in this Pull Request:
* Use release 0.0.4 of jetpack-boost-critical-css-gen

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Create a [webpage that would produce critical CSS with keyframe](https://gist.github.com/eAdnan007/f7d2bbf2a7990d2ef3e088654cbcc9cd)
* Generate Critical CSS for that page and make sure no @keyframe rules are present.
