### PR TITLE
My Jetpack: add error styles to the whole Product card component

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -130,6 +130,7 @@ const ProductCard = props => {
 		[ styles.plugin_absent ]: isAbsent,
 		[ styles[ 'is-purchase-required' ] ]: isPurchaseRequired,
 		[ styles[ 'is-link' ] ]: isAbsent,
+		[ styles[ 'has-error' ] ]: isError,
 	} );
 
 	const statusClassName = classNames( styles.status, {

--- a/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
@@ -31,6 +31,10 @@
 			outline: 3px solid transparent;
 		}
 	}
+
+	&.has-error {
+		box-shadow: 0 0 0 1.5px var( --jp-red-60 );
+	}
 }
 
 .name {

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-add-error-style-to-product-card
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-add-error-style-to-product-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+My Jetpack: add error styles to the whole Product card component


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds error styles to the whole Product card component, according to the design feedback:

before | after
----|----
<img width="287" alt="image" src="https://user-images.githubusercontent.com/77539/159361853-b4ef7e68-041b-4b08-a740-d418d5cfdc8b.png"> | <img width="285" alt="image" src="https://user-images.githubusercontent.com/77539/159361901-ac466c1d-d532-49d3-bccd-0e51725aa301.png">

Fixes https://github.com/Automattic/jetpack/issues/23518
Related with https://github.com/Automattic/jetpack/issues/23483

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: add error styles to the whole Product card component

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use storybook
* Go to Product Card story http://localhost:50240/?path=/story/packages-my-jetpack-product-card--default
* Set the error status
* Confirm you see the red border around the product card
<img width="1069" alt="image" src="https://user-images.githubusercontent.com/77539/159361312-7161f98e-f965-46f9-b868-7f6a7814fc56.png">

