### PR TITLE
RNA: fix ProductOffer button loading state issue

### DIFF
--- a/projects/js-packages/components/changelog/update-js-components-fix-offer-issues
+++ b/projects/js-packages/components/changelog/update-js-components-fix-offer-issues
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+RNA: fix ProductOffer button loading state issue

--- a/projects/js-packages/components/components/product-offer/index.jsx
+++ b/projects/js-packages/components/components/product-offer/index.jsx
@@ -174,7 +174,6 @@ ProductOffer.propTypes = {
 	supportedProducts: PropTypes.arrayOf( PropTypes.string ),
 	className: PropTypes.string,
 	hasRequiredPlan: PropTypes.bool,
-	isFree: PropTypes.bool,
 	isLoading: PropTypes.bool,
 	onAdd: PropTypes.func,
 	addProductUrl: PropTypes.string,

--- a/projects/js-packages/components/components/product-offer/style.module.scss
+++ b/projects/js-packages/components/components/product-offer/style.module.scss
@@ -85,8 +85,7 @@
 
 .add-button {
 	width: 100%;
-	display: block;
-	text-align: center;
+	justify-content: center;
 	
 	&:global(.is-primary):disabled {
 		opacity: 1;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

It fixes a visual issue reported by @keoshi [here](https://github.com/Automattic/jetpack/pull/23842#issuecomment-1092604456)

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* RNA: fix ProductOffer button loading state issue

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use Storybook
* Go to `Packages/Componens/ProductOffer` story
* Confirm the Add button doesn't change when switching to `isLoading` state

https://user-images.githubusercontent.com/77539/162460837-cf40d946-2276-4cea-b488-a0022897a145.mov


