### PR TITLE
Mailchimp Popup widget: Widget Deprecation

### DIFF
--- a/projects/plugins/jetpack/changelog/update-mailchimp-popup-widget-deprecate
+++ b/projects/plugins/jetpack/changelog/update-mailchimp-popup-widget-deprecate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Mailchimp Popup widget: Widget deprecation

--- a/projects/plugins/jetpack/modules/widgets/mailchimp.php
+++ b/projects/plugins/jetpack/modules/widgets/mailchimp.php
@@ -40,6 +40,19 @@ if ( ! class_exists( 'Jetpack_MailChimp_Subscriber_Popup_Widget' ) ) {
 					'customize_selective_refresh' => true,
 				)
 			);
+
+			add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_widget_in_block_editor' ) );
+		}
+
+		/**
+		 * Remove the "Mailchimp Subscriber Popup" widget from the Legacy Widget block
+		 *
+		 * @param array $widget_types List of widgets that are currently removed from the Legacy Widget block.
+		 * @return array $widget_types New list of widgets that will be removed.
+		 */
+		public function hide_widget_in_block_editor( $widget_types ) {
+			$widget_types[] = 'widget_mailchimp_subscriber_popup';
+			return $widget_types;
 		}
 
 		/**


### PR DESCRIPTION
The proposed change hides the _Mailchimp Popup_ widget from the block inserter and _Legacy widget_ block drop-down menu.

**Before**

  Block inserter  |  Legacy Widget block
:-------------------------:|:-------------------------:
![Markup on 2022-04-01 at 13:22:49](https://user-images.githubusercontent.com/25105483/161257352-02466dea-a55d-4324-a78a-ce10bb6d007a.png) | ![Markup on 2022-04-01 at 13:23:40](https://user-images.githubusercontent.com/25105483/161257413-12410a38-fd61-45bc-a380-7d11de914112.png)

**After**

  Block inserter  |  Legacy Widget block
:-------------------------:|:-------------------------:
![Markup on 2022-04-01 at 13:32:23](https://user-images.githubusercontent.com/25105483/161257461-6143cbd1-ba80-46d7-9d10-539c4346c587.png) | ![Markup on 2022-04-01 at 13:33:20](https://user-images.githubusercontent.com/25105483/161257497-d1533e55-757b-4e44-9087-4b0e1a8eb48a.png)

#### Changes proposed in this Pull Request:
- Add filter to deprecate the _Mailchimp Popup_ widget

#### Jetpack product discussion
- pdf5j4-7f-p2

#### Does this pull request change what data or activity we track or use?
No, it does not.

#### Testing instructions:
1. Make sure the test site has a theme that support widgets activated (e.g. Twenty Twenty-onee)
2. Make sure the "_Make extra widgets available for use on your site including subscription forms and Twitter streams_" Jetpack setting in `wp-admin/admin.php?page=jetpack#/writing` is activated:
![Markup on 2022-04-01 at 13:22:05](https://user-images.githubusercontent.com/25105483/161257185-d3d1c6df-e890-42f7-8608-ca874347d664.png)
3. Navigate to Customizer → Widgets
4. Add the _Legacy widget_ block and take a look at the dropdown menu. The _Mailchimp Popup_ widget should not be available.
5. Try to search for the widget in the block inserter in Customizer as well. It should not come up.