### PR TITLE
My Jetpack: fix a bug when adding a product

### DIFF
--- a/projects/js-packages/components/changelog/update-my-jetpack-fix-activating-plugin
+++ b/projects/js-packages/components/changelog/update-my-jetpack-fix-activating-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: fix issues when activating/buying a product

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.11.1",
+	"version": "0.11.2-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/packages/my-jetpack/_inc/components/connected-product-offer/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-offer/index.jsx
@@ -62,12 +62,6 @@ const ConnectedProductOffer = ( { slug, onClick, trackButtonClick, ...rest } ) =
 		}
 	}, [ onClick, trackButtonClick ] );
 
-	/**
-	 * When onClick prop is defined,
-	 * the checkout page will be set as undefined.
-	 */
-	const checkoutPage = onClick ? undefined : addProductUrl;
-
 	return (
 		<ProductOffer
 			slug={ slug }
@@ -79,7 +73,7 @@ const ConnectedProductOffer = ( { slug, onClick, trackButtonClick, ...rest } ) =
 			supportedProducts={ supportedProducts }
 			hasRequiredPlan={ hasRequiredPlan }
 			onAdd={ clickHandler }
-			addProductUrl={ checkoutPage }
+			addProductUrl={ onClick ? undefined : addProductUrl }
 			isLoading={ isFetching }
 			{ ...rest }
 		/>

--- a/projects/packages/my-jetpack/_inc/components/connected-product-offer/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-offer/index.jsx
@@ -62,6 +62,12 @@ const ConnectedProductOffer = ( { slug, onClick, trackButtonClick, ...rest } ) =
 		}
 	}, [ onClick, trackButtonClick ] );
 
+	/**
+	 * When onClick prop is defined,
+	 * the checkout page will be set as undefined.
+	 */
+	const checkoutPage = onClick ? undefined : addProductUrl;
+
 	return (
 		<ProductOffer
 			slug={ slug }
@@ -73,7 +79,7 @@ const ConnectedProductOffer = ( { slug, onClick, trackButtonClick, ...rest } ) =
 			supportedProducts={ supportedProducts }
 			hasRequiredPlan={ hasRequiredPlan }
 			onAdd={ clickHandler }
-			addProductUrl={ addProductUrl }
+			addProductUrl={ checkoutPage }
 			isLoading={ isFetching }
 			{ ...rest }
 		/>

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-fix-activating-plugin
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-fix-activating-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: fix issues when activating/buying a product


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes a bug introduced by https://github.com/Automattic/jetpack/pull/23874.
The issues is when the `onClick` prop of the `<ConnectedProductOffer />` is defined, the `addProductUrl` prop of the `<ProductOffer />` should be `undefined`. With this, we'll activate the plugin **before** to send the user to the checkout page.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: fix a bug when adding a product

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1649860877787919-slack-C02TQF5VAJD

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test in a JN site with Jetpack beta plugin
* Uninstall Jetpack in case it's installed
* switch to this branch in though of beta tester plugin for either Boost or Backup
* Activate Plugin
* Go to My Jetpack overview
* Try to add `Scan` product
* After the whole process, the My jetpack dashboard should show the product added.