### PR TITLE
Required reviews: allow Reach to approve Publicize&Social changes

### DIFF
--- a/.github/files/required-review.yaml
+++ b/.github/files/required-review.yaml
@@ -55,6 +55,15 @@
    - jetpack-search
    - jetpack-approvers
 
+# The Reach team reviews changes to the Social plugin, and the Publicize package.
+- name: Social
+  paths:
+   - 'projects/plugins/social/**'
+   - 'projects/packages/publicize/**'
+  teams:
+   - jetpack-reach
+   - jetpack-approvers
+
 # Jetpack Approvers review everything that hasn't been specifically assigned above.
 # This needs to be last.
 - name: Default to Jetpack Approvers

--- a/.github/files/required-review.yaml
+++ b/.github/files/required-review.yaml
@@ -16,6 +16,7 @@
    - yamato-backup-and-security
    - heart-of-gold
    - jetpack-search
+   - jetpack-reach
 
 # Jetpack Approvers review the Jetpack plugin and all packages.
 - name: Jetpack and packages
@@ -24,6 +25,7 @@
    - 'projects/plugins/jetpack/**'
    # Exclude packages managed by other teams, which are covered by other blocks below.
    - '!projects/packages/search/**'
+   - '!projects/packages/publicize/**'
   teams:
    - jetpack-approvers
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

The Reach team have started to work on the Social plugin; they should be able to approve changes to their plugin, as well as to the Publicize package which they'll work on a lot.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Not much to test for now, once merged the Reach folks should be able to merge PRs like #23768 without approvers' approval.
