### PR TITLE
Update/videopress shortcode add muted support

### DIFF
--- a/projects/plugins/jetpack/changelog/update-videopress-shortcode-add-muted-support
+++ b/projects/plugins/jetpack/changelog/update-videopress-shortcode-add-muted-support
@@ -1,4 +1,4 @@
 Significance: minor
 Type: compat
 
-Added support for the `muted` property in the wpvideo and videopress shortcodes.
+Added support for the `muted`, `controls` and `playsinline` properties on the wpvideo and videopress shortcodes.

--- a/projects/plugins/jetpack/changelog/update-videopress-shortcode-add-muted-support
+++ b/projects/plugins/jetpack/changelog/update-videopress-shortcode-add-muted-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Added support for the `muted` property in the wpvideo and videopress shortcodes.

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
@@ -643,6 +643,7 @@ class VideoPress_Player {
 				case 'loop':
 				case 'permalink':
 				case 'cover':
+				case 'muted':
 					if ( in_array( $value, array( 1, 'true' ) ) ) {
 						$videopress_options[ $option ] = true;
 					} elseif ( in_array( $value, array( 0, 'false' ) ) ) {

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
@@ -644,6 +644,8 @@ class VideoPress_Player {
 				case 'permalink':
 				case 'cover':
 				case 'muted':
+				case 'controls':
+				case 'playsinline':
 					if ( in_array( $value, array( 1, 'true' ) ) ) {
 						$videopress_options[ $option ] = true;
 					} elseif ( in_array( $value, array( 0, 'false' ) ) ) {

--- a/projects/plugins/jetpack/modules/videopress/shortcode.php
+++ b/projects/plugins/jetpack/modules/videopress/shortcode.php
@@ -83,6 +83,8 @@ class VideoPress_Shortcode {
 			'defaultlangcode' => false, // Default language code
 			'cover'           => true,  // Whether to scale the video to its container.
 			'muted'           => false, // Whether the video should start without sound.
+			'controls'        => true,  // Whether the video should display controls.
+			'playsinline'     => false, // Whether the video should be allowed to play inline (for browsers that support this).
 		);
 
 		$attr = shortcode_atts( $defaults, $attr, 'videopress' );
@@ -142,6 +144,8 @@ class VideoPress_Shortcode {
 				'defaultlangcode' => $attr['defaultlangcode'],
 				'forcestatic'     => false, // This used to be a displayed option, but now is only.
 				'muted'           => $attr['muted'],
+				'controls'        => $attr['controls'],
+				'playsinline'     => $attr['playsinline'],
 			// accessible via the `videopress_shortcode_options` filter.
 			)
 		);

--- a/projects/plugins/jetpack/modules/videopress/shortcode.php
+++ b/projects/plugins/jetpack/modules/videopress/shortcode.php
@@ -82,6 +82,7 @@ class VideoPress_Shortcode {
 			'flashonly'       => false, // Whether to support the Flash player exclusively
 			'defaultlangcode' => false, // Default language code
 			'cover'           => true,  // Whether to scale the video to its container.
+			'muted'           => false, // Whether the video should start without sound.
 		);
 
 		$attr = shortcode_atts( $defaults, $attr, 'videopress' );
@@ -139,7 +140,8 @@ class VideoPress_Shortcode {
 				'permalink'       => $attr['permalink'],
 				'force_flash'     => (bool) $attr['flashonly'],
 				'defaultlangcode' => $attr['defaultlangcode'],
-				'forcestatic'     => false, // This used to be a displayed option, but now is only
+				'forcestatic'     => false, // This used to be a displayed option, but now is only.
+				'muted'           => $attr['muted'],
 			// accessible via the `videopress_shortcode_options` filter.
 			)
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes # 1133-gh-Automattic/greenhouse

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* adds support for passing the `muted`, `controls` and `playsinline` properties to a shortcode and into the videopress player's options.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
nope
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* apply branch
* in a post, add a few `videopress` and `wpvideo` shortcode with the following scenarios:
   * no options, just the video guid `[wpvideo q4DChOON]` - defaults should all be applied correctly (no auto play, not muted, shows controls)
   * all options set with various values to test inputs (ex true and 1 should both enable a setting) `[wpvideo q4DChOON autoplay=true muted=true controls=false playsinline=1]`
   * another shortcode with different values set for the new properties
* publish the page then view it in a new window
* inspect each video's iframe URL and see that the shortcode properties are passed as query string parameters with the correct state. To test "plays inline" works correctly, view on an iphone (video shouldn't open full screen). 