### PR TITLE
Jetpack: Add View and Download buttons to QRPost

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-view-and-dowload-qr-post-code
+++ b/projects/plugins/jetpack/changelog/update-jetpack-view-and-dowload-qr-post-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: add actions button to QRPost panel

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/components/image-actions-panel-row.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/components/image-actions-panel-row.js
@@ -6,7 +6,15 @@ import { PanelRow, Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 
-function handleDownloadCode( slug, ref, download = true ) {
+/**
+ * Handler function to create an image from the QR code.
+ *
+ * @param {string} slug      - The slug of the image to create.
+ * @param {object} ref       - The ref of the QR code DOM element.
+ * @param {boolean} download - Whether to download the image. Defaults to true.
+ * @returns {void}           - Nothing when the image is not created.
+ */
+function handleDownloadQRCode( slug, ref, download = true ) {
 	if ( ! slug ) {
 		return;
 	}
@@ -20,11 +28,12 @@ function handleDownloadCode( slug, ref, download = true ) {
 		return;
 	}
 
-	// Convert to bitsmap, and download.
+	// Convert to canvas element to data URL image.
 	canvasElement.toBlob( imageBlob => {
 		const imageURL = URL.createObjectURL( imageBlob );
 		const tempLink = document.createElement( 'a' );
 		tempLink.href = imageURL;
+		// Download, or not.
 		tempLink.setAttribute( download ? 'download' : 'target', `qr-post-${ slug }.png` );
 		tempLink.click();
 	} );
@@ -43,11 +52,11 @@ export default function QRCodeImageActionsPanelRow( { qrCodeRef } ) {
 
 	return (
 		<PanelRow>
-			<Button isSecondary isSmall onClick={ () => handleDownloadCode( slug, qrCodeRef, false ) }>
+			<Button isSecondary isSmall onClick={ () => handleDownloadQRCode( slug, qrCodeRef, false ) }>
 				{ __( 'View', 'jetpack' ) }
 			</Button>
 
-			<Button isSecondary isSmall onClick={ () => handleDownloadCode( slug, qrCodeRef ) }>
+			<Button isSecondary isSmall onClick={ () => handleDownloadQRCode( slug, qrCodeRef ) }>
 				{ __( 'Download', 'jetpack' ) }
 			</Button>
 		</PanelRow>

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/components/image-actions-panel-row.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/components/image-actions-panel-row.js
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { PanelRow, Button } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+
+function handleDownloadCode( slug, ref, download = true ) {
+	if ( ! slug ) {
+		return;
+	}
+
+	if ( ! ref?.current ) {
+		return;
+	}
+
+	const canvasElement = ref.current.querySelector( 'canvas' );
+	if ( ! canvasElement ) {
+		return;
+	}
+
+	// Convert to bitsmap, and download.
+	canvasElement.toBlob( imageBlob => {
+		const imageURL = URL.createObjectURL( imageBlob );
+		const tempLink = document.createElement( 'a' );
+		tempLink.href = imageURL;
+		tempLink.setAttribute( download ? 'download' : 'target', `qr-post-${ slug }.png` );
+		tempLink.click();
+	} );
+}
+
+/**
+ * Row panel component to address the actions
+ * about the QR Code image.
+ *
+ * @param {object} props           - The component props.
+ * @param {string} props.qrCodeRef - The reference to the QR Code image.
+ * @returns {object} The component.
+ */
+export default function QRCodeImageActionsPanelRow( { qrCodeRef } ) {
+	const slug = useSelect( select => select( editorStore ).getEditedPostSlug(), [] );
+
+	return (
+		<PanelRow>
+			<Button isSecondary isSmall onClick={ () => handleDownloadCode( slug, qrCodeRef, false ) }>
+				{ __( 'View', 'jetpack' ) }
+			</Button>
+
+			<Button isSecondary isSmall onClick={ () => handleDownloadCode( slug, qrCodeRef ) }>
+				{ __( 'Download', 'jetpack' ) }
+			</Button>
+		</PanelRow>
+	);
+}

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/components/qr-post.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/components/qr-post.js
@@ -36,7 +36,7 @@ export default function QRPost() {
 	return (
 		<QRCode
 			value={ codeContent }
-			size={ 248 }
+			size={ 238 }
 			imageSettings={ src && { src, width: 48, height: 48, excavate: true } }
 			renderAs="canvas"
 			level="H"

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/components/qr-post.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/components/qr-post.js
@@ -30,20 +30,14 @@ export default function QRPost() {
 	);
 
 	const codeContent = `${ title } ${ permalink }`;
-	const { url: siteLogologoUrl } = useSiteLogo();
+	const data = useSiteLogo( { generateDataUrl: true } );
+	const { dataUrl: src } = data;
 
 	return (
 		<QRCode
 			value={ codeContent }
 			size={ 248 }
-			imageSettings={
-				siteLogologoUrl && {
-					src: siteLogologoUrl,
-					width: 48,
-					height: 48,
-					excavate: true,
-				}
-			}
+			imageSettings={ src && { src, width: 48, height: 48, excavate: true } }
 			renderAs="canvas"
 			level="H"
 		/>

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/editor.scss
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/editor.scss
@@ -15,3 +15,7 @@
 		}
 	}
 }
+.post-publish-qr-post-panel__container {
+	display: flex;
+	justify-content: center;
+}

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/editor.scss
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/editor.scss
@@ -4,4 +4,14 @@
 			margin-left: 5px;
 		}
 	}
+
+	.components-panel__row {
+		.components-button {
+			flex-grow: 1;
+			padding: 3px 10px 4px;
+			margin: 5px;
+			justify-content: center;
+			text-align: center;
+		}
+	}
 }

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/hooks/use-site-logo.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/hooks/use-site-logo.js
@@ -54,8 +54,12 @@ export default function useSiteLogo( { generateDataUrl = false } ) {
 		canvas.height = this.naturalHeight;
 		canvas.width = this.naturalWidth;
 		context.drawImage( this, 0, 0 );
-		const generatedDataUrl = canvas.toDataURL( 'image/jpeg' );
-		setDataUrl( generatedDataUrl );
+		try {
+			setDataUrl( canvas.toDataURL( 'image/png' ) );
+		} catch ( error ) {
+			console.error( 'Error generating QR code image:', error ); // eslint-disable-line no-console
+			setDataUrl( null );
+		}
 	};
 
 	image.src = mediaItemData?.url;

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/hooks/use-site-logo.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/hooks/use-site-logo.js
@@ -57,7 +57,13 @@ export default function useSiteLogo( { generateDataUrl = false } ) {
 		try {
 			setDataUrl( canvas.toDataURL( 'image/png' ) );
 		} catch ( error ) {
-			console.error( 'Error generating QR code image:', error ); // eslint-disable-line no-console
+			/* eslint-disable no-console */
+			console.error( 'Error generating QR code image:', error );
+			console.error(
+				"In case it's a cross-origin issue, take a look at https://developer.wordpress.org/block-editor/reference-guides/filters/editor-filters/#media-crossorigin"
+			);
+			/* eslint-enable no-console */
+
 			setDataUrl( null );
 		}
 	};

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/hooks/use-site-logo.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/hooks/use-site-logo.js
@@ -47,7 +47,6 @@ export default function useSiteLogo( { generateDataUrl = false } ) {
 	}
 
 	const image = new Image();
-	image.crossOrigin = 'Anonymous';
 
 	image.onload = function () {
 		const canvas = document.createElement( 'canvas' );

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/hooks/use-site-logo.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/hooks/use-site-logo.js
@@ -2,14 +2,18 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { useState } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * React hook that returns the site logo data.
  *
+ * @param {object} params - Hook parameters.
+ * @param {boolean} params.generateDataUrl - Whether to convert the data URL to a blob. Default: false.
  * @returns {object} Site Logo object data.
  */
-export default function useSiteLogo() {
+export default function useSiteLogo( { generateDataUrl = false } ) {
+	const [ dataUrl, setDataUrl ] = useState();
 	const { id, mediaItemData } = useSelect( select => {
 		const { canUser, getEntityRecord, getEditedEntityRecord } = select( coreStore );
 		const siteSettings = getEditedEntityRecord( 'root', 'site' );
@@ -34,5 +38,28 @@ export default function useSiteLogo() {
 		};
 	}, [] );
 
-	return { id, ...mediaItemData };
+	if ( ! id || ! mediaItemData?.url ) {
+		return {};
+	}
+
+	if ( ! generateDataUrl ) {
+		return { id, ...mediaItemData };
+	}
+
+	const image = new Image();
+	image.crossOrigin = 'Anonymous';
+
+	image.onload = function () {
+		const canvas = document.createElement( 'canvas' );
+		const context = canvas.getContext( '2d' );
+		canvas.height = this.naturalHeight;
+		canvas.width = this.naturalWidth;
+		context.drawImage( this, 0, 0 );
+		const generatedDataUrl = canvas.toDataURL( 'image/jpeg' );
+		setDataUrl( generatedDataUrl );
+	};
+
+	image.src = mediaItemData?.url;
+
+	return { id, ...mediaItemData, dataUrl };
 }

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { PluginPostPublishPanel } from '@wordpress/edit-post';
+import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { __ } from '@wordpress/i18n';
 import { useRef } from '@wordpress/element';
 
@@ -19,7 +19,7 @@ export const settings = {
 	render: function PluginPostPublishPanelQRPost() {
 		const qrCodeRef = useRef();
 		return (
-			<PluginPostPublishPanel
+			<PluginPrePublishPanel
 				name="post-publish-qr-post-panel"
 				title={ __( 'QR Code', 'jetpack' ) }
 				className="post-publish-qr-post-panel"
@@ -31,7 +31,7 @@ export const settings = {
 				</div>
 
 				<ImageActionsPanelRow qrCodeRef={ qrCodeRef } />
-			</PluginPostPublishPanel>
+			</PluginPrePublishPanel>
 		);
 	},
 };

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { PluginPrePublishPanel } from '@wordpress/edit-post';
+import { PluginPostPublishPanel } from '@wordpress/edit-post';
 import { __ } from '@wordpress/i18n';
 import { useRef } from '@wordpress/element';
 
@@ -19,7 +19,7 @@ export const settings = {
 	render: function PluginPostPublishPanelQRPost() {
 		const qrCodeRef = useRef();
 		return (
-			<PluginPrePublishPanel
+			<PluginPostPublishPanel
 				name="post-publish-qr-post-panel"
 				title={ __( 'QR Code', 'jetpack' ) }
 				className="post-publish-qr-post-panel"
@@ -31,7 +31,7 @@ export const settings = {
 				</div>
 
 				<ImageActionsPanelRow qrCodeRef={ qrCodeRef } />
-			</PluginPrePublishPanel>
+			</PluginPostPublishPanel>
 		);
 	},
 };

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/index.js
@@ -3,18 +3,21 @@
  */
 import { PluginPostPublishPanel } from '@wordpress/edit-post';
 import { __ } from '@wordpress/i18n';
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import QRIcon from './components/icon.js';
 import QRPost from './components/qr-post.js';
+import ImageActionsPanelRow from './components/image-actions-panel-row.js';
 import './editor.scss';
 
 export const name = 'post-publish-qr-post-panel';
 
 export const settings = {
 	render: function PluginPostPublishPanelQRPost() {
+		const qrCodeRef = useRef();
 		return (
 			<PluginPostPublishPanel
 				name="post-publish-qr-post-panel"
@@ -23,9 +26,11 @@ export const settings = {
 				icon={ <QRIcon /> }
 				initialOpen={ true }
 			>
-				<div className="post-publish-qr-post-panel__container">
+				<div className="post-publish-qr-post-panel__container" ref={ qrCodeRef }>
 					<QRPost />
 				</div>
+
+				<ImageActionsPanelRow qrCodeRef={ qrCodeRef } />
 			</PluginPostPublishPanel>
 		);
 	},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds two buttons to the QRPost panel to `view` and `download` the QRCode.
Under the hood, when the site has a logo, it's converted to data (base64) to avoid the [Tainted canvases may not be exported.](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image) issue that occurs in some servers.

<img width="336" alt="image" src="https://user-images.githubusercontent.com/77539/157470058-ef3f1503-4c5d-4851-83e3-01829ed85bc5.png">

### Cross-Origin issue
It's possible that, for some reason, the origin of the image doesn't match with the site hostname. Under this situation, it catches the error and shows a message in the console of the client, with useful information to handle the error.

```
Error generating QR code image: DOMException: Failed to execute 'toDataURL' on 'HTMLCanvasElement':
Tainted canvases may not be exported.
```

```
In case it's a cross-origin issue, take a look at
https://developer.wordpress.org/block-editor/reference-guides/filters/editor-filters/#media-crossorigin
```

Fixes https://github.com/Automattic/jetpack/issues/23294

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack: Add View and Download buttons to QRPost

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to add a new post
* Publish
* Confirm you can see the QR code image by clicking on the `View` button. It's opened in a new tab.
* Confirm you can download the image by clicking on the `Download` button
* Confirm it works also when the site has defined a logo.


https://user-images.githubusercontent.com/77539/157469278-5b6b5d7e-b285-4703-ac82-c5a040de7be1.mov


