### PR TITLE
Boost: check for tracks

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/utils/analytics.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/analytics.ts
@@ -9,5 +9,10 @@ export function recordBoostEvent(
 		eventProp.boost_version = Jetpack_Boost.version;
 	}
 
-	jpTracksAJAX.record_ajax_event( `boost_${ eventName }`, 'click', eventProp );
+	if (
+		typeof jpTracksAJAX !== 'undefined' &&
+		typeof jpTracksAJAX.record_ajax_event === 'function'
+	) {
+		jpTracksAJAX.record_ajax_event( `boost_${ eventName }`, 'click', eventProp );
+	}
 }

--- a/projects/plugins/boost/changelog/fix-check-for-tracks
+++ b/projects/plugins/boost/changelog/fix-check-for-tracks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Minor bug fix
+
+


### PR DESCRIPTION
Fixes #22443

#### Changes proposed in this Pull Request:
* Check if tracks library is present before using it

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Dequeue tracks library
* Try to generate critical CSS
* See if it succeeds
