### PR TITLE
Protect: Redesign `Summary` component

### DIFF
--- a/projects/plugins/protect/changelog/update-protect-summary-redesign
+++ b/projects/plugins/protect/changelog/update-protect-summary-redesign
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Protect: Redesign Summary component

--- a/projects/plugins/protect/src/js/components/summary/index.jsx
+++ b/projects/plugins/protect/src/js/components/summary/index.jsx
@@ -3,7 +3,9 @@
  */
 import React from 'react';
 import { Container, Col, Text, Title } from '@automattic/jetpack-components';
-import { Icon, wordpress, plugins, color, shield } from '@wordpress/icons';
+import { __, sprintf } from '@wordpress/i18n';
+import { Icon, shield } from '@wordpress/icons';
+import { dateI18n } from '@wordpress/date';
 
 /**
  * Internal dependencies
@@ -11,34 +13,27 @@ import { Icon, wordpress, plugins, color, shield } from '@wordpress/icons';
 import styles from './styles.module.scss';
 import useProtectData from '../../hooks/use-protect-data';
 
-const Cards = ( { name, vulnerabilities, icon } ) => {
-	return (
-		<Col lg={ 2 } className={ styles.card }>
-			{ icon && <Icon icon={ icon } /> }
-			<Text variant="label">{ name }</Text>
-			<Text variant="body-extra-small">Vulnerabilities</Text>
-			<Text variant="headline-small">{ vulnerabilities }</Text>
-		</Col>
-	);
-};
-
 const Summary = () => {
-	const { core, numThemesVulnerabilities, numPluginsVulnerabilities } = useProtectData();
-	const coreCount = core.vulnerabilities?.length || 0;
+	const { numVulnerabilities, lastChecked } = useProtectData();
 	return (
 		<Container fluid>
-			<Col lg={ 6 }>
+			<Col>
 				<Title size="small" className={ styles.title }>
 					<Icon icon={ shield } size={ 32 } className={ styles.icon } />
-					Last check
+					{ sprintf(
+						/* translators: %s: Latest check date  */
+						__( 'Latest results as of %s', 'jetpack-protect' ),
+						dateI18n( 'F jS', lastChecked )
+					) }
 				</Title>
 				<Text variant="headline-small" component="h1">
-					Today, 4:43PM
+					{ sprintf(
+						/* translators: %s: Total number of vulnerabilities  */
+						__( '%s vulnerabilities found', 'jetpack-protect' ),
+						numVulnerabilities
+					) }
 				</Text>
 			</Col>
-			<Cards name="WordPress" vulnerabilities={ coreCount } icon={ wordpress } />
-			<Cards name="Plugins" vulnerabilities={ numPluginsVulnerabilities } icon={ plugins } />
-			<Cards name="Themes" vulnerabilities={ numThemesVulnerabilities } icon={ color } />
 		</Container>
 	);
 };

--- a/projects/plugins/protect/src/js/components/summary/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/summary/styles.module.scss
@@ -1,11 +1,3 @@
-.card {
-	background-color: var(--jp-white);
-	padding: calc( var(--spacing-base) * 2 ); // 16px
-	box-shadow: 0px 0px 40px rgba(0, 0, 0, 0.08);
-	fill: var(--jp-green);
-	border-radius: var(--jp-border-radius);
-}
-
 .title {
 	display: flex;
 	align-items: center;

--- a/projects/plugins/protect/src/js/components/summary/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/summary/styles.module.scss
@@ -9,10 +9,9 @@
 .title {
 	display: flex;
 	align-items: center;
-	margin-left: -4px; // this fix a blank space on right/left from @wordpress/icons
 }
 
 .icon {
-	fill: var(--jp-green);
+	margin-left: -4px; // this fix a blank space on right/left from @wordpress/icons
 	margin-right: var(--spacing-base);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Update Summary to match the new layout.

⚠️ Storybook doesn't work right now, since we need to mock data.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Remove cards from `Summary` component.
* Get data from `useProtectData` hook.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-fFV-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start `Protect`
* Navigate to plugin page.

### Demo

![Screen Shot 2022-04-26 at 23 32 58](https://user-images.githubusercontent.com/1663717/165428394-0fef93db-9477-489f-be30-fc45a33295fd.png)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202117981194293