### PR TITLE
Assets: Fix defer for async scripts

### DIFF
--- a/projects/packages/assets/changelog/fix-assets-defer-with-translations
+++ b/projects/packages/assets/changelog/fix-assets-defer-with-translations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Assets: Defer the enqueued script instead of its translations

--- a/projects/packages/assets/src/class-assets.php
+++ b/projects/packages/assets/src/class-assets.php
@@ -92,7 +92,7 @@ class Assets {
 		}
 
 		if ( in_array( $handle, $this->defer_script_handles, true ) ) {
-			return preg_replace( '/<script(.*) src=/i', '<script defer$1 src=', $tag );
+			return preg_replace( '/<script( [^>]*)? src=/i', '<script defer$1 src=', $tag );
 		}
 
 		return $tag;

--- a/projects/packages/assets/src/class-assets.php
+++ b/projects/packages/assets/src/class-assets.php
@@ -92,6 +92,7 @@ class Assets {
 		}
 
 		if ( in_array( $handle, $this->defer_script_handles, true ) ) {
+			// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 			return preg_replace( '/<script( [^>]*)? src=/i', '<script defer$1 src=', $tag );
 		}
 

--- a/projects/packages/assets/src/class-assets.php
+++ b/projects/packages/assets/src/class-assets.php
@@ -92,7 +92,7 @@ class Assets {
 		}
 
 		if ( in_array( $handle, $this->defer_script_handles, true ) ) {
-			return preg_replace( '/^<script /i', '<script defer ', $tag );
+			return preg_replace( '/<script(.*) src=/i', '<script defer$1 src=', $tag );
 		}
 
 		return $tag;

--- a/projects/packages/assets/tests/php/test-assets.php
+++ b/projects/packages/assets/tests/php/test-assets.php
@@ -258,6 +258,22 @@ class AssetsTest extends TestCase {
 	}
 
 	/**
+	 * Test that the `defer` attribute is not added to incorrect script tags.
+	 */
+	public function test_defer_attribute_with_incorrect_tag() {
+		Functions\expect( 'wp_enqueue_script' )
+			->once()
+			->with( 'handle', Assets::get_file_url_for_environment( '/minpath.js', '/path.js' ), array(), '123', true );
+		Assets::enqueue_async_script( 'handle', '/minpath.js', '/path.js', array(), '123', true );
+
+		$asset_instance = Assets::instance();
+		$tag            = '<scriptfoo src="/minpath.js" id="handle"></scriptfoo>';
+		$actual         = $asset_instance->script_add_async( $tag, 'handle' );
+		$expected       = '<scriptfoo src="/minpath.js" id="handle"></scriptfoo>';
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
 	 * Test whether static resources are properly updated to use a WordPress.com static domain.
 	 *
 	 * @covers Automattic\Jetpack\Assets::staticize_subdomain

--- a/projects/packages/assets/tests/php/test-assets.php
+++ b/projects/packages/assets/tests/php/test-assets.php
@@ -226,8 +226,10 @@ class AssetsTest extends TestCase {
 
 		$asset_instance = Assets::instance();
 
-		$tag      = '<script src="/minpath.js" id="handle"></script>';
-		$actual   = $asset_instance->script_add_async( $tag, 'handle' );
+		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		$tag    = '<script src="/minpath.js" id="handle"></script>';
+		$actual = $asset_instance->script_add_async( $tag, 'handle' );
+		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		$expected = '<script defer src="/minpath.js" id="handle"></script>';
 		$this->assertEquals( $expected, $actual );
 	}
@@ -244,6 +246,7 @@ class AssetsTest extends TestCase {
 		$asset_instance = Assets::instance();
 
 		$translations =
+			// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 			'<script id="handle-js-translations">
 			( function( domain, translations ) {
 				var localeData = translations.locale_data[ domain ] || translations.locale_data.messages;
@@ -251,9 +254,11 @@ class AssetsTest extends TestCase {
 				wp.i18n.setLocaleData( localeData, domain );
 			} )( "default", { "locale_data": { "messages": { "": {} } } } );
 			</script>';
-		$tag          = $translations . '<script src="/minpath.js" id="handle"></script>';
-		$actual       = $asset_instance->script_add_async( $tag, 'handle' );
-		$expected     = $translations . '<script defer src="/minpath.js" id="handle"></script>';
+		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		$tag    = $translations . '<script src="/minpath.js" id="handle"></script>';
+		$actual = $asset_instance->script_add_async( $tag, 'handle' );
+		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		$expected = $translations . '<script defer src="/minpath.js" id="handle"></script>';
 		$this->assertEquals( $expected, $actual );
 	}
 
@@ -267,9 +272,11 @@ class AssetsTest extends TestCase {
 		Assets::enqueue_async_script( 'handle', '/minpath.js', '/path.js', array(), '123', true );
 
 		$asset_instance = Assets::instance();
-		$tag            = '<scriptfoo src="/minpath.js" id="handle"></scriptfoo>';
-		$actual         = $asset_instance->script_add_async( $tag, 'handle' );
-		$expected       = '<scriptfoo src="/minpath.js" id="handle"></scriptfoo>';
+		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		$tag    = '<scriptfoo src="/minpath.js" id="handle"></scriptfoo>';
+		$actual = $asset_instance->script_add_async( $tag, 'handle' );
+		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		$expected = '<scriptfoo src="/minpath.js" id="handle"></scriptfoo>';
 		$this->assertEquals( $expected, $actual );
 	}
 

--- a/projects/packages/assets/tests/php/test-assets.php
+++ b/projects/packages/assets/tests/php/test-assets.php
@@ -216,6 +216,48 @@ class AssetsTest extends TestCase {
 	}
 
 	/**
+	 * Test that the `defer` attribute is properly added to the script tags for async scripts.
+	 */
+	public function test_defer_attribute_properly_added() {
+		Functions\expect( 'wp_enqueue_script' )
+			->once()
+			->with( 'handle', Assets::get_file_url_for_environment( '/minpath.js', '/path.js' ), array(), '123', true );
+		Assets::enqueue_async_script( 'handle', '/minpath.js', '/path.js', array(), '123', true );
+
+		$asset_instance = Assets::instance();
+
+		$tag      = '<script src="/minpath.js" id="handle"></script>';
+		$actual   = $asset_instance->script_add_async( $tag, 'handle' );
+		$expected = '<script defer src="/minpath.js" id="handle"></script>';
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Test that the `defer` attribute is properly added to the script tags for async scripts with translations.
+	 */
+	public function test_defer_attribute_properly_added_with_translations() {
+		Functions\expect( 'wp_enqueue_script' )
+			->once()
+			->with( 'handle', Assets::get_file_url_for_environment( '/minpath.js', '/path.js' ), array(), '123', true );
+		Assets::enqueue_async_script( 'handle', '/minpath.js', '/path.js', array(), '123', true );
+
+		$asset_instance = Assets::instance();
+
+		$translations =
+			'<script id="handle-js-translations">
+			( function( domain, translations ) {
+				var localeData = translations.locale_data[ domain ] || translations.locale_data.messages;
+				localeData[""].domain = domain;
+				wp.i18n.setLocaleData( localeData, domain );
+			} )( "default", { "locale_data": { "messages": { "": {} } } } );
+			</script>';
+		$tag          = $translations . '<script src="/minpath.js" id="handle"></script>';
+		$actual       = $asset_instance->script_add_async( $tag, 'handle' );
+		$expected     = $translations . '<script defer src="/minpath.js" id="handle"></script>';
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
 	 * Test whether static resources are properly updated to use a WordPress.com static domain.
 	 *
 	 * @covers Automattic\Jetpack\Assets::staticize_subdomain


### PR DESCRIPTION
I've noticed that whenever we register a script as `async`, it will add a `defer` attribute to the translations script tag that is rendered before the enqueued script tag. 

This PR fixes that behavior so we defer the script we enqueued instead.

I'm also adding a couple of tests to confirm that the behavior is working as expected.

#### Changes proposed in this Pull Request:
Assets: Defer the enqueued script instead of its translations

#### Jetpack product discussion
No related product discussion 

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Verify package tests pass.
* Verify that if you add `async => true` to a script you register, `defer` will be added to the script and not to its translations.