### PR TITLE
repo-gardening: Consider both old and new names of moved files as modified

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/fix-repo-gardening-changelog-check
+++ b/projects/github-actions/repo-gardening/changelog/fix-repo-gardening-changelog-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+When a file is renamed, treat both the old and new names as modified.

--- a/projects/github-actions/repo-gardening/src/get-files.js
+++ b/projects/github-actions/repo-gardening/src/get-files.js
@@ -31,6 +31,9 @@ async function getFiles( octokit, owner, repo, number ) {
 	} ) ) {
 		response.data.map( file => {
 			fileList.push( file.filename );
+			if ( file.previous_filename ) {
+				fileList.push( file.previous_filename );
+			}
 		} );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We've long had a problem where the "add changelog entries" check was
incorrectly detecting that no change entry was added. Looking into this,
I find that it seems to always be release PRs, where GitHub is detecting
the removed change files as being renamed into a different project.

The fix is to have our `getFiles()` function record both the old and new
names of renamed files so they can be properly considered.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Nothing specific

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You could run the following two commands, which should produce the same output
  * `git -c core.quotepath=off diff --no-renames --name-only 5774b9d^...5774b9d | sort`
  * Assuming TOKEN in the environment holds a GitHub access token and you're in the repo-gardening directory, `node -e 'process.env.NODE_ENV="test"; const { getOctokit } = require( "@actions/github" ); const getFiles = require( "./src/get-files.js" ); getFiles( new getOctokit( process.env.TOKEN ), "Automattic", "jetpack", 22920 ).then( v => console.log( v.join( "\n" ) ) );' | sort`
* Or I suppose you might fork the repo, recreate something like #22920 that had this problem and verify it still happens, then merge this into master and re-run the workflow.