### PR TITLE
CLI: Prefer pnpx jetpack cli link

### DIFF
--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -50,7 +50,7 @@ First time working with the monorepo? We got you covered.
 
 For the first time only:
 
-* From the root of the repo, run `pnpm cli-setup` (if you want the `jetpack` CLI tool installed globally) or `pnpm install` (if you don't).
+* From the root of the repo, run `pnpm install && pnpx jetpack cli link` (if you want the `jetpack` CLI tool installed globally) or `pnpm install` (if you don't).
 * That’s it. You won’t need to do that again unless you nuke your node_modules directory.
 
 Once you’ve done that, it’s easy: run `jetpack` (or `pnpx jetpack`) while anywhere in the Jetpack repo. To explore on your own, run `jetpack --help` to see the available commands.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -38,7 +38,7 @@ The Jetpack Monorepo requires the following to be installed on your machine:
 - PNPM (a Node.js package manager): `npm install -g pnpm`
 - PHP (the language at the core of the WordPress ecosystem): `source .github/versions.sh && brew install php@$PHP_VERSION`
 - Composer (our PHP package manager): `brew install composer`
-- Jetpack CLI (an internal tool that assists with development): `pnpm install && pnpm cli-setup`
+- Jetpack CLI (an internal tool that assists with development): `pnpm install && pnpx jetpack cli link`
 	- [You can read more about using the CLI here](https://github.com/Automattic/jetpack/blob/master/tools/cli/README.md).
 
 ## Running Jetpack locally

--- a/docs/yarn-upgrade.md
+++ b/docs/yarn-upgrade.md
@@ -26,7 +26,7 @@ Before checking out a branch using pnpm, you'll likely want to remove any `node_
 rm -rf node_modules projects/*/*/node_modules projects/plugins/jetpack/tests/e2e/node_modules tools/cli/node_modules
 ```
 You may also want to uninstall the Jetpack CLI from yarn with `yarn cli-unlink`.
-Then, after checking out the branch, execute `pnpm install` or `pnpm cli-setup`.
+Then, after checking out the branch, execute `pnpm install`.
 
 If you forget to do this, you'll most like get the following message when checking out the branch:
 ```

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic",
 	"scripts": {
-		"cli-link": "pnpm jetpack cli link",
-		"cli-setup": "pnpm install && pnpm jetpack cli link",
+		"cli-link": "pnpx jetpack cli link",
+		"cli-setup": "pnpm install && pnpx jetpack cli link",
 		"cli-unlink": "jetpack cli unlink",
 		"lint": "pnpm run lint-file -- .",
 		"lint-changed": "eslint-changed --ext .js,.jsx,.cjs,.mjs,.ts,.tsx,.svelte --git",

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -7,7 +7,7 @@ The `jetpack` CLI tool is used to help with development in [the Jetpack monorepo
 If you normally use just one Jetpack Monorepo checkout, you can add `jetpack` to your path by running
 ```sh
 pnpm install
-pnpm cli-setup
+pnpx jetpack cli link
 ```
 from the monorepo root.
 
@@ -21,7 +21,7 @@ You run a command by using `jetpack [command] [arguments]`. Every command suppor
 
 **Linking and Unlinking the CLI**
 
-The CLI commands can be run from anywhere, and the changes will be made in whichever directory it’s symlinked to. To change the directory that you want the CLI to run commands in, you can first run jetpack cli unlink, then change into the directory you want and run pnpm cli-setup again.
+The CLI commands can be run from anywhere, and the changes will be made in whichever directory it’s symlinked to. To change the directory that you want the CLI to run commands in, you can first run jetpack cli unlink, then change into the directory you want and run pnpx jetpack cli link again.
 
 ## Available Commands
 

--- a/tools/cli/commands/cli.js
+++ b/tools/cli/commands/cli.js
@@ -24,7 +24,7 @@ function cliStatus() {
 				fileURLToPath( new URL( `../../../`, import.meta.url ) )
 		)
 	);
-	console.log( 'To change the linked directory of the CLI, run `pnpm cli-setup` ' );
+	console.log( 'To change the linked directory of the CLI, run `pnpx jetpack cli link` ' );
 }
 /**
  * CLI link.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

pnpm cli-setup seems flaky at best, but `pnpx jetpack cli link` seems to always work. Should we prefer that in our docs and processes?

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update various things to use pnpx instead.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Various.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a fresh system, try `pnpm install && pnpx jetpack cli link`
* `jetpack cli status` -- does it work?
