### PR TITLE
actions: Handle uninstall errors in plugin upgrade test

### DIFF
--- a/.github/files/test-plugin-update/test.sh
+++ b/.github/files/test-plugin-update/test.sh
@@ -17,12 +17,28 @@ for SLUG in "${SLUGS[@]}"; do
 		for HOW in web cli; do
 			[[ -e "$ZIPDIR/$SLUG-$FROM.zip" ]] || continue
 
-			echo "::group::Installing $SLUG $FROM"
-			wp --allow-root plugin install --activate "$ZIPDIR/$SLUG-$FROM.zip"
-			rm -f "/var/www/html/wp-content/plugins/$SLUG/ci-flag.txt"
-			# TODO: Connect Jetpack, since most upgrades will happen while connected.
-			echo "::endgroup::"
+			printf '\n\e[1mTest upgrade of %s from %s via %s\e[0m\n' "$SLUG" "$FROM" "$HOW"
 
+			ERRMSG=
+			echo "::group::Installing $SLUG $FROM"
+			: > /var/www/html/wp-content/debug.log
+			if ! wp --allow-root plugin install --activate "$ZIPDIR/$SLUG-$FROM.zip"; then
+				ERRMSG="Plugin install failed for $SLUG $FROM!"
+				EXIT=1
+			fi
+			echo '== Debug log =='
+			cat /var/www/html/wp-content/debug.log
+			rm -f "/var/www/html/wp-content/plugins/$SLUG/ci-flag.txt"
+			echo "::endgroup::"
+			if [[ -n "$ERRMSG" ]]; then
+				rm -rf "/var/www/html/wp-content/plugins/$SLUG"
+				echo "::error::$ERRMSG"
+				continue
+			fi
+
+			# TODO: Connect Jetpack, since most upgrades will happen while connected.
+
+			ERRMSG=
 			echo "::group::Upgrading $SLUG via $HOW"
 			P="$(wp --allow-root plugin path "$SLUG" | sed 's!^/var/www/html/wp-content/plugins/!!')"
 			wp --allow-root --quiet option set fake_plugin_update_plugin "$P"
@@ -30,7 +46,7 @@ for SLUG in "${SLUGS[@]}"; do
 			: > /var/www/html/wp-content/debug.log
 			if [[ "$HOW" == 'cli' ]]; then
 				if ! wp --allow-root plugin upgrade "$SLUG" 2>&1 | tee "$GITHUB_WORKSPACE/out.txt"; then
-					echo "::error::CLI upgrade of $SLUG from $FROM exited with a non-zero status"
+					ERRMSG="CLI upgrade of $SLUG from $FROM exited with a non-zero status"
 					EXIT=1
 				fi
 			else
@@ -42,6 +58,9 @@ for SLUG in "${SLUGS[@]}"; do
 			echo '== Debug log =='
 			cat /var/www/html/wp-content/debug.log
 			echo "::endgroup::"
+			if [[ -n "$ERRMSG" ]]; then
+				echo "::error::$ERRMSG"
+			fi
 			ERR="$(grep -i 'Fatal error' /var/www/html/wp-content/debug.log || true)"
 			if [[ -n "$ERR" ]]; then
 				echo "::error::Mid-upgrade fatal detected for $SLUG $HOW update from $FROM!%0A$ERR"
@@ -51,12 +70,37 @@ for SLUG in "${SLUGS[@]}"; do
 				EXIT=1
 			fi
 
+			ERRMSG=
+			echo "::group::Deactivating $SLUG"
+			: > /var/www/html/wp-content/debug.log
+			if ! wp --allow-root plugin deactivate "$SLUG"; then
+				ERRMSG="Plugin deactivate failed after $SLUG $HOW update from $FROM!"
+				EXIT=1
+			fi
+			echo '== Debug log =='
+			cat /var/www/html/wp-content/debug.log
+			echo '::endgroup::'
+			if [[ -n "$ERRMSG" ]]; then
+				echo "::error::$ERRMSG"
+			fi
+
+			ERRMSG=
 			echo "::group::Uninstalling $SLUG"
-			wp --allow-root plugin deactivate "$SLUG"
-			wp --allow-root plugin uninstall "$SLUG"
+			: > /var/www/html/wp-content/debug.log
+			if ! wp --allow-root plugin uninstall "$SLUG"; then
+				ERRMSG="Plugin uninstall failed after $SLUG $HOW update from $FROM!"
+				EXIT=1
+				rm -rf "/var/www/html/wp-content/plugins/$SLUG"
+			fi
+			echo '== Debug log =='
+			cat /var/www/html/wp-content/debug.log
+			echo "::endgroup::"
+			if [[ -n "$ERRMSG" ]]; then
+				echo "::error::$ERRMSG"
+			fi
+
 			wp --allow-root --quiet option delete fake_plugin_update_plugin
 			wp --allow-root --quiet option delete fake_plugin_update_url
-			echo "::endgroup::"
 		done
 	done
 done


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
In #23076 we ran into some errors during plugin uninstall, which
produced unhelpful output. We should catch those errors to produce
helpful output instead.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None really.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the run of the job in this PR where it was based on #23076 rather than master.
  * :heavy_check_mark: https://github.com/Automattic/jetpack/runs/5630770699?check_suite_focus=true