### PR TITLE
renovate: Fix errors post-upgrade scripts

### DIFF
--- a/.github/files/renovate-post-upgrade-run.sh
+++ b/.github/files/renovate-post-upgrade-run.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 
+# The docker container logs annoying errors if /var/log/php/xdebug_remote.log isn't writable.
+if [[ ! -e /tmp/dummy-log/xdebug_remote.log ]]; then
+	mkdir -p /tmp/dummy-log
+	ln -s /dev/null /tmp/dummy-log/xdebug_remote.log
+fi
+
 docker pull --quiet ghcr.io/automattic/jetpack-wordpress-dev:latest
-docker run --rm --workdir "$PWD" --user $EUID --volume /tmp/:/tmp/ ghcr.io/automattic/jetpack-wordpress-dev:latest /tmp/monorepo/.github/files/renovate-post-upgrade.sh "$@"
+docker run --rm --workdir "$PWD" --user $EUID --volume /tmp/:/tmp/ --volume /tmp/dummy-log:/var/log/php ghcr.io/automattic/jetpack-wordpress-dev:latest /tmp/monorepo/.github/files/renovate-post-upgrade.sh "$@"

--- a/.github/files/renovate-post-upgrade.sh
+++ b/.github/files/renovate-post-upgrade.sh
@@ -13,10 +13,19 @@ function die {
 	exit 1
 }
 
+# Renovate may get confused if we leave installed node_modules or the like behind.
+# So delete everything that's git-ignored on exit.
+function cleanup {
+	cd "$BASE"
+	git config --unset core.hooksPath || true
+	git clean -qfdX || true
+}
+trap "cleanup" EXIT
+
 # Renovate puts some cache dirs in different places.
 if [[ "$HOME" == "/" ]]; then
-    mkdir /var/tmp/home
-    export HOME=/var/tmp/home
+	mkdir /var/tmp/home
+	export HOME=/var/tmp/home
 fi
 pnpm config set --location=user store-dir /tmp/renovate/cache/others/pnpm
 composer config --global cache-dir /tmp/renovate/cache/others/composer


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The post-upgrade script is printing spurious Xdebug warnings due to an
unwritable log file, which may hide legitimate problems. Symlink that
log file to /dev/null to avoid that.

Renovate's pnpm lock file maintenance works by deleting the lock file
then doing a `pnpm install` to recreate it. But if pnpm finds its
metadata in `node_modules/`, it will use that instead of recreating the
lock file from scratch as renovate intends. So we need to make sure the
post-upgrade script doesn't leave a `node_modules/` behind.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
The lock file maintenance problem is mentioned in https://github.com/Automattic/jetpack/pull/23893#issuecomment-1095253142

The spurious Xdebug warning can be seen at https://github.com/Automattic/jetpack/pull/23893#issuecomment-1095548421

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

If you really want to test this:
* Fork the repo, with master set to just before #23893.
* Cherry-pick this into the fork.
* Adjust the renovate config in the fork to run in the forked repo, and avoid it breaking due to that `use-subscription` package. <details>
  <summary>Maybe like this</summary>

   ```diff
   diff --git a/.github/renovate-config.js b/.github/renovate-config.js
   --- a/.github/renovate-config.js
   +++ b/.github/renovate-config.js
   @@ -26,7 +26,8 @@ module.exports = {
    	allowScripts: true,
    	gitAuthor: 'Renovate Bot (self-hosted) <bot@renovateapp.com>',
    	platform: 'github',
   -	repositories: [ 'Automattic/jetpack' ],
   +	includeForks: true,
   +	repositories: [ 'me/jetpack' ],
    
    	// We're including configuration in this file.
    	onboarding: false,
   diff --git a/.pnpmfile.cjs b/.pnpmfile.cjs
   --- a/.pnpmfile.cjs
   +++ b/.pnpmfile.cjs
   @@ -19,6 +19,7 @@ function fixDeps( pkg ) {
    	if ( pkg.name === 'i18n-calypso' && pkg.dependencies[ 'interpolate-components' ] ) {
    		// 5.0.0 published 2020-07-01
    		pkg.dependencies[ 'interpolate-components' ] = 'npm:@automattic/interpolate-components@^1.2.0';
   +		pkg.dependencies[ 'use-subscription' ] += ' <1.6.0';
    	}
    	if ( pkg.name === '@automattic/social-previews' ) {
    		// 1.1.1 published 2021-04-08
   ```

  </details>
* Arrange for some non-lock-file-maintenance branch to be updated at the same time as the lock file maintenance (e.g. checking boxes on the dashboard issue).
* Run the renovate action in the fork.
