### PR TITLE
Add TypeScript support for blocks

### DIFF
--- a/projects/js-packages/webpack-config/changelog/add-webpack-utils-module
+++ b/projects/js-packages/webpack-config/changelog/add-webpack-utils-module
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added utils module to use for webpack specific utility functions

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "1.1.9",
+	"version": "1.1.10-alpha",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -65,7 +65,8 @@
 		".": "./src/index.js",
 		"./webpack": "./src/webpack.js",
 		"./babel": "./src/babel.js",
-		"./babel/preset": "./src/babel-preset.js"
+		"./babel/preset": "./src/babel-preset.js",
+		"./utils": "./src/utils.js"
 	},
 	"engines": {
 		"node": "^14.18.3 || ^16.13.2",

--- a/projects/js-packages/webpack-config/src/utils.js
+++ b/projects/js-packages/webpack-config/src/utils.js
@@ -1,0 +1,25 @@
+const fs = require( 'fs' );
+
+const { resolve } = require( './webpack' );
+
+/**
+ * Check if a module exists as per the webpack config.
+ *
+ * Path can be passed with or without file extension. If the path is passed without extension
+ * it will try to find the module with any of the extensions set in webpack config
+ *
+ * @param {string} modulePath - Path with or without file extension
+ * @returns {boolean} - Whether the module exists
+ */
+const moduleExists = modulePath => {
+	return (
+		// If the file already exists, it may already have file extension set
+		fs.existsSync( modulePath ) ||
+		// otherwise check the file with all the allowed file extensions
+		resolve.extensions.some( ext => fs.existsSync( `${ modulePath }${ ext }` ) )
+	);
+};
+
+module.exports = {
+	moduleExists,
+};

--- a/projects/plugins/jetpack/changelog/update-add-ts-suppor-for-blocks
+++ b/projects/plugins/jetpack/changelog/update-add-ts-suppor-for-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Added TypeScript support for blocks.

--- a/projects/plugins/jetpack/tools/webpack.config.extensions.js
+++ b/projects/plugins/jetpack/tools/webpack.config.extensions.js
@@ -5,9 +5,9 @@
 /**
  * External dependencies
  */
-const fs = require( 'fs' );
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
+const jetpackWebpackUtils = require( '@automattic/jetpack-webpack-config/utils' );
 const path = require( 'path' );
 const webpack = jetpackWebpackConfig.webpack;
 const StaticSiteGeneratorPlugin = require( 'static-site-generator-webpack-plugin' );
@@ -38,9 +38,9 @@ const noop = function () {};
 function presetProductionExtensions( type, inputDir, presetBlocks ) {
 	return presetBlocks
 		.flatMap( block =>
-			blockEditorDirectories.map( dir => path.join( inputDir, dir, block, `${ type }.js` ) )
+			blockEditorDirectories.map( dir => path.join( inputDir, dir, block, type ) )
 		)
-		.filter( fs.existsSync );
+		.filter( jetpackWebpackUtils.moduleExists );
 }
 
 const presetPath = path.join( __dirname, '../extensions', 'index.json' );
@@ -57,8 +57,8 @@ const presetBetaBlocks = [ ...presetExperimentalBlocks, ...( presetIndex.beta ||
 
 // Helps split up each block into its own folder view script
 const viewBlocksScripts = presetBetaBlocks.reduce( ( viewBlocks, block ) => {
-	const viewScriptPath = path.join( __dirname, '../extensions/blocks', block, 'view.js' );
-	if ( fs.existsSync( viewScriptPath ) ) {
+	const viewScriptPath = path.join( __dirname, '../extensions/blocks', block, 'view' );
+	if ( jetpackWebpackUtils.moduleExists( viewScriptPath ) ) {
 		viewBlocks[ block + '/view' ] = [ viewSetup, ...[ viewScriptPath ] ];
 	}
 	return viewBlocks;


### PR DESCRIPTION
Although we added TypeScript support in monorepo in #23522, but it seems like blocks are built using separate webpack config.

Related #16375 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update webpack config for extensions/blocks to allow usage of TypeScript
* Create `utils` module in `js-packages/webpack-config` to use for webpack specific utility functions

#### Jetpack product discussion
#16375 

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Boot up the PR
* Run `jetpack build plugins/jetpack`
* Confirm that all the blocks are built successfully
