### PR TITLE
Nav-unification: update nudge to support Pro plan.

### DIFF
--- a/projects/plugins/jetpack/changelog/sync-gmovr-r242892-wpcom
+++ b/projects/plugins/jetpack/changelog/sync-gmovr-r242892-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Nav-unification: update nudge to support Pro plan.

--- a/projects/plugins/jetpack/changelog/sync-gmovr-r242892-wpcom
+++ b/projects/plugins/jetpack/changelog/sync-gmovr-r242892-wpcom
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Nav-unification: update nudge to support Pro plan.
+Nav-unification: Update nudge to support Pro plan.

--- a/projects/plugins/jetpack/modules/masterbar/nudges/additional-css/class-atomic-additional-css-manager.php
+++ b/projects/plugins/jetpack/modules/masterbar/nudges/additional-css/class-atomic-additional-css-manager.php
@@ -41,7 +41,7 @@ class Atomic_Additional_CSS_Manager {
 
 		$nudge = new CSS_Customizer_Nudge(
 			$this->get_nudge_url(),
-			__( 'Purchase a Business Plan to<br> activate CSS customization', 'jetpack' )
+			__( 'Purchase a Pro Plan to<br> activate CSS customization', 'jetpack' )
 		);
 
 		$wp_customize_manager->remove_control( 'custom_css' );
@@ -56,6 +56,6 @@ class Atomic_Additional_CSS_Manager {
 	 * @return string
 	 */
 	private function get_nudge_url() {
-		return '/checkout/' . $this->domain . '/business';
+		return '/checkout/' . $this->domain . '/pro';
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/nudges/additional-css/class-wpcom-additional-css-manager.php
+++ b/projects/plugins/jetpack/modules/masterbar/nudges/additional-css/class-wpcom-additional-css-manager.php
@@ -39,16 +39,7 @@ class WPCOM_Additional_CSS_Manager {
 	 */
 	public function register_nudge( \WP_Customize_Manager $wp_customize_manager ) {
 		$nudge_url  = $this->get_nudge_url();
-		$nudge_text = __( 'Purchase a Premium Plan to<br> activate CSS customization', 'jetpack' );
-
-		if (
-			( defined( 'ENABLE_PRO_PLAN' ) && ENABLE_PRO_PLAN ) ||
-			! empty( $_GET['enable_pro_plan'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Only used to customize output.
-			! empty( $_COOKIE['enable_pro_plan'] )
-		) {
-			$nudge_text = __( 'Purchase a Pro Plan to<br> activate CSS customization', 'jetpack' );
-			$nudge_url  = preg_replace( '/premium$/', 'pro', $nudge_url );
-		}
+		$nudge_text = __( 'Purchase a Pro Plan to<br> activate CSS customization', 'jetpack' );
 
 		$nudge = new CSS_Customizer_Nudge(
 			$nudge_url,
@@ -65,6 +56,6 @@ class WPCOM_Additional_CSS_Manager {
 	 * @return string
 	 */
 	private function get_nudge_url() {
-		return '/checkout/' . $this->domain . '/premium';
+		return '/checkout/' . $this->domain . '/pro';
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-additional-css-manager.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-additional-css-manager.php
@@ -46,11 +46,11 @@ class Test_Atomic_Additional_CSS_Manager extends \WP_UnitTestCase {
 
 		$manager->register_nudge( $this->wp_customize );
 		$this->assertEquals(
-			'/checkout/foo.com/business',
+			'/checkout/foo.com/pro',
 			$this->wp_customize->controls()['custom_css_control']->cta_url
 		);
 		$this->assertEquals(
-			'Purchase a Business Plan to<br> activate CSS customization',
+			'Purchase a Pro Plan to<br> activate CSS customization',
 			$this->wp_customize->controls()['custom_css_control']->nudge_copy
 		);
 	}

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-additional-css-manager.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-additional-css-manager.php
@@ -47,11 +47,11 @@ class Test_WPCOM_Additional_Css_Manager extends \WP_UnitTestCase {
 
 		$manager->register_nudge( $this->wp_customize );
 		$this->assertEquals(
-			'/checkout/foo.com/premium',
+			'/checkout/foo.com/pro',
 			$this->wp_customize->controls()['jetpack_custom_css_control']->cta_url
 		);
 		$this->assertEquals(
-			'Purchase a Premium Plan to<br> activate CSS customization',
+			'Purchase a Pro Plan to<br> activate CSS customization',
 			$this->wp_customize->controls()['jetpack_custom_css_control']->nudge_copy
 		);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR updates Jetpack following similar changes on WordPress.com.

﻿- Masterbar: Update nudge for Pro plan
- Update tests

WordPress.com references:
- D77832-code
- D77823-code

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* See diffs above for instructions.
* Is CI happy?
