### PR TITLE
Jetpack CLI: Update .gitattributes generated by starter-plugin as a template

### DIFF
--- a/projects/plugins/starter-plugin/.gitattributes
+++ b/projects/plugins/starter-plugin/.gitattributes
@@ -6,11 +6,31 @@ package.json      export-ignore
 # Files to include in the mirror repo, but excluded via gitignore
 # Remember to end all directories with `/**` to properly tag every file.
 # /src/js/example.min.js  production-include
+build/**                                        production-include
+jetpack_vendor/**                               production-include
+vendor/autoload.php                             production-include
+vendor/autoload_packages.php                    production-include
+vendor/automattic/**                            production-include
+vendor/composer/**                              production-include
+vendor/jetpack-autoloader/**                    production-include
 
 # Files to exclude from the mirror repo, but included in the monorepo.
 # Remember to end all directories with `/**` to properly tag every file.
-.gitignore        production-exclude
-.phpcs.dir.xml    production-exclude
-changelog/**      production-exclude
-phpunit.xml.dist  production-exclude
-tests/**          production-exclude
+.babelrc                                        production-exclude
+/.eslintrc.js                                   production-exclude
+.gitattributes                                  production-exclude
+.gitignore                                      production-exclude
+.phpcs.dir.xml                                  production-exclude
+babel.config.js                                 production-exclude
+build/**/*.js.map                               production-exclude
+changelog/**                                    production-exclude
+composer.lock                                   production-exclude
+package.json                                    production-exclude
+phpunit.xml.dist                                production-exclude
+README.md                                       production-exclude
+src/js/**                                       production-exclude
+tests/**                                        production-exclude
+/vendor/automattic/jetpack-autoloader/**        production-exclude
+/vendor/automattic/jetpack-changelogger/**      production-exclude
+/vendor/automattic/jetpack-composer-plugin/**   production-exclude
+webpack.config.js                               production-exclude

--- a/projects/plugins/starter-plugin/changelog/update-starter-plugin-git-attributes-for-proper-building
+++ b/projects/plugins/starter-plugin/changelog/update-starter-plugin-git-attributes-for-proper-building
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Updated .gitattributes file so it is able to build properly by the CI build jobs


### PR DESCRIPTION
Follow up to  #23434


See report in https://github.com/Automattic/jetpack/pull/23589#issuecomment-1077482685

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*  Updates the file `.gitattributes` so it has the proper entries for buildnig properly on CI


#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to  checks, download the `plugins` artifact for this build
* Unzip the file.
* Unzip the file `jetpack-protect-dev` and confirm it includes the `vendor` and `jetpack_vendor` dirs
