### PR TITLE
Search: add back cli and version reporting

### DIFF
--- a/projects/packages/search/changelog/fix-add-back-cli-and-version-reporting
+++ b/projects/packages/search/changelog/fix-add-back-cli-and-version-reporting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: fixed cli and package version reporting broken in #23435

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.11.1",
+	"version": "0.11.2-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.11.1';
+	const VERSION = '0.11.2-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/initializers/class-jetpack-initializer.php
+++ b/projects/packages/search/src/initializers/class-jetpack-initializer.php
@@ -17,6 +17,9 @@ class Jetpack_Initializer extends Initializer {
 	 * Initializes either the Classic Search or the Instant Search experience.
 	 */
 	public static function initialize() {
+		// Set up package version hook.
+		add_filter( 'jetpack_package_versions', __NAMESPACE__ . '\Package::send_version_to_tracker' );
+
 		// Check whether Jetpack Search should be initialized in the first place.
 		if ( ! self::is_connected() || ! self::is_search_supported() ) {
 			/**
@@ -34,6 +37,10 @@ class Jetpack_Initializer extends Initializer {
 		if ( ! $blog_id ) {
 			do_action( 'jetpack_search_abort', 'no_blog_id', null );
 			return;
+		}
+
+		if ( defined( 'WP_CLI' ) && \WP_CLI ) {
+			\WP_CLI::add_command( 'jetpack-search', __NAMESPACE__ . '\CLI' );
 		}
 
 		// registers Jetpack Search widget.


### PR DESCRIPTION
Fixes issue introduced in #23435

#### Changes proposed in this Pull Request:
Initialize CLI and package reporting removed in `search.php`, which would lead to issues not be able to detect search package versions on JP sites and the `jetpack-search` CLI would be missing.

However we have the Jetpack plugin version as a fallback, so it wouldn't hurt our activation process and the CLI is intended for E2E tests and not required by the end users.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Ensure E2E tests pass on GitHub