### PR TITLE
Search: revamp record meter notice box

### DIFF
--- a/projects/packages/search/changelog/add-search-dismissable-notice-boxes
+++ b/projects/packages/search/changelog/add-search-dismissable-notice-boxes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Record meter: updates noticeboxes to be dismissable & styled

--- a/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
@@ -87,31 +87,37 @@ export function NoticeBox( props ) {
 	// deal with localStorage for ensuring dismissed notice boxs are not re-displayed
 	const dismissedNoticesString = localStorage.getItem( DISMISSED_NOTICES ) ?? '';
 
+	const DATA_NOT_VALID = '1',
+		HAS_NOT_BEEN_INDEXED = '2',
+		NO_INDEXABLE_ITEMS = '3',
+		OVER_RECORD_LIMIT = '4',
+		CLOSE_TO_LIMIT = '5';
+
 	// check if data is valid
 	props.hasValidData === false &&
-		! dismissedNoticesString.includes( '1' ) &&
-		activeNoticeIds.push( '1' );
+		! dismissedNoticesString.includes( DATA_NOT_VALID ) &&
+		activeNoticeIds.push( DATA_NOT_VALID );
 
 	// check site has been indexed
 	props.hasBeenIndexed === false &&
-		! dismissedNoticesString.includes( '2' ) &&
-		activeNoticeIds.push( '2' );
+		! dismissedNoticesString.includes( HAS_NOT_BEEN_INDEXED ) &&
+		activeNoticeIds.push( HAS_NOT_BEEN_INDEXED );
 
 	// check at least one indexable item
 	props.hasItems === false &&
-		! dismissedNoticesString.includes( '3' ) &&
-		activeNoticeIds.push( '3' );
+		! dismissedNoticesString.includes( NO_INDEXABLE_ITEMS ) &&
+		activeNoticeIds.push( NO_INDEXABLE_ITEMS );
 
 	// check if over limit
 	props.recordCount > props.planRecordLimit &&
-		! dismissedNoticesString.includes( '4' ) &&
-		activeNoticeIds.push( '4' );
+		! dismissedNoticesString.includes( OVER_RECORD_LIMIT ) &&
+		activeNoticeIds.push( OVER_RECORD_LIMIT );
 
 	// check if close to reaching limit
 	props.recordCount > props.planRecordLimit * CLOSE_TO_LIMIT_PERCENT &&
 		props.recordCount < props.planRecordLimit &&
-		! dismissedNoticesString.includes( '5' ) &&
-		activeNoticeIds.push( '5' );
+		! dismissedNoticesString.includes( CLOSE_TO_LIMIT ) &&
+		activeNoticeIds.push( CLOSE_TO_LIMIT );
 
 	if ( ! activeNoticeIds || activeNoticeIds.length < 1 || ! showNotice ) {
 		return null;

--- a/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
@@ -82,18 +82,10 @@ const getNotices = ( planRecordLimit = null ) => {
 export function NoticeBox( props ) {
 	const activeNoticeIds = [];
 	const NOTICES = getNotices( props.planRecordLimit );
-	let notice = activeNoticeIds[ 0 ] ? NOTICES[ activeNoticeIds[ 0 ] ] : [];
 	const [ showNotice, setShowNotice ] = useState( true );
 
 	// deal with localStorage for ensuring dismissed notice boxs are not re-displayed
 	const dismissedNoticesString = localStorage.getItem( DISMISSED_NOTICES ) ?? '';
-
-	const dismissNoticeBox = () => {
-		setShowNotice( false );
-		if ( ! dismissedNoticesString.includes( notice.id ) ) {
-			localStorage.setItem( DISMISSED_NOTICES, dismissedNoticesString + ',' + notice.id );
-		}
-	};
 
 	// check if data is valid
 	props.hasValidData === false &&
@@ -125,11 +117,18 @@ export function NoticeBox( props ) {
 		return null;
 	}
 
-	notice = NOTICES[ activeNoticeIds[ 0 ] ];
+	const notice = NOTICES[ activeNoticeIds[ 0 ] ];
 
 	const noticeBoxClassName = notice.isImportant
 		? 'jp-search-notice-box jp-search-notice-box__important'
 		: 'jp-search-notice-box';
+
+	const dismissNoticeBox = () => {
+		setShowNotice( false );
+		if ( ! dismissedNoticesString.includes( notice.id ) ) {
+			localStorage.setItem( DISMISSED_NOTICES, dismissedNoticesString + notice.id );
+		}
+	};
 
 	return (
 		<SimpleNotice

--- a/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
@@ -119,7 +119,7 @@ export function NoticeBox( props ) {
 		! dismissedNoticesString.includes( CLOSE_TO_LIMIT ) &&
 		activeNoticeIds.push( CLOSE_TO_LIMIT );
 
-	if ( ! activeNoticeIds || activeNoticeIds.length < 1 || ! showNotice ) {
+	if ( activeNoticeIds.length < 1 || ! showNotice ) {
 		return null;
 	}
 

--- a/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
@@ -1,10 +1,72 @@
+/* eslint-disable no-console */
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useState } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 
-const CLOSE_TO_LIMIT_PERCENT = 0.8; //TODO: currently 'close' is defined as 80%. This has not been decided/finalised to be the best number here yet
+/**
+ * Internal dependencies
+ */
+import SimpleNotice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action.jsx';
+
+const CLOSE_TO_LIMIT_PERCENT = 0.8;
+const DISMISSED_NOTICES = 'jetpack-search-dismissed-notices';
+
+const getNotices = ( planRecordLimit = null ) => {
+	return {
+		1: {
+			id: 1,
+			message: __(
+				"We weren't able to properly locate your content for Search",
+				'jetpack-search-pkg'
+			),
+			isImportant: true,
+		},
+		2: {
+			id: 2,
+			message: __( 'Your content has not yet been indexed for Search', 'jetpack-search-pkg' ),
+		},
+		3: {
+			id: 3,
+			message: __(
+				"We weren't able to locate any content for Search to index. Perhaps you don't yet have any posts or pages?",
+				'jetpack-search-pkg'
+			),
+		},
+		4: {
+			id: 4,
+			message: sprintf(
+				// translators: %s: site's current plan record limit
+				__(
+					'You recently surpassed %d records and will be automatically upgraded to the next billing tier',
+					'jetpack-search-pkg'
+				),
+				planRecordLimit
+			),
+			link: {
+				text: __( 'learn more', 'jetpack-search-pkg' ),
+				url: 'https://jetpack.com/support/search/product-pricing/',
+			},
+		},
+		5: {
+			id: 5,
+			message: sprintf(
+				// translators: %s: site's current plan record limit
+				__(
+					"You're close to the max amount of records for this billing tier. Once you hit %s indexed records, you'll automatically be billed for the next tier",
+					'jetpack-search-pkg'
+				),
+				planRecordLimit
+			),
+			link: {
+				text: __( 'learn more', 'jetpack-search-pkg' ),
+				url: 'https://jetpack.com/support/search/product-pricing/',
+			},
+		},
+	};
+};
 
 /**
  * Returns a notice box for displaying notices about record count and plan limits
@@ -18,81 +80,71 @@ const CLOSE_TO_LIMIT_PERCENT = 0.8; //TODO: currently 'close' is defined as 80%.
  * @returns {React.Component} notice box component.
  */
 export function NoticeBox( props ) {
-	const notices = [];
-	const recordLimitAsString =
-		typeof props.planRecordLimit === 'number'
-			? props.planRecordLimit?.toLocaleString()
-			: props.planRecordLimit;
+	const activeNoticeIds = [];
+	const NOTICES = getNotices( props.planRecordLimit );
+	let notice = activeNoticeIds[ 0 ] ? NOTICES[ activeNoticeIds[ 0 ] ] : [];
+	const [ showNotice, setShowNotice ] = useState( true );
 
-	// check data is valid
-	if ( props.hasValidData === false ) {
-		notices.push( {
-			message: __(
-				"We weren't able to properly locate your content for Search",
-				'jetpack-search-pkg'
-			),
-			isImportant: true,
-		} );
-	}
+	// deal with localStorage for ensuring dismissed notice boxs are not re-displayed
+	const dismissedNoticesString = localStorage.getItem( DISMISSED_NOTICES ) ?? '';
+
+	const dismissNoticeBox = () => {
+		setShowNotice( false );
+		if ( ! dismissedNoticesString.includes( notice.id ) ) {
+			localStorage.setItem( DISMISSED_NOTICES, dismissedNoticesString + ',' + notice.id );
+		}
+	};
+
+	// check if data is valid
+	props.hasValidData === false &&
+		! dismissedNoticesString.includes( '1' ) &&
+		activeNoticeIds.push( '1' );
 
 	// check site has been indexed
-	if ( props.hasBeenIndexed === false ) {
-		notices.push( {
-			message: __( 'Your content has not yet been indexed for Search', 'jetpack-search-pkg' ),
-		} );
-	}
+	props.hasBeenIndexed === false &&
+		! dismissedNoticesString.includes( '2' ) &&
+		activeNoticeIds.push( '2' );
 
 	// check at least one indexable item
-	if ( props.hasItems === false ) {
-		notices.push( {
-			message: __(
-				"We weren't able to locate any content for Search to index. Perhaps you don't yet have any posts or pages?",
-				'jetpack-search-pkg'
-			),
-		} );
-	}
+	props.hasItems === false &&
+		! dismissedNoticesString.includes( '3' ) &&
+		activeNoticeIds.push( '3' );
 
-	if ( props.recordCount > props.planRecordLimit ) {
-		notices.push( {
-			message: sprintf(
-				// translators: %s: site's current plan record limit
-				__(
-					'You recently surpassed %s records and will be automatically upgraded to the next billing tier', //TODO: add a link to the tier pricing/upgrade info page
-					'jetpack-search-pkg'
-				),
-				recordLimitAsString
-			),
-		} );
-	}
+	// check if over limit
+	props.recordCount > props.planRecordLimit &&
+		! dismissedNoticesString.includes( '4' ) &&
+		activeNoticeIds.push( '4' );
 
-	if (
-		props.recordCount > props.planRecordLimit * CLOSE_TO_LIMIT_PERCENT &&
-		props.recordCount < props.planRecordLimit
-	) {
-		notices.push( {
-			message: sprintf(
-				// translators: %s: site's current plan record limit
-				__(
-					"You're close to the max amount of records for this billing tier. Once you hit %s indexed records, you'll automatically be billed for the next tier",
-					'jetpack-search-pkg'
-				),
-				recordLimitAsString
-			),
-		} );
-	}
+	// check if close to reaching limit
+	props.recordCount > props.planRecordLimit * CLOSE_TO_LIMIT_PERCENT &&
+		props.recordCount < props.planRecordLimit &&
+		! dismissedNoticesString.includes( '5' ) &&
+		activeNoticeIds.push( '5' );
 
-	if ( ! notices || notices.length < 1 ) {
+	if ( ! activeNoticeIds || activeNoticeIds.length < 1 || ! showNotice ) {
 		return null;
 	}
 
-	const noticeBoxClassName = notices[ 0 ].isImportant
-		? 'jp-search-notice-box__important'
+	notice = NOTICES[ activeNoticeIds[ 0 ] ];
+
+	const noticeBoxClassName = notice.isImportant
+		? 'jp-search-notice-box jp-search-notice-box__important'
 		: 'jp-search-notice-box';
 
 	return (
-		<div data-testid="notice-box" className={ noticeBoxClassName }>
-			<p>{ notices[ 0 ].message }</p>
-		</div>
+		<SimpleNotice
+			isCompact={ false }
+			status={ 'is-info' }
+			className={ noticeBoxClassName }
+			onDismissClick={ dismissNoticeBox }
+		>
+			{ notice.message }
+			{ notice.link && (
+				<NoticeAction href={ notice.link.url } external={ true }>
+					{ notice.link.text }
+				</NoticeAction>
+			) }
+		</SimpleNotice>
 	);
 }
 

--- a/projects/packages/search/src/dashboard/components/record-meter/style.scss
+++ b/projects/packages/search/src/dashboard/components/record-meter/style.scss
@@ -2,8 +2,16 @@
 	max-height: 40px;
 }
 
+.jp-search-chart-legend__box {
+	margin-right: 3px;
+	margin-left: 6px;
+	width: 15px;
+	height: 15px;
+	border-radius: 100%;
+	display: inline-block;
+}
+
 .jp-search-chart-legend {
-	font-size: 0.9em;
 	list-style: none;
 	display: inline-block;
 }
@@ -27,33 +35,53 @@ ul.jp-search-chart-legend {
 	display: inherit;
 }
 
-.jp-search-chart-legend__box {
-	margin-right: 3px;
-	margin-left: 6px;
-	width: 15px;
-	height: 15px;
-	border-radius: 100%;
-	display: inline-block;
-}
-
 .jp-search-notice-box {
-	border: solid 0.5px lightgrey;
-	margin-left: 5px;
-	padding: 0 5px;
+	background-color: white;
+	color: black;
+	border: lightgray 0.5px solid;
+	border-radius: 5px;
 }
 
 .jp-search-notice-box__important {
-	border: solid 0.5px red;
+	border: red 0.5px solid;
+}
+
+.jp-search-notice-box span.dops-notice__icon-wrapper,
+.jp-search-notice-box__important span.dops-notice__icon-wrapper {
+	background-color: white;
+}
+
+.jp-search-notice-box a.dops-notice__action {
+	display: inline;
+	color: black;
+	padding: 0 0 0 5px;
+	font-weight: bold;
+}
+
+.jp-search-notice-box span.dops-notice__dismiss > svg {
+	color: darkgrey;
+}
+
+.jp-search-notice-box span.dops-notice__dismiss > svg:hover {
+	color: black;
+}
+
+.jp-search-notice-box .dops-notice__icon-wrapper {
+	align-items: center;
+	color: grey;
+}
+
+.jp-search-notice-box__important a.dops-notice__action,
+.jp-search-notice-box__important .dops-notice__icon-wrapper,
+.jp-search-notice-box__important,
+.jp-search-notice-box__important a.dops-notice__action {
 	color: red;
-	margin-left: 5px;
-	padding: 0 5px;
 }
 
-.jp-search-record-count p {
-	font-size: 1em;
+.jp-search-notice-box > span.dops-notice__icon-wrapper > svg {
+	margin: 0;
 }
 
-.jp-search-record-meter {
-	border-bottom: 1px solid rgb( 225, 225, 225 );
-	padding: 30px 0;
+.jp-search-record-meter .jp-search-notice-box > span.dops-notice__icon-wrapper {
+	background-color: rgba( 255, 255, 255, 0 );
 }


### PR DESCRIPTION
This PR upgrades the existing NoticeBox component to use SimpleNotice components for styling & functionality, and makes notice boxes dismissible. 

#### Changes proposed in this Pull Request:

* Uses `SimpleNotice` components to create the notice box for the `NoticeBox` component
* Adds styling to the noticebox
* Adds dismissible (closing) element to notices
* Uses localStorage to persist dismissed notices

![image](https://user-images.githubusercontent.com/30754158/161786253-b322ebcd-464c-4690-8d28-88c38135aaca.png)


#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* On a site with an active Jetpack Search subscription, go to /wp-admin/admin.php?page=jetpack-search&features=record-meter and check there is currently no notice box displaying. 

* toggle off/on the different states `hasBeenIndexed` `hasValidData` and 'hasItems` to trigger the different notices. Note that `hasValidData` being false should resolve a red notice box instead:

| toggle the states in inspector  | red noticed when `hasValidData` is false |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/30754158/161786542-3a6e9a2c-ec79-40dd-9102-c9f729877bda.png)  | ![image](https://user-images.githubusercontent.com/30754158/161787716-b9a5ad54-7ce9-4f17-8324-a47ff3e634df.png)  |

* Try dismissing the notice box using the 'X' in the top right corner of the notice box. It should disappear. When the window is refreshed, dismissed notice should persist. However, other notices should still be able to be displayed (until they too are dismissed)

#### Notes & Questions

I spent quite some time thinking through the logic of how best to store which notices were dismissed, without blanket-preventing any other notice display. I went with (for now) giving each notice an ID, and storing the list as a string in localStorage. This is all pretty new to me, so I would not be surprised if this way I've approached it could be vastly improved upon. Gladly accepting advice & suggestions!