### PR TITLE
Comments: Fix comments on post types that don't support Jetpack comment forms.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-comment-form-nonce-check
+++ b/projects/plugins/jetpack/changelog/fix-comment-form-nonce-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Comments: Don't require nonce verification on post types not supporting comment forms.

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -536,6 +536,11 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 	public function pre_comment_on_post() {
 		$post_array = stripslashes_deep( $_POST );
 
+		/** This filter is documented in modules/comments/comments.php */
+		if ( ! apply_filters( 'jetpack_comment_form_enabled_for_' . get_post_type( $post_array['comment_post_ID'] ), true ) ) {
+			return;
+		}
+
 		if ( empty( $post_array['jetpack_comments_nonce'] ) || ! wp_verify_nonce( $post_array['jetpack_comments_nonce'], "jetpack_comments_nonce-{$post_array['comment_post_ID']}" ) ) {
 			wp_die( esc_html__( 'Nonce verification failed.', 'jetpack' ), 400 );
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Fixes #62646

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
- Smarter nonce checks hooked onto pre_comment_on_post

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1649892098202479-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate Jetpack Comments 
* Add a product via Woo
* Try to leave a review