### PR TITLE
Jetpack: QRPost: use only permalink to generate QR code

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-qr-post-remove-title-from-qr-content
+++ b/projects/plugins/jetpack/changelog/update-jetpack-qr-post-remove-title-from-qr-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: QRPost: use only permalink to generate QR code

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/components/qr-post.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/components/qr-post.js
@@ -38,26 +38,14 @@ export default function QRPost() {
 	}, [ wrapperElementRef ] );
 
 	// Pick title and permalink post.
-	const {
-		post: { title },
-		permalink,
-	} = useSelect(
-		select => ( {
-			post: select( editorStore ).getCurrentPost(),
-			permalink: select( editorStore ).getPermalink(),
-		} ),
-		[]
-	);
-
+	const permalink = useSelect( select => select( editorStore ).getPermalink(), [] );
 	const { dataUrl: siteLogoUrl } = useSiteLogo( { generateDataUrl: true } );
 	const codeLogo = siteLogoUrl || jetpackLogoUrl;
-
-	const codeContent = `${ title } ${ permalink }`;
 
 	return (
 		<div ref={ wrapperElementRef }>
 			<QRCode
-				value={ codeContent }
+				value={ permalink }
 				size={ 238 }
 				imageSettings={
 					codeLogo && {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Currently, we are using post title and post permalink to generate the QR code. This PR removes the title and uses only the permalink that, in the end, is what we need to lead the user to the post page.

Fixes https://github.com/Automattic/jetpack/issues/23372

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack: QRPost: use only permalink to generate QR code

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test the QRPost feature as usual
* Everything should work as expected
