### PR TITLE
Update several removed methods to be more defensive for backwards compatibility.

### DIFF
--- a/projects/packages/search/changelog/update-defensive-is-onboarding
+++ b/projects/packages/search/changelog/update-defensive-is-onboarding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added deprecated methods as a safety.

--- a/projects/packages/search/src/class-module-control.php
+++ b/projects/packages/search/src/class-module-control.php
@@ -202,7 +202,7 @@ class Module_Control {
 	public function get_active_modules() {
 		_deprecated_function(
 			__METHOD__,
-			'jetpack-search-$next-version$',
+			'jetpack-search-$$next-version$$',
 			'Automattic\\Jetpack\\Modules\\get_active'
 		);
 

--- a/projects/packages/search/src/class-module-control.php
+++ b/projects/packages/search/src/class-module-control.php
@@ -196,7 +196,7 @@ class Module_Control {
 	/**
 	 * Get a list of activated modules as an array of module slugs.
 	 *
-	 * @deprecated $next-version$
+	 * @deprecated $$next-version$$
 	 * @return Array $active_modules
 	 */
 	public function get_active_modules() {

--- a/projects/packages/search/src/class-module-control.php
+++ b/projects/packages/search/src/class-module-control.php
@@ -202,7 +202,7 @@ class Module_Control {
 	public function get_active_modules() {
 		_deprecated_function(
 			__METHOD__,
-			'jetpack-search-$$next-version$$',
+			'jetpack-search-0.12.3',
 			'Automattic\\Jetpack\\Modules\\get_active'
 		);
 

--- a/projects/packages/search/src/class-module-control.php
+++ b/projects/packages/search/src/class-module-control.php
@@ -156,6 +156,15 @@ class Module_Control {
 	}
 
 	/**
+	 * Update module status
+	 *
+	 * @param boolean $active - true to activate, false to deactivate.
+	 */
+	public function update_status( $active ) {
+		return $active ? $this->activate() : $this->deactivate();
+	}
+
+	/**
 	 * Disable Instant Search Experience
 	 */
 	public function disable_instant_search() {
@@ -182,5 +191,21 @@ class Module_Control {
 	 */
 	public function update_instant_search_status( $enabled ) {
 		return $enabled ? $this->enable_instant_search() : $this->disable_instant_search();
+	}
+
+	/**
+	 * Get a list of activated modules as an array of module slugs.
+	 *
+	 * @deprecated $next-version$
+	 * @return Array $active_modules
+	 */
+	public function get_active_modules() {
+		_deprecated_function(
+			__METHOD__,
+			'jetpack-search-$next-version$',
+			'Automattic\\Jetpack\\Modules\\get_active'
+		);
+
+		return ( new Modules() )->get_active();
 	}
 }

--- a/projects/plugins/jetpack/changelog/update-defensive-is-onboarding
+++ b/projects/plugins/jetpack/changelog/update-defensive-is-onboarding
@@ -1,0 +1,5 @@
+Significance: patch
+Type: compat
+Comment: I already mentioned the change in another changelog.
+
+

--- a/projects/plugins/jetpack/changelog/update-defensive-is-onboarding
+++ b/projects/plugins/jetpack/changelog/update-defensive-is-onboarding
@@ -1,5 +1,4 @@
 Significance: patch
 Type: compat
-Comment: I already mentioned the change in another changelog.
 
-
+Added several removed methods back in order to ensure backwards compatibility with other Jetpack plugins.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -1614,6 +1614,7 @@ class Jetpack {
 	 * A site is considered as being onboarded if it currently has an onboarding token.
 	 *
 	 * @since 5.8
+	 * @deprecated Use \Automattic\Jetpack\Status()->is_onboarding()
 	 *
 	 * @access public
 	 * @static
@@ -1621,6 +1622,11 @@ class Jetpack {
 	 * @return bool True if the site is currently onboarding, false otherwise
 	 */
 	public static function is_onboarding() {
+		_deprecated_function( __METHOD__, 'jetpack-10.9', 'Automattic\\Jetpack\\Status\\is_onboarding' );
+
+		if ( ! method_exists( 'Automattic\Jetpack\Status', 'is_onboarding' ) ) {
+			return Jetpack_Options::get_option( 'onboarding' ) !== false;
+		}
 		return ( new Status() )->is_onboarding();
 	}
 
@@ -1779,7 +1785,7 @@ class Jetpack {
 		if (
 			! self::is_connection_ready()
 			&& ! $status->is_offline_mode()
-			&& ! $status->is_onboarding()
+			&& ! self::is_onboarding()
 			&& (
 				! is_multisite()
 				|| ! get_site_option( 'jetpack_protect_active' )

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -1782,10 +1782,17 @@ class Jetpack {
 	 */
 	public static function load_modules() {
 		$status = new Status();
+
+		if ( method_exists( 'is_onboarding', $status ) ) {
+			$is_onboarding = $status->is_onboarding();
+		} else {
+			$is_onboarding = self::is_onboarding();
+		}
+
 		if (
 			! self::is_connection_ready()
 			&& ! $status->is_offline_mode()
-			&& ! self::is_onboarding()
+			&& ! $is_onboarding
 			&& (
 				! is_multisite()
 				|| ! get_site_option( 'jetpack_protect_active' )

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -1783,7 +1783,7 @@ class Jetpack {
 	public static function load_modules() {
 		$status = new Status();
 
-		if ( method_exists( 'is_onboarding', $status ) ) {
+		if ( method_exists( $status, 'is_onboarding' ) ) {
 			$is_onboarding = $status->is_onboarding();
 		} else {
 			$is_onboarding = self::is_onboarding();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Based on #23716 this PR adds a couple of removed methods back as a safety measure.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds `is_onboarding` existence check.
* Adds `update_status` back because it was specific to the package.
* Adds `get_active_modules` back as a deprecated method because it was public API.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
* N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
* No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Make sure tests pass.
* Make sure Search can manage its Jetpack module successfully.
