### PR TITLE
Jetpack: fix missing "Connect User" button after connection restore.

### DIFF
--- a/projects/plugins/jetpack/_inc/client/state/connection/actions.js
+++ b/projects/plugins/jetpack/_inc/client/state/connection/actions.js
@@ -29,7 +29,6 @@ import {
 	JETPACK_CONNECTION_HAS_SEEN_WC_CONNECTION_MODAL,
 } from 'state/action-types';
 import restApi from '@automattic/jetpack-api';
-import { isSafari, doNotUseConnectionIframe } from 'state/initial-state';
 
 export const fetchSiteConnectionStatus = () => {
 	return dispatch => {
@@ -240,7 +239,7 @@ export const resetConnectUser = () => {
 };
 
 export const reconnectSite = () => {
-	return ( dispatch, getState ) => {
+	return dispatch => {
 		dispatch( {
 			type: SITE_RECONNECT,
 		} );
@@ -256,11 +255,9 @@ export const reconnectSite = () => {
 				const authorizeUrl = connectionStatusData.authorizeUrl;
 				// status: in_progress, aka user needs to re-connect their WP.com account.
 				if ( 'in_progress' === status ) {
-					// Redirect user to authorize WP.com if in-place connection is restricted.
-					if ( isSafari( getState() ) || doNotUseConnectionIframe( getState() ) ) {
-						return window.location.replace( authorizeUrl );
-					}
-					// Set connectUrl and initiate in-place auth flow.
+					dispatch( { type: UNLINK_USER_SUCCESS } );
+
+					// Set connectUrl and initiate the connection flow.
 					dispatch( {
 						type: CONNECT_URL_FETCH_SUCCESS,
 						connectUrl: authorizeUrl,

--- a/projects/plugins/jetpack/changelog/fix-restore-connection-missing-button
+++ b/projects/plugins/jetpack/changelog/fix-restore-connection-missing-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix missing "Connect User" button after restoring connection.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* adjust the Jetpack state to mark user as unlinked after it's been unlinked during connection restore

#### Jetpack product discussion
p9F6qB-7xg-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Connect Jetpack.
2. Set invalid blog and user tokens.
3. Go to Jetpack Dashboard, you should see the error notice with "Restore Connection" button.
4. Click "Restore Connection". After a little wait, you should see the connection screen. Confirm that the "Connect Your User Account" button shows up.
5. Finish the connection flow, confirm it works correctly.

#### The Button
<img width="438" alt="Screen Shot 2022-03-09 at 17 57 00" src="https://user-images.githubusercontent.com/1341249/157553089-2c09cf52-fbec-4625-87bd-3f35c8b9ac3b.png">