### PR TITLE
packages/search: release version 0.11.3

### DIFF
--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.3] - 2022-03-24
+### Added
+- Search: adds a record count above the record meter chart.
+
+### Fixed
+- Deactivation: Do not attempt to redirect on a behind-the-scene deactivation.
+
 ## [0.11.2] - 2022-03-23
 ### Added
 - adds basic structure for record meter with dummy data
@@ -171,6 +178,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.11.3]: https://github.com/Automattic/jetpack-search/compare/v0.11.2...v0.11.3
 [0.11.2]: https://github.com/Automattic/jetpack-search/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/Automattic/jetpack-search/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/Automattic/jetpack-search/compare/v0.10.0...v0.11.0

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,10 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.11.3] - 2022-03-24
-### Fixed
-- Deactivation: do not attempt to redirect on a behind-the-scene deactivation.
-
 ## [0.11.2] - 2022-03-23
 ### Added
 - adds basic structure for record meter with dummy data
@@ -175,7 +171,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
-[0.11.3]: https://github.com/Automattic/jetpack-search/compare/v0.11.2...v0.11.3
 [0.11.2]: https://github.com/Automattic/jetpack-search/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/Automattic/jetpack-search/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/Automattic/jetpack-search/compare/v0.10.0...v0.11.0

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.3] - 2022-03-24
+### Fixed
+- Deactivation: do not attempt to redirect on a behind-the-scene deactivation.
+
 ## [0.11.2] - 2022-03-23
 ### Added
 - adds basic structure for record meter with dummy data
@@ -171,6 +175,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.11.3]: https://github.com/Automattic/jetpack-search/compare/v0.11.2...v0.11.3
 [0.11.2]: https://github.com/Automattic/jetpack-search/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/Automattic/jetpack-search/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/Automattic/jetpack-search/compare/v0.10.0...v0.11.0

--- a/projects/packages/search/changelog/record meter: add record-count
+++ b/projects/packages/search/changelog/record meter: add record-count
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Search: adds a record count above the record meter chart

--- a/projects/packages/search/changelog/temp-remove-search-submenu-if-no-search-plan
+++ b/projects/packages/search/changelog/temp-remove-search-submenu-if-no-search-plan
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Temp: temporary fix for Jetpack 10.8-a.9 release to prevent Search submenu item from showing on sites without eligible Search plans. Removing this since sites w/out Search plan won't be able to interact with the Search page.
+
+

--- a/projects/packages/search/changelog/temp-remove-search-submenu-if-no-search-plan
+++ b/projects/packages/search/changelog/temp-remove-search-submenu-if-no-search-plan
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Temp: temporary fix for Jetpack 10.8-a.9 release to prevent Search submenu item from showing on sites without eligible Search plans. Removing this since sites w/out Search plan won't be able to interact with the Search page.
-
-

--- a/projects/packages/search/changelog/try-revert-search
+++ b/projects/packages/search/changelog/try-revert-search
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Deactivation: Do not attempt to redirect on a behind-the-scene deactivation.

--- a/projects/packages/search/changelog/try-revert-search
+++ b/projects/packages/search/changelog/try-revert-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Deactivation: Do not attempt to redirect on a behind-the-scene deactivation.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.11.3-alpha",
+	"version": "0.11.3",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.11.3",
+	"version": "0.11.3-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.11.3-alpha';
+	const VERSION = '0.11.3';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.11.3';
+	const VERSION = '0.11.3-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/plugins/jetpack/changelog/jetpack-branch-10.8
+++ b/projects/plugins/jetpack/changelog/jetpack-branch-10.8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/jetpack-branch-10.8
+++ b/projects/plugins/jetpack/changelog/jetpack-branch-10.8
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

packages/search: release version 0.11.3 so it can be used in the Jetpack 10.8-a.9 release branch.

#### Jetpack product discussion

Internal: p1648151417545039-slack-C01U2KGS2PQ

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

Proofread.