### PR TITLE
waf: Fix WordPress.Security.ValidatedSanitizedInput sniff

### DIFF
--- a/projects/packages/waf/.phpcs.dir.xml
+++ b/projects/packages/waf/.phpcs.dir.xml
@@ -50,9 +50,4 @@
 		<severity>0</severity>
 	</rule>
 
-	<!-- Temporarily disable this until it passes. -->
-	<rule ref="WordPress.Security.ValidatedSanitizedInput">
-		<severity>0</severity>
-	</rule>
-
 </ruleset>

--- a/projects/packages/waf/changelog/fix-WordPress.Security.ValidatedSanitizedInput-in-waf
+++ b/projects/packages/waf/changelog/fix-WordPress.Security.ValidatedSanitizedInput-in-waf
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`

--- a/projects/packages/waf/src/class-waf-runtime.php
+++ b/projects/packages/waf/src/class-waf-runtime.php
@@ -7,6 +7,10 @@
 
 namespace Automattic\Jetpack\Waf;
 
+require_once __DIR__ . '/functions.php';
+
+// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This class is all about sanitizing input.
+
 /**
  * The environment variable that defined the WAF running mode.
  *
@@ -242,7 +246,8 @@ class Waf_Runtime {
 		error_log( "Jetpack WAF Blocked Request\t$action\t$rule_id\t$status_code\t$reason" );
 		header( "X-JetpackWAF-Blocked: $status_code $reason" );
 		if ( defined( 'JETPACK_WAF_MODE' ) && 'normal' === JETPACK_WAF_MODE ) {
-			header( $_SERVER['SERVER_PROTOCOL'] . ' 403 Forbidden', true, $status_code );
+			$protocol = isset( $_SERVER['SERVER_PROTOCOL'] ) ? wp_unslash( $_SERVER['SERVER_PROTOCOL'] ) : 'HTTP';
+			header( $protocol . ' 403 Forbidden', true, $status_code );
 			die( "rule $rule_id" );
 		}
 	}
@@ -458,35 +463,35 @@ class Waf_Runtime {
 				case 'remote_addr':
 					$value = '';
 					if ( ! empty( $_SERVER['HTTP_CLIENT_IP'] ) ) {
-						$value = $_SERVER['HTTP_CLIENT_IP'];
+						$value = wp_unslash( $_SERVER['HTTP_CLIENT_IP'] );
 					} elseif ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
-						$value = $_SERVER['HTTP_X_FORWARDED_FOR'];
+						$value = wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] );
 					} elseif ( ! empty( $_SERVER['REMOTE_ADDR'] ) ) {
-						$value = $_SERVER['REMOTE_ADDR'];
+						$value = wp_unslash( $_SERVER['REMOTE_ADDR'] );
 					}
 					break;
 				case 'request_method':
 					$value = empty( $_SERVER['REQUEST_METHOD'] )
 						? 'GET'
-						: $_SERVER['REQUEST_METHOD'];
+						: wp_unslash( $_SERVER['REQUEST_METHOD'] );
 					break;
 				case 'request_protocol':
 					$value = empty( $_SERVER['SERVER_PROTOCOL'] )
 						? ( empty( $_SERVER['HTTPS'] ) ? 'HTTP' : 'HTTPS' )
-						: $_SERVER['SERVER_PROTOCOL'];
+						: wp_unslash( $_SERVER['SERVER_PROTOCOL'] );
 					break;
 				case 'request_uri':
 					$value = isset( $_SERVER['REQUEST_URI'] )
-						? $_SERVER['REQUEST_URI']
+						? wp_unslash( $_SERVER['REQUEST_URI'] )
 						: '';
 					break;
 				case 'request_uri_raw':
-					$value = ( isset( $_SERVER['https'] ) ? 'https://' : 'http://' ) . $_SERVER['SERVER_NAME'] . $this->meta( 'request_uri' );
+					$value = ( isset( $_SERVER['https'] ) ? 'https://' : 'http://' ) . ( isset( $_SERVER['SERVER_NAME'] ) ? wp_unslash( $_SERVER['SERVER_NAME'] ) : '' ) . $this->meta( 'request_uri' );
 					break;
 				case 'request_filename':
 					$value = strtok(
 						isset( $_SERVER['REQUEST_URI'] )
-							? $_SERVER['REQUEST_URI']
+							? wp_unslash( $_SERVER['REQUEST_URI'] )
 							: '',
 						'?'
 					);
@@ -506,7 +511,7 @@ class Waf_Runtime {
 					$value = file_get_contents( 'php://input' );
 					break;
 				case 'query_string':
-					$value = isset( $_SERVER['QUERY_STRING'] ) ? $_SERVER['QUERY_STRING'] : '';
+					$value = isset( $_SERVER['QUERY_STRING'] ) ? wp_unslash( $_SERVER['QUERY_STRING'] ) : '';
 			}
 			$this->metadata[ $key ] = $value;
 		}

--- a/projects/packages/waf/src/functions.php
+++ b/projects/packages/waf/src/functions.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Utility functions for WAF.
+ *
+ * @package automattic/jetpack-waf
+ */
+
+namespace Automattic\Jetpack\Waf;
+
+/**
+ * A wrapper for WordPress's `wp_unslash()`.
+ *
+ * Even though PHP itself dropped the option to add slashes to superglobals a decade ago,
+ * WordPress still does it through some misguided extreme backwards compatibility. 🙄
+ *
+ * If WordPress's function exists, assume it needs to be called. If not, assume it doesn't.
+ *
+ * @param string|array $value String or array of data to unslash.
+ * @return string|array Possibly unslashed $value.
+ */
+function wp_unslash( $value ) {
+	if ( function_exists( '\\wp_unslash' ) ) {
+		return \wp_unslash( $value );
+	} else {
+		return $value;
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Three messages:

* InputNotValidated: Add a few `isset()` checks.
* MissingUnslash: Add a stub `Automattic\Jetpack\Waf\wp_unslash()` that
  will call WordPress's `wp_unslash()` if it is defined or do nothing
  otherwise, on the assumption that in the former case WordPress has
  mangled the superglobals with `wp_slash()` while in the latter that
  hasn't happened (yet).
* InputNotSanitized: Ignore. This code is all about sanitization, we
  don't need to pre-sanitize before we sanitize.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See #23942

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure things still work properly, both in standalone mode and not.