### PR TITLE
Protect: Add empty scenario for `List` and `Summary`

### DIFF
--- a/projects/plugins/protect/changelog/update-protect-vuls-list-empty
+++ b/projects/plugins/protect/changelog/update-protect-vuls-list-empty
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Protect: Add empty state for no vuls

--- a/projects/plugins/protect/src/js/components/summary/index.jsx
+++ b/projects/plugins/protect/src/js/components/summary/index.jsx
@@ -26,13 +26,15 @@ const Summary = () => {
 						dateI18n( 'F jS', lastChecked )
 					) }
 				</Title>
-				<Text variant="headline-small" component="h1">
-					{ sprintf(
-						/* translators: %s: Total number of vulnerabilities  */
-						__( '%s vulnerabilities found', 'jetpack-protect' ),
-						numVulnerabilities
-					) }
-				</Text>
+				{ numVulnerabilities > 0 && (
+					<Text variant="headline-small" component="h1">
+						{ sprintf(
+							/* translators: %s: Total number of vulnerabilities  */
+							__( '%s vulnerabilities found', 'jetpack-protect' ),
+							numVulnerabilities
+						) }
+					</Text>
+				) }
 			</Col>
 		</Container>
 	);

--- a/projects/plugins/protect/src/js/components/vulnerabilities-list/empty.jsx
+++ b/projects/plugins/protect/src/js/components/vulnerabilities-list/empty.jsx
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { H3, Text } from '@automattic/jetpack-components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import styles from './styles.module.scss';
+
+const ProtectCheck = () => (
+	<svg width="80" height="96" viewBox="0 0 80 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M40 0.00634766L80 17.7891V44.2985C80 66.8965 65.1605 88.2927 44.2352 95.0425C41.4856 95.9295 38.5144 95.9295 35.7648 95.0425C14.8395 88.2927 0 66.8965 0 44.2985V17.7891L40 0.00634766Z"
+			fill="#069E08"
+		/>
+		<path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M60.9 33.6909L35.375 67.9124L19.2047 55.9263L22.7848 51.1264L34.1403 59.5436L56.0851 30.122L60.9 33.6909Z"
+			fill="white"
+		/>
+	</svg>
+);
+
+const EmptyList = () => {
+	return (
+		<div className={ styles.empty }>
+			<ProtectCheck />
+			<H3 weight="bold" mt={ 8 }>
+				{ __( "Don't worry about a thing", 'jetpack-protect' ) }
+			</H3>
+			<Text>
+				{ __( 'The last Protect scan ran and everything looked great.', 'jetpack-protect' ) }
+			</Text>
+		</div>
+	);
+};
+
+export default EmptyList;

--- a/projects/plugins/protect/src/js/components/vulnerabilities-list/index.jsx
+++ b/projects/plugins/protect/src/js/components/vulnerabilities-list/index.jsx
@@ -10,6 +10,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import VulnerabilitiesNavigation from './navigation';
 import List from './list';
+import EmptyList from './empty';
 import useVulsList from './use-vuls-list';
 
 const VulnerabilitiesList = () => {
@@ -21,22 +22,28 @@ const VulnerabilitiesList = () => {
 				<VulnerabilitiesNavigation selected={ selected } onSelect={ setSelected } />
 			</Col>
 			<Col lg={ 8 }>
-				<Title>
-					{ selected === 'all'
-						? sprintf(
-								/* translators: Translates to Update to. %1$s: Name. %2$s: Fixed version */
-								__( 'All %s vulnerabilities', 'jetpack-protect' ),
-								list.length
-						  )
-						: sprintf(
-								/* translators: Translates to Update to. %1$s: Name. %2$s: Fixed version */
-								__( '%1$s vulnerabilities in your %2$s %3$s', 'jetpack-protect' ),
-								list.length,
-								item?.name,
-								item?.version
-						  ) }
-				</Title>
-				<List list={ list } />
+				{ list?.length > 0 ? (
+					<>
+						<Title>
+							{ selected === 'all'
+								? sprintf(
+										/* translators: Translates to Update to. %1$s: Name. %2$s: Fixed version */
+										__( 'All %s vulnerabilities', 'jetpack-protect' ),
+										list.length
+								  )
+								: sprintf(
+										/* translators: Translates to Update to. %1$s: Name. %2$s: Fixed version */
+										__( '%1$s vulnerabilities in your %2$s %3$s', 'jetpack-protect' ),
+										list.length,
+										item?.name,
+										item?.version
+								  ) }
+						</Title>
+						<List list={ list } />
+					</>
+				) : (
+					<EmptyList />
+				) }
 			</Col>
 		</Container>
 	);

--- a/projects/plugins/protect/src/js/components/vulnerabilities-list/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/vulnerabilities-list/styles.module.scss
@@ -1,0 +1,9 @@
+.empty {
+	display: flex;
+	width: 100%;
+	height: 100%;
+	align-items: center;
+	justify-content: center;
+	max-height: 600px;
+	flex-direction: column;
+}

--- a/projects/plugins/protect/src/js/components/vulnerabilities-list/use-vuls-list.js
+++ b/projects/plugins/protect/src/js/components/vulnerabilities-list/use-vuls-list.js
@@ -29,9 +29,9 @@ const mergeAllVuls = ( { core, plugins, themes } ) => [
 
 const useVulsList = () => {
 	const { plugins, themes, core } = useProtectData();
-	const [ selected, setSelected ] = useState( 'all' );
 	const [ item, setItem ] = useState( {} );
 	const [ list, setList ] = useState( mergeAllVuls( { core, plugins, themes } ) );
+	const [ selected, setSelected ] = useState( list?.length ? 'all' : null );
 
 	const handleSelected = id => {
 		setSelected( id );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Insert the empty mode, when no vulnerabilities have been found.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add `EmptyList` in `VulnerabilitiesList`.
* Do not select the initial item at `Navigation` if has no vul.
* Do not render the number of vuls text at `Summary` if has no vul.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1202064326332560-as-1202117981194332/f

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start `Protect`
* Navigate to admin page.
* Set `JETPACK_PROTECT_DEV__API_RESPONSE_TYPE` to `complete_green`.
* You should see empty state.

#### Demo

![Screen Shot 2022-04-27 at 18 26 52](https://user-images.githubusercontent.com/1663717/165634787-4e26759d-731a-452e-be95-029859220a87.png)