### PR TITLE
WAF: Save log info in the database

### DIFF
--- a/projects/packages/waf/changelog/fix-waf-db-log
+++ b/projects/packages/waf/changelog/fix-waf-db-log
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+fixed database logging

--- a/projects/packages/waf/src/class-waf-runtime.php
+++ b/projects/packages/waf/src/class-waf-runtime.php
@@ -303,8 +303,6 @@ class Waf_Runtime {
 			$statement->bind_param( 'sis', $log_data['reason'], $log_data['rule_id'], $log_data['timestamp'] );
 			$statement->execute();
 
-			var_dump( $conn );
-
 			if ( $conn->insert_id > 100 ) {
 				$conn->query( "DELETE FROM {$table_prefix}jetpack_waf_blocklog ORDER BY log_id LIMIT 1" );
 			}

--- a/projects/packages/waf/src/class-waf-runtime.php
+++ b/projects/packages/waf/src/class-waf-runtime.php
@@ -301,6 +301,9 @@ class Waf_Runtime {
 		$statement = $conn->prepare( "INSERT INTO {$table_prefix}jetpack_waf_blocklog(reason,rule_id, timestamp) VALUES (?, ?, ?)" );
 		if ( false !== $statement ) {
 			$statement->bind_param( 'sis', $log_data['reason'], $log_data['rule_id'], $log_data['timestamp'] );
+			$statement->execute();
+
+			var_dump( $conn );
 
 			if ( $conn->insert_id > 100 ) {
 				$conn->query( "DELETE FROM {$table_prefix}jetpack_waf_blocklog ORDER BY log_id LIMIT 1" );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix db logging when a request is blocked by our WAF

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1650845956991089/1650639283.564489-slack-C029WFNV69M

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch and build the plugin with all it's dependencies
* Force a request to be blocked with the `jetpack-waf-always-block` query string parameter
* Verify that the request was logged to the blocklog file and the database as well.
*