### PR TITLE
Dedicated Sync: Allow spawning request with expired Retry-After

### DIFF
--- a/projects/packages/sync/changelog/fix-dedicated-sync-retry-after
+++ b/projects/packages/sync/changelog/fix-dedicated-sync-retry-after
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dedicated Sync: Allow spawning request with expired Retry-After

--- a/projects/packages/sync/src/class-dedicated-sender.php
+++ b/projects/packages/sync/src/class-dedicated-sender.php
@@ -58,9 +58,9 @@ class Dedicated_Sender {
 			return new WP_Error( 'empty_queue_' . $queue->id );
 		}
 
-		// Return early if we've gotten a retry-after header response.
+		// Return early if we've gotten a retry-after header response that is not expired.
 		$retry_time = get_option( Actions::RETRY_AFTER_PREFIX . $queue->id );
-		if ( $retry_time ) {
+		if ( $retry_time && $retry_time >= microtime( true ) ) {
 			return new WP_Error( 'retry_after_' . $queue->id );
 		}
 


### PR DESCRIPTION
Fixes a logic error in the Dedicated Sync flow:
When checking whether we should spawn the Dedicated Sync request we used to return an error if the corresponding `Retry-After` option was set.
This option is set when WPCOM sends us a `Retry-After` header in the response, however when checking it's possible that this is already expired.
If that's the case we need to actually spawn the Dedicated Sync request so that the corresponding option get's cleared.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* `Dedicated_Sender::spawn_sync`: Allow spawning the Dedicated Sync request if Retry-After is expired.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
**Before**
- In a connected JN site set this option to a past timestamp, aka `wp option update jp_sync_retry_after_sync 1648027252.236685`
- Enable Dedicated Sync `wp option update jetpack_sync_settings_dedicated_sync_enabled 1`
- Trigger some Sync related actions (eg adding a post) and note that the queue is never emptied: `wp jetpack sync status`

**After**
- Enable this branch using Jetpack Beta
- Trigger some Sync related actions (eg adding a post) and note that the queue is actually emptied
