### PR TITLE
Admin: reverted using WP_Filesystem to file_get_contents

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -200,9 +200,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		do_action( 'jetpack_notices' );
 
 		// Fetch static.html.
-		global $wp_filesystem;
-		WP_Filesystem();
-		$static_html = $wp_filesystem->get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static.html' );
+		$static_html = @file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static.html' ); //phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, Not fetching a remote file.
 
 		// Sanitize static.html data.
 		$allowed_html = wp_kses_allowed_html( 'post' );

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -47,12 +47,9 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 	public function page_render() {
 		$list_table = new Jetpack_Modules_List_Table();
 
-		WP_Filesystem();
-		global $wp_filesystem;
-
 		// We have static.html so let's continue trying to fetch the others.
-		$noscript_notice = $wp_filesystem->get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-noscript-notice.html' );
-		$rest_api_notice = $wp_filesystem->get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-version-notice.html' );
+		$noscript_notice = @file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-noscript-notice.html' ); //phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, Not fetching a remote file.
+		$rest_api_notice = @file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-version-notice.html' ); //phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, Not fetching a remote file.
 
 		$noscript_notice = str_replace(
 			'#HEADER_TEXT#',

--- a/projects/plugins/jetpack/changelog/fix-admin_pages_filesystem_error
+++ b/projects/plugins/jetpack/changelog/fix-admin_pages_filesystem_error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Admin pages: reverting code added in #23219 to fix a bug.


### PR DESCRIPTION
WP_Filesystem is not needed when reading files that are a part of the plugin.<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixing a bug introduced in #23219 related to the usage of WP_Filesystem.

Discussion in: 

* p1646733934456429-slack-CBG1CP4EN
* p1646740974319369-slack-C02HQGKMFJ8

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Reverted using WP_Filesystem to file_get_contents.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

none

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* E2E test shouldn't fail.
* Try loading admin pages in e2e environment.