### PR TITLE
Adding skipUserConnection option to the connection screen

### DIFF
--- a/projects/js-packages/connection/changelog/update-connect-screen-add-skip-user
+++ b/projects/js-packages/connection/changelog/update-connect-screen-add-skip-user
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add skipUserConnection option to connectScreen component

--- a/projects/js-packages/connection/components/connect-screen/basic/index.jsx
+++ b/projects/js-packages/connection/components/connect-screen/basic/index.jsx
@@ -31,6 +31,7 @@ const ConnectScreen = props => {
 		assetBaseUrl,
 		autoTrigger,
 		footer,
+		skipUserConnection,
 	} = props;
 
 	const {
@@ -47,6 +48,7 @@ const ConnectScreen = props => {
 		apiNonce,
 		autoTrigger,
 		from,
+		skipUserConnection,
 	} );
 
 	const showConnectButton = ! isRegistered || ! isUserConnected;
@@ -91,6 +93,8 @@ ConnectScreen.propTypes = {
 	images: PropTypes.arrayOf( PropTypes.string ),
 	/** The assets base URL. */
 	assetBaseUrl: PropTypes.string,
+	/** Whether to not require a user connection and just redirect after site connection. */
+	skipUserConnection: PropTypes.bool,
 };
 
 ConnectScreen.defaultProps = {
@@ -99,6 +103,7 @@ ConnectScreen.defaultProps = {
 	images: [],
 	redirectUri: null,
 	autoTrigger: false,
+	skipUserConnection: false,
 };
 
 export default ConnectScreen;

--- a/projects/js-packages/connection/components/use-connection/index.jsx
+++ b/projects/js-packages/connection/components/use-connection/index.jsx
@@ -10,7 +10,15 @@ import restApi from '@automattic/jetpack-api';
  */
 import { STORE_ID } from '../../state/store';
 
-export default ( { registrationNonce, redirectUri, apiRoot, apiNonce, autoTrigger, from } ) => {
+export default ( {
+	registrationNonce,
+	redirectUri,
+	apiRoot,
+	apiNonce,
+	autoTrigger,
+	from,
+	skipUserConnection,
+} ) => {
 	const { registerSite, connectUser } = useDispatch( STORE_ID );
 
 	const registrationError = useSelect( select => select( STORE_ID ).getRegistrationError() );
@@ -28,7 +36,13 @@ export default ( { registrationNonce, redirectUri, apiRoot, apiNonce, autoTrigge
 		...select( STORE_ID ).getConnectionStatus(),
 	} ) );
 
-	const handleConnectUser = () => connectUser( { from, redirectUri } );
+	const handleConnectUser = () => {
+		if ( ! skipUserConnection ) {
+			connectUser( { from, redirectUri } );
+		} else {
+			window.location = redirectUri;
+		}
+	};
 
 	/**
 	 * Initialize the site registration process.

--- a/projects/js-packages/connection/components/use-connection/index.jsx
+++ b/projects/js-packages/connection/components/use-connection/index.jsx
@@ -39,7 +39,7 @@ export default ( {
 	const handleConnectUser = () => {
 		if ( ! skipUserConnection ) {
 			connectUser( { from, redirectUri } );
-		} else {
+		} else if ( redirectUri ) {
 			window.location = redirectUri;
 		}
 	};

--- a/projects/plugins/protect/changelog/update-connect-screen-add-skip-user
+++ b/projects/plugins/protect/changelog/update-connect-screen-add-skip-user
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+require only site level connection

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -61,7 +61,7 @@ const ConnectionSection = () => {
 				'jetpack-protect'
 			) }
 			buttonLabel={ __( 'Set up Jetpack Protect', 'jetpack-protect' ) }
-			redirectUri="admin.php?page=jetpack-protect"
+			//redirectUri="admin.php?page=jetpack-protect"
 			skipUserConnection
 		>
 			<h3>{ __( 'Jetpack’s security features include', 'jetpack-protect' ) }</h3>

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -18,8 +18,8 @@ const Admin = () => {
 		select => select( CONNECTION_STORE_ID ).getConnectionStatus(),
 		[]
 	);
-	const { isUserConnected, isRegistered } = connectionStatus;
-	const showConnectionCard = ! isRegistered || ! isUserConnected;
+	const { isRegistered } = connectionStatus;
+	const showConnectionCard = ! isRegistered;
 	return (
 		<AdminPage moduleName={ __( 'Jetpack Protect', 'jetpack-protect' ) }>
 			<AdminSectionHero>
@@ -62,6 +62,7 @@ const ConnectionSection = () => {
 			) }
 			buttonLabel={ __( 'Set up Jetpack Protect', 'jetpack-protect' ) }
 			redirectUri="admin.php?page=jetpack-protect"
+			skipUserConnection
 		>
 			<h3>{ __( 'Jetpack’s security features include', 'jetpack-protect' ) }</h3>
 			<ul>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds the option to skip the user connection step in the ConnectionScreen component.

This allows plugins to provide a one click connection experience.

We also add this behavior to the Protect plugin

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds the `skipUserConnection` prop to the `ConnectScreen` component
* Make Protect plugin require only a site-level connection

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-fgl-p2#comment-53520

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate only Protect
* Go to Protect page and click Set up
* Confirm that the Protect main admin page is loaded after connection is established without any page refreshes
* Confirm that the site is properly connected at a site level