### PR TITLE
Shortlinks: ensure the block editor shows for CPTs.

### DIFF
--- a/projects/plugins/jetpack/changelog/add-shortlinks-support-editor
+++ b/projects/plugins/jetpack/changelog/add-shortlinks-support-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Shortlinks: display the shortlinks interface in the block editor for all post types that support shortlinks.

--- a/projects/plugins/jetpack/modules/shortlinks.php
+++ b/projects/plugins/jetpack/modules/shortlinks.php
@@ -131,12 +131,25 @@ function wpme_get_shortlink_handler( $shortlink, $id, $context, $allow_slugs ) {
  * @uses register_rest_field, wpme_rest_get_shortlink
  */
 function wpme_rest_register_shortlinks() {
+	// Post types that support shortlinks by default.
+	$supported_post_types = array(
+		'attachment',
+		'page',
+		'post',
+	);
+
+	// Add any CPT that may have declared support for shortlinks.
+	foreach ( get_post_types() as $post_type ) {
+		if (
+			post_type_supports( $post_type, 'shortlinks' )
+			&& post_type_supports( $post_type, 'editor' )
+		) {
+			$supported_post_types[] = $post_type;
+		}
+	}
+
 	register_rest_field(
-		array(
-			'attachment',
-			'page',
-			'post',
-		),
+		$supported_post_types,
 		'jetpack_shortlink',
 		array(
 			'get_callback'    => 'wpme_rest_get_shortlink',


### PR DESCRIPTION
Fixes #12934

#### Changes proposed in this Pull Request:

* We currently only add the Shortlinks interface in the block editor for a few hardcoded post types. Since site owners can declare shortlinks support in their own post types, we should ensure the shortlinks interface is displayed when editing those custom post types as well.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Go to Jetpack > Settings, and enable the Shortlinks feature.
* Go to Posts > Add New, save a draft, and ensure you see the shortlinks interface in the Jetpack plugin sidebar.
* Go to Plugins > Add New and add the Code Snippets plugin.
* Create a new snippet where you'll paste a random post type you'll have created [here](https://generatewp.com/post-type/).
* In that post type snippet, add 2 things:
    * In the `supports` declaration, add both `shortlinks` and `editor`.
    * Add the `show_in_rest` arg and set it to true.
* Now go to Your Post Type > Add New
* In the editor that appears, you should see the Jetpack plugin sidebar, and the shortlinks interface.
