### PR TITLE
My Jetpack: Remove beta badge from  menu item

### DIFF
--- a/projects/packages/my-jetpack/changelog/remove-my-jetpack-beta-badge
+++ b/projects/packages/my-jetpack/changelog/remove-my-jetpack-beta-badge
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Removed Beta badge from menu item

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -50,11 +50,7 @@ class Initializer {
 
 		$page_suffix = Admin_Menu::add_menu(
 			__( 'My Jetpack', 'jetpack-my-jetpack' ),
-			sprintf(
-			/* translators: %s: "beta" label on Menu item for My Jetpack. */
-				__( 'My Jetpack %s', 'jetpack-my-jetpack' ),
-				'<span style="display:inline-block; margin: 0 8px; color: #bbb;">' . __( 'beta', 'jetpack-my-jetpack' ) . '</span>'
-			),
+			__( 'My Jetpack', 'jetpack-my-jetpack' ),
 			'manage_options',
 			'my-jetpack',
 			array( __CLASS__, 'admin_page' ),


### PR DESCRIPTION
Removes beta Badge from My Jetpack menu item

<table>
<tr>
	<td>
Before<br/>
<img width="161" alt="image" src="https://user-images.githubusercontent.com/746152/158190447-46889695-3b87-4db0-8fc1-86dd2e9a1dd8.png">
	<td>After<br/>
<img width="161" alt="image" src="https://user-images.githubusercontent.com/746152/158190582-2d985c4e-8ca5-4d5b-b3c8-20c7b6d82dd2.png">
</table>




#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes the Beta indicator from the menu item for My Jetpack

#### Jetpack product discussion


#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch on a connected site
* Confirm the beta badge for My Jetpack on the sidebar is gone