### PR TITLE
VideoPress Block: Fix issue where id attribute was not restoring properly when using resumable uploads

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-videopress-resumable-upload-id-type
+++ b/projects/plugins/jetpack/changelog/fix-videopress-resumable-upload-id-type
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Non-production issue fix
+
+

--- a/projects/plugins/jetpack/extensions/blocks/videopress/resumable-upload/use-uploader.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/resumable-upload/use-uploader.js
@@ -54,7 +54,7 @@ export const resumableUploader = ( { onError, onProgress, onSuccess } ) => {
 				const mediaId = res.getHeader( MEDIA_ID_HEADER );
 				const src = res.getHeader( SRC_URL_HEADER );
 				if ( guid && mediaId && src ) {
-					onSuccess && onSuccess( { mediaId, guid, src } );
+					onSuccess && onSuccess( { mediaId: Number( mediaId ), guid, src } );
 					return;
 				}
 


### PR DESCRIPTION
Additional follow-up from https://github.com/Automattic/jetpack/pull/23226

Fixes an issue when using resumable VideoPress uploads where the block's `id` was incorrectly set with a string data type, causing the id to be lost when the page was reloaded due to a type mismatch.

#### Changes proposed in this Pull Request:
* Convert the `mediaId` passed down when a resumable upload succeeds to a `Number` so that the `id` will be saved and restored properly.

#### Jetpack product discussion
pxWta-16I-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Enable Jetpack VideoPress
* Add this code at line 235 of `class.videopress-gutenberg.php` to enable resumable uploads:
`wp_add_inline_script( 'jetpack-videopress-gutenberg-override-video-upload', 'var videoPressResumableEnabled = true;' );`
* Upload a new video to the block editor, it should use the resumable uploader.
* Switch to the `Code editor` mode, and the block should have an `id` attribute set with an int value (no quotes around it)
* Save the post and reload, the `id` attribute should still be there.
* You should be able to toggle the `Allow download` setting in the block successfully.
* Also select a video from the media library and it should still have a proper `id` attribute set.
