### PR TITLE
E2E tests: Ignore a console React warning that's polluting test logs

### DIFF
--- a/tools/e2e-commons/config/default.cjs
+++ b/tools/e2e-commons/config/default.cjs
@@ -35,6 +35,7 @@ const config = {
 		'is deprecated',
 		'SharedArrayBuffer will require cross-origin isolation as of M91, around May 2021',
 		'Warning: getDefaultProps is only used on classic React.createClass definitions',
+		'Warning: A future version of React will block javascript: URLs as a security precaution',
 	],
 	repository: {
 		url: 'https://github.com/Automattic/jetpack',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

A React warning started polluting the e2e tests logs. This PR adds it in the console ignore list.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* CI green