### PR TITLE
Backup: Use real site title (name) when showing progresss text on admin page

### DIFF
--- a/projects/plugins/backup/changelog/fix-backup-site-title-on-progress
+++ b/projects/plugins/backup/changelog/fix-backup-site-title-on-progress
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed progress state in admin page to use real site title (name)

--- a/projects/plugins/backup/src/js/components/Backups.js
+++ b/projects/plugins/backup/src/js/components/Backups.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { getDate, date, dateI18n } from '@wordpress/date';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { createInterpolateElement, useState, useEffect } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
@@ -37,6 +37,7 @@ const Backups = () => {
 		themes: 0,
 	} );
 	const domain = useSelect( select => select( STORE_ID ).getCalypsoSlug(), [] );
+	const siteTitle = useSelect( select => select( STORE_ID ).getSiteTitle(), '' );
 
 	const BACKUP_STATE = {
 		LOADING: 0,
@@ -121,7 +122,13 @@ const Backups = () => {
 					{ showProgressBar && (
 						<div className="backup__progress">
 							<div className="backup__progress-info">
-								<p>{ __( 'Backing up Your Groovy Site…', 'jetpack-backup' ) }</p>
+								<p>
+									{ sprintf(
+										/* translators: placeholder is the Site Title */
+										__( 'Backing up %s', 'jetpack-backup' ),
+										siteTitle
+									) }
+								</p>
 								<p className="backup__progress-info-percentage">{ progress }%</p>
 							</div>
 							<div className="backup__progress-bar">

--- a/projects/plugins/backup/src/js/selectors/site-data.js
+++ b/projects/plugins/backup/src/js/selectors/site-data.js
@@ -1,5 +1,6 @@
 const siteDataSelectors = {
 	getSiteData: state => state.siteData || [],
+	getSiteTitle: state => state.siteData?.title || '',
 };
 
 export default siteDataSelectors;

--- a/projects/plugins/backup/src/php/class-initial-state.php
+++ b/projects/plugins/backup/src/php/class-initial-state.php
@@ -29,7 +29,8 @@ class Initial_State {
 			),
 			'connectedPlugins' => Connection_Plugin_Storage::get_all(),
 			'siteData'         => array(
-				'id' => \Jetpack_Options::get_option( 'id' ),
+				'id'    => \Jetpack_Options::get_option( 'id' ),
+				'title' => get_bloginfo( 'name' ) ? get_bloginfo( 'name' ) : get_site_url(),
 			),
 			'assets'           => array(
 				'buildUrl' => plugins_url( 'build/', JETPACK_BACKUP_PLUGIN_ROOT_FILE ),


### PR DESCRIPTION
Fixes rendering of rogue site title


  <img width="361" alt="image" src="https://user-images.githubusercontent.com/746152/160113072-5f03a4c8-e24b-40e6-a67b-86278658542b.png">

Fixes #23619

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Leverages the site title in the message shown while a backup is in progress


#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

**Fresh site**
1. On a fresh site running this branch ([JN link](https://jurassic.ninja/create?jetpack-beta&branches.jetpack-backup=fix/backup-site-title-on-progress&wp-debug-log)), install Backup and connect it paying for a plan
2. Expect to be back on the Backup admin page and see the progress bar reading "Backing up your Site Name" (where Site Name) should be your real site name)
    ![image](https://user-images.githubusercontent.com/746152/160114594-6f15a8b5-ac94-4362-9059-946aa487943f.png)


**On a dev environment**
1. Checkout this branch
2. Visit the Backup admin page, and open the dev console, then switch to the Component tab
4. Find the <Backups/> component and updated the first "Select" entry to read `1`.   
  ![image](https://user-images.githubusercontent.com/746152/160112887-8b19b735-f74a-46ad-8a08-3120a745abfa.png)
5. Expect to see the progress status showing your site's title
  <img width="461" alt="image" src="https://user-images.githubusercontent.com/746152/160112990-5f8cac27-fe06-4fb9-a97c-fd02f79c8ec9.png">


