### PR TITLE
Search plugin: tidy up for alpha release

### DIFF
--- a/projects/packages/search/changelog/fix-search-plugin-tidy-up
+++ b/projects/packages/search/changelog/fix-search-plugin-tidy-up
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: address feeback for #23477

--- a/projects/packages/search/changelog/update-fix-condition-to-show-search-submenu
+++ b/projects/packages/search/changelog/update-fix-condition-to-show-search-submenu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: move Jetpack plugin compatibility to the package

--- a/projects/packages/search/compatibility/jetpack.php
+++ b/projects/packages/search/compatibility/jetpack.php
@@ -11,7 +11,7 @@ use Automattic\Jetpack\Search\Plan;
 use Jetpack;
 
 /**
- * Override the condition to show Search submenu.
+ * Override the condition to show Search submenu when Jetpack plugin exists.
  */
 function should_show_jetpack_search_submenu() {
 	if ( ! current_user_can( 'manage_options' ) ) {

--- a/projects/packages/search/src/dashboard/class-dashboard.php
+++ b/projects/packages/search/src/dashboard/class-dashboard.php
@@ -102,17 +102,6 @@ class Dashboard {
 	 */
 	protected function should_add_search_submenu() {
 		/**
-		 * Todo: temporary fix for Jetpack 10.8-a.9 release to prevent Search submenu item from showing on
-		 * sites without eligible Search plans.
-		 *
-		 * Currently sites without a Search plan will not be able to interact with the Search page toggles,
-		 * so that could lead to user confusion/frustration.
-		 */
-		if ( ! $this->plan->supports_search() ) {
-			return false;
-		}
-
-		/**
 		 * The filter allows to ommit adding a submenu item for Jetpack Search.
 		 *
 		 * @since 0.11.2

--- a/projects/packages/search/src/dashboard/components/dashboard/use-connection.jsx
+++ b/projects/packages/search/src/dashboard/components/dashboard/use-connection.jsx
@@ -90,7 +90,7 @@ export default function useConnection() {
 						href="https://jetpack.com/support/search/product-pricing/"
 						className="jp-search-dashboard-connection-footer__link"
 					>
-						Learn more
+						{ __( 'Learn more', 'jetpack-search-pkg' ) }
 					</a>
 				</p>
 			</div>

--- a/projects/packages/search/src/dashboard/components/dashboard/use-connection.jsx
+++ b/projects/packages/search/src/dashboard/components/dashboard/use-connection.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { useSelect } from '@wordpress/data';
 import { ConnectScreenRequiredPlan, CONNECTION_STORE_ID } from '@automattic/jetpack-connection';
+import { getRedirectUrl } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -87,7 +88,7 @@ export default function useConnection() {
 						'jetpack-search-pkg'
 					) }
 					<a
-						href="https://jetpack.com/support/search/product-pricing/"
+						href={ getRedirectUrl( 'search-product-pricing' ) }
 						className="jp-search-dashboard-connection-footer__link"
 					>
 						{ __( 'Learn more', 'jetpack-search-pkg' ) }

--- a/projects/packages/search/src/initializers/class-initializer.php
+++ b/projects/packages/search/src/initializers/class-initializer.php
@@ -62,6 +62,9 @@ class Initializer {
 			return;
 		}
 
+		// Load compatibility files.
+		add_action( 'plugins_loaded', array( static::class, 'include_compatibility_files' ) );
+
 		// Initialize search package.
 		if ( ! static::init_search( $blog_id ) ) {
 			/** This filter is documented in search/src/initalizers/class-initalizer.php */
@@ -75,6 +78,15 @@ class Initializer {
 		 * @since 0.11.2
 		 */
 		do_action( 'jetpack_search_loaded' );
+	}
+
+	/**
+	 * Extra tweaks to make Jetpack Search play well with others.
+	 */
+	public static function include_compatibility_files() {
+		if ( class_exists( 'Jetpack' ) ) {
+			require_once Package::get_installed_path() . 'compatibility/jetpack.php';
+		}
 	}
 
 	/**

--- a/projects/plugins/search/.gitattributes
+++ b/projects/plugins/search/.gitattributes
@@ -7,7 +7,7 @@ vendor/automattic/**                            production-include
 vendor/composer/**                              production-include
 vendor/jetpack-autoloader/**                    production-include
 
-# Files to exclude from mirror repo: Automattic/jetpack-backup-plugin
+# Files to exclude from mirror repo: Automattic/jetpack-search-plugin
 .babelrc                                        production-exclude
 .eslintrc.js                                    production-exclude
 .gitattributes                                  production-exclude

--- a/projects/plugins/search/changelog/fix-search-plugin-tidy-up
+++ b/projects/plugins/search/changelog/fix-search-plugin-tidy-up
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: address feeback for #23477

--- a/projects/plugins/search/changelog/update-fix-condition-to-show-search-submenu
+++ b/projects/plugins/search/changelog/update-fix-condition-to-show-search-submenu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: move Jetpack plugin compatibility to the package

--- a/projects/plugins/search/jetpack-search.php
+++ b/projects/plugins/search/jetpack-search.php
@@ -88,16 +88,6 @@ if ( ! is_readable( $autoload_packages_path ) ) {
 }
 
 /**
- * Extra tweaks to make Jetpack Search play well with others.
- */
-function include_compatibility_files() {
-	if ( class_exists( 'Jetpack' ) ) {
-		require_once __DIR__ . '/compatibility/jetpack.php';
-	}
-}
-add_action( 'plugins_loaded', __NAMESPACE__ . '\include_compatibility_files' );
-
-/**
  * Setup autoloading
  */
 require_once $autoload_packages_path;

--- a/projects/plugins/search/src/class-jetpack-search-plugin.php
+++ b/projects/plugins/search/src/class-jetpack-search-plugin.php
@@ -53,7 +53,7 @@ class Jetpack_Search_Plugin {
 	public static function initialize() {
 		// Set up the REST authentication hooks.
 		Connection_Rest_Authentication::init();
-		// Ininitialize My Jetpack.
+		// Initialize My Jetpack.
 		My_Jetpack_Initializer::init();
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Addresses feedback from @jeherve (Thanks!) for #23477 and fixed the condition to show Search submenu.

- Corrects typo in comments
- Fixes an i18n issue
- Uses JP Redirect for URL
- Moves Jetpack compatibility to the package

#### Jetpack product discussion
#23477 
p1648147013140099-jetpack-search-team-slack

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
##### Test link works
- Create a JN site with only the Search plugin of the branch ([JN special ops](https://jurassic.ninja/specialops/))
    - Uncheck `Include Jetapck`
    - Check `Include Jetapck Beta`
    - Enter branch name for Jetpack Search - `fix/search-plugin-tidy-up`
- Navigate to `/wp-admin/admin.php?page=jetpack-search`
- Ensure `Learn more` link in footer is redirected to `https://jetpack.com/support/search/product-pricing/?utm_source=jetpack-search-plugin`

##### Test Search submenu visibility
- Use Jetpack Beta plugin to install Jetpack of the branch `fix/search-plugin-tidy-up`
- Ensure Search submenu is shown
- Deactivate Search plugin
- Ensure Search submenu is not shown / only Jetpack top menu is shown
- Connect and purchase a Search subscription
- Ensure Search submenu is shown