### PR TITLE
Reorganize how exposing and consuming connection data

### DIFF
--- a/projects/js-packages/connection/changelog/update-re-organize-exposing-connection-data
+++ b/projects/js-packages/connection/changelog/update-re-organize-exposing-connection-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+JS Connection: use connection global state as a fallback to be used by the useProductCheckoutWorkflow() custom hook

--- a/projects/js-packages/connection/hooks/use-product-checkout-workflow/Readme.md
+++ b/projects/js-packages/connection/hooks/use-product-checkout-workflow/Readme.md
@@ -6,19 +6,20 @@ The hook delegates the task to connect the user when it's disconnected, adding a
 
 ## API
 
+### Arguments
 The hook expects a `props` object argument with the following specs:
 
-* **productSlug**:
+#### productSlug
 this is the WordPress.com product slug.
-For instance, for security bundle it's usually defined with `jetpack_security_t1_yearly`.
-* **siteSuffix**:
-site slug suffix to be used as part of Calypso URLs. Take adventage of [get_site_suffix](../../../../packages/status/src/class-status.php#L327) backend helper
-* **redirectUrl**:
+#### redirectUrl
 The URL to redirect to after checkout.
+For instance, for security bundle it's usually defined with `jetpack_security_t1_yearly`.
+#### siteSuffix (optional)
+Site slug suffix to be used as part of Calypso URLs. As default, tt's defined by the [get_site_suffix()](../../../../packages/status/src/class-status.php#L327) backend helper.
 
 And it returns also an object with the following keys:
 
-* **run**:
+#### run
 helper function to run the checkout process. Usually, you'd like to asign this function as to an event callback.
 
 ```jsx
@@ -37,10 +38,10 @@ function MyComponent() {
 }
 ```
 
-* **isRegisterd**
+#### isRegisterd
 determine if the site is registered, or not. It's shortcut to the [getSiteIsRegistering](../../state/selectors.jsx#L10) selector.
 
-* **hasCheckoutStarted**:
+#### hasCheckoutStarted*
 True right after the checkout process starts. Take advantage of this prop to deal with the delay that happens when the browser starts to redirect to the checkout page.
 
 ```jsx

--- a/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
+++ b/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
@@ -11,24 +11,27 @@ import { getProductCheckoutUrl } from '@automattic/jetpack-components';
  */
 import { STORE_ID } from '../../state/store.jsx';
 
-const { registrationNonce, apiRoot, apiNonce } = window?.JP_CONNECTION_INITIAL_STATE
-	? window.JP_CONNECTION_INITIAL_STATE
-	: {};
+const {
+	registrationNonce,
+	apiRoot,
+	apiNonce,
+	siteSuffix: defaultSiteSuffix,
+} = window?.JP_CONNECTION_INITIAL_STATE ? window.JP_CONNECTION_INITIAL_STATE : {};
 
 /**
  * Custom hook that performs the needed steps
  * to concrete the checkout workflow.
  *
- * @param {object} props             - The props passed to the hook.
- * @param {string} props.productSlug - The WordPress product slug.
- * @param {string} props.siteSuffix  - The site suffix.
- * @param {string} props.redirectUrl - The URI to redirect to after checkout.
- * @returns {Function}				 - The useEffect hook.
+ * @param {object} props              - The props passed to the hook.
+ * @param {string} props.productSlug  - The WordPress product slug.
+ * @param {string} props.redirectUrl  - The URI to redirect to after checkout.
+ * @param {string} [props.siteSuffix] - The site suffix.
+ * @returns {Function}				  - The useEffect hook.
  */
 export default function useProductCheckoutWorkflow( {
 	productSlug,
-	siteSuffix,
 	redirectUrl,
+	siteSuffix = defaultSiteSuffix,
 } = {} ) {
 	const [ hasCheckoutStarted, setCheckoutStarted ] = useState( false );
 	const { registerSite } = useDispatch( STORE_ID );
@@ -40,8 +43,8 @@ export default function useProductCheckoutWorkflow( {
 	// Build the checkout URL.
 	const checkoutProductUrl = getProductCheckoutUrl(
 		productSlug,
-		siteSuffix,
 		redirectUrl,
+		siteSuffix,
 		isUserConnected
 	);
 

--- a/projects/packages/connection/changelog/update-re-organize-exposing-connection-data
+++ b/projects/packages/connection/changelog/update-re-organize-exposing-connection-data
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Connection: Expose wpVersion, siteSuffix and adminUrl in the global initial state var
+Connection: Expose wpVersion and siteSuffix in the global initial state var

--- a/projects/packages/connection/changelog/update-re-organize-exposing-connection-data
+++ b/projects/packages/connection/changelog/update-re-organize-exposing-connection-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Connection: Expose wpVersion, siteSuffix and adminUrl in the global initial state var

--- a/projects/packages/connection/src/class-initial-state.php
+++ b/projects/packages/connection/src/class-initial-state.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Connection;
 
+use Automattic\Jetpack\Status;
+
 /**
  * The React initial state.
  */
@@ -25,6 +27,8 @@ class Initial_State {
 	 * @return array
 	 */
 	private static function get_data() {
+		global $wp_version;
+
 		return array(
 			'apiRoot'            => esc_url_raw( rest_url() ),
 			'apiNonce'           => wp_create_nonce( 'wp_rest' ),
@@ -32,6 +36,8 @@ class Initial_State {
 			'connectionStatus'   => REST_Connector::connection_status( false ),
 			'userConnectionData' => REST_Connector::get_user_connection_data( false ),
 			'connectedPlugins'   => REST_Connector::get_connection_plugins( false ),
+			'wpVersion'          => $wp_version,
+			'siteSuffix'         => ( new Status() )->get_site_suffix(),
 		);
 	}
 

--- a/projects/plugins/protect/changelog/update-re-organize-exposing-connection-data
+++ b/projects/plugins/protect/changelog/update-re-organize-exposing-connection-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Protect: clean connection data. Update to latest connection API

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -17,7 +17,6 @@ use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
 use Automattic\Jetpack\Plugins_Installer;
 use Automattic\Jetpack\Protect\Site_Health;
 use Automattic\Jetpack\Protect\Status as Protect_Status;
-use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Sync\Functions as Sync_Functions;
 /**
  * Class Jetpack_Protect
@@ -138,7 +137,6 @@ class Jetpack_Protect {
 			'installedPlugins'  => Plugins_Installer::get_plugins(),
 			'installedThemes'   => Sync_Functions::get_themes(),
 			'wpVersion'         => $wp_version,
-			'siteSuffix'        => ( new Status() )->get_site_suffix(),
 			'adminUrl'          => admin_url( 'admin.php?page=jetpack-protect' ),
 		);
 	}

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -18,11 +18,10 @@ import Footer from '../footer';
 export const SECURITY_BUNDLE = 'jetpack_security_t1_yearly';
 
 const Admin = () => {
-	const { siteSuffix, adminUrl } = window.jetpackProtectInitialState || {};
+	const { adminUrl } = window.jetpackProtectInitialState || {};
 
 	const { run, isRegistered, hasCheckoutStarted } = useProductCheckoutWorkflow( {
 		productSlug: SECURITY_BUNDLE,
-		siteSuffix,
 		redirectUrl: adminUrl,
 	} );
 

--- a/projects/plugins/protect/src/js/components/footer/index.jsx
+++ b/projects/plugins/protect/src/js/components/footer/index.jsx
@@ -22,11 +22,11 @@ import { SECURITY_BUNDLE } from '../admin-page';
 
 const Footer = () => {
 	const learnMoreUrl = getRedirectUrl( 'jetpack-protect-footer-learn-more' );
-	const { siteSuffix, adminUrl } = window.jetpackProtectInitialState || {};
+
+	const { adminUrl } = window.jetpackProtectInitialState || {};
 
 	const { run, hasCheckoutStarted } = useProductCheckoutWorkflow( {
 		productSlug: SECURITY_BUNDLE,
-		siteSuffix,
 		redirectUrl: adminUrl,
 	} );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR reorganizes the code among Connect, JS Connect, and the Protect plugin in order to make the API of some helpers and hooks simpler, making the focus on the recent `useProductCheckoutWorkflow()` custom hook.

Follow-up from https://github.com/Automattic/jetpack/pull/24122#discussion_r860154635

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1651081554136539-slack-C02TQF5VAJD

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with Protect plugin
* Connect the site
* You should see the Footer section, with the `Get Jetpack Security` button there
* Confirm the browser leads you properly to the checkout page. It will try to log in the user in case it isn't already logged.
* It should go back to the Protect primary page
* Also you can take a look at the URL, trying to confirm it's well-formed.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202183659789068