### PR TITLE
Protect: Move `VulnerabilitiesList` to hero section

### DIFF
--- a/projects/plugins/protect/changelog/update-protect-list-section
+++ b/projects/plugins/protect/changelog/update-protect-list-section
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Protect: Move VulnerabilitiesList to section hero

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -3,13 +3,7 @@
  */
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import {
-	AdminPage,
-	AdminSectionHero,
-	AdminSection,
-	Container,
-	Col,
-} from '@automattic/jetpack-components';
+import { AdminPage, AdminSectionHero, Container, Col } from '@automattic/jetpack-components';
 import { useConnection } from '@automattic/jetpack-connection';
 
 /**
@@ -42,19 +36,15 @@ const Admin = () => {
 	return (
 		<AdminPage moduleName={ __( 'Jetpack Protect', 'jetpack-protect' ) }>
 			<AdminSectionHero>
-				<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
+				<Container horizontalSpacing={ 3 } horizontalGap={ 7 }>
 					<Col>
 						<Summary />
 					</Col>
-				</Container>
-			</AdminSectionHero>
-			<AdminSection>
-				<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 					<Col>
 						<VulnerabilitiesList />
 					</Col>
 				</Container>
-			</AdminSection>
+			</AdminSectionHero>
 		</AdminPage>
 	);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Move `VulnerabilitiesList` back to the hero section.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Move `VulnerabilitiesList` to `AdminHeroSection`.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start Protect
* Navigate to admin page.
* You should see `Vuls List` inside `Hero Section`

#### Demo

![image](https://user-images.githubusercontent.com/1663717/165569884-8f8caef9-6979-42f1-ac22-c5e2f4632a7e.png)