### PR TITLE
Protect: replace ConnectionScreen with the Interstitial component

### DIFF
--- a/projects/js-packages/components/changelog/tweak-dialog-and-product-offer-components
+++ b/projects/js-packages/components/changelog/tweak-dialog-and-product-offer-components
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+JS Components: improve box-model composed by dialog and product-offer components

--- a/projects/js-packages/components/components/dialog/style.module.scss
+++ b/projects/js-packages/components/components/dialog/style.module.scss
@@ -13,7 +13,7 @@
 	}
 }
 
-.secondary {
+.primary,
+.secodanary {
 	display: flex;
-	align-items: center;
 }

--- a/projects/js-packages/components/components/product-offer/index.jsx
+++ b/projects/js-packages/components/components/product-offer/index.jsx
@@ -119,8 +119,11 @@ const ProductOffer = ( {
 	const { isFree, price, currency, offPrice } = pricing;
 	const needsPurchase = ! isFree && ! hasRequiredPlan;
 
-	/* translators: placeholder is product name. */
-	const defautlButtonText = sprintf( __( 'Add %s', 'jetpack' ), title );
+	const defautlButtonText = sprintf(
+		/* translators: placeholder is product name. */
+		__( 'Add %s', 'jetpack' ),
+		title
+	);
 
 	return (
 		<div

--- a/projects/js-packages/components/components/product-offer/style.module.scss
+++ b/projects/js-packages/components/components/product-offer/style.module.scss
@@ -1,5 +1,4 @@
 .wrapper {
-	height: 100%;
 	padding: calc( var( --spacing-base ) * 8 );
 	position: relative;
 
@@ -26,6 +25,7 @@
 	top: 0;
 	left: 0;
 	width: 100%;
+	box-sizing: border-box;
 }
 
 .card-container {

--- a/projects/plugins/protect/changelog/update-protect-update-connect-page
+++ b/projects/plugins/protect/changelog/update-protect-update-connect-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Protect: Change ConnectScreen by the Interstitial component

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -21,7 +21,7 @@ import useProtectData from '../../hooks/use-protect-data';
 import Interstitial from '../interstitial';
 
 const Admin = () => {
-	const { isRegistered, handleRegisterSite } = useConnection( { skipUserConnection: true } );
+	const { isRegistered } = useConnection( { skipUserConnection: true } );
 	const { plugins, themes, core } = useProtectData();
 
 	// Show interstital page when Jetpack is not connected.
@@ -34,7 +34,7 @@ const Admin = () => {
 			>
 				<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 					<Col sm={ 4 } md={ 8 } lg={ 12 }>
-						<Interstitial onProtectAdd={ handleRegisterSite } />
+						<Interstitial />
 					</Col>
 				</Container>
 			</AdminPage>

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -10,8 +10,7 @@ import {
 	Col,
 } from '@automattic/jetpack-components';
 
-import { useSelect } from '@wordpress/data';
-import { ConnectScreen, CONNECTION_STORE_ID } from '@automattic/jetpack-connection';
+import { useConnection } from '@automattic/jetpack-connection';
 import React from 'react';
 
 /**
@@ -20,78 +19,55 @@ import React from 'react';
 import Summary from '../summary';
 import VulnerabilitiesList from '../vulnerabilities-list';
 import useProtectData from '../../hooks/use-protect-data';
+import Interstitial from '../interstitial';
 
 const Admin = () => {
-	const connectionStatus = useSelect(
-		select => select( CONNECTION_STORE_ID ).getConnectionStatus(),
-		[]
-	);
-	const { isRegistered } = connectionStatus;
-	const showConnectionCard = ! isRegistered;
+	const { isRegistered, handleRegisterSite } = useConnection( { skipUserConnection: true } );
 	const { plugins, themes, core } = useProtectData();
-	return (
-		<AdminPage moduleName={ __( 'Jetpack Protect', 'jetpack-protect' ) }>
-			{ showConnectionCard ? (
+
+	// Show interstital page when Jetpack is not connected.
+	if ( ! isRegistered ) {
+		return (
+			<AdminPage
+				moduleName={ __( 'Jetpack Protect', 'jetpack-protect' ) }
+				showHeader={ false }
+				showBackground={ false }
+			>
 				<AdminSectionHero>
 					<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 						<Col sm={ 4 } md={ 8 } lg={ 12 }>
-							<ConnectionSection />
+							<Interstitial onProtectAdd={ handleRegisterSite } />
 						</Col>
 					</Container>
 				</AdminSectionHero>
-			) : (
-				<>
-					<AdminSectionHero>
-						<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
-							<Col>
-								<Summary />
-							</Col>
-						</Container>
-					</AdminSectionHero>
-					<AdminSection>
-						<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
-							<Col>
-								<VulnerabilitiesList title="WordPress" list={ [ core ] } />
-							</Col>
-							<Col>
-								<VulnerabilitiesList title="Plugins" list={ plugins } />
-							</Col>
-							<Col>
-								<VulnerabilitiesList title="Themes" list={ themes } />
-							</Col>
-						</Container>
-					</AdminSection>
-				</>
-			) }
+			</AdminPage>
+		);
+	}
+
+	return (
+		<AdminPage moduleName={ __( 'Jetpack Protect', 'jetpack-protect' ) }>
+			<AdminSectionHero>
+				<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
+					<Col>
+						<Summary />
+					</Col>
+				</Container>
+			</AdminSectionHero>
+			<AdminSection>
+				<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
+					<Col>
+						<VulnerabilitiesList title="WordPress" list={ [ core ] } />
+					</Col>
+					<Col>
+						<VulnerabilitiesList title="Plugins" list={ plugins } />
+					</Col>
+					<Col>
+						<VulnerabilitiesList title="Themes" list={ themes } />
+					</Col>
+				</Container>
+			</AdminSection>
 		</AdminPage>
 	);
 };
 
 export default Admin;
-
-const ConnectionSection = () => {
-	const { apiNonce, apiRoot, registrationNonce } = window.jetpackProtectInitialState;
-	return (
-		<ConnectScreen
-			apiNonce={ apiNonce }
-			registrationNonce={ registrationNonce }
-			apiRoot={ apiRoot }
-			// images={ [ '/images/jetpack-protect-connect.png' ] }
-			// assetBaseUrl={ assetBaseUrl }
-			from={ 'jetpack-protect' }
-			title={ __(
-				'Security tools that keep your site safe and sound, from posts to plugins.',
-				'jetpack-protect'
-			) }
-			buttonLabel={ __( 'Set up Jetpack Protect', 'jetpack-protect' ) }
-			//redirectUri="admin.php?page=jetpack-protect"
-			skipUserConnection
-		>
-			<h3>{ __( 'Jetpack’s security features include', 'jetpack-protect' ) }</h3>
-			<ul>
-				<li>{ __( 'Scan for known plugin & theme vulnerabilities', 'jetpack-protect' ) }</li>
-				<li>{ __( 'Database of vulnerabilities manually updated daily', 'jetpack-protect' ) }</li>
-			</ul>
-		</ConnectScreen>
-	);
-};

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { __ } from '@wordpress/i18n';
 import {
 	AdminPage,
@@ -9,9 +10,7 @@ import {
 	Container,
 	Col,
 } from '@automattic/jetpack-components';
-
 import { useConnection } from '@automattic/jetpack-connection';
-import React from 'react';
 
 /**
  * Internal dependencies
@@ -33,13 +32,11 @@ const Admin = () => {
 				showHeader={ false }
 				showBackground={ false }
 			>
-				<AdminSectionHero>
-					<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
-						<Col sm={ 4 } md={ 8 } lg={ 12 }>
-							<Interstitial onProtectAdd={ handleRegisterSite } />
-						</Col>
-					</Container>
-				</AdminSectionHero>
+				<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
+					<Col sm={ 4 } md={ 8 } lg={ 12 }>
+						<Interstitial onProtectAdd={ handleRegisterSite } />
+					</Col>
+				</Container>
 			</AdminPage>
 		);
 	}

--- a/projects/plugins/protect/src/js/components/interstitial/index.jsx
+++ b/projects/plugins/protect/src/js/components/interstitial/index.jsx
@@ -2,9 +2,9 @@
  * External dependencies
  */
 import React from 'react';
-import PropTypes from 'prop-types';
 import { __ } from '@wordpress/i18n';
 import { Dialog, ProductOffer } from '@automattic/jetpack-components';
+import { useConnection } from '@automattic/jetpack-connection';
 
 /**
  * Internal dependencies
@@ -41,38 +41,26 @@ const SecurityBundle = props => (
 /**
  * Intersitial Protect component.
  *
- * @param {object} props                 - Component props.
- * @param {Function} props.isFetching    - Whether there is a fetching in progress
- * @param {Function} props.onProtectAdd  - Callback to bind when adding the Protect product.
- * @param {Function} props.onSecurityAdd - Callback to bind when adding the Security bundle product.
- * @returns {React.Component}              Interstitial react component.
+ * @returns {React.Component} Interstitial react component.
  */
-const Interstitial = ( { onProtectAdd, onSecurityAdd, isFetching } ) => {
+const Interstitial = () => {
+	const { siteIsRegistering, handleRegisterSite } = useConnection( {
+		skipUserConnection: true,
+	} );
+
 	return (
 		<Dialog
 			primary={
-				<ConnectedProductOffer onAdd={ onProtectAdd } isLoading={ isFetching } isCard={ true } />
+				<ConnectedProductOffer
+					onAdd={ handleRegisterSite }
+					isLoading={ siteIsRegistering }
+					isCard={ true }
+				/>
 			}
-			secondary={ <SecurityBundle onAdd={ onSecurityAdd } isLoading={ isFetching } /> }
+			secondary={ <SecurityBundle /> }
 			split={ true }
 		/>
 	);
-};
-Interstitial.propTypes = {
-	/** Callback function to bind when adding the Protect product. */
-	onProtectAdd: PropTypes.func,
-
-	/** Callback function to bind when adding the Security bundle product. */
-	onSecurityAdd: PropTypes.func,
-
-	/** Whether there is a fetching in progress */
-	isFetching: PropTypes.bool,
-};
-
-Interstitial.defaultProps = {
-	onProtectAdd: () => {},
-	onSecurityAdd: () => {},
-	isFetching: false,
 };
 
 export default Interstitial;

--- a/projects/plugins/protect/src/js/components/interstitial/index.jsx
+++ b/projects/plugins/protect/src/js/components/interstitial/index.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { Dialog, ProductOffer } from '@automattic/jetpack-components';
-import { useConnection } from '@automattic/jetpack-connection';
 
 /**
  * Internal dependencies
@@ -44,19 +43,9 @@ const SecurityBundle = props => (
  * @returns {React.Component} Interstitial react component.
  */
 const Interstitial = () => {
-	const { siteIsRegistering, handleRegisterSite } = useConnection( {
-		skipUserConnection: true,
-	} );
-
 	return (
 		<Dialog
-			primary={
-				<ConnectedProductOffer
-					onAdd={ handleRegisterSite }
-					isLoading={ siteIsRegistering }
-					isCard={ true }
-				/>
-			}
+			primary={ <ConnectedProductOffer isCard={ true } /> }
 			secondary={ <SecurityBundle /> }
 			split={ true }
 		/>

--- a/projects/plugins/protect/src/js/components/interstitial/stories/index.jsx
+++ b/projects/plugins/protect/src/js/components/interstitial/stories/index.jsx
@@ -20,6 +20,3 @@ export default {
 
 const InterstitialTemplate = args => <Interstitial { ...args } />;
 export const Default = InterstitialTemplate.bind( {} );
-Default.args = {
-	isFetching: false,
-};

--- a/projects/plugins/protect/src/js/components/product-offer/index.jsx
+++ b/projects/plugins/protect/src/js/components/product-offer/index.jsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-import React, { useCallback } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { ProductOffer as ProductOfferComponent } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
+import { ProductOffer as ProductOfferComponent } from '@automattic/jetpack-components';
+import { useConnection } from '@automattic/jetpack-connection';
 
 const PROTECT_PRODUCT_MOCK = {
 	slug: 'protect',
@@ -30,16 +31,9 @@ const PROTECT_PRODUCT_MOCK = {
  * @returns {object}                    ConnectedProductOffer react component.
  */
 const ConnectedProductOffer = ( { onAdd, ...rest } ) => {
-	/**
-	 * ToDo: Implement bound function when adding the product.
-	 *
-	 * @returns {boolean} False. Todo: implement.
-	 */
-	const AddButtonHandler = useCallback( () => {
-		if ( onAdd ) {
-			onAdd();
-		}
-	}, [ onAdd ] );
+	const { siteIsRegistering, handleRegisterSite } = useConnection( {
+		skipUserConnection: true,
+	} );
 
 	return (
 		<ProductOfferComponent
@@ -49,9 +43,10 @@ const ConnectedProductOffer = ( { onAdd, ...rest } ) => {
 			features={ PROTECT_PRODUCT_MOCK.features }
 			pricing={ { isFree: true } }
 			isBundle={ false }
-			onAdd={ AddButtonHandler }
+			onAdd={ handleRegisterSite }
 			buttonText={ __( 'Get started with Jetpack Protect', 'jetpack-protect' ) }
 			icon="jetpack"
+			isLoading={ siteIsRegistering }
 			{ ...rest }
 		/>
 	);

--- a/projects/plugins/protect/src/js/components/product-offer/index.jsx
+++ b/projects/plugins/protect/src/js/components/product-offer/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { __ } from '@wordpress/i18n';
-import { ProductOffer as ProductOfferComponent } from '@automattic/jetpack-components';
+import { ProductOffer } from '@automattic/jetpack-components';
 import { useConnection } from '@automattic/jetpack-connection';
 
 const PROTECT_PRODUCT_MOCK = {
@@ -36,7 +36,7 @@ const ConnectedProductOffer = ( { onAdd, ...rest } ) => {
 	} );
 
 	return (
-		<ProductOfferComponent
+		<ProductOffer
 			slug={ PROTECT_PRODUCT_MOCK.slug }
 			title={ PROTECT_PRODUCT_MOCK.title }
 			description={ PROTECT_PRODUCT_MOCK.description }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR replaces the usage of the `<ConnectionScreen />` component (which belongs to jetpack-connection pkg) by the Protect Interstitial page.

Disclaimer: It implements the connection workflow for the Protect plugin. Security bundle will be addressed in a follow-up PR.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Security: replace ConnectionScreen with the Interstitial component. Relevant changes:
- Update AdminPage component
- Tweak Dialog and ProductOffer jetpack-components
- Simplify Protect interstitial page

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Disconnect the site
* Go to Protect plugin page
* Confirm you see the interstitial page
* Confirm you can connect the site by clicking on the `Get started with Jetpack Protect` button.

https://user-images.githubusercontent.com/77539/164505463-f90df7ec-9ff8-43af-b174-86950e3f4e20.mov


