### PR TITLE
Protect: implement "Add Security plan" workflow.

### DIFF
--- a/projects/plugins/protect/changelog/update-protect-implement-add-security-workflow
+++ b/projects/plugins/protect/changelog/update-protect-implement-add-security-workflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Protect: implement Add Security bundle workflow

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -16,6 +16,8 @@ use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authent
 use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
 use Automattic\Jetpack\Plugins_Installer;
 use Automattic\Jetpack\Protect\Site_Health;
+use Automattic\Jetpack\Protect\Status as Protect_Status;
+use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Sync\Functions as Sync_Functions;
 /**
  * Class Jetpack_Protect
@@ -133,8 +135,6 @@ class Jetpack_Protect {
 			'apiNonce'          => wp_create_nonce( 'wp_rest' ),
 			'registrationNonce' => wp_create_nonce( 'jetpack-registration-nonce' ),
 			'status'            => Protect_Status::get_status(),
-			'siteSuffix'        => ( new JetpackStatus() )->get_site_suffix(),
-			'redirectUrl'       => admin_url( 'admin.php?page=jetpack-protect' ),
 			'installedPlugins'  => Plugins_Installer::get_plugins(),
 			'installedThemes'   => Sync_Functions::get_themes(),
 			'wpVersion'         => $wp_version,

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -134,7 +134,7 @@ class Jetpack_Protect {
 			'registrationNonce' => wp_create_nonce( 'jetpack-registration-nonce' ),
 			'status'            => Protect_Status::get_status(),
 			'siteSuffix'        => ( new JetpackStatus() )->get_site_suffix(),
-			'redirectUrl'       => admin_url( 'admin.php?page=my-jetpack' ),
+			'redirectUrl'       => admin_url( 'admin.php?page=jetpack-protect' ),
 			'installedPlugins'  => Plugins_Installer::get_plugins(),
 			'installedThemes'   => Sync_Functions::get_themes(),
 			'wpVersion'         => $wp_version,

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -16,8 +16,6 @@ use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authent
 use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
 use Automattic\Jetpack\Plugins_Installer;
 use Automattic\Jetpack\Protect\Site_Health;
-use Automattic\Jetpack\Protect\Status as Protect_Status;
-use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Sync\Functions as Sync_Functions;
 /**
  * Class Jetpack_Protect
@@ -135,6 +133,8 @@ class Jetpack_Protect {
 			'apiNonce'          => wp_create_nonce( 'wp_rest' ),
 			'registrationNonce' => wp_create_nonce( 'jetpack-registration-nonce' ),
 			'status'            => Protect_Status::get_status(),
+			'siteSuffix'        => ( new JetpackStatus() )->get_site_suffix(),
+			'redirectUrl'       => admin_url( 'admin.php?page=my-jetpack' ),
 			'installedPlugins'  => Plugins_Installer::get_plugins(),
 			'installedThemes'   => Sync_Functions::get_themes(),
 			'wpVersion'         => $wp_version,

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { __ } from '@wordpress/i18n';
 
 import { AdminPage, AdminSectionHero, Container, Col } from '@automattic/jetpack-components';
-import { useConnection } from '@automattic/jetpack-connection';
+import { useProductCheckoutWorkflow } from '@automattic/jetpack-connection';
 
 /**
  * Internal dependencies
@@ -17,11 +17,23 @@ import Footer from '../footer';
 
 export const SECURITY_BUNDLE = 'jetpack_security_t1_yearly';
 
-const Admin = () => {
-	const { isRegistered } = useConnection( { skipUserConnection: true } );
+const SECURITY_BUNDLE = 'jetpack_security_t1_yearly';
 
-	// Show interstital page when Jetpack is not connected.
-	if ( ! isRegistered ) {
+const Admin = () => {
+	const { siteSuffix, redirectUrl } = window.jetpackProtectInitialState || {};
+
+	const { run, isRegistered, hasCheckoutStarted } = useProductCheckoutWorkflow( {
+		productSlug: SECURITY_BUNDLE,
+		siteSuffix,
+		redirectUrl,
+	} );
+
+	/*
+	 * Show interstital page when
+	 * - Site is not registered
+	 * - Checkout workflow has started
+	 */
+	if ( ! isRegistered || hasCheckoutStarted ) {
 		return (
 			<AdminPage
 				moduleName={ __( 'Jetpack Protect', 'jetpack-protect' ) }
@@ -30,7 +42,7 @@ const Admin = () => {
 			>
 				<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 					<Col sm={ 4 } md={ 8 } lg={ 12 }>
-						<Interstitial />
+						<Interstitial onSecurityAdd={ run } securityJustAdded={ hasCheckoutStarted } />
 					</Col>
 				</Container>
 			</AdminPage>

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -18,12 +18,12 @@ import Footer from '../footer';
 export const SECURITY_BUNDLE = 'jetpack_security_t1_yearly';
 
 const Admin = () => {
-	const { siteSuffix, redirectUrl } = window.jetpackProtectInitialState || {};
+	const { siteSuffix, adminUrl } = window.jetpackProtectInitialState || {};
 
 	const { run, isRegistered, hasCheckoutStarted } = useProductCheckoutWorkflow( {
 		productSlug: SECURITY_BUNDLE,
 		siteSuffix,
-		redirectUrl,
+		redirectUrl: adminUrl,
 	} );
 
 	/*

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -17,8 +17,6 @@ import Footer from '../footer';
 
 export const SECURITY_BUNDLE = 'jetpack_security_t1_yearly';
 
-const SECURITY_BUNDLE = 'jetpack_security_t1_yearly';
-
 const Admin = () => {
 	const { siteSuffix, redirectUrl } = window.jetpackProtectInitialState || {};
 

--- a/projects/plugins/protect/src/js/components/footer/index.jsx
+++ b/projects/plugins/protect/src/js/components/footer/index.jsx
@@ -22,12 +22,12 @@ import { SECURITY_BUNDLE } from '../admin-page';
 
 const Footer = () => {
 	const learnMoreUrl = getRedirectUrl( 'jetpack-protect-footer-learn-more' );
-	const { siteSuffix, redirectUrl } = window.jetpackProtectInitialState || {};
+	const { siteSuffix, adminUrl } = window.jetpackProtectInitialState || {};
 
 	const { run, hasCheckoutStarted } = useProductCheckoutWorkflow( {
 		productSlug: SECURITY_BUNDLE,
 		siteSuffix,
-		redirectUrl,
+		redirectUrl: adminUrl,
 	} );
 
 	return (

--- a/projects/plugins/protect/src/js/components/interstitial/index.jsx
+++ b/projects/plugins/protect/src/js/components/interstitial/index.jsx
@@ -4,24 +4,13 @@
 import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { Dialog, ProductOffer } from '@automattic/jetpack-components';
-import { useProductCheckoutWorkflow } from '@automattic/jetpack-connection';
-
-const SECURITY_BUNDLE = 'jetpack_security_t1_yearly';
 
 /**
  * Internal dependencies
  */
 import ConnectedProductOffer from '../product-offer';
 
-const SecurityBundle = ( { rest } ) => {
-	const { siteSuffix, redirectUrl } = window.jetpackProtectInitialState || {};
-
-	const { run: runCheckout, hasCheckoutStarted } = useProductCheckoutWorkflow( {
-		productSlug: SECURITY_BUNDLE,
-		siteSuffix,
-		redirectUrl,
-	} );
-
+const SecurityBundle = ( { onAdd, redirecting, rest } ) => {
 	return (
 		<ProductOffer
 			slug="security"
@@ -45,8 +34,8 @@ const SecurityBundle = ( { rest } ) => {
 				offPrice: 12.42,
 			} }
 			hasRequiredPlan={ false }
-			onAdd={ runCheckout }
-			isLoading={ hasCheckoutStarted }
+			onAdd={ onAdd }
+			isLoading={ redirecting }
 			{ ...rest }
 		/>
 	);
@@ -55,13 +44,16 @@ const SecurityBundle = ( { rest } ) => {
 /**
  * Intersitial Protect component.
  *
+ * @param {object} props                   - The props passed to Component.
+ * @param {string} props.securityJustAdded - True when the checkout is just added/started.
+ * @param {string} props.onSecurityAdd     - Checkout callback handler.
  * @returns {React.Component} Interstitial react component.
  */
-const Interstitial = () => {
+const Interstitial = ( { onSecurityAdd, securityJustAdded } ) => {
 	return (
 		<Dialog
 			primary={ <ConnectedProductOffer isCard={ true } /> }
-			secondary={ <SecurityBundle /> }
+			secondary={ <SecurityBundle onAdd={ onSecurityAdd } redirecting={ securityJustAdded } /> }
 			split={ true }
 		/>
 	);

--- a/projects/plugins/protect/src/js/components/interstitial/index.jsx
+++ b/projects/plugins/protect/src/js/components/interstitial/index.jsx
@@ -4,38 +4,53 @@
 import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { Dialog, ProductOffer } from '@automattic/jetpack-components';
+import { useProductCheckoutWorkflow } from '@automattic/jetpack-connection';
+
+const SECURITY_BUNDLE = 'jetpack_security_t1_yearly';
 
 /**
  * Internal dependencies
  */
 import ConnectedProductOffer from '../product-offer';
 
-const SecurityBundle = props => (
-	<ProductOffer
-		slug="security"
-		name={ __( 'Security', 'jetpack-protect' ) }
-		title={ __( 'Security', 'jetpack-protect' ) }
-		description={ __(
-			'Comprehensive site security, including Backup, Scan, and Anti-spam.',
-			'jetpack-protect'
-		) }
-		isBundle={ true }
-		supportedProducts={ [ 'backup', 'scan', 'anti-spam' ] }
-		features={ [
-			__( 'Real time cloud backups with 10GB storage', 'jetpack-protect' ),
-			__( 'Automated real-time malware scan', 'jetpack-protect' ),
-			__( 'One click fixes for most threats', 'jetpack-protect' ),
-			__( 'Comment & form spam protection', 'jetpack-protect' ),
-		] }
-		pricing={ {
-			currency: 'USD',
-			price: 24.92,
-			offPrice: 12.42,
-		} }
-		hasRequiredPlan={ false }
-		{ ...props }
-	/>
-);
+const SecurityBundle = ( { rest } ) => {
+	const { siteSuffix, redirectUrl } = window.jetpackProtectInitialState || {};
+
+	const { run: runCheckout, hasCheckoutStarted } = useProductCheckoutWorkflow( {
+		productSlug: SECURITY_BUNDLE,
+		siteSuffix,
+		redirectUrl,
+	} );
+
+	return (
+		<ProductOffer
+			slug="security"
+			name={ __( 'Security', 'jetpack-protect' ) }
+			title={ __( 'Security', 'jetpack-protect' ) }
+			description={ __(
+				'Comprehensive site security, including Backup, Scan, and Anti-spam.',
+				'jetpack-protect'
+			) }
+			isBundle={ true }
+			supportedProducts={ [ 'backup', 'scan', 'anti-spam' ] }
+			features={ [
+				__( 'Real time cloud backups with 10GB storage', 'jetpack-protect' ),
+				__( 'Automated real-time malware scan', 'jetpack-protect' ),
+				__( 'One click fixes for most threats', 'jetpack-protect' ),
+				__( 'Comment & form spam protection', 'jetpack-protect' ),
+			] }
+			pricing={ {
+				currency: 'USD',
+				price: 24.92,
+				offPrice: 12.42,
+			} }
+			hasRequiredPlan={ false }
+			onAdd={ runCheckout }
+			isLoading={ hasCheckoutStarted }
+			{ ...rest }
+		/>
+	);
+};
 
 /**
  * Intersitial Protect component.

--- a/projects/plugins/protect/src/js/components/product-offer/index.jsx
+++ b/projects/plugins/protect/src/js/components/product-offer/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { __ } from '@wordpress/i18n';
 import { ProductOffer } from '@automattic/jetpack-components';
@@ -35,6 +35,14 @@ const ConnectedProductOffer = ( { onAdd, ...rest } ) => {
 		skipUserConnection: true,
 	} );
 
+	const onAddHandler = useCallback( () => {
+		if ( onAdd ) {
+			onAdd();
+		}
+
+		handleRegisterSite();
+	}, [ handleRegisterSite, onAdd ] );
+
 	return (
 		<ProductOffer
 			slug={ PROTECT_PRODUCT_MOCK.slug }
@@ -43,7 +51,7 @@ const ConnectedProductOffer = ( { onAdd, ...rest } ) => {
 			features={ PROTECT_PRODUCT_MOCK.features }
 			pricing={ { isFree: true } }
 			isBundle={ false }
-			onAdd={ handleRegisterSite }
+			onAdd={ onAddHandler }
 			buttonText={ __( 'Get started with Jetpack Protect', 'jetpack-protect' ) }
 			icon="jetpack"
 			isLoading={ siteIsRegistering }

--- a/projects/plugins/protect/src/js/components/product-offer/stories/index.jsx
+++ b/projects/plugins/protect/src/js/components/product-offer/stories/index.jsx
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import React from 'react';
 
 /**
@@ -28,14 +27,12 @@ export default {
 };
 
 const DefaultDefaultProductOffer = args => {
-	const error = args.showError
-		? __( 'An error occurred. Please try again.', 'jetpack-protect' )
-		: '';
-	return <ConnectedProductOffer { ...args } error={ error } />;
+	return <ConnectedProductOffer { ...args } />;
 };
 
 export const Default = DefaultDefaultProductOffer.bind( {} );
 Default.args = {
 	isCard: false,
 	showError: false,
+	onAdd: () => {},
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR implements the Add Security checkout workflow. It uses the implementations done in https://github.com/Automattic/jetpack/pull/24122 and https://github.com/Automattic/jetpack/pull/24113.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Protect: implement "Add Security plan" workflow.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with a site with a Free plan
* No connected user either site
* Active Protect plugin
* Go to Protect plugin page
* You should see the interstitial page
* Click on `Add Security plan` to walk thourhg of the checkout process
* Confirm you get redirected to the Jetpack connect user page
* Once user connects, the client redirect to the checkout page
* Once you buy the plan, the client redirects to the Plugin page
* Confirm you don't see the interstitial page. Instead, you see the Protect plugin page

https://user-images.githubusercontent.com/77539/165594447-93423766-b7e9-4567-a51b-ee42ec982cb7.mov


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202182937012551