### PR TITLE
JS Components: Add `icon` property to the ProductOffer component

### DIFF
--- a/projects/js-packages/components/changelog/update-js-components-product-offer-support-jetpack-logo
+++ b/projects/js-packages/components/changelog/update-js-components-product-offer-support-jetpack-logo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+JS Components: add `icon` property to ProductOffer component

--- a/projects/js-packages/components/components/product-icons/index.jsx
+++ b/projects/js-packages/components/components/product-icons/index.jsx
@@ -135,6 +135,7 @@ const iconsMap = {
 	search: SearchIcon,
 	star: StarIcon,
 	videopress: VideopressIcon,
+	jetpack: JetpackIcon,
 };
 
 /**

--- a/projects/js-packages/components/components/product-icons/index.jsx
+++ b/projects/js-packages/components/components/product-icons/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { Path, SVG, G } from '@wordpress/components';
+import { Path, SVG, G, Polygon } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -111,6 +111,19 @@ export const CheckmarkIcon = ( { size, className = styles[ 'checkmark-icon' ] } 
 		<Path d="M11 17.768l-4.884-4.884 1.768-1.768L11 14.232l8.658-8.658C17.823 3.39 15.075 2 12 2 6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10c0-1.528-.353-2.97-.966-4.266L11 17.768z" />
 	</IconWrapper>
 );
+
+export const JetpackIcon = ( { size, className = styles.jetpack } ) => {
+	return (
+		<IconWrapper className={ className } size={ size } viewBox="0 0 32 32">
+			<Path
+				className="jetpack-logo__icon-circle"
+				d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z"
+			/>
+			<Polygon fill="#fff" points="15,19 7,19 15,3" />
+			<Polygon fill="#fff" points="17,29 17,13 25,13" />
+		</IconWrapper>
+	);
+};
 
 const iconsMap = {
 	'anti-spam': AntiSpamIcon,

--- a/projects/js-packages/components/components/product-icons/style.module.scss
+++ b/projects/js-packages/components/components/product-icons/style.module.scss
@@ -2,6 +2,7 @@
 	fill: black;
 }
 
+.jetpack,
 .checkmark-icon {
 	---jp-green-primary: #069e08;
 	fill: var(---jp-green-primary);

--- a/projects/js-packages/components/components/product-offer/index.jsx
+++ b/projects/js-packages/components/components/product-offer/index.jsx
@@ -81,15 +81,15 @@ function CardIcons( { products, icon } ) {
  *
  * @param {object} props                  - Component props.
  * @param {string} props.slug             - Product slug.
- * @param {string} props.icon 			  - Custom Icon slug.
- * @param {string} props.title 			  - Product title.
- * @param {string} props.subTitle 		  - Product sub-title.
+ * @param {string} props.icon 	          - Custom Icon slug.
+ * @param {string} props.title            - Product title.
+ * @param {string} props.subTitle         - Product sub-title.
  * @param {string} props.description      - Product description.
  * @param {Array}  props.features         - Features list of the product.
  * @param {boolean} props.isCard          - Add the styles to look like a card.
  * @param {boolean} props.isBundle        - Whether or not the product is a bundle.
  * @param {Array} props.supportedProducts - List of supported products (for bundles).
- * @param {Object} props.pricing 	      - Product Pricing object.
+ * @param {Object} props.pricing          - Product Pricing object.
  * @param {boolean} props.hasRequiredPlan - Whether or not the product has the required plan.
  * @param {boolean} props.isLoading       - Applies the isLoading style to the component.
  * @param {string} props.className        - A className to be concat with default ones.

--- a/projects/js-packages/components/components/product-offer/index.jsx
+++ b/projects/js-packages/components/components/product-offer/index.jsx
@@ -40,7 +40,7 @@ function ProductOfferHeader( { title = __( 'Popular upgrade', 'jetpack' ) } ) {
  * @param {Array} props.products - List of supported products.
  * @returns {React.Component}    Bundle product icons react component.
  */
-function ProductIcons( { products } ) {
+function CardIcons( { products } ) {
 	return (
 		<div className={ styles[ 'product-bundle-icons' ] }>
 			{ products.map( ( product, index ) => {
@@ -120,7 +120,7 @@ const ProductOffer = ( {
 			{ isBundle && <ProductOfferHeader /> }
 
 			<div className={ styles[ 'card-container' ] }>
-				<ProductIcons
+				<CardIcons
 					slug={ slug }
 					products={ supportedProducts?.length ? supportedProducts : [ slug ] }
 				/>

--- a/projects/js-packages/components/components/product-offer/index.jsx
+++ b/projects/js-packages/components/components/product-offer/index.jsx
@@ -37,10 +37,20 @@ function ProductOfferHeader( { title = __( 'Popular upgrade', 'jetpack' ) } ) {
  * based on the list of supported products.
  *
  * @param {object} props         - Component props.
+ * @param {Array} props.icon     - Custom icon slug.
  * @param {Array} props.products - List of supported products.
- * @returns {React.Component}    Bundle product icons react component.
+ * @returns {React.Component}      Bundle product icons react component.
  */
-function CardIcons( { products } ) {
+function CardIcons( { products, icon } ) {
+	if ( icon ) {
+		const CustomIcon = getIconBySlug( icon );
+		return (
+			<div className={ styles[ 'product-bundle-icons' ] }>
+				<CustomIcon size={ 32 } />
+			</div>
+		);
+	}
+
 	return (
 		<div className={ styles[ 'product-bundle-icons' ] }>
 			{ products.map( ( product, index ) => {
@@ -71,6 +81,7 @@ function CardIcons( { products } ) {
  *
  * @param {object} props                  - Component props.
  * @param {string} props.slug             - Product slug.
+ * @param {string} props.icon 			  - Custom Icon slug.
  * @param {string} props.title 			  - Product title.
  * @param {string} props.subTitle 		  - Product sub-title.
  * @param {string} props.description      - Product description.
@@ -91,6 +102,7 @@ const ProductOffer = ( {
 	className,
 	slug,
 	title,
+	icon,
 	subTitle,
 	description,
 	features,
@@ -122,6 +134,7 @@ const ProductOffer = ( {
 			<div className={ styles[ 'card-container' ] }>
 				<CardIcons
 					slug={ slug }
+					icon={ icon }
 					products={ supportedProducts?.length ? supportedProducts : [ slug ] }
 				/>
 				<H3>{ title }</H3>
@@ -170,6 +183,9 @@ const ProductOffer = ( {
 ProductOffer.propTypes = {
 	slug: PropTypes.string.isRequired,
 	name: PropTypes.string,
+
+	/** Custom icon slug */
+	icon: PropTypes.string,
 	/** Product title. Primary heading */
 	title: PropTypes.string,
 

--- a/projects/js-packages/components/components/product-offer/stories/index.jsx
+++ b/projects/js-packages/components/components/product-offer/stories/index.jsx
@@ -26,6 +26,7 @@ export const SecurityBundle = Template.bind( {} );
 SecurityBundle.parameters = {};
 SecurityBundle.args = {
 	slug: 'security',
+	icon: '',
 	name: 'Security',
 	title: 'Security',
 	subTitle: '',
@@ -54,6 +55,7 @@ export const JetpackBackup = Template.bind( {} );
 JetpackBackup.parameters = {};
 JetpackBackup.args = {
 	slug: 'backup',
+	icon: '',
 	name: 'Backup',
 	title: 'Jepack Backup',
 	subTitle: '',
@@ -81,6 +83,7 @@ export const JetpackProtect = Template.bind( {} );
 JetpackProtect.parameters = {};
 JetpackProtect.args = {
 	slug: 'protect',
+	icon: 'jetpack',
 	title: 'Protect',
 	subTitle: 'Protect your site and scan for security vulnerabilities listed in our database.',
 	features: [

--- a/projects/js-packages/components/components/product-offer/stories/index.jsx
+++ b/projects/js-packages/components/components/product-offer/stories/index.jsx
@@ -32,7 +32,7 @@ SecurityBundle.args = {
 	description: 'Comprehensive site security, including Backup, Scan, and Anti-spam.',
 	isBundle: true,
 	isCard: true,
-	supportedProducts: [ 'backup', 'scan', 'anti-spam' ],
+	supportedProducts: [ 'jetpack', 'backup', 'scan', 'anti-spam' ],
 	features: [
 		'Real-time cloud backups with 10GB storage',
 		'Automated real-time malware scan',
@@ -71,6 +71,28 @@ JetpackBackup.args = {
 		currency: 'USD',
 		price: 9.66,
 		offPrice: 3.95,
+	},
+	addProductUrl: '',
+	hasRequiredPlan: false,
+	isLoading: false,
+};
+
+export const JetpackProtect = Template.bind( {} );
+JetpackProtect.parameters = {};
+JetpackProtect.args = {
+	slug: 'protect',
+	title: 'Protect',
+	description: 'Protect your site and scan for security vulnerabilities listed in our database.',
+	features: [
+		'Over 20,000 listed vulnerabilities',
+		'Daily automatic scans',
+		'Check plugin and theme version status',
+		'Easy to navigate and use',
+	],
+	isBundle: false,
+	isCard: true,
+	pricing: {
+		isFree: true,
 	},
 	addProductUrl: '',
 	hasRequiredPlan: false,

--- a/projects/js-packages/components/components/product-offer/stories/index.jsx
+++ b/projects/js-packages/components/components/product-offer/stories/index.jsx
@@ -32,7 +32,7 @@ SecurityBundle.args = {
 	description: 'Comprehensive site security, including Backup, Scan, and Anti-spam.',
 	isBundle: true,
 	isCard: true,
-	supportedProducts: [ 'jetpack', 'backup', 'scan', 'anti-spam' ],
+	supportedProducts: [ 'backup', 'scan', 'anti-spam' ],
 	features: [
 		'Real-time cloud backups with 10GB storage',
 		'Automated real-time malware scan',

--- a/projects/js-packages/components/components/product-offer/stories/index.jsx
+++ b/projects/js-packages/components/components/product-offer/stories/index.jsx
@@ -82,7 +82,7 @@ JetpackProtect.parameters = {};
 JetpackProtect.args = {
 	slug: 'protect',
 	title: 'Protect',
-	description: 'Protect your site and scan for security vulnerabilities listed in our database.',
+	subTitle: 'Protect your site and scan for security vulnerabilities listed in our database.',
 	features: [
 		'Over 20,000 listed vulnerabilities',
 		'Daily automatic scans',

--- a/projects/js-packages/components/components/product-offer/style.module.scss
+++ b/projects/js-packages/components/components/product-offer/style.module.scss
@@ -43,7 +43,6 @@
 .product-icon {
 	display: flex;
 	align-items: center;
-	height: calc( var( --spacing-base ) * 4 );
 	margin-bottom: calc( var( --spacing-base ) * 4 );
 }
 

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.11.2",
+	"version": "0.11.3-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR allows to set a custom icon to the ProductOffer component. it comes up because currently is not possible to implement part of the Protect interstitial page:

<img width="680" alt="Screen Shot 2022-04-20 at 9 01 25 AM" src="https://user-images.githubusercontent.com/77539/164226046-09bb19a4-f0b0-49e5-9226-57cac219d8ef.png">

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add and expose `<JetpackIcon />` component
* Add `icon` property to the ProductOffer component

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1650293215361349-slack-C02TQF5VAJD

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use Storybook
* This PR adds a new story to the ProductOffer named `Jetpack Protect`
* Take a look at the card header.
* Confirm the Jetpack icon is there.
* Confirm the size (32px)

<img width="756" alt="image" src="https://user-images.githubusercontent.com/77539/164226457-998cade8-80b6-40ae-9096-cf6835ce6a39.png">
