### PR TITLE
Boost: clear cloud CSS status poll

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/Module.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/Module.svelte
@@ -38,6 +38,8 @@
 		try {
 			if ( await updateModuleState( slug, ! $isEnabled ) ) {
 				dispatch( 'enabled' );
+			} else {
+				dispatch( 'disabled' );
 			}
 		} catch ( caughtError ) {
 			error = caughtError;

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -3,7 +3,11 @@
 	 * Internal dependencies
 	 */
 	import { maybeGenerateCriticalCss } from '../../../utils/generate-critical-css';
-	import { requestCloudCss, pollCloudCssStatus } from '../../../utils/cloud-css';
+	import {
+		requestCloudCss,
+		pollCloudCssStatus,
+		stopPollingCloudCssStatus,
+	} from '../../../utils/cloud-css';
 	import GenerateCss from '../elements/GenerateCSS.svelte';
 	import CloudCssMeta from '../elements/CloudCssMeta.svelte';
 	import Module from '../elements/Module.svelte';
@@ -40,7 +44,12 @@
 		</div>
 	</Module>
 
-	<Module slug={'cloud-css'} on:enabled={requestCloudCss} on:mountEnabled={pollCloudCssStatus}>
+	<Module
+		slug={'cloud-css'}
+		on:enabled={requestCloudCss}
+		on:disabled={stopPollingCloudCssStatus}
+		on:mountEnabled={pollCloudCssStatus}
+	>
 		<h3 slot="title">
 			{__( 'Optimize CSS Loading from Cloud', 'jetpack-boost' )}
 		</h3>

--- a/projects/plugins/boost/app/assets/src/js/utils/cloud-css.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/cloud-css.ts
@@ -31,9 +31,8 @@ export function pollCloudCssStatus() {
 	let status = getStatus();
 	const interval = pollIntervalForStatus( getStatus() );
 
-	if ( statusIntervalId !== null ) {
-		clearInterval( statusIntervalId );
-	}
+	// If we are creating a new poll, clear the previous one.
+	stopPollingCloudCssStatus();
 
 	statusIntervalId = setInterval( async () => {
 		status = await api.get< CloudCssStatus >( '/cloud-css/status' );

--- a/projects/plugins/boost/app/assets/src/js/utils/cloud-css.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/cloud-css.ts
@@ -44,3 +44,10 @@ export function pollCloudCssStatus() {
 		}
 	}, interval );
 }
+
+export function stopPollingCloudCssStatus() {
+	if ( statusIntervalId !== null ) {
+		clearInterval( statusIntervalId );
+		statusIntervalId = null;
+	}
+}

--- a/projects/plugins/boost/changelog/update-clear-cloud-css-status-poll
+++ b/projects/plugins/boost/changelog/update-clear-cloud-css-status-poll
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: This is a minor fix for a feature within the current release
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #23263

#### Changes proposed in this Pull Request:
* Add an event handler for module `disabled`.
* Stop polling cloud CSS status if the module is disabled.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Open dev-tools on browser and monitor the network tab.
* Enable(or disable and re-enable) the cloud CSS module.
* Once it is enabled, notice that cloud CSS status is polling (`GET wp-json/jetpack-boost/v1/cloud-css/status`).
* Disable the module.
* The requests going out to the polling URL should stop once the module is disabled.
