### PR TITLE
Allow secondary users to connect from My Jetpack

### DIFF
--- a/projects/js-packages/connection/changelog/add-allow-secondary-user-conn-my-jetpack
+++ b/projects/js-packages/connection/changelog/add-allow-secondary-user-conn-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Allow secondary users to connect from My Jetpack

--- a/projects/js-packages/connection/components/connection-status-card/index.jsx
+++ b/projects/js-packages/connection/components/connection-status-card/index.jsx
@@ -156,7 +156,7 @@ const ConnectionStatusCard = props => {
 					</li>
 				) }
 
-				{ ! hasConnectedOwner && (
+				{ ( ! isUserConnected || ! hasConnectedOwner ) && (
 					<li
 						className={ `jp-connection-status-card--list-item-${
 							requiresUserConnection ? 'error' : 'info'

--- a/projects/js-packages/connection/components/connection-status-card/test/component.jsx
+++ b/projects/js-packages/connection/components/connection-status-card/test/component.jsx
@@ -92,9 +92,9 @@ describe( 'ConnectionStatusCard', () => {
 			expect( wrapper.find( '.jp-connection-status-card--list-item-error' ) ).to.have.lengthOf( 0 );
 		} );
 
-		it( 'Doesn\'t render the "Connect your user account" button', () => {
+		it( 'renders the "Connect your user account" button', () => {
 			expect( wrapper.find( '.jp-connection-status-card--btn-connect-user' ) ).to.have.lengthOf(
-				0
+				1
 			);
 		} );
 	} );
@@ -124,6 +124,10 @@ describe( 'ConnectionStatusCard', () => {
 			expect(
 				wrapper.find( '.jp-connection-status-card--list-item-success' ).at( 1 ).render().text()
 			).to.be.equal( 'Logged in as ' );
+		} );
+
+		it( 'Doesn\'t render the "Account not connected" error list item', () => {
+			expect( wrapper.find( '.jp-connection-status-card--list-item-error' ) ).to.have.lengthOf( 0 );
 		} );
 
 		it( 'doesn\'t render the "Connect your WordPress.com account" button', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #23914

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Allow secondary users to connect from My Jetpack

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
NA

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install Jetpack or any jetpack plugin and fully connect site and user
* Go to My Jetpack and confirm you see the information that your user is connected
* Log in with another admin and visit My Jetpack
* Confirm you see a link to connect your user
* Connect your user with a different wpcom user
* Confirm the flow works (test a flow where you are already logged in to wpcom and another one where you are not)
* Back to My Jetpack, confirm you see the information about your user connection

Things outside the scope of this PR:

- only admins will be able to connect from My Jetpack because My Jetpack is not visible to other users
- Some connection flows are broken if you are using only a stand-alone plugin - because the links that takes the user from Calypso pricing page back to the site take them to Jetpack-plugin specific pages
