### PR TITLE
actions: Improve the "tool setup" action

### DIFF
--- a/.github/actions/tool-setup/action.yml
+++ b/.github/actions/tool-setup/action.yml
@@ -4,7 +4,7 @@ inputs:
   php:
     description: "Override the PHP version, or set 'false' to skip setting up PHP."
   coverage:
-    description: "Set the coverage driver, e.g. 'none' or 'pcov'."
+    description: "Set the PHP coverage driver, e.g. 'none' or 'pcov'."
     default: 'none'
   node:
     description: "Override the Node version, or set 'false' to skip setting up Node and Pnpm."
@@ -18,6 +18,7 @@ runs:
         INPUT_NODE: ${{ inputs.node }}
         INPUT_PHP: ${{ inputs.php }}
       run: |
+        # Read tool versions
         . .github/versions.sh
 
         printf "\n\e[1mSelected tool versions\e[0m\n"
@@ -37,7 +38,7 @@ runs:
         PHP: ${{ steps.versions.outputs.php-version }}
         NODE: ${{ steps.versions.outputs.node-version }}
       run: |
-        printf "\n\e[1mRemoving installed versions of disabled tools\e[0m\n"
+        # Remove disabled tools
         torm=()
         if [[ "$PHP" == "false" ]]; then
           torm+=( php composer )
@@ -51,9 +52,6 @@ runs:
           done
         done
 
-    - run: printf "\n\e[1mSetup PHP\e[0m\n"
-      shell: bash
-      if: steps.versions.outputs.php-version != 'false'
     - name: Setup PHP
       if: steps.versions.outputs.php-version != 'false'
       uses: shivammathur/setup-php@v2
@@ -64,23 +62,12 @@ runs:
         extensions: mysql, imagick
         coverage: ${{ inputs.coverage }}
 
-    - run: printf "\n\e[1mSetup Node\e[0m\n"
-      shell: bash
-      if: steps.versions.outputs.node-version != 'false'
-    - name: Setup Node
-      if: steps.versions.outputs.node-version != 'false'
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ steps.versions.outputs.node-version }}
-
-    - run: printf "\n\e[1mSetup Composer cache\e[0m\n"
-      shell: bash
-      if: steps.versions.outputs.php-version != 'false'
     - name: Get Composer cache directory
       if: steps.versions.outputs.php-version != 'false'
       id: composer-cache
       shell: bash
       run: |
+        # Get Composer cache directory
         echo "::set-output name=dir::$(composer config cache-files-dir)"
     - name: Use composer cache
       if: steps.versions.outputs.php-version != 'false'
@@ -91,26 +78,23 @@ runs:
         restore-keys: |
           ${{ runner.os }}-composer-
 
-    - run: printf "\n\e[1mSetup pnpm\e[0m\n"
-      shell: bash
-      if: steps.versions.outputs.node-version != 'false'
-    - name: Use pnpm cache
-      if: steps.versions.outputs.node-version != 'false'
-      uses: actions/cache@v2
-      with:
-        path: ~/.pnpm-store
-        key: ${{ runner.os }}-pnpm-${{ steps.versions.outputs.node-version }}-${{ hashFiles('**/package.json') }}
-        restore-keys: |
-          ${{ runner.os }}-pnpm-${{ steps.versions.outputs.node-version }}-
     - name: Setup pnpm
       if: steps.versions.outputs.node-version != 'false'
       uses: pnpm/action-setup@v2.2.1
       with:
         version: ${{ steps.versions.outputs.pnpm-version }}
+    - name: Setup Node
+      if: steps.versions.outputs.node-version != 'false'
+      uses: actions/setup-node@v3
+      with:
+        # Prefix the version with a caret as otherwise actions/setup-node will waste API calls finding where to download the exact version.
+        node-version: ^${{ steps.versions.outputs.node-version }}
+        cache: pnpm
 
     - name: Tool versions
       shell: bash
       run: |
+        # Tool versions
         function docmd {
           if [[ -z "$(command -v $1)" ]]; then
             echo "$1 is not available"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The main thing here is changing the call to actions/setup-node to pass a
version like `^16.13.2` instead of `16.13.2`. It turns out that action
wastes API calls if given an explicit version that isn't one of the ones
in GitHub's cache (and GH currently has 16.14.0 cached rather than
16.13.2), and this can be avoided with the caret-range.

This also does some other cleanup:

* GH has improved the logging output for compound actions, we probably
  don't need the sectioning printfs anymore.
* For run steps, add a comment as the first line for better output.
* Let actions/setup-node set up the pnpm caching instead of manually
  calling actions/cache.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the appropriate steps of some of our workflow jobs using the action.
  * :heavy_check_mark: It should be pulling in Node 16.14.0 from cache, rather than downloading 16.13.2.
  * :heavy_check_mark: Output should still make sense.
  * :heavy_check_mark: `pnpm install` should pull from a cache on a second run, indicated by it not downloading every package.