### PR TITLE
Search: temporary fix for Jetpack 10.8-a.9 submenu item

### DIFF
--- a/projects/packages/search/changelog/temp-remove-search-submenu-if-no-search-plan
+++ b/projects/packages/search/changelog/temp-remove-search-submenu-if-no-search-plan
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Temp: temporary fix for Jetpack 10.8-a.9 release to prevent Search submenu item from showing on sites without eligible Search plans. Removing this since sites w/out Search plan won't be able to interact with the Search page.
+
+

--- a/projects/packages/search/src/dashboard/class-dashboard.php
+++ b/projects/packages/search/src/dashboard/class-dashboard.php
@@ -101,6 +101,17 @@ class Dashboard {
 	 */
 	protected function should_add_search_submenu() {
 		/**
+		 * Todo: temporary fix for Jetpack 10.8-a.9 release to prevent Search submenu item from showing on
+		 * sites without eligible Search plans.
+		 *
+		 * Currently sites without a Search plan will not be able to interact with the Search page toggles,
+		 * so that could lead to user confusion/frustration.
+		 */
+		if ( ! $this->plan->supports_search() ) {
+			return false;
+		}
+
+		/**
 		 * The filter allows to ommit adding a submenu item for Jetpack Search.
 		 *
 		 * @since 0.11.2


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Prevent the nested `Search` submenu item from showing on sites without eligible Search plans. Currently sites without Search plans will see the `Search` submenu item, but when visiting that page users can't interact with it so it's confusing.

This is intended to be a temp fix so we can get the Atomic release out until Search team can have a further look.

#### Jetpack product discussion

- Internal: p1648147013140099-slack-C82FZ5T4G

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Pre-patching, on a JP connected site with no Search plan, running bleeding edge or RC, verify you see the Search submenu item nested under Jetpack. Visit the Search page - the toggles won't be able to be used.
* Patch with these changes, the Search submenu item should be hidden.
* Add a paid Search plan, and the Search submenu should be visible & functional.