### PR TITLE
PHPCS: Add WordPress ruleset

### DIFF
--- a/projects/packages/codesniffer/Jetpack/ruleset.xml
+++ b/projects/packages/codesniffer/Jetpack/ruleset.xml
@@ -3,6 +3,7 @@
 	<description>Jetpack coding standards. Based on the WordPress coding standards, with some additions.</description>
 
 	<rule ref="PHPCompatibilityWP" />
+	<rule ref="WordPress" />
 	<rule ref="WordPress-Core" />
 	<rule ref="WordPress-Docs" />
 	<rule ref="WordPress-Extra" />

--- a/projects/packages/codesniffer/changelog/update-phpcs-wpcom
+++ b/projects/packages/codesniffer/changelog/update-phpcs-wpcom
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+WordPress ruleset


### PR DESCRIPTION
- Use the generic WordPress ruleset to match WP.com

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The docs read to me that the generic WordPress ruleset just add a combo of other rules, but apparently, it has its own sniffs too. Adding this to match what WP.com has.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds WordPress ruleset

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See how mad the CI gets.
