### PR TITLE
VideoPress: Update API endpoint with new feature check function

### DIFF
--- a/projects/plugins/jetpack/changelog/update-api-allow-video-uploads
+++ b/projects/plugins/jetpack/changelog/update-api-allow-video-uploads
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+(WP.com only) Sync class.json-api-endpoints.php changes from D76475

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -2352,7 +2352,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 		}
 
 		// bail early if they already have the upgrade..
-		if ( (string) get_option( 'video_upgrade' ) === '1' ) {
+		if ( wpcom_site_has_videopress() ) {
 			return $mimes;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Updates `class.json-api-endpoints.php` with changes from D76475-code. These changes only affect WP.com, since [we bail the `allow_video_uploads` check for self-hosted Jetpack sites](https://github.com/Automattic/jetpack/blob/c58670b53bef25f41e03dc8b8b0939ff1b09851d/projects/plugins/jetpack/class.json-api-endpoints.php#L2344-L2347).

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Not needed, since changes have been already tested in D76475-code and they only affect WP.com.
