### PR TITLE
Form Block: handle situation when an API request sends no response

### DIFF
--- a/projects/plugins/jetpack/changelog/update-crm-panel-api-no-response
+++ b/projects/plugins/jetpack/changelog/update-crm-panel-api-no-response
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Form Block: avoid displaying an empty CRM Integration panel when we get an empty API response.

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-crm-integration/jetpack-crm-integration-settings-extension.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-crm-integration/jetpack-crm-integration-settings-extension.js
@@ -23,11 +23,13 @@ const useOnExtensionActivationClick = (
 		} )
 			.then( result => {
 				if ( 'success' !== result.code ) {
-					throw new Error( result.code );
+					const errorMessage = __( 'There was an error activating the extension.', 'jetpack' );
+					setExtActivationError( errorMessage );
+				} else {
+					const newCRMData = Object.assign( {}, crmData );
+					newCRMData.jp_form_ext_enabled = true;
+					setCRMData( newCRMData );
 				}
-				const newCRMData = Object.assign( {}, crmData );
-				newCRMData.jp_form_ext_enabled = true;
-				setCRMData( newCRMData );
 			} )
 			.catch( error => {
 				setExtActivationError( error.message );

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-crm-integration/jetpack-crm-integration-settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-crm-integration/jetpack-crm-integration-settings.js
@@ -16,7 +16,8 @@ const fetchCRMData = ( setHasCRMDataError, setCRMData, setIsFetchingCRMData ) =>
 		path: '/jetpack/v4/jetpack_crm',
 	} )
 		.then( result => {
-			if ( result.error ) {
+			if ( result.error || 'success' !== result.code ) {
+				setHasCRMDataError( true );
 				throw result.message;
 			}
 			setHasCRMDataError( false );


### PR DESCRIPTION
Follow-up from #23618.

#### Changes proposed in this Pull Request:

* In some cases, especially on JN, and as reported by @tbradsha, the API request that returns info about Jetpack CRM returns an empty response. Let's handle that better.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start a new JN Site.
* Connect the site to WordPress.com.
* Go to Posts > Add New
* Add a Form Block
* Select it, and open the CRM panel in the plugin sidebar.
* Install the CRM plugin.
* Ensure you get a proper display in the UI.
