### PR TITLE
Make Jetpack rely on webhooks

### DIFF
--- a/projects/packages/connection/changelog/update-jetpack-now-uses-webhooks
+++ b/projects/packages/connection/changelog/update-jetpack-now-uses-webhooks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Jetpack now relies on Connection Webooks for authorize and authorize_redirect actions

--- a/projects/packages/connection/src/class-webhooks.php
+++ b/projects/packages/connection/src/class-webhooks.php
@@ -51,9 +51,7 @@ class Webhooks {
 	 * actions from Calypso and WPCOM that reach that route regardless of the site having the Jetpack plugin or not. That's why we are still handling it here.
 	 */
 	public function fallback_jetpack_controller() {
-		if ( ! class_exists( 'Jetpack' ) ) {
-			$this->controller( true );
-		}
+		$this->controller( true );
 	}
 
 	/**
@@ -65,9 +63,14 @@ class Webhooks {
 		if ( ! $force ) {
 			// The nonce is verified in specific handlers.
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			if ( empty( $_GET['handler'] ) || empty( $_GET['action'] ) || 'jetpack-connection-webhooks' !== $_GET['handler'] ) {
+			if ( empty( $_GET['handler'] ) || 'jetpack-connection-webhooks' !== $_GET['handler'] ) {
 				return;
 			}
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( empty( $_GET['action'] ) ) {
+			return;
 		}
 
 		// The nonce is verified in specific handlers.

--- a/projects/plugins/jetpack/changelog/update-jetpack-now-uses-webhooks
+++ b/projects/plugins/jetpack/changelog/update-jetpack-now-uses-webhooks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Jetpack now relies on Connection Webooks for authorize and authorize_redirect actions

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -17,7 +17,6 @@ use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authent
 use Automattic\Jetpack\Connection\Secrets;
 use Automattic\Jetpack\Connection\Tokens;
 use Automattic\Jetpack\Connection\Utils as Connection_Utils;
-use Automattic\Jetpack\Connection\Webhooks as Connection_Webhooks;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Device_Detection\User_Agent_Info;
 use Automattic\Jetpack\Identity_Crisis;
@@ -4298,55 +4297,12 @@ p {
 
 		if ( isset( $_GET['action'] ) ) {
 			switch ( $_GET['action'] ) {
+				/**
+				 * Cases authorize and authorize_redirect are now handled by Connection package Webhooks
+				 */
 				case 'authorize_redirect':
-					self::log( 'authorize_redirect' );
-
-					add_filter(
-						'allowed_redirect_hosts',
-						function ( $domains ) {
-							$domains[] = 'jetpack.com';
-							$domains[] = 'jetpack.wordpress.com';
-							$domains[] = 'wordpress.com';
-							$domains[] = wp_parse_url( static::get_calypso_host(), PHP_URL_HOST ); // May differ from `wordpress.com`.
-							return array_unique( $domains );
-						}
-					);
-
-					// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-					$dest_url = empty( $_GET['dest_url'] ) ? null : $_GET['dest_url'];
-
-					if ( ! $dest_url || ( 0 === stripos( $dest_url, 'https://jetpack.com/' ) && 0 === stripos( $dest_url, 'https://wordpress.com/' ) ) ) {
-						// The destination URL is missing or invalid, nothing to do here.
-						exit;
-					}
-
-					if ( static::connection()->is_connected() && static::connection()->is_user_connected() ) {
-						// The user is either already connected, or finished the connection process.
-						wp_safe_redirect( $dest_url );
-						exit;
-					} elseif ( ! empty( $_GET['done'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-						// The user decided not to proceed with setting up the connection.
-						wp_safe_redirect( self::admin_url( 'page=jetpack' ) );
-						exit;
-					}
-
-					$redirect_args = array(
-						'page'     => 'jetpack',
-						'action'   => 'authorize_redirect',
-						'dest_url' => rawurlencode( $dest_url ),
-						'done'     => '1',
-					);
-
-					if ( ! empty( $_GET['from'] ) && 'jetpack_site_only_checkout' === $_GET['from'] ) {
-						$redirect_args['from'] = 'jetpack_site_only_checkout';
-					}
-
-					wp_safe_redirect( static::build_authorize_url( self::admin_url( $redirect_args ) ) );
-					exit;
 				case 'authorize':
-					_doing_it_wrong( __METHOD__, 'The `page=jetpack&action=authorize` webhook is deprecated. Use `handler=jetpack-connection-webhooks&action=authorize` instead', 'Jetpack 9.5.0' );
-					( new Connection_Webhooks( $this->connection_manager ) )->handle_authorize();
-					exit;
+					break;
 				case 'register':
 					if ( ! current_user_can( 'jetpack_connect' ) ) {
 						$error = 'cheatin';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In #22990 we extracted the `authorize_redirect` action handler from the plugin into the Connection package. We also created a fallback that made the Connection webooks handle the legacy Jetpack `action` hooks in case Jetpack is not there.

This PR removes the action handlers from the plugin, leaving `authorize` and `authorize_redirect` exclusive in the Connection package. No mode code duplication.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Remove action handlers from the Jetpack plugin. These actions are no handled by Connection package wehooks

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Nothing should change. Check for regressions in the connection/authorization flows.

* Connect Jetpack
* Make sure authorizing a user works
* On a site connected only at site level, go to My Jetpack page and click to add Backup or Search.
* Make sure you are redirected to the authorization page and the user is properly added as the connection owner of the site
