### PR TITLE
Payment Blocks: Fix add new product not working on child blocks

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-product-manager-child-blocks-add-new
+++ b/projects/plugins/jetpack/changelog/fix-product-manager-child-blocks-add-new
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Select the correct payment block before opening its sidebar when adding a new product.

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/edit.js
@@ -120,6 +120,7 @@ function Edit( props ) {
 					) }
 					<ProductManagementControls
 						blockName="premium-content"
+						clientId={ clientId }
 						productType={ PRODUCT_TYPE_SUBSCRIPTION }
 						selectedProductId={ selectedPlanId }
 						setSelectedProductId={ setSelectedProductId }

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/edit.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/edit.jsx
@@ -64,8 +64,8 @@ export default function Edit( { attributes, clientId, context, setAttributes } )
 		<div className="wp-block-jetpack-recurring-payments">
 			{ showControls && (
 				<ProductManagementControls
-					allowCreateOneTimeInterval={ true }
 					blockName="recurring-payments"
+					clientId={ clientId }
 					selectedProductId={ planId }
 					setSelectedProductId={ updateSubscriptionPlan }
 				/>

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/context.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/context.js
@@ -10,6 +10,7 @@ import { PRODUCT_TYPE_PAYMENT_PLAN } from './constants';
 
 export const ProductManagementContext = createContext( {
 	blockName: undefined,
+	clientId: undefined,
 	products: [],
 	productType: PRODUCT_TYPE_PAYMENT_PLAN,
 	selectedProductId: 0,

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/context.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/context.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { createContext, useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { PRODUCT_TYPE_PAYMENT_PLAN } from './constants';
+
+export const ProductManagementContext = createContext( {
+	blockName: undefined,
+	products: [],
+	productType: PRODUCT_TYPE_PAYMENT_PLAN,
+	selectedProductId: 0,
+	setSelectedProductId: () => {},
+} );
+
+export const useProductManagementContext = () => useContext( ProductManagementContext );

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/index.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/index.js
@@ -8,6 +8,7 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { PRODUCT_TYPE_PAYMENT_PLAN } from './constants';
+import { ProductManagementContext } from './context';
 import ProductManagementInspectorControl from './inspector-control';
 import ProductManagementToolbarControl from './toolbar-control';
 import InvalidProductWarning from './invalid-product-warning';
@@ -49,8 +50,16 @@ export default function ProductManagementControls( {
 		return null;
 	}
 
+	const context = {
+		blockName,
+		products,
+		productType,
+		selectedProductId,
+		setSelectedProductId,
+	};
+
 	return (
-		<>
+		<ProductManagementContext.Provider value={ context }>
 			{ ! isApiConnected && !! connectUrl && (
 				<BlockControls __experimentalShareWithChildBlocks group="block">
 					<StripeConnectToolbarButton blockName={ blockName } connectUrl={ connectUrl } />
@@ -58,21 +67,11 @@ export default function ProductManagementControls( {
 			) }
 			{ isApiConnected && (
 				<>
-					<ProductManagementInspectorControl
-						productType={ productType }
-						setSelectedProductId={ setSelectedProductId }
-					/>
-					<ProductManagementToolbarControl
-						products={ products }
-						productType={ productType }
-						selectedProductId={ selectedProductId }
-						setSelectedProductId={ setSelectedProductId }
-					/>
+					<ProductManagementInspectorControl />
+					<ProductManagementToolbarControl />
 				</>
 			) }
-			{ isApiConnected && isSelectedProductInvalid && (
-				<InvalidProductWarning productType={ productType } />
-			) }
-		</>
+			{ isApiConnected && isSelectedProductInvalid && <InvalidProductWarning /> }
+		</ProductManagementContext.Provider>
 	);
 }

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/index.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/index.js
@@ -19,6 +19,7 @@ import './style.scss';
 
 export default function ProductManagementControls( {
 	blockName,
+	clientId,
 	productType = PRODUCT_TYPE_PAYMENT_PLAN,
 	selectedProductId = 0,
 	setSelectedProductId = () => {},
@@ -52,6 +53,7 @@ export default function ProductManagementControls( {
 
 	const context = {
 		blockName,
+		clientId,
 		products,
 		productType,
 		selectedProductId,

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/inspector-control.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/inspector-control.js
@@ -21,11 +21,13 @@ import { lock } from '@wordpress/icons';
  * Internal dependencies
  */
 import { API_STATE_NOT_REQUESTING, API_STATE_REQUESTING } from './constants';
+import { useProductManagementContext } from './context';
 import { getMessageByProductType } from './utils';
 import { CURRENCY_OPTIONS } from '../../currencies';
 import { store as membershipProductsStore } from '../../../store/membership-products';
 
-export default function ProductManagementInspectorControl( { productType, setSelectedProductId } ) {
+export default function ProductManagementInspectorControl() {
+	const { productType, setSelectedProductId } = useProductManagementContext();
 	const siteSlug = useSelect( select => select( membershipProductsStore ).getSiteSlug() );
 	const { saveProduct } = useDispatch( membershipProductsStore );
 

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/invalid-product-warning.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/invalid-product-warning.js
@@ -7,9 +7,11 @@ import { Icon, warning } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import { useProductManagementContext } from './context';
 import { getMessageByProductType } from './utils';
 
-export default function InvalidProductWarning( { productType } ) {
+export default function InvalidProductWarning() {
+	const { productType } = useProductManagementContext();
 	return (
 		<Warning className="product-management-control-nudge">
 			<span className="product-management-control-nudge__info">

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/toolbar-control.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/toolbar-control.js
@@ -6,9 +6,9 @@ import formatCurrency from '@automattic/format-currency';
 /**
  * WordPress dependencies
  */
-import { BlockControls, store as blockEditorStore } from '@wordpress/block-editor';
+import { BlockControls } from '@wordpress/block-editor';
 import { MenuGroup, MenuItem, ToolbarDropdownMenu } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { check, update, warning } from '@wordpress/icons';
 
@@ -70,14 +70,10 @@ function Product( { onClose, product } ) {
 
 function NewProduct( { onClose } ) {
 	const { clientId, productType } = useProductManagementContext();
-	const openBlockSidebar = useOpenBlockSidebar();
-	const { selectBlock } = useDispatch( blockEditorStore );
+	const openBlockSidebar = useOpenBlockSidebar( clientId );
 
 	const handleClick = event => {
 		event.preventDefault();
-		if ( clientId ) {
-			selectBlock( clientId );
-		}
 		openBlockSidebar();
 		setTimeout( () => {
 			const input = document.getElementById( 'new-product-title' );

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/toolbar-control.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/toolbar-control.js
@@ -15,6 +15,7 @@ import { check, update, warning } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import { useProductManagementContext } from './context';
 import useOpenBlockSidebar from './use-open-block-sidebar';
 import { getMessageByProductType } from './utils';
 import { store as membershipProductsStore } from '../../../store/membership-products';
@@ -46,7 +47,9 @@ function getProductDescription( product ) {
 	);
 }
 
-function Product( { onClose, product, selectedProductId, setSelectedProductId } ) {
+function Product( { onClose, product } ) {
+	const { selectedProductId, setSelectedProductId } = useProductManagementContext();
+
 	const { id, title } = product;
 	const isSelected = selectedProductId && selectedProductId === id;
 	const icon = isSelected ? check : undefined;
@@ -65,7 +68,8 @@ function Product( { onClose, product, selectedProductId, setSelectedProductId } 
 	);
 }
 
-function NewProduct( { onClose, productType } ) {
+function NewProduct( { onClose } ) {
+	const { productType } = useProductManagementContext();
 	const openBlockSidebar = useOpenBlockSidebar();
 
 	const handleClick = event => {
@@ -88,12 +92,9 @@ function NewProduct( { onClose, productType } ) {
 	);
 }
 
-export default function ProductManagementToolbarControl( {
-	products,
-	productType,
-	selectedProductId,
-	setSelectedProductId,
-} ) {
+export default function ProductManagementToolbarControl() {
+	const { products, productType, selectedProductId } = useProductManagementContext();
+
 	const selectedProduct = useSelect( select =>
 		select( membershipProductsStore ).getProduct( selectedProductId )
 	);
@@ -121,17 +122,11 @@ export default function ProductManagementToolbarControl( {
 					<>
 						<MenuGroup>
 							{ products.map( product => (
-								<Product
-									key={ product.id }
-									onClose={ onClose }
-									product={ product }
-									selectedProductId={ selectedProductId }
-									setSelectedProductId={ setSelectedProductId }
-								/>
+								<Product key={ product.id } onClose={ onClose } product={ product } />
 							) ) }
 						</MenuGroup>
 						<MenuGroup>
-							<NewProduct onClose={ onClose } productType={ productType } />
+							<NewProduct onClose={ onClose } />
 						</MenuGroup>
 					</>
 				) }

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/toolbar-control.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/toolbar-control.js
@@ -6,9 +6,9 @@ import formatCurrency from '@automattic/format-currency';
 /**
  * WordPress dependencies
  */
-import { BlockControls } from '@wordpress/block-editor';
+import { BlockControls, store as blockEditorStore } from '@wordpress/block-editor';
 import { MenuGroup, MenuItem, ToolbarDropdownMenu } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { check, update, warning } from '@wordpress/icons';
 
@@ -69,11 +69,15 @@ function Product( { onClose, product } ) {
 }
 
 function NewProduct( { onClose } ) {
-	const { productType } = useProductManagementContext();
+	const { clientId, productType } = useProductManagementContext();
 	const openBlockSidebar = useOpenBlockSidebar();
+	const { selectBlock } = useDispatch( blockEditorStore );
 
 	const handleClick = event => {
 		event.preventDefault();
+		if ( clientId ) {
+			selectBlock( clientId );
+		}
 		openBlockSidebar();
 		setTimeout( () => {
 			const input = document.getElementById( 'new-product-title' );

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/use-open-block-sidebar.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/use-open-block-sidebar.js
@@ -1,19 +1,27 @@
 /**
  * WordPress dependencies
  */
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useDispatch } from '@wordpress/data';
 import { getEditorType, SITE_EDITOR, WIDGET_EDITOR } from '../../get-editor-type';
 
-export default function useOpenBlockSidebar() {
+export default function useOpenBlockSidebar( clientId ) {
 	const editorType = getEditorType();
+	const { selectBlock } = useDispatch( blockEditorStore );
 	const { enableComplementaryArea } = useDispatch( 'core/interface' );
 
-	switch ( editorType ) {
-		case SITE_EDITOR:
-			return () => enableComplementaryArea( 'core/edit-site', 'edit-site/block-inspector' );
-		case WIDGET_EDITOR:
-			return () => enableComplementaryArea( 'core/edit-widgets', 'edit-widgets/block-inspector' );
-		default:
-			return () => enableComplementaryArea( 'core/edit-post', 'edit-post/block' );
-	}
+	return () => {
+		if ( clientId ) {
+			selectBlock( clientId );
+		}
+
+		switch ( editorType ) {
+			case SITE_EDITOR:
+				return enableComplementaryArea( 'core/edit-site', 'edit-site/block-inspector' );
+			case WIDGET_EDITOR:
+				return enableComplementaryArea( 'core/edit-widgets', 'edit-widgets/block-inspector' );
+			default:
+				enableComplementaryArea( 'core/edit-post', 'edit-post/block' );
+		}
+	};
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to #23633

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Select the parent payment block before opening its sidebar when creating a new product.
* Also refactor the `ProductManagementControls` component to use context instead of unnecessarily passing props around.

This change fixes a minor issue introduced by https://github.com/Automattic/jetpack/pull/23567 which exposes the parent payment button controls to children blocks.
The controls' "add new" toolbar item opens the sidebar, where the form is displayed.
Though, doing so from a child block would open the child's sidebar instead of the parent's.

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a site with a paid plan and an active Stripe connection, add the Payment Button block.
* Click on the button: it should select the child Jetpack Button block (double-check in the List View if you need confirmation).
* Click on the product management toolbar control.
* Click on the "Add new" button in the popover.
* Make sure the sidebar will switch form Jetpack Button to Payment Button, focusing on the new product form.