### PR TITLE
Protect: Introduce `jetpack-protect` store.

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1313,6 +1313,7 @@ importers:
       '@wordpress/element': 4.4.0
       '@wordpress/i18n': 4.6.0
       '@wordpress/icons': 8.2.0
+      camelize: 1.0.0
       classnames: 2.3.1
       concurrently: 6.0.2
       react: 17.0.2
@@ -1330,6 +1331,7 @@ importers:
       '@wordpress/element': 4.4.0
       '@wordpress/i18n': 4.6.0
       '@wordpress/icons': 8.2.0
+      camelize: 1.0.0
       classnames: 2.3.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -9464,6 +9466,10 @@ packages:
   /camelcase/6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
+
+  /camelize/1.0.0:
+    resolution: {integrity: sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=}
+    dev: false
 
   /caniuse-api/3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
@@ -20608,7 +20614,7 @@ packages:
       serialize-javascript: 6.0.0
       source-map: 0.6.1
       terser: 5.12.1
-      webpack: 5.65.0
+      webpack: 5.65.0_webpack-cli@4.9.1
 
   /terser/5.12.1:
     resolution: {integrity: sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==}

--- a/projects/plugins/protect/changelog/add-protect-store
+++ b/projects/plugins/protect/changelog/add-protect-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Protect: Introduce jetpack-protect store

--- a/projects/plugins/protect/package.json
+++ b/projects/plugins/protect/package.json
@@ -32,6 +32,7 @@
 		"@wordpress/element": "4.4.0",
 		"@wordpress/i18n": "4.6.0",
 		"@wordpress/icons": "8.2.0",
+		"camelize": "1.0.0",
 		"classnames": "2.3.1",
 		"react": "17.0.2",
 		"react-dom": "17.0.2"

--- a/projects/plugins/protect/src/js/index.js
+++ b/projects/plugins/protect/src/js/index.js
@@ -9,6 +9,10 @@ import { ThemeProvider } from '@automattic/jetpack-components';
  * Internal dependencies
  */
 import AdminPage from './components/admin-page';
+import { initStore } from './state/store';
+
+// Initialize Jetpack Protect store
+initStore();
 
 /**
  * Initial render function.

--- a/projects/plugins/protect/src/js/state/actions.js
+++ b/projects/plugins/protect/src/js/state/actions.js
@@ -1,0 +1,2 @@
+const actions = {};
+export { actions as default };

--- a/projects/plugins/protect/src/js/state/reducers.js
+++ b/projects/plugins/protect/src/js/state/reducers.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { combineReducers } from '@wordpress/data';
+
+const status = ( state = {}, action ) => {
+	switch ( action.type ) {
+		default:
+			return state;
+	}
+};
+
+const reducers = combineReducers( {
+	status,
+} );
+
+export default reducers;

--- a/projects/plugins/protect/src/js/state/store-holder.js
+++ b/projects/plugins/protect/src/js/state/store-holder.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { createReduxStore, register } from '@wordpress/data';
+
+class storeHolder {
+	static store = null;
+
+	static mayBeInit( storeId, storeConfig ) {
+		if ( null === storeHolder.store ) {
+			storeHolder.store = createReduxStore( storeId, storeConfig );
+			register( storeHolder.store );
+		}
+	}
+}
+
+export default storeHolder;

--- a/projects/plugins/protect/src/js/state/store.js
+++ b/projects/plugins/protect/src/js/state/store.js
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+import actions from './actions';
+import reducer from './reducers';
+import storeHolder from './store-holder';
+import camelize from 'camelize';
+
+const STORE_ID = 'jetpack-protect';
+
+/**
+ * Inits redux store for Jetpack Protect
+ */
+function initStore() {
+	storeHolder.mayBeInit( STORE_ID, {
+		__experimentalUseThunks: true, // never stop experiment :sweat_smile:
+		reducer,
+		actions,
+		initialState: camelize( window.jetpackProtectInitialState ) || {},
+	} );
+}
+
+export { STORE_ID, initStore };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Introduce the store for `jetpack-protect` reading data from `initial state`.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add `store` and `store-holder`.
* Add initial `reducers`.
* Add initial `actions`.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1202064326332560-as-1202117981194279/f

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start `Jetpack Protect`
* Navigate to the homepage.
* Open dev tools and goes to `redux` extension.
* You should see `jetpack-protect` as one of the stores.