### PR TITLE
Jetpack: Render QR Post into a modal component

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-qr-block-open-in-a-modal
+++ b/projects/plugins/jetpack/changelog/update-jetpack-qr-block-open-in-a-modal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jepack: Render QRPost into a modal component

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/components/image-actions-panel-row.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/components/image-actions-panel-row.js
@@ -7,37 +7,9 @@ import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 
 /**
- * Handler function to create an image from the QR code.
- *
- * @param {string} slug      - The slug of the image to create.
- * @param {object} ref       - The ref of the QR code DOM element.
- * @param {boolean} download - Whether to download the image. Defaults to true.
- * @returns {void}           - Nothing when the image is not created.
+ * Internal dependencies
  */
-function handleDownloadQRCode( slug, ref, download = true ) {
-	if ( ! slug ) {
-		return;
-	}
-
-	if ( ! ref?.current ) {
-		return;
-	}
-
-	const canvasElement = ref.current.querySelector( 'canvas' );
-	if ( ! canvasElement ) {
-		return;
-	}
-
-	// Convert to canvas element to data URL image.
-	canvasElement.toBlob( imageBlob => {
-		const imageURL = URL.createObjectURL( imageBlob );
-		const tempLink = document.createElement( 'a' );
-		tempLink.href = imageURL;
-		// Download, or not.
-		tempLink.setAttribute( download ? 'download' : 'target', `qr-post-${ slug }.png` );
-		tempLink.click();
-	} );
-}
+import handleDownloadQRCode from '../utils/handle-download-qrcode.js';
 
 /**
  * Row panel component to address the actions

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/components/qr-post.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/components/qr-post.js
@@ -91,19 +91,11 @@ export function QRPostButton() {
 					</div>
 
 					<div className="qr-post-modal__actions_buttons">
-						<Button
-							isSmall
-							isSecondary
-							onClick={ () => handleDownloadQRCode( slug, qrCodeRef, false ) }
-						>
-							{ __( 'View', 'jetpack' ) }
-						</Button>
-
-						<Button isSmall isSecondary onClick={ () => handleDownloadQRCode( slug, qrCodeRef ) }>
+						<Button isSecondary onClick={ () => handleDownloadQRCode( slug, qrCodeRef ) }>
 							{ __( 'Download', 'jetpack' ) }
 						</Button>
 
-						<Button isSmall isSecondary onClick={ closeModal }>
+						<Button isSecondary onClick={ closeModal }>
 							{ __( 'Close', 'jetpack' ) }
 						</Button>
 					</div>

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/components/qr-post.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/components/qr-post.js
@@ -18,7 +18,7 @@ import useSiteLogo from '../hooks/use-site-logo.js';
  *
  * @returns {Component}   The react component.
  */
-export default function QRPost() {
+export function QRPost() {
 	const wrapperElementRef = useRef();
 
 	// Pick and convert Jetpack logo to data image.

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/components/qr-post.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/components/qr-post.js
@@ -12,12 +12,13 @@ import { JetpackLogo, QRCode } from '@automattic/jetpack-components';
  * Internal dependencies
  */
 import useSiteLogo from '../hooks/use-site-logo.js';
+import { handleDownloadQRCode } from '../utils/handle-download-qr-code.js';
 
 /**
  * React component that renders a QR code for the post,
  * pulling the post data from the editor store.
  *
- * @returns {Component}   The react component.
+ * @returns {Component} The react component.
  */
 export function QRPost() {
 	const wrapperElementRef = useRef();
@@ -66,30 +67,46 @@ export function QRPost() {
 }
 
 export function QRPostButton() {
+	const qrCodeRef = useRef();
+	const slug = useSelect( select => select( editorStore ).getEditedPostSlug(), [] );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const switchModal = () => setIsModalOpen( v => ! v );
 	const closeModal = () => setIsModalOpen( false );
 
 	return (
 		<div className="qr-post-button">
-			<Button
-				isSecondary
-				onClick={ switchModal }
-				help={ __(
-					'Get advantage of the QR code to open the post in different devices, on the fly.',
-					'jetpack'
-				) }
-			>
+			<Button isSecondary onClick={ switchModal }>
 				{ __( 'Get QR code', 'jetpack' ) }
 			</Button>
 
 			{ isModalOpen && (
-				<Modal title={ __( 'QR Post code', 'jetpack' ) } onRequestClose={ closeModal }>
-					<QRPost />
+				<Modal
+					title={ __( 'QR Post code', 'jetpack' ) }
+					onRequestClose={ closeModal }
+					className="qr-post-modal"
+					ref={ qrCodeRef }
+				>
+					<div className="qr-post-modal__qr-code">
+						<QRPost />
+					</div>
 
-					<Button variant="secondary" isSmall onClick={ closeModal }>
-						{ __( 'Close', 'jetpack' ) }
-					</Button>
+					<div className="qr-post-modal__actions_buttons">
+						<Button
+							isSmall
+							isSecondary
+							onClick={ () => handleDownloadQRCode( slug, qrCodeRef, false ) }
+						>
+							{ __( 'View', 'jetpack' ) }
+						</Button>
+
+						<Button isSmall isSecondary onClick={ () => handleDownloadQRCode( slug, qrCodeRef ) }>
+							{ __( 'Download', 'jetpack' ) }
+						</Button>
+
+						<Button isSmall isSecondary onClick={ closeModal }>
+							{ __( 'Close', 'jetpack' ) }
+						</Button>
+					</div>
 				</Modal>
 			) }
 		</div>

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/components/qr-post.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/components/qr-post.js
@@ -84,9 +84,8 @@ export function QRPostButton() {
 					title={ __( 'QR Post code', 'jetpack' ) }
 					onRequestClose={ closeModal }
 					className="qr-post-modal"
-					ref={ qrCodeRef }
 				>
-					<div className="qr-post-modal__qr-code">
+					<div className="qr-post-modal__qr-code" ref={ qrCodeRef }>
 						<QRPost />
 					</div>
 

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/components/qr-post.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/components/qr-post.js
@@ -3,9 +3,10 @@
  */
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { Component } from '@wordpress/components';
-import { JetpackLogo, QRCode } from '@automattic/jetpack-components';
+import { Component, Button, Modal } from '@wordpress/components';
 import { useRef, useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { JetpackLogo, QRCode } from '@automattic/jetpack-components';
 
 /**
  * Internal dependencies
@@ -46,7 +47,7 @@ export function QRPost() {
 		<div ref={ wrapperElementRef }>
 			<QRCode
 				value={ permalink }
-				size={ 238 }
+				size={ 300 }
 				imageSettings={
 					codeLogo && {
 						src: codeLogo,
@@ -60,6 +61,37 @@ export function QRPost() {
 			/>
 
 			<JetpackLogo className="qr-post-jetpack-logo" width={ 48 } height={ 48 } showText={ false } />
+		</div>
+	);
+}
+
+export function QRPostButton() {
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const switchModal = () => setIsModalOpen( v => ! v );
+	const closeModal = () => setIsModalOpen( false );
+
+	return (
+		<div className="qr-post-button">
+			<Button
+				isSecondary
+				onClick={ switchModal }
+				help={ __(
+					'Get advantage of the QR code to open the post in different devices, on the fly.',
+					'jetpack'
+				) }
+			>
+				{ __( 'Get QR code', 'jetpack' ) }
+			</Button>
+
+			{ isModalOpen && (
+				<Modal title={ __( 'QR Post code', 'jetpack' ) } onRequestClose={ closeModal }>
+					<QRPost />
+
+					<Button variant="secondary" isSmall onClick={ closeModal }>
+						{ __( 'Close', 'jetpack' ) }
+					</Button>
+				</Modal>
+			) }
 		</div>
 	);
 }

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/editor.scss
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/editor.scss
@@ -16,6 +16,20 @@
 	}
 }
 
+.post-publish-qr-post-panel__container {
+	display: flex;
+	justify-content: center;
+}
+
 .qr-post-jetpack-logo {
 	display: none;
+}
+
+.qr-post-modal__actions_buttons {
+	display: flex;
+	justify-content: right;
+	margin-top: 10px;
+	.components-button {
+		margin-left: 5px;
+	}
 }

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/editor.scss
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/editor.scss
@@ -16,7 +16,7 @@
 	}
 }
 
-.post-publish-qr-post-panel__container {
+.qr-post-modal__qr-code {
 	display: flex;
 	justify-content: center;
 }
@@ -28,7 +28,8 @@
 .qr-post-modal__actions_buttons {
 	display: flex;
 	justify-content: right;
-	margin-top: 10px;
+	margin: 10px auto;
+	max-width: 300px;
 	.components-button {
 		margin-left: 5px;
 	}

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/editor.scss
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/editor.scss
@@ -16,11 +16,6 @@
 	}
 }
 
-.post-publish-qr-post-panel__container {
-	display: flex;
-	justify-content: center;
-}
-
 .qr-post-jetpack-logo {
 	display: none;
 }

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/index.js
@@ -4,7 +4,6 @@
 import { PanelBody, PanelRow } from '@wordpress/components';
 import { PluginPostPublishPanel } from '@wordpress/edit-post';
 import { __ } from '@wordpress/i18n';
-import { useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 
@@ -23,8 +22,6 @@ export const name = 'post-publish-qr-post-panel';
 
 export const settings = {
 	render: function PluginPostPublishPanelQRPost() {
-		const qrCodeRef = useRef();
-
 		const panelBodyProps = {
 			name: 'post-publish-qr-post-panel',
 			title: __( 'QR Code', 'jetpack' ),
@@ -40,7 +37,7 @@ export const settings = {
 
 		function QRPostPanelBodyContent() {
 			return (
-				<div className="post-publish-qr-post-panel__container" ref={ qrCodeRef }>
+				<>
 					<PanelRow>
 						<p>
 							{ __(
@@ -50,7 +47,7 @@ export const settings = {
 						</p>
 					</PanelRow>
 					<QRPostButton />
-				</div>
+				</>
 			);
 		}
 

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { PanelBody } from '@wordpress/components';
+import { PanelBody, PanelRow } from '@wordpress/components';
 import { PluginPostPublishPanel } from '@wordpress/edit-post';
 import { __ } from '@wordpress/i18n';
 import { useRef } from '@wordpress/element';
@@ -16,9 +16,7 @@ import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar.js';
 /**
  * Internal dependencies
  */
-import QRIcon from './components/icon.js';
-import { QRPost } from './components/qr-post.js';
-import ImageActionsPanelRow from './components/image-actions-panel-row.js';
+import { QRPostButton } from './components/qr-post.js';
 import './editor.scss';
 
 export const name = 'post-publish-qr-post-panel';
@@ -31,7 +29,7 @@ export const settings = {
 			name: 'post-publish-qr-post-panel',
 			title: __( 'QR Code', 'jetpack' ),
 			className: 'post-publish-qr-post-panel',
-			icon: <QRIcon />,
+			icon: null,
 			initialOpen: true,
 		};
 
@@ -42,13 +40,17 @@ export const settings = {
 
 		function QRPostPanelBodyContent() {
 			return (
-				<>
-					<div className="post-publish-qr-post-panel__container" ref={ qrCodeRef }>
-						<QRPost />
-					</div>
-
-					<ImageActionsPanelRow qrCodeRef={ qrCodeRef } />
-				</>
+				<div className="post-publish-qr-post-panel__container" ref={ qrCodeRef }>
+					<PanelRow>
+						<p>
+							{ __(
+								'Take advantage of the QR code to open the post from different devices.',
+								'jetpack'
+							) }
+						</p>
+					</PanelRow>
+					<QRPostButton />
+				</div>
 			);
 		}
 

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/index.js
@@ -17,7 +17,7 @@ import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar.js';
  * Internal dependencies
  */
 import QRIcon from './components/icon.js';
-import QRPost from './components/qr-post.js';
+import { QRPost } from './components/qr-post.js';
 import ImageActionsPanelRow from './components/image-actions-panel-row.js';
 import './editor.scss';
 

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/utils/handle-download-qr-code.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/utils/handle-download-qr-code.js
@@ -1,0 +1,32 @@
+/**
+ * Handler function to create an image from the QR code.
+ *
+ * @param {string} slug      - The slug of the image to create.
+ * @param {object} ref       - The ref of the QR code DOM element.
+ * @param {boolean} download - Whether to download the image. Defaults to true.
+ * @returns {void}           - Nothing when the image is not created.
+ */
+export function handleDownloadQRCode( slug, ref, download = true ) {
+	if ( ! slug ) {
+		return;
+	}
+
+	if ( ! ref?.current ) {
+		return;
+	}
+
+	const canvasElement = ref.current.querySelector( 'canvas' );
+	if ( ! canvasElement ) {
+		return;
+	}
+
+	// Convert to canvas element to data URL image.
+	canvasElement.toBlob( imageBlob => {
+		const imageURL = URL.createObjectURL( imageBlob );
+		const tempLink = document.createElement( 'a' );
+		tempLink.href = imageURL;
+		// Download, or not.
+		tempLink.setAttribute( download ? 'download' : 'target', `qr-post-${ slug }.png` );
+		tempLink.click();
+	} );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR renders the QR code of the post into a modal component.

before | after
------|------
<img width="516" alt="image" src="https://user-images.githubusercontent.com/77539/157933762-cee13024-ccaf-4603-8d3c-f821667a760b.png"> | <img width="668" alt="image" src="https://user-images.githubusercontent.com/77539/157933675-1df20b46-8264-47f2-be61-57f188819f45.png">


Fixes Jetpack: Render QRPost into a modal component

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack: Render QRPost into a modal component

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new post or edit a published post
* Confirm you see the `Get QR code` button in both sidebars (post publish and Jetpack)
* Confirm the QR code shows in a modal by clicking on the button mentioned above
* Confirm you can view and download the qr code image


https://user-images.githubusercontent.com/77539/157935403-ae209337-1160-405c-8623-05a84b7f0bf2.mov

