### PR TITLE
Form Block: require a more recent version of the CRM plugin.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-crm-update-cta
+++ b/projects/plugins/jetpack/changelog/update-crm-update-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Block Form: update required Jetpack CRM version.

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-crm-integration/jetpack-crm-integration-settings-plugin-state.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-crm-integration/jetpack-crm-integration-settings-plugin-state.js
@@ -28,7 +28,7 @@ export const pluginStateEnum = Object.freeze( {
 const CRMPluginNoVersion = () => {
 	return (
 		<p className="jetpack-contact-form__crm_text">
-			{ __( 'The Jetpack CRM is installed but has an invalid version.', 'jetpack' ) }
+			{ __( 'The Jetpack CRM plugin is installed but has an invalid version.', 'jetpack' ) }
 		</p>
 	);
 };
@@ -37,7 +37,7 @@ const CRMPluginUpdate = () => {
 	return (
 		<p className="jetpack-contact-form__crm_text">
 			{ __(
-				'The Zero BS CRM plugin is now Jetpack CRM. Update to the latest version to integrate your contact form with your CRM.',
+				'Please update to the latest version of the Jetpack CRM plugin to integrate your contact form with your CRM.',
 				'jetpack'
 			) }
 		</p>
@@ -153,8 +153,10 @@ const CRMPluginState = ( {
 		return <CRMPluginNoVersion />;
 	}
 
-	if ( crmData.crm_installed && semver.lt( crmPluginVersion, '3.0.19' ) ) {
-		// Old versions of Jetpack CRM can't use the form submission data.
+	if ( crmData.crm_installed && semver.lt( crmPluginVersion, '4.9.1' ) ) {
+		// Old versions of Jetpack CRM can't use the form submission data,
+		// or include a welcome wizard that can get in the way.
+		// @see https://github.com/Automattic/jetpack/pull/23618#issuecomment-1079430205
 		return <CRMPluginUpdate />;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

﻿See https://github.com/Automattic/jetpack/pull/23618#issuecomment-1079430205

> I'd prefer we suggest updating if they're not at least on JPCRM 4.9.1 (which is when we added code to prevent the welcome wizard from hijacking the next wp-admin pageload upon activation).

> The rebrand message can probably be removed

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start from a site with Jetpack installed with this branch, and with the Contact form module active. A JN site can be perfect for that, launched using [Jetpack Live Branches](https://github.com/Automattic/jetpack/blob/master/tools/jetpack-live-branches/README.md).
* Install the WP Rollback plugin.
* Go to Pages > Add New, and add a form block.
* In the form settings sidebar (ensure you're selecting the form block, and not a child block of the form block), you will see option panels, including a CRM panel.
* From there, try to install the CRM plugin.
* Head over to the Plugins menu.
* Switch the CRM plugin back to version 4.8
* Go back to the page editor.
* Notice an update message.
* Update back to the most recent version of the CRM plugin.
* The update message should be gone.
