### PR TITLE
Janitorial: remove mentions of defunct Google+ service.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-googleplus-rm
+++ b/projects/plugins/jetpack/changelog/update-googleplus-rm
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Janitorial: remove mentions of defunct Google+ service.
+
+

--- a/projects/plugins/jetpack/modules/comments.php
+++ b/projects/plugins/jetpack/modules/comments.php
@@ -8,7 +8,7 @@
  * Auto Activate: No
  * Module Tags: Social
  * Feature: Engagement
- * Additional Search Queries: comments, comment, facebook, twitter, google+, social
+ * Additional Search Queries: comments, comment, facebook, twitter, google, social
  *
  * @package automattic/jetpack
  */

--- a/projects/plugins/jetpack/modules/module-info.php
+++ b/projects/plugins/jetpack/modules/module-info.php
@@ -191,7 +191,7 @@ add_filter( 'jetpack_learn_more_button_sharedaddy', 'sharedaddy_load_more_link' 
  */
 function sharedaddy_more_info() {
 	esc_html_e(
-		'Visitors can share your posts with Twitter, Facebook, Reddit, Digg, LinkedIn, Google+, print,
+		'Visitors can share your posts with Twitter, Facebook, Reddit, Digg, LinkedIn, print,
 		and email. You can configure services to appear as icons, text, or both and some services like Twitter
 		have additional options.',
 		'jetpack'

--- a/projects/plugins/jetpack/modules/sharedaddy.php
+++ b/projects/plugins/jetpack/modules/sharedaddy.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: Sharing
- * Module Description: Add Twitter, Facebook and Google+ buttons at the bottom of each post, making it easy for visitors to share your content.
+ * Module Description: Add Twitter and Facebook buttons at the bottom of each post, making it easy for visitors to share your content.
  * Sort Order: 7
  * Recommendation Order: 6
  * First Introduced: 1.1

--- a/projects/plugins/jetpack/modules/shortcodes.php
+++ b/projects/plugins/jetpack/modules/shortcodes.php
@@ -9,7 +9,7 @@
  * Auto Activate: No
  * Module Tags: Photos and Videos, Social, Writing, Appearance
  * Feature: Writing
- * Additional Search Queries: shortcodes, shortcode, embeds, media, bandcamp, dailymotion, facebook, flickr, google calendars, google maps, google+, polldaddy, recipe, recipes, scribd, slideshare, slideshow, slideshows, soundcloud, ted, twitter, vimeo, vine, youtube
+ * Additional Search Queries: shortcodes, shortcode, embeds, media, bandcamp, dailymotion, facebook, flickr, google calendars, google maps, polldaddy, recipe, recipes, scribd, slideshare, slideshow, slideshows, soundcloud, ted, twitter, vimeo, vine, youtube
  *
  * @package automattic/jetpack
  */


### PR DESCRIPTION
Fixes #23837

#### Changes proposed in this Pull Request:

* Remove mentions of the old "Google+" service from our descriptions.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Not much to test here, this is just updating some old strings.
