### PR TITLE
Connection: ConnectScreenRequiredPlanVisual  Update login in link-button label from "Log in" to "Log in to get started"

### DIFF
--- a/projects/js-packages/connection/changelog/update-fix-login-link-connection-card
+++ b/projects/js-packages/connection/changelog/update-fix-login-link-connection-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Updated link-button label from "Log In" to "Log In to get started"

--- a/projects/js-packages/connection/components/connect-screen/required-plan/test/component.jsx
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/test/component.jsx
@@ -83,7 +83,7 @@ describe( 'ConnectScreenRequiredPlan', () => {
 		render(
 			<ConnectScreenRequiredPlan { ...requiredProps } handleButtonClick={ handleButtonClick } />
 		);
-		const button = screen.getByRole( 'button', { name: 'Log in' } );
+		const button = screen.getByRole( 'button', { name: 'Log in to get started' } );
 		userEvent.click( button );
 		expect( handleButtonClick.called ).to.be.true;
 	} );

--- a/projects/js-packages/connection/components/connect-screen/required-plan/visual.jsx
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/visual.jsx
@@ -56,11 +56,11 @@ const ConnectScreenRequiredPlanVisual = props => {
 	);
 
 	const withSubscription = createInterpolateElement(
-		__( 'Already have a subscription? <connectButton/> to get started.', 'jetpack' ),
+		__( 'Already have a subscription? <connectButton/>', 'jetpack' ),
 		{
 			connectButton: (
 				<ActionButton
-					label={ __( 'Log in', 'jetpack' ) }
+					label={ __( 'Log in to get started', 'jetpack' ) }
 					onClick={ handleButtonClick }
 					isLoading={ buttonIsLoading }
 				/>


### PR DESCRIPTION
Fixes #23286

Addressed partially #23055

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates the label for the ActionButton on the ConnectScreenRequiredPlanVisual to read "Log in to get started" instead of "Log in"
* Updates related test

#### Jetpack product discussion
p1HpG7-ePH-p2#comment-52499

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
1. Checkout this branch
2. On a site connected but with disconnected user, and the Jetpack backup plugn installed, visit the Jetpack backup admin page
3. Confirm the "Log in to get started" is a full link"
4. Click it to connect
5. Expect to see the whole sentence switch to a spinner