### PR TITLE
VideoPress: Design tweaks for resumable uploader

### DIFF
--- a/projects/plugins/jetpack/changelog/update-videopress-resumable-uploader-design
+++ b/projects/plugins/jetpack/changelog/update-videopress-resumable-uploader-design
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Updated design of resumable uploader block.

--- a/projects/plugins/jetpack/extensions/blocks/videopress/resumable-upload/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/resumable-upload/index.js
@@ -121,7 +121,7 @@ export default function ResumableUpload( { file } ) {
 		<div { ...blockProps }>
 			<div className="resumable-upload__logo">
 				<Icon icon={ VideoPressIcon } />
-				<div className="resumable-upload__logo-text">{ __( 'Video', 'jetpack' ) }</div>
+				<div className="resumable-upload__logo-text">{ __( 'VideoPress', 'jetpack' ) }</div>
 			</div>
 			{ null !== error ? (
 				<div className="resumable-upload__error">
@@ -146,6 +146,7 @@ export default function ResumableUpload( { file } ) {
 				<div className="resumable-upload__status">
 					<div className="resumable-upload__file-info">
 						<div className="resumable-upload__file-name">{ fileNameLabel }</div>
+						&nbsp;&#8212;&nbsp;
 						<div className="resumable-upload__file-size">{ fileSizeLabel }</div>
 					</div>
 					<div className="resumable-upload__progress">

--- a/projects/plugins/jetpack/extensions/blocks/videopress/resumable-upload/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/resumable-upload/style.scss
@@ -35,16 +35,15 @@
 .resumable-upload__file-info {
 	display: flex;
 	flex-direction: row;
-	justify-content: space-between;
 	width: 100%;
-	margin-bottom: $grid-unit-30;
+	margin-bottom: $grid-unit-20;
 }
 
 .resumable-upload__progress {
-	height: 20px;
+	height: 8px;
 	background: #D2D2D2;
 	width: 100%;
-	border-radius: 2px;
+	border-radius: 4px;
 	box-sizing: border-box;
 	overflow: hidden;
 }
@@ -54,7 +53,7 @@
 	text-align: center;
 	color: white;
 	height: 100%;
-	min-height: 20px;
+	min-height: 8px;
 	transition: width 0.3s ease;
 }
 


### PR DESCRIPTION
Updates the design of the resumable uploader based on some design feedback from @evilluendas:

<img width="676" alt="Screen Shot 2022-03-09 at 12 51 19 PM" src="https://user-images.githubusercontent.com/789137/157524896-379034a1-7f80-4a9d-ba0e-180ca775e502.png">

#### Changes proposed in this Pull Request:
* Changes `Video` label to `VideoPress`
* Tighter margin between text and progress bar
* Rounded progress bar with 8px height
* File size moved to the left side with an `emdash` added between it and the file name.

#### Jetpack product discussion
pxWta-16I-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Enable Jetpack VideoPress
* Add this code at line `235` of `class.videopress-gutenberg.php` to enable resumable uploads: 

`wp_add_inline_script( 'jetpack-videopress-gutenberg-override-video-upload', 'var videoPressResumableEnabled = true;' );`
* Add a video in the block editor.
* Observe that the new styles look good and the block still works as expected.
