### PR TITLE
Boost: Add premium upgrade flow

### DIFF
--- a/projects/plugins/boost/app/admin/class-admin.php
+++ b/projects/plugins/boost/app/admin/class-admin.php
@@ -81,6 +81,9 @@ class Admin {
 	 * Enqueue scripts and styles for the admin page.
 	 */
 	public function admin_init() {
+		// Clear premium features cache when the plugin settings page is loaded.
+		Premium_Features::clear_cache();
+
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 	}

--- a/projects/plugins/boost/app/admin/class-admin.php
+++ b/projects/plugins/boost/app/admin/class-admin.php
@@ -15,6 +15,7 @@ use Automattic\Jetpack_Boost\Features\Speed_Score\Speed_Score;
 use Automattic\Jetpack_Boost\Jetpack_Boost;
 use Automattic\Jetpack_Boost\Lib\Analytics;
 use Automattic\Jetpack_Boost\Lib\Environment_Change_Detector;
+use Automattic\Jetpack_Boost\Lib\Premium_Features;
 use Automattic\Jetpack_Boost\REST_API\Permissions\Nonce;
 
 class Admin {
@@ -137,7 +138,7 @@ class Admin {
 			'shownAdminNoticeIds' => $this->get_shown_admin_notice_ids(),
 			'preferences'         => array(
 				'showRatingPrompt' => $this->get_show_rating_prompt(),
-				'paidPlan'         => ( defined( 'JETPACK_BOOST_CLOUD_CSS' ) && true === JETPACK_BOOST_CLOUD_CSS ),
+				'prioritySupport'  => Premium_Features::has_feature( Premium_Features::PRIORITY_SUPPORT ),
 			),
 
 			/**

--- a/projects/plugins/boost/app/admin/class-admin.php
+++ b/projects/plugins/boost/app/admin/class-admin.php
@@ -129,6 +129,7 @@ class Admin {
 			'optimizations'       => $optimizations,
 			'locale'              => get_locale(),
 			'site'                => array(
+				'domain'    => ( new Status() )->get_site_suffix(),
 				'url'       => get_home_url(),
 				'online'    => ! ( new Status() )->is_offline_mode(),
 				'assetPath' => plugins_url( $internal_path, JETPACK_BOOST_PATH ),

--- a/projects/plugins/boost/app/assets/src/js/global.d.ts
+++ b/projects/plugins/boost/app/assets/src/js/global.d.ts
@@ -25,7 +25,7 @@ declare global {
 	const Jetpack_Boost: {
 		preferences: {
 			showRatingPrompt: boolean;
-			paidPlan: boolean;
+			prioritySupport: boolean;
 		};
 		version: string;
 		api: {

--- a/projects/plugins/boost/app/assets/src/js/global.d.ts
+++ b/projects/plugins/boost/app/assets/src/js/global.d.ts
@@ -39,6 +39,7 @@ declare global {
 		showRatingPromptNonce?: string;
 		criticalCssDismissedRecommendations: string[];
 		site: {
+			domain: string;
 			url: string;
 			online: boolean;
 			assetPath: string;

--- a/projects/plugins/boost/app/assets/src/js/pages/benefits/BenefitsInterstitial.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/benefits/BenefitsInterstitial.svelte
@@ -4,7 +4,8 @@
 	 */
 	import BackButton from '../../elements/BackButton.svelte';
 	import ReactComponent from '../../elements/ReactComponent.svelte';
-
+	import { jetpackURL } from '../../utils/jetpack-url';
+	import { getUpgradeURL } from '../../utils/upgrade';
 	import Logo from '../../svg/jetpack-green.svg';
 
 	/**
@@ -16,14 +17,12 @@
 	 * WordPress dependencies
 	 */
 	import { __ } from '@wordpress/i18n';
-	import { jetpackURL } from '../../utils/jetpack-url';
 	import { createInterpolateElement } from '@wordpress/element';
 
 	import React from 'react';
 
 	function onCtaClick() {
-		/* eslint-disable no-console */
-		console.log( 'CTA clicked' );
+		window.location.href = getUpgradeURL();
 	}
 
 	// svelte-ignore unused-export-let - Ignored values supplied by svelte-navigator.

--- a/projects/plugins/boost/app/assets/src/js/pages/purchase-success/PurchaseSuccess.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/purchase-success/PurchaseSuccess.svelte
@@ -1,5 +1,11 @@
 <script>
 	/**
+	 * External dependencies.
+	 */
+	import { onMount } from 'svelte';
+	import { updateModuleState } from '../../stores/modules';
+
+	/**
 	 * Internal dependencies
 	 */
 	import BackButton from '../../elements/BackButton.svelte';
@@ -15,6 +21,11 @@
 
 	// svelte-ignore unused-export-let - Ignored values supplied by svelte-navigator.
 	export let location, navigate;
+
+	onMount( () => {
+		// Enable cloud-css on a successful upgrade.
+		updateModuleState( 'cloud-css', true );
+	} );
 </script>
 
 <div id="jb-settings" class="jb-settings">

--- a/projects/plugins/boost/app/assets/src/js/pages/purchase-success/PurchaseSuccess.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/purchase-success/PurchaseSuccess.svelte
@@ -3,13 +3,14 @@
 	 * External dependencies.
 	 */
 	import { onMount } from 'svelte';
-	import { updateModuleState } from '../../stores/modules';
 
 	/**
 	 * Internal dependencies
 	 */
 	import BackButton from '../../elements/BackButton.svelte';
 	import { Button } from '@wordpress/components';
+	import { updateModuleState } from '../../stores/modules';
+	import { requestCloudCss } from '../../utils/cloud-css';
 
 	import Logo from '../../svg/jetpack-green.svg';
 
@@ -22,9 +23,10 @@
 	// svelte-ignore unused-export-let - Ignored values supplied by svelte-navigator.
 	export let location, navigate;
 
-	onMount( () => {
+	onMount( async () => {
 		// Enable cloud-css on a successful upgrade.
-		updateModuleState( 'cloud-css', true );
+		await updateModuleState( 'cloud-css', true );
+		await requestCloudCss();
 	} );
 </script>
 

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PremiumCTA.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PremiumCTA.svelte
@@ -8,9 +8,12 @@
 	 * Internal dependencies
 	 */
 	import RightArrow from '../../../svg/right-arrow.svg';
+	import routerHistory from '../../../utils/router-history';
+
+	const { navigate } = routerHistory;
 
 	function showBenefits() {
-		// Todo: Navigate to Benefits Interstitial.
+		navigate( '/upgrade' );
 	}
 </script>
 

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Support.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Support.svelte
@@ -2,7 +2,7 @@
 	/**
 	 * Internal dependencies
 	 */
-	import { isPaidPlan, openPaidSupport } from '../../../utils/paid-plan';
+	import { hasPrioritySupport, openPaidSupport } from '../../../utils/paid-plan';
 
 	/**
 	 * WordPress dependencies
@@ -10,7 +10,7 @@
 	import { __ } from '@wordpress/i18n';
 </script>
 
-{#if isPaidPlan}
+{#if hasPrioritySupport}
 	<div class="jb-section">
 		<div class="jb-container--narrow">
 			<div class="jb-support">

--- a/projects/plugins/boost/app/assets/src/js/utils/paid-plan.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/paid-plan.ts
@@ -3,7 +3,7 @@
  */
 import config from '../stores/config';
 
-export const isPaidPlan = config.preferences.paidPlan;
+export const hasPrioritySupport = config.preferences.prioritySupport;
 
 export const openPaidSupport = () => {
 	const supportUrl = 'https://jetpackme.wordpress.com/contact-support/';

--- a/projects/plugins/boost/app/assets/src/js/utils/upgrade.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/upgrade.ts
@@ -26,6 +26,7 @@ export function getUpgradeURL() {
 
 	// Add site to query string.
 	checkoutProductUrl.searchParams.set( 'site', siteSuffix );
+	checkoutProductUrl.searchParams.set( 'unlinked', '1' );
 
 	return checkoutProductUrl.toString();
 }

--- a/projects/plugins/boost/app/assets/src/js/utils/upgrade.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/upgrade.ts
@@ -17,8 +17,9 @@ export function getUpgradeURL() {
 	const redirectUrl = new URL( window.location.href );
 	redirectUrl.hash = '#/purchase-successful';
 
-	const checkoutUrl = new URL( 'https://wordpress.com/checkout/' );
-	const checkoutProductUrl = new URL( `${ checkoutUrl }${ siteSuffix }/${ product }` );
+	const checkoutProductUrl = new URL(
+		`https://wordpress.com/checkout/${ siteSuffix }/${ product }`
+	);
 
 	// Add redirect_to parameter
 	checkoutProductUrl.searchParams.set( 'redirect_to', redirectUrl.toString() );

--- a/projects/plugins/boost/app/assets/src/js/utils/upgrade.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/upgrade.ts
@@ -1,0 +1,33 @@
+/**
+ * Internal dependencies
+ */
+import config from '../stores/config';
+
+/**
+ * Get the URL to upgrade boost.
+ *
+ * Ideally this function should not exist and
+ * `getRedirectUrl( 'boost-plugin-upgrade-default', { site: config.site.domain, query, anchor: 'purchased' } )`
+ * should be used instead. However, the redirect changes the redirect URL in a broken manner.
+ */
+export function getUpgradeURL() {
+	const siteSuffix = config.site.domain;
+	const product = 'jetpack_boost_monthly';
+
+	const redirectUrl = new URL( window.location.href );
+	redirectUrl.hash = '#/purchase-successful';
+
+	// Prepare the redirect url
+	// url.searchParams.set( 'purchase', 'success' );
+
+	const checkoutUrl = new URL( 'https://wordpress.com/checkout/' );
+	const checkoutProductUrl = new URL( `${ config.site.domain }/${ product }`, checkoutUrl );
+
+	// Add redirect_to parameter
+	checkoutProductUrl.searchParams.set( 'redirect_to', redirectUrl.toString() );
+
+	// Add site to query string.
+	checkoutProductUrl.searchParams.set( 'site', siteSuffix );
+
+	return checkoutProductUrl.toString();
+}

--- a/projects/plugins/boost/app/assets/src/js/utils/upgrade.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/upgrade.ts
@@ -17,11 +17,8 @@ export function getUpgradeURL() {
 	const redirectUrl = new URL( window.location.href );
 	redirectUrl.hash = '#/purchase-successful';
 
-	// Prepare the redirect url
-	// url.searchParams.set( 'purchase', 'success' );
-
 	const checkoutUrl = new URL( 'https://wordpress.com/checkout/' );
-	const checkoutProductUrl = new URL( `${ config.site.domain }/${ product }`, checkoutUrl );
+	const checkoutProductUrl = new URL( `${ checkoutUrl }${ siteSuffix }/${ product }` );
 
 	// Add redirect_to parameter
 	checkoutProductUrl.searchParams.set( 'redirect_to', redirectUrl.toString() );

--- a/projects/plugins/boost/app/contracts/Boost_API_Client.php
+++ b/projects/plugins/boost/app/contracts/Boost_API_Client.php
@@ -18,4 +18,12 @@ interface Boost_API_Client {
 	 * @return mixed
 	 */
 	public function post( $path, $payload = array() );
+
+	/**
+	 * Make a get request to boost API and return response.
+	 *
+	 * @param $path string Request path
+	 * @param $query mixed[] Query parameters
+	 */
+	public function get( $path, $query = array() );
 }

--- a/projects/plugins/boost/app/features/optimizations/Optimizations.php
+++ b/projects/plugins/boost/app/features/optimizations/Optimizations.php
@@ -7,6 +7,7 @@ use Automattic\Jetpack_Boost\Features\Optimizations\Cloud_CSS\Cloud_CSS;
 use Automattic\Jetpack_Boost\Features\Optimizations\Critical_CSS\Critical_CSS;
 use Automattic\Jetpack_Boost\Features\Optimizations\Lazy_Images\Lazy_Images;
 use Automattic\Jetpack_Boost\Features\Optimizations\Render_Blocking_JS\Render_Blocking_JS;
+use Automattic\Jetpack_Boost\Lib\Premium_Features;
 use Automattic\Jetpack_Boost\REST_API\Contracts\Has_Endpoints;
 
 class Optimizations implements Has_Setup {
@@ -25,7 +26,7 @@ class Optimizations implements Has_Setup {
 	public function __construct() {
 
 		$critical_css_class = Critical_CSS::class;
-		if ( defined( 'JETPACK_BOOST_CLOUD_CSS' ) && true === JETPACK_BOOST_CLOUD_CSS ) {
+		if ( Premium_Features::has_feature( Premium_Features::CLOUD_CSS ) ) {
 			$critical_css_class = Cloud_CSS::class;
 		}
 

--- a/projects/plugins/boost/app/lib/Boost_API.php
+++ b/projects/plugins/boost/app/lib/Boost_API.php
@@ -24,4 +24,13 @@ class Boost_API {
 		}
 		return self::$api_client;
 	}
+
+	public static function get( $path, $args = array() ) {
+		return self::get_client()->get( $path, $args );
+	}
+
+	public static function post( $path, $payload = array() ) {
+		return self::get_client()->post( $path, $payload );
+	}
+
 }

--- a/projects/plugins/boost/app/lib/Premium_Features.php
+++ b/projects/plugins/boost/app/lib/Premium_Features.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Lib;
+
+class Premium_Features {
+
+	const CLOUD_CSS        = 'cloud-critical-css';
+	const PRIORITY_SUPPORT = 'support';
+
+	const TRANSIENT_KEY = 'premium_features';
+
+	public static function has_feature( $feature ) {
+		$features = self::get_features();
+		return in_array( $feature, $features, true );
+	}
+
+	public static function get_features() {
+		$features = Transient::get( self::TRANSIENT_KEY, null );
+
+		if ( ! $features ) {
+			$features = Boost_API::get( 'features' );
+			Transient::set( self::TRANSIENT_KEY, $features, 3 * DAY_IN_SECONDS );
+		}
+
+		return $features;
+	}
+}

--- a/projects/plugins/boost/app/lib/Premium_Features.php
+++ b/projects/plugins/boost/app/lib/Premium_Features.php
@@ -11,7 +11,9 @@ class Premium_Features {
 
 	public static function has_feature( $feature ) {
 		$features = self::get_features();
-		return in_array( $feature, $features, true );
+		$result   = in_array( $feature, $features, true );
+
+		return apply_filters( "jetpack_boost_has_feature_$feature", $result );
 	}
 
 	public static function get_features() {

--- a/projects/plugins/boost/app/lib/Premium_Features.php
+++ b/projects/plugins/boost/app/lib/Premium_Features.php
@@ -19,6 +19,9 @@ class Premium_Features {
 
 		if ( empty( $features ) ) {
 			$features = Boost_API::get( 'features' );
+			if ( ! is_array( $features ) ) {
+				$features = array();
+			}
 			Transient::set( self::TRANSIENT_KEY, $features, 3 * DAY_IN_SECONDS );
 		}
 

--- a/projects/plugins/boost/app/lib/Premium_Features.php
+++ b/projects/plugins/boost/app/lib/Premium_Features.php
@@ -15,9 +15,9 @@ class Premium_Features {
 	}
 
 	public static function get_features() {
-		$features = Transient::get( self::TRANSIENT_KEY, null );
+		$features = Transient::get( self::TRANSIENT_KEY, array() );
 
-		if ( ! $features ) {
+		if ( empty( $features ) ) {
 			$features = Boost_API::get( 'features' );
 			Transient::set( self::TRANSIENT_KEY, $features, 3 * DAY_IN_SECONDS );
 		}

--- a/projects/plugins/boost/app/lib/Premium_Features.php
+++ b/projects/plugins/boost/app/lib/Premium_Features.php
@@ -24,4 +24,8 @@ class Premium_Features {
 
 		return $features;
 	}
+
+	public static function clear_cache() {
+		Transient::delete( self::TRANSIENT_KEY );
+	}
 }

--- a/projects/plugins/boost/app/lib/WPCOM_Boost_API_Client.php
+++ b/projects/plugins/boost/app/lib/WPCOM_Boost_API_Client.php
@@ -17,6 +17,13 @@ class WPCOM_Boost_API_Client implements Boost_API_Client {
 		);
 	}
 
+	public function get( $path, $query = array() ) {
+		return Utils::send_wpcom_request(
+			'GET',
+			add_query_arg( $query, $this->get_api_path( $path ) )
+		);
+	}
+
 	private function get_api_path( $path ) {
 		$blog_id = (int) \Jetpack_Options::get_option( 'id' );
 

--- a/projects/plugins/boost/app/rest-api/endpoints/Optimization_Status.php
+++ b/projects/plugins/boost/app/rest-api/endpoints/Optimization_Status.php
@@ -30,7 +30,7 @@ class Optimization_Status implements Endpoint {
 		$success    = $state->update( (bool) $params['status'] );
 
 		return rest_ensure_response(
-			$success ? $new_status : ! $new_status
+			$success ? $new_status : $state->is_enabled()
 		);
 	}
 

--- a/projects/plugins/boost/changelog/add-premium-upgrade-flow
+++ b/projects/plugins/boost/changelog/add-premium-upgrade-flow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Upgrade flow


### PR DESCRIPTION
Fixes 44-gh-Automattic/boost-shield-api

Requires patch: D78422-code

#### Changes proposed in this Pull Request:
- [x] Clicking upgrade cta will take the user to the benefits page.
- [x] User can click "Upgrade Jetpack Boost" to go to wp.com checkout page and purchase the plan.
- [x] After plan is purchased, the user will reach the post-purchase landing page.
- [x] Enable and request cloud-css on purchase success.
- [x] Detect if the plugin is upgraded and show cloud CSS or critical CSS based on that.

#### Jetpack product discussion
pc9hqz-iD-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Apply D78422-code on your sandbox
* Load the boost settings page and follow the upgrade flow
* After the purchase is done, you should be able to see that Automatic critical CSS replaced the local critical CSS module