### PR TITLE
Fix bug in checkout URLs for sites in subdirs

### DIFF
--- a/projects/packages/my-jetpack/_inc/utils/get-product-checkout-url.js
+++ b/projects/packages/my-jetpack/_inc/utils/get-product-checkout-url.js
@@ -15,7 +15,7 @@ export default function getProductCheckoutUrl( product, isUserConnected ) {
 	const { siteSuffix, redirectUrl } = window?.myJetpackInitialState || {};
 
 	const checkoutUrl = new URL( 'https://wordpress.com/checkout/' );
-	const checkoutProductUrl = new URL( `${ siteSuffix }/${ product }`, checkoutUrl );
+	const checkoutProductUrl = new URL( `${ checkoutUrl }${ siteSuffix }/${ product }` );
 
 	// Add redirect_to parameter
 	checkoutProductUrl.searchParams.set( 'redirect_to', redirectUrl );

--- a/projects/packages/my-jetpack/changelog/fix-checkout-url-for-subdirs
+++ b/projects/packages/my-jetpack/changelog/fix-checkout-url-for-subdirs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed bug in checkout URLs for sites installed in subdirs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #23812

All references to sites in Calypso uses a sanitized URL for the site where slashes are replaces with `::`.

The bug was that we were building the URL using the JS `URL` object and when it saw the `::` in the URL it was mistaken it as the protocol.

The fix was to do a simple concatenation.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix bug in checkout URLs for sites in installed subdirs

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See  #23812 and/or directly test the function behavior by playing with the value of `siteSuffix`

