### PR TITLE
Related Posts: allow using the block only, without adding related posts to the bottom of each post.

### DIFF
--- a/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
@@ -370,6 +370,16 @@ export function currentThemeSupports( state, feature ) {
 }
 
 /**
+ * Check that a theme is a block-enabled theme.
+ *
+ * @param {Object} state - Global state tree.
+ * @returns {boolean} Is the theme a block-enabled theme.
+ */
+export function isBlockTheme( state ) {
+	return get( state.jetpack.initialState.themeData, 'isBlockTheme', false );
+}
+
+/**
  * Check if backups UI should be displayed.
  *
  * @param {object} state Global state tree

--- a/projects/plugins/jetpack/_inc/client/traffic/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/index.jsx
@@ -25,10 +25,10 @@ import { GoogleAnalytics } from './google-analytics';
 import { Ads } from './ads';
 import { SiteStats } from './site-stats';
 import Shortlinks from './shortlinks';
-import { RelatedPosts } from './related-posts';
+import RelatedPosts from './related-posts';
 import { VerificationServices } from './verification-services';
 import Sitemaps from './sitemaps';
-import { getLastPostUrl, isAtomicSite } from 'state/initial-state';
+import { isAtomicSite } from 'state/initial-state';
 
 export class Traffic extends React.Component {
 	static displayName = 'TrafficSettings';
@@ -94,19 +94,7 @@ export class Traffic extends React.Component {
 						} ) }
 					/>
 				) }
-				{ foundRelated && (
-					<RelatedPosts
-						{ ...commonProps }
-						configureUrl={
-							this.props.siteAdminUrl +
-							'customize.php?autofocus[section]=jetpack_relatedposts' +
-							'&return=' +
-							encodeURIComponent( this.props.siteAdminUrl + 'admin.php?page=jetpack#/traffic' ) +
-							'&url=' +
-							encodeURIComponent( this.props.lastPostUrl )
-						}
-					/>
-				) }
+				{ foundRelated && <RelatedPosts { ...commonProps } /> }
 				{ foundSeo && (
 					<SEO
 						{ ...commonProps }
@@ -142,7 +130,6 @@ export default connect( state => {
 		isUnavailableInOfflineMode: module_name => isUnavailableInOfflineMode( state, module_name ),
 		isModuleFound: module_name => isModuleFound( state, module_name ),
 		isSiteConnected: isSiteConnected( state ),
-		lastPostUrl: getLastPostUrl( state ),
 		getModuleOverride: module_name => getModuleOverride( state, module_name ),
 		isAtomicSite: isAtomicSite( state ),
 		hasConnectedOwner: hasConnectedOwner( state ),

--- a/projects/plugins/jetpack/_inc/client/traffic/related-posts.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/related-posts.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 /**
  * WordPress dependencies
@@ -21,22 +22,24 @@ import { ModuleToggle } from 'components/module-toggle';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
+import { isBlockTheme, getLastPostUrl } from 'state/initial-state';
 
-class RelatedPostsComponent extends React.Component {
+class RelatedPosts extends Component {
 	/**
 	 * Get options for initial state.
 	 *
-	 * @returns {{show_headline: Boolean, show_thumbnails: Boolean}} Initial state object.
+	 * @returns {{show_headline: boolean, show_thumbnails: boolean, append_to_posts: boolean}} Initial state object.
 	 */
 	state = {
 		show_headline: this.props.getOptionValue( 'show_headline', 'related-posts' ),
 		show_thumbnails: this.props.getOptionValue( 'show_thumbnails', 'related-posts' ),
+		append_to_posts: this.props.getOptionValue( 'append_to_posts', 'related-posts' ),
 	};
 
 	/**
 	 * Update state so preview is updated instantly and toggle options.
 	 *
-	 * @param {string} optionName Slug of option to update.
+	 * @param {string} optionName - Slug of option to update.
 	 */
 	updateOptions = optionName => {
 		this.setState(
@@ -55,11 +58,166 @@ class RelatedPostsComponent extends React.Component {
 		this.updateOptions( 'show_thumbnails' );
 	};
 
-	trackConfigureClick = () => {
-		analytics.tracks.recordJetpackClick( 'configure-related-posts' );
+	handleAppendPostsToggleChange = () => {
+		this.updateOptions( 'append_to_posts' );
 	};
 
+	trackConfigureClick = type => {
+		analytics.tracks.recordJetpackClick( {
+			target: 'configure-related-posts',
+			type, // Classic for classic themes (customizer link), // blockTheme for block themes (site editor link).
+		} );
+	};
+
+	configureLink() {
+		const { siteAdminUrl, isBlockEnabledTheme, lastPostUrl } = this.props;
+
+		// For block themes, folks will want to add the Related Posts block directly in the site editor.
+		if ( isBlockEnabledTheme ) {
+			return (
+				<Card
+					compact
+					className="jp-settings-card__configure-link"
+					onClick={ this.trackConfigureClick( 'blockTheme' ) }
+					href={ `${ siteAdminUrl }site-editor.php` }
+				>
+					{ __( 'Add a Related Posts Block to your site.', 'jetpack' ) }
+				</Card>
+			);
+		}
+
+		const configureUrl =
+			siteAdminUrl +
+			'customize.php?autofocus[section]=jetpack_relatedposts' +
+			'&return=' +
+			encodeURIComponent( siteAdminUrl + 'admin.php?page=jetpack#/traffic' ) +
+			'&url=' +
+			encodeURIComponent( lastPostUrl );
+
+		return (
+			<Card
+				compact
+				className="jp-settings-card__configure-link"
+				onClick={ this.trackConfigureClick( 'classic' ) }
+				href={ configureUrl }
+			>
+				{ __( 'Configure related posts in the Customizer', 'jetpack' ) }
+			</Card>
+		);
+	}
+
+	classicRelatedPostsSettings() {
+		return (
+			<>
+				<CompactFormToggle
+					checked={ this.state.append_to_posts }
+					disabled={ this.props.isSavingAnyOption( [ 'related-posts', 'append_to_posts' ] ) }
+					onChange={ this.handleAppendPostsToggleChange }
+				>
+					<span className="jp-form-toggle-explanation">
+						{ __(
+							'Automatically display related posts to the bottom of each one of your posts.',
+							'jetpack'
+						) }
+					</span>
+				</CompactFormToggle>
+				{ this.state.append_to_posts && (
+					<>
+						<CompactFormToggle
+							checked={ this.state.show_headline }
+							disabled={ this.props.isSavingAnyOption( [
+								'related-posts',
+								'show_headline',
+								'append_posts',
+							] ) }
+							onChange={ this.handleShowHeadlineToggleChange }
+						>
+							<span className="jp-form-toggle-explanation">
+								{ __( 'Highlight related content with a heading', 'jetpack' ) }
+							</span>
+						</CompactFormToggle>
+						<CompactFormToggle
+							checked={ this.state.show_thumbnails }
+							disabled={ this.props.isSavingAnyOption( [
+								'related-posts',
+								'show_thumbnails',
+								'append_posts',
+							] ) }
+							onChange={ this.handleShowThumbnailsToggleChange }
+						>
+							<span className="jp-form-toggle-explanation">
+								{ __( 'Show a thumbnail image where available', 'jetpack' ) }
+							</span>
+						</CompactFormToggle>
+						{ this.relatedPostsPreview() }
+					</>
+				) }
+			</>
+		);
+	}
+
+	relatedPostsPreview() {
+		const fakePosts = [
+			{
+				url: 'cat-blog.png',
+				text: __( 'Big iPhone/iPad Update Now Available', 'jetpack' ),
+				context: _x(
+					'In "Mobile"',
+					'It refers to the category where a post was found. Used in an example preview.',
+					'jetpack'
+				),
+			},
+			{
+				url: 'devices.jpg',
+				text: __( 'The WordPress for Android App Gets a Big Facelift', 'jetpack' ),
+				context: _x(
+					'In "Mobile"',
+					'It refers to the category where a post was found. Used in an example preview.',
+					'jetpack'
+				),
+			},
+			{
+				url: 'mobile-wedding.jpg',
+				text: __( 'Upgrade Focus: VideoPress For Weddings', 'jetpack' ),
+				context: _x(
+					'In "Upgrade"',
+					'It refers to the category where a post was found. Used in an example preview.',
+					'jetpack'
+				),
+			},
+		];
+
+		return (
+			<div>
+				<FormLabel className="jp-form-label-wide">
+					{ _x( 'Preview', 'A header for a preview area in the configuration screen.', 'jetpack' ) }
+				</FormLabel>
+				<Card className="jp-related-posts-preview">
+					{ this.state.show_headline && (
+						<div className="jp-related-posts-preview__title">{ __( 'Related', 'jetpack' ) }</div>
+					) }
+					{ fakePosts.map( ( item, index ) => (
+						<div key={ `preview_${ index }` } className="jp-related-posts-preview__item">
+							{ this.state.show_thumbnails && (
+								<img
+									src={ `https://jetpackme.files.wordpress.com/2019/03/${ item.url }` }
+									alt={ item.text }
+								/>
+							) }
+							<h4 className="jp-related-posts-preview__post-title">
+								<a href="#/traffic">{ item.text }</a>
+							</h4>
+							<p className="jp-related-posts-preview__post-context">{ item.context }</p>
+						</div>
+					) ) }
+				</Card>
+			</div>
+		);
+	}
+
 	render() {
+		const { isBlockEnabledTheme } = this.props;
+
 		const isRelatedPostsActive = this.props.getOptionValue( 'related-posts' ),
 			unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'related-posts' );
 		return (
@@ -79,7 +237,7 @@ class RelatedPostsComponent extends React.Component {
 					<p>
 						{ createInterpolateElement(
 							__(
-								'Keep your visitors engaged with related content at the bottom of each post. These settings won’t apply to <a>related posts added using the block editor</a>.',
+								'Keep your visitors engaged with related content at the bottom of each post, or anywhere within your content thanks to the <a>Related Posts Block</a>.',
 								'jetpack'
 							),
 							{
@@ -101,111 +259,26 @@ class RelatedPostsComponent extends React.Component {
 						toggleModule={ this.props.toggleModuleNow }
 					>
 						<span className="jp-form-toggle-explanation">
-							{ __( 'Show related content after posts', 'jetpack' ) }
+							{ __( 'Show related content for each one of your posts.', 'jetpack' ) }
 						</span>
 					</ModuleToggle>
-					<FormFieldset>
-						<CompactFormToggle
-							checked={ this.state.show_headline }
-							disabled={
-								! isRelatedPostsActive ||
-								unavailableInOfflineMode ||
-								this.props.isSavingAnyOption( [ 'related-posts', 'show_headline' ] )
-							}
-							onChange={ this.handleShowHeadlineToggleChange }
-						>
-							<span className="jp-form-toggle-explanation">
-								{ __( 'Highlight related content with a heading', 'jetpack' ) }
-							</span>
-						</CompactFormToggle>
-						<CompactFormToggle
-							checked={ this.state.show_thumbnails }
-							disabled={
-								! isRelatedPostsActive ||
-								unavailableInOfflineMode ||
-								this.props.isSavingAnyOption( [ 'related-posts', 'show_thumbnails' ] )
-							}
-							onChange={ this.handleShowThumbnailsToggleChange }
-						>
-							<span className="jp-form-toggle-explanation">
-								{ __( 'Show a thumbnail image where available', 'jetpack' ) }
-							</span>
-						</CompactFormToggle>
-						{ isRelatedPostsActive && (
-							<div>
-								<FormLabel className="jp-form-label-wide">
-									{ _x(
-										'Preview',
-										'A header for a preview area in the configuration screen.',
-										'jetpack'
-									) }
-								</FormLabel>
-								<Card className="jp-related-posts-preview">
-									{ this.state.show_headline && (
-										<div className="jp-related-posts-preview__title">
-											{ __( 'Related', 'jetpack' ) }
-										</div>
-									) }
-									{ [
-										{
-											url: 'cat-blog.png',
-											text: __( 'Big iPhone/iPad Update Now Available', 'jetpack' ),
-											context: _x(
-												'In "Mobile"',
-												'It refers to the category where a post was found. Used in an example preview.',
-												'jetpack'
-											),
-										},
-										{
-											url: 'devices.jpg',
-											text: __( 'The WordPress for Android App Gets a Big Facelift', 'jetpack' ),
-											context: _x(
-												'In "Mobile"',
-												'It refers to the category where a post was found. Used in an example preview.',
-												'jetpack'
-											),
-										},
-										{
-											url: 'mobile-wedding.jpg',
-											text: __( 'Upgrade Focus: VideoPress For Weddings', 'jetpack' ),
-											context: _x(
-												'In "Upgrade"',
-												'It refers to the category where a post was found. Used in an example preview.',
-												'jetpack'
-											),
-										},
-									].map( ( item, index ) => (
-										<div key={ `preview_${ index }` } className="jp-related-posts-preview__item">
-											{ this.state.show_thumbnails && (
-												<img
-													src={ `https://jetpackme.files.wordpress.com/2019/03/${ item.url }` }
-													alt={ item.text }
-												/>
-											) }
-											<h4 className="jp-related-posts-preview__post-title">
-												<a href="#/traffic">{ item.text }</a>
-											</h4>
-											<p className="jp-related-posts-preview__post-context">{ item.context }</p>
-										</div>
-									) ) }
-								</Card>
-							</div>
-						) }
-					</FormFieldset>
+					{ isRelatedPostsActive && (
+						<FormFieldset>
+							{ ! isBlockEnabledTheme &&
+								! unavailableInOfflineMode &&
+								this.classicRelatedPostsSettings() }
+						</FormFieldset>
+					) }
 				</SettingsGroup>
-				{ ! this.props.isUnavailableInOfflineMode( 'related-posts' ) && isRelatedPostsActive && (
-					<Card
-						compact
-						className="jp-settings-card__configure-link"
-						onClick={ this.trackConfigureClick }
-						href={ this.props.configureUrl }
-					>
-						{ __( 'Configure related posts in the Customizer', 'jetpack' ) }
-					</Card>
-				) }
+				{ ! unavailableInOfflineMode && isRelatedPostsActive && this.configureLink() }
 			</SettingsCard>
 		);
 	}
 }
 
-export const RelatedPosts = withModuleSettingsFormHelpers( RelatedPostsComponent );
+export default connect( state => {
+	return {
+		isBlockEnabledTheme: isBlockTheme( state ),
+		lastPostUrl: getLastPostUrl( state ),
+	};
+} )( withModuleSettingsFormHelpers( RelatedPosts ) );

--- a/projects/plugins/jetpack/_inc/client/traffic/related-posts.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/related-posts.jsx
@@ -115,10 +115,7 @@ class RelatedPosts extends Component {
 					onChange={ this.handleAppendPostsToggleChange }
 				>
 					<span className="jp-form-toggle-explanation">
-						{ __(
-							'Automatically display related posts to the bottom of each one of your posts.',
-							'jetpack'
-						) }
+						{ __( 'Automatically display related posts at the bottom of each post.', 'jetpack' ) }
 					</span>
 				</CompactFormToggle>
 				{ this.state.append_to_posts && (

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -180,12 +180,13 @@ class Jetpack_Redux_State_Helper {
 				'dateFormat'                 => get_option( 'date_format' ),
 			),
 			'themeData'                   => array(
-				'name'      => $current_theme->get( 'Name' ),
-				'hasUpdate' => (bool) get_theme_update_available( $current_theme ),
-				'support'   => array(
+				'name'         => $current_theme->get( 'Name' ),
+				'hasUpdate'    => (bool) get_theme_update_available( $current_theme ),
+				'support'      => array(
 					'infinite-scroll' => current_theme_supports( 'infinite-scroll' ) || in_array( $current_theme->get_stylesheet(), $inf_scr_support_themes, true ),
 					'webfonts'        => WP_Theme_JSON_Resolver::theme_has_support() && function_exists( 'wp_register_webfont_provider' ) && function_exists( 'wp_register_webfonts' ),
 				),
+				'isBlockTheme' => function_exists( 'wp_is_block_theme' ) && wp_is_block_theme(),
 			),
 			'jetpackStateNotices'         => array(
 				'messageCode'      => Jetpack::state( 'message' ),

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2548,7 +2548,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'append_to_posts'                      => array(
 				'description'       => esc_html__( 'Automattically display related posts to the bottom of each one of your posts', 'jetpack' ),
 				'type'              => 'boolean',
-				'default'           => 1,
+				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'related-posts',
 			),

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2546,7 +2546,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'related-posts',
 			),
 			'append_to_posts'                      => array(
-				'description'       => esc_html__( 'Automattically display related posts to the bottom of each one of your posts', 'jetpack' ),
+				'description'       => esc_html__( 'Automatically display related posts at the bottom of each one of your posts', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2545,6 +2545,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'related-posts',
 			),
+			'append_to_posts'                      => array(
+				'description'       => esc_html__( 'Automattically display related posts to the bottom of each one of your posts', 'jetpack' ),
+				'type'              => 'boolean',
+				'default'           => 1,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'related-posts',
+			),
 
 			// Search.
 			'instant_search_enabled'               => array(

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -759,6 +759,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 
 				case 'show_headline':
 				case 'show_thumbnails':
+				case 'append_to_posts':
 					$grouped_options_current    = (array) Jetpack_Options::get_option( 'relatedposts' );
 					$grouped_options            = $grouped_options_current;
 					$grouped_options[ $option ] = $value;

--- a/projects/plugins/jetpack/changelog/update-related-posts-behaviour
+++ b/projects/plugins/jetpack/changelog/update-related-posts-behaviour
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Related Posts: ensure the block can be used without adding posts at the bottom of each post.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -476,7 +476,23 @@ class Jetpack {
 
 				// check which active modules actually exist and remove others from active_modules list.
 				$unfiltered_modules = self::get_active_modules();
-				$modules            = array_filter( $unfiltered_modules, array( 'Jetpack', 'is_module' ) );
+
+				/*
+				 * Update to Jetpack 11.0
+				 * (Related Posts default behavior change).
+				 *
+				 * If the module is already active, enable new option
+				 * so related posts keep getting appended to posts.
+				 */
+				if ( in_array( 'related-posts', $unfiltered_modules, true ) ) {
+					$relatedposts_options = Jetpack_Options::get_option( 'relatedposts' );
+					if ( empty( $relatedposts_options['append_to_posts'] ) ) {
+						$relatedposts_options['append_to_posts'] = 1;
+						Jetpack_Options::update_option( 'relatedposts', $relatedposts_options );
+					}
+				}
+
+				$modules = array_filter( $unfiltered_modules, array( 'Jetpack', 'is_module' ) );
 				if ( array_diff( $unfiltered_modules, $modules ) ) {
 					self::update_active_modules( $modules );
 				}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -53,6 +53,7 @@ new WPCOM_JSON_API_Site_Settings_Endpoint(
 			'jetpack_relatedposts_enabled'            => '(bool) Enable related posts?',
 			'jetpack_relatedposts_show_headline'      => '(bool) Show headline in related posts?',
 			'jetpack_relatedposts_show_thumbnails'    => '(bool) Show thumbnails in related posts?',
+			'jetpack_relatedposts_append_to_posts'    => '(bool) Automattically display related posts to the bottom of each one of your posts?',
 			'jetpack_protect_whitelist'               => '(array) List of IP addresses to whitelist',
 			'instant_search_enabled'                  => '(bool) Enable the new Jetpack Instant Search interface',
 			'jetpack_search_enabled'                  => '(bool) Enable Jetpack Search',
@@ -372,6 +373,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'jetpack_relatedposts_enabled'     => (bool) $jetpack_relatedposts_options['enabled'],
 						'jetpack_relatedposts_show_headline' => (bool) isset( $jetpack_relatedposts_options['show_headline'] ) ? $jetpack_relatedposts_options['show_headline'] : false,
 						'jetpack_relatedposts_show_thumbnails' => (bool) isset( $jetpack_relatedposts_options['show_thumbnails'] ) ? $jetpack_relatedposts_options['show_thumbnails'] : false,
+						'jetpack_relatedposts_append_to_posts' => (bool) isset( $jetpack_relatedposts_options['append_to_posts'] ) ? $jetpack_relatedposts_options['append_to_posts'] : true,
 						'jetpack_search_enabled'           => (bool) $jetpack_search_active,
 						'jetpack_search_supported'         => (bool) $jetpack_search_supported,
 						'default_category'                 => (int) get_option( 'default_category' ),
@@ -606,6 +608,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 				case 'jetpack_relatedposts_enabled':
 				case 'jetpack_relatedposts_show_thumbnails':
 				case 'jetpack_relatedposts_show_headline':
+				case 'jetpack_relatedposts_append_to_posts':
 					if ( ! $this->jetpack_relatedposts_supported() ) {
 						break;
 					}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -53,7 +53,7 @@ new WPCOM_JSON_API_Site_Settings_Endpoint(
 			'jetpack_relatedposts_enabled'            => '(bool) Enable related posts?',
 			'jetpack_relatedposts_show_headline'      => '(bool) Show headline in related posts?',
 			'jetpack_relatedposts_show_thumbnails'    => '(bool) Show thumbnails in related posts?',
-			'jetpack_relatedposts_append_to_posts'    => '(bool) Automattically display related posts to the bottom of each one of your posts?',
+			'jetpack_relatedposts_append_to_posts'    => '(bool) Automatically display related posts after each post?',
 			'jetpack_protect_whitelist'               => '(array) List of IP addresses to whitelist',
 			'instant_search_enabled'                  => '(bool) Enable the new Jetpack Instant Search interface',
 			'jetpack_search_enabled'                  => '(bool) Enable Jetpack Search',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -373,7 +373,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'jetpack_relatedposts_enabled'     => (bool) $jetpack_relatedposts_options['enabled'],
 						'jetpack_relatedposts_show_headline' => (bool) isset( $jetpack_relatedposts_options['show_headline'] ) ? $jetpack_relatedposts_options['show_headline'] : false,
 						'jetpack_relatedposts_show_thumbnails' => (bool) isset( $jetpack_relatedposts_options['show_thumbnails'] ) ? $jetpack_relatedposts_options['show_thumbnails'] : false,
-						'jetpack_relatedposts_append_to_posts' => (bool) isset( $jetpack_relatedposts_options['append_to_posts'] ) ? $jetpack_relatedposts_options['append_to_posts'] : true,
+						'jetpack_relatedposts_append_to_posts' => (bool) isset( $jetpack_relatedposts_options['append_to_posts'] ) ? $jetpack_relatedposts_options['append_to_posts'] : false,
 						'jetpack_search_enabled'           => (bool) $jetpack_search_active,
 						'jetpack_search_supported'         => (bool) $jetpack_search_supported,
 						'default_category'                 => (int) get_option( 'default_category' ),

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
@@ -42,6 +42,7 @@ new WPCOM_JSON_API_Site_Settings_V1_2_Endpoint( array(
 		'jetpack_relatedposts_enabled'            => '(bool) Enable related posts?',
 		'jetpack_relatedposts_show_headline'      => '(bool) Show headline in related posts?',
 		'jetpack_relatedposts_show_thumbnails'    => '(bool) Show thumbnails in related posts?',
+		'jetpack_relatedposts_append_to_posts'    => '(bool) Automattically display related posts to the bottom of each one of your posts?',
 		'instant_search_enabled'                  => '(bool) Enable the new Jetpack Instant Search interface',
 		'jetpack_search_enabled'                  => '(bool) Enable Jetpack Search',
 		'jetpack_search_supported'                => '(bool) Jetpack Search supported',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
@@ -42,7 +42,7 @@ new WPCOM_JSON_API_Site_Settings_V1_2_Endpoint( array(
 		'jetpack_relatedposts_enabled'            => '(bool) Enable related posts?',
 		'jetpack_relatedposts_show_headline'      => '(bool) Show headline in related posts?',
 		'jetpack_relatedposts_show_thumbnails'    => '(bool) Show thumbnails in related posts?',
-		'jetpack_relatedposts_append_to_posts'    => '(bool) Automattically display related posts to the bottom of each one of your posts?',
+		'jetpack_relatedposts_append_to_posts'    => '(bool) Automatically display related posts after each post?',
 		'instant_search_enabled'                  => '(bool) Enable the new Jetpack Instant Search interface',
 		'jetpack_search_enabled'                  => '(bool) Enable Jetpack Search',
 		'jetpack_search_supported'                => '(bool) Jetpack Search supported',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
@@ -42,7 +42,7 @@ new WPCOM_JSON_API_Site_Settings_V1_3_Endpoint( array(
 		'jetpack_relatedposts_enabled'            => '(bool) Enable related posts?',
 		'jetpack_relatedposts_show_headline'      => '(bool) Show headline in related posts?',
 		'jetpack_relatedposts_show_thumbnails'    => '(bool) Show thumbnails in related posts?',
-		'jetpack_relatedposts_append_to_posts'    => '(bool) Automattically display related posts to the bottom of each one of your posts?',
+		'jetpack_relatedposts_append_to_posts'    => '(bool) Automatically display related posts after each post?',
 		'instant_search_enabled'                  => '(bool) Enable the new Jetpack Instant Search interface',
 		'jetpack_search_enabled'                  => '(bool) Enable Jetpack Search',
 		'jetpack_search_supported'                => '(bool) Jetpack Search supported',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
@@ -42,6 +42,7 @@ new WPCOM_JSON_API_Site_Settings_V1_3_Endpoint( array(
 		'jetpack_relatedposts_enabled'            => '(bool) Enable related posts?',
 		'jetpack_relatedposts_show_headline'      => '(bool) Show headline in related posts?',
 		'jetpack_relatedposts_show_thumbnails'    => '(bool) Show thumbnails in related posts?',
+		'jetpack_relatedposts_append_to_posts'    => '(bool) Automattically display related posts to the bottom of each one of your posts?',
 		'instant_search_enabled'                  => '(bool) Enable the new Jetpack Instant Search interface',
 		'jetpack_search_enabled'                  => '(bool) Enable Jetpack Search',
 		'jetpack_search_supported'                => '(bool) Jetpack Search supported',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -42,7 +42,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint( array(
 		'jetpack_relatedposts_enabled'            => '(bool) Enable related posts?',
 		'jetpack_relatedposts_show_headline'      => '(bool) Show headline in related posts?',
 		'jetpack_relatedposts_show_thumbnails'    => '(bool) Show thumbnails in related posts?',
-		'jetpack_relatedposts_append_to_posts'    => '(bool) Automattically display related posts to the bottom of each one of your posts?',
+		'jetpack_relatedposts_append_to_posts'    => '(bool) Automatically display related posts after each post?',
 		'instant_search_enabled'                  => '(bool) Enable the new Jetpack Instant Search interface',
 		'jetpack_search_enabled'                  => '(bool) Enable Jetpack Search',
 		'jetpack_search_supported'                => '(bool) Jetpack Search supported',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -42,6 +42,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint( array(
 		'jetpack_relatedposts_enabled'            => '(bool) Enable related posts?',
 		'jetpack_relatedposts_show_headline'      => '(bool) Show headline in related posts?',
 		'jetpack_relatedposts_show_thumbnails'    => '(bool) Show thumbnails in related posts?',
+		'jetpack_relatedposts_append_to_posts'    => '(bool) Automattically display related posts to the bottom of each one of your posts?',
 		'instant_search_enabled'                  => '(bool) Enable the new Jetpack Instant Search interface',
 		'jetpack_search_enabled'                  => '(bool) Enable Jetpack Search',
 		'jetpack_search_supported'                => '(bool) Jetpack Search supported',

--- a/projects/plugins/jetpack/modules/related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts.php
@@ -6,7 +6,7 @@
  * Sort Order: 29
  * Recommendation Order: 9
  * Requires Connection: Yes
- * Auto Activate: No
+ * Auto Activate: Yes
  * Module Tags: Recommended
  * Feature: Engagement
  * // phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -549,9 +549,6 @@ EOT;
 			if ( ! is_array( $this->options ) ) {
 				$this->options = array();
 			}
-			if ( ! isset( $this->options['append_to_posts'] ) ) {
-				$this->options['append_to_posts'] = true;
-			}
 			if ( ! isset( $this->options['enabled'] ) ) {
 				$this->options['enabled'] = true;
 			}

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -1749,8 +1749,7 @@ EOT;
 			&& ! is_attachment()
 			&& ! is_admin()
 			&& ! is_embed()
-			&& ( ! $this->allow_feature_toggle() || $this->get_option( 'enabled' ) )
-			&& $this->get_option( 'append_to_posts' );
+			&& ( ! $this->allow_feature_toggle() || $this->get_option( 'enabled' ) );
 
 		/**
 		 * Filter the Enabled value to allow related posts to be shown on pages as well.
@@ -1800,7 +1799,7 @@ EOT;
 	protected function enqueue_assets( $script, $style ) {
 		$dependencies = is_customize_preview() ? array( 'customize-base' ) : array();
 		// Do not enqueue scripts unless they are required.
-		if ( $script && $this->requires_scripts() ) {
+		if ( $script && $this->requires_scripts() && $this->get_option( 'append_to_posts' ) ) {
 			wp_enqueue_script(
 				'jetpack_related-posts',
 				Assets::get_file_url_for_environment(

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -201,7 +201,7 @@ class Jetpack_RelatedPosts {
 			$this->action_frontend_init_ajax( $excludes );
 		} else {
 			if ( isset( $_GET['relatedposts_hit'], $_GET['relatedposts_origin'], $_GET['relatedposts_position'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- checking if fields are set to setup tracking, nothing is changing on the site.
-				$this->previous_post_id = (int) $_GET['relatedposts_origin']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- fetching a previous post ID for tracking, nothing is changing on the site. 
+				$this->previous_post_id = (int) $_GET['relatedposts_origin']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- fetching a previous post ID for tracking, nothing is changing on the site.
 				$this->log_click( $this->previous_post_id, get_the_ID(), sanitize_text_field( wp_unslash( $_GET['relatedposts_position'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- logging the click for tracking, nothing is changing on the site.
 			}
 
@@ -548,6 +548,9 @@ EOT;
 			$this->options = Jetpack_Options::get_option( 'relatedposts', array() );
 			if ( ! is_array( $this->options ) ) {
 				$this->options = array();
+			}
+			if ( ! isset( $this->options['append_to_posts'] ) ) {
+				$this->options['append_to_posts'] = true;
 			}
 			if ( ! isset( $this->options['enabled'] ) ) {
 				$this->options['enabled'] = true;
@@ -1749,7 +1752,8 @@ EOT;
 			&& ! is_attachment()
 			&& ! is_admin()
 			&& ! is_embed()
-			&& ( ! $this->allow_feature_toggle() || $this->get_option( 'enabled' ) );
+			&& ( ! $this->allow_feature_toggle() || $this->get_option( 'enabled' ) )
+			&& $this->get_option( 'append_to_posts' );
 
 		/**
 		 * Filter the Enabled value to allow related posts to be shown on pages as well.

--- a/projects/plugins/jetpack/tests/php/json-api/test-class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test-class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -194,6 +194,7 @@ class WP_Test_WPCOM_JSON_API_Site_Settings_V1_4_Endpoint extends WP_UnitTestCase
 					'jetpack_relatedposts_enabled'         => '(bool) Enable related posts?',
 					'jetpack_relatedposts_show_headline'   => '(bool) Show headline in related posts?',
 					'jetpack_relatedposts_show_thumbnails' => '(bool) Show thumbnails in related posts?',
+					'jetpack_relatedposts_append_to_posts' => '(bool) Automattically display related posts to the bottom of each one of your posts?',
 					'instant_search_enabled'               => '(bool) Enable the new Jetpack Instant Search interface',
 					'jetpack_search_enabled'               => '(bool) Enable Jetpack Search',
 					'jetpack_search_supported'             => '(bool) Jetpack Search supported',

--- a/tools/eslint-excludelist.json
+++ b/tools/eslint-excludelist.json
@@ -78,7 +78,6 @@
 	"projects/plugins/jetpack/_inc/client/state/site-verify/reducer.js",
 	"projects/plugins/jetpack/_inc/client/state/site/reducer.js",
 	"projects/plugins/jetpack/_inc/client/state/tracking/reducer.js",
-	"projects/plugins/jetpack/_inc/client/traffic/related-posts.jsx",
 	"projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx",
 	"projects/plugins/jetpack/_inc/client/utils/onkeydown-callback.js",
 	"projects/plugins/jetpack/_inc/client/writing/composing.jsx",


### PR DESCRIPTION
Fixes #11021

#### Changes proposed in this Pull Request:

This PR changes the default behaviour of the Related Posts feature.

We want a few things:

- The module should be automatically activated on sites that are newly connected to WordPress.com, or sites that update. That should be handled by switching the auto-activation setting for the module.
- When you do activate the module, posts should **not** get automatically added to all your posts for you. This should be done by you via the settings under Jetpack > Settings > Traffic.
- If you have been using the module until today, when updating to the most recent of Jetpack that toggle should be enabled for you, so you do not lose access to related posts at the bottom of your posts.
- When you use a block-enabled theme, those settings are not relevant to you; the posts will not appear at the bottom of all single posts. We'll consequently update the settings UI to point you to the site editor in those cases, so you can add a Related Posts block there.

<img width="1107" alt="image" src="https://user-images.githubusercontent.com/426388/165097680-a950558a-a39b-4b13-920f-ad055b939847.png">

#### Jetpack product discussion

* p1HpG7-fIo-p2
* pcjTuq-hx-p2

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

You'll want to test things with multiple sites, to test different scenarios.

**1. New site**

* Start with a site with some existing content, so related posts can be shown.
* Connect the site to your WordPress.com account
* The Related Posts module should be automatically activated.
* The option under Jetpack > Settings > Traffic should show the active module, but without the related posts appended to all posts.
* Toggling that option should start showing related posts at the bottom of all posts.

**2. Old site using Related Posts**

* Start with a site that's been connected to WordPress.com for some time, and where Related Posts were active and displayed.
* Switch to this branch; the related posts should remain shown. The settings under Jetpack > Settings > Traffic should show the new option checked already.

**3. Old site that did not use Related Posts**

* Start with a site that's been connected to WordPress.com for some time, but where the Related Posts module is not active.
* When updating to this branch, the module should become active, but the option under Jetpack > Settings > Traffic should not add the related posts section at the bottom of each posts.
* The Related Posts block, however, should be available.

**4. WordPress.com sites**

* Test that related posts still work on WordPress.com simple sites as well, where related posts get enabled differently.