### PR TITLE
My Jetpack: Fix jetpack_my_jetpack_should_initialize filter to respect when set to true. 

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-should-initialize-filter
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-should-initialize-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: jetpack_my_jetpack_should_initialize filter now respected when set to true.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -208,29 +208,28 @@ class Initializer {
 	}
 
 	/**
-	 * Return true if we should initialize the My Jetpack
+	 * Return true if we should initialize the My Jetpack admin page.
 	 */
 	public static function should_initialize() {
+		$should = true;
 
 		if ( is_multisite() ) {
-			return false;
+			$should = false;
+		}
+
+		// Do not initialize My Jetpack if site is not connected.
+		if ( ! ( new Connection_Manager() )->is_connected() ) {
+			$should = false;
 		}
 
 		/**
-		 * Allows filtering whether My Jetpack should be initialized
+		 * Allows filtering whether My Jetpack should be initialized.
 		 *
 		 * @since 0.5.0-alpha
 		 *
 		 * @param bool $shoud_initialize Should we initialize My Jetpack?
 		 */
-		$should = apply_filters( 'jetpack_my_jetpack_should_initialize', true );
-
-		// Do not initialize My Jetpack if site is not connected.
-		if ( ! ( new Connection_Manager() )->is_connected() ) {
-			return false;
-		}
-
-		return $should;
+		return apply_filters( 'jetpack_my_jetpack_should_initialize', $should );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Currently the filter gets superseded by the connection. It's expected that setting the filter manually should be the final decider on whether it should load. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Minor refactor of should_initialize() to respect `jetpack_my_jetpack_should_initialize` when set to true and not connected. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

With filters: 
- `add_filter( 'jetpack_my_jetpack_should_initialize', '__return_true' );` When the site is not connected should show My Jetpack. 

- `add_filter( 'jetpack_my_jetpack_should_initialize', '__return_false' );` When the site is connected should not show My Jetpack. 

No filter applied: 
- When not connected, no My Jetpack
- When connected, My Jetpack.
