### PR TITLE
jetpack: Rework popover dismissal to remove obsolete indirect dep

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1064,7 +1064,6 @@ importers:
       chai: 4.3.4
       chalk: 4.1.2
       classnames: 2.3.1
-      click-outside: 2.0.2
       clipboard: 2.0.6
       commander: 7.2.0
       component-uid: 0.0.2
@@ -1176,7 +1175,6 @@ importers:
       '@wordpress/widgets': 2.3.0_978f344c876a57c1143ffe356b90df31
       bounding-client-rect: 1.0.5
       classnames: 2.3.1
-      click-outside: 2.0.2
       clipboard: 2.0.6
       component-uid: 0.0.2
       cookie: 0.4.1
@@ -10033,13 +10031,6 @@ packages:
       babel-plugin-jest-hoist: 27.5.1
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.17.8
 
-  /babel-runtime/6.26.0:
-    resolution: {integrity: sha1-llxwWGaOgrVde/4E/yM3vItWR/4=}
-    dependencies:
-      core-js: 2.6.12
-      regenerator-runtime: 0.11.1
-    dev: false
-
   /bail/1.0.5:
     resolution: {integrity: sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==}
     dev: true
@@ -10743,14 +10734,6 @@ packages:
     resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
     engines: {node: '>= 10'}
 
-  /click-outside/2.0.2:
-    resolution: {integrity: sha1-tT9zWwanxdo0Wr8X1BmAlHaXk6Y=}
-    dependencies:
-      babel-runtime: 6.26.0
-      component-event: 0.1.4
-      node-contains: 1.0.0
-    dev: false
-
   /clipboard/2.0.10:
     resolution: {integrity: sha512-cz3m2YVwFz95qSEbCDi2fzLN/epEN9zXBvfgAoGkvGOJZATMl9gtTDVOtBYkx2ODUJl2kvmud7n32sV2BpYR4g==}
     dependencies:
@@ -10950,10 +10933,6 @@ packages:
     resolution: {integrity: sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==}
     dev: true
 
-  /component-event/0.1.4:
-    resolution: {integrity: sha1-PeePwoeCOBeH4kvyp8U2vwFCybQ=}
-    dev: false
-
   /component-uid/0.0.2:
     resolution: {integrity: sha1-ydeJPUsEmtMMa4qkwB1tGv1WlZY=}
     dev: false
@@ -11144,12 +11123,6 @@ packages:
   /core-js-pure/3.21.1:
     resolution: {integrity: sha512-12VZfFIu+wyVbBebyHmRTuEE/tZrB4tJToWcwAMcsp3h4+sHR+fMJWbKpYiCRWlhFBq+KNyO8rIV9rTkeVmznQ==}
     requiresBuild: true
-
-  /core-js/2.6.12:
-    resolution: {integrity: sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==}
-    deprecated: core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.
-    requiresBuild: true
-    dev: false
 
   /core-js/3.11.1:
     resolution: {integrity: sha512-k93Isqg7e4txZWMGNYwevZL9MiogLk8pd1PtwrmFmi8IBq4GXqUaVW/a33Llt6amSI36uSjd0GWwc9pTT9ALlQ==}
@@ -17207,10 +17180,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /node-contains/1.0.0:
-    resolution: {integrity: sha1-0sJzUkU22jtWGvBTnjM0T3yQLLg=}
-    dev: false
-
   /node-dir/0.1.17:
     resolution: {integrity: sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=}
     engines: {node: '>= 0.10.5'}
@@ -20178,10 +20147,6 @@ packages:
 
   /regenerate/1.4.2:
     resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==}
-
-  /regenerator-runtime/0.11.1:
-    resolution: {integrity: sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==}
-    dev: false
 
   /regenerator-runtime/0.13.9:
     resolution: {integrity: sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==}

--- a/projects/plugins/jetpack/_inc/client/components/popover/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/popover/index.jsx
@@ -6,7 +6,6 @@ import React, { Component } from 'react';
 import ReactDom from 'react-dom';
 import debugFactory from 'debug';
 import classNames from 'classnames';
-import clickOutside from 'click-outside';
 import uid from 'component-uid';
 import { assign } from 'lodash';
 
@@ -170,7 +169,7 @@ class Popover extends Component {
 		this.close( true );
 	}
 
-	// --- cliclout side ---
+	// --- click outside ---
 	bindClickoutHandler( el = this.domContainer ) {
 		if ( ! el ) {
 			this.debug( 'no element to bind clickout side ' );
@@ -183,13 +182,18 @@ class Popover extends Component {
 		}
 
 		this.debug( 'binding `clickout` event' );
-		this._clickoutHandlerReference = clickOutside( el, this.onClickout );
+		this._clickoutHandlerReference = e => {
+			if ( ! el.contains( e.target ) ) {
+				this.onClickout( e );
+			}
+		};
+		document.addEventListener( 'click', this._clickoutHandlerReference, true );
 	}
 
 	unbindClickoutHandler() {
 		if ( this._clickoutHandlerReference ) {
 			this.debug( 'unbinding `clickout` listener ...' );
-			this._clickoutHandlerReference();
+			document.removeEventListener( 'click', this._clickoutHandlerReference, true );
 			this._clickoutHandlerReference = null;
 		}
 	}
@@ -342,7 +346,7 @@ class Popover extends Component {
 	}
 
 	hide() {
-		// unbind clickout-side event every time the component is hidden.
+		// unbind click-outside event every time the component is hidden.
 		this.unbindClickoutHandler();
 		this.setState( { show: false } );
 		this.clearShowTimer();

--- a/projects/plugins/jetpack/changelog/remove-old-core-js-dep
+++ b/projects/plugins/jetpack/changelog/remove-old-core-js-dep
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Remove indirect dependency on an obselete version of the `core-js` package.

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -77,7 +77,6 @@
 		"@wordpress/widgets": "2.3.0",
 		"bounding-client-rect": "1.0.5",
 		"classnames": "2.3.1",
-		"click-outside": "2.0.2",
 		"clipboard": "2.0.6",
 		"component-uid": "0.0.2",
 		"cookie": "0.4.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
core-js v2.6.12 has a deprecation notice:

> core-js@<3.4 is no longer maintained and not recommended for usage due
> to the number of issues. Because of the V8 engine whims, feature
> detection in old core-js versions could cause a slowdown up to 100x
> even if nothing is polyfilled. Please, upgrade your dependencies to
> the actual version of core-js.

That's being pulled in as an indirect dependency of a package
`click-outside`, last updated 6 years ago and easily replaceable with a
tiny bit of inline code now that we've dropped support for IE9.

Removing that package drops 4 other indirect deps on old packages.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack's Settings page. Click the ⓘ icon next to one of the settings that has it, and make sure the popover doesn't go away if you click inside but does if you click elsewhere on the page.