### PR TITLE
Admin menu: changed logic for displaying admin links

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -1641,7 +1641,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		$body   = wp_remote_retrieve_body( $response );
 		$result = json_decode( $body );
-		set_transient( 'jetpack_rewind_state', $result, 30 * MINUTE_IN_SECONDS );
+		set_transient( 'jetpack_rewind_state', $result, 1 * DAY_IN_SECONDS );
 
 		return $result;
 	}
@@ -1712,7 +1712,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		$body   = wp_remote_retrieve_body( $response );
 		$result = json_decode( $body );
-		set_transient( 'jetpack_scan_state', $result, 30 * MINUTE_IN_SECONDS );
+		set_transient( 'jetpack_scan_state', $result, 1 * DAY_IN_SECONDS );
 
 		return $result;
 	}

--- a/projects/plugins/jetpack/changelog/fix-paid-features-in-admin
+++ b/projects/plugins/jetpack/changelog/fix-paid-features-in-admin
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Admin menu: improved logic for scan & backup links

--- a/projects/plugins/jetpack/modules/scan/class-admin-sidebar-link.php
+++ b/projects/plugins/jetpack/modules/scan/class-admin-sidebar-link.php
@@ -155,7 +155,7 @@ class Admin_Sidebar_Link {
 	private function has_scan() {
 		$this->maybe_refresh_transient_cache();
 		$scan_state = get_transient( 'jetpack_scan_state' );
-		return ! $scan_state || 'unavailable' !== $scan_state->state;
+		return $scan_state && 'unavailable' !== $scan_state->state;
 	}
 
 	/**
@@ -166,7 +166,7 @@ class Admin_Sidebar_Link {
 	private function has_backup() {
 		$this->maybe_refresh_transient_cache();
 		$rewind_state = get_transient( 'jetpack_rewind_state' );
-		return ! $rewind_state || 'unavailable' !== $rewind_state->state;
+		return $rewind_state && 'unavailable' !== $rewind_state->state;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #22665

Scan & backup links show up in the admin menu based on the existence and information in two transients, jetpack_scan_state, and jetpack_rewind_state. If the transient is missing, links show up in the menu although the site doesn't have appropriate plans.

Another issue mentioned is that the transients expire after 30 minutes.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* In class-admin-sidebar-link.php I changed the logic so the links don't show up in the admin menu if the transient doesn't exist.
* In class-admin-sidebar-link.php I changed the transient expiry to 1 day.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Before the patch:

* Install Transient Manager plugin and delete jetpack_scan_state and jetpack_rewind_state.
* Once deleted, but before loading any other page, Scan & Backup links should show up in the menu.

After the patch:

* Delete the transients again and check the menu. Links shouldn't be there.
* Upgrade to scan and/or backup plans and check the menu. Links should show up.
* Check the transients, they should show a new state.
* Remove plans and reload the Jetpack dashboard. Links should be gone and transients should show a new state.
