### PR TITLE
My Jetpack: Add connected plugins to tracking events

### DIFF
--- a/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.js
@@ -1,3 +1,4 @@
+/* global myJetpackInitialState */
 /**
  * External dependencies
  */
@@ -8,6 +9,7 @@ import useMyJetpackConnection from '../use-my-jetpack-connection';
 const useAnalytics = () => {
 	const { isUserConnected, userConnectionData = {} } = useMyJetpackConnection();
 	const { login, ID } = userConnectionData.currentUser?.wpcomUser || {};
+	const { connectedPlugins } = myJetpackInitialState;
 
 	/**
 	 * Initialize tracks with user data.
@@ -18,6 +20,12 @@ const useAnalytics = () => {
 			jetpackAnalytics.initialize( ID, login );
 		}
 	}, [ ID, isUserConnected, login ] );
+
+	// Concatenated plugins slugs in alphabetical order
+	const connectedPluginsSlugs = Object.keys( connectedPlugins )
+		.sort()
+		.join( ',' )
+		.replaceAll( 'jetpack-', '' );
 
 	const {
 		clearedIdentity,
@@ -42,9 +50,10 @@ const useAnalytics = () => {
 			tracks.recordEvent( event, {
 				...properties,
 				version: window?.myJetpackInitialState?.myJetpackVersion,
+				referring_plugins: connectedPluginsSlugs,
 			} );
 		},
-		[ tracks ]
+		[ tracks, connectedPluginsSlugs ]
 	);
 
 	return {

--- a/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.js
@@ -22,7 +22,7 @@ const useAnalytics = () => {
 	}, [ ID, isUserConnected, login ] );
 
 	// Concatenated plugins slugs in alphabetical order
-	const connectedPluginsSlugs = Object.keys( connectedPlugins )
+	const connectedPluginsSlugs = Object.keys( connectedPlugins || {} )
 		.sort()
 		.join( ',' )
 		.replaceAll( 'jetpack-', '' );

--- a/projects/packages/my-jetpack/changelog/add-referring-plugins-to-tracks
+++ b/projects/packages/my-jetpack/changelog/add-referring-plugins-to-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added connected plugins slugs to My Jetpack tracking events


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #23169 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add a new property to My Jetpack tracking events containing the slugs of the connected plugins

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Yes. It adds an additional property to the tracking events triggered by My Jetpack. This property contains the slugs of all the plugins from the Jetpack family that are being powered by the Jetpack connection

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable debigging for tracks typing `localStorage.setItem( 'debug', 'dops:analytics*' );` in your console (if you haven't done this before) 
* Go to My Jetpack
* Click the buttons
* Make sure the events triggered (and logged into the console) contain a new `referral_plugins` property
* Make sure the value of the property correclty matches the active jetpack plugins
* Is the property name good?
* The value should always be a list of the jetpack plugins slugs without the `jetpack-` prefix, separated by a comma.
