### PR TITLE
Assistant: Hide old background behind discount card

### DIFF
--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/prompt-layout/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/prompt-layout/index.jsx
@@ -78,7 +78,7 @@ const PromptLayout = props => {
 			className={ classNames( 'jp-recommendations-question__main', {
 				'jp-recommendations-question__main--with-sidebar': !! illustrationPath || !! sidebarCard,
 				'jp-recommendations-question__main--with-illustration':
-					! isLoadingSideContent && !! illustrationPath,
+					! isLoadingSideContent && !! illustrationPath && ! sidebarCard,
 				'jp-recommendations-question__main--with-illustration--rna': !! illustrationPath && !! rna,
 			} ) }
 		>

--- a/projects/plugins/jetpack/changelog/fix-assistant-discount-card-bg
+++ b/projects/plugins/jetpack/changelog/fix-assistant-discount-card-bg
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Assistant: Hide old background behind discount card


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR removes a lingering background showing behind the discount card in the Assistant, when starting the flow from the banner in the dashboard.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Context: [p8oabR-QB-p2#comment-6250](p8oabR-QB-p2#comment-6254)

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a new JN site with this branch
- Complete the connection flow, getting Jetpack Free
- Visit `/wp-admin/index.php`
- Click _Continue_ in the Assistant banner in the dashboard
<img width="1093" alt="Screen Shot 2022-04-28 at 10 52 49 AM" src="https://user-images.githubusercontent.com/1620183/165780540-016e13eb-1ec1-4c0b-b8ae-cbc1ee2abf64.png">


- You should now see the discount card in the Assistant. Make sure there's no background except the color blob behind the discount card.

_Before_
<img width="1006" alt="Screen Shot 2022-04-28 at 10 21 44 AM" src="https://user-images.githubusercontent.com/1620183/165780300-ff5be262-21f4-43d5-8b02-a2ba15290799.png">


_After_
<img width="1009" alt="Screen Shot 2022-04-28 at 10 54 08 AM" src="https://user-images.githubusercontent.com/1620183/165780911-67729935-6bfd-45fa-8657-10e4e60e225a.png">


