### PR TITLE
WAF: Add cron to regularly update rules

### DIFF
--- a/projects/packages/waf/actions.php
+++ b/projects/packages/waf/actions.php
@@ -26,7 +26,7 @@ add_action(
 add_action( 'jetpack_waf_rules_update_cron', array( __NAMESPACE__ . '\Waf_Runner', 'update_rules_cron' ) );
 
 if ( ! wp_next_scheduled( 'jetpack_waf_rules_update_cron' ) ) {
-	wp_schedule_event( time(), 'hourly', 'jetpack_waf_rules_update_cron' );
+	wp_schedule_event( time(), 'twicedaily', 'jetpack_waf_rules_update_cron' );
 }
 
 /**

--- a/projects/packages/waf/actions.php
+++ b/projects/packages/waf/actions.php
@@ -21,6 +21,15 @@ add_action(
 );
 
 /**
+ * Cron to update the rules periodically.
+ */
+add_action( 'jetpack_waf_rules_update_cron', array( __NAMESPACE__ . '\Waf_Runner', 'update_rules_cron' ) );
+
+if ( ! wp_next_scheduled( 'jetpack_waf_rules_update_cron' ) ) {
+	wp_schedule_event( time(), 'hourly', 'jetpack_waf_rules_update_cron' );
+}
+
+/**
  * Runs the WAF in the WP context.
  *
  * @return void

--- a/projects/packages/waf/changelog/add-waf-update-cron
+++ b/projects/packages/waf/changelog/add-waf-update-cron
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+added cron to update rules


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a cron to update the rules hourly
* Changes the way we connect to the remote API, when on a cron context we don't have a logged in user, so we need to connect to the API using a blog token instead of a user token.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1201069996155224-as-1201965730421001

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the cron events page under tool in your wp-admin and force the cron to run
* Verify that the rules were updated accordingly
* Verify that a timestamp of when the cron ran was saved in the `jetpack_waf_last_updated_timestamp` wp_option