### PR TITLE
Publicize: Add missing isset check

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-publicize-isset-check
+++ b/projects/plugins/jetpack/changelog/fix-publicize-isset-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Bug only caused a warning with WP_DEBUG enabled
+
+

--- a/projects/plugins/jetpack/modules/publicize/publicize-jetpack.php
+++ b/projects/plugins/jetpack/modules/publicize/publicize-jetpack.php
@@ -274,9 +274,9 @@ class Publicize extends Publicize_Base {
 	 * Show error on settings page if applicable.
 	 */
 	public function admin_page_load() {
-		$action = sanitize_text_field( wp_unslash( $_GET['action'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$action = isset( $_GET['action'] ) ? sanitize_text_field( wp_unslash( $_GET['action'] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-		if ( ! empty( $action ) && 'error' === $action ) {
+		if ( 'error' === $action ) {
 			add_action( 'pre_admin_screen_sharing', array( $this, 'display_connection_error' ), 9 );
 		}
 	}


### PR DESCRIPTION
Fixes an error with the Publicize settings page in Jetpack showing a warning with `WP_DEBUG` enabled.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add missing isset check.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable `WP_DEBUG`: `define( 'WP_DEBUG', true )`
* Go to Jetpack > Sharing settings (https://example.com/wp-admin/options-general.php?page=sharing)
* Verify there's no visible warning
