### PR TITLE
Payment Blocks: Use correct product type nomenclature in the shared management controls

### DIFF
--- a/projects/plugins/jetpack/changelog/update-product-management-nomenclature
+++ b/projects/plugins/jetpack/changelog/update-product-management-nomenclature
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add distinct nomenclature to ProductManagementControls depending on product type

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/edit.js
@@ -16,6 +16,7 @@ import Context from './_inc/context';
 import './editor.scss';
 import ViewSelector from './_inc/view-selector';
 import ProductManagementControls from '../../shared/components/product-management-controls';
+import { PRODUCT_TYPE_SUBSCRIPTION } from '../../shared/components/product-management-controls/constants';
 import { store as membershipProductsStore } from '../../store/membership-products';
 
 /**
@@ -120,6 +121,7 @@ function Edit( props ) {
 					<ProductManagementControls
 						allowCreateOneTimeInterval={ false }
 						blockName="premium-content"
+						productType={ PRODUCT_TYPE_SUBSCRIPTION }
 						selectedProductId={ selectedPlanId }
 						setSelectedProductId={ setSelectedProductId }
 					/>

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/constants.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/constants.js
@@ -1,2 +1,5 @@
 export const API_STATE_NOT_REQUESTING = 0;
 export const API_STATE_REQUESTING = 1;
+
+export const PRODUCT_TYPE_PAYMENT_PLAN = 'payment-plan';
+export const PRODUCT_TYPE_SUBSCRIPTION = 'subscription';

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/index.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/index.js
@@ -7,6 +7,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import { PRODUCT_TYPE_PAYMENT_PLAN } from './constants';
 import ProductManagementInspectorControl from './inspector-control';
 import ProductManagementToolbarControl from './toolbar-control';
 import InvalidProductWarning from './invalid-product-warning';
@@ -18,6 +19,7 @@ import './style.scss';
 export default function ProductManagementControls( {
 	allowCreateOneTimeInterval = true,
 	blockName,
+	productType = PRODUCT_TYPE_PAYMENT_PLAN,
 	selectedProductId = 0,
 	setSelectedProductId = () => {},
 } ) {
@@ -55,10 +57,12 @@ export default function ProductManagementControls( {
 				<>
 					<ProductManagementInspectorControl
 						allowCreateOneTimeInterval={ allowCreateOneTimeInterval }
+						productType={ productType }
 						setSelectedProductId={ setSelectedProductId }
 					/>
 					<ProductManagementToolbarControl
 						products={ products }
+						productType={ productType }
 						selectedProductId={ selectedProductId }
 						setSelectedProductId={ setSelectedProductId }
 					/>

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/inspector-control.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/inspector-control.js
@@ -21,18 +21,22 @@ import { lock } from '@wordpress/icons';
  * Internal dependencies
  */
 import { API_STATE_NOT_REQUESTING, API_STATE_REQUESTING } from './constants';
+import { getMessageByProductType } from './utils';
 import { CURRENCY_OPTIONS } from '../../currencies';
 import { store as membershipProductsStore } from '../../../store/membership-products';
 
 export default function ProductManagementInspectorControl( {
 	allowCreateOneTimeInterval,
+	productType,
 	setSelectedProductId,
 } ) {
 	const siteSlug = useSelect( select => select( membershipProductsStore ).getSiteSlug() );
 	const { saveProduct } = useDispatch( membershipProductsStore );
 
 	const [ apiState, setApiState ] = useState( API_STATE_NOT_REQUESTING );
-	const [ title, setTitle ] = useState( __( 'Monthly Subscription', 'jetpack' ) );
+	const [ title, setTitle ] = useState(
+		getMessageByProductType( 'default new product title', productType )
+	);
 	const [ currency, setCurrency ] = useState( 'USD' );
 	const [ price, setPrice ] = useState( 5 );
 	const [ interval, setInterval ] = useState( '1 month' );
@@ -48,13 +52,18 @@ export default function ProductManagementInspectorControl( {
 	const handleSubmit = event => {
 		event.preventDefault();
 		setApiState( API_STATE_REQUESTING );
-		saveProduct( { title, currency, price, interval }, setSelectedProductId, success => {
-			setApiState( API_STATE_NOT_REQUESTING );
-			if ( success ) {
-				setPrice( 5 );
-				setTitle( '' );
+		saveProduct(
+			{ title, currency, price, interval },
+			productType,
+			setSelectedProductId,
+			success => {
+				setApiState( API_STATE_NOT_REQUESTING );
+				if ( success ) {
+					setPrice( 5 );
+					setTitle( '' );
+				}
 			}
-		} );
+		);
 	};
 
 	return (
@@ -64,19 +73,18 @@ export default function ProductManagementInspectorControl( {
 					href={ `https://wordpress.com/earn/payments/${ siteSlug }` }
 					className={ 'product-management-control-inspector__link-to-earn' }
 				>
-					{ __( 'Manage your subscriptions.', 'jetpack' ) }
+					{ getMessageByProductType( 'manage your products', productType ) }
 				</ExternalLink>
 			) }
 			<PanelBody
-				title={ __( 'Add a new subscription', 'jetpack' ) }
+				title={ getMessageByProductType( 'add a new product', productType ) }
 				initialOpen={ true }
 				className={ 'product-management-control-inspector__add-plan' }
 			>
 				{ apiState === API_STATE_REQUESTING && (
 					<Placeholder
 						icon={ lock }
-						label={ __( 'Premium Content', 'jetpack' ) }
-						instructions={ __( 'Saving plan…', 'jetpack' ) }
+						label={ getMessageByProductType( 'saving product', productType ) }
 					>
 						<Spinner />
 					</Placeholder>
@@ -115,7 +123,7 @@ export default function ProductManagementInspectorControl( {
 						</PanelRow>
 						<PanelRow>
 							<Button onClick={ handleSubmit } variant="secondary">
-								{ __( 'Add subscription', 'jetpack' ) }
+								{ getMessageByProductType( 'add product', productType ) }
 							</Button>
 						</PanelRow>
 					</>

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/toolbar-control.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/toolbar-control.js
@@ -16,6 +16,7 @@ import { check, update, warning } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import { getMessageByProductType } from './utils';
 import { store as membershipProductsStore } from '../../../store/membership-products';
 
 function getProductDescription( product ) {
@@ -64,7 +65,7 @@ function Product( { onClose, product, selectedProductId, setSelectedProductId } 
 	);
 }
 
-function NewProduct( { onClose } ) {
+function NewProduct( { onClose, productType } ) {
 	const isEditorSidebarOpened = useSelect( select =>
 		select( editPostStore ).isEditorSidebarOpened()
 	);
@@ -84,11 +85,16 @@ function NewProduct( { onClose } ) {
 		onClose();
 	};
 
-	return <MenuItem onClick={ handleClick }>{ __( 'Add a new subscription', 'jetpack' ) }</MenuItem>;
+	return (
+		<MenuItem onClick={ handleClick }>
+			{ getMessageByProductType( 'add a new product', productType ) }
+		</MenuItem>
+	);
 }
 
 export default function ProductManagementToolbarControl( {
 	products,
+	productType,
 	selectedProductId,
 	setSelectedProductId,
 } ) {
@@ -103,7 +109,7 @@ export default function ProductManagementToolbarControl( {
 		productDescription = getProductDescription( selectedProduct );
 	}
 	if ( selectedProductId && ! selectedProduct ) {
-		productDescription = __( 'Subscription not found', 'jetpack' );
+		productDescription = getMessageByProductType( 'product not found', productType );
 		subscriptionIcon = warning;
 	}
 
@@ -112,7 +118,7 @@ export default function ProductManagementToolbarControl( {
 			<ToolbarDropdownMenu
 				className="product-management-control-toolbar__dropdown-button"
 				icon={ subscriptionIcon }
-				label={ __( 'Select a plan', 'jetpack' ) }
+				label={ getMessageByProductType( 'select a product', productType ) }
 				text={ productDescription }
 			>
 				{ ( { onClose } ) => (
@@ -129,7 +135,7 @@ export default function ProductManagementToolbarControl( {
 							) ) }
 						</MenuGroup>
 						<MenuGroup>
-							<NewProduct onClose={ onClose } />
+							<NewProduct onClose={ onClose } productType={ productType } />
 						</MenuGroup>
 					</>
 				) }

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/utils.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/utils.js
@@ -1,0 +1,66 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { PRODUCT_TYPE_PAYMENT_PLAN, PRODUCT_TYPE_SUBSCRIPTION } from './constants';
+
+const messages = {
+	'add a new product': {
+		[ PRODUCT_TYPE_PAYMENT_PLAN ]: __( 'Add a new payment plan', 'jetpack' ),
+		[ PRODUCT_TYPE_SUBSCRIPTION ]: __( 'Add a new subscription', 'jetpack' ),
+	},
+	'product not found': {
+		[ PRODUCT_TYPE_PAYMENT_PLAN ]: __( 'Payment plan not found', 'jetpack' ),
+		[ PRODUCT_TYPE_SUBSCRIPTION ]: __( 'Subscription not found', 'jetpack' ),
+	},
+	'select a product': {
+		[ PRODUCT_TYPE_PAYMENT_PLAN ]: __( 'Select a payment plan', 'jetpack' ),
+		[ PRODUCT_TYPE_SUBSCRIPTION ]: __( 'Select a subscription', 'jetpack' ),
+	},
+	'default new product title': {
+		[ PRODUCT_TYPE_PAYMENT_PLAN ]: __( 'Monthly Subscription', 'jetpack' ),
+		[ PRODUCT_TYPE_SUBSCRIPTION ]: __( 'Monthly Subscription', 'jetpack' ),
+	},
+	'manage your products': {
+		[ PRODUCT_TYPE_PAYMENT_PLAN ]: __( 'Manage your payment plans.', 'jetpack' ),
+		[ PRODUCT_TYPE_SUBSCRIPTION ]: __( 'Manage your subscriptions.', 'jetpack' ),
+	},
+	'saving product': {
+		[ PRODUCT_TYPE_PAYMENT_PLAN ]: __( 'Saving payment plan…', 'jetpack' ),
+		[ PRODUCT_TYPE_SUBSCRIPTION ]: __( 'Saving subscription…', 'jetpack' ),
+	},
+	'add product': {
+		[ PRODUCT_TYPE_PAYMENT_PLAN ]: __( 'Add payment plan', 'jetpack' ),
+		[ PRODUCT_TYPE_SUBSCRIPTION ]: __( 'Add subscription', 'jetpack' ),
+	},
+	'product requires a name': {
+		[ PRODUCT_TYPE_PAYMENT_PLAN ]: __( 'Payment plan requires a name', 'jetpack' ),
+		[ PRODUCT_TYPE_SUBSCRIPTION ]: __( 'Subscription requires a name', 'jetpack' ),
+	},
+	'product requires a valid price': {
+		[ PRODUCT_TYPE_PAYMENT_PLAN ]: __( 'Payment plan requires a valid price', 'jetpack' ),
+		[ PRODUCT_TYPE_SUBSCRIPTION ]: __( 'Subscription requires a valid price', 'jetpack' ),
+	},
+	'successfully created product': {
+		[ PRODUCT_TYPE_PAYMENT_PLAN ]: __( 'Successfully created payment plan', 'jetpack' ),
+		[ PRODUCT_TYPE_SUBSCRIPTION ]: __( 'Successfully created subscription', 'jetpack' ),
+	},
+	'there was an error when adding the product': {
+		[ PRODUCT_TYPE_PAYMENT_PLAN ]: __(
+			'There was an error when adding the payment plan.',
+			'jetpack'
+		),
+		[ PRODUCT_TYPE_SUBSCRIPTION ]: __(
+			'There was an error when adding the subscription.',
+			'jetpack'
+		),
+	},
+};
+
+export function getMessageByProductType( message, productType = PRODUCT_TYPE_PAYMENT_PLAN ) {
+	return messages?.[ message ]?.[ productType ] || null;
+}

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/utils.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/utils.js
@@ -8,6 +8,15 @@ import { __ } from '@wordpress/i18n';
  */
 import { PRODUCT_TYPE_PAYMENT_PLAN, PRODUCT_TYPE_SUBSCRIPTION } from './constants';
 
+/**
+ * This list is supposed to be used by the ProductManagementControls component
+ * and the jetpack/membership-products store, based on a given product type.
+ * We've chosen this centralized approach instead of the more common `sprintf`
+ * because it's a bit clearer, generates less cognitive load on the
+ * component's consumers, and it's easier to maintain.
+ *
+ * @see p1648029677784879-slack-CDLH4C1UZ
+ */
 const messages = {
 	'add a new product': {
 		[ PRODUCT_TYPE_PAYMENT_PLAN ]: __( 'Add a new payment plan', 'jetpack' ),
@@ -22,6 +31,7 @@ const messages = {
 		[ PRODUCT_TYPE_SUBSCRIPTION ]: __( 'Select a subscription', 'jetpack' ),
 	},
 	'default new product title': {
+		// The PAYMENT_PLAN message is intentionally the same as SUBSCRIPTION.
 		[ PRODUCT_TYPE_PAYMENT_PLAN ]: __( 'Monthly Subscription', 'jetpack' ),
 		[ PRODUCT_TYPE_SUBSCRIPTION ]: __( 'Monthly Subscription', 'jetpack' ),
 	},

--- a/projects/plugins/jetpack/extensions/store/membership-products/actions.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/actions.js
@@ -15,6 +15,8 @@ import { __, sprintf } from '@wordpress/i18n';
 import { STORE_NAME } from './constants';
 import { onError, onSuccess } from './utils';
 import { isPriceValid, minimumTransactionAmountForCurrency } from '../../shared/currencies';
+import { PRODUCT_TYPE_PAYMENT_PLAN } from '../../shared/components/product-management-controls/constants';
+import { getMessageByProductType } from '../../shared/components/product-management-controls/utils';
 
 export const setProducts = products => ( {
 	type: 'SET_PRODUCTS',
@@ -48,13 +50,14 @@ export const setUpgradeUrl = upgradeUrl => ( {
 
 export const saveProduct = (
 	product,
+	productType = PRODUCT_TYPE_PAYMENT_PLAN,
 	setSelectedProductId = () => {},
 	callback = () => {}
 ) => async ( { dispatch, registry } ) => {
 	const { title, price, currency } = product;
 
 	if ( ! title || 0 === title.length ) {
-		onError( __( 'Plan requires a name', 'jetpack' ), registry );
+		onError( getMessageByProductType( 'product requires a name', productType ), registry );
 		callback( false );
 		return;
 	}
@@ -67,13 +70,14 @@ export const saveProduct = (
 				// translators: %s: Price
 				__( 'Minimum allowed price is %s.', 'jetpack' ),
 				formatCurrency( minPrice, currency )
-			)
+			),
+			registry
 		);
 		callback( false );
 		return;
 	}
 	if ( ! isPriceValid( currency, parsedPrice ) ) {
-		onError( __( 'Plan requires a valid price', 'jetpack' ), registry );
+		onError( getMessageByProductType( 'product requires a valid price', productType ), registry );
 		callback( false );
 		return;
 	}
@@ -97,10 +101,13 @@ export const saveProduct = (
 
 		dispatch( setProducts( products.concat( [ newProduct ] ) ) );
 		setSelectedProductId( newProduct.id );
-		onSuccess( __( 'Successfully created plan', 'jetpack' ), registry );
+		onSuccess( getMessageByProductType( 'successfully created product', productType ), registry );
 		callback( true );
 	} catch ( error ) {
-		onError( __( 'There was an error when adding the plan.', 'jetpack' ), registry );
+		onError(
+			getMessageByProductType( 'there was an error when adding the product', productType ),
+			registry
+		);
 		callback( false );
 	}
 };

--- a/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
@@ -3,7 +3,6 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { store as editorStore } from '@wordpress/editor';
-import { __ } from '@wordpress/i18n';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
 
 /**
@@ -21,11 +20,14 @@ import {
 import { onError } from './utils';
 import { API_STATE_CONNECTED, API_STATE_NOTCONNECTED } from './constants';
 import getConnectUrl from '../../shared/get-connect-url';
+import { PRODUCT_TYPE_PAYMENT_PLAN } from '../../shared/components/product-management-controls/constants';
+import { getMessageByProductType } from '../../shared/components/product-management-controls/utils';
 
-export const getProducts = ( selectedProductId = 0, setSelectedProductId = () => {} ) => async ( {
-	dispatch,
-	registry,
-} ) => {
+export const getProducts = (
+	productType = PRODUCT_TYPE_PAYMENT_PLAN,
+	selectedProductId = 0,
+	setSelectedProductId = () => {}
+) => async ( { dispatch, registry } ) => {
 	const origin = getQueryArg( window.location.href, 'origin' );
 	const path = addQueryArgs( '/wpcom/v2/memberships/status', {
 		source: origin === 'https://wordpress.com' ? 'gutenberg-wpcom' : 'gutenberg',
@@ -68,11 +70,12 @@ export const getProducts = ( selectedProductId = 0, setSelectedProductId = () =>
 			await dispatch(
 				saveProduct(
 					{
-						title: __( 'Monthly Subscription', 'jetpack' ),
+						title: getMessageByProductType( 'default new product title', productType ),
 						currency: 'USD',
 						price: 5,
 						interval: '1 month',
 					},
+					productType,
 					setSelectedProductId
 				)
 			);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #23571

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add a list of strings to be used by the `ProductManagementControls` component and the `jetpack/membership-products` store, based on a given product type.

We've chosen this centralized approach instead of the more common `sprintf` because it's a bit clearer, generates less cognitive load on the component's consumers, and it's easier to maintain.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1648029677784879-slack-CDLH4C1UZ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox a WordPress.com site on a paid plan and an active Stripe connection.
* Open the editor and insert a Premium Content block.
* Look around the block (toolbar, sidebar), try adding new products.
* Make sure all the strings and messages are about "subscriptions".
