### PR TITLE
PHPCS: Ignore all hits on `WordPress.DB.SlowDBQuery`

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -32,11 +32,6 @@
 	</rule>
 
 	<!-- Temporarily disable this until it passes. -->
-	<rule ref="WordPress.DB.SlowDBQuery">
-		<exclude name="WordPress.DB.SlowDBQuery"/>
-	</rule>
-
-	<!-- Temporarily disable this until it passes. -->
 	<rule ref="WordPress.Security.ValidatedSanitizedInput">
 		<exclude name="WordPress.Security.ValidatedSanitizedInput"/>
 	</rule>

--- a/projects/packages/sync/changelog/fix-WordPress.DB.SlowDBQuery-for-certain-values-of-fix
+++ b/projects/packages/sync/changelog/fix-WordPress.DB.SlowDBQuery-for-certain-values-of-fix
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Ignore all hits on `WordPress.DB.SlowDBQuery`
+
+

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.30.7';
+	const PACKAGE_VERSION = '1.30.8-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/sync/src/class-replicastore.php
+++ b/projects/packages/sync/src/class-replicastore.php
@@ -637,7 +637,9 @@ class Replicastore implements Replicastore_Interface {
 			$wpdb->update(
 				$table,
 				array(
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- False positive
 					'meta_key'   => $meta_key,
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- False positive
 					'meta_value' => maybe_serialize( $meta_value ),
 				),
 				array( 'meta_id' => $meta_id )
@@ -649,7 +651,9 @@ class Replicastore implements Replicastore_Interface {
 				array(
 					'meta_id'        => $meta_id,
 					$object_id_field => $object_id,
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- False positive
 					'meta_key'       => $meta_key,
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- False positive
 					'meta_value'     => maybe_serialize( $meta_value ),
 				)
 			);

--- a/projects/packages/sync/src/class-settings.php
+++ b/projects/packages/sync/src/class-settings.php
@@ -293,6 +293,7 @@ class Settings {
 	 */
 	public static function get_allowed_post_meta_structured() {
 		return array(
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 			'meta_key' => array(
 				'operator' => 'IN',
 				'values'   => array_map( 'esc_sql', self::get_setting( 'post_meta_whitelist' ) ),
@@ -361,6 +362,7 @@ class Settings {
 	 */
 	public static function get_allowed_comment_meta_structured() {
 		return array(
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 			'meta_key' => array(
 				'operator' => 'IN',
 				'values'   => array_map( 'esc_sql', self::get_setting( 'comment_meta_whitelist' ) ),
@@ -385,6 +387,7 @@ class Settings {
 		$values = \Automattic\Jetpack\Sync\Modules\WooCommerce::$order_item_meta_whitelist;
 
 		return array(
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 			'meta_key' => array(
 				'operator' => 'IN',
 				'values'   => array_map( 'esc_sql', $values ),

--- a/projects/packages/sync/src/modules/class-meta.php
+++ b/projects/packages/sync/src/modules/class-meta.php
@@ -54,6 +54,7 @@ class Meta extends Module {
 			if ( isset( $item['id'] ) && isset( $item['meta_key'] ) ) {
 				$meta = $this->get_object_by_id( $object_type, (int) $item['id'], (string) $item['meta_key'] );
 			}
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- False positive
 			$meta_objects[ $item['id'] . '-' . $item['meta_key'] ] = $meta;
 		}
 
@@ -95,12 +96,15 @@ class Meta extends Module {
 		if ( ! is_wp_error( $meta ) && ! empty( $meta ) ) {
 			foreach ( $meta as $meta_entry ) {
 				if ( 'post' === $object_type && strlen( $meta_entry['meta_value'] ) >= Posts::MAX_POST_META_LENGTH ) {
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- False positive
 					$meta_entry['meta_value'] = '';
 				}
 				$meta_objects[] = array(
 					'meta_type'  => $object_type,
 					'meta_id'    => $meta_entry['meta_id'],
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- False positive
 					'meta_key'   => $meta_key,
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- False positive
 					'meta_value' => $meta_entry['meta_value'],
 					'object_id'  => $meta_entry[ $object_id_column ],
 				);

--- a/projects/packages/sync/src/modules/class-search.php
+++ b/projects/packages/sync/src/modules/class-search.php
@@ -319,7 +319,9 @@ class Search extends Module {
 		'meta_description'                   => array( 'searchable_in_all_content' => true ),
 		'meta_id'                            => array(),
 		'meta_index'                         => array(),
+		// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- False positive
 		'meta_key'                           => array(),
+		// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- False positive
 		'meta_value'                         => array(),
 		'modal-dialog-id'                    => array(),
 		'name'                               => array( 'searchable_in_all_content' => true ),

--- a/projects/plugins/jetpack/changelog/fix-WordPress.DB.SlowDBQuery-for-certain-values-of-fix
+++ b/projects/plugins/jetpack/changelog/fix-WordPress.DB.SlowDBQuery-for-certain-values-of-fix
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Ignore all hits on `WordPress.DB.SlowDBQuery`
+
+

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-media-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-media-v1-1-endpoint.php
@@ -117,6 +117,7 @@ class WPCOM_JSON_API_List_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint { 
 			'order'          => isset( $args['order'] ) ? $args['order'] : 'DESC',
 			'orderby'        => isset( $args['order_by'] ) ? $args['order_by'] : 'date',
 			's'              => isset( $args['search'] ) ? $args['search'] : null,
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			'meta_query'     => array(
 				array(
 					'key'     => 'videopress_poster_image',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-endpoint.php
@@ -58,7 +58,9 @@ new WPCOM_JSON_API_List_Posts_Endpoint(
 			),
 			'author'       => "(int) Author's user ID",
 			'search'       => '(string) Search query',
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- False positive
 			'meta_key'     => '(string) Metadata key that the post should contain',
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- False positive
 			'meta_value'   => '(string) Metadata value that the post should contain. Will only be applied if a `meta_key` is also given',
 		),
 
@@ -215,6 +217,7 @@ class WPCOM_JSON_API_List_Posts_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 				$meta['value'] = $args['meta_value'];
 			}
 
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			$query['meta_query'] = array( $meta );
 		}
 
@@ -273,6 +276,7 @@ class WPCOM_JSON_API_List_Posts_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 		}
 
 		if ( ! empty( $args['term'] ) ) {
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 			$query['tax_query'] = array();
 			foreach ( $args['term'] as $taxonomy => $slug ) {
 				$taxonomy_object = get_taxonomy( $taxonomy );

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
@@ -55,7 +55,9 @@ new WPCOM_JSON_API_List_Posts_v1_1_Endpoint(
 			),
 			'author'          => "(int) Author's user ID",
 			'search'          => '(string) Search query',
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- False positive
 			'meta_key'        => '(string) Metadata key that the post should contain',
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- False positive
 			'meta_value'      => '(string) Metadata value that the post should contain. Will only be applied if a `meta_key` is also given',
 		),
 
@@ -240,6 +242,7 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 				$meta['value'] = $args['meta_value'];
 			}
 
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			$query['meta_query'] = array( $meta );
 		}
 
@@ -300,6 +303,7 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 		}
 
 		if ( ! empty( $args['term'] ) ) {
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 			$query['tax_query'] = array();
 			foreach ( $args['term'] as $taxonomy => $slug ) {
 				$taxonomy_object = get_taxonomy( $taxonomy );

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
@@ -56,7 +56,9 @@ new WPCOM_JSON_API_List_Posts_v1_2_Endpoint(
 			),
 			'author'                => "(int) Author's user ID",
 			'search'                => '(string) Search query',
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- False positive
 			'meta_key'              => '(string) Metadata key that the post should contain',
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- False positive
 			'meta_value'            => '(string) Metadata value that the post should contain. Will only be applied if a `meta_key` is also given',
 		),
 
@@ -207,6 +209,7 @@ class WPCOM_JSON_API_List_Posts_v1_2_Endpoint extends WPCOM_JSON_API_List_Posts_
 				$meta['value'] = $args['meta_value'];
 			}
 
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			$query['meta_query'] = array( $meta );
 		}
 
@@ -267,6 +270,7 @@ class WPCOM_JSON_API_List_Posts_v1_2_Endpoint extends WPCOM_JSON_API_List_Posts_
 		}
 
 		if ( ! empty( $args['term'] ) ) {
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 			$query['tax_query'] = array();
 			foreach ( $args['term'] as $taxonomy => $slug ) {
 				$taxonomy_object = get_taxonomy( $taxonomy );

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -1221,6 +1221,7 @@ EOT;
 					'posts_per_page'   => $options['size'],
 					'post__not_in'     => $excluded_posts,
 					'post_type'        => $current_post->post_type,
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 					'meta_key'         => '_thumbnail_id',
 					'suppress_filters' => false,
 				)
@@ -1234,6 +1235,7 @@ EOT;
 						'posts_per_page'   => $more,
 						'post__not_in'     => $excluded_posts,
 						'post_type'        => $current_post->post_type,
+						// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 						'meta_query'       => array(
 							array(
 								'key'     => '_thumbnail_id',

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -115,7 +115,9 @@ class Jetpack_SSO {
 	public function xmlrpc_user_disconnect( $user_id ) {
 		$user_query = new WP_User_Query(
 			array(
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				'meta_key'   => 'wpcom_user_id',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 				'meta_value' => $user_id,
 			)
 		);
@@ -1109,7 +1111,9 @@ class Jetpack_SSO {
 	public static function get_user_by_wpcom_id( $wpcom_user_id ) {
 		$user_query = new WP_User_Query(
 			array(
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				'meta_key'   => 'wpcom_user_id',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 				'meta_value' => (int) $wpcom_user_id,
 				'number'     => 1,
 			)

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -430,7 +430,9 @@ class Jetpack_Widget_Conditions {
 			'hierarchical' => 1,
 			'exclude'      => array(),
 			'include'      => array(),
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- False positive
 			'meta_key'     => '',
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- False positive
 			'meta_value'   => '',
 			'authors'      => '',
 			'parent'       => -1,

--- a/projects/plugins/jetpack/modules/widgets/migrate-to-core/image-widget.php
+++ b/projects/plugins/jetpack/modules/widgets/migrate-to-core/image-widget.php
@@ -132,6 +132,7 @@ function jetpack_migrate_image_widget() {
 		$attachment_ids = get_posts(
 			array(
 				'fields'           => 'ids',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 				'meta_query'       => array(
 					array(
 						'value'   => basename( $image_basename ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Several are readily identifiable as false positives. The rest I figure
we've been running these queries in production for long enough that if
they were really a problem we'd already have issues filed about them.

Overall I can't say I'm terribly impressed with this sniff. It just
blindly looks for assignments to certain array keys with no context. And
thanks to WordPress's general lack-of-abstraction DB layer I saw plenty
of places where it missed uses of the things it's sniffing for. If it
weren't for wpcom enforcing it, I'd not bother with it in our ruleset.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Follow-up to #23932

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?
* Double check that it actually ran the "PHP Code Sniffer (non-excluded files only)" job.
