### PR TITLE
[WordAds]: Replace "Jetpack Ads" with WordAds

### DIFF
--- a/projects/plugins/jetpack/_inc/client/traffic/ads.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/ads.jsx
@@ -90,7 +90,7 @@ export const Ads = withModuleSettingsFormHelpers(
 								{ isAdsActive &&
 									createInterpolateElement(
 										__(
-											'Jetpack Ads automatically generates a custom <link1>ads.txt</link1> tailored for your site. If you need to add additional entries for other networks please add them in the space below, one per line. <link2>Check here for more details</link2>.',
+											'WordAds automatically generates a custom <link1>ads.txt</link1> tailored for your site. If you need to add additional entries for other networks please add them in the space below, one per line. <link2>Check here for more details</link2>.',
 											'jetpack'
 										),
 										{

--- a/projects/plugins/jetpack/changelog/fix-change-jetpack-ads-to-wordads
+++ b/projects/plugins/jetpack/changelog/fix-change-jetpack-ads-to-wordads
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Replace "Jetpack Ads" language with WordAds.

--- a/projects/plugins/jetpack/modules/widgets/eu-cookie-law/form.php
+++ b/projects/plugins/jetpack/modules/widgets/eu-cookie-law/form.php
@@ -94,7 +94,7 @@ use Automattic\Jetpack\Redirect;
 						echo sprintf(
 							wp_kses(
 								/* Translators: %s is the URL to a Jetpack support article. */
-								__( 'For GDPR compliance, please make sure your policy contains <a href="%s" target="_blank">privacy information relating to Jetpack Ads</a>.', 'jetpack' ),
+								__( 'For GDPR compliance, please make sure your policy contains <a href="%s" target="_blank">privacy information relating to WordAds</a>.', 'jetpack' ),
 								array(
 									'a' => array(
 										'href'   => array(),
@@ -198,7 +198,7 @@ use Automattic\Jetpack\Redirect;
 	<?php if ( Jetpack::is_module_active( 'wordads' ) ) : ?>
 		<span class="notice notice-warning" style="display: block;">
 			<span style="display: block; margin: .5em 0;">
-				<?php esc_html_e( 'Visitors must provide consent by clicking the dismiss button when Jetpack Ads is turned on.', 'jetpack' ); ?>
+				<?php esc_html_e( 'Visitors must provide consent by clicking the dismiss button when WordAds is turned on.', 'jetpack' ); ?>
 			</span>
 		</span>
 	<?php endif; ?>

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -209,11 +209,11 @@ class WordAds {
 
 		if ( '/ads.txt' === $_SERVER['REQUEST_URI'] ) {
 
-			$ads_txt_transient = get_transient( 'jetpack_ads_txt' );
+			$ads_txt_transient = get_transient( 'wordads_ads_txt' );
 
 			if ( false === ( $ads_txt_transient ) ) {
 				$ads_txt_transient = ! is_wp_error( WordAds_API::get_wordads_ads_txt() ) ? WordAds_API::get_wordads_ads_txt() : '';
-				set_transient( 'jetpack_ads_txt', $ads_txt_transient, DAY_IN_SECONDS );
+				set_transient( 'wordads_ads_txt', $ads_txt_transient, DAY_IN_SECONDS );
 			}
 
 			/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR replaces the words "Jetpack Ads" with WordAds.

#### Jetpack product discussion
82-gh-Automattic/wordads-issues
p1647977972298469-slack-C02S30USNRM

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Before testing, if you already have the Jetpack project, remember to update the dependencies to see the changes:
```
jetpack build
? What type of project are you working on today? plugins
? Please choose which project jetpack
? Build dependencies of plugins/jetpack too? Yes
```

Test instructions for changes on `projects/plugins/jetpack/_inc/client/traffic/ads.jsx`:
* Go to Jetpack > Settings > Traffic tab.
* Enable option "Customize your ads.txt" file.
* Check if the word WordAds is shown instead of "Jetpack Ads".

![image](https://user-images.githubusercontent.com/692065/162829036-29344e07-af0b-4620-881e-c1998099c272.png)

Test instructions for changes on `projects/plugins/jetpack/modules/widgets/eu-cookie-law/form.php`:

![image](https://user-images.githubusercontent.com/692065/162968653-42c170df-6d9d-4fc7-85e5-477f8197e7fc.png)

* Go to Jetpack > Settings > Writing tab.
* Enable option "Make extra widgets available for use on your site including subscription forms and Twitter streams" on the Widgets card section.
* Configure a theme that is possible to use widgets, for example, the "Twenty Twenty" theme.
* Go  to Appearance > Widgets > Click on the `+` button and add the widget "Cookies  & Consents Banner (Jetpack)".
* On Developer Console run the code `document.querySelector('div.wp-block-legacy-widget__edit-form > div > div > form > div > span').style.setProperty('display', 'block', 'important')` to see the changes, the text is currently hidden by default.
