### PR TITLE
CLI: Change Changelogger Auto-add behavior

### DIFF
--- a/projects/github-actions/pr-is-up-to-date/funcs.sh
+++ b/projects/github-actions/pr-is-up-to-date/funcs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eo pipefail
+set -eo pipefail 
 
 # Execute `git` with logging of commands.
 #

--- a/projects/github-actions/pr-is-up-to-date/funcs.sh
+++ b/projects/github-actions/pr-is-up-to-date/funcs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eo pipefail 
+set -eo pipefail
 
 # Execute `git` with logging of commands.
 #

--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -309,7 +309,7 @@ async function changelogAdd( argv ) {
 		const promptType = await changelogAddPrompt( argv, needChangelog, uniqueProjects );
 
 		// Bail if user doesn't want to auto-add.
-		if ( ! promptType.autoPrompt ) {
+		if ( ! promptType.autoAdd && ! promptType.autoPrompt ) {
 			console.log(
 				chalk.green(
 					`Auto changelog cancelled. You can run 'jetpack changelog add [project-type/project]' to add changelogs individually.`

--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -308,6 +308,16 @@ async function changelogAdd( argv ) {
 
 		const promptType = await changelogAddPrompt( argv, needChangelog, uniqueProjects );
 
+		// Bail if user doesn't want to auto-add.
+		if ( ! promptType.autoPrompt ) {
+			console.log(
+				chalk.green(
+					`Auto changelog cancelled. You can run 'jetpack changelog add [project-type/project]' to add changelogs individually.`
+				)
+			);
+			return;
+		}
+
 		// Auto add the changelog files for the projects that we can:
 		if ( promptType.autoAdd ) {
 			console.log(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
When someone runs `jetpack changelog add`, the auto-adder prompts if you want to add the changelog files automatically if it finds projects that need one. Previously if you declined, it would default to interactive mode. This changes the behavior so it just stops the process, since it's not very clear that saying no would default you to interactive mode at all.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jetpack/pull/23359#issuecomment-1070997218

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make a change to a project
* Run `jetpack changelog add`
* saying yes should give you the prompts as usual
* saying no should exit the changelogger altogether (instead of defaulting to interactive mode)
*
