### PR TITLE
autoloader: Better error message if test fails due to download error

### DIFF
--- a/projects/packages/autoloader/changelog/fix-autoloader-test-failed-download-check
+++ b/projects/packages/autoloader/changelog/fix-autoloader-test-failed-download-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Tests only: Give a better error message if the test fails due to failure to download a file.
+
+

--- a/projects/packages/autoloader/tests/php/lib/class-test-plugin-factory.php
+++ b/projects/packages/autoloader/tests/php/lib/class-test-plugin-factory.php
@@ -150,6 +150,19 @@ class Test_Plugin_Factory {
 	}
 
 	/**
+	 * Calls `error_clear_last()` or emulates it.
+	 */
+	public static function error_clear_last() {
+		if ( is_callable( 'error_clear_last' ) ) {
+			// phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.error_clear_lastFound
+			error_clear_last();
+		} else {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+			@trigger_error( '', E_USER_NOTICE );
+		}
+	}
+
+	/**
 	 * Adds a file to the plugin being built.
 	 *
 	 * @param string $path    The path for the file in the plugin directory.
@@ -400,8 +413,14 @@ class Test_Plugin_Factory {
 		// Download the selected version of Composer if we haven't already done so.
 		$composer_bin = TEST_TEMP_BIN_DIR . DIRECTORY_SEPARATOR . 'composer_' . str_replace( '.', '_', $selected ) . '.phar';
 		if ( ! file_exists( $composer_bin ) ) {
-			$data    = $composer_versions[ $selected ];
+			$data = $composer_versions[ $selected ];
+			self::error_clear_last();
 			$content = file_get_contents( $data['url'] );
+			if ( false === $content ) {
+				$err = error_get_last();
+				$err = $err ? $err['message'] : 'unknown error';
+				throw new \RuntimeException( "Failed to download {$data['url']}: $err" );
+			}
 			if ( hash( 'sha256', $content ) !== $data['sha256'] ) {
 				throw new \RuntimeException( 'The Composer file downloaded has a different SHA256 than expected.' );
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Rather than failing with "The Composer file downloaded has a different
SHA256 than expected", fail with something along the lines of
"Failed to download &lt;url>: &lt;reason>".

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1648197192791289/1648194130.870349-slack-C034JEXD1RD

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* I suppose you could edit the URL to something invalid then try running the tests locally. Don't forget to remove `tests/php/tmp/` first so it doesn't used a cached download.