### PR TITLE
Correct JETPACK_VERSION constant

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack_version
+++ b/projects/plugins/jetpack/changelog/fix-jetpack_version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Swap JETPACK_VERSION for the correct JETPACK__VERSION

--- a/projects/plugins/jetpack/modules/widgets/simple-payments.php
+++ b/projects/plugins/jetpack/modules/widgets/simple-payments.php
@@ -160,7 +160,7 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 				'jetpack-simple-payments-widget-customizer',
 				plugins_url( 'simple-payments/customizer.css', __FILE__ ),
 				array(),
-				JETPACK_VERSION
+				JETPACK__VERSION
 			);
 		}
 


### PR DESCRIPTION
Should be JETPACK__VERSION

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to /wp-admin/widgets.php
* You shouldn't see a `WARNING: wp-content/mu-plugins/widgets/simple-payments.php:163 - Use of undefined constant JETPACK_VERSION - assumed 'JETPACK_VERSION' (this will throw an Error in a future version of PHP)`
