### PR TITLE
Assistant: Show product price if no intro offer

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-assistant-show-base-price
+++ b/projects/plugins/jetpack/changelog/fix-assistant-show-base-price
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Assistant: Show product price if no intro offer


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR makes sure a price is shown in the Assistant product cards, even if no introductory offer is available.

_Backup has no introductory offer, and the product card doesn't show any price_
<img width="1009" alt="Screen Shot 2022-04-28 at 12 03 23 PM" src="https://user-images.githubusercontent.com/1620183/165795909-aba95324-55c7-4ce7-9fd6-9d074bc81506.png">

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Context: p8oabR-QB-p2#comment-6247

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Regression testing**
- Make sure that your curency has an intro offer for Backup and Security, such as with USD
- Spin up a new JN site with this branch, and another one with the release candidate branch
- Complete the connection flow, getting Jetpack Free, with both of them
- Visit `/wp-admin/admin.php?page=jetpack#/recommendations/product-suggestions` in both sites, and make sure prices are the same
- Then visit `/wp-admin/admin.php?page=jetpack#/recommendations/summary` and do the same

**Actual testing**
- Update your currency to Turkish lira (TRY)
- Spin up a new JN site with this branch
- Complete the connection flow, getting Jetpack Free
- Visit `/wp-admin/admin.php?page=jetpack#/recommendations/product-suggestions` and check that both product cards show a price
<img width="1009" alt="Screen Shot 2022-04-28 at 12 08 25 PM" src="https://user-images.githubusercontent.com/1620183/165796254-5ea3e0ab-2913-48e6-97e1-26878d0f7ebf.png">

- Then visit `/wp-admin/admin.php?page=jetpack#/recommendations/summary` and do the same


