### PR TITLE
Search: Fix search on private WordPress.com-on-Atomic sites

### DIFF
--- a/projects/packages/search/changelog/try-private-atomic-search-auth
+++ b/projects/packages/search/changelog/try-private-atomic-search-auth
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: Fix search for private WoA sites

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -257,13 +257,12 @@ class REST_Controller {
 	 * @param WP_REST_Request $request - REST request.
 	 */
 	public function get_search_results( $request ) {
-		$blog_id = $this->get_blog_id();
-		$path    = sprintf( '/sites/%d/search', absint( $blog_id ) );
-		$path    = add_query_arg(
+		$blog_id  = $this->get_blog_id();
+		$path     = sprintf( '/sites/%d/search', absint( $blog_id ) );
+		$path     = add_query_arg(
 			$request->get_query_params(),
 			sprintf( '/sites/%d/search', absint( $blog_id ) )
 		);
-
 		$response = Client::wpcom_json_api_request_as_blog( $path, '1.3', array(), null, 'rest' );
 		return rest_ensure_response( $this->make_proper_response( $response ) );
 	}

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -257,13 +257,14 @@ class REST_Controller {
 	 * @param WP_REST_Request $request - REST request.
 	 */
 	public function get_search_results( $request ) {
-		$blog_id  = $this->get_blog_id();
-		$path     = sprintf( '/sites/%d/search', absint( $blog_id ) );
-		$path     = add_query_arg(
+		$blog_id = $this->get_blog_id();
+		$path    = sprintf( '/sites/%d/search', absint( $blog_id ) );
+		$path    = add_query_arg(
 			$request->get_query_params(),
 			sprintf( '/sites/%d/search', absint( $blog_id ) )
 		);
-		$response = Client::wpcom_json_api_request_as_user( $path, '1.3', array(), null, 'rest' );
+
+		$response = Client::wpcom_json_api_request_as_blog( $path, '1.3', array(), null, 'rest' );
 		return rest_ensure_response( $this->make_proper_response( $response ) );
 	}
 

--- a/projects/packages/search/src/instant-search/lib/api.js
+++ b/projects/packages/search/src/instant-search/lib/api.js
@@ -424,7 +424,7 @@ export function search( options, requestId ) {
 	//       "Private" Jetpack sites are not yet supported.
 	const urlForPublicApi = `https://public-api.wordpress.com/rest/v1.3${ pathForPublicApi }`;
 	const urlForWpcomOrigin = `${ homeUrl }/wp-json/wpcom-origin/v1.3${ pathForPublicApi }`;
-	const urlForAtomicOrigin = `${ apiRoot }wpcom/v2/search?${ queryString }`;
+	const urlForAtomicOrigin = `${ apiRoot }jetpack/v4/search?${ queryString }`;
 	let url = urlForPublicApi;
 	if ( isPrivateSite && isWpcom ) {
 		url = urlForWpcomOrigin;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #24197.

#### Changes proposed in this Pull Request:
Fixes search on private WordPress.com-on-Atomic (WoA) sites by signing the requests with a blog token instead of a user token.

Also changes the local API URL to the one provided by the search package instead of the one provided by the Jetpack plugin. 

<!-- #### Jetpack product discussion -->
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Note: This PR is only testable by a12s.

1. Spin up a WoA site (either via Pro plan purchase + Jetpack Beta plugin install or via WoA developer blogs — p9o2xV-1r2).
2. Purchase Jetpack Search for the WoA site.
3. Navigate to `/?s=`. Ensure that the search interface works as expected.
4. Navigate to `https://wordpress.com/settings/general/` and change site visibility to Private.
5. Repeat the site search from step 3; ensure that the search API request fails in the network console.
6. Install the Jetpack Beta plugin (if you haven't in step 1) and change the plugin branch to this one.
7. Repeat step 5; ensure that the search API request succeeds.
8. Revert the site privacy back to Public and repeat step 5, just in case.

