### PR TITLE
Premium content block: Fixed store middleware regression on older Gutenberg versions.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-gutenberg-store-error
+++ b/projects/plugins/jetpack/changelog/fix-gutenberg-store-error
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Fixed a Redux store middleware regression on older Gutenberg versions
+Premium Content Block: fix a Redux store middleware regression on older Gutenberg versions.

--- a/projects/plugins/jetpack/changelog/fix-gutenberg-store-error
+++ b/projects/plugins/jetpack/changelog/fix-gutenberg-store-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed a Redux store middleware regression on older Gutenberg versions

--- a/projects/plugins/jetpack/extensions/store/membership-products/index.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/index.js
@@ -17,6 +17,7 @@ export const store = createReduxStore( STORE_NAME, {
 	reducer,
 	resolvers,
 	selectors,
+	__experimentalUseThunks: true,
 } );
 
 register( store );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Fixes a Redux Store regression for Premium content block
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes a regression in Premium content block when the Gutenberg plugin is disabled on Atomic sites.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Atomic: Switch to this branch using Jetpack Beta
* Disable the Gutenberg plugin on your site
* Go to wp-admin/post-new.php
* Add the Premium Content block.
* Make sure the block is added without displaying an error in the console log: 
