### PR TITLE
Google Fonts: mark feature as Beta and remove from dashboard.

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/settings-card/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/components/settings-card/test/component.js
@@ -68,7 +68,6 @@ describe( 'SettingsCard', () => {
 			'comments',
 			'json-api',
 			'photon',
-			'google-fonts',
 		],
 		allCardsForNonAdmin = [ 'post-by-email' ];
 

--- a/projects/plugins/jetpack/_inc/client/components/settings-group/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/components/settings-group/test/component.js
@@ -48,7 +48,6 @@ describe( 'SettingsGroup', () => {
 			'comments',
 			'json-api',
 			'photon',
-			'google-fonts',
 		],
 		allGroupsForNonAdmin = [ 'post-by-email' ];
 

--- a/projects/plugins/jetpack/_inc/client/writing/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/index.jsx
@@ -45,7 +45,6 @@ export class Writing extends React.Component {
 			'carousel',
 			'copy-post',
 			'custom-css',
-			'google-fonts',
 			'latex',
 			'masterbar',
 			'markdown',

--- a/projects/plugins/jetpack/_inc/client/writing/theme-enhancements.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/theme-enhancements.jsx
@@ -107,16 +107,14 @@ class ThemeEnhancements extends React.Component {
 
 	render() {
 		const foundInfiniteScroll = this.props.isModuleFound( 'infinite-scroll' ),
-			foundCustomCSS = this.props.isModuleFound( 'custom-css' ),
-			foundGoogleFonts = this.props.isModuleFound( 'google-fonts' );
+			foundCustomCSS = this.props.isModuleFound( 'custom-css' );
 
-		if ( ! foundInfiniteScroll && ! foundCustomCSS && ! foundGoogleFonts ) {
+		if ( ! foundInfiniteScroll && ! foundCustomCSS ) {
 			return null;
 		}
 
 		const infScr = this.props.getModule( 'infinite-scroll' );
 		const customCSS = this.props.getModule( 'custom-css' );
-		const googleFonts = this.props.getModule( 'google-fonts' );
 
 		const infiniteScrollDisabledByOverride =
 			'inactive' === this.props.getModuleOverride( 'infinite-scroll' );
@@ -216,27 +214,6 @@ class ThemeEnhancements extends React.Component {
 						</ModuleToggle>
 					</SettingsGroup>
 				) }
-				{ foundGoogleFonts && this.props.isWebfontsSupported && (
-					<SettingsGroup
-						module={ { module: googleFonts.module } }
-						support={ {
-							text: googleFonts.description,
-							link: getRedirectUrl( 'jetpack-support-google-fonts' ),
-						} }
-					>
-						<ModuleToggle
-							slug="google-fonts"
-							activated={ !! this.props.getOptionValue( 'google-fonts' ) }
-							toggling={ this.props.isSavingAnyOption( [ 'google-fonts' ] ) }
-							disabled={ this.props.isSavingAnyOption( [ 'google-fonts' ] ) }
-							toggleModule={ this.props.toggleModuleNow }
-						>
-							<span className="jp-form-toggle-explanation">
-								{ __( 'Use Google Fonts in your block enabled theme', 'jetpack' ) }
-							</span>
-						</ModuleToggle>
-					</SettingsGroup>
-				) }
 			</SettingsCard>
 		);
 	}
@@ -247,6 +224,5 @@ export default connect( state => {
 		module: module_name => getModule( state, module_name ),
 		isInfiniteScrollSupported: currentThemeSupports( state, 'infinite-scroll' ),
 		isModuleFound: module_name => isModuleFound( state, module_name ),
-		isWebfontsSupported: currentThemeSupports( state, 'webfonts' ),
 	};
 } )( withModuleSettingsFormHelpers( ThemeEnhancements ) );

--- a/projects/plugins/jetpack/changelog/update-google-fonts-beta
+++ b/projects/plugins/jetpack/changelog/update-google-fonts-beta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Google Fonts: mark the feature as Beta, and remove toggle from dashboard.

--- a/projects/plugins/jetpack/modules/google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Module Name: Google Fonts
- * Module Description: A selection of Google fonts for block enabled themes.
+ * Module Name: Google Fonts (Beta)
+ * Module Description: A selection of Google fonts for block enabled themes. This feature is still being developed.
  * Sort Order: 1
  * Recommendation Order: 2
  * First Introduced: 10.8.0

--- a/projects/plugins/jetpack/modules/module-info.php
+++ b/projects/plugins/jetpack/modules/module-info.php
@@ -886,6 +886,6 @@ add_action( 'jetpack_learn_more_button_google-fonts', 'jetpack_google_fonts_more
  * Google Fonts description.
  */
 function jetpack_more_info_google_fonts() {
-	esc_html_e( 'A selection of Google fonts for block enabled themes.', 'jetpack' );
+	esc_html_e( 'A selection of Google fonts for block enabled themes.  This feature is still being developed.', 'jetpack' );
 }
 add_action( 'jetpack_module_more_info_google-fonts', 'jetpack_more_info_google_fonts' );


### PR DESCRIPTION
Follow-up from #23295

#### Changes proposed in this Pull Request:

* The feature is still under development, and we'll need to make some more changes before it's ready for prime-time. Let's make that clear in the plugin by marking the module as beta and removing the toggle from the dashboard to avoid setting wrong expectations.

#### Jetpack product discussion

* Internal reference: p1HpG7-flD-p2#comment-53417

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Go to Jetpack > Settings > Writing, and scroll down to the Theme Enhancements section; you should not see a section about Google Fonts.
* Go to Jetpack > Modules (from the link at the bottom of the dashboard page). You should see the Google Fonts module, but with a Beta label.
