### PR TITLE
Jetpack Sync: Run cron sync only once on Dedicated Sync flow

### DIFF
--- a/projects/packages/sync/changelog/update-cron-dedicated-sync
+++ b/projects/packages/sync/changelog/update-cron-dedicated-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dedicated Sync: Only try to run the sender once if Dedicated Sync is enabled as it has its own requeueing mechanism.

--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -676,6 +676,14 @@ class Actions {
 				break;
 			}
 
+			/**
+			 * Only try to sync once if Dedicated Sync is enabled. Dedicated Sync has its own requeueing mechanism
+			 * that will re-run it if there are items in the queue at the end.
+			 */
+			if ( 'sync' === $type && $executions >= 1 && Settings::is_dedicated_sync_enabled() ) {
+				break;
+			}
+
 			$result = 'full_sync' === $type ? self::$sender->do_full_sync() : self::$sender->do_sync();
 
 			// # of send actions performed.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

If Dedicated Sync is enabled, and there are items in the queue, and WP-Cron runs and picks up the Sync cron job it would try to continuously start the Dedicated Sync thread/request. 

This causes a lot of errors on the WPCOM side that might slow down the sync flow. 

This PR makes Dedicated sync run only once if in WP-Cron context.

#### Jetpack product discussion

N/a

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

* Apply PR
* Add events in the Sync queue
  * For example using generate: `wp post generate --count=800 --url="<YOUR_TEST_SITE>"`
* Wait for the Cron to run
* Make sure the `do_sync` call is done only once.

Notes: It might be helpful if you add logging entries to the `do_sync` and `\Automattic\Jetpack\Sync\Actions::do_cron_sync_by_type` methods to monitor how the cron process runs them. 


Props to @bisko , see https://github.com/Automattic/jetpack/pull/23755