### PR TITLE
Protect: Add empty state for `Summary` component

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1315,6 +1315,7 @@ importers:
       '@wordpress/icons': 8.2.0
       classnames: 2.3.1
       concurrently: 6.0.2
+      prop-types: 15.8.1
       react: 17.0.2
       react-dom: 17.0.2
       sass: 1.43.3
@@ -1331,6 +1332,7 @@ importers:
       '@wordpress/i18n': 4.6.0
       '@wordpress/icons': 8.2.0
       classnames: 2.3.1
+      prop-types: 15.8.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
@@ -8879,7 +8881,7 @@ packages:
       loader-utils: 2.0.2
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.65.0_webpack-cli@4.9.1
+      webpack: 5.65.0
 
   /babel-plugin-add-react-displayname/0.0.5:
     resolution: {integrity: sha1-M51M3be2X9YtHfnbn+BN4TQSK9U=}
@@ -10355,7 +10357,7 @@ packages:
       postcss-modules-values: 4.0.0_postcss@8.3.11
       postcss-value-parser: 4.2.0
       semver: 7.3.6
-      webpack: 5.65.0_webpack-cli@4.9.1
+      webpack: 5.65.0
 
   /css-minimizer-webpack-plugin/3.1.4_webpack@5.65.0:
     resolution: {integrity: sha512-JXnwBEA+a3FrmuBIJz7tKnCYGyraP86nuvX+wAqik1Lc8Ne9Ql8h5RpFbM3HjMpjXfhnqRBoTYIfArji5mteOg==}
@@ -20608,7 +20610,7 @@ packages:
       serialize-javascript: 6.0.0
       source-map: 0.6.1
       terser: 5.12.1
-      webpack: 5.65.0
+      webpack: 5.65.0_webpack-cli@4.9.1
 
   /terser/5.12.1:
     resolution: {integrity: sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==}

--- a/projects/plugins/protect/changelog/update-protect-empty-state
+++ b/projects/plugins/protect/changelog/update-protect-empty-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Protect: Add Summary empty state

--- a/projects/plugins/protect/package.json
+++ b/projects/plugins/protect/package.json
@@ -33,6 +33,7 @@
 		"@wordpress/i18n": "4.6.0",
 		"@wordpress/icons": "8.2.0",
 		"classnames": "2.3.1",
+		"prop-types": "15.8.1",
 		"react": "17.0.2",
 		"react-dom": "17.0.2"
 	},

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -111,7 +111,7 @@ const Admin = () => {
 					<AdminSectionHero>
 						<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 							<Col>
-								<Summary />
+								<Summary wordpressVuls={ 1 } themesVuls={ 2 } pluginsVuls={ 4 } />
 							</Col>
 						</Container>
 					</AdminSectionHero>

--- a/projects/plugins/protect/src/js/components/summary/index.jsx
+++ b/projects/plugins/protect/src/js/components/summary/index.jsx
@@ -2,8 +2,10 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
+import { __ } from '@wordpress/i18n';
 import { Container, Col, Text, Title } from '@automattic/jetpack-components';
-import { Icon, wordpress, plugins, color, shield } from '@wordpress/icons';
+import { Icon, wordpress, plugins, color, shield, check } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -15,29 +17,60 @@ const Cards = ( { name, vulnerabilities, icon } ) => {
 		<Col lg={ 2 } className={ styles.card }>
 			{ icon && <Icon icon={ icon } /> }
 			<Text variant="label">{ name }</Text>
-			<Text variant="body-extra-small">Vulnerabilities</Text>
+			<Text variant="body-extra-small">{ __( 'Vulnerabilities', 'jetpack-protect' ) }</Text>
 			<Text variant="headline-small">{ vulnerabilities }</Text>
 		</Col>
 	);
 };
 
-const Summary = () => {
+const Summary = ( { wordpressVuls, pluginsVuls, themesVuls } ) => {
+	const hasVuls = wordpressVuls + pluginsVuls + themesVuls > 0;
+
 	return (
 		<Container fluid>
-			<Col lg={ 6 }>
+			<Col lg={ 6 } className={ styles.latest }>
 				<Title size="small" className={ styles.title }>
 					<Icon icon={ shield } size={ 32 } className={ styles.icon } />
-					Last check
+					{ __( 'Latest scan', 'jetpack-protect' ) }
 				</Title>
 				<Text variant="headline-small" component="h1">
 					Today, 4:43PM
 				</Text>
 			</Col>
-			<Cards name="WordPress" vulnerabilities={ 3 } icon={ wordpress } />
-			<Cards name="Plugins" vulnerabilities={ 5 } icon={ plugins } />
-			<Cards name="Themes" vulnerabilities={ 10 } icon={ color } />
+			{ hasVuls ? (
+				<>
+					<Cards
+						name={ __( 'WordPress', 'jetpack-protect' ) }
+						vulnerabilities={ wordpressVuls }
+						icon={ wordpress }
+					/>
+					<Cards
+						name={ __( 'Plugins', 'jetpack-protect' ) }
+						vulnerabilities={ pluginsVuls }
+						icon={ plugins }
+					/>
+					<Cards
+						name={ __( 'Themes', 'jetpack-protect' ) }
+						vulnerabilities={ themesVuls }
+						icon={ color }
+					/>
+				</>
+			) : (
+				<Col lg={ 6 } className={ styles[ 'no-vul' ] }>
+					<Text variant="headline-small" className={ styles[ 'no-vul-text' ] }>
+						<Icon icon={ check } size={ 40 } className={ styles.icon } />
+						{ __( 'No vulnerabilities found!', 'jetpack-protect' ) }
+					</Text>
+				</Col>
+			) }
 		</Container>
 	);
+};
+
+Summary.propTypes = {
+	wordpressVuls: PropTypes.number.isRequired,
+	pluginsVuls: PropTypes.number.isRequired,
+	themesVuls: PropTypes.number.isRequired,
 };
 
 export default Summary;

--- a/projects/plugins/protect/src/js/components/summary/stories/index.jsx
+++ b/projects/plugins/protect/src/js/components/summary/stories/index.jsx
@@ -13,4 +13,18 @@ export default {
 	component: Summary,
 };
 
-export const Default = () => <Summary />;
+const Template = args => <Summary { ...args } />;
+
+export const Default = Template.bind( {} );
+Default.args = {
+	wordpressVuls: 1,
+	themesVuls: 2,
+	pluginsVuls: 3,
+};
+
+export const Empty = Template.bind( {} );
+Empty.args = {
+	wordpressVuls: 0,
+	themesVuls: 0,
+	pluginsVuls: 0,
+};

--- a/projects/plugins/protect/src/js/components/summary/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/summary/styles.module.scss
@@ -6,6 +6,12 @@
 	border-radius: var(--jp-border-radius);
 }
 
+.latest {
+	display: flex;
+	justify-content: center;
+	flex-direction: column;
+}
+
 .title {
 	display: flex;
 	align-items: center;
@@ -15,4 +21,15 @@
 .icon {
 	fill: var(--jp-green);
 	margin-right: var(--spacing-base);
+}
+
+.no-vul {
+	min-height: 135px;
+
+	&-text {
+		display: flex;
+		align-items: center;
+		height: 100%;
+		justify-content: center;
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Add a new state for `Summary` which is used when we have no vulnerabilities.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add new state for `Summary`.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1202064326332560-as-1202075586755900/f

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start `Storybook`
* Navigate to `Protect/Components/Summary`
* You should see a new story for `Empty`.

#### Demo

![Screen Shot 2022-04-13 at 17 13 15](https://user-images.githubusercontent.com/1663717/163263313-b30bd41f-7502-4415-b8c8-1227af5e9b7f.png)
