### PR TITLE
Fix React warning

### DIFF
--- a/projects/js-packages/connection/changelog/fix-jetpack-react-warning
+++ b/projects/js-packages/connection/changelog/fix-jetpack-react-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid Warning in React PropTypes

--- a/projects/js-packages/connection/components/disconnect-dialog/index.jsx
+++ b/projects/js-packages/connection/components/disconnect-dialog/index.jsx
@@ -390,7 +390,7 @@ DisconnectDialog.propTypes = {
 	/** The context in which this component is being used. */
 	context: PropTypes.string,
 	/** Plugins that are using the Jetpack connection. */
-	connectedPlugins: PropTypes.array,
+	connectedPlugins: PropTypes.oneOfType( [ PropTypes.array, PropTypes.object ] ),
 	/** Callback function that is called just before the request to disconnect is made when the context is "plugins". */
 	pluginScreenDisconnectCallback: PropTypes.func,
 	/** A component to render as part of the disconnect step. */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes a PropType warning in Jetpack Dashboard.

This component is used by other components in the js packages, but also directly consumed by Jetpack plugin, which passes this argument in a different way, but both ways work.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix a React warning in the Jetpack dashboard

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/23358#issuecomment-1100076974

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure you have `define( 'SCRIPT_DEBUG', true );` in your wp-config
* Connect Jetpack
* Activate other Jetpack plugin
* Go to Jetpack Dashboard
* Confirm there is no warning in the console about `connectedPlugins` type
