### PR TITLE
Stripe Nudge: Add missing stripe nudge to payment blocks

### DIFF
--- a/projects/plugins/jetpack/changelog/add-missing-stripe-nudge-to-payment-blocks
+++ b/projects/plugins/jetpack/changelog/add-missing-stripe-nudge-to-payment-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Created a Stripe connect nudge that is aware of the product management store

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/edit.js
@@ -18,6 +18,7 @@ import ViewSelector from './_inc/view-selector';
 import ProductManagementControls from '../../shared/components/product-management-controls';
 import { PRODUCT_TYPE_SUBSCRIPTION } from '../../shared/components/product-management-controls/constants';
 import { store as membershipProductsStore } from '../../store/membership-products';
+import { MembershipStoreAwareStripeNudge } from '../../shared/components/stripe-nudge';
 
 /**
  * Tab definitions
@@ -42,7 +43,7 @@ const tabs = [
 
 const CONTENT_TAB = 0;
 const WALL_TAB = 1;
-
+const BLOCK_NAME = 'premium-content';
 /**
  *
  * @typedef { import('react').MutableRefObject<?object> } ContainerRef
@@ -119,7 +120,7 @@ function Edit( props ) {
 						</Placeholder>
 					) }
 					<ProductManagementControls
-						blockName="premium-content"
+						blockName={ BLOCK_NAME }
 						clientId={ clientId }
 						productType={ PRODUCT_TYPE_SUBSCRIPTION }
 						selectedProductId={ selectedPlanId }
@@ -135,9 +136,12 @@ function Edit( props ) {
 				</>
 			) }
 			{ ! isApiLoading && (
-				<Context.Provider value={ { selectedTab } }>
-					<Blocks />
-				</Context.Provider>
+				<>
+					<MembershipStoreAwareStripeNudge blockName={ BLOCK_NAME } />
+					<Context.Provider value={ { selectedTab } }>
+						<Blocks />
+					</Context.Provider>
+				</>
 			) }
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/editor.scss
@@ -34,44 +34,6 @@
 	margin: 0;
 }
 
-.premium-content-block-nudge .editor-warning {
-	margin-bottom: 0;
-}
-
-.premium-content-block-nudge .editor-warning__message {
-	margin: 13px 0;
-}
-
-.premium-content-block-nudge .editor-warning__actions {
-	line-height: 1;
-}
-
-.premium-content-block-nudge .premium-content-block-nudge__info {
-	font-size: $default-font-size;
-	display: flex;
-	flex-direction: row;
-	line-height: 1.4;
-}
-
-.premium-content-block-nudge .premium-content-block-nudge__text-container {
-	display: flex;
-	flex-direction: column;
-	padding-left: 10px;
-}
-
-.premium-content-block-nudge .premium-content-block-nudge__title {
-	font-size: 14px;
-}
-
-.premium-content-block-nudge__message {
-	color: var( --color-text-subtle );
-}
-
-.editor-styles-wrapper a.premium-content-block-nudge__button {
-	color: #0075af;
-	text-decoration: none;
-}
-
 .membership-button__disclaimer {
 	color: var( --color-gray-200 );
 	flex-basis: 100%;
@@ -100,7 +62,7 @@
 
 /* Hide Stripe nudge from Jetpack payments block */
 /* https://github.com/Automattic/wp-calypso/issues/44332 */
-.wp-block-premium-content-container .jetpack-block-nudge {
+.wp-block-premium-content-container .premium-content-wrapper .jetpack-block-nudge {
 	display: none;
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/edit.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/edit.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { getJetpackExtensionAvailability } from '@automattic/jetpack-shared-extension-utils';
+import { useCallback } from 'react';
 
 /**
  * WordPress dependencies
@@ -12,6 +13,7 @@ import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -20,8 +22,10 @@ import { icon, title } from './';
 import ProductManagementControls from '../../shared/components/product-management-controls';
 import { store as membershipProductsStore } from '../../store/membership-products';
 import { getEditorType, POST_EDITOR } from '../../shared/get-editor-type';
-import { useEffect } from '@wordpress/element';
-import { useCallback } from 'react';
+import { MembershipStoreAwareStripeNudge } from '../../shared/components/stripe-nudge';
+
+// If we use the name on index.js and the block name changes the events block name will also change.
+const BLOCK_NAME = 'recurring-payments';
 
 export default function Edit( { attributes, clientId, context, setAttributes } ) {
 	const { planId } = attributes;
@@ -74,7 +78,7 @@ export default function Edit( { attributes, clientId, context, setAttributes } )
 		<div className="wp-block-jetpack-recurring-payments">
 			{ showControls && (
 				<ProductManagementControls
-					blockName="recurring-payments"
+					blockName={ BLOCK_NAME }
 					clientId={ clientId }
 					selectedProductId={ planId }
 					setSelectedProductId={ updateSubscriptionPlan }
@@ -100,7 +104,7 @@ export default function Edit( { attributes, clientId, context, setAttributes } )
 					</div>
 				</Placeholder>
 			) }
-
+			<MembershipStoreAwareStripeNudge blockName={ BLOCK_NAME } />
 			<InnerBlocks
 				template={ [
 					[

--- a/projects/plugins/jetpack/extensions/shared/components/stripe-nudge/index.jsx
+++ b/projects/plugins/jetpack/extensions/shared/components/stripe-nudge/index.jsx
@@ -7,6 +7,7 @@ import GridiconStar from 'gridicons/dist/star';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { select } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -14,6 +15,7 @@ import { __ } from '@wordpress/i18n';
 import analytics from '../../../../_inc/client/lib/analytics';
 import BlockNudge from '../block-nudge';
 import getConnectUrl from '../../get-connect-url';
+import { store as membershipProductsStore } from '../../../store/membership-products';
 
 import './style.scss';
 
@@ -43,6 +45,17 @@ export const StripeNudge = ( { blockName, url } ) => (
 		) }
 	/>
 );
+
+export const MembershipStoreAwareStripeNudge = ( { blockName } ) => {
+	const store = select( membershipProductsStore );
+	const stripeConnectUrl = store.getConnectUrl();
+
+	if ( store.getShouldUpgrade() || ! stripeConnectUrl ) {
+		return null;
+	}
+
+	return <StripeNudge blockName={ blockName } url={ stripeConnectUrl } />;
+};
 
 export default ( { blockName, postId, stripeConnectUrl } ) => {
 	const url = getConnectUrl( postId, stripeConnectUrl );

--- a/projects/plugins/jetpack/extensions/shared/test/stripe-nudge-test.js
+++ b/projects/plugins/jetpack/extensions/shared/test/stripe-nudge-test.js
@@ -1,0 +1,72 @@
+/**
+ * WordPress dependencies
+ */
+import * as data from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { MembershipStoreAwareStripeNudge } from "../components/stripe-nudge";
+
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom/extend-expect';
+import { render, screen, waitFor } from "@testing-library/react";
+
+describe( 'Stripe nudge component', () => {
+
+    describe( 'Membership store aware stripe nudge tests', () => {
+
+        const selectSpy = jest.spyOn( data, 'select' );
+        const ANY_VALID_CONNECT_URL = 'anyValidConnectUrl';
+        const ANY_INVALID_CONNECT_URL = null;
+        const USER_SHOULD_NOT_UPGRADE_PLAN = false;
+        const USER_MUST_UPGRADE_PLAN = true;
+        const ANY_BLOCK_NAME = 'anyBlockName';
+        const NUDGE_RENDERED_TEXT = 'Connect to Stripe to use this block on your site';
+
+        test( 'Given that we have a paid plan and a Stripe connect URL, we display the Stripe connect nudge.', async () => {
+            // Given
+            selectSpy.mockImplementation(() => ( {
+                getShouldUpgrade: () => USER_SHOULD_NOT_UPGRADE_PLAN,
+                getConnectUrl: () => ANY_VALID_CONNECT_URL
+            } ) );
+
+            // When
+            render( <MembershipStoreAwareStripeNudge blockName={ ANY_BLOCK_NAME } /> );
+
+            // Then
+            await waitFor( () => expect( screen.getByText( NUDGE_RENDERED_TEXT ) ).toBeInTheDocument() );
+        } );
+
+        test( 'When the user needs to upgrade his plan we will not show the Stripe nudge.', async () => {
+            // Given
+            selectSpy.mockImplementation(() => ( {
+                getShouldUpgrade: () => USER_MUST_UPGRADE_PLAN,
+                getConnectUrl: () => ANY_VALID_CONNECT_URL
+            } ) );
+
+            // When
+            render( <MembershipStoreAwareStripeNudge blockName={ ANY_BLOCK_NAME } /> );
+
+            // Then
+            await waitFor( () => expect( screen.queryByText( NUDGE_RENDERED_TEXT ) ).not.toBeInTheDocument() );
+        } );
+
+        test( 'When we do not have a connect URL to connect to we will not show the Stripe connect nudge', async () => {
+            // Given
+            selectSpy.mockImplementation(() => ( {
+                getShouldUpgrade: () => USER_SHOULD_NOT_UPGRADE_PLAN,
+                getConnectUrl: () => ANY_INVALID_CONNECT_URL
+            } ) );
+
+            // When
+            render( <MembershipStoreAwareStripeNudge blockName={ ANY_BLOCK_NAME } /> );
+
+            // Then
+            await waitFor( () => expect( screen.queryByText( NUDGE_RENDERED_TEXT ) ).not.toBeInTheDocument() );
+        } );
+    } )
+} );
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #24034

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Created a new Stripe Nudge component that is aware of the membership-products store. This component will show the Stripe Nudge when necessary without requiring any parametrization other than the blockName.
* Cleaned up some unnecessary CSS code in the Premium Content Block specific to the Stripe connect nudge since the payment blocks are not responsible for the Stripe connect nudge component.
* Other minor improvements: organized some incorrectly placed imports.
* Added unit tests for the Stripe Nudge (only for new code)

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure that you do not have a Stripe connection active.
* Create or Edit a Post.
* Add a Premium Content Block and a Payments Block (recurring payments)
* Both of these blocks should have a Stripe connect nudge.
* Once you finish the connection process the nudge should not be displayed.
* When we require to upgrade our plan the upgrade plan nudge should be shown instead of the connect Stripe nudge.

#### Testing nudge is displayed
https://user-images.githubusercontent.com/1989914/164457718-9a50e9b5-b1b1-4262-b847-55686618dac3.mp4

#### Testing nudge isn't shown after connection
https://user-images.githubusercontent.com/1989914/164458195-862780e1-f325-4201-a137-f14ad665b8ce.mp4

#### Testing upgrade nudge overrides connect nudge
https://user-images.githubusercontent.com/1989914/164458516-23d7d08f-b2a6-4b76-a175-22d49d8a89ce.mp4



