### PR TITLE
JS Components: Add story doc to Text components

### DIFF
--- a/projects/js-packages/components/changelog/update-js-components-improve-text-doc
+++ b/projects/js-packages/components/changelog/update-js-components-improve-text-doc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+JS Components: Add story doc to Text components

--- a/projects/js-packages/components/components/text/stories/Text-MDX-Documentation.mdx
+++ b/projects/js-packages/components/components/text/stories/Text-MDX-Documentation.mdx
@@ -23,18 +23,18 @@ Set of React jetpack-components intended to facilitate when dealing with renderi
 Define the text Typography variant among the options offered by the ThemeProvider component.
 
 <Source
-	language='jsx'
-	code={dedent`
-		import Text from '@automattic/jetpack-components';
-		
-		function Hello() {
-			return (
-				<Text variant="headline-medium">
-					Hello, Text component!
-				</Text>
-			);
-		}
-	`}
+  language='jsx'
+  code={dedent`
+    import Text from '@automattic/jetpack-components';
+    
+    function Hello() {
+      return (
+        <Text variant="headline-medium">
+          Hello, Text component!
+        </Text>
+      );
+    }
+  `}
 />
 
 #### Spacing properties
@@ -62,19 +62,58 @@ Prop | Description
 **py** | padding top and bottom
 
 <Source
-	language='jsx'
-	code={dedent`
-		import Text from '@automattic/jetpack-components';
-		
-		function HelloBoxModel() {
-			return (
-				<Text mt={ 2 } px={ 4 }>
-					Hello, Text component!
-				</Text>
-			);
-		}
-	`}
+  language='jsx'
+  code={dedent`
+    import Text from '@automattic/jetpack-components';
+    
+    function HelloBoxModel() {
+      return (
+        <Text mt={ 2 } px={ 4 }>
+          Hello, Text component!
+        </Text>
+      );
+    }
+  `}
 />
+
+#### component
+
+**Type**: `elementType`, `string`.
+
+Force an specific tag (`<span />`, `<div />`) or use a custom component that will receive className and children.
+
+<Source
+  language='jsx'
+  code={dedent`
+    import Text from '@automattic/jetpack-components';
+    
+    function CustomComponent( { children, className } ) {
+      // className, provided by Text, is "custom-classname"
+      return (
+        <div className={ className }>{ children }</div>
+      );
+    }
+    
+    // Use a custom component when rendering the <Text />,
+    // it passes down the className property to it.
+    function CustomTextComponent() {
+      return (
+        <Text
+          className="custom-classname"
+          component={ CustomComponent }
+        >
+          Hello, Custom Text component!
+        </Text>
+      );
+    }
+  `}
+/>
+
+#### Children
+
+**Type**: `node`.
+
+The text itself that will be rendered.
 
 # Text based components
 
@@ -89,16 +128,16 @@ Text shorthand to render a `heading-small` text, applying proper spacing.
 #### Weight: `bold` (default) | `regular`
 
 <Source
-	language='jsx'
-	code={dedent`
-		import { H3 } from '@automattic/jetpack-components';
-		
-		function Subtitle() {
-			return (
-				<H3 weight="regular">Let's explaining what H3 is</H3>
-			);
-		}
-	`}
+  language='jsx'
+  code={dedent`
+    import { H3 } from '@automattic/jetpack-components';
+    
+    function Subtitle() {
+      return (
+        <H3 weight="regular">Let's explaining what H3 is</H3>
+      );
+    }
+  `}
 />
 
 ## <Title /\>
@@ -109,16 +148,16 @@ Text shorthand to render a `body` text, applying proper spacing.
 #### Size: `medium` (default) | `small`
 
 <Source
-	language='jsx'
-	code={dedent`
-		import { Title } from '@automattic/jetpack-components';
-		
-		function Subtitle() {
-			return (
-				<Title size="small">
-					To explain what a Title component does, we should before...
-				</Title>
-			);
-		}
-	`}
+  language='jsx'
+  code={dedent`
+    import { Title } from '@automattic/jetpack-components';
+    
+    function Subtitle() {
+      return (
+        <Title size="small">
+          To explain what a Title component does, we should before...
+        </Title>
+      );
+    }
+  `}
 />

--- a/projects/js-packages/components/components/text/stories/Text-MDX-Documentation.mdx
+++ b/projects/js-packages/components/components/text/stories/Text-MDX-Documentation.mdx
@@ -109,6 +109,8 @@ Force an specific tag (`<span />`, `<div />`) or use a custom component that wil
   `}
 />
 
+[Custom Tag story](.?path=/story/js-packages-components-text--custom-tag) and [Custom Component story](.?path=/story/js-packages-components-text--custom-component)
+
 #### Children
 
 **Type**: `node`.
@@ -120,8 +122,12 @@ The text itself that will be rendered.
 ## <H2 /\>
 Text shorthand to render a `heading-medium` text, applying proper spacing.
 
+[▶️ Story](.?path=/story/js-packages-components-text-heading--headline-h-2)
+
 ## <H3 /\>
 Text shorthand to render a `heading-small` text, applying proper spacing.
+
+[▶️ Story](.?path=/story/js-packages-components-text-heading--headline-h-3)
 
 ### Props
 
@@ -161,3 +167,5 @@ Text shorthand to render a `body` text, applying proper spacing.
     }
   `}
 />
+
+[▶️ Story](.?path=/story/js-packages-components-text-title--default)

--- a/projects/js-packages/components/components/text/stories/Text-MDX-Documentation.mdx
+++ b/projects/js-packages/components/components/text/stories/Text-MDX-Documentation.mdx
@@ -1,0 +1,123 @@
+import { Meta, Source, Story, Canvas } from '@storybook/addon-docs';
+import dedent from 'ts-dedent';
+import Text, { SPACING_VALUES, BOX_MODEL_VALUES, H2, H3, Title } from '../index.jsx';
+
+<Meta title="JS Packages/Components/Text/Readme" />
+
+# Text
+Set of React jetpack-components intended to facilitate when dealing with rendering text content.
+
+## <Text /\>
+
+`Text` is the primary component that renders text, supporting the following features:
+
+* **Typography**: provided by the ThemeProvider component.
+* **Spacing**: A simple range of shorthand classes to modify the text element's margin and padding.
+
+### Props
+
+#### variant
+
+**Type**: `headline-medium`, `headline-small`, `headline-small-regular`, `title-medium`, `title-small`, `body`, `body-small`, `body-extra-small`, `label`.
+
+Define the text Typography variant among the options offered by the ThemeProvider component.
+
+<Source
+	language='jsx'
+	code={dedent`
+		import Text from '@automattic/jetpack-components';
+		
+		function Hello() {
+			return (
+				<Text variant="headline-medium">
+					Hello, Text component!
+				</Text>
+			);
+		}
+	`}
+/>
+
+#### Spacing properties
+
+**Type**: number, one of `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`.
+
+Use the following properties to define margin and padding of the text. The unit is defined by the `--spacing-base` value.
+
+Prop | Description
+---|---
+**m** | margin
+**mt** | margin-top
+**mr** | margin-right
+**mb** | margin-bottom
+**ml** | margin-left
+**mx** | margin left and right
+**my** | margin top and bottom
+**p** | padding
+**pt** | padding-top
+**pr** | padding-right
+**pb** | padding-bottom
+**pl** | padding-left
+**px** | padding left and right
+**py** | padding top and bottom
+
+<Source
+	language='jsx'
+	code={dedent`
+		import Text from '@automattic/jetpack-components';
+		
+		function HelloBoxModel() {
+			return (
+				<Text mt={ 2 } px={ 4 }>
+					Hello, Text component!
+				</Text>
+			);
+		}
+	`}
+/>
+
+# Text based components
+
+## <H2 /\>
+Text shorthand to render a `heading-medium` text, applying proper spacing.
+
+## <H3 /\>
+Text shorthand to render a `heading-small` text, applying proper spacing.
+
+### Props
+
+#### Weight: `bold` (default) | `regular`
+
+<Source
+	language='jsx'
+	code={dedent`
+		import { H3 } from '@automattic/jetpack-components';
+		
+		function Subtitle() {
+			return (
+				<H3 weight="regular">Let's explaining what H3 is</H3>
+			);
+		}
+	`}
+/>
+
+## <Title /\>
+Text shorthand to render a `body` text, applying proper spacing.
+
+### Props
+
+#### Size: `medium` (default) | `small`
+
+<Source
+	language='jsx'
+	code={dedent`
+		import { Title } from '@automattic/jetpack-components';
+		
+		function Subtitle() {
+			return (
+				<Title size="small">
+					To explain what a Title component does, we should before...
+				</Title>
+			);
+		}
+	`}
+/>

--- a/projects/js-packages/components/components/text/stories/Text-MDX-Documentation.mdx
+++ b/projects/js-packages/components/components/text/stories/Text-MDX-Documentation.mdx
@@ -80,7 +80,26 @@ Prop | Description
 
 **Type**: `elementType`, `string`.
 
-Force an specific tag (`<span />`, `<div />`) or use a custom component that will receive className and children.
+Force an specific tag (`"span"`, `"div"`) or use a custom component that will receive className and children.
+
+The example below renders the component with a `<span />` element.
+
+<Source
+  language='jsx'
+  code={dedent`
+    import Text from '@automattic/jetpack-components';
+    function SpanTextComponent() {
+      return (
+        <Text component="span" variant="title-medium">
+          Never underestimate the span element
+        </Text>
+      );
+    }
+  `}
+/>
+
+The following example shows how to define the typography and the margin for a Custom component.
+The className is passed down to the custom component, while the properties that belong to the Text component (in this case, `component`, `variant` and `mb`) are not.
 
 <Source
   language='jsx'
@@ -99,8 +118,10 @@ Force an specific tag (`<span />`, `<div />`) or use a custom component that wil
     function CustomTextComponent() {
       return (
         <Text
-          className="custom-classname"
           component={ CustomComponent }
+          className="custom-classname"
+          variant="title-medium"
+          mb={ 3 }
         >
           Hello, Custom Text component!
         </Text>
@@ -109,7 +130,7 @@ Force an specific tag (`<span />`, `<div />`) or use a custom component that wil
   `}
 />
 
-[Custom Tag story](.?path=/story/js-packages-components-text--custom-tag) and [Custom Component story](.?path=/story/js-packages-components-text--custom-component)
+[▶️ Custom Tag story](.?path=/story/js-packages-components-text--custom-tag) and [▶️ Custom Component story](.?path=/story/js-packages-components-text--custom-component)
 
 #### Children
 

--- a/projects/js-packages/components/components/text/stories/Text-MDX-Documentation.mdx
+++ b/projects/js-packages/components/components/text/stories/Text-MDX-Documentation.mdx
@@ -42,6 +42,7 @@ Define the text Typography variant among the options offered by the ThemeProvide
 **Type**: number, one of `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`.
 
 Use the following properties to define margin and padding of the text. The unit is defined by the `--spacing-base` value.
+You can see how it works playing with the [Box Model](./?path=/story/js-packages-components-text--box-model) story.
 
 Prop | Description
 ---|---

--- a/projects/js-packages/components/components/text/stories/headings.index.jsx
+++ b/projects/js-packages/components/components/text/stories/headings.index.jsx
@@ -70,14 +70,14 @@ const DefaultArgs = {};
 export const Default = Template.bind( {} );
 Default.args = DefaultArgs;
 
-export const HeadlineMedium = TemplateH2.bind( {} );
-HeadlineMedium.storyName = 'H2';
-HeadlineMedium.args = {
+export const HeadlineH2 = TemplateH2.bind( {} );
+HeadlineH2.storyName = 'H2';
+HeadlineH2.args = {
 	weight: 'bold',
 };
 
-export const HeadlineSmall = TemplateH3.bind( {} );
-HeadlineSmall.storyName = 'H3';
-HeadlineSmall.args = {
+export const HeadlineH3 = TemplateH3.bind( {} );
+HeadlineH3.storyName = 'H3';
+HeadlineH3.args = {
 	weight: 'bold',
 };

--- a/projects/js-packages/components/components/text/stories/index.jsx
+++ b/projects/js-packages/components/components/text/stories/index.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import Text, { SPACING_VALUES, BOX_MODEL_VALUES } from '../index.jsx';
+import Text, { SPACING_VALUES, BOX_MODEL_VALUES, H2, H3, Title } from '../index.jsx';
 import styles from './style.module.scss';
 
 export default {
@@ -23,6 +23,7 @@ export default {
 			{}
 		),
 	},
+	subcomponents: { H2, H3, Title },
 };
 
 const Template = args => <Text { ...args }>{ args.variant ?? 'body' }</Text>;

--- a/projects/js-packages/components/components/text/stories/index.jsx
+++ b/projects/js-packages/components/components/text/stories/index.jsx
@@ -8,6 +8,7 @@ import React from 'react';
  */
 import Text, { SPACING_VALUES, BOX_MODEL_VALUES, H2, H3, Title } from '../index.jsx';
 import styles from './style.module.scss';
+import TextMDXDocumentation from './Text-MDX-Documentation.mdx';
 
 export default {
 	title: 'JS Packages/Components/Text',
@@ -24,6 +25,11 @@ export default {
 		),
 	},
 	subcomponents: { H2, H3, Title },
+	parameters: {
+		docs: {
+			page: TextMDXDocumentation,
+		},
+	},
 };
 
 const Template = args => <Text { ...args }>{ args.variant ?? 'body' }</Text>;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds a story document to the `<Text />`

Fixes https://github.com/Automattic/jetpack/issues/23592

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* JS Components: Add story doc to Text components

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run storybook
* Go to Text story (default)
* Click on doc tab
* Take a look at the document (feedback more than welcomed)

https://user-images.githubusercontent.com/77539/161064357-a12bb841-52c0-44a7-a7d4-78ca3376b9a6.mov
