### PR TITLE
Added Autoloader debugger enhancements for better debugging.

### DIFF
--- a/projects/plugins/debug-helper/changelog/add-autoloader-debugger-enhancements
+++ b/projects/plugins/debug-helper/changelog/add-autoloader-debugger-enhancements
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added several enhancements to the Autoloader debugger module that make debugging easier.

--- a/projects/plugins/debug-helper/modules/class-autoloader-debug-helper.php
+++ b/projects/plugins/debug-helper/modules/class-autoloader-debug-helper.php
@@ -112,6 +112,9 @@ class Autoloader_Debug_Helper {
 								<?php if ( ! $entry['is_readable'] ) : ?>
 									<br /><strong style="color:red;">FILE UNREADABLE</strong>
 								<?php endif; ?>
+								<?php if ( $entry['is_included'] ) : ?>
+									<br /><strong style="color:green;">Currently loaded</strong>
+								<?php endif; ?>
 							</td>
 						<?php else : ?>
 							<td>
@@ -119,6 +122,9 @@ class Autoloader_Debug_Helper {
 								(in <?php echo esc_html( $entry['manifest'] ); ?>)
 								<?php if ( ! $entry['is_readable'] ) : ?>
 									<br /><strong style="color:red;">FILE UNREADABLE</strong>
+								<?php endif; ?>
+								<?php if ( $entry['is_included'] ) : ?>
+									<br /><strong style="color:green;">Currently loaded</strong>
 								<?php endif; ?>
 							</td>
 						<?php endif; ?>
@@ -210,6 +216,7 @@ class Autoloader_Debug_Helper {
 			);
 		}
 
+		$included_files           = get_included_files();
 		$manifest_by_classname    = array();
 		$data['unreadable_found'] = false;
 		foreach ( $manifest as $plugin_manifest_type => $manifest_data ) {
@@ -219,6 +226,12 @@ class Autoloader_Debug_Helper {
 
 				if ( ! $is_readable ) {
 					$data['unreadable_found'] = true;
+				}
+
+				if ( in_array( $entry['path'], $included_files, true ) ) {
+					$entry['is_included'] = true;
+				} else {
+					$entry['is_included'] = false;
 				}
 
 				$manifest_by_classname[ $classname ][] = array_merge(

--- a/projects/plugins/debug-helper/modules/class-autoloader-debug-helper.php
+++ b/projects/plugins/debug-helper/modules/class-autoloader-debug-helper.php
@@ -135,24 +135,6 @@ class Autoloader_Debug_Helper {
 	}
 
 	/**
-	 * Finds and returns Automattic classes that are available in the global scope.
-	 *
-	 * @return Array $classes
-	 */
-	public function get_a8c_classes() {
-		$classes = array();
-
-		foreach ( get_declared_classes() as $class ) {
-
-			if ( 0 === strpos( $class, 'Automattic' ) ) {
-				$classes [] = $class;
-			}
-		}
-
-		return $classes;
-	}
-
-	/**
 	 * Based on the existing defined Automattic classes finds the namespace that
 	 * is currently in use. We can't do it statically because the namespace is
 	 * randomized for each version of the build.
@@ -160,25 +142,14 @@ class Autoloader_Debug_Helper {
 	 * @return String $namespace
 	 * */
 	public function get_autoloader_namespace() {
-		$classes = $this->get_a8c_classes();
+		global $jetpack_autoloader_loader;
 
-		foreach ( $classes as $class ) {
+		$classname = get_class( $jetpack_autoloader_loader );
 
-			if ( 0 === strpos( $class, 'Automattic\Jetpack\Autoloader' ) ) {
+		$parts = explode( '\\', $classname );
+		array_pop( $parts );
 
-				$parts = explode( '\\', $class );
-				array_pop( $parts );
-
-				$candidate = join( '\\', $parts );
-
-				// Older autoloaders also have namespaces, but don't have the Container.
-				if ( ! class_exists( $candidate . '\Container' ) ) {
-					continue;
-				}
-
-				return $candidate;
-			}
-		}
+		return join( '\\', $parts );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Thanks to a suggestion by @ObliviousHarmony this PR changes the way we find the Autoloader namespace and avoids unnecessary looping. In addition to that it adds currently loaded file indicator:

![image](https://user-images.githubusercontent.com/374293/163217523-0c3838d1-7c93-4644-b48d-8836654afc87.png)

#### Changes proposed in this Pull Request:
* Adds better namespace detection.
* Adds loaded file indicator.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
* N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Enable the Autoloader debugger in the Jetpack Debug Tools plugin.
* Open the Autoloader debugger page.
* Make sure the current plugin version and path are detected correctly, try disabling/enabling development packages autoloading: `define( 'JETPACK_AUTOLOAD_DEV', true );`
* Make sure you see the currently loaded file indicators and things look sane (only one included file per class, etc.)
