### PR TITLE
required-review: Fix handling of re-reviews

### DIFF
--- a/projects/github-actions/required-review/changelog/fix-required-review-rereview
+++ b/projects/github-actions/required-review/changelog/fix-required-review-rereview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix handling of re-reviews, only look at the latest review per user.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
It seems that GitHub, in at least some cases, will return re-reviews
separately from its API. When checking if a PR is mergable it only looks
at the latest review from each user. This action should do the same.

Fortunately the API appears to return the reviews in the proper order
already, so we can just add or remove the user from the list of
approvers as we see each one.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Fixes #23083

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Arrange for the modified copy of the action to be used somewhere, then make a PR and try various combinations of approving, dismissing, and re-reviewing (to approve or request changes) without dismissing.
