### PR TITLE
Updated the styles for card statuses

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -38,6 +38,7 @@ const ActionButton = ( {
 	onFixConnection,
 	isFetching,
 	className,
+	onAdd,
 } ) => {
 	if ( ! admin ) {
 		return (
@@ -57,7 +58,6 @@ const ActionButton = ( {
 	};
 
 	switch ( status ) {
-		case PRODUCT_STATUSES.NEEDS_PURCHASE:
 		case PRODUCT_STATUSES.ABSENT:
 			return (
 				<span className={ styles[ 'action-link-button' ] }>
@@ -66,6 +66,12 @@ const ActionButton = ( {
 						sprintf( __( 'Add %s', 'jetpack-my-jetpack' ), name )
 					}
 				</span>
+			);
+		case PRODUCT_STATUSES.NEEDS_PURCHASE:
+			return (
+				<Button { ...buttonState } onClick={ onAdd }>
+					{ __( 'Purchase', 'jetpack-my-jetpack' ) }
+				</Button>
 			);
 		case PRODUCT_STATUSES.ACTIVE:
 			return (
@@ -81,7 +87,7 @@ const ActionButton = ( {
 			);
 		case PRODUCT_STATUSES.INACTIVE:
 			return (
-				<Button { ...buttonState } onClick={ onActivate }>
+				<Button { ...buttonState } variant="secondary" onClick={ onActivate }>
 					{ __( 'Activate', 'jetpack-my-jetpack' ) }
 				</Button>
 			);
@@ -107,7 +113,7 @@ const ProductCard = props => {
 	const isActive = status === PRODUCT_STATUSES.ACTIVE;
 	const isError = status === PRODUCT_STATUSES.ERROR;
 	const isInactive = status === PRODUCT_STATUSES.INACTIVE;
-	const isAbsent = status === PRODUCT_STATUSES.ABSENT || status === PRODUCT_STATUSES.NEEDS_PURCHASE;
+	const isAbsent = status === PRODUCT_STATUSES.ABSENT;
 	const isPurchaseRequired = status === PRODUCT_STATUSES.NEEDS_PURCHASE;
 	const flagLabel = PRODUCT_STATUSES_LABELS[ status ];
 
@@ -120,7 +126,7 @@ const ProductCard = props => {
 
 	const statusClassName = classNames( styles.status, {
 		[ styles.active ]: isActive,
-		[ styles.inactive ]: isInactive,
+		[ styles.inactive ]: isInactive || isPurchaseRequired,
 		[ styles.error ]: isError,
 		[ styles[ 'is-fetching' ] ]: isFetching,
 	} );

--- a/projects/packages/my-jetpack/changelog/update-product-status-styles
+++ b/projects/packages/my-jetpack/changelog/update-product-status-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated styles for each product card status

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -116,7 +116,7 @@ class Products {
 				'status'      => array(
 					'title' => 'The product status',
 					'type'  => 'string',
-					'enum'  => array( 'active', 'inactive', 'plugin_absent' ),
+					'enum'  => array( 'active', 'inactive', 'plugin_absent', 'needs_purchase', 'error' ),
 				),
 				'class'       => array(
 					'title' => 'The product class handler',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #23550 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update the way produc cards look in each status

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-fbl-p2#comment-53125

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack
* Test product cards in all 5 different possible states and make sure they look the same as defined in the issue (screenshot below)
* Note: At this moment, we are not allowing non-admins to access My Jetpack, so ignore this part of the design

Changes from previous version:
* `plugin_absent` now looks like an Inactive card, but with a primary button with the "Purchase" label that takes the user to the interstitial page
* `inactive` now displays a secondary button (not primary)


![Captura de tela de 2022-03-22 11-49-46](https://user-images.githubusercontent.com/971483/159509952-25ff73fd-2df8-4171-83c9-200b73db92e1.png)