### PR TITLE
Make remove_connection a proxy method

### DIFF
--- a/projects/packages/connection/changelog/update-remove_connection_function
+++ b/projects/packages/connection/changelog/update-remove_connection_function
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Make remove_connection a proxy method to ensure all trackings are triggered

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -1637,15 +1637,16 @@ class Manager {
 	 * This is a proxy method to simplify the Connection package API.
 	 *
 	 * @see Manager::disable_plugin()
-	 * @see Manager::disconnect_site_wpcom()
-	 * @see Manager::delete_all_connection_tokens()
+	 * @see Manager::disconnect_site()
 	 *
+	 * @param boolean $disconnect_wpcom Should disconnect_site_wpcom be called.
+	 * @param bool    $ignore_connected_plugins Delete the tokens even if there are other connected plugins.
 	 * @return bool
 	 */
-	public function remove_connection() {
+	public function remove_connection( $disconnect_wpcom = true, $ignore_connected_plugins = false ) {
+
 		$this->disable_plugin();
-		$this->disconnect_site_wpcom();
-		$this->delete_all_connection_tokens();
+		$this->disconnect_site( $disconnect_wpcom, $ignore_connected_plugins );
 
 		return true;
 	}
@@ -1976,8 +1977,13 @@ class Manager {
 	 * Forgets all connection details and tells the Jetpack servers to do the same.
 	 *
 	 * @param boolean $disconnect_wpcom Should disconnect_site_wpcom be called.
+	 * @param bool    $ignore_connected_plugins Delete the tokens even if there are other connected plugins.
 	 */
-	public function disconnect_site( $disconnect_wpcom = true ) {
+	public function disconnect_site( $disconnect_wpcom = true, $ignore_connected_plugins = true ) {
+		if ( ! $ignore_connected_plugins && null !== $this->plugin && ! $this->plugin->is_only() ) {
+			return false;
+		}
+
 		wp_clear_scheduled_hook( 'jetpack_clean_nonces' );
 
 		( new Nonce_Handler() )->clean_all();
@@ -1995,10 +2001,10 @@ class Manager {
 			$tracking = new Tracking();
 			$tracking->record_user_event( 'disconnect_site', array() );
 
-			$this->disconnect_site_wpcom( true );
+			$this->disconnect_site_wpcom( $ignore_connected_plugins );
 		}
 
-		$this->delete_all_connection_tokens( true );
+		$this->delete_all_connection_tokens( $ignore_connected_plugins );
 
 		// Remove tracked package versions, since they depend on the Jetpack Connection.
 		delete_option( Package_Version_Tracker::PACKAGE_VERSION_OPTION );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We had 2 methods that were doing a very similar things: disconnecting jetpack.

`disconnect_jetpack` was doing some extra cleaning and also firing track events, while `remove_connection` was the preferred API for stand-alone plugins and did not perform those additional cleaning and tracking.

This PR unifies it all in `jetpack_disconnect` and makes `remove_connection` a simple proxy method with different default values for the parameters.

This ensures that Jetpack will still trigger disconnection events after https://github.com/Automattic/jetpack/pull/23957

Note: https://github.com/Automattic/jetpack/pull/23991 will also change `remove_connection` and it will end up with just one line.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Make remove_connection a proxy method and centralize disconnection on just one method

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-4n9-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install and activate Jetpack and Boost
* Connect
* Deactivate one of the plugins
* Make sure the other plugin is still connected
* Deactivate the second plugin and activate one of them again
* Make sure the connection is gone and you have to re-connect
* reconnect
* Go to My Jetpack and Disconnect. make sure it works
* Reconnect
* Go to Jetpack Dashboard, click in "Manage connection" and disconnect. Make sure it works