### PR TITLE
Protect: Add `VulnerabilitiesList` component

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1339,6 +1339,7 @@ importers:
       '@wordpress/element': 4.3.0
       '@wordpress/i18n': 4.5.0
       '@wordpress/icons': 8.1.0
+      classnames: 2.3.1
       concurrently: 6.0.2
       react: 17.0.2
       react-dom: 17.0.2
@@ -1355,6 +1356,7 @@ importers:
       '@wordpress/element': 4.3.0
       '@wordpress/i18n': 4.5.0
       '@wordpress/icons': 8.1.0
+      classnames: 2.3.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
@@ -23296,7 +23298,7 @@ packages:
       serialize-javascript: 6.0.0
       source-map: 0.6.1
       terser: 5.12.1
-      webpack: 5.65.0
+      webpack: 5.65.0_webpack-cli@4.9.1
 
   /terser/5.12.0:
     resolution: {integrity: sha512-R3AUhNBGWiFc77HXag+1fXpAxTAFRQTJemlJKjAgD9r8xXTpjNKqIXwHM/o7Rh+O0kUJtS3WQVdBeMKFk5sw9A==}

--- a/projects/js-packages/components/index.jsx
+++ b/projects/js-packages/components/index.jsx
@@ -34,4 +34,3 @@ export { default as Text, H2, H3, Title } from './components/text';
 export { default as numberFormat } from './components/number-format';
 export { default as QRCode } from './components/qr-code';
 export { getUserLocale, cleanLocale } from './lib/locale';
-export { default as Button } from './components/button';

--- a/projects/js-packages/components/index.jsx
+++ b/projects/js-packages/components/index.jsx
@@ -34,3 +34,4 @@ export { default as Text, H2, H3, Title } from './components/text';
 export { default as numberFormat } from './components/number-format';
 export { default as QRCode } from './components/qr-code';
 export { getUserLocale, cleanLocale } from './lib/locale';
+export { default as Button } from './components/button';

--- a/projects/plugins/protect/changelog/add-protect-vulnerabilities-list
+++ b/projects/plugins/protect/changelog/add-protect-vulnerabilities-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Protect: Introduce VulnerabilitiesList component

--- a/projects/plugins/protect/package.json
+++ b/projects/plugins/protect/package.json
@@ -32,6 +32,7 @@
 		"@wordpress/element": "4.3.0",
 		"@wordpress/i18n": "4.5.0",
 		"@wordpress/icons": "8.1.0",
+		"classnames": "2.3.1",
 		"react": "17.0.2",
 		"react-dom": "17.0.2"
 	},

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -2,7 +2,13 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { AdminPage, AdminSectionHero, Container, Col } from '@automattic/jetpack-components';
+import {
+	AdminPage,
+	AdminSectionHero,
+	AdminSection,
+	Container,
+	Col,
+} from '@automattic/jetpack-components';
 
 import { useSelect } from '@wordpress/data';
 import { ConnectScreen, CONNECTION_STORE_ID } from '@automattic/jetpack-connection';
@@ -12,6 +18,92 @@ import React from 'react';
  * Internal dependencies
  */
 import Summary from '../summary';
+import VulnerabilitiesList from '../vulnerabilities-list';
+
+const coreListMock = [
+	{
+		name: 'WordPress',
+		version: '5.4.1',
+		vulnerabilities: [
+			{
+				risk: 'low',
+				description: 'Vulnerability Number 1',
+			},
+			{
+				risk: 'high',
+				description: 'Vulnerability Number 2',
+			},
+		],
+	},
+];
+
+const pluginsListMock = [
+	{
+		name: 'Jetpack Backup',
+		version: '1.0.1',
+		vulnerabilities: [
+			{
+				risk: 'low',
+				description: 'Vulnerability Number 1',
+			},
+			{
+				risk: 'high',
+				description: 'Vulnerability Number 2',
+			},
+			{
+				risk: 'medium',
+				description: 'Vulnerability Number 3',
+			},
+			{
+				risk: 'low',
+				description: 'Vulnerability Number 4',
+			},
+		],
+	},
+	{
+		name: 'Jetpack Boost',
+		version: '1.2.1',
+		vulnerabilities: [
+			{
+				risk: 'high',
+				description: 'Vulnerability Number 1',
+			},
+			{
+				risk: 'low',
+				description: 'Vulnerability Number 2',
+			},
+			{
+				risk: 'medium',
+				description: 'Vulnerability Number 3',
+			},
+			{
+				risk: 'low',
+				description: 'Vulnerability Number 4',
+			},
+		],
+	},
+];
+
+const themeListMock = [
+	{
+		name: 'Famous Theme',
+		version: '1.0.2',
+		vulnerabilities: [
+			{
+				risk: 'low',
+				description: 'Vulnerability Number 1',
+			},
+			{
+				risk: 'low',
+				description: 'Vulnerability Number 2',
+			},
+			{
+				risk: 'medium',
+				description: 'Vulnerability Number 3',
+			},
+		],
+	},
+];
 
 const Admin = () => {
 	const connectionStatus = useSelect(
@@ -22,21 +114,38 @@ const Admin = () => {
 	const showConnectionCard = ! isRegistered || ! isUserConnected;
 	return (
 		<AdminPage moduleName={ __( 'Jetpack Protect', 'jetpack-protect' ) }>
-			<AdminSectionHero>
-				{ showConnectionCard ? (
+			{ showConnectionCard ? (
+				<AdminSectionHero>
 					<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 						<Col sm={ 4 } md={ 8 } lg={ 12 }>
 							<ConnectionSection />
 						</Col>
 					</Container>
-				) : (
-					<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
-						<Col>
-							<Summary />
-						</Col>
-					</Container>
-				) }
-			</AdminSectionHero>
+				</AdminSectionHero>
+			) : (
+				<>
+					<AdminSectionHero>
+						<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
+							<Col>
+								<Summary />
+							</Col>
+						</Container>
+					</AdminSectionHero>
+					<AdminSection>
+						<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
+							<Col>
+								<VulnerabilitiesList title="WordPress" list={ coreListMock } />
+							</Col>
+							<Col>
+								<VulnerabilitiesList title="Plugins" list={ pluginsListMock } />
+							</Col>
+							<Col>
+								<VulnerabilitiesList title="Themes" list={ themeListMock } />
+							</Col>
+						</Container>
+					</AdminSection>
+				</>
+			) }
 		</AdminPage>
 	);
 };

--- a/projects/plugins/protect/src/js/components/vulnerabilities-list/index.jsx
+++ b/projects/plugins/protect/src/js/components/vulnerabilities-list/index.jsx
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { Container, Col, Text, H3 } from '@automattic/jetpack-components';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import styles from './styles.module.scss';
+
+const RISKS_LEVELS = {
+	LOW: 'low',
+	MEDIUM: 'medium',
+	HIGH: 'high',
+};
+
+const RISKS_LABELS = {
+	[ RISKS_LEVELS.LOW ]: 'Low',
+	[ RISKS_LEVELS.MEDIUM ]: 'Medium',
+	[ RISKS_LEVELS.HIGH ]: 'High',
+};
+
+const VulnerabilityRisk = ( { risk } ) => {
+	const className = classNames( styles.risk, {
+		[ styles.low ]: risk === RISKS_LEVELS.LOW,
+		[ styles.medium ]: risk === RISKS_LEVELS.MEDIUM,
+		[ styles.high ]: risk === RISKS_LEVELS.HIGH,
+	} );
+
+	return (
+		<Text component="div" className={ className }>
+			{ RISKS_LABELS[ risk ] }
+		</Text>
+	);
+};
+
+const VulnerabilityItem = ( { name, version, vulnerabilities } ) => {
+	return (
+		<Container fluid className={ styles.item }>
+			<Col lg={ 4 } className={ styles.name }>
+				<Text variant="title-small">{ name }</Text>
+				<Text variant="body-small">Version { version }</Text>
+			</Col>
+			<Col lg={ 8 }>
+				{ vulnerabilities.map( vulnerability => (
+					<div className={ styles.vulnerability }>
+						<VulnerabilityRisk risk={ vulnerability.risk } />
+						<Text>{ vulnerability.description }</Text>
+					</div>
+				) ) }
+			</Col>
+		</Container>
+	);
+};
+
+const VulnerabilitiesList = ( { title, list } ) => {
+	return (
+		<>
+			<H3>{ title }</H3>
+			{ list.map( item => (
+				<VulnerabilityItem
+					name={ item.name }
+					version={ item.version }
+					vulnerabilities={ item.vulnerabilities }
+				/>
+			) ) }
+		</>
+	);
+};
+
+export default VulnerabilitiesList;

--- a/projects/plugins/protect/src/js/components/vulnerabilities-list/stories/index.jsx
+++ b/projects/plugins/protect/src/js/components/vulnerabilities-list/stories/index.jsx
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import VulnerabilitiesList from '..';
+
+export default {
+	title: 'Plugins/Protect/VulnerabilitiesList',
+	component: VulnerabilitiesList,
+};
+
+const Template = args => <VulnerabilitiesList { ...args } />;
+export const Default = Template.bind( {} );
+Default.args = {
+	title: 'Plugins',
+	list: [
+		{
+			name: 'Jetpack Backup',
+			version: '1.0.1',
+			vulnerabilities: [
+				{
+					risk: 'low',
+					description: 'Vulnerability Number 1',
+				},
+				{
+					risk: 'high',
+					description: 'Vulnerability Number 2',
+				},
+				{
+					risk: 'medium',
+					description: 'Vulnerability Number 3',
+				},
+				{
+					risk: 'low',
+					description: 'Vulnerability Number 4',
+				},
+			],
+		},
+		{
+			name: 'Jetpack Boost',
+			version: '1.2.1',
+			vulnerabilities: [
+				{
+					risk: 'high',
+					description: 'Vulnerability Number 1',
+				},
+				{
+					risk: 'low',
+					description: 'Vulnerability Number 2',
+				},
+				{
+					risk: 'medium',
+					description: 'Vulnerability Number 3',
+				},
+				{
+					risk: 'low',
+					description: 'Vulnerability Number 4',
+				},
+			],
+		},
+	],
+};

--- a/projects/plugins/protect/src/js/components/vulnerabilities-list/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/vulnerabilities-list/styles.module.scss
@@ -1,0 +1,42 @@
+.item {
+	background-color: none;
+	&:nth-child(even) {
+		background-color: var(--jp-white-off);
+	}
+}
+
+.name {
+	padding: 0 calc( var(--spacing-base) * 2 ); // 16px
+}
+
+.risk {
+	padding: var(--spacing-base);
+	width: 100px;
+	border-radius: var(--jp-border-radius);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	margin-right: calc( var(--spacing-base) * 2 ); // 16px
+
+	&.low {
+		background-color: var(--jp-green-0);
+		color: var(--jp-green-50);
+	}
+
+	// TODO: Update to yellow
+	&.medium {
+		background-color: var(--jp-pink);
+		color: var(--jp-white);
+	}
+
+	&.high {
+		background-color: var(--jp-red-0);
+		color: var(--jp-red-50);
+	}
+}
+
+.vulnerability {
+	display: flex;
+	align-items: center;
+	margin-bottom: var(--spacing-base);
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Introduce the `VulnerabilitiesList` component, which renders the list of vulnerabilities with risk.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add `VulnerabilitiesList` component.
* Use `VulnerabilitiesList` component at `AdminPage`.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1202064326332560-as-1202064326332567/f

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start `protect` plugin
* Navigate to `homepage`.
* You should see vulnerabilities list.

#### Demo

![Screen Shot 2022-04-04 at 20 37 26](https://user-images.githubusercontent.com/1663717/161650041-276a4510-6b68-4f0b-b5e5-d4ef950e55b5.png)
