### PR TITLE
Boost: Update Cloud CSS request to contain unique request ID

### DIFF
--- a/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS_Request.php
+++ b/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS_Request.php
@@ -19,7 +19,7 @@ class Cloud_CSS_Request {
 	public function request_generate( $providers ) {
 		$client               = Boost_API::get_client();
 		$payload              = array( 'providers' => $providers );
-		$payload['requestId'] = md5( wp_json_encode( $payload ) );
+		$payload['requestId'] = md5( wp_json_encode( $payload ) . time() );
 
 		$this->reset_existing_css();
 		return $client->post( 'cloud-css', $payload );

--- a/projects/plugins/boost/changelog/update-cloud-css-request-id
+++ b/projects/plugins/boost/changelog/update-cloud-css-request-id
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Refactored Cloud CSS request to contain unique request ID with time.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Cloud CSS request is updated to contain a unique request ID with the help of timestamp.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
NA

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout the changes from this PR
* Follow the instructions in 53-gh-Automattic/boost-shield-api to test the logs
* Ensure that each request is listed separately under the `Requests` section in the dashboard.