### PR TITLE
Search: fix new settings are overriden by old settings in auto config process

### DIFF
--- a/projects/packages/search/changelog/fix-return-earyl-if-exclude-posts-configured
+++ b/projects/packages/search/changelog/fix-return-earyl-if-exclude-posts-configured
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: auto config should not override option if exists

--- a/projects/packages/search/src/instant-search/class-instant-search.php
+++ b/projects/packages/search/src/instant-search/class-instant-search.php
@@ -721,6 +721,10 @@ class Instant_Search extends Classic_Search {
 	 * @since  8.8.0
 	 */
 	public function auto_config_excluded_post_types() {
+		// if `excluded_post_types` exists, then we do nothing.
+		if ( false !== get_option( Options::OPTION_PREFIX . 'excluded_post_types', false ) ) {
+			return;
+		}
 		$post_types         = get_post_types(
 			array(
 				'exclude_from_search' => false,
@@ -743,7 +747,8 @@ class Instant_Search extends Classic_Search {
 
 		if ( ! empty( $enabled_post_types ) ) {
 			$post_types_to_disable = array_diff( $post_types, $enabled_post_types );
-			update_option( Options::OPTION_PREFIX . 'excluded_post_types', join( ',', $post_types_to_disable ) );
+			// better to use `add_option` which wouldn't override option value if exists.
+			add_option( Options::OPTION_PREFIX . 'excluded_post_types', join( ',', $post_types_to_disable ) );
 		}
 	}
 


### PR DESCRIPTION
Fixes #23645

#### Changes proposed in this Pull Request:
The auto config process always apply old post type setting from widgets to override users settings, which caused user setting lost from time to time. If new config exists, then we should just discard the old settings rather than importing it to override user's new settings.

#### Jetpack product discussion
#23645
https://github.com/Automattic/jpop-issues/issues/7241

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- [Create a JN site with Jetpack Beta](https://jurassic.ninja/specialops/)
- Switch Jetpack to branch `fix/return-earyl-if-exclude-posts-configured`
- Run the following command:
`echo '{"_multiwidget":1,"3":{"title":"","search_box_enabled":"0","user_sort_enabled":"0","sort":null,"post_types":["post","page"]}}' | wp option update widget_jetpack-search-filters --format=json`
- Purchase a Search plan
- Ensure Media is showing as checked (excluded) in Customizer or Customberg
![image](https://user-images.githubusercontent.com/1425433/161868546-f718d1c4-b3be-4a15-afb1-3a54a1e1c8a9.png)
- Uncheck Media and save
- Run `wp jetpack-search auto_config 1`
- Ensure Media is still unchecked


