### PR TITLE
Fix deprecation warnings from PHP 8.1

### DIFF
--- a/projects/plugins/boost/app/rest-api/endpoints/Recommendations_Dismiss.php
+++ b/projects/plugins/boost/app/rest-api/endpoints/Recommendations_Dismiss.php
@@ -14,7 +14,7 @@ class Recommendations_Dismiss implements Endpoint {
 	}
 
 	public function response( $request ) {
-		$provider_key = filter_var( $request['providerKey'], FILTER_SANITIZE_STRING );
+		$provider_key = sanitize_title( $request['providerKey'] );
 		if ( empty( $provider_key ) ) {
 			wp_send_json_error();
 		}

--- a/projects/plugins/boost/changelog/fix-deprecation-warnings
+++ b/projects/plugins/boost/changelog/fix-deprecation-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+General: Clean up use of FILTER_SANITIZE_STRING as it is deprecated in PHP 8.1

--- a/projects/plugins/jetpack/changelog/fix-deprecation-warnings
+++ b/projects/plugins/jetpack/changelog/fix-deprecation-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Clean up use of deprecated FILTER_SANITIZE_STRING constant - and mark WPCom_Markdown::get_post_screen_post_type as deprecated due to lack of use

--- a/projects/plugins/jetpack/modules/markdown/easy-markdown.php
+++ b/projects/plugins/jetpack/modules/markdown/easy-markdown.php
@@ -411,8 +411,10 @@ class WPCom_Markdown {
 	 * @return string Current post_type
 	 */
 	protected function get_post_screen_post_type() {
+		_deprecated_function( __METHOD__, 'jetpack-10.8', '' );
+
 		global $pagenow;
-		$post_type = filter_input( INPUT_GET, 'post_type', FILTER_SANITIZE_STRING );
+		$post_type = filter_input( INPUT_GET, 'post_type', FILTER_UNSAFE_RAW );
 		$post_id   = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
 
 		if ( 'post-new.php' === $pagenow ) {

--- a/projects/plugins/jetpack/modules/markdown/easy-markdown.php
+++ b/projects/plugins/jetpack/modules/markdown/easy-markdown.php
@@ -408,6 +408,7 @@ class WPCom_Markdown {
 	/**
 	 * Figure out the post type of the post screen we're on
 	 *
+	 * @deprecated since 10.8
 	 * @return string Current post_type
 	 */
 	protected function get_post_screen_post_type() {


### PR DESCRIPTION
PHP 8.1 deprecates the `FILTER_SANITIZE_STRING` constant. We only reference it in two places; a no-longer-used method `WPCom_Markdown::get_post_screen_post_type()` method, and in Jetpack Boost's Recommendation dismissal API endpoint.

This PR cleans up both instances, and additionally marks `WPCom_Markdown::get_post_screen_post_type()` as deprecated to verify it can safely be removed in future versions of Jetpack.

#### Changes proposed in this Pull Request:
* Replace `FILTER_SANITIZE_STRING` with `FILTER_UNSAFE_RAW` in `WPCom_Markdown::get_post_screen_post_type()`
* Mark `WPCom_Markdown::get_post_screen_post_type()` as deprecated.
* Replace `FILTER_SANITIZE_STRING` with `sanitize_title` in the Boost recommendation dismissal API endpoint.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Ensure you can still delete Critical CSS recommendations in Jetpack Boost.