### PR TITLE
beta: Set `Update URI` in the plugin header

### DIFF
--- a/projects/plugins/beta/changelog/add-beta-plugin-update-uri
+++ b/projects/plugins/beta/changelog/add-beta-plugin-update-uri
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Set `Update URI` in the plugin header.

--- a/projects/plugins/beta/jetpack-beta.php
+++ b/projects/plugins/beta/jetpack-beta.php
@@ -6,6 +6,7 @@
  * Version: 3.1.2-alpha
  * Author: Automattic
  * Author URI: https://jetpack.com/
+ * Update URI: https://jetpack.com/download-jetpack-beta/
  * License: GPLv2 or later
  * Text Domain: jetpack-beta
  *

--- a/projects/plugins/beta/src/class-autoupdateself.php
+++ b/projects/plugins/beta/src/class-autoupdateself.php
@@ -162,6 +162,8 @@ class AutoupdateSelf {
 	 * when an update is available. This is the way: catch the setting of the relevant
 	 * transient and add ourself in.
 	 *
+	 * @todo Consider switching to the `update_plugins_${hostmane}` hook introduced in WP 5.8.
+	 *
 	 * @param object $transient The transient we're checking.
 	 * @return object $transient
 	 */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
WordPress 5.8 [added an "Update URI" plugin header][1], to make it clearer
when a plugin is not supposed to be hosted in the WordPress.org
repository. This helps prevent them from being accidentally submitted
there, and prevents accidental updates if someone somehow gets a plugin
registered there under the name.

Since the Jetpack Beta plugin cannot be hosted there (its whole point
goes against their rule 8, AFAICT), let's set that header.

WP 5.8 also introduced a new filter that could be used for the Beta
plugin's self-updates, but changing to use that is left for a future PR.
We still need to use the existing method for managed plugins anyway.

[1]: p2AvED-nam-p2

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Nothing really to test. Just verify that the added header looks sensible.