### PR TITLE
Masterbar: avoid PHP notices when locale is not defined

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-notice-masterbar-20220329
+++ b/projects/plugins/jetpack/changelog/fix-notice-masterbar-20220329
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+WordPress.com Toolbar: avoid PHP notices when locale is not defined.

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
@@ -439,7 +439,11 @@ class Masterbar {
 			}
 		}
 
-		return $jetpack_locale;
+		if ( isset( $jetpack_locale ) ) {
+			return $jetpack_locale;
+		}
+
+		return 'en_US';
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

﻿Avoid PHP notices like this one:

```
[28-Mar-2022 09:38:57 UTC] PHP Notice:  Undefined variable: jetpack_locale in /srv/htdocs/wp-content/plugins/jetpack-dev/modules/masterbar/masterbar/class-masterbar.php on line 442
```

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

I'm not quite sure how to reproduce, I ran into the issue when checking the logs for my WoA sandbox.

* Try to go to Jetpack > Settings > Writing
* Enable the WordPress.com toolbar module
* Ensure you do not see the above error in your logs.
