### PR TITLE
Google Fonts: fix warning when webfonts API not available

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-google-fonts-error-without-gutenberg
+++ b/projects/plugins/jetpack/changelog/fix-google-fonts-error-without-gutenberg
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Google Fonts: prevent error when Webfonts API is not available

--- a/projects/plugins/jetpack/modules/google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts.php
@@ -96,5 +96,16 @@ function jetpack_add_google_fonts_provider() {
 }
 add_action( 'after_setup_theme', 'jetpack_add_google_fonts_provider' );
 
-// Run on an early priority to print out the preconnect link tag near the start of the page source.
-add_action( 'wp_head', '\Automattic\Jetpack\Fonts\Google_Fonts_Provider::preconnect_font_source', 0 );
+/**
+ * Add a preconnect link to the `<head>`, if fonts API is available.
+ */
+function jetpack_add_google_fonts_preconnect() {
+	if ( ! class_exists( 'WP_Webfonts_Provider' ) ) {
+		return;
+	}
+
+	// Run on an early priority to print out the preconnect link tag near the start of the page source.
+	add_action( 'wp_head', '\Automattic\Jetpack\Fonts\Google_Fonts_Provider::preconnect_font_source', 0 );
+}
+
+add_action( 'init', 'jetpack_add_google_fonts_preconnect' );

--- a/projects/plugins/jetpack/modules/google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts.php
@@ -97,7 +97,7 @@ function jetpack_add_google_fonts_provider() {
 add_action( 'after_setup_theme', 'jetpack_add_google_fonts_provider' );
 
 /**
- * Add a preconnect link to the `<head>`, if fonts API is available.
+ * Add a preconnect link to the `<head>`, if Webfonts API is available.
  */
 function jetpack_add_google_fonts_preconnect() {
 	if ( ! class_exists( 'WP_Webfonts_Provider' ) ) {
@@ -107,5 +107,4 @@ function jetpack_add_google_fonts_preconnect() {
 	// Run on an early priority to print out the preconnect link tag near the start of the page source.
 	add_action( 'wp_head', '\Automattic\Jetpack\Fonts\Google_Fonts_Provider::preconnect_font_source', 0 );
 }
-
 add_action( 'init', 'jetpack_add_google_fonts_preconnect' );


### PR DESCRIPTION
Small follow up to https://github.com/Automattic/jetpack/pull/23045

Prevents a warning when the Webfonts API is not available (from the Gutenberg plugin).

```
PHP Warning:  call_user_func_array() expects parameter 1 to be a valid callback, class '\Automattic\Jetpack\Fonts\Google_Fonts_Provider' not found in /Users/Grant/Automattic/Sites/wordpress-develop/src/wp-includes/class-wp-hook.php
```

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

See https://github.com/Automattic/jetpack/pull/23045 for more detalis.

- Enable the module and check that Google fonts are available.
- Enable and disable the Gutenberg plugin and make sure no errors are logged.
