### PR TITLE
Payments: do not load the block on P2's frontend editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-recurring-payments-no-editor
+++ b/projects/plugins/jetpack/changelog/fix-recurring-payments-no-editor
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Blocks: do not load the Payments block on P2's frontend editor.
+
+

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -61,7 +61,6 @@
 		"opentable",
 		"pinterest",
 		"rating-star",
-		"recurring-payments",
 		"related-posts",
 		"repeat-visitor",
 		"revue",


### PR DESCRIPTION
Fixes #24031

#### Changes proposed in this Pull Request:

* Do not load the Payment Button block on P2's frontend editor.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* On WordPress.com Simple, sandbox a P2 site
* Apply this patch (D79443-code)
* Open the site; you should see Jetpack blocks available in the block picker, such as the Markdown block or the Slideshow block.
