### PR TITLE
renovate: Explicitly disable semantic commits

### DIFF
--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -30,6 +30,7 @@ module.exports = {
 	timezone: 'UTC',
 	schedule: [ 'before 3am on the first day of the month' ],
 	updateNotScheduled: false,
+	semanticCommits: 'disabled',
 	packageRules: [
 		// Monorepo packages shouldn't be processed by renovate.
 		{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
By default renovate tries to autodetect whether it should use semantic
commits or not. The autodetection seems somewhat flaky, it decides "yes"
if the latest commit starts with "Fix".

Since we don't currently want to use these, let's explicitly disable
them.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. But it's why https://github.com/Automattic/jetpack/pull/23744#event-6354927242 happened.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* 🤷 You'd first have to make the latest commit fool renovate's autodetection to be able to tell.