### PR TITLE
Use workspace package name for imports from js-tools

### DIFF
--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -197,7 +197,7 @@ We use eslint and phpcs to lint JavaScript and PHP code. Projects should comply 
   Note we're using something of a hack to get eslint to read ignore rules from `.gitignore` and per-directory `.eslintignore` files.
   Any eslintrc that does `root: true` or an `extends` that extends from an eslintrc that includes the hack will have to do like
   ```js
-  const loadIgnorePatterns = require( '../../../tools/js-tools/load-eslint-ignore.js' );
+  const loadIgnorePatterns = require( 'jetpack-js-tools/load-eslint-ignore.js' );
   module.exports = {
   	// Whatever stuff, including `root: true` or `extends`.
   	ignorePatterns: loadIgnorePatterns( __dirname ),

--- a/projects/js-packages/components/.eslintrc.cjs
+++ b/projects/js-packages/components/.eslintrc.cjs
@@ -1,5 +1,5 @@
 module.exports = {
-	extends: [ '../../../tools/js-tools/eslintrc/react.js' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
 	parserOptions: {
 		requireConfigFile: false,
 		babelOptions: {

--- a/projects/js-packages/components/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/js-packages/components/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.
 
-Comment: Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.. Monorepo tooling only, no change to the package.

--- a/projects/js-packages/components/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/js-packages/components/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Use workspace for imports from js-tools
+Comment: Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.. Monorepo tooling only, no change to the package.

--- a/projects/js-packages/components/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/js-packages/components/changelog/update-use-workspace-imports-for-js-tools
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use workspace for imports from js-tools

--- a/projects/js-packages/components/jsconfig.json
+++ b/projects/js-packages/components/jsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../tools/js-tools/tsconfig.base.json",
+	"extends": "jetpack-js-tools/tsconfig.base.json",
 	// List all sources and source-containing subdirs.
 	"include": [ "./index.jsx", "./components", "./lib", "./tools" ]
 }

--- a/projects/js-packages/connection/.eslintrc.cjs
+++ b/projects/js-packages/connection/.eslintrc.cjs
@@ -1,5 +1,5 @@
 module.exports = {
-	extends: [ '../../../tools/js-tools/eslintrc/react.js' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
 	parserOptions: {
 		requireConfigFile: false,
 		babelOptions: {

--- a/projects/js-packages/connection/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/js-packages/connection/changelog/update-use-workspace-imports-for-js-tools
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use workspace for imports from js-tools

--- a/projects/js-packages/connection/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/js-packages/connection/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
-
 Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.
+

--- a/projects/js-packages/connection/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/js-packages/connection/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Use workspace for imports from js-tools
+Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.

--- a/projects/js-packages/idc/.eslintrc.cjs
+++ b/projects/js-packages/idc/.eslintrc.cjs
@@ -1,5 +1,5 @@
 module.exports = {
-	extends: [ '../../../tools/js-tools/eslintrc/react.js' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
 	parserOptions: {
 		requireConfigFile: false,
 		babelOptions: {

--- a/projects/js-packages/idc/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/js-packages/idc/changelog/update-use-workspace-imports-for-js-tools
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use workspace for imports from js-tools

--- a/projects/js-packages/idc/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/js-packages/idc/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
-
 Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.
+

--- a/projects/js-packages/idc/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/js-packages/idc/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Use workspace for imports from js-tools
+Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.

--- a/projects/js-packages/licensing/.eslintrc.cjs
+++ b/projects/js-packages/licensing/.eslintrc.cjs
@@ -1,5 +1,5 @@
 module.exports = {
-	extends: [ '../../../tools/js-tools/eslintrc/react.js' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
 	parserOptions: {
 		requireConfigFile: false,
 		babelOptions: {

--- a/projects/js-packages/licensing/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/js-packages/licensing/changelog/update-use-workspace-imports-for-js-tools
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use workspace for imports from js-tools

--- a/projects/js-packages/licensing/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/js-packages/licensing/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
-
 Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.
+

--- a/projects/js-packages/licensing/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/js-packages/licensing/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Use workspace for imports from js-tools
+Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.

--- a/projects/js-packages/partner-coupon/.eslintrc.cjs
+++ b/projects/js-packages/partner-coupon/.eslintrc.cjs
@@ -1,5 +1,5 @@
 module.exports = {
-	extends: [ '../../../tools/js-tools/eslintrc/react.js' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
 	parserOptions: {
 		requireConfigFile: false,
 		babelOptions: {

--- a/projects/js-packages/partner-coupon/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/js-packages/partner-coupon/changelog/update-use-workspace-imports-for-js-tools
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use workspace for imports from js-tools

--- a/projects/js-packages/partner-coupon/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/js-packages/partner-coupon/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
-
 Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.
+

--- a/projects/js-packages/partner-coupon/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/js-packages/partner-coupon/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Use workspace for imports from js-tools
+Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.

--- a/projects/js-packages/shared-extension-utils/.eslintrc.cjs
+++ b/projects/js-packages/shared-extension-utils/.eslintrc.cjs
@@ -1,5 +1,5 @@
 module.exports = {
-	extends: [ '../../../tools/js-tools/eslintrc/react.js' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
 	parserOptions: {
 		requireConfigFile: false,
 		babelOptions: {

--- a/projects/js-packages/shared-extension-utils/.eslintrc.js
+++ b/projects/js-packages/shared-extension-utils/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-	extends: [ '../../../tools/js-tools/eslintrc/react.js' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
 	parserOptions: {
 		requireConfigFile: false,
 		babelOptions: {

--- a/projects/js-packages/shared-extension-utils/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/js-packages/shared-extension-utils/changelog/update-use-workspace-imports-for-js-tools
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use workspace for imports from js-tools

--- a/projects/js-packages/shared-extension-utils/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/js-packages/shared-extension-utils/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
-
 Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.
+

--- a/projects/js-packages/shared-extension-utils/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/js-packages/shared-extension-utils/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Use workspace for imports from js-tools
+Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.

--- a/projects/js-packages/storybook/.eslintrc.cjs
+++ b/projects/js-packages/storybook/.eslintrc.cjs
@@ -1,5 +1,5 @@
 module.exports = {
-	extends: [ '../../../tools/js-tools/eslintrc/react.js' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
 	parserOptions: {
 		requireConfigFile: false,
 		babelOptions: {

--- a/projects/js-packages/storybook/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/js-packages/storybook/changelog/update-use-workspace-imports-for-js-tools
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use workspace for imports from js-tools

--- a/projects/js-packages/storybook/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/js-packages/storybook/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
-
 Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.
+

--- a/projects/js-packages/storybook/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/js-packages/storybook/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Use workspace for imports from js-tools
+Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.

--- a/projects/packages/connection-ui/.eslintrc.js
+++ b/projects/packages/connection-ui/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-	extends: [ '../../../tools/js-tools/eslintrc/react.js' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
 	parserOptions: {
 		babelOptions: {
 			configFile: require.resolve( './babel.config.js' ),

--- a/projects/packages/connection-ui/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/packages/connection-ui/changelog/update-use-workspace-imports-for-js-tools
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use workspace for imports from js-tools

--- a/projects/packages/connection-ui/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/packages/connection-ui/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
-
 Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.
+

--- a/projects/packages/connection-ui/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/packages/connection-ui/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Use workspace for imports from js-tools
+Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.

--- a/projects/packages/connection/.eslintrc.js
+++ b/projects/packages/connection/.eslintrc.js
@@ -1,4 +1,4 @@
-var loadIgnorePatterns = require( '../../../tools/js-tools/load-eslint-ignore.js' );
+var loadIgnorePatterns = require( 'jetpack-js-tools/load-eslint-ignore.js' );
 
 /* eslint-env node */
 module.exports = {

--- a/projects/packages/connection/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/packages/connection/changelog/update-use-workspace-imports-for-js-tools
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use workspace for imports from js-tools

--- a/projects/packages/connection/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/packages/connection/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
-
 Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.
+

--- a/projects/packages/connection/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/packages/connection/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Use workspace for imports from js-tools
+Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.

--- a/projects/packages/identity-crisis/.eslintrc.js
+++ b/projects/packages/identity-crisis/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-	extends: [ '../../../tools/js-tools/eslintrc/react.js' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
 	parserOptions: {
 		babelOptions: {
 			configFile: require.resolve( './babel.config.js' ),

--- a/projects/packages/identity-crisis/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/packages/identity-crisis/changelog/update-use-workspace-imports-for-js-tools
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use workspace for imports from js-tools

--- a/projects/packages/identity-crisis/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/packages/identity-crisis/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
-
 Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.
+

--- a/projects/packages/identity-crisis/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/packages/identity-crisis/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Use workspace for imports from js-tools
+Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.

--- a/projects/packages/lazy-images/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/packages/lazy-images/changelog/update-use-workspace-imports-for-js-tools
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use workspace for imports from js-tools

--- a/projects/packages/lazy-images/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/packages/lazy-images/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
-
 Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.
+

--- a/projects/packages/lazy-images/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/packages/lazy-images/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Use workspace for imports from js-tools
+Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.

--- a/projects/packages/lazy-images/src/.eslintrc.js
+++ b/projects/packages/lazy-images/src/.eslintrc.js
@@ -1,4 +1,4 @@
-var loadIgnorePatterns = require( '../../../../tools/js-tools/load-eslint-ignore.js' );
+var loadIgnorePatterns = require( 'jetpack-js-tools/load-eslint-ignore.js' );
 
 /* eslint-env node */
 module.exports = {

--- a/projects/packages/my-jetpack/.eslintrc.js
+++ b/projects/packages/my-jetpack/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-	extends: [ '../../../tools/js-tools/eslintrc/react.js' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
 	parserOptions: {
 		babelOptions: {
 			configFile: require.resolve( './babel.config.js' ),

--- a/projects/packages/my-jetpack/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/packages/my-jetpack/changelog/update-use-workspace-imports-for-js-tools
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use workspace for imports from js-tools

--- a/projects/packages/my-jetpack/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/packages/my-jetpack/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
-
 Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.
+

--- a/projects/packages/my-jetpack/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/packages/my-jetpack/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Use workspace for imports from js-tools
+Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.

--- a/projects/packages/search/.eslintrc.js
+++ b/projects/packages/search/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-	extends: [ '../../../tools/js-tools/eslintrc/react.js' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
 	parserOptions: {
 		babelOptions: {
 			configFile: require.resolve( './babel.config.js' ),

--- a/projects/packages/search/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/packages/search/changelog/update-use-workspace-imports-for-js-tools
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use workspace for imports from js-tools

--- a/projects/packages/search/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/packages/search/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
-
 Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.
+

--- a/projects/packages/search/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/packages/search/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Use workspace for imports from js-tools
+Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.

--- a/projects/packages/search/src/instant-search/components/test/.eslintrc.js
+++ b/projects/packages/search/src/instant-search/components/test/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-	extends: [ '../../../../../../../tools/js-tools/eslintrc/jest' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
 };

--- a/projects/packages/search/src/instant-search/lib/test/.eslintrc.js
+++ b/projects/packages/search/src/instant-search/lib/test/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-	extends: [ '../../../../../../../tools/js-tools/eslintrc/jest' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
 };

--- a/projects/packages/search/src/instant-search/store/test/.eslintrc.js
+++ b/projects/packages/search/src/instant-search/store/test/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-	extends: [ '../../../../../../../tools/js-tools/eslintrc/jest' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
 };

--- a/projects/packages/wordads/.eslintrc.js
+++ b/projects/packages/wordads/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-	extends: [ '../../../tools/js-tools/eslintrc/react.js' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
 	parserOptions: {
 		babelOptions: {
 			configFile: require.resolve( './babel.config.js' ),

--- a/projects/packages/wordads/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/packages/wordads/changelog/update-use-workspace-imports-for-js-tools
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use workspace for imports from js-tools

--- a/projects/packages/wordads/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/packages/wordads/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
-
 Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.
+

--- a/projects/packages/wordads/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/packages/wordads/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Use workspace for imports from js-tools
+Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.

--- a/projects/plugins/backup/.eslintrc.js
+++ b/projects/plugins/backup/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-	extends: [ '../../../tools/js-tools/eslintrc/react.js' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
 	parserOptions: {
 		babelOptions: {
 			configFile: require.resolve( './babel.config.js' ),

--- a/projects/plugins/backup/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/plugins/backup/changelog/update-use-workspace-imports-for-js-tools
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use workspace for imports from js-tools

--- a/projects/plugins/backup/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/plugins/backup/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
-
 Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.
+

--- a/projects/plugins/backup/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/plugins/backup/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Use workspace for imports from js-tools
+Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.

--- a/projects/plugins/boost/.eslintrc.cjs
+++ b/projects/plugins/boost/.eslintrc.cjs
@@ -1,11 +1,12 @@
-const loadIgnorePatterns = require( '../../../tools/js-tools/load-eslint-ignore.js' );
+// eslint-disable-next-line import/no-extraneous-dependencies
+const loadIgnorePatterns = require( 'jetpack-js-tools/load-eslint-ignore.js' );
 
 module.exports = {
 	root: true,
 	parser: '@typescript-eslint/parser',
 	extends: [
 		// '@sveltejs',
-		'../../../tools/js-tools/eslintrc/base.js',
+		require.resolve( 'jetpack-js-tools/eslintrc/base' ),
 		'plugin:@typescript-eslint/recommended',
 		'plugin:@wordpress/eslint-plugin/recommended',
 	],

--- a/projects/plugins/boost/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/plugins/boost/changelog/update-use-workspace-imports-for-js-tools
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use workspace for imports from js-tools

--- a/projects/plugins/boost/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/plugins/boost/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
-
 Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.
+

--- a/projects/plugins/boost/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/plugins/boost/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Use workspace for imports from js-tools
+Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.

--- a/projects/plugins/boost/tests/e2e/.eslintrc.cjs
+++ b/projects/plugins/boost/tests/e2e/.eslintrc.cjs
@@ -1,4 +1,4 @@
-const loadIgnorePatterns = require( '../../../../../tools/js-tools/load-eslint-ignore.js' );
+const loadIgnorePatterns = require( 'jetpack-js-tools/load-eslint-ignore.js' );
 
 module.exports = {
 	extends: [ require.resolve( 'jetpack-e2e-commons/.eslintrc.cjs' ) ],

--- a/projects/plugins/jetpack/.eslintrc.js
+++ b/projects/plugins/jetpack/.eslintrc.js
@@ -2,7 +2,7 @@
  * @type {import("eslint").Linter.Config}
  */
 module.exports = {
-	extends: [ '../../../tools/js-tools/eslintrc/react.js' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
 	parserOptions: {
 		babelOptions: {
 			configFile: require.resolve( './babel.config.js' ),

--- a/projects/plugins/jetpack/_inc/.eslintrc.js
+++ b/projects/plugins/jetpack/_inc/.eslintrc.js
@@ -1,5 +1,5 @@
 /* eslint-env node */
-const loadIgnorePatterns = require( '../../../../tools/js-tools/load-eslint-ignore.js' );
+const loadIgnorePatterns = require( 'jetpack-js-tools/load-eslint-ignore.js' );
 
 module.exports = {
 	// Use ESlint from modules folder. JS files here are not transpiled unless otherwise configured.

--- a/projects/plugins/jetpack/_inc/client/.eslintrc.js
+++ b/projects/plugins/jetpack/_inc/client/.eslintrc.js
@@ -1,4 +1,4 @@
-const loadIgnorePatterns = require( '../../../../../tools/js-tools/load-eslint-ignore.js' );
+const loadIgnorePatterns = require( 'jetpack-js-tools/load-eslint-ignore.js' );
 
 module.exports = {
 	// Use root level ESlint configuration.

--- a/projects/plugins/jetpack/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/plugins/jetpack/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Use workspace for imports from js-tools
+Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.

--- a/projects/plugins/jetpack/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/plugins/jetpack/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
-
 Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.
+

--- a/projects/plugins/jetpack/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/plugins/jetpack/changelog/update-use-workspace-imports-for-js-tools
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Use workspace for imports from js-tools

--- a/projects/plugins/jetpack/extensions/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/.eslintrc.js
@@ -1,7 +1,7 @@
-const loadIgnorePatterns = require( '../../../../tools/js-tools/load-eslint-ignore.js' );
+const loadIgnorePatterns = require( 'jetpack-js-tools/load-eslint-ignore.js' );
 
 module.exports = {
-	extends: [ '../../../../tools/js-tools/eslintrc/jest' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
 	ignorePatterns: loadIgnorePatterns( __dirname ),
 	rules: {
 		'react/forbid-elements': [

--- a/projects/plugins/jetpack/extensions/blocks/calendly/test/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/test/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-	extends: [ '../../../../../../../tools/js-tools/eslintrc/jest' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
 };

--- a/projects/plugins/jetpack/extensions/blocks/gathering-tweetstorms/test/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/blocks/gathering-tweetstorms/test/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-	extends: [ '../../../../../../../tools/js-tools/eslintrc/jest' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
 };

--- a/projects/plugins/jetpack/extensions/blocks/google-calendar/test/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/blocks/google-calendar/test/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-	extends: [ '../../../../../../../tools/js-tools/eslintrc/jest' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
 };

--- a/projects/plugins/jetpack/extensions/blocks/markdown/test/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/blocks/markdown/test/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-	extends: [ '../../../../../../../tools/js-tools/eslintrc/jest' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
 };

--- a/projects/plugins/jetpack/extensions/blocks/opentable/test/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/blocks/opentable/test/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-	extends: [ '../../../../../../../tools/js-tools/eslintrc/jest' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
 };

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/test/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/test/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-	extends: [ '../../../../../../../tools/js-tools/eslintrc/jest' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
 };

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-	extends: [ '../../../../../../../../../tools/js-tools/eslintrc/jest' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
 };

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/test/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/test/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-	extends: [ '../../../../../../../../tools/js-tools/eslintrc/jest' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
 };

--- a/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/test/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/test/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-	extends: [ '../../../../../../../tools/js-tools/eslintrc/jest' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
 };

--- a/projects/plugins/jetpack/extensions/plugins/publicize/components/twitter/test/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/components/twitter/test/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-	extends: [ '../../../../../../../../../tools/js-tools/eslintrc/jest' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
 };

--- a/projects/plugins/jetpack/extensions/plugins/publicize/store/test/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/store/test/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-	extends: [ '../../../../../../../../tools/js-tools/eslintrc/jest' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
 };

--- a/projects/plugins/jetpack/extensions/shared/plan-upgrade-notification.js
+++ b/projects/plugins/jetpack/extensions/shared/plan-upgrade-notification.js
@@ -15,12 +15,12 @@ import {
  * Returns a URL where the current site's plan can be viewed from.
  * [Relative to current domain for JP sites]
  *
- * @returns {string|null} A URL where the current site plan is viewable - null if not retrievable.
+ * @return {string|null} A URL where the current site plan is viewable - null if not retrievable.
  */
 function getPlanUrl() {
 	const siteFragment = getSiteFragment();
 
-	if ( 'undefined' !== typeof window && window.location && siteFragment ) {
+	if ( undefined !== typeof window && window.location && siteFragment ) {
 		if ( isSimpleSite() || isAtomicSite() ) {
 			return `https://wordpress.com/plans/my-plan/${ siteFragment }`;
 		}
@@ -41,7 +41,7 @@ function getPlanUrl() {
  * after redirection from WPCOM.
  */
 ( async () => {
-	if ( 'undefined' !== typeof window && window.location ) {
+	if ( undefined !== typeof window && window.location ) {
 		const queryParams = new URLSearchParams( window.location.search );
 
 		if ( queryParams.get( 'plan_upgraded' ) ) {

--- a/projects/plugins/jetpack/extensions/shared/plan-upgrade-notification.js
+++ b/projects/plugins/jetpack/extensions/shared/plan-upgrade-notification.js
@@ -15,12 +15,12 @@ import {
  * Returns a URL where the current site's plan can be viewed from.
  * [Relative to current domain for JP sites]
  *
- * @return {string|null} A URL where the current site plan is viewable - null if not retrievable.
+ * @returns {string|null} A URL where the current site plan is viewable - null if not retrievable.
  */
 function getPlanUrl() {
 	const siteFragment = getSiteFragment();
 
-	if ( undefined !== typeof window && window.location && siteFragment ) {
+	if ( 'undefined' !== typeof window && window.location && siteFragment ) {
 		if ( isSimpleSite() || isAtomicSite() ) {
 			return `https://wordpress.com/plans/my-plan/${ siteFragment }`;
 		}
@@ -41,7 +41,7 @@ function getPlanUrl() {
  * after redirection from WPCOM.
  */
 ( async () => {
-	if ( undefined !== typeof window && window.location ) {
+	if ( 'undefined' !== typeof window && window.location ) {
 		const queryParams = new URLSearchParams( window.location.search );
 
 		if ( queryParams.get( 'plan_upgraded' ) ) {

--- a/projects/plugins/jetpack/extensions/shared/test/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/shared/test/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-	extends: [ '../../../../../../tools/js-tools/eslintrc/jest' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
 };

--- a/projects/plugins/jetpack/jsconfig.json
+++ b/projects/plugins/jetpack/jsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../tools/js-tools/tsconfig.base.json",
+	"extends": "jetpack-js-tools/tsconfig.base.json",
 	"compilerOptions": {
 		"baseUrl": ".",
 		"paths": {

--- a/projects/plugins/jetpack/modules/.eslintrc.js
+++ b/projects/plugins/jetpack/modules/.eslintrc.js
@@ -1,5 +1,5 @@
 /* eslint-env node */
-const loadIgnorePatterns = require( '../../../../tools/js-tools/load-eslint-ignore.js' );
+const loadIgnorePatterns = require( 'jetpack-js-tools/load-eslint-ignore.js' );
 
 module.exports = {
 	root: true,

--- a/projects/plugins/jetpack/modules/widget-visibility/editor/.eslintrc.js
+++ b/projects/plugins/jetpack/modules/widget-visibility/editor/.eslintrc.js
@@ -1,4 +1,5 @@
-const loadIgnorePatterns = require( '../../../../../../tools/js-tools/load-eslint-ignore.js' );
+// eslint-disable-next-line import/no-extraneous-dependencies
+const loadIgnorePatterns = require( 'jetpack-js-tools/load-eslint-ignore.js' );
 
 module.exports = {
 	extends: [

--- a/projects/plugins/jetpack/tests/e2e/.eslintrc.cjs
+++ b/projects/plugins/jetpack/tests/e2e/.eslintrc.cjs
@@ -1,4 +1,4 @@
-const loadIgnorePatterns = require( '../../../../../tools/js-tools/load-eslint-ignore.js' );
+const loadIgnorePatterns = require( 'jetpack-js-tools/load-eslint-ignore.js' );
 
 module.exports = {
 	extends: [ require.resolve( 'jetpack-e2e-commons/.eslintrc.cjs' ) ],

--- a/projects/plugins/protect/.eslintrc.js
+++ b/projects/plugins/protect/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-	extends: [ '../../../tools/js-tools/eslintrc/react.js' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
 	parserOptions: {
 		babelOptions: {
 			configFile: require.resolve( './babel.config.js' ),

--- a/projects/plugins/protect/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/plugins/protect/changelog/update-use-workspace-imports-for-js-tools
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use workspace for imports from js-tools

--- a/projects/plugins/protect/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/plugins/protect/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
-
 Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.
+

--- a/projects/plugins/protect/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/plugins/protect/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Use workspace for imports from js-tools
+Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.

--- a/projects/plugins/search/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/plugins/search/changelog/update-use-workspace-imports-for-js-tools
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use workspace for imports from js-tools

--- a/projects/plugins/search/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/plugins/search/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
-
 Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.
+

--- a/projects/plugins/search/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/plugins/search/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Use workspace for imports from js-tools
+Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.

--- a/projects/plugins/search/tests/e2e/.eslintrc.cjs
+++ b/projects/plugins/search/tests/e2e/.eslintrc.cjs
@@ -1,4 +1,4 @@
-const loadIgnorePatterns = require( '../../../../../tools/js-tools/load-eslint-ignore.js' );
+const loadIgnorePatterns = require( 'jetpack-js-tools/load-eslint-ignore.js' );
 
 module.exports = {
 	extends: [ require.resolve( 'jetpack-e2e-commons/.eslintrc.cjs' ) ],

--- a/projects/plugins/social/.eslintrc.js
+++ b/projects/plugins/social/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-	extends: [ '../../../tools/js-tools/eslintrc/react.js' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
 	parserOptions: {
 		babelOptions: {
 			configFile: require.resolve( './babel.config.js' ),

--- a/projects/plugins/social/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/plugins/social/changelog/update-use-workspace-imports-for-js-tools
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use workspace for imports from js-tools

--- a/projects/plugins/social/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/plugins/social/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
-
 Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.
+

--- a/projects/plugins/social/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/plugins/social/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Use workspace for imports from js-tools
+Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.

--- a/projects/plugins/starter-plugin/.eslintrc.js
+++ b/projects/plugins/starter-plugin/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-	extends: [ '../../../tools/js-tools/eslintrc/react.js' ],
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
 	parserOptions: {
 		babelOptions: {
 			configFile: require.resolve( './babel.config.js' ),

--- a/projects/plugins/starter-plugin/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/plugins/starter-plugin/changelog/update-use-workspace-imports-for-js-tools
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use workspace for imports from js-tools

--- a/projects/plugins/starter-plugin/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/plugins/starter-plugin/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
-
 Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.
+

--- a/projects/plugins/starter-plugin/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/plugins/starter-plugin/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Use workspace for imports from js-tools
+Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.

--- a/tools/e2e-commons/.eslintrc.cjs
+++ b/tools/e2e-commons/.eslintrc.cjs
@@ -1,4 +1,4 @@
-const loadIgnorePatterns = require( '../../tools/js-tools/load-eslint-ignore.js' );
+const loadIgnorePatterns = require( 'jetpack-js-tools/load-eslint-ignore.js' );
 
 // .eslintrc.js
 module.exports = {

--- a/tools/js-tools/eslintrc/base.js
+++ b/tools/js-tools/eslintrc/base.js
@@ -1,10 +1,10 @@
 // eslint config for normal projects. If for some reason you can't just inherit from .eslintrc.js, extend this instead of .eslintrc.js, probably like this:
 //
 // ```
-// const loadIgnorePatterns = require( '../../../tools/js-tools/load-eslint-ignore.js' );
+// const loadIgnorePatterns = require( 'jetpack-js-tools/load-eslint-ignore.js' );
 // module.exports = {
 // 	root: true,
-// 	extends: [ '../../../tools/js-tools/eslintrc/base.js' ],
+// 	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/base' ) ],
 // 	ignorePatterns: loadIgnorePatterns( __dirname ),
 // 	parserOptions: {
 // 		babelOptions: {


### PR DESCRIPTION


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR updates `eslintrc` and `jsconfig.json` files to use the workspace path instead of relative path for imports from `js-tools` package.


#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check if ESLint works properly
* Optionally follow the testing instructions for #23568 and #23773
