### PR TITLE
Try: Add endpoint for Woo menu items

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-woo-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-woo-admin-menu.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * REST API endpoint for Woo.com admin menus.
+ *
+ * @package automattic/jetpack
+ */
+
+/**
+ * Class WPCOM_REST_API_V2_Endpoint_Woo_Admin_Menu
+ */
+class WPCOM_REST_API_V2_Endpoint_Woo_Admin_Menu extends WP_REST_Controller {
+
+	/**
+	 * Namespace prefix.
+	 *
+	 * @var string
+	 */
+	public $namespace = 'wpcom/v2';
+
+	/**
+	 * Endpoint base route.
+	 *
+	 * @var string
+	 */
+	public $rest_base = 'woo-admin-menu';
+
+	/**
+	 * WPCOM_REST_API_V2_Endpoint_Woo_Admin_Menu constructor.
+	 */
+	public function __construct() {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Checks if a given request has access to admin menus.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access for the item, WP_Error object otherwise.
+	 */
+	public function get_items_permissions_check( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( ! current_user_can( 'read' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you are not allowed to view menus on this site.', 'jetpack' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieves the admin menu.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_items( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( ! isset( $GLOBALS['woo_admin_menu'] ) ) {
+			return new WP_Error(
+				'woo_admin_menu_inactive',
+				__( 'WooCommerce Admin Menu is not active on this site.', 'jetpack' )
+			);
+		}
+
+		$woo_admin_menu = $GLOBALS['woo_admin_menu']; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+
+		return rest_ensure_response( $woo_admin_menu->get_menus_json() );
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Woo_Admin_Menu' );

--- a/projects/plugins/jetpack/changelog/try-woo-menu-rest
+++ b/projects/plugins/jetpack/changelog/try-woo-menu-rest
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add REST endpoint for Woo menu items


### PR DESCRIPTION
**DO NOT MERGE.**

This is a POC for getting Woo menu items via endpoint for use in dotcom.

`/wp-json/wpcom/v2/woo-admin-menu`

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*
