### PR TITLE
[Boost] Defer admin bar

### DIFF
--- a/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS.php
+++ b/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS.php
@@ -2,6 +2,7 @@
 namespace Automattic\Jetpack_Boost\Features\Optimizations\Cloud_CSS;
 
 use Automattic\Jetpack_Boost\Contracts\Feature;
+use Automattic\Jetpack_Boost\Lib\Critical_CSS\Admin_Bar_Compatibility;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Invalidator;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_State;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Storage;
@@ -97,6 +98,9 @@ class Cloud_CSS implements Feature, Has_Endpoints {
 		add_action( 'wp_head', array( $display, 'display_critical_css' ), 0 );
 		add_filter( 'style_loader_tag', array( $display, 'asynchronize_stylesheets' ), 10, 4 );
 		add_action( 'wp_footer', array( $display, 'onload_flip_stylesheets' ) );
+
+		// Ensure admin bar compatibility.
+		Admin_Bar_Compatibility::init();
 	}
 
 	/**

--- a/projects/plugins/boost/app/features/optimizations/critical-css/Critical_CSS.php
+++ b/projects/plugins/boost/app/features/optimizations/critical-css/Critical_CSS.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack_Boost\Features\Optimizations\Critical_CSS;
 
 use Automattic\Jetpack_Boost\Contracts\Feature;
+use Automattic\Jetpack_Boost\Lib\Critical_CSS\Admin_Bar_Compatibility;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Invalidator;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Storage;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Display_Critical_CSS;
@@ -108,6 +109,9 @@ class Critical_CSS implements Feature, Has_Endpoints {
 		add_action( 'wp_head', array( $display, 'display_critical_css' ), 0 );
 		add_filter( 'style_loader_tag', array( $display, 'asynchronize_stylesheets' ), 10, 4 );
 		add_action( 'wp_footer', array( $display, 'onload_flip_stylesheets' ) );
+
+		// Ensure admin bar compatibility.
+		Admin_Bar_Compatibility::init();
 	}
 
 	/**

--- a/projects/plugins/boost/app/lib/critical-css/Admin_Bar_Compatibilty.php
+++ b/projects/plugins/boost/app/lib/critical-css/Admin_Bar_Compatibilty.php
@@ -1,7 +1,7 @@
 <?php
 namespace Automattic\Jetpack_Boost\Lib\Critical_CSS;
 
-class Admin_Bar_Compatibilty {
+class Admin_Bar_Compatibility {
 
 	/**
 	 * Enforces the admin bar stylesheet to load late and synchronously

--- a/projects/plugins/boost/changelog/fix-boost-admin-bar
+++ b/projects/plugins/boost/changelog/fix-boost-admin-bar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Added missing reference to Admin Bar compatibility class


### PR DESCRIPTION
When loading a site as a logged-in user, the admin bar can sometimes appear as a full screen FOUC when using Critical CSS.

In previous versions of Boost, we mitigated this by pushing the admin bar's HTML elements down to the footer - so that they are only brought up to the head of the page via CSS styles.

However, when we refactored our Critical CSS classes this got left out.

This PR reinstates our admin-bar compatibility fix for Critical CSS.

#### Changes proposed in this Pull Request:
* Reinstate calls to admin-bar compatibility classes.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Generate Critical CSS for your site
* Visit your homepage as a logged in user
* Verify the admin bar looks ok, there is no FOUC, and the admin bar's div is near the footer in the HTML source.