### PR TITLE
VideoPress: Fixing an issue adding video descriptions in WordPress.com

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-videopress-metadata
+++ b/projects/plugins/jetpack/changelog/fix-videopress-metadata
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixing issue adding video descriptions and metadata via the WordPress.com dashboard.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-v1-1-endpoint.php
@@ -20,16 +20,17 @@ new WPCOM_JSON_API_Update_Media_v1_1_Endpoint(
 		),
 
 		'request_format'       => array(
-			'parent_id'      => '(int) ID of the post this media is attached to',
-			'title'          => '(string) The file name.',
-			'caption'        => '(string) File caption.',
-			'description'    => '(HTML) Description of the file.',
-			'alt'            => '(string) Alternative text for image files.',
-			'rating'         => '(string) Video only. Video rating.',
-			'display_embed'  => '(string) Video only. Whether to share or not the video.',
-			'allow_download' => '(string) Video only. Whether the video can be downloaded or not.',
-			'artist'         => '(string) Audio Only. Artist metadata for the audio track.',
-			'album'          => '(string) Audio Only. Album metadata for the audio track.',
+			'parent_id'       => '(int) ID of the post this media is attached to',
+			'title'           => '(string) The file name.',
+			'caption'         => '(string) File caption.',
+			'description'     => '(HTML) Description of the file.',
+			'alt'             => '(string) Alternative text for image files.',
+			'rating'          => '(string) Video only. Video rating.',
+			'display_embed'   => '(string) Video only. Whether to share or not the video.',
+			'allow_download'  => '(string) Video only. Whether the video can be downloaded or not.',
+			'privacy_setting' => '(int) Video only. The privacy level for the video.',
+			'artist'          => '(string) Audio Only. Artist metadata for the audio track.',
+			'album'           => '(string) Audio Only. Album metadata for the audio track.',
 		),
 
 		'response_format'      => array(
@@ -54,6 +55,7 @@ new WPCOM_JSON_API_Update_Media_v1_1_Endpoint(
 			'rating'                     => '(string) (Video only) VideoPress rating of the video',
 			'display_embed'              => '(string) Video only. Whether to share or not the video.',
 			'allow_download'             => '(string) Video only. Whether the video can be downloaded or not.',
+			'privacy_setting'            => '(int) Video only. The privacy level for the video.',
 			'videopress_guid'            => '(string) (Video only) VideoPress GUID of the video when uploaded on a blog with VideoPress',
 			'videopress_processing_done' => '(bool) (Video only) If the video is uploaded on a blog with VideoPress, this will return the status of processing on the video.',
 		),
@@ -191,7 +193,8 @@ class WPCOM_JSON_API_Update_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint 
 			$input['description'],
 			$input['rating'],
 			$input['display_embed'],
-			$input['allow_download']
+			$input['allow_download'],
+			isset( $input['privacy_setting'] ) ? $input['privacy_setting'] : null
 		);
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* This PR adds some functionality that was added in WordPress.com, that includes video privacy metadata. Without that information it isn't possible to add video descriptions via the WordPress.com dashboard (https://wordpress.com/media/).

#### Jetpack product discussion

p1650010696620729-slack-CBG1CP4EN
p9o2xV-21I-p2#comment-5794

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Apply this PR, and in the WordPress.com dashboard (https://wordpress.com/media/) upload a new video. Once uploaded, click to edit and add a description. There shouldn't be any errors and the description should stick.
