### PR TITLE
My Jetpack: Better error handling

### DIFF
--- a/projects/packages/my-jetpack/_inc/state/resolvers.js
+++ b/projects/packages/my-jetpack/_inc/state/resolvers.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -51,7 +52,15 @@ const myJetpackResolvers = {
 			dispatch.setPurchasesIsFetching( false );
 		} catch ( error ) {
 			dispatch.setPurchasesIsFetching( false );
-			throw error;
+			dispatch.setGlobalNotice(
+				__(
+					'There was an error fetching your purchases information. Check your site connectivity and try again.',
+					'jetpack-my-jetpack'
+				),
+				{
+					status: 'error',
+				}
+			);
 		}
 	},
 };

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-error-handling
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-error-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Better error handling for when the WPCOM server is unreachable

--- a/projects/packages/my-jetpack/src/class-rest-purchases.php
+++ b/projects/packages/my-jetpack/src/class-rest-purchases.php
@@ -68,7 +68,7 @@ class REST_Purchases {
 		$body              = json_decode( wp_remote_retrieve_body( $response ) );
 
 		if ( is_wp_error( $response ) || empty( $response['body'] ) ) {
-			return new \WP_Error( 'site_data_fetch_failed', 'Site data fetch failed', array( 'status' => $response_code ) );
+			return new \WP_Error( 'site_data_fetch_failed', 'Site data fetch failed', array( 'status' => $response_code ? $response_code : 400 ) );
 		}
 
 		return rest_ensure_response( $body, 200 );

--- a/projects/packages/my-jetpack/src/products/class-backup.php
+++ b/projects/packages/my-jetpack/src/products/class-backup.php
@@ -134,7 +134,7 @@ class Backup extends Hybrid_Product {
 
 		$site_id = Jetpack_Options::get_option( 'id' );
 
-		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d/rewind', $site_id ) . '?force=wpcom', '2', array(), null, 'wpcom' );
+		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d/rewind', $site_id ) . '?force=wpcom', '2', array( 'timeout' => 2 ), null, 'wpcom' );
 
 		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			return new WP_Error( 'rewind_state_fetch_failed' );

--- a/projects/packages/my-jetpack/src/products/class-scan.php
+++ b/projects/packages/my-jetpack/src/products/class-scan.php
@@ -122,7 +122,7 @@ class Scan extends Module_Product {
 
 		$site_id = Jetpack_Options::get_option( 'id' );
 
-		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d/scan', $site_id ) . '?force=wpcom', '2', array(), null, 'wpcom' );
+		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d/scan', $site_id ) . '?force=wpcom', '2', array( 'timeout' => 2 ), null, 'wpcom' );
 
 		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			return new WP_Error( 'scan_state_fetch_failed' );

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -125,7 +125,7 @@ class Search extends Module_Product {
 		$response = Client::wpcom_json_api_request_as_blog(
 			'/sites/' . $blog_id . '/jetpack-search/plan',
 			'2',
-			array(),
+			array( 'timeout' => 2 ),
 			null,
 			'wpcom'
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR makes 2 changes to better handle errors in My Jetpack. Mostly errors related to the site being unable to reach WPCOM.

First, we reduce the timeout of the requests we make to check for each product statuses. Since we can make many requests, each requests hangs for a while and the server may run out of time. Reducing the timeout of each individual requests helps avoid it from happening.

Also, if WPCOM was unreachable, the whole UI would crash because the `PlansSection` component would fail to render the purchases data. This PR avoids the error and adds a error message to the global notices in the page

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: Better error handling when the server is unreachable

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Easiest way to emulate the problem is to sandbox your site and make sure the sandbox is offline
* Visit My Jetpack
* Make sure the page loads
* Make sure there's an error in the global notices section
* Is copy ok? typos?
