### PR TITLE
My Jetpack: align price boxes in the interstitial product page

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -174,13 +174,15 @@ const ProductDetailCard = ( { slug, onClick, trackButtonClick, className } ) => 
 				</ul>
 
 				{ needsPurchase && (
-					<div className={ styles[ 'price-container' ] }>
-						<Price value={ price } currency={ currencyCode } isOld={ true } />
-						<Price value={ discountPrice } currency={ currencyCode } isOld={ false } />
+					<>
+						<div className={ styles[ 'price-container' ] }>
+							<Price value={ price } currency={ currencyCode } isOld={ true } />
+							<Price value={ discountPrice } currency={ currencyCode } isOld={ false } />
+						</div>
 						<Text className={ styles[ 'price-description' ] }>
 							{ __( '/month, paid yearly', 'jetpack-my-jetpack' ) }
 						</Text>
-					</div>
+					</>
 				) }
 
 				{ isFree && <H3>{ __( 'Free', 'jetpack-my-jetpack' ) }</H3> }

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/style.module.scss
@@ -87,7 +87,7 @@
 
 	svg {
 		fill: var( --jp-green-primary);
-                margin-right: var( --spacing-base );
+		margin-right: var( --spacing-base );
 		flex-shrink: 0;
 	}
 }
@@ -97,14 +97,13 @@
 	flex-wrap: wrap;
 	align-items: flex-end;
 	color: var( --jp-text-color);
-	margin-bottom: calc( var( --spacing-base ) * 3 );
 }
 
 .price {
 	position: relative;
 
 	&:first-child {
-		margin-right: var( --spacing-base );
+		margin-right: calc( var( --spacing-base ) * 2 );
 	}
 
 	&.is-old {
@@ -126,6 +125,6 @@
 }
 
 .price-description {
-	flex-grow: 2;
-	color: var( --jp-gray-40);
+	color: var( --jp-gray-40 );
+	margin-bottom: calc( var( --spacing-base ) * 3 );
 }

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-align-prices-in-interstitial-cmp
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-align-prices-in-interstitial-cmp
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: align price boxes in the interstitial product page


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR aligns the price boxes in the interstitial page.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: align price boxes in the interstitial product page

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1649161731079189-slack-C02TQF5VAJD

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to some interstitial upgradable page, for instance `https://<your-testing-site>/wp-admin/admin.php?page=my-jetpack#/add-backup`
* Confirm price description is located below to the prices.

**before**
![image](https://user-images.githubusercontent.com/77539/161757931-ea8f5b4d-139e-4a32-96fa-105ad75b1034.png)

**after**
![image](https://user-images.githubusercontent.com/77539/161757907-f1d07c59-52f5-41bc-b0c5-0a74c4f523a7.png)