### PR TITLE
Publicize: Move the LinkedIn reauth check to within the loop

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/publicize-connection-test-results.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/publicize-connection-test-results.php
@@ -114,10 +114,10 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connection_Test_Results extends 
 			foreach ( $mapping as $field => $test_result_field ) {
 				$item[ $field ] = $test_result[ $test_result_field ];
 			}
-		}
 
-		if ( 'linkedin' === $item['id'] && 'must_reauth' === $test_result['connectionTestPassed'] ) {
-			$item['test_success'] = 'must_reauth';
+			if ( 'linkedin' === $item['id'] && 'must_reauth' === $test_result['connectionTestPassed'] ) {
+				$item['test_success'] = 'must_reauth';
+			}
 		}
 
 		$response = rest_ensure_response( $items );

--- a/projects/plugins/jetpack/changelog/update-linkedin-reauth-check
+++ b/projects/plugins/jetpack/changelog/update-linkedin-reauth-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Ensure that all LinkedIn Publicize connections are checked for the need to re-authenticate


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

When we check the status of the Publicize connections, there is
currently a check outside of the loop for whether a LinkedIn connection
needs to be reauthorised, but in testing another change, I was seeing
warnings about variables being undefined.
    
Looking at the intention of the code, this check should be moved within
the loop, so it is performed on each connection. This change does that.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
TBD
