### PR TITLE
Comments: Prevent nonce verification when post-types don't support Jetpack comment forms.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-comment-form-nonce
+++ b/projects/plugins/jetpack/changelog/fix-comment-form-nonce
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Comments: Checking that Jetpack comments are supported before requiring nonce verification.

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -536,14 +536,15 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 	public function pre_comment_on_post() {
 		$post_array = stripslashes_deep( $_POST );
 
-		if ( empty( $post_array['jetpack_comments_nonce'] ) || ! wp_verify_nonce( $post_array['jetpack_comments_nonce'], "jetpack_comments_nonce-{$post_array['comment_post_ID']}" ) ) {
-			wp_die( esc_html__( 'Nonce verification failed.', 'jetpack' ), 400 );
-		}
 		// Bail if missing the Jetpack token.
 		if ( ! isset( $post_array['sig'] ) || ! isset( $post_array['token_key'] ) ) {
 			unset( $_POST['hc_post_as'] );
 
 			return;
+		}
+
+		if ( empty( $post_array['jetpack_comments_nonce'] ) || ! wp_verify_nonce( $post_array['jetpack_comments_nonce'], "jetpack_comments_nonce-{$post_array['comment_post_ID']}" ) ) {
+				wp_die( esc_html__( 'Nonce verification failed.', 'jetpack' ), 400 );
 		}
 
 		if ( false !== strpos( $post_array['hc_avatar'], '.gravatar.com' ) ) {


### PR DESCRIPTION
Fixes wp-calypso#62646

Issue originally introduced here: #23439

#### Changes proposed in this Pull Request:

* This PR moves around two code blocks, prioritising a check for Jetpack 'sig' and 'token_key' parameters before verifying the nonce, as those parameters don't exist on comments for non-support post-types.
* This fixes the issue (nonce verification failure message) that occurs when attempting to add a product review on a Jetpack and WooCommerce connected site. It also enables people to post comments when using custom post-types, which was also resulting in the nonce verification failure message.

#### Jetpack product discussion

* p1649892098202479-slack-CBG1CP4EN
* Also related to #23944

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Activate Jetpack Comments at Jetpack > Settings > Discussion
* Install and activate WooCommerce and add a product. Add a product review, and you shouldn't see a nonce verification failure message.
* Additionally, install a custom post type plugin and enable comments for that post type. Add a new custom post-type post, and add a comment to that post. There should be no nonce verification failure message.