### PR TITLE
Publicize: Force theme support for post-thumbnails feature

### DIFF
--- a/projects/packages/publicize/changelog/update-publicize-post-thumbnails-support
+++ b/projects/packages/publicize/changelog/update-publicize-post-thumbnails-support
@@ -1,4 +1,4 @@
 Significance: minor
-Type: enhancement
+Type: changed
 
 Publicize: Allow users to set the image for their social post even when themes don't support featured images.

--- a/projects/packages/publicize/composer.json
+++ b/projects/packages/publicize/composer.json
@@ -51,7 +51,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-master": "0.5.x-dev"
+			"dev-master": "0.6.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.5.1-alpha",
+	"version": "0.6.0-alpha",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -220,6 +220,7 @@ abstract class Publicize_Base {
 		// Connection test callback.
 		add_action( 'wp_ajax_test_publicize_conns', array( $this, 'test_publicize_conns' ) );
 
+		// Custom priority to ensure post type support is added prior to thumbnail support being added to the theme.
 		add_action( 'init', array( $this, 'add_post_type_support' ), 8 );
 		add_action( 'init', array( $this, 'register_post_meta' ), 20 );
 

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -9,6 +9,7 @@
 
 namespace Automattic\Jetpack\Publicize;
 
+use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
 
@@ -222,9 +223,11 @@ abstract class Publicize_Base {
 		add_action( 'init', array( $this, 'add_post_type_support' ), 8 );
 		add_action( 'init', array( $this, 'register_post_meta' ), 20 );
 
-		// The custom priority for this action ensures that any existing code that
-		// removes post-thumbnails support during 'init' continues to work.
-		add_action( 'init', __NAMESPACE__ . '\add_theme_post_thumbnails_support', 8 );
+		if ( ( new Modules() )->is_active( 'publicize' ) ) {
+			// The custom priority for this action ensures that any existing code that
+			// removes post-thumbnails support during 'init' continues to work.
+			add_action( 'init', __NAMESPACE__ . '\add_theme_post_thumbnails_support', 8 );
+		}
 	}
 
 	/**

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -219,8 +219,12 @@ abstract class Publicize_Base {
 		// Connection test callback.
 		add_action( 'wp_ajax_test_publicize_conns', array( $this, 'test_publicize_conns' ) );
 
-		add_action( 'init', array( $this, 'add_post_type_support' ) );
+		add_action( 'init', array( $this, 'add_post_type_support' ), 8 );
 		add_action( 'init', array( $this, 'register_post_meta' ), 20 );
+
+		// The custom priority for this action ensures that any existing code that
+		// removes post-thumbnails support during 'init' continues to work.
+		add_action( 'init', __NAMESPACE__ . '\add_theme_post_thumbnails_support', 8 );
 	}
 
 	/**
@@ -1449,4 +1453,14 @@ abstract class Publicize_Base {
 function publicize_calypso_url() {
 	_deprecated_function( __METHOD__, '0.2.0', 'Publicize::publicize_connections_url' );
 	return Redirect::get_url( 'calypso-marketing-connections', array( 'site' => ( new Status() )->get_site_suffix() ) );
+}
+
+/**
+ * Adds support for the post-thumbnails feature, regardless of underlying theme support.
+ *
+ * This ensures the featured image UI appears in the editor, allowing the user to
+ * explicitly set an image for their social media post.
+ */
+function add_theme_post_thumbnails_support() {
+	add_theme_support( 'post-thumbnails', get_post_types_by_support( 'publicize' ) );
 }

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -9,7 +9,6 @@
 
 namespace Automattic\Jetpack\Publicize;
 
-use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
 
@@ -224,11 +223,9 @@ abstract class Publicize_Base {
 		add_action( 'init', array( $this, 'add_post_type_support' ), 8 );
 		add_action( 'init', array( $this, 'register_post_meta' ), 20 );
 
-		if ( ( new Modules() )->is_active( 'publicize' ) ) {
-			// The custom priority for this action ensures that any existing code that
-			// removes post-thumbnails support during 'init' continues to work.
-			add_action( 'init', __NAMESPACE__ . '\add_theme_post_thumbnails_support', 8 );
-		}
+		// The custom priority for this action ensures that any existing code that
+		// removes post-thumbnails support during 'init' continues to work.
+		add_action( 'init', __NAMESPACE__ . '\add_theme_post_thumbnails_support', 8 );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-publicize-post-thumbnails-support
+++ b/projects/plugins/jetpack/changelog/update-publicize-post-thumbnails-support
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/update-publicize-post-thumbnails-support
+++ b/projects/plugins/jetpack/changelog/update-publicize-post-thumbnails-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Publicize: Allow users to set the image for their social post even when themes don't support featured images.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -34,7 +34,7 @@
 		"automattic/jetpack-my-jetpack": "1.6.x-dev",
 		"automattic/jetpack-partner": "1.7.x-dev",
 		"automattic/jetpack-plugins-installer": "0.1.x-dev",
-		"automattic/jetpack-publicize": "0.5.x-dev",
+		"automattic/jetpack-publicize": "0.6.x-dev",
 		"automattic/jetpack-redirect": "1.7.x-dev",
 		"automattic/jetpack-roles": "1.4.x-dev",
 		"automattic/jetpack-search": "0.15.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f34cd78e795a226eaab1ad83463a974d",
+    "content-hash": "d312fb72f1623206c6fd896bbb00e09c",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1415,7 +1415,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/publicize",
-                "reference": "9d844142d2ef396763c668bf8fca1a1b457afe28"
+                "reference": "ccb2624d3c2367c4a34e2e64036b7fb0a429a9eb"
             },
             "require": {
                 "automattic/jetpack-autoloader": "^2.11",
@@ -1436,7 +1436,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "0.5.x-dev"
+                    "dev-master": "0.6.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/modules/publicize/publicize.php
+++ b/projects/plugins/jetpack/modules/publicize/publicize.php
@@ -220,10 +220,6 @@ abstract class Publicize_Base {
 		add_action( 'init', array( $this, 'add_post_type_support' ) );
 		add_action( 'init', array( $this, 'register_post_meta' ), 20 );
 		add_action( 'jetpack_register_gutenberg_extensions', array( $this, 'register_gutenberg_extension' ) );
-
-		// The custom priority for this action ensures that any existing code that
-		// removes post-thumbnails support during 'init' continues to work.
-		add_action( 'init', 'add_theme_post_thumbnails_support', 8 );
 	}
 
 	/**
@@ -1466,14 +1462,4 @@ abstract class Publicize_Base {
 function publicize_calypso_url() {
 	_deprecated_function( __METHOD__, '11.0', 'Publicize::publicize_connections_url' );
 	return Redirect::get_url( 'calypso-marketing-connections', array( 'site' => ( new Status() )->get_site_suffix() ) );
-}
-
-/**
- * Adds support for the post-thumbnails feature, regardless of underlying theme support.
- *
- * This ensures the featured image UI appears in the editor, allowing the user to
- * explicitly set an image for their social media post.
- */
-function add_theme_post_thumbnails_support() {
-	add_theme_support( 'post-thumbnails', array( 'post' ) );
 }

--- a/projects/plugins/jetpack/modules/publicize/publicize.php
+++ b/projects/plugins/jetpack/modules/publicize/publicize.php
@@ -220,6 +220,10 @@ abstract class Publicize_Base {
 		add_action( 'init', array( $this, 'add_post_type_support' ) );
 		add_action( 'init', array( $this, 'register_post_meta' ), 20 );
 		add_action( 'jetpack_register_gutenberg_extensions', array( $this, 'register_gutenberg_extension' ) );
+
+		// The custom priority for this action ensures that any existing code that
+		// removes post-thumbnails support during 'init' continues to work.
+		add_action( 'init', 'add_theme_post_thumbnails_support', 8 );
 	}
 
 	/**
@@ -1462,4 +1466,14 @@ abstract class Publicize_Base {
 function publicize_calypso_url() {
 	_deprecated_function( __METHOD__, '11.0', 'Publicize::publicize_connections_url' );
 	return Redirect::get_url( 'calypso-marketing-connections', array( 'site' => ( new Status() )->get_site_suffix() ) );
+}
+
+/**
+ * Adds support for the post-thumbnails feature, regardless of underlying theme support.
+ *
+ * This ensures the featured image UI appears in the editor, allowing the user to
+ * explicitly set an image for their social media post.
+ */
+function add_theme_post_thumbnails_support() {
+	add_theme_support( 'post-thumbnails', array( 'post' ) );
 }

--- a/projects/plugins/social/changelog/update-publicize-post-thumbnails-support
+++ b/projects/plugins/social/changelog/update-publicize-post-thumbnails-support
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -10,7 +10,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.9.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-publicize": "0.5.x-dev",
+		"automattic/jetpack-publicize": "0.6.x-dev",
 		"automattic/jetpack-options": "1.16.x-dev",
 		"automattic/jetpack-connection": "1.40.x-dev",
 		"automattic/jetpack-my-jetpack": "1.6.x-dev",

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6283d7f0d8241a60c21895684f8ded03",
+    "content-hash": "edb548d16efd2ecc6fb34c8e42be89b4",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -844,7 +844,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/publicize",
-                "reference": "9d844142d2ef396763c668bf8fca1a1b457afe28"
+                "reference": "ccb2624d3c2367c4a34e2e64036b7fb0a429a9eb"
             },
             "require": {
                 "automattic/jetpack-autoloader": "^2.11",
@@ -865,7 +865,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "0.5.x-dev"
+                    "dev-master": "0.6.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
Forces the "Featured image" UI to appear in the block editor when the publicize module is enabled, even if the theme doesn't support the "post-thumbnails" feature.

Posts to Twitter and Facebook use the featured image if it's available, so even if a theme doesn't support it there's still value in allowing users to set it.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

_Before_
<img width="1598" alt="Screenshot 2022-04-08 at 3 28 44 PM" src="https://user-images.githubusercontent.com/1500769/162358852-5837e0bb-01c9-4cb0-86e7-66ef0e7d7261.png">

_After_
<img width="1598" alt="Screenshot 2022-04-08 at 3 24 17 PM" src="https://user-images.githubusercontent.com/1500769/162358828-9d08ed8b-25cf-40fd-92aa-6087e9858cc0.png">

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add `'post-thumbnails'` support to the current theme, which causes the featured image UI to appear in the block editor sidebar.
* Add new `'jetpack_publicize_force_featured_image_panel'` filter which can be used to disable this behaviour.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Fixes Automattic/wp-calypso#55081 on WordPress.com, but this should really be a fix for all Publicize users p1HpG7-frH-p2


#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install a theme that doesn't support the `post-thumbnails` feature ([you can download Plane from WordPress.com](https://public-api.wordpress.com/rest/v1/themes/download/plane.zip))
* Ensure Publicize module is enabled
* Open post editor
   * The "Featured image" UI should be available in the sidebar
   * Confirm the network tools confirm the `/wp/v2/themes` API response includes `post-thumbnails=true`
* Disable the Publicize module
* Reopen post editor
   * The "Featured image" UI shouldn't be in the sidebar
   * Confirm the network tools confirm the `/wp/v2/themes` API response includes `post-thumbnails=false`

When I connected to Twitter and tested publicize I didn't see the featured image actually show up in the tweet. I put this down to a limitation in `jurassic.tunnel` maybe? When I do the same on WordPress.com the image appears in the tweet.