### PR TITLE
JS Components: fix className prop in Button component

### DIFF
--- a/projects/js-packages/components/changelog/update-js-component-fix-button-classname-issue
+++ b/projects/js-packages/components/changelog/update-js-component-fix-button-classname-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+JS Components: fix className prop in Button component

--- a/projects/js-packages/components/components/button/index.jsx
+++ b/projects/js-packages/components/components/button/index.jsx
@@ -37,7 +37,7 @@ const Button = ( {
 		[ styles.normal ]: size === BUTTON_SIZES.NORMAL,
 		[ styles.small ]: size === BUTTON_SIZES.SMALL,
 		[ styles.icon ]: Boolean( icon ),
-		propsClassName,
+		[ propsClassName ]: Boolean( propsClassName ),
 	} );
 
 	const isExternalLink = variant === BUTTON_VARIANTS.EXTERNAL_LINK;

--- a/projects/js-packages/components/components/button/index.jsx
+++ b/projects/js-packages/components/components/button/index.jsx
@@ -33,11 +33,10 @@ const Button = ( {
 	text,
 	...componentProps
 } ) => {
-	const className = classNames( styles.button, {
+	const className = classNames( styles.button, propsClassName, {
 		[ styles.normal ]: size === BUTTON_SIZES.NORMAL,
 		[ styles.small ]: size === BUTTON_SIZES.SMALL,
 		[ styles.icon ]: Boolean( icon ),
-		[ propsClassName ]: Boolean( propsClassName ),
 	} );
 
 	const isExternalLink = variant === BUTTON_VARIANTS.EXTERNAL_LINK;

--- a/projects/js-packages/components/components/button/stories/index.jsx
+++ b/projects/js-packages/components/components/button/stories/index.jsx
@@ -50,16 +50,18 @@ const DisableIcon = {
 	},
 };
 
+const disableClassName = {
+	className: {
+		table: {
+			disable: true,
+		},
+	},
+};
+
 export default {
 	title: 'JS Packages/Components/Button',
 	component: Button,
-	argTypes: {
-		className: {
-			table: {
-				disable: true,
-			},
-		},
-	},
+	argTypes: {},
 	parameters: {
 		backgrounds: {
 			default: 'Light',
@@ -93,6 +95,7 @@ ButtonSecondary.argTypes = {
 	...DisableIcon,
 	...DisableIsLoading,
 	...DisableIsDestructive,
+	...disableClassName,
 };
 ButtonSecondary.args = {
 	size: 'normal',
@@ -107,6 +110,7 @@ ButtonLink.argTypes = {
 	...DisableIcon,
 	...DisableIsLoading,
 	...DisableIsDestructive,
+	...disableClassName,
 };
 ButtonLink.args = {
 	size: 'normal',
@@ -121,6 +125,7 @@ ButtonExternalLink.argTypes = {
 	...DisableIcon,
 	...DisableIsLoading,
 	...DisableIsDestructive,
+	...disableClassName,
 };
 ButtonExternalLink.args = {
 	size: 'normal',
@@ -134,6 +139,7 @@ Icon.argTypes = {
 	...DisableDisabled,
 	...DisableIsLoading,
 	...DisableIsDestructive,
+	...disableClassName,
 };
 Icon.args = {
 	size: 'normal',
@@ -147,6 +153,7 @@ Disabled.argTypes = {
 	...DisableDisabled,
 	...DisableIsDestructive,
 	...DisableIsLoading,
+	...disableClassName,
 };
 Disabled.args = {
 	size: 'normal',
@@ -160,6 +167,7 @@ Destructive.argTypes = {
 	...DisableIsDestructive,
 	...DisableIsLoading,
 	...DisableDisabled,
+	...disableClassName,
 };
 Destructive.args = {
 	size: 'normal',
@@ -173,6 +181,7 @@ Loading.argTypes = {
 	...DisableIsDestructive,
 	...DisableIsLoading,
 	...DisableDisabled,
+	...disableClassName,
 };
 Loading.args = {
 	size: 'normal',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes an issue when trying to add a custom className to the Button component. Currently, a `propsClassName` class name is added instead of the proper one.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* JS Components: fix className prop in Button component

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with Storybook
* Use the Primary story
* Confirm you can set and edit the custom class name

<img width="1489" alt="Screen Shot 2022-04-06 at 2 38 32 PM" src="https://user-images.githubusercontent.com/77539/162035163-7c117ea9-cb80-4994-a3a7-15981adff71c.png">

