### PR TITLE
Payment Blocks: Fix failing tests because of an editor type mismatch

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-recurring-payments-failing-test
+++ b/projects/plugins/jetpack/changelog/fix-recurring-payments-failing-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix failing tests because of an editor type mismatch caused by imported packages side-effects

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/edit.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/edit.jsx
@@ -33,7 +33,7 @@ export default function Edit( { attributes, clientId, context, setAttributes } )
 	const updateSubscriptionPlan = useCallback(
 		newPlanId => {
 			const resolvePaymentUrl = paymentPlanId => {
-				if ( POST_EDITOR !== editorType ) {
+				if ( POST_EDITOR !== editorType || ! postLink ) {
 					return '#';
 				}
 

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/test/edit.js
@@ -16,6 +16,9 @@ jest.mock( '@wordpress/block-editor', () => ( {
 	InnerBlocks: () => <button>Mocked button</button>,
 } ) );
 
+// Mock the @wordpress/edit-post, used internally to resolve the fallback URL.
+jest.mock( '@wordpress/edit-post', () => jest.fn() );
+
 /**
  * Internal dependencies
  */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Fix failing tests because of an editor type mismatch caused by imported packages side-effects.

The Payment Button block uses the `getEditorType` utility to determine the current editor type.
If the block is used in the post editor, it will use the post's permalink as a fallback URL for the button, when it's rendered off-site (e.g. email, RSS feed, etc.).

`getEditorType` relies on the various core `edit-` packages. E.g. `@wordpress/edit-site` would indicate that we are using the site editor.

In a testing context, `getEditorType` would return "unknown", which would correctly stop the Payment Button to try to grab the post permalink.

https://github.com/Automattic/jetpack/pull/23979 added a `@wordpress/edit-post` store import into a component internally used by the Payment Button block.

The side effect of this import is that now the testing context **has** `@wordpress/edit-post`, and `getEditorType` returns "post", which in turn tries to get the permalink, which doesn't exist.

This change adds an additional guard for `! postLink` so that we don't try to resolve the URL if it doesn't exist.
Plus mocks the package to better isolate the test from dependencies side effects.

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Navigate to `projects/plugins/jetpack`.
* Run `pnpm jest extensions/blocks/recurring-payments/test/edit.js`.
* Make sure all tests pass.
