### PR TITLE
VideoPress: Fix broken styles in resumable uploader component

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-resumable-uploader-core-styles
+++ b/projects/plugins/jetpack/changelog/fix-resumable-uploader-core-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed broken styles on resumable uploader component.

--- a/projects/plugins/jetpack/extensions/blocks/videopress/resumable-upload/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/resumable-upload/style.scss
@@ -1,13 +1,15 @@
 @import '../../../shared/styles/gutenberg-base-styles.scss';
 
 .resumable-upload {
-	background: #FFFFFF;
+	background: $white;
+	color: $gray-900;
+	font-family: $default-font;
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
 	padding: 20px;
-	border: 1px solid #1E1E1E;
+	border: 1px solid $gray-900;
 	border-radius: 2px;
 	font-size: $default-font-size;
 }


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/61983

Setting the default `color` and `font-family` for the component fixes the issue where a theme could apply a different text color or font.

Before:
<img width="637" alt="Screen Shot 2022-03-16 at 8 54 00 AM" src="https://user-images.githubusercontent.com/789137/158621143-57327457-e707-40be-b7ce-47b2b2be6d19.png">

After:
<img width="633" alt="Screen Shot 2022-03-16 at 8 55 12 AM" src="https://user-images.githubusercontent.com/789137/158621187-8d81744e-ad77-496e-821d-1410bb2e9c31.png">

#### Changes proposed in this Pull Request:
* CSS Fixes

#### Jetpack product discussion
pxWta-16I-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Apply diff to wp.com sandbox.
* Install the `Kingsley` theme.
* Add a resumable upload to a post, the text color should be black and the font should be the default for the block editor.