### PR TITLE
Approvals: Scan to approve Scan code

### DIFF
--- a/.github/files/required-review.yaml
+++ b/.github/files/required-review.yaml
@@ -34,7 +34,7 @@
 
 # The Backup team reviews changes to the VaultPress and Backup plugin,
 # and can add dependencies to the monorepo's lock file.
-- name: VaultPress & Backup, and Scan
+- name: VaultPress & Backup
   paths:
    - 'projects/packages/backup/**'
    - 'projects/plugins/vaultpress/**'
@@ -45,7 +45,7 @@
 
 # The Scan team reviews changes to the protect plugin, the WAF package, etc,
 # and can add dependencies to the monorepo's lock file.
-- name: VaultPress & Backup, and Scan
+- name: Scan
   paths:
     - 'projects/packages/waf/**'
     - 'projects/plugins/protect/**'

--- a/.github/files/required-review.yaml
+++ b/.github/files/required-review.yaml
@@ -12,32 +12,46 @@
    - 'pnpm-lock.yaml'
   teams:
    # Unfortunately this list need to be maintaned manually...
+   # yamato-backup-and-security is the group that consists of both yamato-scan and yamato-backup teams.
    - jetpack-approvers
    - yamato-backup-and-security
    - heart-of-gold
    - jetpack-search
    - jetpack-reach
 
-# Jetpack Approvers review the Jetpack plugin and all packages.
+# Jetpack Approvers review the Jetpack plugin and all packages, except for those with specific team ownership.
 - name: Jetpack and packages
   paths:
    - 'projects/packages/**'
    - 'projects/plugins/jetpack/**'
    # Exclude packages managed by other teams, which are covered by other blocks below.
+   - '!projects/packages/backup/**'
    - '!projects/packages/search/**'
    - '!projects/packages/publicize/**'
+   - '!projects/packages/waf/**'
   teams:
    - jetpack-approvers
 
 # The Backup team reviews changes to the VaultPress and Backup plugin,
 # and can add dependencies to the monorepo's lock file.
-- name: VaultPress and Backup
+- name: VaultPress & Backup, and Scan
   paths:
+   - 'projects/packages/backup/**'
    - 'projects/plugins/vaultpress/**'
    - 'projects/plugins/backup/**'
   teams:
-   - yamato-backup-and-security
+   - yamato-backup
    - jetpack-approvers
+
+# The Scan team reviews changes to the protect plugin, the WAF package, etc,
+# and can add dependencies to the monorepo's lock file.
+- name: VaultPress & Backup, and Scan
+  paths:
+    - 'projects/packages/waf/**'
+    - 'projects/plugins/protect/**'
+  teams:
+    - yamato-scan
+    - jetpack-approvers
 
 # The Boost team reviews changes to the Boost plugin,
 # and can add dependencies to the monorepo's lock file.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

With the WAF package and the Protect plugin, the Scan team has ownership of these two projects. Granting them approval ability so they can approve 
PRs that consist of their code.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds Scan projects and team.
* Per discussion, split Backup and Scan permissions to the proper team.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1649156720075049-slack-C029WFNV69M
I'll p2 once it lands.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a PR based on this branch. Only touch a WAF package. Submit and have a member of Scan approve.