### PR TITLE
My Jetpack: change action buttons of the Product card

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -5,7 +5,7 @@ import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { __, sprintf } from '@wordpress/i18n';
-import { ButtonGroup, Button, DropdownMenu } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { Text } from '@automattic/jetpack-components';
 
 /**
@@ -28,17 +28,6 @@ const PRODUCT_STATUSES_LABELS = {
 	[ PRODUCT_STATUSES.NEEDS_PURCHASE ]: __( 'Inactive', 'jetpack-my-jetpack' ),
 	[ PRODUCT_STATUSES.ERROR ]: __( 'Error', 'jetpack-my-jetpack' ),
 };
-
-const DownIcon = () => (
-	<svg width="15" height="9" fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="10 9 4 7">
-		<path
-			fillRule="evenodd"
-			clipRule="evenodd"
-			d="m18.004 10.555-6.005 5.459-6.004-5.459 1.009-1.11 4.995 4.542 4.996-4.542 1.009 1.11Z"
-			fill="#fff"
-		/>
-	</svg>
-);
 
 const ActionButton = ( {
 	status,
@@ -105,18 +94,15 @@ const ActionButton = ( {
 const ProductCard = props => {
 	const {
 		name,
-		admin,
 		description,
 		icon,
 		status,
 		onActivate,
 		onAdd,
-		onDeactivate,
 		onFixConnection,
 		onManage,
 		isFetching,
 		slug,
-		showDeactivate,
 	} = props;
 	const isActive = status === PRODUCT_STATUSES.ACTIVE;
 	const isError = status === PRODUCT_STATUSES.ERROR;
@@ -124,7 +110,6 @@ const ProductCard = props => {
 	const isAbsent = status === PRODUCT_STATUSES.ABSENT || status === PRODUCT_STATUSES.NEEDS_PURCHASE;
 	const isPurchaseRequired = status === PRODUCT_STATUSES.NEEDS_PURCHASE;
 	const flagLabel = PRODUCT_STATUSES_LABELS[ status ];
-	const canDeactivate = ( isActive || isError ) && admin && showDeactivate;
 
 	const containerClassName = classNames( styles.container, {
 		[ styles.plugin_absent ]: isAbsent,
@@ -141,16 +126,6 @@ const ProductCard = props => {
 	} );
 
 	const { recordEvent } = useAnalytics();
-
-	/**
-	 * Calls the passed function onDeactivate after firing Tracks event
-	 */
-	const deactivateHandler = useCallback( () => {
-		recordEvent( 'jetpack_myjetpack_product_card_deactivate_click', {
-			product: slug,
-		} );
-		onDeactivate();
-	}, [ slug, onDeactivate, recordEvent ] );
 
 	/**
 	 * Calls the passed function onActivate after firing Tracks event
@@ -217,39 +192,13 @@ const ProductCard = props => {
 				{ description }
 			</Text>
 			<div className={ styles.actions }>
-				{ canDeactivate ? (
-					<ButtonGroup className={ styles.group }>
-						<ActionButton
-							{ ...props }
-							onActivate={ activateHandler }
-							onFixConnection={ fixConnectionHandler }
-							onManage={ manageHandler }
-							className={ styles.button }
-						/>
-						<DropdownMenu
-							className={ styles.dropdown }
-							toggleProps={ { isPrimary: true, disabled: isFetching, className: styles.button } }
-							popoverProps={ { noArrow: false } }
-							icon={ DownIcon }
-							disableOpenOnArrowDown={ true }
-							controls={ [
-								{
-									title: __( 'Deactivate', 'jetpack-my-jetpack' ),
-									icon: null,
-									onClick: deactivateHandler,
-								},
-							] }
-						/>
-					</ButtonGroup>
-				) : (
-					<ActionButton
-						{ ...props }
-						onFixConnection={ fixConnectionHandler }
-						onActivate={ activateHandler }
-						onAdd={ addHandler }
-						className={ styles.button }
-					/>
-				) }
+				<ActionButton
+					{ ...props }
+					onActivate={ activateHandler }
+					onFixConnection={ fixConnectionHandler }
+					onManage={ manageHandler }
+					className={ styles.button }
+				/>
 				{ ! isAbsent && (
 					<Text variant="label" className={ statusClassName }>
 						{ flagLabel }
@@ -266,7 +215,6 @@ ProductCard.propTypes = {
 	icon: PropTypes.element,
 	admin: PropTypes.bool.isRequired,
 	isFetching: PropTypes.bool,
-	onDeactivate: PropTypes.func,
 	onManage: PropTypes.func,
 	onFixConnection: PropTypes.func,
 	onActivate: PropTypes.func,
@@ -285,7 +233,6 @@ ProductCard.propTypes = {
 ProductCard.defaultProps = {
 	icon: null,
 	isFetching: false,
-	onDeactivate: () => {},
 	onManage: () => {},
 	onFixConnection: () => {},
 	onActivate: () => {},

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -69,7 +69,7 @@ const ActionButton = ( {
 			);
 		case PRODUCT_STATUSES.ACTIVE:
 			return (
-				<Button { ...buttonState } onClick={ onManage }>
+				<Button { ...buttonState } variant="secondary" onClick={ onManage }>
 					{ __( 'Manage', 'jetpack-my-jetpack' ) }
 				</Button>
 			);

--- a/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
@@ -70,20 +70,6 @@
 	text-decoration: underline;
 }
 
-.group {
-	display: flex;
-	height: var(--actions-size);
-	border-radius: var(--jp-border-radius);
-
-	& > .button:first-child {
-		border-radius: var(--jp-border-radius) 0 0 var(--jp-border-radius);
-	}
-
-	& > :global(.components-dropdown) > .button {
-		border-radius: 0 var(--jp-border-radius) var(--jp-border-radius) 0;
-	}
-}
-
 .status {
 	margin-left: var(--spacing-base); // 8px
 	white-space: nowrap;

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-update-card-buttons
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-update-card-buttons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: remove dropdown from CTA button in Product cards


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR changes the action buttons of the Product Card according to the design feedback,
p1HpG7-fbl-p2#comment-53119

before | after
------|------
<img width="546" alt="image" src="https://user-images.githubusercontent.com/77539/159478429-82b04dbb-99b7-4da0-81db-d62043c8e68f.png"> | <img width="555" alt="image" src="https://user-images.githubusercontent.com/77539/159478453-dfd5a35a-827c-4feb-b537-0c8346deb500.png">


Fixes https://github.com/Automattic/jetpack/issues/23483

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: Replace Manage button with a simple button (no more dropdown). Disconnect button is removed, too.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
Yes. We stop firing the `jetpack_myjetpack_product_card_deactivate_click` event

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use storybook
* Go to Product Card story http://localhost:50240/?path=/story/packages-my-jetpack-product-card--default
* Change the status
* Confirm you see the changes in the Manage button
------------
* Go to My Jetpack overview
* Confirm you can activate the product for those inactive ones
* Confirm you see a (secondary) manage button for active products
* Confirm the manage button leads to the proper page


https://user-images.githubusercontent.com/77539/159478481-c42e5145-bedc-4095-8fc3-5eaf6e1bbe04.mov