### PR TITLE
linting: Fix monorepo version refs lint

### DIFF
--- a/.github/files/lint-project-structure.sh
+++ b/.github/files/lint-project-structure.sh
@@ -301,13 +301,13 @@ fi
 # - package.json engines should be satisfied by .github/versions.sh.
 debug "Checking .github/versions.sh vs package.json engines"
 RANGE="$(jq -r '.engines.node' package.json)"
-if ! pnpx semver --range "$RANGE" "$NODE_VERSION" &>/dev/null; then
+if ! pnpx --no-install semver --range "$RANGE" "$NODE_VERSION" &>/dev/null; then
 	EXIT=1
 	LINE=$(jq --stream 'if length == 1 then .[0][:-1] else .[0] end | if . == ["engines","node"] then input_line_number - 1 else empty end' package.json)
 	echo "::error file=package.json,line=$LINE::Node version $NODE_VERSION in .github/versions.sh does not satisfy requirement $RANGE from package.json"
 fi
 RANGE="$(jq -r '.engines.pnpm' package.json)"
-if ! pnpx semver --range "$RANGE" "$PNPM_VERSION" &>/dev/null; then
+if ! pnpx --no-install semver --range "$RANGE" "$PNPM_VERSION" &>/dev/null; then
 	EXIT=1
 	LINE=$(jq --stream 'if length == 1 then .[0][:-1] else .[0] end | if . == ["engines","pnpm"] then input_line_number - 1 else empty end' package.json)
 	echo "::error file=package.json,line=$LINE::Pnpm version $PNPM_VERSION in .github/versions.sh does not satisfy requirement $RANGE from package.json"

--- a/.github/files/list-changed-projects.sh
+++ b/.github/files/list-changed-projects.sh
@@ -39,4 +39,4 @@ if [[ -n "$EXTRA" ]]; then
 	fi
 fi
 
-pnpx jetpack dependencies list "${ARGS[@]}" | jq -ncR 'reduce inputs as $i ({}; .[$i] |= true)'
+pnpx --no-install jetpack dependencies list "${ARGS[@]}" | jq -ncR 'reduce inputs as $i ({}; .[$i] |= true)'

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -463,13 +463,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: needs.changed_files.outputs.lockfiles == 'true' || needs.changed_files.outputs.misc == 'true'
-    timeout-minutes: 1  # 2021-01-18: Successful runs take just a few seconds
+    timeout-minutes: 5  # 2022-03-25: The pnpm install will probably take a minute or so.
     steps:
       - uses: actions/checkout@v3
       - name: Setup tools
         uses: ./.github/actions/tool-setup
         with:
           php: false
+      - run: pnpm install
       - run: tools/check-intra-monorepo-deps.sh -v
       - run: .github/files/check-monorepo-package-repos.sh
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1289,9 +1289,9 @@ importers:
   projects/plugins/protect:
     specifiers:
       '@automattic/jetpack-base-styles': workspace:^0.1.10
-      '@automattic/jetpack-components': workspace:^0.10.11-alpha
-      '@automattic/jetpack-connection': workspace:^0.17.4-alpha
-      '@automattic/jetpack-webpack-config': workspace:^1.1.5-alpha
+      '@automattic/jetpack-components': workspace:^0.10.11
+      '@automattic/jetpack-connection': workspace:^0.17.4
+      '@automattic/jetpack-webpack-config': workspace:^1.1.5
       '@babel/core': 7.16.0
       '@babel/preset-env': 7.16.4
       '@babel/register': 7.16.0
@@ -1399,9 +1399,9 @@ importers:
   projects/plugins/starter-plugin:
     specifiers:
       '@automattic/jetpack-base-styles': workspace:^0.1.10
-      '@automattic/jetpack-components': workspace:^0.10.11-alpha
-      '@automattic/jetpack-connection': workspace:^0.17.4-alpha
-      '@automattic/jetpack-webpack-config': workspace:^1.1.5-alpha
+      '@automattic/jetpack-components': workspace:^0.10.11
+      '@automattic/jetpack-connection': workspace:^0.17.4
+      '@automattic/jetpack-webpack-config': workspace:^1.1.5
       '@babel/core': 7.16.0
       '@babel/preset-env': 7.16.4
       '@babel/register': 7.16.0

--- a/projects/plugins/protect/changelog/fix-monorepo-version-refs-lint
+++ b/projects/plugins/protect/changelog/fix-monorepo-version-refs-lint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -776,7 +776,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plugins-installer",
-                "reference": "19c930344c337c188d411a51938c7c870ea511a1"
+                "reference": "0b68b85dd5075ccbecfe63a877b31a848feecca0"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4"
@@ -785,7 +785,7 @@
                 "automattic/jetpack-changelogger": "^3.0",
                 "yoast/phpunit-polyfills": "1.0.3"
             },
-            "type": "library",
+            "type": "jetpack-library",
             "extra": {
                 "branch-alias": {
                     "dev-master": "0.1.x-dev"

--- a/projects/plugins/protect/package.json
+++ b/projects/plugins/protect/package.json
@@ -25,8 +25,8 @@
 	],
 	"dependencies": {
 		"@automattic/jetpack-base-styles": "workspace:^0.1.10",
-		"@automattic/jetpack-components": "workspace:^0.10.11-alpha",
-		"@automattic/jetpack-connection": "workspace:^0.17.4-alpha",
+		"@automattic/jetpack-components": "workspace:^0.10.11",
+		"@automattic/jetpack-connection": "workspace:^0.17.4",
 		"@wordpress/data": "6.3.0",
 		"@wordpress/element": "4.1.1",
 		"@wordpress/date": "4.3.1",
@@ -35,7 +35,7 @@
 		"react-dom": "17.0.2"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-webpack-config": "workspace:^1.1.5-alpha",
+		"@automattic/jetpack-webpack-config": "workspace:^1.1.5",
 		"@babel/core": "7.16.0",
 		"@babel/preset-env": "7.16.4",
 		"@babel/register": "7.16.0",

--- a/projects/plugins/starter-plugin/changelog/fix-monorepo-version-refs-lint
+++ b/projects/plugins/starter-plugin/changelog/fix-monorepo-version-refs-lint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/starter-plugin/package.json
+++ b/projects/plugins/starter-plugin/package.json
@@ -25,8 +25,8 @@
 	],
 	"dependencies": {
 		"@automattic/jetpack-base-styles": "workspace:^0.1.10",
-		"@automattic/jetpack-components": "workspace:^0.10.11-alpha",
-		"@automattic/jetpack-connection": "workspace:^0.17.4-alpha",
+		"@automattic/jetpack-components": "workspace:^0.10.11",
+		"@automattic/jetpack-connection": "workspace:^0.17.4",
 		"@wordpress/data": "6.3.0",
 		"@wordpress/element": "4.1.1",
 		"@wordpress/date": "4.3.1",
@@ -35,7 +35,7 @@
 		"react-dom": "17.0.2"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-webpack-config": "workspace:^1.1.5-alpha",
+		"@automattic/jetpack-webpack-config": "workspace:^1.1.5",
 		"@babel/core": "7.16.0",
 		"@babel/preset-env": "7.16.4",
 		"@babel/register": "7.16.0",

--- a/tools/version-packages.sh
+++ b/tools/version-packages.sh
@@ -104,7 +104,7 @@ EXIT=0
 while IFS=$'\t' read -r PKG OLDVER NEWVER; do
 	OV=$(sed -e 's/\.x-dev$/.0-alpha/' <<<"$OLDVER")
 	NV=$(sed -e 's/^\^//' -e 's/\.x-dev$/.0-alpha/' <<<"$NEWVER")
-	if ! pnpx semver -c -r ">$OV" "$NV" >/dev/null; then
+	if ! pnpx --no-install semver -c -r ">$OV" "$NV" >/dev/null; then
 		EXIT=1
 		error "$PKG was not upgraded ($NEWVER <= $OLDVER)"
 	fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
It seems likely to have been broken since #22433 added a call to the
Jetpack CLI without there being a `pnpm install` first. Add that to the
action.

Also update the script to detect this sort of error and handle it
better, instead of trying to lint a project with the improbably name of
"? Install the following package: jetpack@latest? (Y/n) ‣ ", and pass
the `--no-install` flag to `pnpx` in a few more places for good measure.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1648211555656609-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* We have some cases in the repo now, see that the run before adding the commit fixing them detects them.
  * :heavy_check_mark: https://github.com/Automattic/jetpack/runs/5692674389?check_suite_focus=true#step:5:77