### PR TITLE
Protect: add error message when adding plugin fails

### DIFF
--- a/projects/plugins/protect/changelog/update-protect-add-error-message-when-adding-plugin
+++ b/projects/plugins/protect/changelog/update-protect-add-error-message-when-adding-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Protect: add error message when adding plugin fails

--- a/projects/plugins/protect/src/js/components/product-offer/index.jsx
+++ b/projects/plugins/protect/src/js/components/product-offer/index.jsx
@@ -31,7 +31,7 @@ const PROTECT_PRODUCT_MOCK = {
  * @returns {object}                    ConnectedProductOffer react component.
  */
 const ConnectedProductOffer = ( { onAdd, ...rest } ) => {
-	const { siteIsRegistering, handleRegisterSite } = useConnection( {
+	const { siteIsRegistering, handleRegisterSite, registrationError } = useConnection( {
 		skipUserConnection: true,
 	} );
 
@@ -47,6 +47,9 @@ const ConnectedProductOffer = ( { onAdd, ...rest } ) => {
 			buttonText={ __( 'Get started with Jetpack Protect', 'jetpack-protect' ) }
 			icon="jetpack"
 			isLoading={ siteIsRegistering }
+			error={
+				registrationError ? __( 'An error occurred. Please try again.', 'jetpack-protect' ) : null
+			}
 			{ ...rest }
 		/>
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds error message to the Protect Offer component when adding the plugin fails.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Protect: add error message when adding plugin fails

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Disconnect the site
* Go to Protect plugin page: `http://<your-testing-site>/wp-admin/admin.php?page=jetpack-protect`
* Test with localhost because it's easy to generate a `403` response error
* Try to add Protect
* You should see the error there

https://user-images.githubusercontent.com/77539/164784410-7496461a-31ba-4999-a7e6-f90bf5a2781f.mov

* Testing with a valid hostname it should connect

https://user-images.githubusercontent.com/77539/164784385-669d784a-367c-4fb1-b6f8-3534b0c11a11.mov


