### PR TITLE
E2E tests: extend the plugin update scenario

### DIFF
--- a/projects/plugins/jetpack/changelog/e2e-plugin-update-from
+++ b/projects/plugins/jetpack/changelog/e2e-plugin-update-from
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+E2E tests: extend the plugin update scenario

--- a/projects/plugins/jetpack/tests/e2e/specs/update/plugin-update.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/update/plugin-update.test.js
@@ -6,37 +6,21 @@ import {
 import { PluginsPage, JetpackPage } from 'jetpack-e2e-commons/pages/wp-admin/index.js';
 import { test, expect } from '../../fixtures/base-test.js';
 import { prerequisitesBuilder } from 'jetpack-e2e-commons/env/index.js';
+import logger from 'jetpack-e2e-commons/logger.cjs';
+const binPath = '/usr/local/src/jetpack-monorepo/projects/plugins/jetpack/tests/e2e/bin/update/';
+let pluginsPage;
 
 test( 'Update Jetpack plugin', async ( { page } ) => {
-	const binPath = '/usr/local/src/jetpack-monorepo/projects/plugins/jetpack/tests/e2e/bin/update/';
-
 	// Prepare for update
 	await execShellCommand( `./bin/update/prepare-zip.sh` );
 	await execContainerShellCommand( `${ binPath }prepare-update.sh ${ resolveSiteUrl() }` );
 
-	// Update
+	// Configure site before update
 	await prerequisitesBuilder( page ).withLoggedIn( true ).withConnection( true ).build();
 
-	let pluginsPage;
-
-	await test.step( 'Navigate to Plugins page', async () => {
-		pluginsPage = await PluginsPage.visit( page );
-	} );
-
-	// Capture Jetpack status before update
-	await execContainerShellCommand( `${ binPath }pre-update.sh ${ resolveSiteUrl() }` );
-
-	await test.step( 'Can update Jetpack', async () => {
-		await pluginsPage.updateJetpack();
-	} );
-
-	// Capture Jetpack status after update
-	await execContainerShellCommand( `${ binPath }post-update.sh` );
-
-	await test.step( 'Jetpack is still connected', async () => {
-		const jetpackPage = await JetpackPage.visit( page );
-		expect( await jetpackPage.isConnected() ).toBeTruthy();
-	} );
+	// Update
+	await updateJetpack( page, 'Update Jetpack from stable to current' );
+	await updateJetpack( page, 'Update Jetpack from current to next' );
 } );
 
 test.afterEach( async () => {
@@ -44,3 +28,35 @@ test.afterEach( async () => {
 		await execShellCommand( `pnpm env:new` );
 	}
 } );
+
+async function updateJetpack( page, stepDescription ) {
+	// Capture Jetpack status before update
+	await execContainerShellCommand( `${ binPath }pre-update.sh ${ resolveSiteUrl() }` );
+
+	await test.step( 'Navigate to Plugins page', async () => {
+		pluginsPage = await PluginsPage.visit( page );
+
+		// Dismiss any banners blocking the view
+		try {
+			const buttons = page.$$( 'text=Dismiss' );
+			for ( const btn of buttons ) {
+				btn.click();
+			}
+		} catch ( e ) {
+			logger.debug( 'No banners found to dismiss or some error occurred.' );
+		}
+	} );
+
+	await test.step( stepDescription, async () => {
+		await pluginsPage.updateJetpack();
+	} );
+
+	// Capture Jetpack status after update
+	await execContainerShellCommand( `${ binPath }post-update.sh` );
+
+	// Check status after update
+	await test.step( 'Jetpack is still connected', async () => {
+		const jetpackPage = await JetpackPage.visit( page );
+		expect( await jetpackPage.isConnected() ).toBeTruthy();
+	} );
+}

--- a/tools/e2e-commons/config/playwright.config.default.cjs
+++ b/tools/e2e-commons/config/playwright.config.default.cjs
@@ -28,7 +28,7 @@ if ( ! fs.existsSync( config.get( 'temp.storage' ) ) ) {
 }
 
 const playwrightConfig = {
-	timeout: 300000,
+	timeout: 600000,
 	retries: 0,
 	workers: 1,
 	outputDir: config.get( 'dirs.output' ),
@@ -37,7 +37,7 @@ const playwrightConfig = {
 		browserName: 'chromium',
 		channel: '',
 		headless: true,
-		viewport: { width: 1280, height: 720 },
+		viewport: { width: 1600, height: 1200 },
 		ignoreHTTPSErrors: true,
 		actionTimeout: 20000,
 		screenshot: 'only-on-failure',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Extend the plugin update end-to-end test with another update step. In this new step the plugin updates to the same build, covering the "update from" scenario.

#### Jetpack product discussion
p9dueE-4zF-p2

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*