### PR TITLE
[WordAds]: Fix double requesting ads.txt

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-double-ads-txt-request
+++ b/projects/plugins/jetpack/changelog/fix-double-ads-txt-request
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: This fix does not affect the functionality, just avoid double requests on WP endpoint.
+
+

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -212,7 +212,8 @@ class WordAds {
 			$ads_txt_transient = get_transient( 'wordads_ads_txt' );
 
 			if ( false === ( $ads_txt_transient ) ) {
-				$ads_txt_transient = ! is_wp_error( WordAds_API::get_wordads_ads_txt() ) ? WordAds_API::get_wordads_ads_txt() : '';
+				$wordads_ads_txt   = WordAds_API::get_wordads_ads_txt();
+				$ads_txt_transient = is_wp_error( $wordads_ads_txt ) ? '' : $wordads_ads_txt;
 				set_transient( 'wordads_ads_txt', $ads_txt_transient, DAY_IN_SECONDS );
 			}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Addressed from 89-gh-Automattic/wordads-issues

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR stores the ads.txt content in a variable, avoiding being requested twice on the WPCOM endpoint.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Access the ads.txt path from url, and check if it's showing as expected.
* Url example: https://yourblog.com/ads.txt