### PR TITLE
Boost: Fix wpcom connection

### DIFF
--- a/projects/plugins/boost/app/lib/class-connection.php
+++ b/projects/plugins/boost/app/lib/class-connection.php
@@ -127,7 +127,7 @@ class Connection {
 			$is_connected = $this->manager->is_registered();
 		}
 
-		return $is_connected && $this->manager->is_plugin_enabled();
+		return $is_connected;
 	}
 
 	/**

--- a/projects/plugins/boost/changelog/fix-boost-wpcom-connection
+++ b/projects/plugins/boost/changelog/fix-boost-wpcom-connection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed boost connection issue after PR #23991
+
+


### PR DESCRIPTION
Fixes broken e2e tests and connection issues.

#23991 has deprecated some method boost uses. As a result, the connection process is broken for boost.

#### Changes proposed in this Pull Request:
* In progress

#### Jetpack product discussion
p1650983193647509-slack-C016BBAFHHS

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
TBD