### PR TITLE
Load block editor styles inline for iframed editors on Atomic sites

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-atomic-gutenberg-missing-styles
+++ b/projects/plugins/jetpack/changelog/fix-atomic-gutenberg-missing-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Load block editor styles inline for iframed editors on Atomic sites.

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -725,7 +725,7 @@ class Jetpack_Gutenberg {
 	 * Add the Gutenberg editor stylesheet to iframed editors, such as the site editor,
 	 * which don't have access to stylesheets added with `wp_enqueue_style`.
 	 *
-	 * This workaround is currently used by WordPress.com Simple sites.
+	 * This workaround is currently used by WordPress.com Simple and Atomic sites.
 	 *
 	 * @since 10.7
 	 *
@@ -1195,13 +1195,20 @@ class Jetpack_Gutenberg {
 	}
 }
 
-/*
- * Enable upgrade nudge for Atomic sites.
- * This feature is false as default,
- * so let's enable it through this filter.
- *
- * More doc: https://github.com/Automattic/jetpack/tree/master/projects/plugins/jetpack/extensions#upgrades-for-blocks
- */
 if ( ( new Host() )->is_woa_site() ) {
+	/**
+	* Enable upgrade nudge for Atomic sites.
+	 * This feature is false as default,
+	 * so let's enable it through this filter.
+	 *
+	 * More doc: https://github.com/Automattic/jetpack/tree/master/projects/plugins/jetpack/extensions#upgrades-for-blocks
+	 */
 	add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );
+
+	/**
+	 * Load block editor styles inline for iframed editors.
+	 *
+	 * @see paYJgx-1Kl-p2
+	 */
+	add_action( 'admin_init', array( 'Jetpack_Gutenberg', 'add_iframed_editor_style' ) );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #22787

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Enable the hotfix we use on Simple Sites for Atomic sites too.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use Jetpack Beta and switch to this branch
* Make sure that your site has Gutenberg plugin activated.
* Make sure that you have a FSE compatible theme installed.
* Go to Appearance > Editor (beta)
* Add the Donations block and make sure that it's styled properly.
* Note: the issue can be reproduced on all browsers, not just FIrefox.
