### PR TITLE
One Click Restores: Use feature checks to determine backup type

### DIFF
--- a/projects/plugins/jetpack/_inc/client/recommendations/sidebar/one-click-restores/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/sidebar/one-click-restores/index.jsx
@@ -36,9 +36,11 @@ const OneClickRestoresComponent = props => {
 		} );
 	}, [] );
 
-	const backupsName = hasRealTimeBackups
-		? __( 'Real-time Backups', 'jetpack' )
-		: __( 'Daily Backups', 'jetpack' );
+	/* Avoid ternary as code minification will break translation function. :( */
+	let backupsName = __( 'Daily Backups', 'jetpack' );
+	if ( hasRealTimeBackups ) {
+		backupsName = __( 'Real-time Backups', 'jetpack' );
+	}
 
 	return (
 		<Layout

--- a/projects/plugins/jetpack/_inc/client/recommendations/sidebar/one-click-restores/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/sidebar/one-click-restores/index.jsx
@@ -13,9 +13,8 @@ import { Layout } from '../layout';
 import Button from 'components/button';
 import { imagePath } from 'constants/urls';
 import analytics from 'lib/analytics';
-import { containsBackupRealtime, getPlanClass } from 'lib/plans/constants';
 import { getSiteRawUrl } from 'state/initial-state';
-import { getActiveBackupPurchase, hasActiveBackupPurchase, getSitePlan } from 'state/site';
+import { hasActiveSiteFeature } from 'state/site';
 
 /**
  * Style dependencies
@@ -23,7 +22,7 @@ import { getActiveBackupPurchase, hasActiveBackupPurchase, getSitePlan } from 's
 import './style.scss';
 
 const OneClickRestoresComponent = props => {
-	const { planClass, siteRawUrl } = props;
+	const { hasRealTimeBackups, siteRawUrl } = props;
 
 	useEffect( () => {
 		analytics.tracks.recordEvent( 'jetpack_recommendations_summary_sidebar_display', {
@@ -37,7 +36,7 @@ const OneClickRestoresComponent = props => {
 		} );
 	}, [] );
 
-	const backupsName = containsBackupRealtime( planClass )
+	const backupsName = hasRealTimeBackups
 		? __( 'Real-time Backups', 'jetpack' )
 		: __( 'Daily Backups', 'jetpack' );
 
@@ -79,10 +78,8 @@ const OneClickRestoresComponent = props => {
 };
 
 const OneClickRestores = connect( state => ( {
+	hasRealTimeBackups: hasActiveSiteFeature( state, 'real-time-backups' ),
 	siteRawUrl: getSiteRawUrl( state ),
-	planClass: hasActiveBackupPurchase( state )
-		? getPlanClass( getActiveBackupPurchase( state ).product_slug )
-		: getPlanClass( getSitePlan( state ).product_slug ),
 } ) )( OneClickRestoresComponent );
 
 export { OneClickRestores };

--- a/projects/plugins/jetpack/changelog/update-oneclickrestores
+++ b/projects/plugins/jetpack/changelog/update-oneclickrestores
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+One Click Restores: Uses feature checks to determine backup type


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* No functional changes
* Replaces plan checks with a feature check to determine if the current site has real-time backups.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* [Create a jurassic ninja site](https://jurassic.ninja/specialops/) with a "Jetpack Backup (Real-time)" plan and Jetpack Beta with this branch being enabled.
* Connect to your site and chose a free plan
* Go through the recommendation steps until the last card.
* Make sure the sidebar card mentions "real-time backups" not daily backups.

<img width="1040" alt="Screen Shot 2022-04-27 at 3 02 02 PM" src="https://user-images.githubusercontent.com/1398304/165638648-29db47e4-2e1a-4320-bd0c-b26c0bb2b29a.png">

