### PR TITLE
JS Connection: add default arg values for the useConnection() hook

### DIFF
--- a/projects/js-packages/connection/changelog/update-js-connection-use-connection-defaul-values
+++ b/projects/js-packages/connection/changelog/update-js-connection-use-connection-defaul-values
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+JS Connection: add default connection arguments for the useConnection() hook

--- a/projects/js-packages/connection/components/use-connection/index.jsx
+++ b/projects/js-packages/connection/components/use-connection/index.jsx
@@ -1,5 +1,3 @@
-/* global JP_CONNECTION_INITIAL_STATE */
-
 /**
  * External dependencies
  */
@@ -12,10 +10,12 @@ import restApi from '@automattic/jetpack-api';
  */
 import { STORE_ID } from '../../state/store';
 
+const initialState = window?.JP_CONNECTION_INITIAL_STATE ? window.JP_CONNECTION_INITIAL_STATE : {};
+
 export default ( {
-	registrationNonce = JP_CONNECTION_INITIAL_STATE?.registrationNonce,
-	apiRoot = JP_CONNECTION_INITIAL_STATE?.apiRoot,
-	apiNonce = JP_CONNECTION_INITIAL_STATE?.apiNonce,
+	registrationNonce = initialState.registrationNonce,
+	apiRoot = initialState.apiRoot,
+	apiNonce = initialState.apiNonce,
 	redirectUri,
 	autoTrigger,
 	from,

--- a/projects/js-packages/connection/components/use-connection/index.jsx
+++ b/projects/js-packages/connection/components/use-connection/index.jsx
@@ -1,3 +1,5 @@
+/* global JP_CONNECTION_INITIAL_STATE */
+
 /**
  * External dependencies
  */
@@ -11,14 +13,14 @@ import restApi from '@automattic/jetpack-api';
 import { STORE_ID } from '../../state/store';
 
 export default ( {
-	registrationNonce,
+	registrationNonce = JP_CONNECTION_INITIAL_STATE?.registrationNonce,
+	apiRoot = JP_CONNECTION_INITIAL_STATE?.apiRoot,
+	apiNonce = JP_CONNECTION_INITIAL_STATE?.apiNonce,
 	redirectUri,
-	apiRoot,
-	apiNonce,
 	autoTrigger,
 	from,
 	skipUserConnection,
-} ) => {
+} = {} ) => {
 	const { registerSite, connectUser, refreshConnectedPlugins } = useDispatch( STORE_ID );
 
 	const registrationError = useSelect( select => select( STORE_ID ).getRegistrationError() );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR defines default values for the `useConnection()` hook. So with these changes is possible to get connection data simply doing something like...

```jsx
const MyComponent = () => {
  const { isRegistered } = useConnection();
  return (
    // ...
  );
}
```

These data is picked from the `JP_CONNECTION_INITIAL_STATE` global var.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* JS Connection: add default arg values for the useConnection() hook

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1650476850617069/1650473629.299269-slack-C02TQF5VAJD

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

These change should not change the workflow of the connection flow, not introducing braking changes either.
I suggest testing the connectivity in My Jetpack overview page.