### PR TITLE
Admin pages: remove extra filtering

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -210,27 +210,10 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			echo '<code>pnpm run distclean && pnpx jetpack build plugins/jetpack</code>';
 			echo '</p>';
 		} else {
-			add_filter( 'wp_kses_allowed_html', array( $this, 'static_allowed' ), 10, 2 );
-			// We got the static.html so let's sanitize and display it.
-			echo wp_kses_post( $static_html );
+			// We got the static.html so let's display it.
+			echo $static_html; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 	}
-	/**
-	 * Extends the 'post' context for wp_kses() by adding style tags.
-	 * Required for .vp-deactivated style in static.html.
-	 *
-	 * @param array  $allowed Extends 'post' context array with extra tags.
-	 * @param string $post Context name.
-	 * @return array Array of tags that extend wp_kses_post().
-	 */
-	public function static_allowed( $allowed, $post = 'post' ) { //phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-
-		$allowed['style'] = array(
-			'type' => array(),
-		);
-		return $allowed;
-	}
-
 	/**
 	 * Allow robust deep links to React.
 	 *

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -202,9 +202,6 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		// Fetch static.html.
 		$static_html = @file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static.html' ); //phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, Not fetching a remote file.
 
-		// Sanitize static.html data.
-		$allowed_html = wp_kses_allowed_html( 'post' );
-
 		if ( false === $static_html ) {
 
 			// If we still have nothing, display an error.
@@ -213,10 +210,25 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			echo '<code>pnpm run distclean && pnpx jetpack build plugins/jetpack</code>';
 			echo '</p>';
 		} else {
-
-			// We got the static.html so let's display it.
-			echo wp_kses( $static_html, $allowed_html );
+			add_filter( 'wp_kses_allowed_html', array( $this, 'static_allowed' ), 10, 2 );
+			// We got the static.html so let's sanitize and display it.
+			echo wp_kses_post( $static_html );
 		}
+	}
+	/**
+	 * Extends the 'post' context for wp_kses() by adding style tags.
+	 * Required for .vp-deactivated style in static.html.
+	 *
+	 * @param array  $allowed Extends 'post' context array with extra tags.
+	 * @param string $post Context name.
+	 * @return array Array of tags that extend wp_kses_post().
+	 */
+	public function static_allowed( $allowed, $post = 'post' ) { //phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+
+		$allowed['style'] = array(
+			'type' => array(),
+		);
+		return $allowed;
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-extend-filtering-admin-pages
+++ b/projects/plugins/jetpack/changelog/fix-extend-filtering-admin-pages
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Admin pages: extend wp_kses() filter to allow inline style.
+Admin pages: remove wp_kses() as it's not needed for static.html.

--- a/projects/plugins/jetpack/changelog/fix-extend-filtering-admin-pages
+++ b/projects/plugins/jetpack/changelog/fix-extend-filtering-admin-pages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Admin pages: extend wp_kses() filter to allow inline style.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In #23219 I added wp_kses() to filter  the contents of static.html page using 'post' as a default context. This caused  a code flash like this:  
<img width="936" alt="code_flash_admin" src="https://user-images.githubusercontent.com/1242807/157673196-cd807827-a4f5-4573-a3ec-0a03f0af32d0.png">


Discussed here: p1646849281583459-slack-C02HQGKMFJ8

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Used wp_kses_allowed_html to extend the filter with 'style' tag.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to any admin page and scroll to the bottom of the page. 
* You shouldn't see the .vp-deactivated show up.


I'm not sure this is the right way to go about this. Pinging @anomiex and @jeherve as you have already helped me with this code.