### PR TITLE
Jetpack Sync: Dedicated Sync: Run cron sync only once

### DIFF
--- a/projects/packages/sync/changelog/add-sync-dedicated-request-flow
+++ b/projects/packages/sync/changelog/add-sync-dedicated-request-flow
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add Sync dedicated request flow.

--- a/projects/packages/sync/changelog/fix-jetpack-sync-dedicated-run-cron-only-once
+++ b/projects/packages/sync/changelog/fix-jetpack-sync-dedicated-run-cron-only-once
@@ -1,4 +1,4 @@
-Significance: patch
+Significance: minor
 Type: fixed
 
 Dedicated Sync: Only try to run the sender once if Dedicated Sync is enabled as it has its own requeueing mechanism.

--- a/projects/packages/sync/changelog/update-manage-dedicated-sync-via-header
+++ b/projects/packages/sync/changelog/update-manage-dedicated-sync-via-header
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Dedicated Sync flow: Allow enabling or disabling via WPCOM response header


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

If Dedicated Sync is enabled, and there are items in the queue, and WP-Cron runs and picks up the Sync cron job it would try to continuously start the Dedicated Sync thread/request. 

This causes a lot of errors on the WPCOM side that might slow down the sync flow. 

This PR makes Dedicated sync run only once if in WP-Cron context.

#### Jetpack product discussion

N/a

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:
TBD

* Apply PR
* Add events in the Sync queue
  * For example using generate: `wp post generate --count=800 --url="<YOUR_TEST_SITE>"`
* Wait for the Cron to run
* Make sure the `do_sync` call is done only once.

Notes: It might be helpful if you add logging entries to the `do_sync` and `\Automattic\Jetpack\Sync\Actions::do_cron_sync_by_type` methods to monitor how the cron process runs them. 
