### PR TITLE
Tiled Gallery: Tighten `Jetpack_Plan` check in block rendering

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-wpcom-tiled-gallery-reader
+++ b/projects/plugins/jetpack/changelog/fix-wpcom-tiled-gallery-reader
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Tiled Gallery Block: Tighten Jetpack_Plan check during block rendering

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -62,7 +62,7 @@ class Tiled_Gallery {
 		$is_squareish_layout = self::is_squareish_layout( $attr );
 
 		// Jetpack_Plan does not exist on WordPress.com.
-		if ( class_exists( 'Jetpack_Plan' ) ) {
+		if ( class_exists( 'Jetpack_Plan' ) && method_exists( 'Jetpack_Plan', 'get' ) ) {
 			$jetpack_plan = Jetpack_Plan::get();
 			wp_localize_script( 'jetpack-gallery-settings', 'jetpack_plan', array( 'data' => $jetpack_plan['product_slug'] ) );
 		}


### PR DESCRIPTION
Currently, some pages on the WP.com Reader will fail loading because on WP.com, the `Jetpack_Plan` class exists for some reason, but it lacks a `get()` method, and we get the following error when attempting to request reader posts:

```
Fatal error: Uncaught Error: Call to undefined method Jetpack_Plan::get() in .../jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php:66
```

This PR tightens the check so the `Jetpack_Plan::get()` method will be executed only if it exists.

#### Changes proposed in this Pull Request:
* Tiled Gallery: Tighten `Jetpack_Plan` check in block rendering

#### Jetpack product discussion
No related product discussion that I'm aware of.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Sandbox the REST API.
* Apply the related WP.com patch on your sandbox.
* Open the WP.com reader on the `a8c` page and scroll down at least 10-20 pages.
* Verify you no longer get any 500 responses for some of the requests.

cc @yuliyan who was also able to reproduce this alongside me.