### PR TITLE
Search: reset border-radius for search buttons

### DIFF
--- a/projects/packages/search/changelog/fix-overlay-close-radius
+++ b/projects/packages/search/changelog/fix-overlay-close-radius
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: reset border-radius for search buttons

--- a/projects/packages/search/src/instant-search/lib/styles/_mixins.scss
+++ b/projects/packages/search/src/instant-search/lib/styles/_mixins.scss
@@ -87,6 +87,7 @@ $customberg-container-selector: '.jp-search-configure-app-wrapper' !default;
 	appearance: none;
 	background: none;
 	border: none;
+	border-radius: 0;
 	box-shadow: none;
 	margin: 0;
 	outline: none;


### PR DESCRIPTION
When testing a newly-launched site with Instant Search, I noticed that a `border-radius` was being used on the overlay close button:

https://www.endthebacklog.org/?s=

<img width="177" alt="Screen Shot 2022-04-27 at 12 04 17" src="https://user-images.githubusercontent.com/17325/165412353-e049009a-70d0-4fbb-8ae3-320a95b705f1.png">

(Similar to https://github.com/Automattic/jetpack/pull/20833.)

#### Changes proposed in this Pull Request:
Include `border-radius` in the list of CSS properties we reset for search buttons.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
On a test with Instant Search enabled, add the following Custom CSS via the Customizer:

```
button, html input[type="button"], input[type="reset"], input[type="submit"] {
    border-radius: 3.75rem;
}
```

Trigger the Instant Search modal and ensure that the buttons do not have a circular border:

<img width="177" alt="Screen Shot 2022-04-27 at 12 07 11" src="https://user-images.githubusercontent.com/17325/165412703-e8b4b940-28ec-4966-b3cc-daffddd3d723.png">