### PR TITLE
Fix VS  Code integration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,4 @@
 
 # We don't need these files in any production mirror.
 .eslintrc.js  production-exclude
+jsconfig.json production-exclude

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,25 @@
+{
+	"compilerOptions": {
+		"jsx": "react-jsx",
+		"paths": {
+			// e.g. "@automattic/jetpack-components"
+			// will resolve to "projects/js-packages/components"
+			"@automattic/jetpack-*": [ "./projects/js-packages/*" ]
+		}
+	},
+	// In order to improve performance, especially in VS Code
+	// Let us exclude large/irrelevant files/directories
+	"exclude": [
+		// external packages/modules
+		"**/node_modules/*",
+		"**/vendor/*",
+		// internal directories to exclude
+		"**/build/*",
+		"**/tests/*",
+		"**/wordpress/*",
+		"**/.cache/*",
+		// exclude large (auto-generated) files
+		"**/*.bundle.js",
+		"projects/plugins/jetpack/_inc/blocks/*"
+	]
+}

--- a/projects/plugins/jetpack/.gitattributes
+++ b/projects/plugins/jetpack/.gitattributes
@@ -22,6 +22,7 @@
 # Remember to end all directories with `/**` to properly tag every file.
 .eslintrc.js                                             production-exclude
 .eslintignore                                            production-exclude
+jsconfig.json                                            production-exclude
 /.gitattributes                                          production-exclude
 /.gitignore                                              production-exclude
 /.phpcsignore                                            production-exclude

--- a/projects/plugins/jetpack/changelog/fix-vs-code-integration
+++ b/projects/plugins/jetpack/changelog/fix-vs-code-integration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fixed VS Code integration

--- a/projects/plugins/jetpack/jsconfig.json
+++ b/projects/plugins/jetpack/jsconfig.json
@@ -1,0 +1,20 @@
+{
+	"compilerOptions": {
+		"jsx": "react",
+		"baseUrl": ".",
+		"paths": {
+			// fallback to resolving imports relative to _inc/client
+			"*": [ "*", "./_inc/client/*" ],
+			// Since we are overriding paths here,
+			// we need to add root paths as well
+			"@automattic/jetpack-*": [ "../../js-packages/*" ]
+		}
+	},
+	"include": [ "./_inc" ],
+	"exclude": [
+		// internal directories to exclude
+		"**/build/*",
+		// exclude large (auto-generated) files
+		"_inc/blocks/*"
+	]
+}


### PR DESCRIPTION
Fixes #22725

This PR (extracted out of #23522 as a smaller PR) basically addresses many concerns and issues expressed in this p2 post p9dueE-4E8-p2. It fixes these issues:

- Go to Definition
- Find References to File
- Type definitions and auto completions for imported variables
- Auto-completions for import suggestions
- Path suggestion for imports from within workspace (pnpm) - BONUS

#### Jetpack product discussion
p9dueE-4E8-p2

#### Does this pull request change what data or activity we track or use?
No

### Testing instructions

- Boot up the PR and run `pnpm install`
- Open **VS Code** and ensure that you restart it or reload the window (`Cmd + Shift + P` > `Developer: Reload Window`) for re-indexing.

#### For "Go to Definition"

- Go to any component file inside `projects/plugins/jetpack/_inc` to test Go to Definition (`Alt/Option + Click`)
- For example, open `projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx`
- Confirm that "Go to Definition" works for all the imports, e.g. the imports from `@automattic/jetpack-*` and `state/*`

DEMO

https://user-images.githubusercontent.com/18226415/159292789-01afcb92-66dd-4caf-ab6a-65bad4e7f85b.mov


#### For "Find References to File"

- Go to any component file inside `projects/plugins/jetpack/_inc/client/components/` to test "Find References to File".
- For example, find `projects/plugins/jetpack/_inc/client/components/forms/index.jsx` in Explorer (`Cmd + Shift + E`).
- Right-click on the file and select `Find File References`.
- Confirm that you see the files in results where the mentioned file has been used/consumed/referenced.

DEMO

https://user-images.githubusercontent.com/18226415/159293392-9c3ab522-a930-427b-95e9-457d2d2b5110.mov

#### For "Auto completions for imported variables"

- Go to any component inside `projects/plugins/jetpack/_inc/client/` that imports `lib/analytics` or similar non-relative import.
- For example, open `projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx` which uses `import analytics from 'lib/analytics';`
- Try to access a property of `analytics` (type `analytics.`) to confirm that you see auto-completion for its properties.
- Try to access `analytics.tracks` (type `analytics.tracks.`) to confirm that you see auto-completion for its properties.

DEMO

https://user-images.githubusercontent.com/18226415/159294200-86db51e9-bcae-4993-b2ad-cae7a541cc07.mov


#### For "Auto-completions for import suggestions"

- Try import from `components/forms` or `state/*` anywhere inside `projects/plugins/jetpack/_inc/client` and try to use import suggestions.
- For example, in `projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx`, try to import another selector from `state/initial-state`.
- Type `"get"` after the already imported selectors above to confirm that you see the import suggestions.

DEMO

https://user-images.githubusercontent.com/18226415/159294584-d8b34636-550c-4efa-bcbf-7a64c9980b8b.mov


#### For "Path sugestion for imports"

- Try import from `components/*` or `state/*` anywhere inside `projects/plugins/jetpack/_inc/client` and try to use the suggested path for the import.
- Try the same for `@automattic/j*` to confirm that you see the path suggestion for `js-packages`.

DEMO

https://user-images.githubusercontent.com/18226415/159294884-ef11594f-cdd3-4569-8b24-a2bbed173e6a.mov
