### PR TITLE
Jetpack: Improve slightly the styles of Dashboard cards

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6312,7 +6312,6 @@ packages:
       react-dom: 17.0.2_react@17.0.2
       react-error-boundary: 3.1.4_react@17.0.2
       react-test-renderer: 17.0.2_react@17.0.2
-    dev: false
 
   /@testing-library/react-hooks/8.0.0_bllccsag72s5i2q7zhblnmav4q:
     resolution: {integrity: sha512-uZqcgtcUUtw7Z9N32W13qQhVAD+Xki2hxbTR461MKax8T6Jr8nsUvZB+vcBTkzY2nFvsUet434CsgF0ncW2yFw==}
@@ -16998,7 +16997,6 @@ packages:
 
   /preact/10.5.15:
     resolution: {integrity: sha512-5chK29n6QcJc3m1lVrKQSQ+V7K1Gb8HeQY6FViQ5AxCAEGu3DaHffWNDkC9+miZgsLvbvU9rxbV1qinGHMHzqA==}
-    dev: false
 
   /prelude-ls/1.1.2:
     resolution: {integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==}
@@ -18522,7 +18520,6 @@ packages:
     hasBin: true
     dependencies:
       chokidar: 3.5.3
-    dev: false
 
   /sass/1.43.3:
     resolution: {integrity: sha512-BJnLngqWpMeS65UvlYYEuCb3/fLxDxhHtOB/gWPxs6NKrslTxGt3ZxwIvOe/0Jm4tWwM/+tIpE3wj4dLEhPDeQ==}
@@ -19452,7 +19449,6 @@ packages:
   /svelte/3.42.4:
     resolution: {integrity: sha512-DqC0AmDdBrrbIA+Kzl3yhBb6qCn4vZOAfxye2pTnIpinLegyagC5sLI8Pe9GPlXu9VpHBXIwpDDedpMfu++epA==}
     engines: {node: '>= 8'}
-    dev: true
 
   /svelte2tsx/0.1.193_jnm2dayjvyndfzimboulpsettu:
     resolution: {integrity: sha512-vzy4YQNYDnoqp2iZPnJy7kpPAY6y121L0HKrSBjU/IWW7DQ6T7RMJed2VVHFmVYm0zAGYMDl9urPc6R4DDUyhg==}

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/akismet.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/akismet.jsx
@@ -140,6 +140,7 @@ class DashAkismet extends Component {
 			if ( this.props.isOfflineMode ) {
 				return (
 					<DashItem
+						headerIcon="anti-spam"
 						label={ labelName }
 						module="akismet"
 						support={ support }
@@ -182,7 +183,13 @@ class DashAkismet extends Component {
 
 		if ( 'N/A' === akismetData ) {
 			return (
-				<DashItem label={ labelName } module="akismet" support={ support } pro={ true }>
+				<DashItem
+					headerIcon="anti-spam"
+					label={ labelName }
+					module="akismet"
+					support={ support }
+					pro={ true }
+				>
 					<p className="jp-dash-item__description">{ __( 'Loading…', 'jetpack' ) }</p>
 				</DashItem>
 			);
@@ -192,6 +199,7 @@ class DashAkismet extends Component {
 			if ( 'not_installed' === akismetData ) {
 				return (
 					<DashItem
+						headerIcon="anti-spam"
 						label={ labelName }
 						module="akismet"
 						support={ support }
@@ -205,6 +213,7 @@ class DashAkismet extends Component {
 			if ( 'not_active' === akismetData ) {
 				return (
 					<DashItem
+						headerIcon="anti-spam"
 						label={ labelName }
 						module="akismet"
 						support={ support }
@@ -218,6 +227,7 @@ class DashAkismet extends Component {
 			if ( 'invalid_key' === akismetData ) {
 				return (
 					<DashItem
+						headerIcon="anti-spam"
 						label={ labelName }
 						module="akismet"
 						support={ support }
@@ -232,6 +242,7 @@ class DashAkismet extends Component {
 		if ( [ 'not_installed', 'not_active', 'invalid_key' ].includes( akismetData ) ) {
 			return (
 				<DashItem
+					headerIcon="anti-spam"
 					label={ labelName }
 					module="akismet"
 					support={ support }
@@ -248,6 +259,7 @@ class DashAkismet extends Component {
 
 		return [
 			<DashItem
+				headerIcon="anti-spam"
 				key="comment-moderation"
 				label={ labelName }
 				module="akismet"

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/backups.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/backups.jsx
@@ -30,6 +30,7 @@ import BackupUpgrade from './backup-upgrade';
  */
 const renderCard = props => (
 	<DashItem
+		headerIcon="backup"
 		label={ __( 'Backup', 'jetpack' ) }
 		module={ props.feature || 'backups' }
 		support={ {

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
@@ -22,6 +22,7 @@ class DashBoost extends Component {
 	render() {
 		return (
 			<PluginDashItem
+				headerIcon="boost"
 				iconAlt={ __( 'Plugin icon', 'jetpack' ) }
 				iconSrc={ boostSvgUrl }
 				pluginName={ _x(

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/crm/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/crm/index.jsx
@@ -19,6 +19,7 @@ class DashCRM extends Component {
 	render() {
 		return (
 			<PluginDashItem
+				headerIcon="crm"
 				iconAlt={ __( 'Plugin icon', 'jetpack' ) }
 				iconSrc={ peopleSvgUrl }
 				pluginName={ _x(

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/scan.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/scan.jsx
@@ -40,6 +40,7 @@ import { isPluginInstalled } from 'state/site/plugins';
  */
 const renderCard = props => (
 	<DashItem
+		headerIcon="scan"
 		label={ __( 'Scan', 'jetpack' ) }
 		module={ props.feature || 'scan' }
 		support={ {

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/search.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/search.jsx
@@ -29,6 +29,7 @@ const SEARCH_SUPPORT = __( 'Search supports many customizations. ', 'jetpack' );
  */
 const renderCard = props => (
 	<DashItem
+		headerIcon="search"
 		label={ __( 'Search', 'jetpack' ) }
 		module="search"
 		support={ {

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/videopress.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/videopress.jsx
@@ -78,6 +78,7 @@ class DashVideoPress extends Component {
 		if ( this.props.getOptionValue( 'videopress' ) && hasConnectedOwner ) {
 			return (
 				<DashItem
+					headerIcon="videopress"
 					className="jp-dash-item__videopress"
 					label={ labelName }
 					module="videopress"

--- a/projects/plugins/jetpack/_inc/client/components/banner/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/banner/index.jsx
@@ -167,7 +167,6 @@ export class Banner extends Component {
 				href={ callToAction ? null : this.getHref() }
 				onClick={ callToAction ? noop : this.handleClick }
 			>
-				{ this.getIcon() }
 				{ this.getContent() }
 			</Card>
 		);

--- a/projects/plugins/jetpack/_inc/client/components/dash-item/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/dash-item/index.jsx
@@ -1,4 +1,4 @@
-import { getRedirectUrl } from '@automattic/jetpack-components';
+import { getIconBySlug, getRedirectUrl } from '@automattic/jetpack-components';
 import { __, _x } from '@wordpress/i18n';
 import classNames from 'classnames';
 import Button from 'components/button';
@@ -20,6 +20,7 @@ import { getModule as _getModule } from 'state/modules';
 
 export class DashItem extends Component {
 	static propTypes = {
+		headerIcon: PropTypes.string,
 		label: PropTypes.string,
 		status: PropTypes.string,
 		statusText: PropTypes.string,
@@ -136,10 +137,16 @@ export class DashItem extends Component {
 		if ( this.props.module && this.props.getModule ) {
 			module = this.props.getModule( this.props.module );
 		}
-
+		const HeaderIcon = this.props.headerIcon && getIconBySlug( this.props.headerIcon );
+		const label = (
+			<>
+				{ this.props.headerIcon && <HeaderIcon /> }
+				{ this.props.label }
+			</>
+		);
 		return (
 			<div className={ classes }>
-				<SectionHeader label={ this.props.label } cardBadge={ proButton }>
+				<SectionHeader label={ label } cardBadge={ proButton }>
 					{ this.props.userCanToggle ? toggle : '' }
 				</SectionHeader>
 				{ this.props.overrideContent ? (

--- a/projects/plugins/jetpack/_inc/client/components/dash-item/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/dash-item/style.scss
@@ -22,10 +22,14 @@
 			font-weight: normal;
 		}
 	}
-
 	.dops-card.dops-section-header.is-compact,
 	.dops-card.is-card-link.is-compact {
 		padding: 8px 16px;
+	}
+
+	.dops-card.dops-section-header
+		.dops-section-header__label-text {
+			font-weight: 500;
 	}
 
 	.dops-card.jp-dash-item__card {

--- a/projects/plugins/jetpack/_inc/client/components/dash-item/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/dash-item/style.scss
@@ -138,7 +138,6 @@
 		}
 	}
 	.jp-dash-item__description {
-		font-style: italic;
 		color: darken( $gray, 20% );
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/components/dash-item/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/dash-item/style.scss
@@ -14,6 +14,23 @@
 			margin: 0;
 		}
 	}
+
+	.dops-card.dops-banner {
+		border-left: none;
+
+		.dops-banner__info .dops-banner__title {
+			font-weight: normal;
+		}
+	}
+
+	.dops-card.dops-section-header.is-compact,
+	.dops-card.is-card-link.is-compact {
+		padding: 8px 16px;
+	}
+
+	.dops-card.jp-dash-item__card {
+		padding:16px;
+	}
 }
 
 .jp-dash-item__content {

--- a/projects/plugins/jetpack/_inc/client/components/dash-item/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/dash-item/style.scss
@@ -30,6 +30,11 @@
 	.dops-card.dops-section-header
 		.dops-section-header__label-text {
 			font-weight: 500;
+			display: flex;
+			align-items: center;
+			svg {
+				margin-right:8px;
+			}
 	}
 
 	.dops-card.jp-dash-item__card {

--- a/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/README.md
+++ b/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/README.md
@@ -9,6 +9,7 @@ import PluginDashItem from 'components/plugin-dash-item';
 
 export default BoostDashItem = () =>
 	<PluginDashItem
+		headerIcon="boost"
 		pluginName="Boost"
 		pluginFiles={ [ 'jetpack-boost/jetpack-boost.php' ] }
 		pluginSlug={ 'jetpack-boost' }

--- a/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/index.jsx
@@ -1,4 +1,5 @@
 import restApi from '@automattic/jetpack-api';
+import { getIconBySlug } from '@automattic/jetpack-components';
 import { Spinner } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import Card from 'components/card';
@@ -19,6 +20,7 @@ import './style.scss';
 
 export const PluginDashItem = ( {
 	fetchPluginsData,
+	headerIcon,
 	iconAlt,
 	iconSrc,
 	installOrActivatePrompt,
@@ -141,15 +143,25 @@ export const PluginDashItem = ( {
 		);
 	};
 
+	const Icon = getIconBySlug( headerIcon );
+	const label = Icon ? (
+		<>
+			{ Icon && <Icon /> }
+			{ pluginName }
+		</>
+	) : (
+		pluginName
+	);
 	return (
 		<div className="plugin-dash-item">
-			<SectionHeader className="plugin-dash-item__section-header" label={ pluginName } />
+			<SectionHeader className="plugin-dash-item__section-header" label={ label } />
 			{ renderContent() }
 		</div>
 	);
 };
 
 PluginDashItem.propTypes = {
+	headerIcon: PropTypes.string,
 	pluginName: PropTypes.string.isRequired,
 	pluginFiles: PropTypes.arrayOf( PropTypes.string ).isRequired,
 	pluginSlug: PropTypes.string.isRequired,

--- a/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/style.scss
@@ -20,10 +20,15 @@
 	}
 
 	.dops-card.dops-section-header
-		.dops-section-header__label-text {
+	.dops-section-header__label-text {
 			font-weight: 500;
+			display: flex;
+			align-items: center;
+			svg {
+				margin-right:8px;
+			}
 	}
-		
+
 	.dops-banner.dops-card {
 		border-left: none;
 

--- a/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/style.scss
@@ -15,8 +15,22 @@
 		margin-bottom: 0;
 	}
 
+	.dops-card.dops-section-header.is-compact {
+		padding: 8px 16px;
+	}
+
+	.dops-card.dops-section-header
+		.dops-section-header__label-text {
+			font-weight: 500;
+	}
+		
 	.dops-banner.dops-card {
-		border-left-color: $color-product;
+		border-left: none;
+
+		.dops-banner__info .dops-banner__title {
+			font-weight: normal;
+		}
+
 		height: 100%;
 		.dops-banner__icons {
 

--- a/projects/plugins/jetpack/_inc/client/components/section-header/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/section-header/index.jsx
@@ -1,6 +1,5 @@
-import classNames from 'classnames';
 import Card from 'components/card';
-import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import React from 'react';
 
 import './style.scss';

--- a/projects/plugins/jetpack/_inc/client/components/section-header/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/section-header/index.jsx
@@ -8,10 +8,6 @@ import './style.scss';
 export default class SectionHeader extends React.Component {
 	static displayName = 'SectionHeader';
 
-	static propTypes = {
-		label: PropTypes.string,
-	};
-
 	static defaultProps = {
 		label: '',
 	};

--- a/projects/plugins/jetpack/_inc/client/components/section-header/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/section-header/index.jsx
@@ -1,5 +1,5 @@
-import Card from 'components/card';
 import classNames from 'classnames';
+import Card from 'components/card';
 import React from 'react';
 
 import './style.scss';

--- a/projects/plugins/jetpack/changelog/update-slightly-improve-admin-dashboar-cards-style
+++ b/projects/plugins/jetpack/changelog/update-slightly-improve-admin-dashboar-cards-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Improve margin, padding, anf font-style on dashboard item cards


### PR DESCRIPTION
Updates some styles on the admin page to transition into future card styles

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Takes control of paddings
* Adds icons to section headers
* Removes usage of italics in cards

<table>
<tr>
<td>After<br/>
<img width="1005" alt="image" src="https://user-images.githubusercontent.com/746152/159886811-0b050cd7-e5e4-4f2c-9e09-99c5b01463bb.png">
</td>

<td>Before<br/>
<img width="1013" alt="image" src="https://user-images.githubusercontent.com/746152/159884823-eb49724e-e658-4bba-9454-43a610e026c2.png"></td>
</table>

<table>
<tr>
<td>After<br/>
<img width="1015" alt="image" src="https://user-images.githubusercontent.com/746152/159887180-6eafdaf6-8d3c-4eb8-bf37-af991b9565cb.png">

</td>

<td>Before<br/>
<img width="1005" alt="image" src="https://user-images.githubusercontent.com/746152/159887237-81a621d9-ffa2-43b6-8234-c5c720f2eef8.png">
</td>
</table>

<table>
<tr>
<td>After<br/>

<img width="1012" alt="image" src="https://user-images.githubusercontent.com/746152/159887504-47786266-65e7-4b35-b781-b1dab6d94b49.png">

</td>

<td>Before<br/>
<img width="1014" alt="image" src="https://user-images.githubusercontent.com/746152/159887307-dd60787c-a500-4ed9-be8d-d7ce85f36217.png">
</td>
</table>



#### Jetpack product discussion
 Based on a rapid mockup

![image](https://user-images.githubusercontent.com/746152/159884596-a3e96d00-e0af-4ed8-a9c3-492fd9128f43.png)


#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
1. checkout this branch... Connect Jetpack, visit the dashboard. 
2. Expect to see... (incoming list of changes)
