### PR TITLE
RNA: Export `Button` and fix `Button` link variant padding and target

### DIFF
--- a/projects/js-packages/components/changelog/fix-button-link-variant
+++ b/projects/js-packages/components/changelog/fix-button-link-variant
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Button: Fix export, external link target and padding

--- a/projects/js-packages/components/components/button/index.jsx
+++ b/projects/js-packages/components/components/button/index.jsx
@@ -31,6 +31,7 @@ const Button = ( {
 	isLoading,
 	className: propsClassName,
 	text,
+	...componentProps
 } ) => {
 	const className = classNames( styles.button, {
 		[ styles.normal ]: size === BUTTON_SIZES.NORMAL,
@@ -42,9 +43,11 @@ const Button = ( {
 	const isExternalLink = variant === BUTTON_VARIANTS.EXTERNAL_LINK;
 	const externalIconSize = size === BUTTON_SIZES.NORMAL ? 20 : 16;
 	const externalIcon = isExternalLink && <Icon size={ externalIconSize } icon={ external } />;
+	const externalTarget = isExternalLink ? '_blank' : undefined;
 
 	return (
 		<WPButton
+			target={ externalTarget }
 			variant={ isExternalLink ? 'link' : variant }
 			className={ className }
 			icon={ icon }
@@ -52,6 +55,7 @@ const Button = ( {
 			disabled={ disabled }
 			isDestructive={ isDestructive }
 			text={ text }
+			{ ...componentProps }
 		>
 			{ isLoading ? (
 				<Spinner />

--- a/projects/js-packages/components/components/button/style.module.scss
+++ b/projects/js-packages/components/components/button/style.module.scss
@@ -82,8 +82,7 @@
 		// Normal & Small Spacing
 		&.normal,
 		&.small {
-			padding-right: calc( var(--spacing-base) / 2 ); // 4px
-			padding-left: calc( var(--spacing-base) / 2 ); // 4px
+			padding: 0;
 		}
 
 		// Hover State

--- a/projects/js-packages/components/index.jsx
+++ b/projects/js-packages/components/index.jsx
@@ -33,4 +33,5 @@ export { default as ThemeProvider } from './components/theme-provider';
 export { default as Text, H2, H3, Title } from './components/text';
 export { default as numberFormat } from './components/number-format';
 export { default as QRCode } from './components/qr-code';
+export { default as Button } from './components/button';
 export { getUserLocale, cleanLocale } from './lib/locale';

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.11.0",
+	"version": "0.11.1-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixing some problems with Button as we started to use it at `Protect`.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Export it at `index`.
* Fix `padding` for `Link` variant.
* Add target as `_blank` for `External` variant.
* Pass rest props down to `WPButton`.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start Storybook.
* Navigate to `JS Packages/Components/Button`.
* You should see: 
   * New padding for Link
   * External opening a new tab
   * Props going down to WPButton.
