### PR TITLE
Performance: Introduce RUM performance tracking

### DIFF
--- a/projects/plugins/jetpack/changelog/add-rum-performance-tracking
+++ b/projects/plugins/jetpack/changelog/add-rum-performance-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Performance: Introduce RUM performance tracking

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -23,6 +23,7 @@ use Automattic\Jetpack\Identity_Crisis;
 use Automattic\Jetpack\Licensing;
 use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
 use Automattic\Jetpack\Partner;
+use Automattic\Jetpack\Plugin\RUM;
 use Automattic\Jetpack\Plugin\Tracking as Plugin_Tracking;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
@@ -944,11 +945,13 @@ class Jetpack {
 
 		if ( ( new Tracking( 'jetpack', $this->connection_manager ) )->should_enable_tracking( new Terms_Of_Service(), new Status() ) ) {
 			add_action( 'init', array( new Plugin_Tracking(), 'init' ) );
+			add_action( 'init', array( new RUM(), 'init' ) );
 		} else {
 			/**
-			 * Initialize tracking right after the user agrees to the terms of service.
+			 * Initialize tracking and RUM right after the user agrees to the terms of service.
 			 */
 			add_action( 'jetpack_agreed_to_terms_of_service', array( new Plugin_Tracking(), 'init' ) );
+			add_action( 'jetpack_agreed_to_terms_of_service', array( new RUM(), 'init' ) );
 		}
 	}
 

--- a/projects/plugins/jetpack/src/class-rum.php
+++ b/projects/plugins/jetpack/src/class-rum.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * RUM class.
+ *
+ * @package automattic/jetpack
+ */
+
+namespace Automattic\Jetpack\Plugin;
+
+/**
+ * RUM class.
+ */
+class RUM {
+	/**
+	 * Prevents the RUM from being intialized more then once.
+	 *
+	 * @var bool
+	 */
+	private $initalized = false;
+
+	/**
+	 * Initialization function.
+	 */
+	public function init() {
+		if ( $this->initalized ) {
+			return;
+		}
+		$this->initalized = true;
+
+		// Collecting RUM performance data
+		add_action( 'wp_footer', array( $this, 'jetpack_footer_rum_js' ) );
+		add_action( 'admin_footer', array( $this, 'jetpack_footer_rum_js' ) );
+	}
+
+	/**
+	 * Collect RUM performance data
+	 *
+	 * @access public
+	 */
+	public function jetpack_footer_rum_js() {
+		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		echo "<script defer id='bilmur' data-provider='wordpress.com' data-service='jetpack' src='https://s0.wp.com/wp-content/js/bilmur.min.js'></script>\n";
+	}
+}


### PR DESCRIPTION
This adds a `defer`ed piece of JavaScript to collect RUM data on Jetpack sites. This is the same code that is already being used on WordPress.com Simple and Atomic sites.

We need this data in order to be able to analyze in-depth the performance of the editor, something that team Calypso has been working on recently. Furthermore, the RUM data can be helpful for analyzing and future improvement of the performance of various areas of the product.

Related: D77835-code for WP.com, 878-gh-Automattic/wpcomsh for Atomic and 26-gh-Automattic/bilmur that enables iframe request data collection (necessary for the iframed editor).

#### Changes proposed in this Pull Request:
* Performance: Introduce RUM performance tracking

#### Jetpack product discussion
No related Jetpack product discussion.

See p9o2xV-XY-p2 for more information.

#### Does this pull request change what data or activity we track or use?
Privacy wise we don’t collect any personally identifiable information. See p9o2xV-XY-p2

#### Testing instructions:
* Open `/wp-admin/post-new.php`.
* Verify that the `/wp-content/js/bilmur.min.js` script is being loaded.
* Open a random page from the frontend of the site.
* Verify that the `/wp-content/js/bilmur.min.js` script is being loaded.