### PR TITLE
Jetpack CRM: adjust wording

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/crm/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/crm/index.jsx
@@ -38,7 +38,7 @@ class DashCRM extends Component {
 				pluginLink={ this.props.siteAdminUrl + CRM_PLUGIN_DASH }
 				installOrActivatePrompt={ createInterpolateElement(
 					__(
-						'Sell more and get more leads with the Jetpack CRM plugin built specifically for WordPress.<br /><ExternalLink>Learn more</ExternalLink>',
+						'Sell more and get more leads with the free Jetpack CRM plugin built specifically for WordPress.<br /><ExternalLink>Learn more</ExternalLink>',
 						'jetpack'
 					),
 					{

--- a/projects/plugins/jetpack/changelog/update-wording-crm-plugin-upsell
+++ b/projects/plugins/jetpack/changelog/update-wording-crm-plugin-upsell
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack CRM: adjust banner's wording.

--- a/projects/plugins/jetpack/modules/stats/class-jetpack-stats-upgrade-nudges.php
+++ b/projects/plugins/jetpack/modules/stats/class-jetpack-stats-upgrade-nudges.php
@@ -528,7 +528,7 @@ class Jetpack_Stats_Upgrade_Nudges {
 		}
 		if ( $print ) {
 			$learn_link = self::get_upgrade_link( 'stats-nudges-crm-learn' );
-			$text       = __( 'Sell more and get more leads with the Jetpack CRM plugin built specifically for WordPress.', 'jetpack' );
+			$text       = __( 'Sell more and get more leads with the free Jetpack CRM plugin built specifically for WordPress.', 'jetpack' );
 			self::print_item( __( 'CRM', 'jetpack' ), $text, 'product-jetpack-crm.svg', $link, 'crm', $learn_link, false, $label );
 		}
 		return true;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Add a mention of "Free" to the Jetpack CRM description.

#### Jetpack product discussion

* ﻿See pbNhbs-2k2-p2#comment-7451

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start with a connected site.
* Go to Jetpack > Dashboard as well as Jetpack > Site Stats
* Check the CRM banners, they should mention "Free".
