### PR TITLE
Masterbar: avoid Fatals when function does not exist

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-notice-masterbar-feature-check-20220329
+++ b/projects/plugins/jetpack/changelog/fix-notice-masterbar-feature-check-20220329
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+WordPress.com Toolbar: check if function exists before to use it.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -121,7 +121,10 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		$plugins_slug = 'https://wordpress.com/plugins/' . $this->domain;
 
 		// Link to the Marketplace on sites that can't manage plugins.
-		if ( ! wpcom_site_has_feature( \WPCOM_Features::MANAGE_PLUGINS ) ) {
+		if (
+			function_exists( 'wpcom_site_has_feature' ) &&
+			! wpcom_site_has_feature( \WPCOM_Features::MANAGE_PLUGINS )
+		) {
 			add_menu_page( __( 'Plugins', 'jetpack' ), __( 'Plugins', 'jetpack' ), 'manage_options', $plugins_slug, null, 'dashicons-admin-plugins', '65' );
 			return;
 		}
@@ -355,7 +358,10 @@ class Atomic_Admin_Menu extends Admin_Menu {
 
 		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 11 );
 
-		if ( wpcom_site_has_feature( \WPCOM_Features::ATOMIC ) ) {
+		if (
+			function_exists( 'wpcom_site_has_feature' ) &&
+			wpcom_site_has_feature( \WPCOM_Features::ATOMIC )
+		) {
 			add_submenu_page( 'options-general.php', esc_attr__( 'Jetpack', 'jetpack' ), __( 'Jetpack', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/jetpack/' . $this->domain, null, 12 );
 		}
 


### PR DESCRIPTION
Follow-up to #23585

#### Changes proposed in this Pull Request:

That function is defined in wpcomsh, but in some cases that mu-plugin may be removed / not up to date, and we need to account for that.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Not easy to test, since you need a WoA sandbox where the wpcomsh mu-plugin is not up to date, but this should be a fairly straightforward change to review.

