### PR TITLE
Jetpack Search :: Add ETB taxonomy to allowed list.

### DIFF
--- a/projects/packages/sync/changelog/update-search-taxonomy-allow-list
+++ b/projects/packages/sync/changelog/update-search-taxonomy-allow-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Sync Settings :: Add ETB taxonomy to allow list.

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.30.2';
+	const PACKAGE_VERSION = '1.30.3-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/sync/src/modules/class-search.php
+++ b/projects/packages/sync/src/modules/class-search.php
@@ -1685,6 +1685,19 @@ class Search extends Module {
 		'zipcode',
 		'zoninator_zones',
 		'zrf_field_group',
+
+		// End The Backlog  @see https://wp.me/p9MPsk-X0.
+		'bill-status',
+		'etb-audience',
+		'etb-state',
+		'etb-target',
+		'etb-topic',
+		'etb-year',
+		'foia-response-status',
+		'target-type',
+		'timeline-pillar',
+		'timeline-type',
+
 	); // end taxonomies.
 
 	/*


### PR DESCRIPTION
ETB requires additional taxonomies to be synced for usage in filters of Jetpack Search. The definitive allow list is maintained in WP.com and updated in D76393. This PR updates the Jetpack mapping which is for informational purposes to users until we update WP.com to use the Jetpack package directly.

Fixes # https://wp.me/p9MPsk-X0

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update the taxonomy allow list to include ETB custom taxonomies

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No changes to synced data.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* N/A. Unit Testing is sufficient.
