### PR TITLE
Publicize Package: Sync recent fixes

### DIFF
--- a/projects/packages/publicize/changelog/update-sync-publicize-package
+++ b/projects/packages/publicize/changelog/update-sync-publicize-package
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync'd changes with the equivalent files in the Publicize module

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1153,7 +1153,7 @@ abstract class Publicize_Base {
 			! empty( $admin_page );
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$title = isset( $_POST['wpas_title'] ) ? sanitize_text_field( wp_unslash( $_POST['wpas_title'] ) ) : null;
+		$title = isset( $_POST['wpas_title'] ) ? sanitize_textarea_field( wp_unslash( $_POST['wpas_title'] ) ) : null;
 
 		if ( ( $from_web || defined( 'POST_BY_EMAIL' ) ) && $title ) {
 			if ( empty( $title ) ) {

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -276,9 +276,9 @@ class Publicize extends Publicize_Base {
 	 * Show error on settings page if applicable.
 	 */
 	public function admin_page_load() {
-		$action = sanitize_text_field( wp_unslash( $_GET['action'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$action = isset( $_GET['action'] ) ? sanitize_text_field( wp_unslash( $_GET['action'] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-		if ( ! empty( $action ) && 'error' === $action ) {
+		if ( 'error' === $action ) {
 			add_action( 'pre_admin_screen_sharing', array( $this, 'display_connection_error' ), 9 );
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

There have been a couple of bug fixes in the Publicize module since the
files were copied to the Publicize package. This makes the necessary
updates to keep them in sync.

The changes in module are since commit 7cfceea7d7

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

This can't be directly tested currently. We need to confirm that this brings over the changes since since 7cfceea7d7

Probably the simplest way would be to run:

```
git diff 7cfceea7d7 projects/plugins/jetpack/modules/publicize
```

In the root of the Jetpack repo.
