### PR TITLE
Slideshow Block: Fix grid blowout when inserted inside Layout Grid Block.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-slideshow-block-in-layout-grid-block-blowout
+++ b/projects/plugins/jetpack/changelog/fix-slideshow-block-in-layout-grid-block-blowout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix grid blowout when Slideshow block is inserted inside a Layout Grid Block.

--- a/projects/plugins/jetpack/changelog/fix-slideshow-block-in-layout-grid-block-blowout
+++ b/projects/plugins/jetpack/changelog/fix-slideshow-block-in-layout-grid-block-blowout
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Fix grid blowout when Slideshow block is inserted inside a Layout Grid Block.
+Slideshow block: Fix grid blowout when Slideshow block is inserted inside a Layout Grid Block.

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/editor.scss
@@ -1,5 +1,24 @@
 @import '../../shared/styles/gutenberg-base-styles.scss';
 
+// When slideshow block appears inside a layout grid block,
+// make it behave like a grid block to prevent grid blowout.
+// https://github.com/Automattic/wp-calypso/issues/39956
+.wp-block-jetpack-layout-grid-column
+	> .block-editor-inner-blocks
+	> .block-editor-block-list__layout
+	> .block-editor-block-list__block {
+	// WPCOM
+	> .wp-block > .wp-block-jetpack-slideshow, 
+	// Self-Hosted
+	> .wp-block-jetpack-slideshow {
+		display: grid;
+
+		> .swiper-container {
+			width: 100%;
+		}
+	}
+}
+
 .wp-block-jetpack-slideshow__add-item {
 	margin-top: 4px;
 	width: 100%;

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/style.scss
@@ -1,21 +1,6 @@
 @import '../../shared/styles/gutenberg-base-styles.scss';
 @import '../../shared/styles/jetpack-variables.scss';
 
-// When slideshow block appears inside a layout grid block,
-// make it behave like a grid block to prevent grid blowout.
-// https://github.com/Automattic/wp-calypso/issues/39956
-.wp-block-jetpack-layout-grid-column
-	> .block-editor-inner-blocks
-	> .block-editor-block-list__layout
-	> .block-editor-block-list__block
-	> .wp-block-jetpack-slideshow {
-	display: grid;
-
-	> .swiper-container {
-		width: 100%;
-	}
-}
-
 .wp-block-jetpack-slideshow {
 	margin-bottom: $jetpack-block-margin-bottom;
 	position: relative;

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/style.scss
@@ -1,6 +1,21 @@
 @import '../../shared/styles/gutenberg-base-styles.scss';
 @import '../../shared/styles/jetpack-variables.scss';
 
+// When slideshow block appears inside a layout grid block,
+// make it behave like a grid block to prevent grid blowout.
+// https://github.com/Automattic/wp-calypso/issues/39956
+.wp-block-jetpack-layout-grid-column
+	> .block-editor-inner-blocks
+	> .block-editor-block-list__layout
+	> .block-editor-block-list__block
+	> .wp-block-jetpack-slideshow {
+	display: grid;
+
+	> .swiper-container {
+		width: 100%;
+	}
+}
+
 .wp-block-jetpack-slideshow {
 	margin-bottom: $jetpack-block-margin-bottom;
 	position: relative;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/39956

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes grid blowout when Slideshow Block is inserted inside Layout Grid Block.

**Why did it break?**
Slideshow block's width is blowing out because the parent grid element expands itself to the width of the slideshow block. The resize observer in the Swiper library detects the change in width and resizes the Slideshow block, causing the parent grid to again re-expands itself. This vicious cycle continues to repeat itself until the width is blown out of proportion.

**How was it fixed?**
Make the slideshow block behave like a grid block when inserted inside the layout grid block.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Maintenance work.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install "Layout Grid Block" plugin.
* Go to block editor.
* Insert a layout grid block.
* Insert slideshow block into the grid.
  * Insert 2 or more pictures.
* The slideshow block should render within the grid's width.
* Publish the post and view the post, it should render fine too.
* Test on both WPCOM and self-hosted version.


![2022-04-07_14-44-31](https://user-images.githubusercontent.com/1287077/162191377-024e4c38-dc58-4558-9929-d81d6c62c568.png)
![2022-04-07_14-43-11](https://user-images.githubusercontent.com/1287077/162191394-b3f912ad-004f-4ed3-b4e0-b427ed87f7c6.png)
![2022-04-07_14-43-03](https://user-images.githubusercontent.com/1287077/162191400-613c7ef6-176f-4935-be35-52d452a2b1eb.png)


