### PR TITLE
My Jetpack: Usage of `Text` and design tokens at `ProductCard`

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { __, sprintf } from '@wordpress/i18n';
 import { ButtonGroup, Button, DropdownMenu } from '@wordpress/components';
+import { Text } from '@automattic/jetpack-components';
 
 /**
  * Internal dependencies
@@ -192,10 +193,12 @@ const ProductCard = props => {
 	return (
 		<div className={ containerClassName }>
 			<div className={ styles.name }>
-				<span>{ name }</span>
+				<Text variant="title-small">{ name }</Text>
 				{ icon }
 			</div>
-			<p className={ styles.description }>{ description }</p>
+			<Text variant="body-small" className={ styles.description }>
+				{ description }
+			</Text>
 			<div className={ styles.actions }>
 				{ canDeactivate ? (
 					<ButtonGroup className={ styles.group }>
@@ -228,7 +231,11 @@ const ProductCard = props => {
 						onAdd={ addHandler }
 					/>
 				) }
-				{ ! isAbsent && <div className={ statusClassName }>{ flagLabel }</div> }
+				{ ! isAbsent && (
+					<Text variant="label" className={ statusClassName }>
+						{ flagLabel }
+					</Text>
+				) }
 			</div>
 		</div>
 	);

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -50,10 +50,13 @@ const ActionButton = ( {
 	onManage,
 	onFixConnection,
 	isFetching,
+	className,
 } ) => {
+	const linkClassName = classNames( styles[ 'action-link-button' ], className );
+
 	if ( ! admin ) {
 		return (
-			<Button variant="link" onClick={ onLearn } className={ styles[ 'action-link-button' ] }>
+			<Button variant="link" onClick={ onLearn } className={ linkClassName }>
 				{
 					/* translators: placeholder is product name. */
 					sprintf( __( 'Learn about %s', 'jetpack-my-jetpack' ), name )
@@ -65,13 +68,14 @@ const ActionButton = ( {
 	const buttonState = {
 		variant: ! isFetching ? 'primary' : undefined,
 		disabled: isFetching,
+		className,
 	};
 
 	switch ( status ) {
 		case PRODUCT_STATUSES.NEEDS_PURCHASE:
 		case PRODUCT_STATUSES.ABSENT:
 			return (
-				<Button variant="link" onClick={ onAdd } className={ styles[ 'action-link-button' ] }>
+				<Button variant="link" onClick={ onAdd } className={ linkClassName }>
 					{
 						/* translators: placeholder is product name. */
 						sprintf( __( 'Add %s', 'jetpack-my-jetpack' ), name )
@@ -207,10 +211,11 @@ const ProductCard = props => {
 							onActivate={ activateHandler }
 							onFixConnection={ fixConnectionHandler }
 							onManage={ manageHandler }
+							className={ styles.button }
 						/>
 						<DropdownMenu
 							className={ styles.dropdown }
-							toggleProps={ { isPrimary: true, disabled: isFetching } }
+							toggleProps={ { isPrimary: true, disabled: isFetching, className: styles.button } }
 							popoverProps={ { noArrow: false } }
 							icon={ DownIcon }
 							disableOpenOnArrowDown={ true }
@@ -229,6 +234,7 @@ const ProductCard = props => {
 						onFixConnection={ fixConnectionHandler }
 						onActivate={ activateHandler }
 						onAdd={ addHandler }
+						className={ styles.button }
 					/>
 				) }
 				{ ! isAbsent && (

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -193,7 +193,7 @@ const ProductCard = props => {
 	return (
 		<div className={ containerClassName }>
 			<div className={ styles.name }>
-				<Text variant="title-small">{ name }</Text>
+				<Text variant="title-medium">{ name }</Text>
 				{ icon }
 			</div>
 			<Text variant="body-small" className={ styles.description }>

--- a/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
@@ -1,25 +1,12 @@
 .container {
-	// all css variables used down in product-card
-	--product-card-shadow: rgba(0, 0, 0, 0.08);
-	--product-card-shadow-size: 40px;
-	--product-card-name-font-size: 24px;
-	--product-card-description-font-size: 14px;
-	--product-card-actions-font-size: 12px;
-	--product-card-spacing-base: 8px;
-	--product-card-actions-size: 32px;
-	--product-card-actions-button-height: 32px;
-	--jp-black: #000;
+	--actions-size: 32px;
+	--actions-button-height: 32px;
 	--status-size: 8px;
-	--status-active: #008710;
-	--status-inactive: #646970;
-	--status-error: #B32D2E;
-	--status-plugin_absent: #C3C4C7;
-	--jp-underline-thickness: 2px;
 
-	padding: calc( var( --product-card-spacing-base ) * 3 ); // 24px
+	padding: calc( var( --spacing-base ) * 3 ); // 24px
 	background: var( --jp-white );
 	border-radius: var( --jp-border-radius );
-	box-shadow: 0 0 var(--product-card-shadow-size) var(--product-card-shadow);
+	box-shadow: 0 0 40px rgba(0, 0, 0, 0.08);
 	height: 100%;
 	display: flex;
 	flex-direction: column;
@@ -28,16 +15,16 @@
 	&.plugin_absent {
 		background: none;
 		box-shadow: none;
-		box-shadow: 0 0 0 1px var( --status-plugin_absent ) inset;
+		box-shadow: 0 0 0 1px var( --jp-gray-10 ) inset;
 	}
 
 	:global {
 		// Buttons
 		& .components-button-group,
 		& .components-button {
-			border-radius: 4px;
-			height: var(--product-card-actions-button-height);
-			line-height: var(--product-card-actions-button-height);
+			border-radius: var(--jp-border-radius);
+			height: var(--actions-button-height);
+			line-height: var(--actions-button-height);
 		}
 
 		& .components-button-group {
@@ -56,18 +43,14 @@
 }
 
 .name {
+	width: 100%;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	width: 100%;
-	font-size: var(--product-card-name-font-size);
-	font-weight: 700;
-	margin-bottom: var(--product-card-spacing-base); // 8px
+	margin-bottom: var(--spacing-base); // 8px
 }
 
 .description {
-	font-size: var(--product-card-description-font-size);
-	margin:0;
 	flex-grow: 1;
 }
 
@@ -76,10 +59,8 @@
 	align-items: center;
 	justify-content: space-between;
 	width: 100%;
-	margin-top: calc( var(--product-card-spacing-base) * 2 ); // 16px
-	min-height: var(--product-card-actions-size);
-	font-size: var(--product-card-actions-font-size);
-	font-weight: 600;
+	margin-top: calc( var(--spacing-base) * 2 ); // 16px
+	min-height: var(--actions-size);
 	flex-wrap: wrap;
 }
 
@@ -90,29 +71,34 @@
 
 .group {
 	display: flex;
-	height: var(--product-card-actions-size);
+	height: var(--actions-size);
 }
 
 .status {
-	margin-left: var(--product-card-spacing-base); // 8px
+	margin-left: var(--spacing-base); // 8px
 	white-space: nowrap;
-	height: var(--product-card-actions-size);
-	line-height: var(--product-card-actions-size);
+	height: var(--actions-size);
+	display: flex;
+	align-items: center;
 
 	&:before {
 		content: "";
 		display: inline-block;
 		width: var(--status-size);
 		height: var(--status-size);
-		margin-right: var(--product-card-spacing-base);
+		margin-right: var(--spacing-base);
 		border-radius: 50%;
 	}
 
 	// in plugin absent case, there's not status flag
-	$statuses: active, inactive, error;
+	$statuses: (
+		"active": "--jp-green-50",
+		"inactive": "--jp-gray-50",
+		"error": "--jp-red-60"
+	);
 
-	@each $status in $statuses {
-		$color: var(--status-#{$status});
+	@each $status, $var in $statuses {
+		$color: var(#{$var});
 
 		&.#{$status} {
 			color: $color;

--- a/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
@@ -1,6 +1,5 @@
 .container {
-	--actions-size: 32px;
-	--actions-button-height: 32px;
+	--actions-size: 28px;
 	--status-size: 8px;
 
 	padding: calc( var( --spacing-base ) * 3 ); // 24px
@@ -17,29 +16,6 @@
 		box-shadow: none;
 		box-shadow: 0 0 0 1px var( --jp-gray-10 ) inset;
 	}
-
-	:global {
-		// Buttons
-		& .components-button-group,
-		& .components-button {
-			border-radius: var(--jp-border-radius);
-			height: var(--actions-button-height);
-			line-height: var(--actions-button-height);
-		}
-
-		& .components-button-group {
-			> .components-button:first-child {
-				border-top-right-radius: 0;
-				border-bottom-right-radius: 0;
-			}
-
-			.components-dropdown-menu > .components-button,
-			> .components-button:last-child {
-				border-top-left-radius: 0;
-				border-bottom-left-radius: 0;
-			}
-		}
-	}
 }
 
 .name {
@@ -52,6 +28,13 @@
 
 .description {
 	flex-grow: 1;
+}
+
+.button {
+	font-size: var(--font-body-extra-small);
+	border-radius: var(--jp-border-radius);
+	height: var(--actions-size);
+	line-height: var(--actions-size);
 }
 
 .actions {
@@ -72,6 +55,15 @@
 .group {
 	display: flex;
 	height: var(--actions-size);
+	border-radius: var(--jp-border-radius);
+
+	& > .button:first-child {
+		border-radius: var(--jp-border-radius) 0 0 var(--jp-border-radius);
+	}
+
+	& > :global(.components-dropdown) > .button {
+		border-radius: 0 var(--jp-border-radius) var(--jp-border-radius) 0;
+	}
 }
 
 .status {

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-product-card-theme
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-product-card-theme
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Use Text and CSS vars on ProductCard


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Keep the movement out of `base-styles` using `design tokens` provided by `ThemeProvider` and `Text` component.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Move texts to use `Text` component.
* Update styles to use `design tokens`.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open `My Jetpack` page.
* Product Card should have no visual effect (*except for the title, since it was using the wrong weight for it variant)

#### Demo

![image](https://user-images.githubusercontent.com/1663717/158640875-0ea3f20f-e4c4-4e75-9bdb-6b73203c7354.png)

