### PR TITLE
boost: Fix broken SQL query on uninstall

### DIFF
--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -187,7 +187,7 @@ class Jetpack_Boost {
 			"
 			DELETE
 			FROM    `$wpdb->options`
-			WHERE   `option_name` LIKE jetpack_boost_%
+			WHERE   `option_name` LIKE 'jetpack_boost_%'
 		"
 		);
 

--- a/projects/plugins/boost/changelog/fix-boost-broken-uninstall-sql
+++ b/projects/plugins/boost/changelog/fix-boost-broken-uninstall-sql
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix broken SQL query on uninstall.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
On uninstall, this gets logged
```
WordPress database error You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '' at line 3 for query
			DELETE
			FROM    `wp_options`
			WHERE   `option_name` LIKE jetpack_boost_%
```
The problem is that the argument to LIKE is not quoted.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1651066777319939-slack-C01U2KGS2PQ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Execute `wp plugin uninstall boost`.
* Check the logs. Without this PR the mentioned message should be logged, while with it the message should not be.