### PR TITLE
tools: Let check-changelogger-use.php detect uncommitted change entries

### DIFF
--- a/tools/check-changelogger-use.php
+++ b/tools/check-changelogger-use.php
@@ -21,20 +21,33 @@ USAGE: {$argv[0]} [--debug|-v] [--list] <base-ref> <head-ref>
 Checks that a monorepo commit contains a Changelogger change entry for each
 project touched.
 
-  --debug, -v  Display verbose output.
-  --list       Just list projects, no explanatory output.
-  <base-ref>   Base git ref to compare for changed files.
-  <head-ref>   Head git ref to compare for changed files.
+  --debug, -v    Display verbose output.
+  --list         Just list projects, no explanatory output.
+  --maybe-merge  If unmerged change entries are detected, offer to merge them.
+  <base-ref>     Base git ref to compare for changed files.
+  <head-ref>     Head git ref to compare for changed files.
+
+Exit codes:
+
+ 0: No change entries are needed.
+ 1: Execution failure of some kind.
+ 2: Projects lack a change entry.
+ 4: Projects have uncommitted change entries. None are missing an entry.
+ 6: Some projects have uncommitted change entries, and some lack a change entry.
+ 8: Change entries were committed. No more change entries are needed.
+10: Change entries were committed. Some change entries are still needed.
 
 EOH;
 	exit( 1 );
 }
 
-$idx     = 0;
-$verbose = false;
-$list    = false;
-$base    = null;
-$head    = null;
+$exit        = 0;
+$idx         = 0;
+$verbose     = false;
+$list        = false;
+$maybe_merge = false;
+$base        = null;
+$head        = null;
 for ( $i = 1; $i < $argc; $i++ ) {
 	switch ( $argv[ $i ] ) {
 		case '-v':
@@ -43,6 +56,9 @@ for ( $i = 1; $i < $argc; $i++ ) {
 			break;
 		case '--list':
 			$list = true;
+			break;
+		case '--maybe-merge':
+			$maybe_merge = true;
 			break;
 		case '-h':
 		case '--help':
@@ -93,6 +109,30 @@ if ( $verbose ) {
 	 * Do not output debug info.
 	 */
 	function debug() {
+	}
+}
+
+if ( $maybe_merge && $list ) {
+	debug( 'Ignoring --maybe-merge, --list was provided' );
+	$maybe_merge = false;
+}
+if ( $maybe_merge && getenv( 'CI' ) ) {
+	debug( 'Ignoring --maybe-merge, running in CI mode' );
+	$maybe_merge = false;
+}
+if ( $maybe_merge && ! ( is_callable( 'posix_isatty' ) && posix_isatty( STDIN ) ) ) {
+	debug( 'Ignoring --maybe-merge, stdin is not a tty' );
+	$maybe_merge = false;
+}
+if ( $maybe_merge ) {
+	$ver = shell_exec( 'git version' );
+	if ( ! $ver ||
+		! preg_match( '/git version (\d+\.\d+\.\d+)/', $ver, $m ) ||
+		// PHP's version_compare is kind of broken, but works for all-numeric versions.
+		version_compare( $m[1], '2.25.0', '<' )
+	) {
+		debug( 'Ignoring --maybe-merge, git is unavailable or too old (version 2.25+ is required)' );
+		$maybe_merge = false;
 	}
 }
 
@@ -165,37 +205,152 @@ while ( ( $line = fgets( $pipes[1] ) ) ) {
 fclose( $pipes[1] );
 $status = proc_close( $p );
 if ( $status ) {
-	exit( $status );
+	exit( 1 );
+}
+
+// Check if any projects needing change entries were found.
+$needed_projects = array_diff_key( $touched_projects, $ok_projects );
+if ( ! $needed_projects ) {
+	exit( 0 );
+}
+
+// Look for unmerged change entry files.
+debug( 'Checking for unmerged change entry files.' );
+$pipes = null;
+$p     = proc_open(
+	'git -c core.quotepath=off status --no-renames --porcelain',
+	array( array( 'pipe', 'r' ), array( 'pipe', 'w' ), STDERR ),
+	$pipes
+);
+if ( ! $p ) {
+	exit( 1 );
+}
+fclose( $pipes[0] );
+
+$unmerged_projects = array();
+// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
+while ( ( $line = fgets( $pipes[1] ) ) ) {
+	$line  = trim( $line );
+	$file  = substr( $line, 3 );
+	$parts = explode( '/', $file, 5 );
+	if ( count( $parts ) < 4 || 'projects' !== $parts[0] ) {
+		debug( 'Ignoring non-project file %s.', $file );
+		continue;
+	}
+	$slug = "{$parts[1]}/{$parts[2]}";
+	if ( ! isset( $changelogger_projects[ $slug ] ) ) {
+		debug( 'Ignoring file %s, project %s does not use changelogger.', $file, $slug );
+		continue;
+	}
+	if ( $parts[3] === $changelogger_projects[ $slug ]['changes-dir'] && '.' !== $parts[4][0] ) {
+		if ( empty( $needed_projects[ $slug ] ) ) {
+			debug( 'Ignoring unmerged change entry file %s, project %s is already ok.', $file, $slug );
+		} else {
+			debug( 'Unmerged changes touch change entry file %s, marking %s as having an unmerged change file.', $file, $slug );
+			$unmerged_projects[ $slug ][] = $file;
+		}
+		continue;
+	}
+
+	debug( 'Ignoring non-change-entry file %s.', $file );
+}
+
+fclose( $pipes[1] );
+$status = proc_close( $p );
+if ( $status ) {
+	exit( 1 );
+}
+
+// Offer to merge, if applicable.
+if ( $unmerged_projects && $maybe_merge ) {
+	echo "The following change entry files exist and are needed but are not committed.\n";
+	echo ' - ' . join( "\n - ", array_merge( ...( array_values( $unmerged_projects ) ) ) ) . "\n";
+	echo 'Shall I merge them for you? [Y/n] ';
+	$do_merge = null;
+	while ( $do_merge === null ) {
+		$c = fgets( STDIN );
+		if ( $c === false || $c === '' ) {
+			$do_merge = false;
+		} else {
+			$c = substr( trim( $c ), 0, 1 );
+			if ( $c === '' || $c === 'y' || $c === 'Y' ) {
+				$do_merge = true;
+			} elseif ( $c === 'n' || $c === 'N' ) {
+				$do_merge = false;
+			}
+		}
+	}
+	if ( $do_merge ) {
+		foreach ( array( 'add', 'commit -m "Changelog"' ) as $cmd ) {
+			$pipes = null;
+			$p     = proc_open(
+				"git --literal-pathspecs $cmd --pathspec-from-file=- --pathspec-file-nul",
+				array( array( 'pipe', 'r' ), STDOUT, STDERR ),
+				$pipes
+			);
+			if ( ! $p ) {
+				exit( 1 );
+			}
+			$str = join( "\0", array_merge( ...( array_values( $unmerged_projects ) ) ) );
+			while ( $str !== '' ) {
+				$l = fwrite( $pipes[0], $str );
+				if ( $l === false ) {
+					exit( 1 );
+				}
+				$str = (string) substr( $str, $l );
+			}
+			fclose( $pipes[0] );
+			$status = proc_close( $p );
+			if ( $status ) {
+				exit( 1 );
+			}
+		}
+		$ok_projects      += $unmerged_projects;
+		$unmerged_projects = array();
+		$exit             |= 8;
+	}
 }
 
 // Output.
 ksort( $touched_projects );
-$exit = 0;
 foreach ( $touched_projects as $slug => $files ) {
 	if ( empty( $ok_projects[ $slug ] ) ) {
-		if ( $list ) {
-			echo "$slug\n";
-		} elseif ( getenv( 'CI' ) ) {
-			printf( "---\n" ); // Bracket message containing newlines for better visibility in GH's logs.
-			printf(
-				"::error::Project %s is being changed, but no change file in %s is touched!%%0A%%0AUse `jetpack changelogger add %s` to add a change file.%%0AGuidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md\n",
+		if ( ! empty( $unmerged_projects[ $slug ] ) ) {
+			$ct = count( $unmerged_projects[ $slug ] );
+			if ( $ct > 1 ) {
+				$msg                                   = 'Project %s is being changed, and change files %s exist but are not committed!';
+				$unmerged_projects[ $slug ][ $ct - 1 ] = 'and ' . $unmerged_projects[ $slug ][ $ct - 1 ];
+			} else {
+				$msg = 'Project %s is being changed, and change file %s exists but is not committed!';
+			}
+			$msg   = sprintf(
+				$msg,
 				$slug,
-				"projects/$slug/{$changelogger_projects[ $slug ]['changes-dir']}/",
-				$slug
+				join( $ct > 2 ? ', ' : ' ', $unmerged_projects[ $slug ] )
 			);
-			printf( "---\n" );
-			$exit = 1;
+			$msg2  = '';
+			$exit |= 4;
 		} else {
-			printf(
-				"\e[1;31mProject %s is being changed, but no change file in %s is touched!\e[0m\n",
+			$msg   = sprintf(
+				'Project %s is being changed, but no change file in %s is touched!',
 				$slug,
 				"projects/$slug/{$changelogger_projects[ $slug ]['changes-dir']}/"
 			);
-			$exit = 1;
+			$msg2  = sprintf( "\n\nUse `jetpack changelogger add %s` to add a change file.\nGuidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md", $slug );
+			$exit |= 2;
+		}
+
+		if ( $list ) {
+			echo "$slug\n";
+		} elseif ( getenv( 'CI' ) ) {
+			$msg = strtr( $msg . $msg2, array( "\n" => '%0A' ) );
+			echo "---\n::error::$msg\n---\n";
+		} else {
+			echo "\e[1;31m$msg\e[0m\n";
 		}
 	}
 }
-if ( $exit && ! getenv( 'CI' ) && ! $list ) {
+if ( ( $exit & 2 ) && ! getenv( 'CI' ) && ! $list ) {
 	printf( "\e[32mUse `jetpack changelogger add <slug>` to add a change file for each project.\e[0m\n" );
 	printf( "\e[32mGuidelines: https://github.com/Automattic/jetpack/blob/master/docs/writing-a-good-changelog-entry.md\e[0m\n" );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
If change entry files exist but aren't committed, the script should say
so instead of saying that they need to be added.

Further, when run from the pre-push hook, it would be nice if it would
offer to commit the entries.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1648733008882149/1648675066.428619-slack-CDLH4C1UZ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test the following cases:

* Push with no missing change entries.
  * Push should succeed.
* Push with only missing change entries.
  * Changelogger should run, as before.
* Push (via command line) with only uncommitted change entries.
  * You should be prompted to merge. Answer "N".
  * Push should be rejected with sensible messages and without trying to run changelogger.
* Push (via command line) with only uncommitted change entries.
  * You should be prompted to merge. Answer "Y".
  * You should be prompted to push again. The uncommitted change entries should now be merged.
* Push (via IDE) with only uncommitted change entries.
  * Push should be rejected with sensible messages and without trying to run changelogger. No commits should have been added.
* Push (via command line) with both missing and uncommitted change entries.
  * You should be prompted to merge. Answer "N".
  * The push should be rejected, without trying to run changelogger.
* Push (via command line) with both missing and uncommitted change entries.
  * You should be prompted to merge. Answer "Y".
  * Changelogger should now be run, as before. If you proceed with that too, after being prompted to push again you should see two commits were added.
* Push (via IDE) with both missing and uncommitted change entries.
  * Push should be rejected with sensible messages and without prompting or trying to run changelogger. No commits should have been added.
* Create a PR based on this one with missing change entries. Does CI flag it properly?