### PR TITLE
Update checks for conditional recommendations

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
@@ -196,26 +196,18 @@ class Jetpack_Recommendations {
 		$plugin_file = $path_parts ? array_pop( $path_parts ) : $plugin;
 
 		if ( ! in_array( $plugin_file, $plugin_whitelist, true ) ) {
-			$has_anti_spam = is_plugin_active( 'akismet/akismet.php' );
+			$products              = array_column( Jetpack_Plan::get_products(), 'product_slug' );
+			$has_anti_spam_product = count( array_intersect( array( 'jetpack_anti_spam', 'jetpack_anti_spam_monthly' ), $products ) ) > 0;
+			$has_anti_spam         = is_plugin_active( 'akismet/akismet.php' ) || Jetpack_Plan::supports( 'antispam' ) || $has_anti_spam_product;
 
 			// Check the backup state.
 			$rewind_state = get_transient( 'jetpack_rewind_state' );
 			$has_backup   = $rewind_state && in_array( $rewind_state->state, array( 'awaiting_credentials', 'provisioning', 'active' ), true );
 
 			// Check for a plan or product that enables scan.
-			$plan_supports_scan = \Jetpack_Plan::supports( 'scan' );
-			$products           = \Jetpack_Plan::get_products();
-			$has_scan_product   = false;
-
-			if ( is_array( $products ) ) {
-				foreach ( $products as $product ) {
-					if ( strpos( $product['product_slug'], 'jetpack_scan' ) === 0 ) {
-						$has_scan_product = true;
-						break;
-					}
-				}
-			}
-			$has_scan = $plan_supports_scan || $has_scan_product;
+			$plan_supports_scan = Jetpack_Plan::supports( 'scan' );
+			$has_scan_product   = count( array_intersect( array( 'jetpack_scan', 'jetpack_scan_monthly' ), $products ) ) > 0;
+			$has_scan           = $plan_supports_scan || $has_scan_product;
 
 			if ( ! $has_scan || ! $has_backup || ! $has_anti_spam ) {
 				self::enable_conditional_recommendation( self::SECURITY_PLAN_RECOMMENDATION );
@@ -231,7 +223,19 @@ class Jetpack_Recommendations {
 	 * @param array   $commentdata Comment data.
 	 */
 	public static function comment_added( $comment_id, $comment_approved, $commentdata ) {
-		if ( Plugins_Installer::is_plugin_active( 'akismet/akismet.php' ) || self::is_conditional_recommendation_enabled( self::ANTI_SPAM_RECOMMENDATION ) ) {
+		if ( self::is_conditional_recommendation_enabled( self::ANTI_SPAM_RECOMMENDATION ) ) {
+			return;
+		}
+
+		if ( Plugins_Installer::is_plugin_active( 'akismet/akismet.php' ) ) {
+			return;
+		}
+
+		// The site has anti-spam features already.
+		$site_products         = array_column( Jetpack_Plan::get_products(), 'product_slug' );
+		$has_anti_spam_product = count( array_intersect( array( 'jetpack_anti_spam', 'jetpack_anti_spam_monthly' ), $site_products ) ) > 0;
+
+		if ( Jetpack_Plan::supports( 'antispam' ) || $has_anti_spam_product ) {
 			return;
 		}
 
@@ -269,19 +273,43 @@ class Jetpack_Recommendations {
 			return;
 		}
 
+		$site_plan     = Jetpack_Plan::get();
+		$site_products = array_column( Jetpack_Plan::get_products(), 'product_slug' );
+
+		if ( self::should_recommend_videopress( $site_plan, $site_products ) ) {
+			self::enable_conditional_recommendation( self::VIDEOPRESS_RECOMMENDATION );
+		}
+	}
+
+	/**
+	 * Should we provide a recommendation for videopress?
+	 * This method exists to facilitate unit testing
+	 *
+	 * @param array $site_plan A representation of the site's plan.
+	 * @param array $site_products An array of product slugs.
+	 * @return boolean
+	 */
+	public static function should_recommend_videopress( $site_plan, $site_products ) {
 		// Does the site have the VideoPress module enabled?
 		if ( Jetpack::is_module_active( 'videopress' ) ) {
-			return;
+			return false;
+		}
+
+		// Does the site plan have upgraded videopress features?
+		// For now, this just checks to see if the site has a free plan.
+		// Jetpack_Plan::supports('videopress') returns true for all plans, since there is a free tier.
+		$is_free_plan = 'free' === $site_plan['class'];
+		if ( ! $is_free_plan ) {
+			return false;
 		}
 
 		// Does this site already have a VideoPress product?
-		$site_products          = array_column( Jetpack_Plan::get_products(), 'product_slug' );
 		$has_videopress_product = count( array_intersect( array( 'jetpack_videopress', 'jetpack_videopress_monthly' ), $site_products ) ) > 0;
 		if ( $has_videopress_product ) {
-			return;
+			return false;
 		}
 
-		self::enable_conditional_recommendation( self::VIDEOPRESS_RECOMMENDATION );
+		return true;
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-plan-checks-for-conditional-recommendations
+++ b/projects/plugins/jetpack/changelog/update-plan-checks-for-conditional-recommendations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Updated checks for enabling conditional recommendations

--- a/projects/plugins/jetpack/tests/php/_inc/lib/test-class-jetpack-recommendations.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/test-class-jetpack-recommendations.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Recommendations unit tests.
+ *
+ * @package automattic/jetpack
+ */
+
+jetpack_require_lib( 'class-jetpack-recommendations' );
+
+/**
+ * Class for testing the Jetpack_Currencies class.
+ */
+class WP_Test_Jetpack_Recommendations extends WP_UnitTestCase {
+
+	// The videopress recommendation should not be enabled if the module is on
+	public function test_videopress_is_not_recommended_if_module_enabled() {
+		\Jetpack::update_active_modules( array( 'videopress' ) );
+		$site_plan     = $this->get_free_plan_mock();
+		$site_products = array();
+
+		$this->assertFalse( Jetpack_Recommendations::should_recommend_videopress( $site_plan, $site_products ) );
+	}
+
+	// Videopress recommendation is only be enabled if the site has a free plan
+	public function test_videopress_is_not_recommended_if_plan_not_free() {
+		$plans         = array(
+			$this->get_security_plan_mock(),
+			$this->get_complete_plan_mock(),
+		);
+		$site_products = array();
+
+		foreach ( $plans as $site_plan ) {
+			$this->assertFalse( Jetpack_Recommendations::should_recommend_videopress( $site_plan, $site_products ) );
+		}
+	}
+
+	// Vidopress recommendation should not be enabled if the site has videopress annual product
+	public function test_videopress_is_not_recommended_if_site_has_videopress_product() {
+		$site_plan     = $this->get_free_plan_mock();
+		$site_products = array( 'jetpack_videopress' );
+
+		$this->assertFalse( Jetpack_Recommendations::should_recommend_videopress( $site_plan, $site_products ) );
+	}
+
+	// Vidopress recommendation should not be enabled if the site has videopress monthly product
+	public function test_videopress_is_not_recommended_if_site_has_videopress_monthly_product() {
+		$site_plan     = $this->get_free_plan_mock();
+		$site_products = array( 'jetpack_videopress_monthly' );
+
+		$this->assertFalse( Jetpack_Recommendations::should_recommend_videopress( $site_plan, $site_products ) );
+	}
+
+	// Videopress recommendation is enabled when a site has a free plan and no products
+	public function test_videopress_is_recommended_with_free_plan_and_no_products() {
+		$site_plan     = $this->get_free_plan_mock();
+		$site_products = array();
+
+		$this->assertTrue( Jetpack_Recommendations::should_recommend_videopress( $site_plan, $site_products ) );
+	}
+
+	private function get_complete_plan_mock() {
+		return array(
+			'class' => 'complete',
+		);
+	}
+
+	private function get_security_plan_mock() {
+		return array(
+			'class' => 'security',
+		);
+	}
+
+	private function get_free_plan_mock() {
+		return array(
+			'class' => 'free',
+		);
+	}
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR updates the logical checks used for enabling conditional recommendations. Primarily, the updates check whether the site's plan provides given features in addition to checking the status of different modules or plugins to determine if a recommendation should be enabled.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This PR updates the logical checks for enabling the following conditional recommendations, which are each addressed below
* Security Plan
* Anti-spam
* VideoPress

Note: if you are using the same test site to test multiple scenarios below, you will need to reset the `recommendations_conditional` option between tests. If you are using the docker development environment, you can run the following command with `jetpack docker`:
```
wp jetpack options delete recommendations_conditional
```

**Security Plan**
* The security plan recommendation should be enabled for a site that meets the following condition:
```
Does not have a Jetpack security plan OR does not have an equivalent combination of products that a security plan provides ( backup + scan + anti-spam )
```
* Test with this branch on a site with a free plan. To enable the security plan recommendation, activate a plugin in wp-admin (you can use hello dolly, which should be there by default). 
* After activating the plugin, navigate to `wp-admin/admin.php?page=jetpack#/recommendations/summary`
* You should see "Site Security" showing on the summary screen with a green "New" badge next to the name:

![Screen Shot 2022-04-25 at 3 04 42 PM](https://user-images.githubusercontent.com/18016357/165158461-849685ce-452e-488d-a113-19a521c4d369.png)


* Now,  repeat the test steps with a site that has a security plan.
* You should NOT see the Security Plan recommendation showing on the recommendations summary screen after activating a plugin

* Now, repeat the test with a site that has three separate products: backup, scan and anti-spam.
* You should also NOT see the Security Plan recommendation after activating a plugin.


**Anti-spam**
* The Anti-spam recommendation should show for a site with the following conditions:
```
1.  The Akismet plugin is not active
2. The site plan does not provide anti-spam features
3. The site does not have an anti-spam product
```
* To trigger the conditional recommendation for anti-spam, you will need to add 5+ comments to a post on the front-end of the site.
* Try testing with a site that has a free plan. After adding 5+ comments to a single post, navigate to `wp-admin/admin.php?page=jetpack#/recommendations/summary`. You should see the "Spam Management" recommendation showing on the summary screen with a green "New" badge.

![Screen Shot 2022-04-25 at 3 16 39 PM](https://user-images.githubusercontent.com/18016357/165158500-58620bd3-4aa9-46c6-8b70-9d871f8f5b90.png)


* Now, repeat this test with a site that has a security plan.
* You should NOT see the "Spam Management" recommendation showing on the summary screen.

* Now, repeat this test with a site that has a free plan and an anti-spam product.
* You should NOT see the "Spam Management" recommendation showing on the summary screen.


**VideoPress**
* The VideoPress recommendation should show for a site with the following conditions:
```
1. The VideoPress module is not active.
2. The site has a free plan.
3. The site does not have a VideoPress product.
```
* The check to enable the VideoPress recommendation happens two weeks after a site is connected. Because this is difficult to test manually, review the unit tests that have been added for enabling the VideoPress recommendation and make sure they are sensible and that they are passing.