### PR TITLE
E2E tests: ignore getDefaultProps console warning

### DIFF
--- a/tools/e2e-commons/config/default.cjs
+++ b/tools/e2e-commons/config/default.cjs
@@ -34,6 +34,7 @@ const config = {
 		'elements with non-unique id #_wpnonce',
 		'is deprecated',
 		'SharedArrayBuffer will require cross-origin isolation as of M91, around May 2021',
+		'Warning: getDefaultProps is only used on classic React.createClass definitions',
 	],
 	repository: {
 		url: 'https://github.com/Automattic/jetpack',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The warning `Warning: getDefaultProps is only used on classic React.createClass definitions` is displayed in console and it pollutes our e2e tests logs. With this PR the warning will be ignored by our logger.

#### Jetpack product discussion
1156386383419466-as-1201996635281920

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Tests pass in CI
* Check e2e-debug log, it should not contain the ignored string