### PR TITLE
Payment Blocks: Fix "add new" not opening the block sidebar on site and widgets editor.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-product-manager-site-editor
+++ b/projects/plugins/jetpack/changelog/fix-product-manager-site-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix ProductManagementControls not being able to open the block settings sidebar on site and widgets editor.

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/toolbar-control.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/toolbar-control.js
@@ -8,14 +8,14 @@ import formatCurrency from '@automattic/format-currency';
  */
 import { BlockControls } from '@wordpress/block-editor';
 import { MenuGroup, MenuItem, ToolbarDropdownMenu } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { store as editPostStore } from '@wordpress/edit-post';
+import { useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { check, update, warning } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
+import useOpenBlockSidebar from './use-open-block-sidebar';
 import { store as membershipProductsStore } from '../../../store/membership-products';
 
 function getProductDescription( product ) {
@@ -65,22 +65,18 @@ function Product( { onClose, product, selectedProductId, setSelectedProductId } 
 }
 
 function NewProduct( { onClose } ) {
-	const isEditorSidebarOpened = useSelect( select =>
-		select( editPostStore ).isEditorSidebarOpened()
-	);
-	const { openGeneralSidebar } = useDispatch( editPostStore );
+	const openBlockSidebar = useOpenBlockSidebar();
 
 	const handleClick = event => {
 		event.preventDefault();
-		// Open the sidebar if not open
-		if ( ! isEditorSidebarOpened ) {
-			openGeneralSidebar( 'edit-post/block' );
-		}
-		const input = document.getElementById( 'new-product-title' );
-		if ( input !== null ) {
-			//Focus on the new product title input
-			input.focus();
-		}
+		openBlockSidebar();
+		setTimeout( () => {
+			const input = document.getElementById( 'new-product-title' );
+			if ( input !== null ) {
+				//Focus on the new product title input
+				input.focus();
+			}
+		}, 100 );
 		onClose();
 	};
 

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/use-open-block-sidebar.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/use-open-block-sidebar.js
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch, select } from '@wordpress/data';
+
+export default function useOpenBlockSidebar() {
+	const { enableComplementaryArea } = useDispatch( 'core/interface' );
+	const isSiteEditor = !! select( 'core/edit-site' );
+	const isWidgetsEditor = !! select( 'core/edit-widgets' );
+
+	return () => {
+		if ( isSiteEditor ) {
+			enableComplementaryArea( 'core/edit-site', 'edit-site/block-inspector' );
+			return;
+		}
+		if ( isWidgetsEditor ) {
+			enableComplementaryArea( 'core/edit-widgets', 'edit-widgets/block-inspector' );
+			return;
+		}
+		enableComplementaryArea( 'core/edit-post', 'edit-post/block' );
+	};
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #23443

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Make the `ProductManagementControls` "add new" toolbar control open the correct sidebar on every editor type.

Post, site, and widgets editor all implement the block settings sidebar in a slightly different way.
The Premium Content block (and subsequently the shared `ProductManagementControls`) only targeted the post editor sidebar when using the "add new" control from the toolbar.

This PR makes the "add new" control handle all three types of editor sidebars.
To know the current editor, it checks if the corresponding Redux store is loaded.
Since we are only checking for existence, not using, we are not importing those stores, and we don't need to add them to the package dependencies.

The PR also:
- Adds a brief timeout to allow for the sidebar to open before attempting to focus the input field.
- Removes the check for "is sidebar open" because it's not strictly needed (trying to open a sidebar that's already open is negligible) and would unnecessarily increase the complexity of the hook.

<img width="908" alt="Screenshot 2022-03-24 at 17 54 39" src="https://user-images.githubusercontent.com/2070010/159979901-a7af31d4-f78f-4ad2-9823-8fd3dda3215f.png">

#### Note

This PR does not work on the Customizer.
In that case, the sidebar is not controlled by Redux, but it's part of the internal state of the editor instance.
I'm not sure how to work around this limitation, and I'm quite tempted to remove the "add new" control when in the Customizer, and just rely on the "show more settings"  button in the toolbar's more menu (which AFAICS is the only way to open the block sidebar).

#### Question

On the other hand, we now use the `@wordpress/interface` package, which is [already used by the editor extensions](https://github.com/Automattic/jetpack/blob/0c8a27a1c1af37b2646dfc39d49c9d1fffe10ce0/projects/plugins/jetpack/extensions/shared/jetpack-plugin-sidebar.js#L30), but not added as dependency.
I think we should probably add it, but I'm not sure what's the procedure.
cc @jeherve 

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Pick a WPCOM site with a paid plan and an active Stripe connection.
* Open the post editor and close the sidebar.
  * Insert the Premium Content block, select it, and open the products toolbar control.
  * Click on "add new subscription".
  * Make sure the block sidebar opens and the title input field is focused.
* Open the site editor (you might need a block theme) and close the sidebar.
  * Repeat the test.
* Open the widget editor (you might need a theme with widgets support such as the vanilla Twenty Twenty-One) and close the sidebar.
  * Repeat the test.