### PR TITLE
Fix webhook handling in Jetpack

### DIFF
--- a/projects/packages/connection/changelog/fix-jetpack-webhooks
+++ b/projects/packages/connection/changelog/fix-jetpack-webhooks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix regression added to Jetpack webhooks handling

--- a/projects/packages/connection/src/class-webhooks.php
+++ b/projects/packages/connection/src/class-webhooks.php
@@ -78,13 +78,15 @@ class Webhooks {
 		switch ( $_GET['action'] ) {
 			case 'authorize':
 				$this->handle_authorize();
+				$this->do_exit();
 				break;
 			case 'authorize_redirect':
 				$this->handle_authorize_redirect();
+				$this->do_exit();
 				break;
+			// Class Jetpack::admin_page_load() still handles other cases.
 		}
 
-		$this->do_exit();
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/test-class-webhooks.php
+++ b/projects/packages/connection/tests/php/test-class-webhooks.php
@@ -126,26 +126,31 @@ class Test_Webhooks extends TestCase {
 	public function test_controller() {
 		$webhooks = $this->getMockBuilder( Webhooks::class )
 			->setConstructorArgs( array( new Manager() ) )
-			->setMethods( array( 'do_exit', 'handle_authorize' ) )
+			->setMethods( array( 'do_exit', 'handle_authorize', 'handle_authorize_redirect' ) )
 			->getMock();
 
 		$controller_skipped = $webhooks->controller();
 
-		$webhooks->expects( $this->exactly( 2 ) )
-			->method( 'do_exit' );
-
 		$webhooks->expects( $this->once() )
 			->method( 'handle_authorize' );
+
+		$webhooks->expects( $this->once() )
+			->method( 'handle_authorize_redirect' );
 
 		$_GET['handler'] = 'jetpack-connection-webhooks';
 		$_GET['action']  = 'invalid-action';
 
-		// `do_exit` gets called for the first time.
+		// No callback should be called because action is empty.
 		$webhooks->controller();
 
 		$_GET['action'] = 'authorize';
 
-		// `do_exit` gets called for the second time, and `handle_authorize` - for the first and only time.
+		// `handle_authorize` gets called.
+		$webhooks->controller();
+
+		$_GET['action'] = 'authorize_redirect';
+
+		// `handle_authorize_redirect` gets called.
 		$webhooks->controller();
 
 		static::assertNull( $controller_skipped );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #23658 

In the Connection package, we were always calling `exit` in the webhook handler, thus not allowing Jetpack class to handle the other cases not covered in the connection package. (cc @sergeymitr FYI)

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes webhook handling by the Jetpack plugin 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1648493724551759-slack-C01U2KGS2PQ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `/wp-admin/admin.php?page=jetpack_modules` and try activating/deactivating modules

Check for regressions on the webhooks handled by the connection package (making sure what was done in https://github.com/Automattic/jetpack/pull/23382 still works)

* launch a new site only with Boost in this branch
* Connect Boost
* Go to My Jetpack
* Click to Add Backup -> then click on the button on the product screen
* You should be redirected to Authorize your user
* After authorizing your user, you should be redirected to the Checkout page of the Backup product
* At the end of the flow (no need to buy the plan) you user should have been added as the connection owner of the site. (just check for the avatar on the Jetpack Dashboard)