### PR TITLE
Fix: search feature never returned from benefit API

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -6,7 +6,7 @@
  */
 
 use Automattic\Jetpack\Connection\Client;
-use Automattic\Jetpack\Search\Initializer as Jetpack_Search_Initializer;
+
 /**
  * This is the endpoint class for `/site` endpoints.
  */
@@ -282,10 +282,10 @@ class Jetpack_Core_API_Site_Endpoint {
 			);
 		}
 
-		if ( Jetpack::is_module_active( 'search' ) && ! Jetpack::is_plugin_active( 'search/jetpack-search.php' ) && class_exists( Jetpack_Search_Initializer::class ) ) {
+		if ( Jetpack::is_module_active( 'search' ) && ! class_exists( 'Automattic\\Jetpack\\Search_Plugin\\Jetpack_Search_Plugin' ) ) {
 			$benefits[] = array(
 				'name'        => 'search',
-				'title'       => esc_html__( 'Jetpack Search', 'jetpack' ),
+				'title'       => esc_html__( 'Search', 'jetpack' ),
 				'description' => esc_html__( 'Help your visitors find exactly what they are looking for, fast', 'jetpack' ),
 			);
 		}

--- a/projects/plugins/jetpack/changelog/fix-search-benefit-api
+++ b/projects/plugins/jetpack/changelog/fix-search-benefit-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: fix the Search is never returned for benefits API


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Fixes https://github.com/Automattic/jetpack/pull/23536, where the condition is always false - I refactored the condition to use an alias::class last minute but which returns the name of the alias and makes the conditions always false. Broken.

Also the `Jetpack::is_plugin_active` is not reliable when plugin is installed in alternative folders like `jetpack-search-dev`, so changed to test plugin class exists.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Go to a site with only Jetpack plugin with Search module enabled
- Navigate to `/wp-admin/plugins.php?plugin_status=all&paged=1&s`
- Click `Disconnect and Deactivate`
- Ensure Search is shown as features in the list

![image](https://user-images.githubusercontent.com/1425433/160498031-e3f3040e-8c54-484f-bfba-4d1ced7e94a1.png)

- Click `Stay Connected`
- Activate Search plugin
- Ensure only Jetpack Search plugin is shown and Search feature is hidden

![image](https://user-images.githubusercontent.com/1425433/160498131-16952da9-3bc3-4be3-a901-df057911947c.png)
