### PR TITLE
linting: Lint for problematic composer dev deps

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -61,7 +61,7 @@
             "dist": {
                 "type": "path",
                 "url": "projects/packages/codesniffer",
-                "reference": "defc334cb374051af045c9f32205a605efc8df09"
+                "reference": "897e7a4cd07c0ab010cfdca75f4eb7d9e51abdcf"
             },
             "require": {
                 "automattic/vipwpcs": "^2.3",
@@ -69,10 +69,11 @@
                 "mediawiki/mediawiki-codesniffer": "^38.0",
                 "phpcompatibility/phpcompatibility-wp": "^2.1",
                 "sirbrillig/phpcs-variable-analysis": "^2.10",
-                "wp-coding-standards/wpcs": "dev-develop as 2.3.1"
+                "wp-coding-standards/wpcs": "^2.3"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.0",
+                "wp-coding-standards/wpcs": "dev-develop#7b39722c38cbf2fe64c55be7154ee6f1807d304c as 2.3.1",
                 "yoast/phpunit-polyfills": "1.0.3"
             },
             "type": "phpcodesniffer-standard",

--- a/projects/packages/codesniffer/changelog/fix-lint-for-dev-deps
+++ b/projects/packages/codesniffer/changelog/fix-lint-for-dev-deps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Adjust deps on dev-develop of wp-coding-standards/wpcs to not require users install it.

--- a/projects/packages/codesniffer/composer.json
+++ b/projects/packages/codesniffer/composer.json
@@ -8,12 +8,13 @@
 		"mediawiki/mediawiki-codesniffer": "^38.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"sirbrillig/phpcs-variable-analysis": "^2.10",
-		"wp-coding-standards/wpcs": "dev-develop as 2.3.1",
+		"wp-coding-standards/wpcs": "^2.3",
 		"automattic/vipwpcs": "^2.3"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "1.0.3",
-		"automattic/jetpack-changelogger": "^3.0"
+		"automattic/jetpack-changelogger": "^3.0",
+		"wp-coding-standards/wpcs": "dev-develop#7b39722c38cbf2fe64c55be7154ee6f1807d304c as 2.3.1",
+		"yoast/phpunit-polyfills": "1.0.3"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/plugins/social/changelog/fix-lint-for-dev-deps
+++ b/projects/plugins/social/changelog/fix-lint-for-dev-deps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Depend on a release version of WorDBless.

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -4,8 +4,8 @@
 	"type": "wordpress-plugin",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-assets": "1.17.x-dev",
 		"automattic/jetpack-admin-ui": "0.2.x-dev",
+		"automattic/jetpack-assets": "1.17.x-dev",
 		"automattic/jetpack-autoloader": "2.11.x-dev",
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.6.x-dev",
@@ -14,9 +14,9 @@
 		"automattic/jetpack-sync": "1.30.x-dev"
 	},
 	"require-dev": {
-		"yoast/phpunit-polyfills": "1.0.3",
 		"automattic/jetpack-changelogger": "^3.0",
-		"automattic/wordbless": "dev-master"
+		"automattic/wordbless": "0.3.1",
+		"yoast/phpunit-polyfills": "1.0.3"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "74a437b626add45540b03f2e4f99647c",
+    "content-hash": "cd42c405875e054677224f0d9f74fe40",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1167,16 +1167,16 @@
         },
         {
             "name": "automattic/wordbless",
-            "version": "dev-master",
+            "version": "0.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/wordbless.git",
-                "reference": "5759b70fcdcfbbfc5bd562b898391034027fe61f"
+                "reference": "fc36fd22a43a9cfd2a47cd576a0584ee88afe521"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/wordbless/zipball/5759b70fcdcfbbfc5bd562b898391034027fe61f",
-                "reference": "5759b70fcdcfbbfc5bd562b898391034027fe61f",
+                "url": "https://api.github.com/repos/Automattic/wordbless/zipball/fc36fd22a43a9cfd2a47cd576a0584ee88afe521",
+                "reference": "fc36fd22a43a9cfd2a47cd576a0584ee88afe521",
                 "shasum": ""
             },
             "require": {
@@ -1186,7 +1186,6 @@
             "require-dev": {
                 "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^9.0"
             },
-            "default-branch": true,
             "type": "wordpress-dropin",
             "autoload": {
                 "psr-4": {
@@ -1205,9 +1204,9 @@
             "description": "WorDBless allows you to use WordPress core functions in your PHPUnit tests without having to set up a database and the whole WordPress environment",
             "support": {
                 "issues": "https://github.com/Automattic/wordbless/issues",
-                "source": "https://github.com/Automattic/wordbless/tree/master"
+                "source": "https://github.com/Automattic/wordbless/tree/0.3.1"
             },
-            "time": "2021-12-01T14:20:14+00:00"
+            "time": "2021-07-07T13:01:21+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -4414,15 +4413,14 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "automattic/jetpack-assets": 20,
         "automattic/jetpack-admin-ui": 20,
+        "automattic/jetpack-assets": 20,
         "automattic/jetpack-autoloader": 20,
         "automattic/jetpack-composer-plugin": 20,
         "automattic/jetpack-config": 20,
         "automattic/jetpack-identity-crisis": 20,
         "automattic/jetpack-my-jetpack": 20,
-        "automattic/jetpack-sync": 20,
-        "automattic/wordbless": 20
+        "automattic/jetpack-sync": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Certain composer dependencies on dev versions of packages cause
problems. Lint for those so people can't accidentally add them.

The problematic cases are:

- Any project committing `composer.lock` has a dep on a dev version of
  something that isn't anchored to a specific git ref.
- Any composer package has a non-dev dep on a dev version of something,
  even if anchored to a specific git ref.
- Monorepo-internal deps are always an exception to the above.

Then fix two cases that trip the new lint check:

- plugins/social needs to depend on a release version of WorDBless, like
  plugins/boost does.
- packages/codesniffer needs to adjust its dep on wp-coding-standards/wpcs
  dev-develop so reusers aren't forced to do the alias dance.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?
* Try reverting some of the project changes, or adding new deps that would be problematic. Are they caught by the linting script?