### PR TITLE
Assistant: Update discount/upsell card CTA

### DIFF
--- a/projects/plugins/jetpack/_inc/client/recommendations/sidebar/discount-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/sidebar/discount-card/index.jsx
@@ -93,7 +93,7 @@ const DiscountCard = ( {
 								onClick={ onCtaClick }
 							>
 								{ hasDiscount && __( 'View discounted products', 'jetpack' ) }
-								{ ! hasDiscount && __( 'View discounted products', 'jetpack' ) }
+								{ ! hasDiscount && __( 'View products', 'jetpack' ) }
 							</Button>
 						) }
 					</div>

--- a/projects/plugins/jetpack/changelog/fix-assistant-discount-card-copy
+++ b/projects/plugins/jetpack/changelog/fix-assistant-discount-card-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Assistant: Update discount card CTA


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR removes the mention of discounted products in the Assistant upsell card, when discount is not available.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Context: p8oabR-QB-p2#comment-6250

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a new JN site with this branch
- Complete the connection flow, getting Jetpack Free
- Open the network panel of your browser
- Visit `/wp-admin/admin.php?page=jetpack#/recommendations/site-type`
- You should see a mention of the discount in the upsell card, and the CTA _View discounted products_
- Note the coupon code in the payload returned by `/wp-json/jetpack/v4/site/discount`
- Delete the coupon in the coupons tool
- Reload the page at `/wp-admin/admin.php?page=jetpack#/recommendations/site-type`
- CTA should now be _View products_
<img width="378" alt="Screen Shot 2022-04-28 at 10 03 47 AM" src="https://user-images.githubusercontent.com/1620183/165772017-0895686b-e143-47a3-b8c4-2dc265c88d65.png">

