### PR TITLE
Dashboard: allow toggling off blocks from Jetpack settings

### DIFF
--- a/projects/packages/options/changelog/update-settings-blocks-admin
+++ b/projects/packages/options/changelog/update-settings-blocks-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Options: add a new option to track disabling blocks.

--- a/projects/packages/options/legacy/class-jetpack-options.php
+++ b/projects/packages/options/legacy/class-jetpack-options.php
@@ -124,6 +124,7 @@ class Jetpack_Options {
 			'has_seen_wc_connection_modal',        // (bool) Whether the site has displayed the WooCommerce Connection modal
 			'partner_coupon',                      // (string) A Jetpack partner issued coupon to promote a sale together with Jetpack.
 			'partner_coupon_added',                // (string) A date for when `partner_coupon` was added, so we can auto-purge after a certain time interval.
+			'blocks_disabled',                     // (bool) Whether the blocks feature is disabled or not.
 		);
 	}
 

--- a/projects/packages/sync/changelog/update-settings-blocks-admin
+++ b/projects/packages/sync/changelog/update-settings-blocks-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Options: add a new option to track disabling blocks.

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -26,6 +26,7 @@ class Defaults {
 		'advanced_seo_title_formats', // Jetpack_SEO_Titles::TITLE_FORMATS_OPTION.
 		'avatar_default',
 		'avatar_rating',
+		'blocks_disabled',
 		'blog_charset',
 		'blog_public',
 		'blogdescription',

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.30.4';
+	const PACKAGE_VERSION = '1.30.5-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/jetpack/_inc/client/writing/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/index.jsx
@@ -55,6 +55,7 @@ export class Writing extends React.Component {
 			'infinite-scroll',
 			'widgets',
 			'widget-visibility',
+			'blocks',
 		].some( this.props.isModuleFound );
 
 		if ( ! this.props.searchTerm && ! this.props.active ) {

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2261,6 +2261,15 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		$options = array(
 
+			// Blocks.
+			'blocks_disabled'                      => array(
+				'description'       => esc_html__( 'Force disable all editor extensions (plugins and blocks).', 'jetpack' ),
+				'type'              => 'boolean',
+				'default'           => 0,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'blocks',
+			),
+
 			// Carousel
 			'carousel_background_color'            => array(
 				'description'       => esc_html__( 'Color scheme.', 'jetpack' ),

--- a/projects/plugins/jetpack/changelog/update-settings-blocks-admin
+++ b/projects/plugins/jetpack/changelog/update-settings-blocks-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Dashboard: add a new toggle to disable editor extensions (blocks and plugins) from the Jetpack dashboard.

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -463,6 +463,12 @@ class Jetpack_Gutenberg {
 			return false;
 		}
 
+		// Allow disabling all extensions via a toggle in the Jetpack dashboard.
+		$blocks_disabled_in_ui = (bool) Jetpack_Options::get_option( 'blocks_disabled', false );
+		if ( true === $blocks_disabled_in_ui ) {
+			return false;
+		}
+
 		/**
 		 * Filter to disable Gutenberg blocks
 		 *

--- a/projects/plugins/jetpack/modules/blocks.php
+++ b/projects/plugins/jetpack/modules/blocks.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Module Name: Blocks
+ * Module Description: Jetpack Blocks give you the power to deliver quality content that hooks website visitors without needing to hire a developer or learn a single line of code.
+ * First Introduced: 10.8.0
+ * Requires Connection: No
+ * Auto Activate: Yes
+ * Feature: Writing
+ * Additional Search Queries: block, blocks, gutenberg
+ *
+ * @package automattic/jetpack
+ */

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -65,6 +65,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 		// check that these values exists in the whitelist options
 		$options = array(
 			'stylesheet'                                   => 'test',
+			'blocks_disabled'                              => false,
 			'blogname'                                     => 'test',
 			'blogdescription'                              => 'banana',
 			'blog_charset'                                 => 'stuffs',


### PR DESCRIPTION
Alternative to #23630

#### Changes proposed in this Pull Request:

This is not quite working just yet, but I wanted to try something else:

- Add a new fake module, just like in #23630, so the feature can be searched.
- Create a new `blocks_disabled` Jetpack option, that will synced.
- Allow updating that options from the Settings v4 endpoint.
- Add a new toggle that plays with that option.
- Short-circuit Gutenberg when the option is set.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start from a site that's connected to WordPress.com.
* Apply this branch
* Go to Posts > Add New
* The Jetpack blocks should still be available
* Go to Jetpack > Settings
* Search for "Blocks"
* You should find the new toggle, as well as the link to the post editor.
* When clicking on the toggle, the option should be triggered, the link to the post editor should disappear, the toggle status should be updated, and the blocks should disappear from the post editor.
