### PR TITLE
Form: make margin around the CRM and Newsletter plugin buttons consistent

### DIFF
--- a/projects/plugins/jetpack/changelog/update-form-plugin-button-spacing
+++ b/projects/plugins/jetpack/changelog/update-form-plugin-button-spacing
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: Make the margin around the CRM and Newsletter plugin buttons consistent.
+
+

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-crm-integration/jetpack-crm-integration-settings-plugin-state.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-crm-integration/jetpack-crm-integration-settings-plugin-state.js
@@ -54,6 +54,7 @@ const CRMPluginIsInstalling = ( { isActivating } ) => {
 			icon={ <Icon style={ { animation: 'rotation 2s infinite linear' } } icon="update" /> }
 			disabled
 			aria-label={ btnTxt }
+			style={ { marginTop: '1em' } }
 		>
 			{ btnTxt }
 		</Button>
@@ -62,7 +63,11 @@ const CRMPluginIsInstalling = ( { isActivating } ) => {
 
 const CRMPluginIsNotInstalled = ( { installAndActivateCRMPlugin, isInstalling } ) => {
 	let button = (
-		<Button variant="secondary" onClick={ installAndActivateCRMPlugin }>
+		<Button
+			variant="secondary"
+			onClick={ installAndActivateCRMPlugin }
+			style={ { marginTop: '1em' } }
+		>
 			{ __( 'Install Jetpack CRM', 'jetpack' ) }
 		</Button>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-crm-integration/jetpack-crm-integration-settings-plugin-state.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-crm-integration/jetpack-crm-integration-settings-plugin-state.js
@@ -54,7 +54,6 @@ const CRMPluginIsInstalling = ( { isActivating } ) => {
 			icon={ <Icon style={ { animation: 'rotation 2s infinite linear' } } icon="update" /> }
 			disabled
 			aria-label={ btnTxt }
-			style={ { marginTop: '1em' } }
 		>
 			{ btnTxt }
 		</Button>
@@ -63,11 +62,7 @@ const CRMPluginIsInstalling = ( { isActivating } ) => {
 
 const CRMPluginIsNotInstalled = ( { installAndActivateCRMPlugin, isInstalling } ) => {
 	let button = (
-		<Button
-			variant="secondary"
-			onClick={ installAndActivateCRMPlugin }
-			style={ { marginTop: '1em' } }
-		>
+		<Button variant="secondary" onClick={ installAndActivateCRMPlugin }>
 			{ __( 'Install Jetpack CRM', 'jetpack' ) }
 		</Button>
 	);
@@ -77,7 +72,7 @@ const CRMPluginIsNotInstalled = ( { installAndActivateCRMPlugin, isInstalling } 
 	}
 
 	return (
-		<p className="jetpack-contact-form__crm_text">
+		<p className="jetpack-contact-form__crm_text jetpack-contact-form__integration-panel">
 			<em style={ { color: 'rgba(38, 46, 57, 0.7)' } }>
 				{ __( 'You can save contacts from Jetpack contact forms in Jetpack CRM.', 'jetpack' ) }
 				<br />
@@ -89,7 +84,7 @@ const CRMPluginIsNotInstalled = ( { installAndActivateCRMPlugin, isInstalling } 
 
 const CRMPluginIsInstalled = ( { activateCRMPlugin, isInstalling } ) => {
 	return (
-		<p className="jetpack-contact-form__crm_text">
+		<p className="jetpack-contact-form__crm_text jetpack-contact-form__integration-panel">
 			<em>
 				{ __(
 					'You already have the Jetpack CRM plugin installed, but it’s not activated.',

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-newsletter-integration-settings-plugin-state.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-newsletter-integration-settings-plugin-state.js
@@ -38,7 +38,7 @@ const CreativeMailPluginIsNotInstalled = ( {
 	isInstalling,
 } ) => {
 	return (
-		<p>
+		<p className="jetpack-contact-form__integration-panel">
 			<em style={ { color: 'rgba(38, 46, 57, 0.7)' } }>
 				{ __(
 					'To start sending email campaigns, install the Creative Mail plugin for WordPress.',
@@ -47,11 +47,7 @@ const CreativeMailPluginIsNotInstalled = ( {
 				<br />
 				{ isInstalling && <CreativeMailPluginIsInstalling /> }
 				{ ! isInstalling && (
-					<Button
-						variant="secondary"
-						onClick={ installAndActivateCreativeMailPlugin }
-						style={ { marginTop: '1em' } }
-					>
+					<Button variant="secondary" onClick={ installAndActivateCreativeMailPlugin }>
 						{ __( 'Install Creative Mail plugin', 'jetpack' ) }
 					</Button>
 				) }
@@ -62,7 +58,7 @@ const CreativeMailPluginIsNotInstalled = ( {
 
 const CreativeMailPluginIsInstalled = ( { activateCreativeMailPlugin, isInstalling } ) => {
 	return (
-		<p>
+		<p className="jetpack-contact-form__integration-panel">
 			<em>
 				{ __(
 					'To start sending email campaigns, activate the Creative Mail plugin for WordPress.',
@@ -72,11 +68,7 @@ const CreativeMailPluginIsInstalled = ( { activateCreativeMailPlugin, isInstalli
 			<br />
 			{ isInstalling && <CreativeMailPluginIsInstalling isActivating /> }
 			{ ! isInstalling && (
-				<Button
-					variant="secondary"
-					onClick={ activateCreativeMailPlugin }
-					style={ { marginTop: '1em' } }
-				>
+				<Button variant="secondary" onClick={ activateCreativeMailPlugin }>
 					{ __( 'Activate Creative Mail Plugin', 'jetpack' ) }
 				</Button>
 			) }

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-newsletter-integration-settings-plugin-state.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-newsletter-integration-settings-plugin-state.js
@@ -26,6 +26,7 @@ const CreativeMailPluginIsInstalling = ( { isActivating } ) => {
 			icon={ <Icon style={ { animation: 'rotation 2s infinite linear' } } icon="update" /> }
 			disabled
 			aria-label={ btnTxt }
+			style={ { marginTop: '1em' } }
 		>
 			{ btnTxt }
 		</Button>
@@ -46,7 +47,11 @@ const CreativeMailPluginIsNotInstalled = ( {
 				<br />
 				{ isInstalling && <CreativeMailPluginIsInstalling /> }
 				{ ! isInstalling && (
-					<Button variant="secondary" onClick={ installAndActivateCreativeMailPlugin }>
+					<Button
+						variant="secondary"
+						onClick={ installAndActivateCreativeMailPlugin }
+						style={ { marginTop: '1em' } }
+					>
 						{ __( 'Install Creative Mail plugin', 'jetpack' ) }
 					</Button>
 				) }
@@ -67,7 +72,11 @@ const CreativeMailPluginIsInstalled = ( { activateCreativeMailPlugin, isInstalli
 			<br />
 			{ isInstalling && <CreativeMailPluginIsInstalling isActivating /> }
 			{ ! isInstalling && (
-				<Button variant="secondary" onClick={ activateCreativeMailPlugin }>
+				<Button
+					variant="secondary"
+					onClick={ activateCreativeMailPlugin }
+					style={ { marginTop: '1em' } }
+				>
 					{ __( 'Activate Creative Mail Plugin', 'jetpack' ) }
 				</Button>
 			) }

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-newsletter-integration-settings-plugin-state.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-newsletter-integration-settings-plugin-state.js
@@ -26,7 +26,6 @@ const CreativeMailPluginIsInstalling = ( { isActivating } ) => {
 			icon={ <Icon style={ { animation: 'rotation 2s infinite linear' } } icon="update" /> }
 			disabled
 			aria-label={ btnTxt }
-			style={ { marginTop: '1em' } }
 		>
 			{ btnTxt }
 		</Button>

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
@@ -109,6 +109,12 @@
 	width: 260px;
 }
 
+.jetpack-contact-form__integration-panel {
+	button {
+		margin-top: 1em;
+	}
+}
+
 .jetpack-field-label {
 	display: flex;
 	flex-direction: row;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Form: make margin around the CRM and Newsletter plugin buttons consistent. Also use same margin for the activating/installing states so the buttons don't jump around.

#### Jetpack product discussion

Raised via internal testing: p8oabR-PC-p2#comment-6134

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

Observe post-patch design.

**Before:**

![Screen Shot 2022-03-30 at 3 49 17 PM](https://user-images.githubusercontent.com/15803018/160939257-8dab2084-bd39-4e9a-9ba5-b4b54cee428f.png)

**After:**

![Screen Shot 2022-03-30 at 3 57 18 PM](https://user-images.githubusercontent.com/15803018/160939316-f48c9c6b-82e4-4449-8202-c0d483998e85.png)

