### PR TITLE
jetpack: Remove old PHP 5.2 compatibility code

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-remove-obsolete-strptime
+++ b/projects/plugins/jetpack/changelog/fix-remove-obsolete-strptime
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Remove use of `strptime`, which was only used in a branch for compatibility with PHP before 5.3.

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-video.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-video.php
@@ -289,19 +289,9 @@ class VideoPress_Video {
 			return false;
 		}
 
-		if (
-			class_exists( 'DateTimeZone' )
-			&& method_exists( 'DateTime', 'createFromFormat' )
-		) {
-			$expires_date = DateTime::createFromFormat( 'D, d M Y H:i:s T', $expires_header, new DateTimeZone( 'UTC' ) );
-			if ( $expires_date instanceof DateTime ) {
-				return date_format( $expires_date, 'U' );
-			}
-		} else {
-			$expires_array = strptime( $expires_header, '%a, %d %b %Y %H:%M:%S %Z' );
-			if ( is_array( $expires_array ) && isset( $expires_array['tm_hour'] ) && isset( $expires_array['tm_min'] ) && isset( $expires_array['tm_sec'] ) && isset( $expires_array['tm_mon'] ) && isset( $expires_array['tm_mday'] ) && isset( $expires_array['tm_year'] ) ) {
-				return gmmktime( $expires_array['tm_hour'], $expires_array['tm_min'], $expires_array['tm_sec'], 1 + $expires_array['tm_mon'], $expires_array['tm_mday'], 1900 + $expires_array['tm_year'] );
-			}
+		$expires_date = DateTime::createFromFormat( 'D, d M Y H:i:s T', $expires_header, new DateTimeZone( 'UTC' ) );
+		if ( $expires_date instanceof DateTime ) {
+			return date_format( $expires_date, 'U' );
 		}
 		return false;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The PHPCompatibility check recently started warning that strptime is
deprecated in PHP 8.1. The only use was in a branch that was kept for
compatibility with PHP 5.2, back when we still supported that version.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* ???