### PR TITLE
Stats: Add ability to filter JS and AMP stats footer data

### DIFF
--- a/projects/plugins/jetpack/changelog/add-filter-stats-footer-data
+++ b/projects/plugins/jetpack/changelog/add-filter-stats-footer-data
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add individual filters for JS and AMP stat footer data.

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -273,8 +273,30 @@ function stats_build_view_data() {
 function stats_footer() {
 	$data = stats_build_view_data();
 	if ( Jetpack_AMP_Support::is_amp_request() ) {
+
+		/**
+		 * Filter the parameters added to the AMP pixel tracking code.
+		 *
+		 * @module stats
+		 *
+		 * @since 10.9
+		 *
+		 * @param array $data Array of options about the site and page you're on.
+		 */
+		$data = (array) apply_filters( 'stats_footer_amp_data', $data );
 		stats_render_amp_footer( $data );
 	} else {
+
+		/**
+		 * Filter the parameters added to the JavaScript stats tracking code.
+		 *
+		 * @module stats
+		 *
+		 * @since 10.9
+		 *
+		 * @param array $data Array of options about the site and page you're on.
+		 */
+		$data = (array) apply_filters( 'stats_footer_js_data', $data );
 		stats_render_footer( $data );
 	}
 
@@ -307,7 +329,7 @@ END;
 /**
  * Render the stats footer for AMP output.
  *
- * @param array $data Array of data for the JS stats tracker.
+ * @param array $data Array of data for the AMP pixel tracker.
  */
 function stats_render_amp_footer( $data ) {
 	$data['host'] = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : ''; // input var ok.

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -283,7 +283,7 @@ function stats_footer() {
 		 *
 		 * @param array $data Array of options about the site and page you're on.
 		 */
-		$data = (array) apply_filters( 'stats_footer_amp_data', $data );
+		$data = (array) apply_filters( 'jetpack_stats_footer_amp_data', $data );
 		stats_render_amp_footer( $data );
 	} else {
 
@@ -296,7 +296,7 @@ function stats_footer() {
 		 *
 		 * @param array $data Array of options about the site and page you're on.
 		 */
-		$data = (array) apply_filters( 'stats_footer_js_data', $data );
+		$data = (array) apply_filters( 'jetpack_stats_footer_js_data', $data );
 		stats_render_footer( $data );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Allow filtering the WPCOM JS and AMP stats footers individually.

#### Does this pull request change what data or activity we track or use?
* WPCOM JS was already filterable via the stats_array hook.

#### Testing instructions:
* Add the following code as an mu-plugin:
```
add_filter( 'jetpack_stats_footer_amp_data', function( $data ) {
	$data['amp_data'] = 'yup';
	return $data;
} );

add_filter( 'jetpack_stats_footer_js_data', function( $data ) {
	$data['js_data'] = 'yup';
	return $data;
} );
```
* Visit a page on the site and observe that the JS stats parameters include `js_data:'yup'`.
* Visit an AMP page on the site (active the AMP plugin and turn on Standard mode) and observe that the AMP pixel stats parameters include `amp_data=yup`.
