### PR TITLE
Custom CSS: Improved saving

### DIFF
--- a/projects/plugins/jetpack/changelog/update-custom-css
+++ b/projects/plugins/jetpack/changelog/update-custom-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Custom CSS: Improve saving for legacy Custom CSS.


### PR DESCRIPTION
Backports p3btAN-1IZ-p2 / r243392-wpcom from WP.com 

#### Changes proposed in this Pull Request:
* This code doesn't run in Jetpack, but still lives here. While we should remove it outright, backporting this until we work on that.

#### Jetpack product discussion
See above.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* n/a doesn't run in Jetpack already running on WP.com.