### PR TITLE
My Jetpack: For testing Monitor Card 23521

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
@@ -15,6 +15,7 @@ import SearchCard from './search-card';
 import VideopressCard from './videopress-card';
 import CrmCard from './crm-card';
 import ExtrasCard from './extras-card';
+import MonitorCard from './monitor-card';
 
 /**
  * Product cards section component.
@@ -47,6 +48,9 @@ const ProductCardsSection = () => {
 			</Col>
 			<Col sm={ 4 } md={ 4 } lg={ 3 }>
 				<ExtrasCard admin={ true } />
+			</Col>
+			<Col sm={ 4 } md={ 4 } lg={ 3 }>
+				<MonitorCard admin={ true } />
 			</Col>
 		</Container>
 	);

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -26,6 +26,7 @@ class Products {
 			Products\Boost::class,
 			Products\Crm::class,
 			Products\Extras::class,
+			Products\Monitor::class,
 			Products\Scan::class,
 			Products\Search::class,
 			Products\Videopress::class,


### PR DESCRIPTION
Reference Pull Request for testing the Monitor card introduced in #23521

This PR allows testing of the Monitor card introduction

<img width="1129" alt="image" src="https://user-images.githubusercontent.com/746152/159319403-dbf1063b-911b-415f-9630-558cffc63f3e.png">


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Reverts last commit of #23521

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
* Checkout this branch on a connected site with Jetpack the plugin
* Confirm there's a new card below the two rows
* Click the activate/deactivate links and confirm they work
