### PR TITLE
required-review: Indicate that the `token` parameter is required

### DIFF
--- a/projects/github-actions/required-review/README.md
+++ b/projects/github-actions/required-review/README.md
@@ -24,6 +24,7 @@ jobs:
     steps:
       - uses: Automattic/action-required-review@v3
         with:
+          token: ${{ secrets.REQUIRED_REVIEWS_TOKEN }}
           requirements: |
             - paths: unmatched
               teams:
@@ -60,9 +61,11 @@ This action is intended to be triggered by the `pull_request_review` event.
     # PR's checks list.
     status: Required review
 
-    # Personal access token used to fetch the list of changed files from Github
-    # REST API, and to submit the status check.
-    token: ${{ github.token }}
+    # GitHub Access Token. The user associated with this token will show up
+    # as the "creator" of the status check, and must have access to read
+    # pull request data, create status checks (`repo:status`), and to read
+    # your organization's teams (`read:org`).
+    token: ${{ secrets.SOME_TOKEN }}
 ```
 
 ## Requirements Format

--- a/projects/github-actions/required-review/action.yml
+++ b/projects/github-actions/required-review/action.yml
@@ -21,10 +21,10 @@ inputs:
   token:
     description: >
       GitHub Access Token. The user associated with this token will show up
-      as the "creator" of the status check, and must have access to read your
-      organization's teams.
-    required: false
-    default: ${{ github.token }}
+      as the "creator" of the status check, and must have access to read
+      pull request data, create status checks (`repo:status`), and to read
+      your organization's teams (`read:org`).
+    required: true
 runs:
   using: node16
   main: dist/index.js

--- a/projects/github-actions/required-review/changelog/update-required-review-needs-token
+++ b/projects/github-actions/required-review/changelog/update-required-review-needs-token
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+The `token` parameter was effectively required, as the default `GITHUB_TOKEN` lacks the ability to read team membership. The parameter is now explicitly required.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
It was always effectively required, as the standard `GITHUB_TOKEN` lacks
the ability to read team membership and reading team membership is
needed for the action to actually do anything.

This adjusts things to better reflect that situation, and documents the
scopes the supplied token needs to have.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Fixes #23938

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Do the updated docs make sense?
* First you'd figure a way to use the dev version of this (e.g. commit the built version to a fork), then try using it without specifying a token.