### PR TITLE
My Jetpack: Reintroduce ConnectedProductOffer (Revamp of 23874)

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connected-product-offer/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-offer/index.jsx
@@ -1,0 +1,91 @@
+/**
+ * External dependencies
+ */
+import React, { useCallback } from 'react';
+import PropTypes from 'prop-types';
+import { ProductOffer } from '@automattic/jetpack-components';
+
+/**
+ * Internal dependencies
+ */
+import getProductCheckoutUrl from '../../utils/get-product-checkout-url';
+import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
+import { useProduct } from '../../hooks/use-product';
+
+/**
+ * Product Detail component.
+ * ToDo: rename event handler properties.
+ *
+ * @param {object} props                    - Component props.
+ * @param {string} props.slug               - Product slug
+ * @param {Function} props.onClick          - Callback for Call To Action button click
+ * @param {Function} props.trackButtonClick - Function to call for tracking clicks on Call To Action button
+ * @returns {object}                          ConnectedProductOffer react component.
+ */
+const ConnectedProductOffer = ( { slug, onClick, trackButtonClick, ...rest } ) => {
+	const { detail, isFetching } = useProduct( slug );
+	const {
+		title,
+		longDescription,
+		features,
+		pricingForUi,
+		isBundle,
+		supportedProducts,
+		hasRequiredPlan,
+	} = detail;
+
+	const {
+		isFree,
+		fullPricePerMonth: price,
+		currencyCode: currency,
+		discountPricePerMonth: offPrice,
+		wpcomProductSlug,
+	} = pricingForUi;
+	const { isUserConnected } = useMyJetpackConnection();
+
+	/*
+	 * Product needs purchase when:
+	 * - it's not free
+	 * - it does not have a required plan
+	 */
+	const needsPurchase = ! isFree && ! hasRequiredPlan;
+
+	const addProductUrl =
+		needsPurchase && wpcomProductSlug
+			? getProductCheckoutUrl( wpcomProductSlug, isUserConnected )
+			: null;
+
+	const clickHandler = useCallback( () => {
+		trackButtonClick();
+		if ( onClick ) {
+			onClick();
+		}
+	}, [ onClick, trackButtonClick ] );
+
+	return (
+		<ProductOffer
+			slug={ slug }
+			title={ title }
+			description={ longDescription }
+			features={ features }
+			pricing={ { isFree, price, offPrice, currency } }
+			isBundle={ isBundle }
+			supportedProducts={ supportedProducts }
+			hasRequiredPlan={ hasRequiredPlan }
+			onAdd={ clickHandler }
+			addProductUrl={ addProductUrl }
+			isLoading={ isFetching }
+			{ ...rest }
+		/>
+	);
+};
+
+ConnectedProductOffer.propTypes = {
+	slug: PropTypes.string.isRequired,
+};
+
+ConnectedProductOffer.defaultProps = {
+	trackButtonClick: () => {},
+};
+
+export default ConnectedProductOffer;

--- a/projects/packages/my-jetpack/_inc/components/connected-product-offer/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-offer/index.jsx
@@ -62,12 +62,6 @@ const ConnectedProductOffer = ( { slug, onClick, trackButtonClick, ...rest } ) =
 		}
 	}, [ onClick, trackButtonClick ] );
 
-	/**
-	 * When onClick prop is defined,
-	 * the checkout page will be set as undefined.
-	 */
-	const checkoutPage = onClick ? undefined : addProductUrl;
-
 	return (
 		<ProductOffer
 			slug={ slug }
@@ -79,7 +73,7 @@ const ConnectedProductOffer = ( { slug, onClick, trackButtonClick, ...rest } ) =
 			supportedProducts={ supportedProducts }
 			hasRequiredPlan={ hasRequiredPlan }
 			onAdd={ clickHandler }
-			addProductUrl={ checkoutPage }
+			addProductUrl={ onClick ? undefined : addProductUrl }
 			isLoading={ isFetching }
 			{ ...rest }
 		/>

--- a/projects/packages/my-jetpack/_inc/components/connected-product-offer/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-offer/index.jsx
@@ -62,6 +62,12 @@ const ConnectedProductOffer = ( { slug, onClick, trackButtonClick, ...rest } ) =
 		}
 	}, [ onClick, trackButtonClick ] );
 
+	/**
+	 * When onClick prop is defined,
+	 * the checkout page will be set as undefined.
+	 */
+	const checkoutPage = onClick ? undefined : addProductUrl;
+
 	return (
 		<ProductOffer
 			slug={ slug }
@@ -73,7 +79,7 @@ const ConnectedProductOffer = ( { slug, onClick, trackButtonClick, ...rest } ) =
 			supportedProducts={ supportedProducts }
 			hasRequiredPlan={ hasRequiredPlan }
 			onAdd={ clickHandler }
-			addProductUrl={ addProductUrl }
+			addProductUrl={ checkoutPage }
 			isLoading={ isFetching }
 			{ ...rest }
 		/>

--- a/projects/packages/my-jetpack/_inc/components/connected-product-offer/stories/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-offer/stories/index.jsx
@@ -1,0 +1,40 @@
+/* eslint-disable react/react-in-jsx-scope */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import withMock from 'storybook-addon-mock';
+
+/**
+ * Internal dependencies
+ */
+import ConnectedProductOffer from '../index.jsx';
+import { getAllMockData, getProductSlugs } from './utils.js';
+
+export default {
+	title: 'Packages/My Jetpack/Connected Product Offer',
+	component: ConnectedProductOffer,
+	decorators: [ withMock ],
+	parameters: {
+		layout: 'centered',
+	},
+	argTypes: {
+		slug: {
+			control: { type: 'select', options: getProductSlugs( true ) },
+		},
+		isCard: {
+			control: { type: 'boolean' },
+		},
+	},
+};
+
+const mockData = getAllMockData();
+
+const DefaultDefaultProductOffer = args => <ConnectedProductOffer { ...args } />;
+
+export const Default = DefaultDefaultProductOffer.bind( {} );
+Default.parameters = { mockData };
+Default.args = {
+	slug: 'backup',
+	isCard: false,
+};

--- a/projects/packages/my-jetpack/_inc/components/connected-product-offer/stories/mock-data.js
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-offer/stories/mock-data.js
@@ -1,0 +1,188 @@
+export const antiSpamProductData = {
+	slug: 'anti-spam',
+	name: 'Anti-Spam',
+	title: 'Jepack Anti-Spam',
+	description: 'Stop comment and form spam',
+	is_upgradable_by_bundle: [ 'security' ],
+	long_description:
+		'Save time and get better responses by automatically blocking spam from your comments and forms.',
+	status: 'active',
+	features: [
+		'Comment and form spam protection',
+		'Powered by Akismet',
+		'Block spam without CAPTCHAs',
+		'Advanced stats',
+	],
+	pricingForUi: {
+		currency_code: 'USD',
+		full_price: 119,
+		discount_price: 59,
+	},
+};
+
+export const backupProductData = {
+	slug: 'backup',
+	name: 'Backup',
+	title: 'Jepack Backup',
+	description: 'Save every change',
+	is_upgradable_by_bundle: [ 'security' ],
+	long_description:
+		'Never lose a word, image, page, or time worrying about your site with automated backups & one-click restores.',
+	status: 'active',
+	features: [
+		'Real-time cloud backups',
+		'10GB of backup storage',
+		'30-day archive & activity log',
+		'One-click restores',
+	],
+	pricingForUi: {
+		currency_code: 'USD',
+		full_price: 119,
+		discount_price: 59,
+	},
+};
+
+export const boostProductData = {
+	slug: 'boost',
+	name: 'Boost',
+	title: 'Jepack Boost',
+	description: 'Instant speed and SEO',
+	long_description:
+		'Jetpack Boost gives your site the same performance advantages as the world’s leading websites, no developer required.',
+	status: 'inactive',
+	features: [
+		'Check your site performance',
+		'Enable improvements in one click',
+		'Standalone free plugin for those focused on speed',
+	],
+	pricingForUi: {
+		available: true,
+		is_free: true,
+	},
+};
+
+export const crmProductData = {
+	slug: 'crm',
+	name: 'CRM',
+	title: 'Jetpack CRM',
+	description: 'Connect with your people',
+	long_description:
+		'All of your contacts in one place. Build better relationships with your customers and clients.',
+	status: 'inactive',
+	features: [
+		'Manage unlimited contacts',
+		'Manage billing and create invoices',
+		'Fully integrated with WordPress & WooCommerce',
+		'Infinitely customizable with integrations and extensions',
+	],
+	pricingForUi: {
+		available: true,
+		is_free: true,
+	},
+};
+
+export const extrasProductData = {
+	slug: 'extras',
+	name: 'Extras',
+	title: 'Jetpack Extras',
+	description: 'Basic tools for a successful site',
+	long_description:
+		"Secure and speed up your site for free with Jetpack's powerful WordPress tools.",
+	status: 'active',
+	features: [
+		'Measure your impact with beautiful stats',
+		'Speed up your site with optimized images',
+		'Protect your site against bot attacks',
+		'Get notifications if your site goes offline',
+		'Enhance your site with dozens of other features',
+	],
+	pricingForUi: {
+		available: true,
+		is_free: true,
+	},
+};
+
+export const scanProductData = {
+	slug: 'scan',
+	name: 'Scan',
+	title: 'Jepack Scan',
+	description: 'Stay one step ahead of threats',
+	is_upgradable_by_bundle: [ 'security' ],
+	long_description:
+		'Automatic scanning and one-click fixes keep your site one step ahead of security threats and malware.',
+	status: 'inactive',
+	features: [
+		'Automated daily scanning',
+		'One-click fixes for most issues',
+		'Instant email notifications',
+	],
+	pricingForUi: {
+		currency_code: 'USD',
+		full_price: 119,
+		discount_price: 59,
+	},
+};
+
+export const searchProductData = {
+	slug: 'search',
+	name: 'Search',
+	title: 'Jetpack Site Search',
+	description: 'Help them find what they need',
+	long_description:
+		'Help your site visitors find answers instantly so they keep reading and buying. Great for sites with a lot of content.',
+	status: 'inactive',
+	features: [
+		'Instant search and indexing',
+		'Powerful filtering',
+		'Supports 29 languages',
+		'Spelling correction',
+	],
+	pricingForUi: {
+		currency_code: 'USD',
+		full_price: 59.95,
+		discount_price: 29.975,
+		coupon_discount: 50,
+	},
+};
+
+export const securityProductData = {
+	slug: 'security',
+	name: 'Security',
+	title: 'Security',
+	description: 'Comprehensive site security, including Backup, Scan, and Anti-spam.',
+	long_description: 'Comprehensive site security, including Backup, Scan, and Anti-spam.',
+	status: 'inactive',
+	is_bundle: true,
+	supportedProducts: [ 'backup', 'scan', 'anti-spam' ],
+	features: [
+		'Real-time cloud backups with 10GB storage',
+		'Automated real-time malware scan',
+		'One-click fixes for most threats',
+		'Comment & form spam protection',
+	],
+	pricingForUi: {
+		currency_code: 'USD',
+		full_price: 299,
+		discount_price: 149,
+	},
+};
+
+export const videoPressProductData = {
+	slug: 'videopress',
+	name: 'VideoPress',
+	title: 'Jetpack Site VideoPress',
+	description: 'High quality, ad-free video',
+	long_description: 'High-quality, ad-free video built specifically for WordPress.',
+	status: 'inactive',
+	features: [
+		'1TB of storage',
+		'Built into WordPress editor',
+		'Ad-free and brandable player',
+		'Unlimited users',
+	],
+	pricingForUi: {
+		currency_code: 'USD',
+		full_price: 119,
+		discount_price: 59,
+	},
+};

--- a/projects/packages/my-jetpack/_inc/components/connected-product-offer/stories/utils.js
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-offer/stories/utils.js
@@ -1,0 +1,84 @@
+/**
+ * Internal dependencies
+ */
+import {
+	antiSpamProductData,
+	backupProductData,
+	boostProductData,
+	crmProductData,
+	extrasProductData,
+	scanProductData,
+	searchProductData,
+	securityProductData,
+	videoPressProductData,
+} from './mock-data.js';
+
+const mapResponse = {
+	'anti-spam': antiSpamProductData,
+	backup: backupProductData,
+	boost: boostProductData,
+	crm: crmProductData,
+	extras: extrasProductData,
+	scan: scanProductData,
+	search: searchProductData,
+	security: securityProductData,
+	videopress: videoPressProductData,
+};
+
+/**
+ * Helper function that returns the story mock data.
+ *
+ * @param {string} product - Product slug
+ * @returns {Array}          Story mock data
+ */
+export function getMockData( product ) {
+	const isArray = product.constructor === Array;
+	const productSlugs = isArray ? product : [ product ];
+
+	const getRequests = productSlugs.map( productSlug => {
+		return {
+			url: `my-jetpack/v1/site/products/${ productSlug }?_locale=user`,
+			method: 'GET',
+			status: 200,
+			response: mapResponse[ productSlug ],
+		};
+	} );
+
+	const postRequests = productSlugs.map( productSlug => {
+		return {
+			url: `my-jetpack/v1/site/products/${ productSlug }?_locale=user`,
+			method: 'POST',
+			status: 200,
+			response: {
+				...mapResponse[ productSlug ],
+				status: mapResponse[ productSlug ].status === 'active' ? 'inactive' : 'active',
+			},
+		};
+	} );
+
+	return [ ...getRequests, ...postRequests ];
+}
+
+/**
+ * Return all product mocked data.
+ *
+ * @returns {Array} All products mocked data.
+ */
+export function getAllMockData() {
+	return getMockData( [ ...Object.keys( mapResponse ) ] );
+}
+
+/**
+ * Return product slugs list
+ *
+ * @param {boolean} includeBundles - Whether to include product bundles
+ * @returns {Array} product slugs list.
+ */
+export function getProductSlugs( includeBundles = false ) {
+	const slugs = Object.keys( mapResponse );
+	if ( includeBundles ) {
+		return slugs;
+	}
+
+	return slugs.filter( slug => ! mapResponse[ slug ].is_bundle );
+}

--- a/projects/packages/my-jetpack/changelog/add-connected-product-offer-component-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/add-connected-product-offer-component-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Introduced ConnectedProductOffer component


### PR DESCRIPTION
Follow-up to #23874

Re-introduces the ConnectedProductOffer component without swapping it for ConnectedProductDetailCard

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Introduces `ConnectedProductOffer` to My Jetpack
* INcludes cherry-picked commits 51ee5bf4a3ef6da9eb5bdb2fdf0725ea817a0153 and 6764bff824b558aba592154a289bd11ade4dfcbe from #23930

#### Jetpack product discussion

See https://github.com/Automattic/jetpack/pull/23931 and p1649860877787919-slack-C02TQF5VAJD

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* Checkout this branch
* Launch Storybook
* Go to the ConnectedProductOffer story
* Switch the product by selecting the slug 

https://user-images.githubusercontent.com/77539/162457966-530c710d-08ca-464a-8965-1245ecbb88e2.mov
