### PR TITLE
Payment Blocks: Avoid creating a new product if the site has no products and the block has an invalid product ID

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-product-manager-no-products-create
+++ b/projects/plugins/jetpack/changelog/fix-product-manager-no-products-create
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Avoid creating a new product for payment blocks if the site has no products and the block as an invalid product ID.

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/index.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/index.js
@@ -70,7 +70,9 @@ export default function ProductManagementControls( {
 					/>
 				</>
 			) }
-			{ isApiConnected && isSelectedProductInvalid && <InvalidProductWarning /> }
+			{ isApiConnected && isSelectedProductInvalid && (
+				<InvalidProductWarning productType={ productType } />
+			) }
 		</>
 	);
 }

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/invalid-product-warning.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/invalid-product-warning.js
@@ -2,22 +2,26 @@
  * WordPress dependencies
  */
 import { Warning } from '@wordpress/block-editor';
-import { __ } from '@wordpress/i18n';
 import { Icon, warning } from '@wordpress/icons';
 
-export default function InvalidProductWarning() {
+/**
+ * Internal dependencies
+ */
+import { getMessageByProductType } from './utils';
+
+export default function InvalidProductWarning( { productType } ) {
 	return (
 		<Warning className="product-management-control-nudge">
 			<span className="product-management-control-nudge__info">
 				{ <Icon icon={ warning } /> }
 				<span className="product-management-control-nudge__text-container">
 					<span className="product-management-control-nudge__title">
-						{ __( 'Invalid subscription configured for this block.', 'jetpack' ) }
+						{ getMessageByProductType( 'invalid product configured for this block', productType ) }
 					</span>
 					<span className="product-management-control-nudge__message">
-						{ __(
-							'The subscribe button will be hidden from your visitors until you select a valid subscription.',
-							'jetpack'
+						{ getMessageByProductType(
+							'the button will be hidden from your visitors until you select a valid product',
+							productType
 						) }
 					</span>
 				</span>

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/utils.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/utils.js
@@ -69,6 +69,26 @@ const messages = {
 			'jetpack'
 		),
 	},
+	'invalid product configured for this block': {
+		[ PRODUCT_TYPE_PAYMENT_PLAN ]: __(
+			'Invalid payment plan configured for this block.',
+			'jetpack'
+		),
+		[ PRODUCT_TYPE_SUBSCRIPTION ]: __(
+			'Invalid subscription configured for this block.',
+			'jetpack'
+		),
+	},
+	'the button will be hidden from your visitors until you select a valid product': {
+		[ PRODUCT_TYPE_PAYMENT_PLAN ]: __(
+			'The button will be hidden from your visitors until you select a valid payment plan.',
+			'jetpack'
+		),
+		[ PRODUCT_TYPE_SUBSCRIPTION ]: __(
+			'The subscribe button will be hidden from your visitors until you select a valid subscription.',
+			'jetpack'
+		),
+	},
 };
 
 export function getMessageByProductType( message, productType = PRODUCT_TYPE_PAYMENT_PLAN ) {

--- a/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
@@ -64,7 +64,8 @@ export const getProducts = (
 		if (
 			! response?.products?.length &&
 			! response.should_upgrade_to_access_memberships &&
-			response.connected_account_id
+			response.connected_account_id &&
+			! selectedProductId
 		) {
 			// Is ready to use and has no product set up yet. Let's create one!
 			await dispatch(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Prevent creating a new product on an existing payment block if the site has no products and the block is using an invalid product ID.
* Update the copy for the Payment Button block to use the generic "payment plan" phrasing instead of the Premium Content-specific "subscription".

This PR fixes an edge case where the `getProducts` selector used by payment blocks would automatically create a new product if the site has no products.
It was mostly intended to pre-populate payment blocks on "empty" sites, but it ended up creating (and auto-selecting) new products also for existing blocks whose product has been deleted.
In that case, the block is supposed to show an invalid product warning instead, but the "no products" case runs earlier than the invalid product scenario.
The fix simply makes sure that we only auto-create a new product for new blocks that don't have a product ID yet.

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a WPCOM Pro site, insert a Payment Button.
* It will automatically be provisioned with a payment plan (either the most recently created one, or a new one if none were available.
* Save the post.
* Head to `https://wordpress.com/earn/payments-plans/` for the site, and delete **all** the payment plans.
* Reload the post editor.
* Make sure the payment block shows an invalid warning instead of being provisioned with a new payment plan.