### PR TITLE
Search: add in CSS classes which were lost in a recent rebase

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10595,7 +10595,7 @@ packages:
       loader-utils: 2.0.2
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.65.0_webpack-cli@4.9.1
+      webpack: 5.65.0
 
   /babel-plugin-add-react-displayname/0.0.5:
     resolution: {integrity: sha1-M51M3be2X9YtHfnbn+BN4TQSK9U=}
@@ -12114,7 +12114,7 @@ packages:
       postcss-modules-values: 4.0.0_postcss@8.3.11
       postcss-value-parser: 4.2.0
       semver: 7.3.6
-      webpack: 5.65.0_webpack-cli@4.9.1
+      webpack: 5.65.0
 
   /css-minimizer-webpack-plugin/3.1.4_webpack@5.65.0:
     resolution: {integrity: sha512-JXnwBEA+a3FrmuBIJz7tKnCYGyraP86nuvX+wAqik1Lc8Ne9Ql8h5RpFbM3HjMpjXfhnqRBoTYIfArji5mteOg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10595,7 +10595,7 @@ packages:
       loader-utils: 2.0.2
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.65.0
+      webpack: 5.65.0_webpack-cli@4.9.1
 
   /babel-plugin-add-react-displayname/0.0.5:
     resolution: {integrity: sha1-M51M3be2X9YtHfnbn+BN4TQSK9U=}
@@ -12114,7 +12114,7 @@ packages:
       postcss-modules-values: 4.0.0_postcss@8.3.11
       postcss-value-parser: 4.2.0
       semver: 7.3.6
-      webpack: 5.65.0
+      webpack: 5.65.0_webpack-cli@4.9.1
 
   /css-minimizer-webpack-plugin/3.1.4_webpack@5.65.0:
     resolution: {integrity: sha512-JXnwBEA+a3FrmuBIJz7tKnCYGyraP86nuvX+wAqik1Lc8Ne9Ql8h5RpFbM3HjMpjXfhnqRBoTYIfArji5mteOg==}

--- a/projects/packages/search/changelog/update-search-record-meter-design-fix
+++ b/projects/packages/search/changelog/update-search-record-meter-design-fix
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: very minor update, re-adding two CSS styles lost in a rebase recently.
+
+

--- a/projects/packages/search/src/dashboard/components/record-meter/style.scss
+++ b/projects/packages/search/src/dashboard/components/record-meter/style.scss
@@ -14,6 +14,7 @@
 .jp-search-chart-legend {
 	list-style: none;
 	display: inline-block;
+	font-size: 0.9em;
 }
 
 ul.jp-search-chart-legend {

--- a/projects/packages/search/src/dashboard/components/record-meter/style.scss
+++ b/projects/packages/search/src/dashboard/components/record-meter/style.scss
@@ -85,3 +85,8 @@ ul.jp-search-chart-legend {
 .jp-search-record-meter .jp-search-notice-box > span.dops-notice__icon-wrapper {
 	background-color: rgba( 255, 255, 255, 0 );
 }
+
+.jp-search-record-meter {
+	border-bottom: 1px solid rgb( 225, 225, 225 );
+	padding: 30px 0;
+}


### PR DESCRIPTION
This (very minor) PR adds back in two CSS classes which were accidentally lost in a recent PR rebase recently. 

#### Changes proposed in this Pull Request:

Adds back in the padding above, and border-line below the record meter
Adds back in the font size styling for the chart legend. 


#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
On a site with an active Jetpack Search subscription, go to /wp-admin/admin.php?page=jetpack-search&features=record-meter and check:

* check that record meter once again has top & bottom padding
* check that chart legend font size is .9em
* check that the record meter section has a bottom border

![image](https://user-images.githubusercontent.com/30754158/164291132-2effe45a-64a0-4192-a9a8-c50988f7ad89.png)

