### PR TITLE
Remove/atomic plan manager

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-atomic-plan-manager
+++ b/projects/plugins/jetpack/changelog/remove-atomic-plan-manager
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Removed unneeded calls to Atomic_Plan_Manager

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -120,13 +120,9 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		// Calypso plugins screens link.
 		$plugins_slug = 'https://wordpress.com/plugins/' . $this->domain;
 
-		// `wpcomsh` restricts the plugins capabilities when the site doesn't have a
-		// supported plan so the Plugins menu it's not registered. We still want the
-		// menu to be available though, since it offers an opportunity to buy again
-		// the needed plan.
-		if ( ! $this->has_atomic_supported_plan() ) {
-			add_menu_page( 'Plugins', 'Plugins', 'manage_options', $plugins_slug, null, 'dashicons-admin-plugins', '65' );
-
+		// Link to the Marketplace on sites that can't manage plugins.
+		if ( ! wpcom_site_has_feature( WPCOM_Features::MANAGE_PLUGINS ) ) {
+			add_menu_page( __( 'Plugins', 'jetpack' ), __( 'Plugins', 'jetpack' ), 'manage_options', $plugins_slug, null, 'dashicons-admin-plugins', '65' );
 			return;
 		}
 
@@ -356,11 +352,9 @@ class Atomic_Admin_Menu extends Admin_Menu {
 				2
 			);
 		}
-		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 11 );
 
-		if ( $this->has_atomic_supported_plan() ) {
-			add_submenu_page( 'options-general.php', esc_attr__( 'Jetpack', 'jetpack' ), __( 'Jetpack', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/jetpack/' . $this->domain, null, 12 );
-		}
+		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 11 );
+		add_submenu_page( 'options-general.php', esc_attr__( 'Jetpack', 'jetpack' ), __( 'Jetpack', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/jetpack/' . $this->domain, null, 12 );
 
 		// Page Optimize is active by default on all Atomic sites and registers a Settings > Performance submenu which
 		// would conflict with our own Settings > Performance that links to Calypso, so we hide it it since the Calypso
@@ -429,17 +423,5 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 */
 	public function hide_search_menu_for_calypso() {
 		$this->hide_submenu_page( 'jetpack', 'https://wordpress.com/jetpack-search/' . $this->domain );
-	}
-
-	/**
-	 * Check if site has Atomic supported plan. `Atomic_Plan_Manager` lives in wpcomsh
-	 */
-	protected function has_atomic_supported_plan() {
-		// Fallback to default behavior if Atomic_Plan_Manager doesn't exists.
-		if ( ! class_exists( 'Atomic_Plan_Manager' ) ) {
-			return true;
-		}
-
-		return \Atomic_Plan_Manager::has_atomic_supported_plan();
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes calls to Atomic_Plan_Manager
*  Replaces on call to use the new `wpcom_has_site_feature()` function.


#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install Jetpack Beta on an Atomic site and switch to this branch
* Make sure that the Settings > Jetpack menu item is available on all plans.  
* Make sure the Plugin menu item only exists once on sites with Business/eCommerce plans.
* Make sure there's a Plugins menu item on sites on a free plan.

