### PR TITLE
SEO Tools: use new feature gating for WPcom sites

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-seo-feature-gating
+++ b/projects/plugins/jetpack/changelog/update-jetpack-seo-feature-gating
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Use the new feature eligibility checks for WPcom sites in the SEO Tools feature

--- a/projects/plugins/jetpack/modules/seo-tools/class-jetpack-seo-utils.php
+++ b/projects/plugins/jetpack/modules/seo-tools/class-jetpack-seo-utils.php
@@ -23,11 +23,9 @@ class Jetpack_SEO_Utils {
 	/**
 	 * Used to check whether SEO tools are enabled for given site.
 	 *
-	 * @param int $site_id Optional. Defaults to current blog id if not given.
-	 *
 	 * @return bool True if SEO tools are enabled, false otherwise.
 	 */
-	public static function is_enabled_jetpack_seo( $site_id = 0 ) {
+	public static function is_enabled_jetpack_seo() {
 		/**
 		 * Can be used by SEO plugin authors to disable the conflicting output of SEO Tools.
 		 *
@@ -41,13 +39,9 @@ class Jetpack_SEO_Utils {
 			return false;
 		}
 
-		if ( function_exists( 'has_any_blog_stickers' ) ) {
-			// For WPCOM simple sites.
-			if ( empty( $site_id ) ) {
-				$site_id = get_current_blog_id();
-			}
-
-			return has_any_blog_stickers( array( 'business-plan', 'ecommerce-plan' ), $site_id );
+		// For WPcom sites.
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM && method_exists( 'Jetpack_Plan', 'supports' ) ) {
+			return Jetpack_Plan::supports( 'advanced-seo' );
 		}
 
 		// For all Jetpack sites.

--- a/projects/plugins/jetpack/modules/seo-tools/class-jetpack-seo-utils.php
+++ b/projects/plugins/jetpack/modules/seo-tools/class-jetpack-seo-utils.php
@@ -39,7 +39,7 @@ class Jetpack_SEO_Utils {
 			return false;
 		}
 
-		// For WPcom sites.
+		// For WPcom simple sites.
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM && method_exists( 'Jetpack_Plan', 'supports' ) ) {
 			return Jetpack_Plan::supports( 'advanced-seo' );
 		}


### PR DESCRIPTION
In #23189, we started using the new feature gating for WPcom sites in `Jetpack_Plan::supports()`. Given upcoming Dotcom pricing changes, this moves the feature gating for the SEO Tools to use `Jetpack_Plan` on WPcom sites.

See: pdgrnI-wV-p2#comment-1061

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* use `Jetpack_Plan::supports()` instead of blog stickers for the SEO Tools gating
* this shouldn't functionally change anything for existing users, just allow the Pro plan to access the tools

#### Does this pull request change what data or activity we track or use?
N/A

#### Testing instructions:

**Jetpack sites:**
- [Spin up a JN site using this branch](https://jurassic.ninja/create?jetpack-beta&branches.jetpack=update/jetpack-seo-feature-gating).
- Set up Jetpack and keep it on the Free plan
- In Calypso, visit Tools > Marketing > Traffic
- Verify that you can see the SEO sections without any gating
- Verify that updating the Page Title Structure correctly saves the changes

**Simple sites:**
- Apply D77860-code to your WP.com sandbox and sandbox the API
- For a simple site with a Free plan:
- In Calypso, visit Tools > Marketing > Traffic
- Verify that the SEO tools are gated behind a plan upgrade
- Add a Pro plan to the site via Store Admin and sandbox the simple site address
- In Calypso, visit Tools > Marketing > Traffic
- Verify that you can see the SEO sections without any gating
- Verify that updating the Page Title Structure correctly saves the changes

**Atomic sites:**
- Create a WoA dev blog with a Business plan (p9o2xV-1r2-p2).
- Install [Jetpack Beta](https://github.com/Automattic/jetpack-beta/releases/latest/download/jetpack-beta.zip), via the Plugins > Upload screen, and activate the branch of this PR.
- In Calypso, visit Tools > Marketing > Traffic
- Verify that you can see the SEO sections without any gating
- Verify that updating the Page Title Structure correctly saves the changes
- Create a WoA dev blog with a Pro Plan (via Store Admin).
- Install [Jetpack Beta](https://github.com/Automattic/jetpack-beta/releases/latest/download/jetpack-beta.zip) and activate the branch of this PR.
- In Calypso, visit Tools > Marketing > Traffic
- Verify that you can see the SEO sections without any gating
- Verify that updating the Page Title Structure correctly saves the changes