### PR TITLE
Search: record meter updates to formatting

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9788,7 +9788,7 @@ packages:
       loader-utils: 1.4.0
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.65.0
+      webpack: 5.65.0_webpack-cli@4.9.1
 
   /babel-loader/8.2.4_9477871d54680372d40c2081e3c861d6:
     resolution: {integrity: sha512-8dytA3gcvPPPv4Grjhnt8b5IIiTcq/zeXOPk4iTYI0SVXcsmuGg7JtBRDp8S9X+gJfhQ8ektjXZlDu1Bb33U8A==}
@@ -11357,7 +11357,7 @@ packages:
       postcss-modules-values: 4.0.0_postcss@8.4.8
       postcss-value-parser: 4.2.0
       semver: 7.3.5
-      webpack: 5.65.0
+      webpack: 5.65.0_webpack-cli@4.9.1
 
   /css-minimizer-webpack-plugin/3.1.4_webpack@5.65.0:
     resolution: {integrity: sha512-JXnwBEA+a3FrmuBIJz7tKnCYGyraP86nuvX+wAqik1Lc8Ne9Ql8h5RpFbM3HjMpjXfhnqRBoTYIfArji5mteOg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9788,7 +9788,7 @@ packages:
       loader-utils: 1.4.0
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.65.0_webpack-cli@4.9.1
+      webpack: 5.65.0
 
   /babel-loader/8.2.4_9477871d54680372d40c2081e3c861d6:
     resolution: {integrity: sha512-8dytA3gcvPPPv4Grjhnt8b5IIiTcq/zeXOPk4iTYI0SVXcsmuGg7JtBRDp8S9X+gJfhQ8ektjXZlDu1Bb33U8A==}
@@ -11357,7 +11357,7 @@ packages:
       postcss-modules-values: 4.0.0_postcss@8.4.8
       postcss-value-parser: 4.2.0
       semver: 7.3.5
-      webpack: 5.65.0_webpack-cli@4.9.1
+      webpack: 5.65.0
 
   /css-minimizer-webpack-plugin/3.1.4_webpack@5.65.0:
     resolution: {integrity: sha512-JXnwBEA+a3FrmuBIJz7tKnCYGyraP86nuvX+wAqik1Lc8Ne9Ql8h5RpFbM3HjMpjXfhnqRBoTYIfArji5mteOg==}

--- a/projects/packages/search/changelog/update-search-record-meter-formatting
+++ b/projects/packages/search/changelog/update-search-record-meter-formatting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Record Meter updates formatting

--- a/projects/packages/search/src/dashboard/components/record-meter/bar-chart.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/bar-chart.jsx
@@ -146,7 +146,7 @@ export class BarChart extends React.Component {
 									/>
 									<span className="jp-search-chart-legend__label" children={ item.text } />
 									<span className="jp-search-chart-legend__count">
-										({ this.props.data[ item.datasetIndex ].data.data.toLocaleString() })
+										({ this.props.data[ item.datasetIndex ].data.data?.toLocaleString() })
 									</span>
 								</li>
 							);

--- a/projects/packages/search/src/dashboard/components/record-meter/bar-chart.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/bar-chart.jsx
@@ -146,7 +146,7 @@ export class BarChart extends React.Component {
 									/>
 									<span className="jp-search-chart-legend__label" children={ item.text } />
 									<span className="jp-search-chart-legend__count">
-										({ this.props.data[ item.datasetIndex ].data.data })
+										({ this.props.data[ item.datasetIndex ].data.data.toLocaleString() })
 									</span>
 								</li>
 							);

--- a/projects/packages/search/src/dashboard/components/record-meter/bar-chart.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/bar-chart.jsx
@@ -136,6 +136,8 @@ export class BarChart extends React.Component {
 				<div className="jp-search-chart-legend__container">
 					<ul className="jp-search-chart-legend">
 						{ this.getLegendItems().map( item => {
+							const legendItemData = this.props.data[ item.datasetIndex ]?.data?.data;
+							const legendItemCount = Array.isArray( legendItemData ) ? legendItemData[ 0 ] : null;
 							return (
 								<li key={ item.text }>
 									<div
@@ -147,9 +149,9 @@ export class BarChart extends React.Component {
 									<span className="jp-search-chart-legend__label" children={ item.text } />
 									<span className="jp-search-chart-legend__count">
 										(
-										{ typeof this.props.data[ item.datasetIndex ]?.data?.data === 'object'
-											? this.props.data[ item.datasetIndex ]?.data?.data?.toLocaleString()
-											: this.props.data[ item.datasetIndex ].data.data }
+										{ typeof legendItemCount === 'number'
+											? legendItemCount.toLocaleString()
+											: legendItemCount }
 										)
 									</span>
 								</li>

--- a/projects/packages/search/src/dashboard/components/record-meter/bar-chart.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/bar-chart.jsx
@@ -52,7 +52,7 @@ const CHART_OPTIONS = {
 
 				labels: {
 					filter: function ( legendItem ) {
-						return ! legendItem.text.includes( __( 'Remaining', 'jetpack-search-pkg' ) );
+						return ! legendItem.text.includes( __( 'remaining', 'jetpack-search-pkg' ) );
 					},
 				},
 			},

--- a/projects/packages/search/src/dashboard/components/record-meter/bar-chart.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/bar-chart.jsx
@@ -146,7 +146,11 @@ export class BarChart extends React.Component {
 									/>
 									<span className="jp-search-chart-legend__label" children={ item.text } />
 									<span className="jp-search-chart-legend__count">
-										({ this.props.data[ item.datasetIndex ].data.data?.toLocaleString() })
+										(
+										{ typeof this.props.data[ item.datasetIndex ]?.data?.data === 'object'
+											? this.props.data[ item.datasetIndex ]?.data?.data?.toLocaleString()
+											: this.props.data[ item.datasetIndex ].data.data }
+										)
 									</span>
 								</li>
 							);

--- a/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
+++ b/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 const PALETTE = require( '@automattic/color-studio' );
 
 /**
@@ -90,7 +91,11 @@ export default function getRecordInfo( post_count, post_type_breakdown, tier, la
 		// if there is remaining unused space in tier, add filler spacing to chart
 		if ( tier - currentCount > 0 ) {
 			recordInfo.push( {
-				data: createData( tier - currentCount, PALETTE.colors[ 'Gray 0' ], 'Remaining' ),
+				data: createData(
+					tier - currentCount,
+					PALETTE.colors[ 'Gray 0' ],
+					__( 'remaining', 'jetpack-search-pkg' )
+				),
 			} );
 		}
 	}

--- a/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
@@ -51,12 +51,12 @@ export function NoticeBox( props ) {
 	if ( props.recordCount > props.planRecordLimit ) {
 		notices.push( {
 			message: sprintf(
-				// translators: %d: site's current plan record limit
+				// translators: %s: site's current plan record limit
 				__(
-					'You recently surpassed %d records and will be automatically upgraded to the next billing tier', //TODO: add a link to the tier pricing/upgrade info page
+					'You recently surpassed %s records and will be automatically upgraded to the next billing tier', //TODO: add a link to the tier pricing/upgrade info page
 					'jetpack-search-pkg'
 				),
-				props.planRecordLimit
+				props.planRecordLimit.toLocaleString()
 			),
 		} );
 	}
@@ -67,12 +67,12 @@ export function NoticeBox( props ) {
 	) {
 		notices.push( {
 			message: sprintf(
-				// translators: %d: site's current plan record limit
+				// translators: %s: site's current plan record limit
 				__(
-					"You're close to the max amount of records for this billing tier. Once you hit %d indexed records, you'll automatically be billed for the next tier",
+					"You're close to the max amount of records for this billing tier. Once you hit %s indexed records, you'll automatically be billed for the next tier",
 					'jetpack-search-pkg'
 				),
-				props.planRecordLimit
+				props.planRecordLimit.toLocaleString()
 			),
 		} );
 	}

--- a/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
@@ -19,6 +19,10 @@ const CLOSE_TO_LIMIT_PERCENT = 0.8; //TODO: currently 'close' is defined as 80%.
  */
 export function NoticeBox( props ) {
 	const notices = [];
+	const record_limit_as_string =
+		typeof props.planRecordLimit === 'number'
+			? props.planRecordLimit?.toLocaleString()
+			: props.planRecordLimit;
 
 	// check data is valid
 	if ( props.hasValidData === false ) {
@@ -56,7 +60,7 @@ export function NoticeBox( props ) {
 					'You recently surpassed %s records and will be automatically upgraded to the next billing tier', //TODO: add a link to the tier pricing/upgrade info page
 					'jetpack-search-pkg'
 				),
-				props.planRecordLimit?.toLocaleString()
+				record_limit_as_string
 			),
 		} );
 	}
@@ -72,7 +76,7 @@ export function NoticeBox( props ) {
 					"You're close to the max amount of records for this billing tier. Once you hit %s indexed records, you'll automatically be billed for the next tier",
 					'jetpack-search-pkg'
 				),
-				props.planRecordLimit?.toLocaleString()
+				record_limit_as_string
 			),
 		} );
 	}

--- a/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
@@ -56,7 +56,7 @@ export function NoticeBox( props ) {
 					'You recently surpassed %s records and will be automatically upgraded to the next billing tier', //TODO: add a link to the tier pricing/upgrade info page
 					'jetpack-search-pkg'
 				),
-				props.planRecordLimit.toLocaleString()
+				props.planRecordLimit?.toLocaleString()
 			),
 		} );
 	}
@@ -72,7 +72,7 @@ export function NoticeBox( props ) {
 					"You're close to the max amount of records for this billing tier. Once you hit %s indexed records, you'll automatically be billed for the next tier",
 					'jetpack-search-pkg'
 				),
-				props.planRecordLimit.toLocaleString()
+				props.planRecordLimit?.toLocaleString()
 			),
 		} );
 	}

--- a/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
@@ -19,7 +19,7 @@ const CLOSE_TO_LIMIT_PERCENT = 0.8; //TODO: currently 'close' is defined as 80%.
  */
 export function NoticeBox( props ) {
 	const notices = [];
-	const record_limit_as_string =
+	const recordLimitAsString =
 		typeof props.planRecordLimit === 'number'
 			? props.planRecordLimit?.toLocaleString()
 			: props.planRecordLimit;
@@ -60,7 +60,7 @@ export function NoticeBox( props ) {
 					'You recently surpassed %s records and will be automatically upgraded to the next billing tier', //TODO: add a link to the tier pricing/upgrade info page
 					'jetpack-search-pkg'
 				),
-				record_limit_as_string
+				recordLimitAsString
 			),
 		} );
 	}
@@ -76,7 +76,7 @@ export function NoticeBox( props ) {
 					"You're close to the max amount of records for this billing tier. Once you hit %s indexed records, you'll automatically be billed for the next tier",
 					'jetpack-search-pkg'
 				),
-				record_limit_as_string
+				recordLimitAsString
 			),
 		} );
 	}

--- a/projects/packages/search/src/dashboard/components/record-meter/record-count.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/record-count.jsx
@@ -27,8 +27,8 @@ export function RecordCount( props ) {
 				'<s>%1$s</s> records indexed out of the <s>%2$s</s> allotted for your current plan',
 				'jetpack-search-pkg'
 			),
-			props.recordCount.toLocaleString(),
-			props.planRecordLimit.toLocaleString()
+			props.recordCount?.toLocaleString(),
+			props.planRecordLimit?.toLocaleString()
 		),
 		{
 			s: <strong />,

--- a/projects/packages/search/src/dashboard/components/record-meter/record-count.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/record-count.jsx
@@ -20,6 +20,14 @@ export function RecordCount( props ) {
 		return null;
 	}
 
+	const recordCount =
+		typeof props.recordCount === 'number' ? props.recordCount?.toLocaleString() : props.recordCount;
+
+	const recordLimit =
+		typeof props.planRecordLimit === 'number'
+			? props.planRecordLimit?.toLocaleString()
+			: props.planRecordLimit;
+
 	const message = createInterpolateElement(
 		sprintf(
 			// translators: %1$s: site's current record count, %2$s: record limit of the current plan
@@ -27,8 +35,8 @@ export function RecordCount( props ) {
 				'<s>%1$s</s> records indexed out of the <s>%2$s</s> allotted for your current plan',
 				'jetpack-search-pkg'
 			),
-			props.recordCount?.toLocaleString(),
-			props.planRecordLimit?.toLocaleString()
+			recordCount,
+			recordLimit
 		),
 		{
 			s: <strong />,

--- a/projects/packages/search/src/dashboard/components/record-meter/record-count.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/record-count.jsx
@@ -19,7 +19,7 @@ export function RecordCount( props ) {
 		<div data-testid="record-count" className="jp-search-record-count">
 			<p>
 				{ sprintf(
-					// translators: %1$d: site's current record count, %2$d: record limit of the current plan
+					// translators: %1$s: site's current record count, %2$s: record limit of the current plan
 					__(
 						'%1$s records indexed out of the %2$s allotted for your current plan',
 						'jetpack-search-pkg'
@@ -28,8 +28,6 @@ export function RecordCount( props ) {
 					props.planRecordLimit.toLocaleString()
 				) }
 			</p>
-
-			{ /* { ( 1234.56789 ).toLocaleString( undefined, { maximumFractionDigits: 2 } ) } */ }
 		</div>
 	);
 }

--- a/projects/packages/search/src/dashboard/components/record-meter/record-count.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/record-count.jsx
@@ -5,6 +5,11 @@ import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
+ * WordPress dependencies
+ */
+import { createInterpolateElement } from '@wordpress/element';
+
+/**
  * Returns record count component showing current records indexed and max records available for tier.
  *
  * @param {object} props - current record count and plan record limit.
@@ -15,19 +20,24 @@ export function RecordCount( props ) {
 		return null;
 	}
 
+	const message = createInterpolateElement(
+		sprintf(
+			// translators: %1$s: site's current record count, %2$s: record limit of the current plan
+			__(
+				'<s>%1$s</s> records indexed out of the <s>%2$s</s> allotted for your current plan',
+				'jetpack-search-pkg'
+			),
+			props.recordCount.toLocaleString(),
+			props.planRecordLimit.toLocaleString()
+		),
+		{
+			s: <strong />,
+		}
+	);
+
 	return (
 		<div data-testid="record-count" className="jp-search-record-count">
-			<p>
-				{ sprintf(
-					// translators: %1$s: site's current record count, %2$s: record limit of the current plan
-					__(
-						'%1$s records indexed out of the %2$s allotted for your current plan',
-						'jetpack-search-pkg'
-					),
-					props.recordCount.toLocaleString(),
-					props.planRecordLimit.toLocaleString()
-				) }
-			</p>
+			<p>{ message }</p>
 		</div>
 	);
 }

--- a/projects/packages/search/src/dashboard/components/record-meter/record-count.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/record-count.jsx
@@ -21,13 +21,15 @@ export function RecordCount( props ) {
 				{ sprintf(
 					// translators: %1$d: site's current record count, %2$d: record limit of the current plan
 					__(
-						'%1$d records indexed out of the %2$d allotted for your current plan',
+						'%1$s records indexed out of the %2$s allotted for your current plan',
 						'jetpack-search-pkg'
 					),
-					props.recordCount,
-					props.planRecordLimit
+					props.recordCount.toLocaleString(),
+					props.planRecordLimit.toLocaleString()
 				) }
 			</p>
+
+			{ /* { ( 1234.56789 ).toLocaleString( undefined, { maximumFractionDigits: 2 } ) } */ }
 		</div>
 	);
 }

--- a/projects/packages/search/src/dashboard/components/record-meter/style.scss
+++ b/projects/packages/search/src/dashboard/components/record-meter/style.scss
@@ -37,7 +37,7 @@ ul.jp-search-chart-legend {
 
 .jp-search-notice-box {
 	border: solid 0.5px lightgrey;
-	margin: 0 0 25px 5px;
+	margin-left: 5px;
 	padding: 0 5px;
 }
 
@@ -58,4 +58,5 @@ ul.jp-search-chart-legend {
 
 .jp-search-record-meter {
 	border-bottom: 1px solid rgb( 225, 225, 225 );
+	padding: 30px 0;
 }

--- a/projects/packages/search/src/dashboard/components/record-meter/style.scss
+++ b/projects/packages/search/src/dashboard/components/record-meter/style.scss
@@ -1,50 +1,57 @@
 .jp-search-bar-chart__container {
-    max-height: 40px; 
-  }
+	max-height: 40px;
+}
 
 .jp-search-chart-legend__box {
-  margin-right: 3px;
-  margin-left: 6px;
-  width: 15px;
-  height: 15px;
-  border-radius: 100%;
-  display:inline-block;
+	margin-right: 3px;
+	margin-left: 6px;
+	width: 15px;
+	height: 15px;
+	border-radius: 100%;
+	display: inline-block;
 }
 
 .jp-search-chart-legend {
-  list-style:none;
-  display:inline-block;
-
+	list-style: none;
+	display: inline-block;
 }
 
 ul.jp-search-chart-legend {
-  padding-left: 0;
+	padding-left: 0;
 }
 
 .jp-search-chart-legend li {
-  display:inherit;
-  padding-bottom:15px;
+	display: inherit;
+	padding-bottom: 15px;
 }
 
-.jp-search-chart-legend li .jp-search-chart-legend__label, .jp-search-chart-legend li .jp-search-chart-legend__count {
-  max-width: 200px;
-  padding-right:3px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display:inherit;
+.jp-search-chart-legend li .jp-search-chart-legend__label,
+.jp-search-chart-legend li .jp-search-chart-legend__count {
+	max-width: 200px;
+	padding-right: 3px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	display: inherit;
 }
 
 .jp-search-notice-box {
-  border: solid .5px lightgrey;
-  margin-left: 5px;
-  padding: 0 5px;
-
+	border: solid 0.5px lightgrey;
+	margin-left: 5px;
+	padding: 0 5px;
 }
 
 .jp-search-notice-box__important {
-  border: solid .5px red;
-  color: red;
-  margin-left: 5px;
-  padding: 0 5px;
+	border: solid 0.5px red;
+	color: red;
+	margin-left: 5px;
+	padding: 0 5px;
+}
+
+.jp-search-chart-legend {
+	font-size: 0.9em;
+}
+
+.jp-search-record-count p {
+	font-size: 1em;
 }

--- a/projects/packages/search/src/dashboard/components/record-meter/style.scss
+++ b/projects/packages/search/src/dashboard/components/record-meter/style.scss
@@ -2,16 +2,8 @@
 	max-height: 40px;
 }
 
-.jp-search-chart-legend__box {
-	margin-right: 3px;
-	margin-left: 6px;
-	width: 15px;
-	height: 15px;
-	border-radius: 100%;
-	display: inline-block;
-}
-
 .jp-search-chart-legend {
+	font-size: 0.9em;
 	list-style: none;
 	display: inline-block;
 }
@@ -35,6 +27,15 @@ ul.jp-search-chart-legend {
 	display: inherit;
 }
 
+.jp-search-chart-legend__box {
+	margin-right: 3px;
+	margin-left: 6px;
+	width: 15px;
+	height: 15px;
+	border-radius: 100%;
+	display: inline-block;
+}
+
 .jp-search-notice-box {
 	border: solid 0.5px lightgrey;
 	margin-left: 5px;
@@ -46,10 +47,6 @@ ul.jp-search-chart-legend {
 	color: red;
 	margin-left: 5px;
 	padding: 0 5px;
-}
-
-.jp-search-chart-legend {
-	font-size: 0.9em;
 }
 
 .jp-search-record-count p {

--- a/projects/packages/search/src/dashboard/components/record-meter/style.scss
+++ b/projects/packages/search/src/dashboard/components/record-meter/style.scss
@@ -55,3 +55,7 @@ ul.jp-search-chart-legend {
 .jp-search-record-count p {
 	font-size: 1em;
 }
+
+.jp-search-record-meter {
+	border-bottom: 1px solid rgb( 225, 225, 225 );
+}

--- a/projects/packages/search/src/dashboard/components/record-meter/style.scss
+++ b/projects/packages/search/src/dashboard/components/record-meter/style.scss
@@ -37,7 +37,7 @@ ul.jp-search-chart-legend {
 
 .jp-search-notice-box {
 	border: solid 0.5px lightgrey;
-	margin-left: 5px;
+	margin: 0 0 25px 5px;
 	padding: 0 5px;
 }
 

--- a/projects/packages/search/src/dashboard/components/record-meter/test/record-count.test.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/test/record-count.test.jsx
@@ -18,9 +18,11 @@ describe( 'record count', () => {
 	test( 'outputs correct record counts', () => {
 		render( <RecordCount recordCount={ 20 } planRecordLimit={ 100 } /> );
 
-		expect( screen.getByText( /20 records indexed/i ) ).toBeInTheDocument();
+		expect( screen.getByText( /20/i ) ).toBeInTheDocument();
 
-		expect( screen.getByText( /100 allotted/i ) ).toBeInTheDocument();
+		expect( screen.getByText( /records indexed/i ) ).toBeInTheDocument();
+
+		expect( screen.getByText( /100/i ) ).toBeInTheDocument();
 	} );
 
 	test( "doesn't output if there are no records", () => {


### PR DESCRIPTION
This PR adds a few small updates to record meter to address formatting/style issues. 

#### Changes proposed in this Pull Request:

* Adds padding top & bottom to Record Meter div so it looks better
* Updates all occurrences of numbers (in chart legend, record count display and notice box notices) to format large (4 + digits) numbers with commas. 
* Bolds the counts in the record count display for emphasis
* Adds a solid line at the bottom of the record meter div

#### Does this pull request change what data or activity we track or use?

no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to a site with an active Jetpack Search subscription
* Go to `/wp-admin/admin.php?page=jetpack-search&features=record-meter` 
* Check the record meter still works & looks correctly, and that the following four additions are visible:

| Padding top and bottom:  |  Updated number formatting:  |
| ------------------- | ------------------- |
|  ![image](https://user-images.githubusercontent.com/30754158/162249164-440880dd-33ed-42f5-b495-dba5ccca8243.png) |  ![image](https://user-images.githubusercontent.com/30754158/162249396-7c706e57-5702-4d94-a38d-239a3b3e8317.png) |

| Bolded record count display numbers:  |  Solid line border at bottom of component:  |
| ------------------- | ------------------- |
|  ![image](https://user-images.githubusercontent.com/30754158/162249926-857d5ec4-b399-4e73-9829-3a17423bd6cd.png) |  ![image](https://user-images.githubusercontent.com/30754158/162249649-1123cfdc-8bea-4181-b4b7-5f1479bcd138.png) |