### PR TITLE
Search: fix condition to show search submenu

### DIFF
--- a/projects/packages/search/changelog/update-fix-condition-to-show-search-submenu
+++ b/projects/packages/search/changelog/update-fix-condition-to-show-search-submenu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: move Jetpack plugin compatibility to the package

--- a/projects/packages/search/compatibility/jetpack.php
+++ b/projects/packages/search/compatibility/jetpack.php
@@ -11,7 +11,7 @@ use Automattic\Jetpack\Search\Plan;
 use Jetpack;
 
 /**
- * Override the condition to show Search submenu.
+ * Override the condition to show Search submenu when Jetpack plugin exists.
  */
 function should_show_jetpack_search_submenu() {
 	if ( ! current_user_can( 'manage_options' ) ) {

--- a/projects/packages/search/src/dashboard/class-dashboard.php
+++ b/projects/packages/search/src/dashboard/class-dashboard.php
@@ -102,17 +102,6 @@ class Dashboard {
 	 */
 	protected function should_add_search_submenu() {
 		/**
-		 * Todo: temporary fix for Jetpack 10.8-a.9 release to prevent Search submenu item from showing on
-		 * sites without eligible Search plans.
-		 *
-		 * Currently sites without a Search plan will not be able to interact with the Search page toggles,
-		 * so that could lead to user confusion/frustration.
-		 */
-		if ( ! $this->plan->supports_search() ) {
-			return false;
-		}
-
-		/**
 		 * The filter allows to ommit adding a submenu item for Jetpack Search.
 		 *
 		 * @since 0.11.2

--- a/projects/packages/search/src/initializers/class-initializer.php
+++ b/projects/packages/search/src/initializers/class-initializer.php
@@ -62,6 +62,9 @@ class Initializer {
 			return;
 		}
 
+		// Load compatibility files.
+		add_action( 'plugins_loaded', array( static::class, 'include_compatibility_files' ) );
+
 		// Initialize search package.
 		if ( ! static::init_search( $blog_id ) ) {
 			/** This filter is documented in search/src/initalizers/class-initalizer.php */
@@ -75,6 +78,15 @@ class Initializer {
 		 * @since 0.11.2
 		 */
 		do_action( 'jetpack_search_loaded' );
+	}
+
+	/**
+	 * Extra tweaks to make Jetpack Search play well with others.
+	 */
+	public static function include_compatibility_files() {
+		if ( class_exists( 'Jetpack' ) ) {
+			require_once Package::get_installed_path() . 'compatibility/jetpack.php';
+		}
 	}
 
 	/**

--- a/projects/plugins/search/changelog/update-fix-condition-to-show-search-submenu
+++ b/projects/plugins/search/changelog/update-fix-condition-to-show-search-submenu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: move Jetpack plugin compatibility to the package

--- a/projects/plugins/search/jetpack-search.php
+++ b/projects/plugins/search/jetpack-search.php
@@ -88,16 +88,6 @@ if ( ! is_readable( $autoload_packages_path ) ) {
 }
 
 /**
- * Extra tweaks to make Jetpack Search play well with others.
- */
-function include_compatibility_files() {
-	if ( class_exists( 'Jetpack' ) ) {
-		require_once __DIR__ . '/compatibility/jetpack.php';
-	}
-}
-add_action( 'plugins_loaded', __NAMESPACE__ . '\include_compatibility_files' );
-
-/**
  * Setup autoloading
  */
 require_once $autoload_packages_path;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The PR moves the compatibility files to package to fixes the issue when Jetpack search is always showing for Jetpack plugin.

#### Jetpack product discussion
p1648147013140099-jetpack-search-team-slack

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Create a JN site with only Jetpack the plugin of the branch ([JN special ops](https://jurassic.ninja/specialops/))
- Ensure Search submenu is not shown / only Jetpack top menu is shown
- Connect and purchase a Search subscription
- Ensure Search submenu is shown