### PR TITLE
Subscribe block: correct default style selection to split style

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribe-block-default-style-selected
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-block-default-style-selected
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Suscribe block: fix default "Styles" block setting selection to "Split"

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/index.js
@@ -65,11 +65,11 @@ export const settings = {
 		{
 			name: 'compact',
 			label: __( 'Compact', 'jetpack' ),
-			isDefault: true,
 		},
 		{
 			name: 'split',
 			label: __( 'Split', 'jetpack' ),
+			isDefault: true,
 		},
 	],
 	transforms: {


### PR DESCRIPTION
Fixing [the issue](https://github.com/Automattic/jetpack/issues/23480) where the subscribe block is displayed in "Split" style in block editor by default while the default "Style" setting selection is incorrectly set as "Compact".
Now both the subscribe block displayed and the "Style" block setting selected will be both set to "Split" by default.
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-ŗtest.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

![Screen Capture on 2022-04-01 at 09-57-14](https://user-images.githubusercontent.com/2019970/161220925-a80236a4-c2a4-43fd-a1bf-53ac736ff948.gif)


#### Changes proposed in this Pull Request:
* make `Split` button in the `Styles` setting of subscribe block selected by default

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

1. Go to create a new post.
2. Insert the Subscribe block.
3. Ensure that both the default style applied and selected in the block's `Styles` setting is `Split`.


