### PR TITLE
Boost: Fix paragraph spacing in settings page

### DIFF
--- a/projects/plugins/boost/app/assets/src/css/main/dashboard.scss
+++ b/projects/plugins/boost/app/assets/src/css/main/dashboard.scss
@@ -3,6 +3,10 @@
 		font-size: 16px;
 	}
 
+  	p {
+	  	margin: 1em 0;
+	}
+
   	&--main {
 	  background-color: $primary-white;
 	}

--- a/projects/plugins/boost/app/assets/src/css/main/dashboard.scss
+++ b/projects/plugins/boost/app/assets/src/css/main/dashboard.scss
@@ -78,6 +78,7 @@
 	justify-content: space-between;
 	align-items: center;
 	margin-top: $padding;
+	margin-bottom: $padding;
 	@include breakpoint( xs ) {
 		flex-direction: column;
 		justify-content: flex-start;

--- a/projects/plugins/boost/changelog/fix-whitespace
+++ b/projects/plugins/boost/changelog/fix-whitespace
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: It is a minor bug introduced few commits ago(f651a7a4ba)
+
+

--- a/projects/plugins/boost/rollup.config.js
+++ b/projects/plugins/boost/rollup.config.js
@@ -115,7 +115,7 @@ export default {
 		postcss( {
 			extensions: [ '.css', '.sss', '.pcss', '.sass', '.scss' ],
 			extract: path.resolve( 'app/assets/dist/jetpack-boost.css' ),
-			minimize: true,
+			minimize: production,
 		} ),
 
 		svelteSVG(),


### PR DESCRIPTION
Fixes #23752

#### Changes proposed in this Pull Request:
* Do not minify CSS during development builds.
* Fix whitespace issue introduced at f651a7a4ba

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:\
* Go to Boost settings page
* Regenerate assets
* Check if whitespace still persists as mentioned in #23752.
* Try `jetpack build plugins/boost` vs `jetpack watch plugins/boost` commands and make sure `build` generates minified CSS while `watch` generates un-minified.
