### PR TITLE
CLI add link and unlink plugin cli command

### DIFF
--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -385,6 +385,15 @@ const buildExecCmd = argv => {
 		);
 	} else if ( cmd === 'run-extras' ) {
 		opts.push( '/var/scripts/run-extras.sh' );
+	} else if ( cmd === 'link-plugin' ) {
+		opts.push(
+			'ln',
+			'-s',
+			`/usr/local/src/jetpack-monorepo/projects/plugins/${ argv.plugin_slug }`,
+			`/var/www/html/wp-content/plugins/${ argv.plugin_slug }`
+		);
+	} else if ( cmd === 'unlink-plugin' ) {
+		opts.push( 'rm', `/var/www/html/wp-content/plugins/${ argv.plugin_slug }` );
 	}
 
 	return buildComposeFiles().concat( opts );
@@ -614,6 +623,30 @@ export function dockerDefine( yargs ) {
 					command: 'run-extras',
 					description: 'Run run-extras.sh bin script',
 					builder: yargExec => defaultOpts( yargExec ),
+					handler: argv => execDockerCmdHandler( argv ),
+				} )
+				.command( {
+					command: 'link-plugin <plugin_slug>',
+					description:
+						'Links a monorepo plugin folder with the plugin folder of your Docker env. Plugin will be considered installed.',
+					builder: yargCmd => {
+						yargCmd.positional( 'plugin_slug', {
+							describe: 'The plugin slug',
+							type: 'string',
+						} );
+					},
+					handler: argv => execDockerCmdHandler( argv ),
+				} )
+				.command( {
+					command: 'unlink-plugin <plugin_slug>',
+					description:
+						'Uninks a monorepo plugin folder from the plugin folder of your Docker env. Plugin will be considered not installed.',
+					builder: yargCmd => {
+						yargCmd.positional( 'plugin_slug', {
+							describe: 'The plugin slug',
+							type: 'string',
+						} );
+					},
 					handler: argv => execDockerCmdHandler( argv ),
 				} )
 				// JT commands


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Very often we have to simulate a situation where a plugin is not present in our site. Using Docker, where all the plugins are linked and present in our plugins folder, the way to achieve it is by removing the symlink in the docker folder.

This is a pair of simple commands to allow us to do it more easily:

Examples:
```
jetpack docker unlink-plugin jetpack # "Uninstall" Jetpack
jetpack docker link-plugin jetpack  # "Install" Jetpack
```
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* CLI add link and unlink plugin cli command

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run the command and check if the sym link is gone. Check the plugin is gone from the Plugins page in wp-admin
* Run the command to link and check everything is back in place
