### PR TITLE
Sync: Enable syncing of dedicated_sync_enabled setting

### DIFF
--- a/projects/packages/sync/changelog/update-sync-dedicated-sync-setting
+++ b/projects/packages/sync/changelog/update-sync-dedicated-sync-setting
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: changed
 
 Enable syncing of dedicated_sync_enabled Sync setting

--- a/projects/packages/sync/changelog/update-sync-dedicated-sync-setting
+++ b/projects/packages/sync/changelog/update-sync-dedicated-sync-setting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Enable syncing of dedicated_sync_enabled Sync setting

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -95,6 +95,7 @@ class Defaults {
 		'jetpack_sync_settings_post_meta_whitelist',
 		'jetpack_sync_settings_post_types_blacklist',
 		'jetpack_sync_settings_taxonomies_blacklist',
+		'jetpack_sync_settings_dedicated_sync_enabled', // is Dedicated Sync flow enabled.
 		'jetpack_testimonial',
 		'jetpack_testimonial_posts_per_page',
 		'jetpack_wga',

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.30.3';
+	const PACKAGE_VERSION = '1.30.4-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/jetpack/changelog/update-sync-dedicated-sync-setting
+++ b/projects/plugins/jetpack/changelog/update-sync-dedicated-sync-setting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Unit tests: Update Sync related unit test

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -217,6 +217,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'jetpack_publicize_options'                    => array(),
 			'jetpack_connection_active_plugins'            => array( 'jetpack' ),
 			'jetpack_sync_non_blocking'                    => false,
+			'jetpack_sync_settings_dedicated_sync_enabled' => false,
 			'jetpack_sync_settings_comment_meta_whitelist' => array( 'jetpack', 'pineapple' ),
 			'jetpack_sync_settings_post_meta_whitelist'    => array( 'jetpack', 'pineapple' ),
 			'jetpack_sync_settings_post_types_blacklist'   => array( 'jetpack', 'pineapple' ),

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -624,9 +624,10 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 	 * Test do_sync will NOT spawn a dedicated Sync request when the corresponding setting is enabled if the Sync queue is empty.
 	 */
 	public function test_do_sync_will_not_spawn_dedicated_sync_request_with_empty_queue() {
-		$this->sender->get_sync_queue()->reset();
-
 		Settings::update_settings( array( 'dedicated_sync_enabled' => 1 ) );
+		// Empty the queue after updating dedicated_sync_enabled, otherwise
+		// a corresponding Sync action will be added as we are syncing this setting as well.
+		$this->sender->get_sync_queue()->reset();
 
 		add_filter( 'pre_http_request', array( $this, 'pre_http_sync_request_spawned' ), 10, 3 );
 		$result = $this->sender->do_sync();


### PR DESCRIPTION
Sync: Enable syncing of dedicated_sync_enabled setting

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds `jetpack_sync_settings_dedicated_sync_enabled` to Sync whitelisted options

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
D77031-code