### PR TITLE
Add WAF to Jetpack Scan feature lists

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -52,6 +52,7 @@
             ],
             "description": "Handle .gitignore style files.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -114,6 +115,7 @@
             ],
             "description": "Jetpack Coding Standards. Based on the WordPress Coding Standards, with some additions.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -160,6 +162,7 @@
             ],
             "description": "A filter for PHP CodeSniffer to add support for .phpcsignore files and per-directory configuration files.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21653,7 +21653,7 @@ packages:
       klona: 2.0.5
       neo-async: 2.6.2
       sass: 1.43.3
-      webpack: 5.65.0_webpack-cli@4.9.1
+      webpack: 5.65.0
     dev: true
 
   /sass-loader/12.4.0_webpack@5.65.0:

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/stories/mock-data.js
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/stories/mock-data.js
@@ -115,6 +115,7 @@ export const scanProductData = {
 		'Automated daily scanning',
 		'One-click fixes for most issues',
 		'Instant email notifications',
+		'Access to latest Firewall rules',
 	],
 	pricingForUi: {
 		currency_code: 'USD',

--- a/projects/packages/my-jetpack/changelog/update-scan-feature-lists
+++ b/projects/packages/my-jetpack/changelog/update-scan-feature-lists
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Added firewall to Jetpack Scan feature lists.

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -72,7 +72,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-master": "1.0.x-dev"
+			"dev-master": "1.1.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "1.0.2-alpha",
+	"version": "1.1.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -27,7 +27,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '1.0.2-alpha';
+	const PACKAGE_VERSION = '1.1.0-alpha';
 
 	/**
 	 * Initialize My Jetapack

--- a/projects/packages/my-jetpack/src/products/class-scan.php
+++ b/projects/packages/my-jetpack/src/products/class-scan.php
@@ -72,13 +72,14 @@ class Scan extends Module_Product {
 	/**
 	 * Get the internationalized features list
 	 *
-	 * @return array Boost features list
+	 * @return array Scan features list
 	 */
 	public static function get_features() {
 		return array(
 			_x( 'Automated daily scanning', 'Scan Product Feature', 'jetpack-my-jetpack' ),
 			_x( 'One-click fixes for most issues', 'Scan Product Feature', 'jetpack-my-jetpack' ),
 			_x( 'Instant email notifications', 'Scan Product Feature', 'jetpack-my-jetpack' ),
+			_x( 'Access to latest Firewall rules', 'Scan Product Feature', 'jetpack-my-jetpack' ),
 		);
 	}
 

--- a/projects/plugins/always-use-jetpack-open-graph/changelog/update-scan-feature-lists
+++ b/projects/plugins/always-use-jetpack-open-graph/changelog/update-scan-feature-lists
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/always-use-jetpack-open-graph/composer.lock
+++ b/projects/plugins/always-use-jetpack-open-graph/composer.lock
@@ -76,6 +76,7 @@
             ],
             "description": "Jetpack Changelogger tool. Allows for managing changelogs by dropping change files into a changelog directory with each PR.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },

--- a/projects/plugins/backup/changelog/update-scan-feature-lists
+++ b/projects/plugins/backup/changelog/update-scan-feature-lists
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -13,7 +13,7 @@
 		"automattic/jetpack-connection": "1.37.x-dev",
 		"automattic/jetpack-connection-ui": "2.3.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-my-jetpack": "1.0.x-dev",
+		"automattic/jetpack-my-jetpack": "1.1.x-dev",
 		"automattic/jetpack-sync": "1.30.x-dev",
 		"automattic/jetpack-status": "1.13.x-dev"
 	},

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "00feb006889c6ff0e477e7d5dbd986c9",
+    "content-hash": "078f70b99c4aeb9460447fc736564d54",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -50,6 +50,7 @@
             ],
             "description": "Used to record internal usage stats for Automattic. Not visible to site owners.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -105,6 +106,7 @@
             ],
             "description": "Generic Jetpack wp-admin UI elements",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -171,6 +173,7 @@
             ],
             "description": "Asset management utilities for Jetpack ecosystem packages",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -226,6 +229,7 @@
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -288,6 +292,7 @@
             ],
             "description": "Tools to assist with backing up Jetpack sites.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -340,6 +345,7 @@
             ],
             "description": "A custom installer plugin for Composer to move Jetpack packages out of `vendor/` so WordPress's translation infrastructure will find their strings.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -376,6 +382,7 @@
             ],
             "description": "Jetpack configuration package that initializes other packages and configures Jetpack's functionality. Can be used as a base for all variants of Jetpack package usage.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -444,6 +451,7 @@
             ],
             "description": "Everything needed to connect to the Jetpack infrastructure",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -499,6 +507,7 @@
             ],
             "description": "Jetpack Connection UI",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -547,6 +556,7 @@
             ],
             "description": "A wrapper for defining constants in a more testable way.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -594,6 +604,7 @@
             ],
             "description": "A way to detect device types based on User-Agent header.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -634,6 +645,7 @@
             ],
             "description": "This adds a cronjob that sends a batch of internal automattic stats to wp.com once a day",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -707,6 +719,7 @@
             ],
             "description": "Identity Crisis.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -754,6 +767,7 @@
             ],
             "description": "A logo for Jetpack",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -763,7 +777,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "09305aae3cc76552f9f1d4ba0e7b89f627f5d338"
+                "reference": "8c8ff9c82adc9e87f676fcffa37a5f1f7450ee27"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -788,7 +802,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"
@@ -837,6 +851,7 @@
             ],
             "description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -876,6 +891,7 @@
             ],
             "description": "A wrapper for wp-options to manage specific Jetpack options.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -928,6 +944,7 @@
             ],
             "description": "Password Checker.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -979,6 +996,7 @@
             ],
             "description": "Handle installation of plugins from WP.org",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1030,6 +1048,7 @@
             ],
             "description": "Utilities to build URLs to the jetpack.com/redirect/ service",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1078,6 +1097,7 @@
             ],
             "description": "Utilities, related with user roles and capabilities.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1129,6 +1149,7 @@
             ],
             "description": "Used to retrieve information about the current status of Jetpack and the site overall.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1194,6 +1215,7 @@
             ],
             "description": "Everything needed to allow syncing to the WP.com infrastructure.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         }
@@ -1268,6 +1290,7 @@
             ],
             "description": "Jetpack Changelogger tool. Allows for managing changelogs by dropping change files into a changelog directory with each PR.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },

--- a/projects/plugins/beta/changelog/update-scan-feature-lists
+++ b/projects/plugins/beta/changelog/update-scan-feature-lists
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/beta/composer.lock
+++ b/projects/plugins/beta/composer.lock
@@ -58,6 +58,7 @@
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -263,6 +264,7 @@
             ],
             "description": "Jetpack Changelogger tool. Allows for managing changelogs by dropping change files into a changelog directory with each PR.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },

--- a/projects/plugins/boost/changelog/update-scan-feature-lists
+++ b/projects/plugins/boost/changelog/update-scan-feature-lists
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -20,7 +20,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.7.x-dev",
 		"automattic/jetpack-connection": "1.37.x-dev",
-		"automattic/jetpack-my-jetpack": "1.0.x-dev",
+		"automattic/jetpack-my-jetpack": "1.1.x-dev",
 		"automattic/jetpack-device-detection": "1.4.x-dev",
 		"automattic/jetpack-lazy-images": "2.1.x-dev",
 		"tedivm/jshrink": "1.4.0"

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5ba129787182ce4d01b547d7a49a8724",
+    "content-hash": "95343f1004c6c99a5d99044057444e4f",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -50,6 +50,7 @@
             ],
             "description": "Used to record internal usage stats for Automattic. Not visible to site owners.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -105,6 +106,7 @@
             ],
             "description": "Generic Jetpack wp-admin UI elements",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -171,6 +173,7 @@
             ],
             "description": "Asset management utilities for Jetpack ecosystem packages",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -226,6 +229,7 @@
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -278,6 +282,7 @@
             ],
             "description": "A custom installer plugin for Composer to move Jetpack packages out of `vendor/` so WordPress's translation infrastructure will find their strings.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -314,6 +319,7 @@
             ],
             "description": "Jetpack configuration package that initializes other packages and configures Jetpack's functionality. Can be used as a base for all variants of Jetpack package usage.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -382,6 +388,7 @@
             ],
             "description": "Everything needed to connect to the Jetpack infrastructure",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -430,6 +437,7 @@
             ],
             "description": "A wrapper for defining constants in a more testable way.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -477,6 +485,7 @@
             ],
             "description": "A way to detect device types based on User-Agent header.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -517,6 +526,7 @@
             ],
             "description": "This adds a cronjob that sends a batch of internal automattic stats to wp.com once a day",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -579,6 +589,7 @@
             ],
             "description": "Speed up your site and create a smoother viewing experience by loading images as visitors scroll down the screen, instead of all at once.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -588,7 +599,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "09305aae3cc76552f9f1d4ba0e7b89f627f5d338"
+                "reference": "8c8ff9c82adc9e87f676fcffa37a5f1f7450ee27"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -613,7 +624,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"
@@ -662,6 +673,7 @@
             ],
             "description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -701,6 +713,7 @@
             ],
             "description": "A wrapper for wp-options to manage specific Jetpack options.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -752,6 +765,7 @@
             ],
             "description": "Handle installation of plugins from WP.org",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -803,6 +817,7 @@
             ],
             "description": "Utilities to build URLs to the jetpack.com/redirect/ service",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -851,6 +866,7 @@
             ],
             "description": "Utilities, related with user roles and capabilities.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -902,6 +918,7 @@
             ],
             "description": "Used to retrieve information about the current status of Jetpack and the site overall.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1080,6 +1097,7 @@
             ],
             "description": "Jetpack Changelogger tool. Allows for managing changelogs by dropping change files into a changelog directory with each PR.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },

--- a/projects/plugins/debug-helper/changelog/update-scan-feature-lists
+++ b/projects/plugins/debug-helper/changelog/update-scan-feature-lists
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/debug-helper/composer.lock
+++ b/projects/plugins/debug-helper/composer.lock
@@ -76,6 +76,7 @@
             ],
             "description": "Jetpack Changelogger tool. Allows for managing changelogs by dropping change files into a changelog directory with each PR.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },

--- a/projects/plugins/jetpack/_inc/client/product-descriptions/product-description/test/fixtures.js
+++ b/projects/plugins/jetpack/_inc/client/product-descriptions/product-description/test/fixtures.js
@@ -31,7 +31,8 @@ export function buildInitialState() {
 						"features": [
 							"Automated daily scanning",
 							"One-click fixes for most issues",
-							"Instant email notifications"
+							"Instant email notifications",
+							"Access to latest Firewall rules"
 						]
 					},
 					"search": {

--- a/projects/plugins/jetpack/changelog/update-scan-feature-lists
+++ b/projects/plugins/jetpack/changelog/update-scan-feature-lists
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Added firewall to Jetpack Scan feature lists.

--- a/projects/plugins/jetpack/changelog/update-scan-feature-lists#2
+++ b/projects/plugins/jetpack/changelog/update-scan-feature-lists#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -6652,6 +6652,7 @@ endif;
 				_x( 'Automated daily scanning', 'Scan Product Feature', 'jetpack' ),
 				_x( 'One-click fixes for most issues', 'Scan Product Feature', 'jetpack' ),
 				_x( 'Instant email notifications', 'Scan Product Feature', 'jetpack' ),
+				_x( 'Access to latest Firewall rules', 'Scan Product Feature', 'jetpack' ),
 			),
 		);
 

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -32,7 +32,7 @@
 		"automattic/jetpack-lazy-images": "2.1.x-dev",
 		"automattic/jetpack-licensing": "1.6.x-dev",
 		"automattic/jetpack-logo": "1.5.x-dev",
-		"automattic/jetpack-my-jetpack": "1.0.x-dev",
+		"automattic/jetpack-my-jetpack": "1.1.x-dev",
 		"automattic/jetpack-options": "1.15.x-dev",
 		"automattic/jetpack-partner": "1.7.x-dev",
 		"automattic/jetpack-plugins-installer": "0.1.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03f8321aa164ea1ef318f71ca2793903",
+    "content-hash": "a8c17eaeecf8be44b4be9113c399bc21",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -50,6 +50,7 @@
             ],
             "description": "Used to record internal usage stats for Automattic. Not visible to site owners.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -105,6 +106,7 @@
             ],
             "description": "Provides an interface to the WP.com A/B tests.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -160,6 +162,7 @@
             ],
             "description": "Generic Jetpack wp-admin UI elements",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -226,6 +229,7 @@
             ],
             "description": "Asset management utilities for Jetpack ecosystem packages",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -281,6 +285,7 @@
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -343,6 +348,7 @@
             ],
             "description": "Tools to assist with backing up Jetpack sites.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -395,6 +401,7 @@
             ],
             "description": "Register and manage blocks within a plugin. Used to manage block registration, enqueues, and more.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -434,6 +441,7 @@
             ],
             "description": "Compatibility layer with previous versions of Jetpack",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -486,6 +494,7 @@
             ],
             "description": "A custom installer plugin for Composer to move Jetpack packages out of `vendor/` so WordPress's translation infrastructure will find their strings.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -522,6 +531,7 @@
             ],
             "description": "Jetpack configuration package that initializes other packages and configures Jetpack's functionality. Can be used as a base for all variants of Jetpack package usage.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -590,6 +600,7 @@
             ],
             "description": "Everything needed to connect to the Jetpack infrastructure",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -645,6 +656,7 @@
             ],
             "description": "Jetpack Connection UI",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -693,6 +705,7 @@
             ],
             "description": "A wrapper for defining constants in a more testable way.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -740,6 +753,7 @@
             ],
             "description": "A way to detect device types based on User-Agent header.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -787,6 +801,7 @@
             ],
             "description": "Jetpack Error - a wrapper around WP_Error.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -836,6 +851,7 @@
             ],
             "description": "WordPress Webfonts provider for Google Fonts",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -876,6 +892,7 @@
             ],
             "description": "This adds a cronjob that sends a batch of internal automattic stats to wp.com once a day",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -949,6 +966,7 @@
             ],
             "description": "Identity Crisis.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1018,6 +1036,7 @@
             ],
             "description": "Just in time messages for Jetpack",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1080,6 +1099,7 @@
             ],
             "description": "Speed up your site and create a smoother viewing experience by loading images as visitors scroll down the screen, instead of all at once.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1136,6 +1156,7 @@
             ],
             "description": "Everything needed to manage Jetpack licenses client-side.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1183,6 +1204,7 @@
             ],
             "description": "A logo for Jetpack",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1192,7 +1214,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "09305aae3cc76552f9f1d4ba0e7b89f627f5d338"
+                "reference": "8c8ff9c82adc9e87f676fcffa37a5f1f7450ee27"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -1217,7 +1239,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"
@@ -1266,6 +1288,7 @@
             ],
             "description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1305,6 +1328,7 @@
             ],
             "description": "A wrapper for wp-options to manage specific Jetpack options.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1362,6 +1386,7 @@
             ],
             "description": "Support functions for Jetpack hosting partners.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1414,6 +1439,7 @@
             ],
             "description": "Password Checker.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1465,6 +1491,7 @@
             ],
             "description": "Handle installation of plugins from WP.org",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1516,6 +1543,7 @@
             ],
             "description": "Utilities to build URLs to the jetpack.com/redirect/ service",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1564,6 +1592,7 @@
             ],
             "description": "Utilities, related with user roles and capabilities.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1645,6 +1674,7 @@
             ],
             "description": "Tools to assist with enabling cloud search for Jetpack sites.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1696,6 +1726,7 @@
             ],
             "description": "Used to retrieve information about the current status of Jetpack and the site overall.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1761,6 +1792,7 @@
             ],
             "description": "Everything needed to allow syncing to the WP.com infrastructure.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1805,6 +1837,7 @@
             "description": "Tracking for Jetpack",
             "abandoned": "automattic/jetpack-connection",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1863,6 +1896,7 @@
             ],
             "description": "Tools to assist with the Jetpack Web Application Firewall",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -2106,6 +2140,7 @@
             ],
             "description": "Jetpack Changelogger tool. Allows for managing changelogs by dropping change files into a changelog directory with each PR.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },

--- a/projects/plugins/protect/changelog/update-scan-feature-lists
+++ b/projects/plugins/protect/changelog/update-scan-feature-lists
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/protect/composer.json
+++ b/projects/plugins/protect/composer.json
@@ -10,7 +10,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.7.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-my-jetpack": "1.0.x-dev",
+		"automattic/jetpack-my-jetpack": "1.1.x-dev",
 		"automattic/jetpack-plugins-installer": "0.1.x-dev",
 		"automattic/jetpack-sync": "1.30.x-dev"
 	},

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1d8d3672ce2a3667012086247e429ef3",
+    "content-hash": "d772c097b2d7c990d837c09f9dcee308",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -50,6 +50,7 @@
             ],
             "description": "Used to record internal usage stats for Automattic. Not visible to site owners.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -105,6 +106,7 @@
             ],
             "description": "Generic Jetpack wp-admin UI elements",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -171,6 +173,7 @@
             ],
             "description": "Asset management utilities for Jetpack ecosystem packages",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -226,6 +229,7 @@
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -278,6 +282,7 @@
             ],
             "description": "A custom installer plugin for Composer to move Jetpack packages out of `vendor/` so WordPress's translation infrastructure will find their strings.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -314,6 +319,7 @@
             ],
             "description": "Jetpack configuration package that initializes other packages and configures Jetpack's functionality. Can be used as a base for all variants of Jetpack package usage.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -382,6 +388,7 @@
             ],
             "description": "Everything needed to connect to the Jetpack infrastructure",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -430,6 +437,7 @@
             ],
             "description": "A wrapper for defining constants in a more testable way.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -470,6 +478,7 @@
             ],
             "description": "This adds a cronjob that sends a batch of internal automattic stats to wp.com once a day",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -543,6 +552,7 @@
             ],
             "description": "Identity Crisis.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -590,6 +600,7 @@
             ],
             "description": "A logo for Jetpack",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -599,7 +610,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "09305aae3cc76552f9f1d4ba0e7b89f627f5d338"
+                "reference": "8c8ff9c82adc9e87f676fcffa37a5f1f7450ee27"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -624,7 +635,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"
@@ -673,6 +684,7 @@
             ],
             "description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -712,6 +724,7 @@
             ],
             "description": "A wrapper for wp-options to manage specific Jetpack options.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -764,6 +777,7 @@
             ],
             "description": "Password Checker.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -815,6 +829,7 @@
             ],
             "description": "Handle installation of plugins from WP.org",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -866,6 +881,7 @@
             ],
             "description": "Utilities to build URLs to the jetpack.com/redirect/ service",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -914,6 +930,7 @@
             ],
             "description": "Utilities, related with user roles and capabilities.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -965,6 +982,7 @@
             ],
             "description": "Used to retrieve information about the current status of Jetpack and the site overall.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1030,6 +1048,7 @@
             ],
             "description": "Everything needed to allow syncing to the WP.com infrastructure.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         }
@@ -1104,6 +1123,7 @@
             ],
             "description": "Jetpack Changelogger tool. Allows for managing changelogs by dropping change files into a changelog directory with each PR.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },

--- a/projects/plugins/search/changelog/update-scan-feature-lists
+++ b/projects/plugins/search/changelog/update-scan-feature-lists
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -8,7 +8,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.7.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-my-jetpack": "1.0.x-dev",
+		"automattic/jetpack-my-jetpack": "1.1.x-dev",
 		"automattic/jetpack-options": "^1.15",
 		"automattic/jetpack-search": "0.12.x-dev",
 		"automattic/jetpack-status": "^1.13",

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0a2f4f801c4e2ad3035b8265ae76381c",
+    "content-hash": "8cbe8411c710b8ed281173b4d8ac5207",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -50,6 +50,7 @@
             ],
             "description": "Used to record internal usage stats for Automattic. Not visible to site owners.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -105,6 +106,7 @@
             ],
             "description": "Generic Jetpack wp-admin UI elements",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -171,6 +173,7 @@
             ],
             "description": "Asset management utilities for Jetpack ecosystem packages",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -226,6 +229,7 @@
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -278,6 +282,7 @@
             ],
             "description": "A custom installer plugin for Composer to move Jetpack packages out of `vendor/` so WordPress's translation infrastructure will find their strings.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -314,6 +319,7 @@
             ],
             "description": "Jetpack configuration package that initializes other packages and configures Jetpack's functionality. Can be used as a base for all variants of Jetpack package usage.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -382,6 +388,7 @@
             ],
             "description": "Everything needed to connect to the Jetpack infrastructure",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -430,6 +437,7 @@
             ],
             "description": "A wrapper for defining constants in a more testable way.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -470,6 +478,7 @@
             ],
             "description": "This adds a cronjob that sends a batch of internal automattic stats to wp.com once a day",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -543,6 +552,7 @@
             ],
             "description": "Identity Crisis.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -590,6 +600,7 @@
             ],
             "description": "A logo for Jetpack",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -599,7 +610,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "09305aae3cc76552f9f1d4ba0e7b89f627f5d338"
+                "reference": "8c8ff9c82adc9e87f676fcffa37a5f1f7450ee27"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -624,7 +635,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"
@@ -673,6 +684,7 @@
             ],
             "description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -712,6 +724,7 @@
             ],
             "description": "A wrapper for wp-options to manage specific Jetpack options.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -764,6 +777,7 @@
             ],
             "description": "Password Checker.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -815,6 +829,7 @@
             ],
             "description": "Handle installation of plugins from WP.org",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -866,6 +881,7 @@
             ],
             "description": "Utilities to build URLs to the jetpack.com/redirect/ service",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -914,6 +930,7 @@
             ],
             "description": "Utilities, related with user roles and capabilities.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -995,6 +1012,7 @@
             ],
             "description": "Tools to assist with enabling cloud search for Jetpack sites.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1046,6 +1064,7 @@
             ],
             "description": "Used to retrieve information about the current status of Jetpack and the site overall.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1111,6 +1130,7 @@
             ],
             "description": "Everything needed to allow syncing to the WP.com infrastructure.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1155,6 +1175,7 @@
             "description": "Tracking for Jetpack",
             "abandoned": "automattic/jetpack-connection",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         }
@@ -1229,6 +1250,7 @@
             ],
             "description": "Jetpack Changelogger tool. Allows for managing changelogs by dropping change files into a changelog directory with each PR.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },

--- a/projects/plugins/social/changelog/update-scan-feature-lists
+++ b/projects/plugins/social/changelog/update-scan-feature-lists
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -10,7 +10,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.7.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-my-jetpack": "1.0.x-dev",
+		"automattic/jetpack-my-jetpack": "1.1.x-dev",
 		"automattic/jetpack-sync": "1.30.x-dev"
 	},
 	"require-dev": {

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fa938d8b32dcc0bddda883e9b28502af",
+    "content-hash": "d6d3f3e77be5637ccfa0cc9f9841ee39",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -50,6 +50,7 @@
             ],
             "description": "Used to record internal usage stats for Automattic. Not visible to site owners.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -105,6 +106,7 @@
             ],
             "description": "Generic Jetpack wp-admin UI elements",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -171,6 +173,7 @@
             ],
             "description": "Asset management utilities for Jetpack ecosystem packages",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -226,6 +229,7 @@
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -278,6 +282,7 @@
             ],
             "description": "A custom installer plugin for Composer to move Jetpack packages out of `vendor/` so WordPress's translation infrastructure will find their strings.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -314,6 +319,7 @@
             ],
             "description": "Jetpack configuration package that initializes other packages and configures Jetpack's functionality. Can be used as a base for all variants of Jetpack package usage.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -382,6 +388,7 @@
             ],
             "description": "Everything needed to connect to the Jetpack infrastructure",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -430,6 +437,7 @@
             ],
             "description": "A wrapper for defining constants in a more testable way.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -470,6 +478,7 @@
             ],
             "description": "This adds a cronjob that sends a batch of internal automattic stats to wp.com once a day",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -543,6 +552,7 @@
             ],
             "description": "Identity Crisis.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -590,6 +600,7 @@
             ],
             "description": "A logo for Jetpack",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -599,7 +610,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "09305aae3cc76552f9f1d4ba0e7b89f627f5d338"
+                "reference": "8c8ff9c82adc9e87f676fcffa37a5f1f7450ee27"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -624,7 +635,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"
@@ -673,6 +684,7 @@
             ],
             "description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -712,6 +724,7 @@
             ],
             "description": "A wrapper for wp-options to manage specific Jetpack options.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -764,6 +777,7 @@
             ],
             "description": "Password Checker.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -815,6 +829,7 @@
             ],
             "description": "Handle installation of plugins from WP.org",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -866,6 +881,7 @@
             ],
             "description": "Utilities to build URLs to the jetpack.com/redirect/ service",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -914,6 +930,7 @@
             ],
             "description": "Utilities, related with user roles and capabilities.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -965,6 +982,7 @@
             ],
             "description": "Used to retrieve information about the current status of Jetpack and the site overall.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1030,6 +1048,7 @@
             ],
             "description": "Everything needed to allow syncing to the WP.com infrastructure.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         }
@@ -1104,6 +1123,7 @@
             ],
             "description": "Jetpack Changelogger tool. Allows for managing changelogs by dropping change files into a changelog directory with each PR.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },

--- a/projects/plugins/starter-plugin/changelog/update-scan-feature-lists
+++ b/projects/plugins/starter-plugin/changelog/update-scan-feature-lists
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/starter-plugin/composer.json
+++ b/projects/plugins/starter-plugin/composer.json
@@ -10,7 +10,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.7.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-my-jetpack": "1.0.x-dev",
+		"automattic/jetpack-my-jetpack": "1.1.x-dev",
 		"automattic/jetpack-sync": "1.30.x-dev"
 	},
 	"require-dev": {

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5aba4332be88bff3b3285d51e8c2e449",
+    "content-hash": "15dab5ba0848cdedc6287afb8df27f1d",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -50,6 +50,7 @@
             ],
             "description": "Used to record internal usage stats for Automattic. Not visible to site owners.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -105,6 +106,7 @@
             ],
             "description": "Generic Jetpack wp-admin UI elements",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -171,6 +173,7 @@
             ],
             "description": "Asset management utilities for Jetpack ecosystem packages",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -226,6 +229,7 @@
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -278,6 +282,7 @@
             ],
             "description": "A custom installer plugin for Composer to move Jetpack packages out of `vendor/` so WordPress's translation infrastructure will find their strings.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -314,6 +319,7 @@
             ],
             "description": "Jetpack configuration package that initializes other packages and configures Jetpack's functionality. Can be used as a base for all variants of Jetpack package usage.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -382,6 +388,7 @@
             ],
             "description": "Everything needed to connect to the Jetpack infrastructure",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -430,6 +437,7 @@
             ],
             "description": "A wrapper for defining constants in a more testable way.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -470,6 +478,7 @@
             ],
             "description": "This adds a cronjob that sends a batch of internal automattic stats to wp.com once a day",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -543,6 +552,7 @@
             ],
             "description": "Identity Crisis.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -590,6 +600,7 @@
             ],
             "description": "A logo for Jetpack",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -599,7 +610,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "09305aae3cc76552f9f1d4ba0e7b89f627f5d338"
+                "reference": "8c8ff9c82adc9e87f676fcffa37a5f1f7450ee27"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -624,7 +635,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"
@@ -673,6 +684,7 @@
             ],
             "description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -712,6 +724,7 @@
             ],
             "description": "A wrapper for wp-options to manage specific Jetpack options.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -764,6 +777,7 @@
             ],
             "description": "Password Checker.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -815,6 +829,7 @@
             ],
             "description": "Handle installation of plugins from WP.org",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -866,6 +881,7 @@
             ],
             "description": "Utilities to build URLs to the jetpack.com/redirect/ service",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -914,6 +930,7 @@
             ],
             "description": "Utilities, related with user roles and capabilities.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -965,6 +982,7 @@
             ],
             "description": "Used to retrieve information about the current status of Jetpack and the site overall.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -1030,6 +1048,7 @@
             ],
             "description": "Everything needed to allow syncing to the WP.com infrastructure.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         }
@@ -1104,6 +1123,7 @@
             ],
             "description": "Jetpack Changelogger tool. Allows for managing changelogs by dropping change files into a changelog directory with each PR.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },

--- a/projects/plugins/vaultpress/changelog/update-scan-feature-lists
+++ b/projects/plugins/vaultpress/changelog/update-scan-feature-lists
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/vaultpress/composer.lock
+++ b/projects/plugins/vaultpress/composer.lock
@@ -58,6 +58,7 @@
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },
@@ -105,6 +106,7 @@
             ],
             "description": "A logo for Jetpack",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         }
@@ -179,6 +181,7 @@
             ],
             "description": "Jetpack Changelogger tool. Allows for managing changelogs by dropping change files into a changelog directory with each PR.",
             "transport-options": {
+                "monorepo": true,
                 "relative": true
             }
         },


### PR DESCRIPTION
⚠️ **This PR should not be merged until Jetpack Firewall is released.** ⚠️

This PR adds "Access to latest Firewall rules" as a bullet point to Jetpack Scan's feature lists.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds "Access to latest Firewall rules" to the Scan feature list in the Jetpack plugin.
* Adds "Access to latest Firewall rules" to the Scan feature list in My Jetpack.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

1201069996155217-as-1202025817736947

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check out this branch and boot up a test site.
* Go to `/wp-admin/admin.php?page=my-jetpack#/add-scan` and validate that "Access to latest Firewall rules" is included in the feature list.
* Go to `/wp-admin/admin.php?page=jetpack#/product/scan` and validate that "Access to latest Firewall rules" is included in the feature list.

#### Screenshots:

<img width="1014" alt="Screen Shot 2022-04-06 at 1 59 09 PM" src="https://user-images.githubusercontent.com/10933065/162060602-c12c3c46-72c6-4084-b90f-2ea250c3dc31.png">