### PR TITLE
Carousel: Fixing comments issue with nonce checks

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-nonce
+++ b/projects/plugins/jetpack/changelog/fix-carousel-nonce
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixing carousel comments issue due to nonce check

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -930,8 +930,10 @@ class Jetpack_Carousel {
 		 */
 		do_action( 'jp_carousel_check_blog_user_privileges' );
 
-		$attachment_id = ( isset( $_REQUEST['id'] ) ) ? (int) $_REQUEST['id'] : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$offset        = ( isset( $_REQUEST['offset'] ) ) ? (int) $_REQUEST['offset'] : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- we do not need to verify the nonce for this public request for publicly accessible data (as checked below).
+		$attachment_id = ( isset( $_REQUEST['id'] ) ) ? (int) $_REQUEST['id'] : 0;
+		$offset        = ( isset( $_REQUEST['offset'] ) ) ? (int) $_REQUEST['offset'] : 0;
+		// phpcs:enable
 
 		if ( ! $attachment_id ) {
 			wp_send_json_error(

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -930,12 +930,8 @@ class Jetpack_Carousel {
 		 */
 		do_action( 'jp_carousel_check_blog_user_privileges' );
 
-		$attachment_id = ( isset( $_REQUEST['id'] ) ) ? (int) $_REQUEST['id'] : 0;
-		$offset        = ( isset( $_REQUEST['offset'] ) ) ? (int) $_REQUEST['offset'] : 0;
-
-		if ( empty( $_POST['nonce'] ) || ! wp_verify_nonce( $_POST['nonce'], 'carousel_nonce' ) ) {
-			die( wp_json_encode( array( 'error' => __( 'Nonce verification failed.', 'jetpack' ) ) ) );
-		}
+		$attachment_id = ( isset( $_REQUEST['id'] ) ) ? (int) $_REQUEST['id'] : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$offset        = ( isset( $_REQUEST['offset'] ) ) ? (int) $_REQUEST['offset'] : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		if ( ! $attachment_id ) {
 			wp_send_json_error(


### PR DESCRIPTION
Fixes #23728

#### Changes proposed in this Pull Request:

* PR #22770 introduced a nonce check which caused issues for comments in carousels. This PR fixes that by removing the nonce check.

#### Jetpack product discussion

p1648736983705859-slack-C01U2KGS2PQ

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* There are some great [testing instructions here](https://github.com/Automattic/jetpack/issues/23728#issuecomment-1084661729) - however the network tab response should now not show a failure message under 'Preview', and comments should show under the images in the carousel.
