### PR TITLE
Protect: Add list of installed pĺugins to the initial state

### DIFF
--- a/projects/plugins/protect/changelog/add-installed-plugins-protect-initial-state
+++ b/projects/plugins/protect/changelog/add-installed-plugins-protect-initial-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added the list of installed pĺugins to the initial state

--- a/projects/plugins/protect/composer.json
+++ b/projects/plugins/protect/composer.json
@@ -11,6 +11,7 @@
 		"automattic/jetpack-config": "1.7.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
 		"automattic/jetpack-my-jetpack": "1.0.x-dev",
+		"automattic/jetpack-plugins-installer": "0.1.x-dev",
 		"automattic/jetpack-sync": "1.30.x-dev"
 	},
 	"require-dev": {

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0866022e4683d5aa274d0c60553f80f7",
+    "content-hash": "1d8d3672ce2a3667012086247e429ef3",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -4362,6 +4362,7 @@
         "automattic/jetpack-config": 20,
         "automattic/jetpack-identity-crisis": 20,
         "automattic/jetpack-my-jetpack": 20,
+        "automattic/jetpack-plugins-installer": 20,
         "automattic/jetpack-sync": 20
     },
     "prefer-stable": true,

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -14,6 +14,7 @@ use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
 use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
+use Automattic\Jetpack\Plugins_Installer;
 use Automattic\Jetpack\Protect\Status;
 
 /**
@@ -112,6 +113,7 @@ class Jetpack_Protect {
 			'apiNonce'          => wp_create_nonce( 'wp_rest' ),
 			'registrationNonce' => wp_create_nonce( 'jetpack-registration-nonce' ),
 			'status'            => Status::get_status(),
+			'installedPlugins'  => Plugins_Installer::get_plugins(),
 		);
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add list of installed pĺugins to the initial state

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-fgl-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack Protect
* Inspect the global variable `jetpackProtectInitialState` in your browser
* Confirm it has a `installedPlugins` property with the list of plugins installed in your site