### PR TITLE
Extensions: Wording change for WPcom workflow in README.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-extensions-documentation
+++ b/projects/plugins/jetpack/changelog/update-extensions-documentation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Very minor doc change.
+
+

--- a/projects/plugins/jetpack/extensions/README.md
+++ b/projects/plugins/jetpack/extensions/README.md
@@ -156,8 +156,8 @@ Simply add branch name to the URL: jurassic.ninja/create/?jetpack-beta&branch=ma
 ### How do I merge extensions to WordPress.com?
 
 - Merge to Jetpack master first.
-- Now, merge the auto-generated diff on WordPress.com.
-- There's no need to wait on release schedules, in fact it is best if you merge your WordPress.com diff immediately after you've merged to Jetpack master.
+- Then, merge the auto-generated diff on WordPress.com.
+- Note: before merging your WordPress.com diff, it is worth considering the release schedule if you are shipping a new feature. This is to avoid a situation where a new feature ends up on WordPress.com before anywhere else, and any subsequent site migrations mean that functionality is lost. Reach out to a Jetpack crew member if in doubt.
 
 ### What if I need to manually create a WordPress.com diff?
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Changing the information under ['How do I merge extensions to WordPress.com?'](https://github.com/Automattic/jetpack/blob/master/projects/plugins/jetpack/extensions/README.md#how-do-i-merge-extensions-to-wordpresscom) to explain more about the impact of release schedules when merging new features to WordPress.com.

#### Jetpack product discussion

p1647957549560379/1647508512.415689-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Check that the wording under ['How do I merge extensions to WordPress.com?'](https://github.com/Automattic/jetpack/blob/master/projects/plugins/jetpack/extensions/README.md#how-do-i-merge-extensions-to-wordpresscom) correctly conveys the possible issue - let me know if not!