### PR TITLE
Jetpack Sync tests: Fix flaky test_strips_non_ascii_chars_for_checksum

### DIFF
--- a/projects/plugins/jetpack/changelog/update-fix-sync-flaky-unit-test
+++ b/projects/plugins/jetpack/changelog/update-fix-sync-flaky-unit-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix Sync related flaky test.

--- a/projects/plugins/jetpack/tests/php/sync/test_interface.jetpack-sync-replicastore.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_interface.jetpack-sync-replicastore.php
@@ -235,24 +235,31 @@ class WP_Test_IJetpack_Sync_Replicastore extends TestCase {
 	 * @dataProvider store_provider
 	 */
 	function test_strips_non_ascii_chars_for_checksum( $store ) {
-		$utf8_post = self::$factory->post( 1, array( 'post_content' => 'Panamá' ) );
-		$ascii_post = self::$factory->post( 1, array( 'post_content' => 'Panam' ) );
-		$utf8_comment = self::$factory->comment( 1, 1, array( 'comment_content' => 'Panamá' ) );
+		$utf8_post     = self::$factory->post( 1, array( 'post_content' => 'Panamá' ) );
+		$ascii_post    = self::$factory->post( 1, array( 'post_content' => 'Panam' ) );
+		$utf8_comment  = self::$factory->comment( 1, 1, array( 'comment_content' => 'Panamá' ) );
 		$ascii_comment = self::$factory->comment( 1, 1, array( 'comment_content' => 'Panam' ) );
 
-		// generate checksums just for utf8 content
+		// Generate checksums just for utf8 content.
 		$store->upsert_post( $utf8_post );
 		$store->upsert_comment( $utf8_comment );
 
-		$utf8_post_checksum = $store->posts_checksum();
+		$utf8_post_checksum    = $store->posts_checksum();
 		$utf8_comment_checksum = $store->comments_checksum();
 
-		// generate checksums just for ascii content
+		// Generate checksums just for ascii content.
+		// We need to set the $ascii_post post_modified field
+		// same as the $utf8_post post_modified, as post checksums take it into account, in order
+		// to avoid any flakiness caused by those two posts having different post_modified fields (defaults to now).
+		$ascii_post->post_modified = $utf8_post->post_modified;
 		$store->upsert_post( $ascii_post );
 		$store->upsert_comment( $ascii_comment );
 
-		$this->assertEquals( $utf8_post_checksum, $store->posts_checksum() );
-		$this->assertEquals( $utf8_comment_checksum, $store->comments_checksum() );
+		$ascii_post_checksum    = $store->posts_checksum();
+		$ascii_comment_checksum = $store->comments_checksum();
+
+		$this->assertEquals( $utf8_post_checksum, $ascii_post_checksum );
+		$this->assertEquals( $utf8_comment_checksum, $ascii_comment_checksum );
 	}
 
 	/**


### PR DESCRIPTION
Fixes the `WP_Test_IJetpack_Sync_Replicastore::test_strips_non_ascii_chars_for_checksum` flaky test.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates `test_strips_non_ascii_chars_for_checksum` sync test to remove the flakiness caused by comparing checksums for 2 posts with potentially different `post_modified` fields.

#### Jetpack product discussion
p1646953394702879-slack-C034JEXD1RD

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Looking at the code should be enough.