### PR TITLE
My Jetpack: Fix warning that should not be displayed

### DIFF
--- a/projects/js-packages/connection/changelog/fix-secondary-user-warning
+++ b/projects/js-packages/connection/changelog/fix-secondary-user-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+do not display warning for secondary users if connection has an owner

--- a/projects/js-packages/connection/components/connection-status-card/index.jsx
+++ b/projects/js-packages/connection/components/connection-status-card/index.jsx
@@ -45,6 +45,7 @@ const ConnectionStatusCard = props => {
 		apiNonce,
 	} );
 
+	const missingConnectedOwner = requiresUserConnection && ! hasConnectedOwner;
 	const avatarRef = useRef();
 	const avatar = userConnectionData.currentUser?.wpcomUser?.avatar;
 
@@ -159,10 +160,10 @@ const ConnectionStatusCard = props => {
 				{ ( ! isUserConnected || ! hasConnectedOwner ) && (
 					<li
 						className={ `jp-connection-status-card--list-item-${
-							requiresUserConnection ? 'error' : 'info'
+							missingConnectedOwner ? 'error' : 'info'
 						}` }
 					>
-						{ requiresUserConnection && __( 'Requires user connection.', 'jetpack' ) }{ ' ' }
+						{ missingConnectedOwner && __( 'Requires user connection.', 'jetpack' ) }{ ' ' }
 						<Button
 							variant="link"
 							disabled={ userIsConnecting }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes  warning that should not be displayed.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
NA
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Connect Jetpack
* Activate VideoPress
* Log in as a secondary user and go to My Jetpack
* Make sure you see a link to connect the user, but no error or warning saying a user is required
* Go to Jetpack debug > Broken tokens and delete user tokens
* Go to My Jetpack with both users and confirm you see the error message
