### PR TITLE
Premium Content Block: show premium content after subscribe

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-show-premium-content-after-subscribe
+++ b/projects/plugins/jetpack/changelog/fix-show-premium-content-after-subscribe
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+When a user subscribes to premium content he now sees the premium content without needing to reload the page.

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/login-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/login-button.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Extensions\Premium_Content;
 
 use Automattic\Jetpack\Blocks;
+use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Token_Subscription_Service;
 use Automattic\Jetpack\Status\Host;
 use Jetpack_Gutenberg;
 
@@ -46,7 +47,11 @@ function render_login_button_block( $attributes, $content ) {
 		return '';
 	}
 
-	if ( is_user_logged_in() ) {
+	$has_auth_cookie = isset( $_COOKIE[ Token_Subscription_Service::JWT_AUTH_TOKEN_COOKIE_NAME ] );
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$has_token_parameter = isset( $_GET['token'] );
+
+	if ( is_user_logged_in() || $has_auth_cookie || $has_token_parameter ) {
 		// The viewer is logged it, so they shouldn't see the login button.
 		return '';
 	}

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
@@ -75,7 +75,7 @@ function render_block( $attributes, $content ) {
 	}
 
 	// We don't use FEATURE_NAME here because styles are not in /container folder.
-	Jetpack_Gutenberg::load_styles_as_required( 'premium-content' );
+	Jetpack_Gutenberg::load_assets_as_required( 'premium-content' );
 	return $content;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [#23135](https://github.com/Automattic/jetpack/issues/23135) & 458-gh-Automattic/payments-shilling

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Now when a user finishes the subscription process he is able to see the premium contents.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

##### Testing premium content can't be viewed.
* Sandbox the store (Recommended).
* View as a user a post that has a premium content block (make sure you aren't logged in).
<img width="1323" alt="Captura de pantalla 2022-03-07 a las 13 42 31" src="https://user-images.githubusercontent.com/1989914/157039991-165c3b78-276b-493d-ad1e-e894a2a2fbdb.png">
* Click on the subscribe button and complete the subscription process.

<img width="1294" alt="Captura de pantalla 2022-03-07 a las 13 42 41" src="https://user-images.githubusercontent.com/1989914/157040018-b84db5f2-973d-45b5-a51c-a8acf407dc18.png">
* Close the subscription window, you should see the premium content.
<img width="1317" alt="Captura de pantalla 2022-03-07 a las 13 47 04" src="https://user-images.githubusercontent.com/1989914/157040055-d63ba9bd-1185-4b99-94b6-e5a8de207e47.png">

##### Testing the login button continues to show after logging in
* The best way to test this scenario is to add an invalid token as a parameter.
* Get the post URL and token=invalid
* Open the URL
* You should not see the login button and see the subscribe button.
* You should not see the premium content.
<img width="1289" alt="Captura de pantalla 2022-03-07 a las 13 50 05" src="https://user-images.githubusercontent.com/1989914/157040536-97419881-9f5d-45d9-b706-acfd3cdaa8fe.png">

