### PR TITLE
Admin Menu: Optimize user blog counting

### DIFF
--- a/projects/plugins/jetpack/changelog/update-admin-menu-optimize-blog-counting
+++ b/projects/plugins/jetpack/changelog/update-admin-menu-optimize-blog-counting
@@ -1,4 +1,4 @@
 Significance: patch
-Type: changed
+Type: enhancement
 
 Admin Menu: Optimize user blog counting

--- a/projects/plugins/jetpack/changelog/update-admin-menu-optimize-blog-counting
+++ b/projects/plugins/jetpack/changelog/update-admin-menu-optimize-blog-counting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Admin Menu: Optimize user blog counting

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -91,7 +91,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	 * Adds the site switcher link if user has more than one site.
 	 */
 	public function add_browse_sites_link() {
-		if ( count( get_blogs_of_user( get_current_user_id() ) ) < 2 ) {
+		if ( get_blog_count_for_user( get_current_user_id() ) < 2 ) {
 			return;
 		}
 
@@ -123,7 +123,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	 * Adds a link to the menu to create a new site.
 	 */
 	public function add_new_site_link() {
-		if ( count( get_blogs_of_user( get_current_user_id() ) ) > 1 ) {
+		if ( get_blog_count_for_user( get_current_user_id() ) > 1 ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -88,10 +88,22 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	}
 
 	/**
+	 * Retrieve the number of blogs that the current user has.
+	 *
+	 * @return int
+	 */
+	public function get_current_user_blog_count() {
+		if ( function_exists( '\get_blog_count_for_user' ) ) {
+			return \get_blog_count_for_user( get_current_user_id() );
+		}
+		return count( get_blogs_of_user( get_current_user_id() ) );
+	}
+
+	/**
 	 * Adds the site switcher link if user has more than one site.
 	 */
 	public function add_browse_sites_link() {
-		if ( get_blog_count_for_user( get_current_user_id() ) < 2 ) {
+		if ( $this->get_current_user_blog_count() < 2 ) {
 			return;
 		}
 
@@ -123,7 +135,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	 * Adds a link to the menu to create a new site.
 	 */
 	public function add_new_site_link() {
-		if ( get_blog_count_for_user( get_current_user_id() ) > 1 ) {
+		if ( $this->get_current_user_blog_count() > 1 ) {
 			return;
 		}
 


### PR DESCRIPTION
Currently, for the admin menu on WP.com simple sites, we'll fetch the number of blogs of the current user. 

However, we're using `count( get_blogs_of_user() )` to do it, and `get_blogs_of_user()` can be quite expensive because it will additionally fetch a bunch of data for each site. 

Since we're only interested in the number of sites, we can use `get_blog_count_for_user()`, which is much faster and more efficient.
 
By doing this improvement, in my testing with a user with many sites, we drop ~150-200ms off the TTFB of every wp-admin page that renders the menu, and that includes the block editor. 

This is part of the effort to improve the initial loading of the block editor.

#### Changes proposed in this Pull Request:
* Admin Menu: Optimize user blog counting

#### Jetpack product discussion
No related product discussion

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Verify the admin menu on a WP.com simple site works the same way
* If you'd like to test the performance improvement, use 2bf13-pb/#diff and test with and without this patch to see the difference.