### PR TITLE
* My Jetpack: tweak plan sections box model

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/heading/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/heading/index.jsx
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Text } from '@automattic/jetpack-components';
+
+/**
+ * Internal dependencies
+ */
+import styles from './style.module.scss';
+
+export const TIPOGRAPHY_WEIGHTS = {
+	regular: 'regular',
+	bold: 'bold',
+};
+
+export const TIPOGRAPHY_SIZES = {
+	medium: 'medium',
+	small: 'small',
+};
+
+const typographiesPropTypes = {
+	weight: PropTypes.oneOf( Object.values( TIPOGRAPHY_WEIGHTS ) ),
+};
+
+const typographiesDefaults = {
+	weight: TIPOGRAPHY_WEIGHTS.bold,
+};
+
+/**
+ * Component to compose the Text instances,
+ * according to root variant and weight.
+ *
+ * @param {object} props                   - Component props.
+ * @param {string} props.rootVariant       - Root variant of the Text instance.
+ * @param {string} props.weight            - Weight of the Text instance (bold|regular).
+ * @param {React.Component} props.children - Text children component.
+ * @returns {React.Component}                Text component instance.
+ */
+function TextComposer( { children, rootVariant, weight } ) {
+	weight = weight === 'bold' ? '' : weight;
+
+	return (
+		<Text
+			variant={ `${ rootVariant }${ weight?.length ? `-${ weight }` : '' }` }
+			className={ styles[ rootVariant ] }
+		>
+			{ children }
+		</Text>
+	);
+}
+
+export const H2 = ( { children, weight } ) => (
+	<TextComposer rootVariant="headline-medium" weight={ weight }>
+		{ children }
+	</TextComposer>
+);
+H2.propTypes = typographiesPropTypes;
+H2.defaultProps = typographiesDefaults;
+
+export const H3 = ( { children, weight } ) => (
+	<TextComposer rootVariant="headline-small" weight={ weight }>
+		{ children }
+	</TextComposer>
+);
+H3.propTypes = typographiesPropTypes;
+H3.defaultProps = typographiesDefaults;
+
+export const Title = ( { children, size = 'medium' } ) => (
+	<TextComposer rootVariant={ `title-${ size }` }>{ children }</TextComposer>
+);
+
+Title.propTypes = {
+	size: PropTypes.oneOf( Object.values( TIPOGRAPHY_SIZES ) ),
+};
+
+Title.defaultProps = {
+	size: TIPOGRAPHY_SIZES.medium,
+};

--- a/projects/packages/my-jetpack/_inc/components/heading/stories/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/heading/stories/index.jsx
@@ -1,0 +1,92 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { H2, H3, Title, TIPOGRAPHY_WEIGHTS, TIPOGRAPHY_SIZES } from '../index.jsx';
+import styles from './style.module.scss';
+
+export default {
+	title: 'Packages/My Jetpack/Heading',
+	component: H2,
+	argTypes: {
+		children: {
+			control: { type: 'text' },
+		},
+		weight: {
+			control: { type: 'select', options: Object.values( TIPOGRAPHY_WEIGHTS ) },
+		},
+		size: {
+			control: { type: 'select', options: Object.values( TIPOGRAPHY_SIZES ) },
+		},
+	},
+};
+
+/**
+ * Helper component to create a the story.
+ *
+ * @param {object} props                   - Component props.
+ * @param {React.Component} props.children - Icon component children.
+ * @returns {React.Component}                Text component instance.
+ */
+function Instance( { children } ) {
+	return (
+		<div className={ styles.instance }>
+			<span>Text above to the the component...</span>
+			{ children }
+			<span>Text below to the the component...</span>
+		</div>
+	);
+}
+
+const TemplateH2 = args => (
+	<Instance>
+		<H2 { ...args }>
+			{ args?.children ||
+				'Headline Medium - Manage your Jetpack plan and products all in one place' }
+		</H2>
+	</Instance>
+);
+
+const TemplateH3 = args => (
+	<Instance>
+		<H3 { ...args }>
+			{ args?.children ||
+				'Headline Small - Manage your Jetpack plan and products all in one place' }
+		</H3>
+	</Instance>
+);
+
+const TemplateTitle = args => (
+	<Instance>
+		<Title { ...args }>
+			{ args?.children || 'Title Medium - Secure, grow, and increase your site speed' }
+		</Title>
+	</Instance>
+);
+
+const Template = args => {
+	return (
+		<>
+			<TemplateH2 { ...args } />
+			<TemplateH3 { ...args } />
+			<TemplateTitle { ...args } />
+		</>
+	);
+};
+
+const DefaultArgs = {};
+export const Default = Template.bind( {} );
+Default.args = DefaultArgs;
+
+export const HeadlineMedium = TemplateH2.bind( {} );
+HeadlineMedium.storyName = 'H2';
+
+export const HeadlineSmall = TemplateH3.bind( {} );
+HeadlineSmall.storyName = 'H3';
+
+export const TitleInstance = TemplateTitle.bind( {} );
+TitleInstance.storyName = 'Title';

--- a/projects/packages/my-jetpack/_inc/components/heading/stories/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/heading/stories/style.module.scss
@@ -1,0 +1,8 @@
+.instance {
+	span {
+		color: var( --jp-gray-40 );
+		display: inline-block;
+		width: 100%;
+		background-color: var( --jp-white-off );
+	}
+}

--- a/projects/packages/my-jetpack/_inc/components/heading/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/heading/style.module.scss
@@ -1,0 +1,12 @@
+.headline-medium {
+	margin-bottom: calc( var(--spacing-base ) * 3 );
+}
+
+.headline-small {
+	margin-bottom: var( --spacing-base );
+}
+
+.title-medium,
+.title-small {
+	margin-bottom: var( --spacing-base );
+}

--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
@@ -12,6 +12,7 @@ import usePurchases from '../../hooks/use-purchases';
 import getManageYourPlanUrl from '../../utils/get-manage-your-plan-url';
 import getPurchasePlanUrl from '../../utils/get-purchase-plan-url';
 import styles from './style.module.scss';
+import { H2, Title2 } from '../heading';
 
 /**
  * Basic plan section component.
@@ -24,7 +25,7 @@ function PlanSection( { purchase = {} } ) {
 	const { product_name, expiry_message } = purchase;
 	return (
 		<>
-			<h4>{ product_name }</h4>
+			<Title2>{ product_name }</Title2>
 			<p>{ expiry_message }</p>
 		</>
 	);
@@ -40,11 +41,11 @@ function PlanSection( { purchase = {} } ) {
 function PlanSectionHeader( { purchases } ) {
 	return (
 		<>
-			<h3>
+			<H2>
 				{ purchases.length <= 1
 					? __( 'Your plan', 'jetpack-my-jetpack' )
 					: __( 'Your plans', 'jetpack-my-jetpack' ) }
-			</h3>
+			</H2>
 			{ purchases.length === 0 && (
 				<p>{ __( 'The extra power you added to your Jetpack.', 'jetpack-my-jetpack' ) }</p>
 			) }

--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
@@ -4,15 +4,16 @@
 import React from 'react';
 import { __, _n } from '@wordpress/i18n';
 import { ExternalLink } from '@wordpress/components';
+import { Text } from '@automattic/jetpack-components';
 
 /**
  * Internal dependencies
  */
+import { H2, Title } from '../heading';
 import usePurchases from '../../hooks/use-purchases';
 import getManageYourPlanUrl from '../../utils/get-manage-your-plan-url';
 import getPurchasePlanUrl from '../../utils/get-purchase-plan-url';
 import styles from './style.module.scss';
-import { H2, Title2 } from '../heading';
 
 /**
  * Basic plan section component.
@@ -25,8 +26,10 @@ function PlanSection( { purchase = {} } ) {
 	const { product_name, expiry_message } = purchase;
 	return (
 		<>
-			<Title2>{ product_name }</Title2>
-			<p>{ expiry_message }</p>
+			<Title>{ product_name }</Title>
+			<Text variant="body" className={ styles[ 'expire-date' ] }>
+				{ expiry_message }
+			</Text>
 		</>
 	);
 }

--- a/projects/packages/my-jetpack/_inc/components/plans-section/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/style.module.scss
@@ -2,20 +2,16 @@
 	a, a:active, a:hover {
 		color: var( --jp-black );
 	}
-
-	p {
-		margin: 16px 0;
-		color: var( --jp-black );
-	}
-
-	p, a, li {
-		font-size: var( --font-body );
-		line-height: 24px;
-	}
 }
 
+.expire-date {
+	margin-bottom: calc( var(--spacing-base ) * 3 );
+}
 
-.external-link:hover {
-	color: var(--jp-black);
-	text-decoration-thickness: var(--jp-underline-thickness);
+.external-link {
+	font-size: var( --font-body );
+	&:hover {
+		color: var( --jp-black );
+		text-decoration-thickness: var( --jp-underline-thickness );
+	}
 }

--- a/projects/packages/my-jetpack/_inc/components/plans-section/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/style.module.scss
@@ -1,20 +1,4 @@
 .container {
-	h3 {
-		font-size: var(--font-title-large);
-		font-weight: 700;
-		margin-top: 48px;
-		line-height: 1.1;
-		color: var( --jp-black );
-		margin: 0;
-	}
-
-	h4 {
-		font-size: var(--font-title-small);
-		font-weight: 500;
-		line-height: 1;
-		color: var( --jp-black );
-	}
-
 	a, a:active, a:hover {
 		color: var( --jp-black );
 	}
@@ -30,9 +14,6 @@
 	}
 }
 
-.purchasesSection {
-	margin-top: 16px;
-}
 
 .external-link:hover {
 	color: var(--jp-black);

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-plans-section-tweakness
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-plans-section-tweakness
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: tweak plan sections styles/sizes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR tweaks the plans sections according to the feedback described here. For this purpose, I've created a couple of components to be reused in the whole UI of the app.

Fixes https://github.com/Automattic/jetpack/issues/23542

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: tweak plan sections box model.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With Storybook
* Check the heading components
* Confirm the margin values:
![image](https://user-images.githubusercontent.com/77539/160019423-edf19135-0e55-46b8-8bba-48c196b65815.png)

<img width="1100" alt="Screen Shot 2022-03-24 at 7 18 35 PM" src="https://user-images.githubusercontent.com/77539/160019539-d1338b6d-3239-4a59-8ed7-1dce69d747f0.png">

<img width="1102" alt="image" src="https://user-images.githubusercontent.com/77539/160019589-28bf5b48-bb7c-4bea-9ca8-432f6fc0fc1f.png">

* Testing with My Jetpack dashboard
<img width="628" alt="image" src="https://user-images.githubusercontent.com/77539/160019678-fcdcaf23-3b87-4ed7-8a38-b0b09692edbf.png">
* Confirm margins look right.
