### PR TITLE
Search: Add search feature to benefits API

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Search\Initializer as Jetpack_Search_Initializer;
 
 /**
  * This is the endpoint class for `/site` endpoints.
@@ -279,6 +280,14 @@ class Jetpack_Core_API_Site_Endpoint {
 				'title'       => esc_html__( 'Sharing', 'jetpack' ),
 				'description' => esc_html__( 'The number of times visitors have shared your posts with the world using Jetpack', 'jetpack' ),
 				'value'       => absint( $stats->stats->shares ),
+			);
+		}
+
+		if ( Jetpack::is_module_active( 'search' ) && ! Jetpack::is_plugin_active( 'search/jetpack-search.php' ) && class_exists( Jetpack_Search_Initializer::class ) ) {
+			$benefits[] = array(
+				'name'        => 'search',
+				'title'       => esc_html__( 'Jetpack Search', 'jetpack' ),
+				'description' => esc_html__( 'Help your visitors find exactly what they are looking for, fast', 'jetpack' ),
 			);
 		}
 

--- a/projects/plugins/jetpack/changelog/add-search-feature-to-benefits-api
+++ b/projects/plugins/jetpack/changelog/add-search-feature-to-benefits-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Search: add search feature for benefits API


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Add search feature to benefits API to show on deactivation screen.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Go to a site with Search subscription and Jetpack plugin activated and Jetpack Search deactivated
* Go to `/wp-admin/plugins.php?plugin_status=all&paged=1`
* Click `Disconnect and Deactivate`
* Ensure there's a Jetpack Search section

![image](https://user-images.githubusercontent.com/1425433/159388470-e27ffb07-9ebc-467c-a522-695873298b3a.png)

