### PR TITLE
pre-push hook: Don't fail if no tty is available

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,7 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-exec < /dev/tty
+if test -c /dev/tty && sh -c ': < /dev/tty' >/dev/null 2>/dev/null; then
+	exec < /dev/tty
+fi
 node tools/js-tools/git-hooks/pre-push-hook.js

--- a/tools/js-tools/git-hooks/pre-push-hook.js
+++ b/tools/js-tools/git-hooks/pre-push-hook.js
@@ -39,6 +39,8 @@ function checkChangelogFiles() {
 				"Allowing push because you're in draft mode. To exit draft mode, use `jetpack draft disable`"
 			)
 		);
+	} else if ( ! process.stdin.isTTY ) {
+		process.exitCode = 1;
 	} else {
 		try {
 			// Run the changelogger.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
PR #23359 added code to have the pre-push hook run `jetpack changelog add`,
but this code fails if the push is happening via an IDE where a tty is
not available.

The fix is in two parts: First, don't redirect stdin from /dev/tty in
.husky/pre-push if it's going to fail. Second, don't try to run
`jetpack` in pre-push-hook.js if stdin isn't a tty.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1648544038507239-slack-CDLH4C1UZ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a branch based on this one, probably one needing a change file added, and try pushes from a console and an IDE.
  * From console, `jetpack changelog add` should be run if needed.
  * From an IDE, `jetpack changelog add` should not be. Instead, the push should just be rejected with an appropriate message if a change entry file is needed.