### PR TITLE
Social: Fix admin page (and remaining references to Reach)

### DIFF
--- a/projects/plugins/social/README.md
+++ b/projects/plugins/social/README.md
@@ -2,7 +2,7 @@
 
 Jetpack Social plugin
 
-## How to install reach
+## How to install Jetpack Social
 
 ### Installation From Git Repo
 
@@ -16,5 +16,5 @@ Need to report a security vulnerability? Go to [https://automattic.com/security/
 
 ## License
 
-reach is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt)
+Jetpack Social is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt)
 

--- a/projects/plugins/social/changelog/fix-jetpack-social-admin-page
+++ b/projects/plugins/social/changelog/fix-jetpack-social-admin-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated remaining references to Jetpack Reach on readme, composer and admin page files

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -67,6 +67,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_reachⓥ0_1_0_alpha"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_socialⓥ0_1_0_alpha"
 	}
 }

--- a/projects/plugins/social/readme.txt
+++ b/projects/plugins/social/readme.txt
@@ -8,7 +8,7 @@ Stable tag: 0.1.0-alpha
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Reach plugin
+Jetpack Social plugin
 
 == Description ==
 

--- a/projects/plugins/social/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/social/src/js/components/admin-page/index.jsx
@@ -84,7 +84,7 @@ const Admin = () => {
 export default Admin;
 
 const ConnectionSection = () => {
-	const { apiNonce, apiRoot, registrationNonce } = window.jetpackReachInitialState;
+	const { apiNonce, apiRoot, registrationNonce } = window.jetpackSocialInitialState;
 	return (
 		<ConnectScreenRequiredPlan
 			buttonLabel={ __( 'Get Jetpack Social', 'jetpack-social' ) }


### PR DESCRIPTION
Follow-up to #23395

Fixes Admin page not loading

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates initial state variable name
* Updates README files references to old name
* Update composer.json file `autoloader-suffix`.

#### Jetpack product discussion

#### Does this pull request change what data or activity we track or use?

no

#### Testing instructions:
1. Checkout this branch
2. Build Jetpack Social with `jetpack build plugins/social`
3. Confirm the admin page for Jetpack Social works