### PR TITLE
Starter Plugin: minor cleanup for CLI generation

### DIFF
--- a/projects/plugins/starter-plugin/changelog/update-starter-plugin-cleanup
+++ b/projects/plugins/starter-plugin/changelog/update-starter-plugin-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack CLI: correctly replace project description and release-branch-prefix.

--- a/projects/plugins/starter-plugin/composer.json
+++ b/projects/plugins/starter-plugin/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "automattic/jetpack-starter-plugin",
-	"description": "Starter Plugin",
+	"description": "plugin--description",
 	"type": "wordpress-plugin",
 	"license": "GPL-2.0-or-later",
 	"require": {

--- a/projects/plugins/starter-plugin/composer.json
+++ b/projects/plugins/starter-plugin/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "automattic/jetpack-starter-plugin",
-	"description": "Social plugin",
+	"description": "Starter Plugin",
 	"type": "wordpress-plugin",
 	"license": "GPL-2.0-or-later",
 	"require": {

--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -312,6 +312,7 @@ async function generatePluginFromStarter( projDir, answers ) {
 
 	// Replace strings.
 	await searchReplaceInFolder( projDir, 'jetpack-starter-plugin', normalizeSlug( answers.name ) );
+	await searchReplaceInFolder( projDir, 'starter-plugin', normalizeSlug( answers.name, false ) );
 	await searchReplaceInFolder(
 		projDir,
 		'starter_plugin',

--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -290,7 +290,7 @@ export async function generateProject(
  * Generates a new plugin using the Starter plugin as a template
  *
  * @param {string} projDir - The project dir path.
- * @param {object} answers - The anwers got from the CLI prompt.
+ * @param {object} answers - Answers from the CLI prompt.
  * @returns {void}
  */
 async function generatePluginFromStarter( projDir, answers ) {

--- a/tools/cli/helpers/projectNameTransformations.js
+++ b/tools/cli/helpers/projectNameTransformations.js
@@ -4,7 +4,7 @@
  * Example: project-slug into Project Slug
  *
  * @param {string} name - The project name
- * @param {boolean} jetpackPrefix - Whether to prefix the name with Jetpack
+ * @param {boolean} jetpackPrefix - Whether to prefix the name with Jetpack, default true.
  * @returns {string} The transformed string
  */
 export function transformToReadableName( name, jetpackPrefix = true ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fixes #23866

- Replace the `description` field in `composer.json` with supplied project description.
- Replace the `release-branch-prefix` in `composer.json` with supplied project name (without jetpack- prefix).

#### Jetpack product discussion

n/a

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* With changes pulled down, run `jetpack generate` using the `plugins`, `mirror repo`, and `use Jetpack Starter plugin` options.
* Check the generated `composer.json` to make sure the entered description has been used, and that the `release-branch-prefix` is the entered project's normalized name. Other generated files should be as expected.