### PR TITLE
My Jetpack: Update Plans section top margin for plan list

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
@@ -90,7 +90,7 @@ export default function PlansSection() {
 		<div className={ styles.container }>
 			<PlanSectionHeader purchases={ purchases } />
 
-			<div className="jp-plans-section__purchases-section">
+			<div className={ styles.purchasesSection }>
 				{ purchases.map( purchase => (
 					<PlanSection key={ `purchase-${ purchase.product_name }` } purchase={ purchase } />
 				) ) }

--- a/projects/packages/my-jetpack/_inc/components/plans-section/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/style.module.scss
@@ -30,6 +30,10 @@
 	}
 }
 
+.purchasesSection {
+	margin-top: 16px;
+}
+
 .external-link:hover {
 	color: var(--jp-black);
 	text-decoration-thickness: var(--jp-underline-thickness);

--- a/projects/packages/my-jetpack/changelog/fix-plan-section-margin-top-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/fix-plan-section-margin-top-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Plans section top margin for plan list


### PR DESCRIPTION
Fixes margin between section title and plan title

Follow-up to #23493 for addressing #23489 and #23512

<table>
<tr>
	<td>Before<br/>
<img width="298" alt="image" src="https://user-images.githubusercontent.com/746152/159338246-a45f8503-b68d-494a-bffc-c63455a1e987.png"></td>
	<td>After<br/>
<img width="273" alt="image" src="https://user-images.githubusercontent.com/746152/159337961-81b117c7-9753-46c7-8385-820994b1c9b8.png">

</table>

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a 16px top margin to the purchases section

#### Jetpack product discussion
none

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
* Checkout this branch on a connected Jetpack site with at least one plan.
* Visit My Jetpack and confirm there's a margin below the "Your plan" header