### PR TITLE
tools: Fix use of jq `inside( array )`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -899,8 +899,8 @@ importers:
 
   projects/plugins/boost:
     specifiers:
-      '@automattic/jetpack-base-styles': workspace:*
-      '@automattic/jetpack-components': workspace:*
+      '@automattic/jetpack-base-styles': workspace:* || ^0.1
+      '@automattic/jetpack-components': workspace:* || ^0.11
       '@babel/core': 7.17.8
       '@babel/preset-env': 7.16.11
       '@babel/preset-react': ^7.16.7

--- a/projects/plugins/boost/changelog/fix-jq-inside-array
+++ b/projects/plugins/boost/changelog/fix-jq-inside-array
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -6,7 +6,7 @@
 		"test": "tests"
 	},
 	"dependencies": {
-		"@automattic/jetpack-base-styles": "workspace:*",
+		"@automattic/jetpack-base-styles": "workspace:* || ^0.1",
 		"@wordpress/components": "19.5.0",
 		"@wordpress/element": "4.1.1",
 		"history": "5.3.0",
@@ -15,7 +15,7 @@
 		"svelte-navigator": "^3.1.5"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-components": "workspace:*",
+		"@automattic/jetpack-components": "workspace:* || ^0.11",
 		"@babel/core": "7.17.8",
 		"@babel/preset-env": "7.16.11",
 		"@babel/preset-react": "^7.16.7",

--- a/tools/check-intra-monorepo-deps.sh
+++ b/tools/check-intra-monorepo-deps.sh
@@ -252,10 +252,10 @@ for SLUG in "${SLUGS[@]}"; do
 			fi
 		done < <(
 			if [[ -e "$PHPFILE" ]]; then
-				jq --argjson packages "$PACKAGES" -r '.require // {}, .["require-dev"] // {} | to_entries[] | select( $packages[.key] as $vals | $vals and ( [ .value ] | inside( $vals ) | not ) ) | [ input_filename, .key, ( $packages[.key] | join( " or " ) ) ] | @tsv' "$PHPFILE"
+				jq --argjson packages "$PACKAGES" -r '.require // {}, .["require-dev"] // {} | to_entries[] | select( .value as $v | $packages[.key] as $vals | $vals and ( $vals | index( $v ) == null ) ) | [ input_filename, .key, ( $packages[.key] | join( " or " ) ) ] | @tsv' "$PHPFILE"
 			fi
 			if [[ -e "$JSFILE" ]]; then
-				jq --argjson packages "$JSPACKAGES" -r '.dependencies // {}, .devDependencies // {}, .peerDependencies // {}, .optionalDependencies // {} | to_entries[] | select( $packages[.key] as $vals | $vals and ( [ .value ] | inside( $vals ) | not ) ) | [ input_filename, .key, ( $packages[.key] | join( " or " ) ) ] | @tsv' "$JSFILE"
+				jq --argjson packages "$JSPACKAGES" -r '.dependencies // {}, .devDependencies // {}, .peerDependencies // {}, .optionalDependencies // {} | to_entries[] | select( .value as $v | $packages[.key] as $vals | $vals and ( $vals | index( $v ) == null ) ) | [ input_filename, .key, ( $packages[.key] | join( " or " ) ) ] | @tsv' "$JSFILE"
 			fi
 		)
 	fi

--- a/tools/version-packages.sh
+++ b/tools/version-packages.sh
@@ -80,17 +80,17 @@ echo "$JSON" > "$DIR/composer.json"
 PACKAGES=$(jq -nc 'reduce inputs as $in ([]; . + [ $in.name ])' "$BASE"/projects/packages/*/composer.json)
 
 # Get current versions from the package.
-OLD_VERSIONS=$(jq -r --argjson packages "$PACKAGES" '( .["require-dev"] // {} ) + ( .require // {} ) | with_entries( select( ( .value | test( "\\.x-dev$" ) ) and ( [ .key ] | inside( $packages ) ) ) )' "$DIR/composer.json")
+OLD_VERSIONS=$(jq -r --argjson packages "$PACKAGES" '( .["require-dev"] // {} ) + ( .require // {} ) | with_entries( select( ( .value | test( "\\.x-dev$" ) ) and ( .key as $k | $packages | index( $k ) ) ) )' "$DIR/composer.json")
 
 # Update the packages that appear in composer.json
 TO_UPDATE=()
-mapfile -t TO_UPDATE < <(jq -r --argjson packages "$PACKAGES" '.require // {} | to_entries[] | select( ( .value | test( "^@dev$|\\.x-dev$" ) ) and ( [ .key ] | inside( $packages ) ) ) | .key' "$DIR/composer.json")
+mapfile -t TO_UPDATE < <(jq -r --argjson packages "$PACKAGES" '.require // {} | to_entries[] | select( ( .value | test( "^@dev$|\\.x-dev$" ) ) and ( .key as $k | $packages | index( $k ) ) ) | .key' "$DIR/composer.json")
 if [[ ${#TO_UPDATE[@]} -gt 0 ]]; then
 	info "Updating packages: ${TO_UPDATE[*]}..."
 	composer require "${COMPOSER_ARGS[@]}" --no-update --working-dir="$DIR" -- "${TO_UPDATE[@]}"
 fi
 TO_UPDATE=()
-mapfile -t TO_UPDATE < <(jq -r --argjson packages "$PACKAGES" '.["require-dev"] // {} | to_entries[] | select( ( .value | test( "^@dev$|\\.x-dev$" ) ) and ( [ .key ] | inside( $packages ) ) ) | .key' "$DIR/composer.json")
+mapfile -t TO_UPDATE < <(jq -r --argjson packages "$PACKAGES" '.["require-dev"] // {} | to_entries[] | select( ( .value | test( "^@dev$|\\.x-dev$" ) ) and ( .key as $k | $packages | index( $k ) ) ) | .key' "$DIR/composer.json")
 if [[ ${#TO_UPDATE[@]} -gt 0 ]]; then
 	info "Updating dev packages: ${TO_UPDATE[*]}..."
 	composer require "${COMPOSER_ARGS[@]}" --no-update --working-dir="$DIR" --dev -- "${TO_UPDATE[@]}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
jq's `$arr1 | inside( $arr2 )`, when `$arr1` and `$arr2` are string
arrays, doesn't test for whether the elements of the input $arr1 are
members of $arr2. It tests for whether all strings in `$arr1` are
substrings of some string in `$arr2`, which is generally not the
behavior we want.

The same goes for `contains()`, but we're not using it on arrays
anywhere.

Instead, we can use `index()` to check for whether a string is in an
array.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try reverting the second commit of this PR, and see that `tools/check-intra-monorepo-deps.sh` detects the problems.
