### PR TITLE
Search: fix two Search submenus for older Jetpack plugin

### DIFF
--- a/projects/packages/search/changelog/fix-allow-search-submenu-added-only-once
+++ b/projects/packages/search/changelog/fix-allow-search-submenu-added-only-once
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: allow Search submenu to be added only once

--- a/projects/packages/search/src/dashboard/class-dashboard.php
+++ b/projects/packages/search/src/dashboard/class-dashboard.php
@@ -61,17 +61,16 @@ class Dashboard {
 	}
 
 	/**
-	 * Initialise hooks
+	 * Initialise hooks.
+	 *
+	 * We use the `config` package to initialize the search package, which ensures the package is
+	 * only initialized once. However earlier versions of Jetpack would still forcely initialize the
+	 * dashboard. As a result, there would be two `Search` submenus if we don't ensure the dashboard
+	 * is initialized only once. So we use `$initialized` to ensure the class is only initialized once.
+	 *
+	 * Ref: https://github.com/Automattic/jetpack/pull/21888/files#diff-aae7d66951585fc55053a4d53b68552a41864d2c69aee900574ef4404b7ad5f7L42
 	 */
 	public function init_hooks() {
-		/**
-		 * We use the `config` package to initialize the search package, which ensures the package is
-		 * only initialized once. However earlier versions of Jetpack would still forcely initialize the
-		 * dashboard. As a result, there would be two `Search` submenus if we don't ensure the dashboard
-		 * is initialized only once.
-		 *
-		 * Ref: https://github.com/Automattic/jetpack/pull/21888/files#diff-aae7d66951585fc55053a4d53b68552a41864d2c69aee900574ef4404b7ad5f7L42
-		 */
 		if ( ! self::$initialized ) {
 			self::$initialized = true;
 			// Jetpack uses 998 and 'Admin_Menu' uses 1000.

--- a/projects/packages/search/src/dashboard/class-dashboard.php
+++ b/projects/packages/search/src/dashboard/class-dashboard.php
@@ -88,6 +88,9 @@ class Dashboard {
 			return;
 		}
 
+		// Jetpack of version <= 10.5 would register `jetpack-search` submenu with its built-in search module.
+		$this->remove_search_submenu_if_exists();
+
 		$page_suffix = Admin_Menu::add_menu(
 			__( 'Search Settings', 'jetpack-search-pkg' ),
 			_x( 'Search', 'product name shown in menu', 'jetpack-search-pkg' ),
@@ -125,6 +128,13 @@ class Dashboard {
 		 * @param boolean $should_add_search_submenu Default value is true.
 		 */
 		return apply_filters( 'jetpack_search_should_add_search_submenu', current_user_can( 'manage_options' ) );
+	}
+
+	/**
+	 * Remove `jetpack-search` submenu page
+	 */
+	protected function remove_search_submenu_if_exists() {
+		remove_submenu_page( 'jetpack', 'jetpack-search' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #23720 

#### Changes proposed in this Pull Request:
We use the `config` package to initialize the search package, which ensures the package is only initialized once. However earlier versions of Jetpack would still forcely initialize the dashboard. As a result, there would be two `Search` submenus if we don't ensure the dashboard is initialized only once.

- Added `$initialized` to ensure the dashboard is only initialized once
- Moved search module deactivation out of the`add_search_submenu`
- Changed to deactivation hook to run only on Jetpack plugins admin pages

Regarding compatibility with older version of Jetpack, other than the admin submenu, [REST routes are register twice too](https://github.com/Automattic/jetpack/pull/23458/files#diff-070fa21fc663a251249af7203ce34ee79a47f322c01eba76c66837a477140678L37). However due to the nature of the matching mechanism, route callbacks are run only once.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- [Create a JN site with Jetpack Beta](https://jurassic.ninja/specialops/)
- Install Jetpack `10.7` and bleeding edge Jetpack Search plugin
- Check there are two `Search` submenus
- Change Jetpack Search plugin to branch `fix/allow-search-submenu-added-only-once`
- Ensure there are only one `Search` submenu
- Repeat with Jetpack `10.4` from the second step

|before       | after|
|---------|---------|
|<img src="https://user-images.githubusercontent.com/1425433/161638252-02f1c03a-00c5-46db-b914-f2efe7af3aa1.png" width="200" />|<img src="https://user-images.githubusercontent.com/1425433/161639654-b1964cce-0704-4785-b9bf-8fdb29fc3f89.png" width="200" /> |


