### PR TITLE
Search: update record meter for new endpoint structure

### DIFF
--- a/projects/packages/search/changelog/update-search-record-meter-endpoint-consumption
+++ b/projects/packages/search/changelog/update-search-record-meter-endpoint-consumption
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-updated how record meter retrieves endpoint data
+Adapt Record Meter to change in API response format

--- a/projects/packages/search/changelog/update-search-record-meter-endpoint-consumption
+++ b/projects/packages/search/changelog/update-search-record-meter-endpoint-consumption
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+updated how record meter retrieves endpoint data

--- a/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
+++ b/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
@@ -54,9 +54,8 @@ export default function getRecordInfo( post_count, post_type_breakdown, tier, la
 
 	if ( numItems > 0 && hasValidData && hasBeenIndexed ) {
 		for ( let i = 0; i < numItems; i++ ) {
-			const theData = Object.values( post_type_breakdown )[ i ];
-			const count = theData.count;
-			const name = theData.title;
+			const postTypeDetails = Object.values( post_type_breakdown )[ i ];
+			const { count, title: name } = postTypeDetails;
 
 			postTypeBreakdown.push( {
 				data: createData( count, colors[ i ], name ),

--- a/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
+++ b/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
@@ -55,12 +55,13 @@ export default function getRecordInfo( post_count, post_type_breakdown, tier, la
 	if ( numItems > 0 && hasValidData && hasBeenIndexed ) {
 		for ( let i = 0; i < numItems; i++ ) {
 			const theData = Object.values( post_type_breakdown )[ i ];
-			const name = Object.keys( post_type_breakdown )[ i ];
+			const count = theData.count;
+			const name = theData.title;
 
 			postTypeBreakdown.push( {
-				data: createData( theData, colors[ i ], name ),
+				data: createData( count, colors[ i ], name ),
 			} );
-			currentCount = currentCount + theData;
+			currentCount = currentCount + count;
 		}
 
 		// sort & split items into included and other

--- a/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
+++ b/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
@@ -55,7 +55,7 @@ export default function getRecordInfo( post_count, post_type_breakdown, tier, la
 	if ( numItems > 0 && hasValidData && hasBeenIndexed ) {
 		for ( let i = 0; i < numItems; i++ ) {
 			const postTypeDetails = Object.values( post_type_breakdown )[ i ];
-			const { count, title: name } = postTypeDetails;
+			const { count, slug: name } = postTypeDetails;
 
 			postTypeBreakdown.push( {
 				data: createData( count, colors[ i ], name ),


### PR DESCRIPTION
This small PR changes the way record meter interprets the data it receives from the search stats endpoint. This is a fix to account for recent structural changes to the endpoint. 

It also returns record meter to using the post type slugs for the time being. 

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

On a site with an active Jetpack Search subscription, go to /wp-admin/admin.php?page=jetpack-search&features=record-meter 

check that the record meter once again loads, and correctly displays the chart data &  legend, and that the legend is using slugs (eg `post` , `page`, `product`)

![image](https://user-images.githubusercontent.com/30754158/165733312-08a5905b-bf57-4ad0-8432-c22000c6a196.png)