### PR TITLE
QR Plugin: update plugin registration

### DIFF
--- a/projects/plugins/jetpack/changelog/update-qr-registration
+++ b/projects/plugins/jetpack/changelog/update-qr-registration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+QR Plugin: update registration

--- a/projects/plugins/jetpack/class.jetpack-plan.php
+++ b/projects/plugins/jetpack/class.jetpack-plan.php
@@ -47,7 +47,6 @@ class Jetpack_Plan {
 				'whatsapp-button',
 				'social-previews',
 				'videopress',
-				'post-publish-qr-post-panel',
 
 				'core/video',
 				'core/cover',

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/post-publish-qr-post-panel.php
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/post-publish-qr-post-panel.php
@@ -1,9 +1,12 @@
 <?php
 /**
- * Block Editor - Republicize feature.
+ * Block Editor - QR Post feature.
  *
  * @package automattic/jetpack
- **/
+ */
+
+// Feature name.
+const FEATURE_NAME = 'post-publish-qr-post-panel';
 
 // Populate the available extensions with post-publish-qr-post-panel.
 add_filter(
@@ -12,7 +15,7 @@ add_filter(
 		return array_merge(
 			$extensions,
 			array(
-				'post-publish-qr-post-panel',
+				FEATURE_NAME,
 			)
 		);
 	}
@@ -22,6 +25,6 @@ add_filter(
 add_action(
 	'jetpack_register_gutenberg_extensions',
 	function () {
-		\Jetpack_Gutenberg::set_availability_for_plan( 'post-publish-qr-post-panel' );
+		\Jetpack_Gutenberg::set_extension_available( FEATURE_NAME );
 	}
 );


### PR DESCRIPTION
Follow-up to #23281

#### Changes proposed in this Pull Request:

﻿Since the plugin will be free for everyone, we do not need to check for a plan in the process.
Discussion: https://github.com/Automattic/jetpack/pull/23281#discussion_r821477445

This will also avoid having to update things on WordPress.com's end to declare support for the new plugin there.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Go to Posts > Add New
* Publish a new post
* You should see the QR post-publish panel.
