### PR TITLE
Sync test: Remove random logic from test_checksum_histogram

### DIFF
--- a/projects/plugins/jetpack/changelog/update-fix-flaky-sync-test
+++ b/projects/plugins/jetpack/changelog/update-fix-flaky-sync-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Small unit test fix.
+
+

--- a/projects/plugins/jetpack/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -264,51 +264,28 @@ class WP_Test_IJetpack_Sync_Replicastore extends TestCase {
 	 */
 	function test_checksum_histogram( $store ) {
 
-		$min_post_id           = 1000000;
-		$max_post_id           = 1;
-		$min_comment_id        = 1000000;
-		$max_comment_id        = 1;
+		$min_post_id           = 1;
+		$max_post_id           = 20;
+		$min_comment_id        = $min_post_id;
+		$max_comment_id        = $max_post_id;
 		$generated_post_ids    = array();
 		$generated_comment_ids = array();
 
-		for ( $i = 1; $i <= 20; $i += 1 ) {
-			do {
-				$post_id = rand( 1, 1000000 );
-			} while ( in_array( $post_id, $generated_post_ids ) );
-
-			$generated_post_ids[] = $post_id;
-
-			$post = self::$factory->post( $post_id, array( 'post_content' => "Test post $i" ) );
+		for ( $i = $max_post_id; $i >= $min_post_id; $i-- ) {
+			$post_id = $i;
+			$post    = self::$factory->post( $post_id, array( 'post_content' => "Test post $i" ) );
 			$store->upsert_post( $post );
-			if ( $min_post_id > $post_id ) {
-				$min_post_id = $post_id;
-			}
+			$generated_post_ids[] = $post->ID;
 
-			if ( $max_post_id < $post_id ) {
-				$max_post_id = $post_id;
-			}
-
-			do {
-				$comment_id = rand( 1, 1000000 );
-			} while ( in_array( $post_id, $generated_comment_ids ) );
-
-			$generated_comment_ids[] = $comment_id;
-
-			$comment = self::$factory->comment( $comment_id, $post_id, array( 'comment_content' => "Test comment $i" ) );
+			$comment_id = $i;
+			$comment    = self::$factory->comment( $comment_id, $post_id, array( 'comment_content' => "Test comment $i" ) );
 			$store->upsert_comment( $comment );
-
-			if ( $min_comment_id > $comment_id ) {
-				$min_comment_id = $comment_id;
-			}
-
-			if ( $max_comment_id < $comment_id ) {
-				$max_comment_id = $comment_id;
-			}
-
+			$generated_comment_ids[] = $comment->ID;
 		}
 
 		foreach ( array( 'posts', 'comments' ) as $object_type ) {
 			$histogram = $store->checksum_histogram( $object_type, 10, 0, 0 );
+
 			$this->assertCount( 10, $histogram );
 
 			// histogram bucket should equal entire histogram of just the ID range for that bucket


### PR DESCRIPTION
Fixes flaky `test_checksum_histogram` Jetpack Sync test.

#### Changes proposed in this Pull Request:
* Fixes a logic error in `test_checksum_histogram`: When randomly generating comments, instead of checking the current comment id exists in the array of generated comments, we were checking for the post id instead.

#### Jetpack product discussion
1201642007924219-as-1201934645546364/f

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Look at the code and make sure the proposed changes are sane.