### PR TITLE
Add template lock to premium-content buttons

### DIFF
--- a/projects/plugins/jetpack/changelog/restrict-premium-content-buttons
+++ b/projects/plugins/jetpack/changelog/restrict-premium-content-buttons
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add a template lock to premium-content buttons. Currently users can add extra payment blocks, which won't unlock the content in question

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/edit.js
@@ -91,6 +91,7 @@ function ButtonsEdit( { context, subscribeButton, setSubscribeButtonPlan } ) {
 				templateInsertUpdatesSelection={ false }
 				__experimentalLayout={ { type: 'default', alignments: [] } }
 				__experimentalMoverDirection="horizontal"
+				templateLock="all"
 			/>
 		</div>
 	);
@@ -98,8 +99,7 @@ function ButtonsEdit( { context, subscribeButton, setSubscribeButtonPlan } ) {
 
 export default compose( [
 	withSelect( ( select, props ) => {
-		// Only first block is assumed to be a subscribe button (users can add additional Recurring Payments blocks for
-		// other plans).
+		// Only first block is assumed to be a subscribe button
 		const subscribeButton = select( 'core/block-editor' )
 			.getBlock( props.clientId )
 			.innerBlocks.find( block => block.name === 'jetpack/recurring-payments' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Currently users can add extra payment blocks to premium-content buttons,
If the button has the same planId as the existing one, then there's no
point adding it - it'll unlock the same content, and have the same
payment terms. If the button has a different planId as the existing one,
then it won't unlock the content it looks to be associated with.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


 1. Create a post with the premium content block 
 2. Select the premium content buttons
 3. It shouldn't be possible to add more child blocks
 4. It shouldn't be possible to remove the existing child blocks

