### PR TITLE
Protect: fix right margin in primary layout

### DIFF
--- a/projects/plugins/protect/changelog/update-protect-fix-primary-layout-spacing
+++ b/projects/plugins/protect/changelog/update-protect-fix-primary-layout-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Protect: fix right margin in primary layout

--- a/projects/plugins/protect/src/js/index.js
+++ b/projects/plugins/protect/src/js/index.js
@@ -10,6 +10,7 @@ import { ThemeProvider } from '@automattic/jetpack-components';
  */
 import AdminPage from './components/admin-page';
 import { initStore } from './state/store';
+import './styles.module.scss';
 
 // Initialize Jetpack Protect store
 initStore();

--- a/projects/plugins/protect/src/js/styles.module.scss
+++ b/projects/plugins/protect/src/js/styles.module.scss
@@ -1,0 +1,5 @@
+:global {
+	* {
+		box-sizing: border-box;
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR sets box-sizing as border-box for all elements, fixing an annoying issue produced in the primary layout.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Protect: fix right margin in primary layout

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Protect page
* Check the layout size is fixed, removing an annoying horizontal scrollbar 
* 
<img width="1058" alt="image" src="https://user-images.githubusercontent.com/77539/165308467-dcef0638-7b92-4f4a-8fa7-ed2f67c165c2.png">

* Confirm the page has a proper margin right.

before | after
------|------
<img width="359" alt="image" src="https://user-images.githubusercontent.com/77539/165308710-c2a5501d-a8bc-438a-86aa-1deb74676470.png"> | <img width="358" alt="image" src="https://user-images.githubusercontent.com/77539/165308626-36bef54d-e0b0-46aa-9ab1-00dc44d722bd.png">



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202182937012539