### PR TITLE
Update Videopress plan checks to feature checks.

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/videopress.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/videopress.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { includes, noop } from 'lodash';
+import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -19,7 +19,6 @@ import { getRedirectUrl } from '@automattic/jetpack-components';
 import DashItem from 'components/dash-item';
 import {
 	isVideoPressLegacySecurityPlan,
-	getPlanClass,
 	getJetpackProductUpsellByFeature,
 	FEATURE_VIDEOPRESS,
 } from 'lib/plans/constants';
@@ -32,11 +31,11 @@ import {
 	isOfflineMode,
 } from 'state/connection';
 import {
-	hasActiveVideoPressPurchase,
 	isFetchingSitePurchases,
 	getSitePlan,
 	getSitePurchases,
 	getVideoPressStorageUsed,
+	hasActiveSiteFeature,
 } from 'state/site';
 import { getProductDescriptionUrl } from 'product-descriptions/utils';
 
@@ -65,27 +64,23 @@ class DashVideoPress extends Component {
 			link: getRedirectUrl( 'jetpack-support-videopress' ),
 		};
 
-		const planClass = getPlanClass( this.props.sitePlan.product_slug );
 		const {
 			hasConnectedOwner,
 			hasVideoPressLegacySecurityPlan,
-			hasVideoPressPurchase,
+			hasVideoPressFeature,
 			isFetching,
 			isOffline,
 			upgradeUrl,
 			videoPressStorageUsed,
 		} = this.props;
 
-		const hasUpgrade =
-			includes( [ 'is-premium-plan', 'is-business-plan', 'is-complete-plan' ], planClass ) ||
-			hasVideoPressLegacySecurityPlan ||
-			hasVideoPressPurchase;
+		const hasUpgrade = hasVideoPressFeature || hasVideoPressLegacySecurityPlan;
 
-		const shouldDisplayStorage = hasVideoPressPurchase && null !== videoPressStorageUsed;
+		const shouldDisplayStorage = hasVideoPressFeature && null !== videoPressStorageUsed;
 		const shouldDisplayBanner = hasConnectedOwner && ! hasUpgrade && ! isOffline && ! isFetching;
 
 		const bannerText =
-			! hasVideoPressPurchase && null !== videoPressStorageUsed && 0 === videoPressStorageUsed
+			! hasVideoPressFeature && null !== videoPressStorageUsed && 0 === videoPressStorageUsed
 				? __(
 						'1 free video available. Upgrade now to unlock more videos and 1TB of storage.',
 						'jetpack'
@@ -192,7 +187,7 @@ class DashVideoPress extends Component {
 export default connect(
 	state => ( {
 		hasConnectedOwner: hasConnectedOwnerSelector( state ),
-		hasVideoPressPurchase: hasActiveVideoPressPurchase( state ),
+		hasVideoPressFeature: hasActiveSiteFeature( state, 'videopress' ),
 		hasVideoPressLegacySecurityPlan: getSitePurchases( state ).find(
 			isVideoPressLegacySecurityPlan
 		),

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/videopress.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/videopress.jsx
@@ -17,11 +17,7 @@ import { getRedirectUrl } from '@automattic/jetpack-components';
  * Internal dependencies
  */
 import DashItem from 'components/dash-item';
-import {
-	isVideoPressLegacySecurityPlan,
-	getJetpackProductUpsellByFeature,
-	FEATURE_VIDEOPRESS,
-} from 'lib/plans/constants';
+import { getJetpackProductUpsellByFeature, FEATURE_VIDEOPRESS } from 'lib/plans/constants';
 import { ProgressBar } from '@automattic/components';
 import JetpackBanner from 'components/jetpack-banner';
 import { isModuleAvailable } from 'state/modules';
@@ -33,9 +29,8 @@ import {
 import {
 	isFetchingSitePurchases,
 	getSitePlan,
-	getSitePurchases,
 	getVideoPressStorageUsed,
-	hasActiveSiteFeature,
+	hasActiveVideoPressFeature,
 } from 'state/site';
 import { getProductDescriptionUrl } from 'product-descriptions/utils';
 
@@ -66,7 +61,6 @@ class DashVideoPress extends Component {
 
 		const {
 			hasConnectedOwner,
-			hasVideoPressLegacySecurityPlan,
 			hasVideoPressFeature,
 			isFetching,
 			isOffline,
@@ -74,10 +68,9 @@ class DashVideoPress extends Component {
 			videoPressStorageUsed,
 		} = this.props;
 
-		const hasUpgrade = hasVideoPressFeature || hasVideoPressLegacySecurityPlan;
-
 		const shouldDisplayStorage = hasVideoPressFeature && null !== videoPressStorageUsed;
-		const shouldDisplayBanner = hasConnectedOwner && ! hasUpgrade && ! isOffline && ! isFetching;
+		const shouldDisplayBanner =
+			hasConnectedOwner && ! hasVideoPressFeature && ! isOffline && ! isFetching;
 
 		const bannerText =
 			! hasVideoPressFeature && null !== videoPressStorageUsed && 0 === videoPressStorageUsed
@@ -187,10 +180,7 @@ class DashVideoPress extends Component {
 export default connect(
 	state => ( {
 		hasConnectedOwner: hasConnectedOwnerSelector( state ),
-		hasVideoPressFeature: hasActiveSiteFeature( state, 'videopress' ),
-		hasVideoPressLegacySecurityPlan: getSitePurchases( state ).find(
-			isVideoPressLegacySecurityPlan
-		),
+		hasVideoPressFeature: hasActiveVideoPressFeature( state ),
 		isModuleAvailable: isModuleAvailable( state, 'videopress' ),
 		isOffline: isOfflineMode( state ),
 		isFetching: isFetchingSitePurchases( state ),

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/videopress.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/videopress.jsx
@@ -70,9 +70,8 @@ class DashVideoPress extends Component {
 			videoPressStorageUsed,
 		} = this.props;
 
-		console.log( '=======> ' + hasVideoPressUnlimitedStorage );
-
-		const shouldDisplayStorage = ! hasVideoPressUnlimitedStorage && null !== videoPressStorageUsed;
+		const shouldDisplayStorage =
+			hasVideoPressFeature && ! hasVideoPressUnlimitedStorage && null !== videoPressStorageUsed;
 		const shouldDisplayBanner =
 			hasConnectedOwner && ! hasVideoPressFeature && ! isOffline && ! isFetching;
 

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/videopress.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/videopress.jsx
@@ -30,6 +30,7 @@ import {
 	isFetchingSitePurchases,
 	getSitePlan,
 	getVideoPressStorageUsed,
+	hasActiveSiteFeature,
 	hasActiveVideoPressFeature,
 } from 'state/site';
 import { getProductDescriptionUrl } from 'product-descriptions/utils';
@@ -62,13 +63,16 @@ class DashVideoPress extends Component {
 		const {
 			hasConnectedOwner,
 			hasVideoPressFeature,
+			hasVideoPressUnlimitedStorage,
 			isFetching,
 			isOffline,
 			upgradeUrl,
 			videoPressStorageUsed,
 		} = this.props;
 
-		const shouldDisplayStorage = hasVideoPressFeature && null !== videoPressStorageUsed;
+		console.log( '=======> ' + hasVideoPressUnlimitedStorage );
+
+		const shouldDisplayStorage = ! hasVideoPressUnlimitedStorage && null !== videoPressStorageUsed;
 		const shouldDisplayBanner =
 			hasConnectedOwner && ! hasVideoPressFeature && ! isOffline && ! isFetching;
 
@@ -181,6 +185,7 @@ export default connect(
 	state => ( {
 		hasConnectedOwner: hasConnectedOwnerSelector( state ),
 		hasVideoPressFeature: hasActiveVideoPressFeature( state ),
+		hasVideoPressUnlimitedStorage: hasActiveSiteFeature( state, 'videopress-unlimited-storage' ),
 		isModuleAvailable: isModuleAvailable( state, 'videopress' ),
 		isOffline: isOfflineMode( state ),
 		isFetching: isFetchingSitePurchases( state ),

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/videopress.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/videopress.jsx
@@ -31,7 +31,6 @@ import {
 	getSitePlan,
 	getVideoPressStorageUsed,
 	hasActiveSiteFeature,
-	hasActiveVideoPressFeature,
 } from 'state/site';
 import { getProductDescriptionUrl } from 'product-descriptions/utils';
 
@@ -183,7 +182,9 @@ class DashVideoPress extends Component {
 export default connect(
 	state => ( {
 		hasConnectedOwner: hasConnectedOwnerSelector( state ),
-		hasVideoPressFeature: hasActiveVideoPressFeature( state ),
+		hasVideoPressFeature:
+			hasActiveSiteFeature( state, 'videopress-1tb-storage' ) ||
+			hasActiveSiteFeature( state, 'videopress-unlimited-storage' ),
 		hasVideoPressUnlimitedStorage: hasActiveSiteFeature( state, 'videopress-unlimited-storage' ),
 		isModuleAvailable: isModuleAvailable( state, 'videopress' ),
 		isOffline: isOfflineMode( state ),

--- a/projects/plugins/jetpack/_inc/client/lib/plans/constants.js
+++ b/projects/plugins/jetpack/_inc/client/lib/plans/constants.js
@@ -515,13 +515,14 @@ export function containsBackupRealtime( planClass ) {
 }
 
 /**
- * Security Daily/Realtime plan no longer includes VideoPress as of Oct 7 2021 00:00 UTC.
- * This check identifies purchases of Security Daily/Realtime purchased before or after that date.
+ * Security plans no longer includes VideoPress as of Oct 7 2021 00:00 UTC.
+ * We use this check to identify purchases of Security plans AFTER Oct 7 2021 00:00 UTC to EXCLUDE them from the
+ * VideoPress feature.
  *
  * @param {*} purchase - The site purchase object.
- * @returns {boolean} True if legacy plan (VideoPress is included), false otherwise.
+ * @returns {boolean} True if Security plan purchased after Oct 7 2021 (VideoPress is NOT included).
  */
-export const isVideoPressLegacySecurityPlan = purchase =>
+export const isSecurityPlanExcludingVideoPress = purchase =>
 	purchase.active &&
 	includes(
 		[
@@ -529,7 +530,11 @@ export const isVideoPressLegacySecurityPlan = purchase =>
 			PLAN_JETPACK_SECURITY_DAILY,
 			PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
 			PLAN_JETPACK_SECURITY_REALTIME,
+			PLAN_JETPACK_SECURITY_T1_YEARLY,
+			PLAN_JETPACK_SECURITY_T1_MONTHLY,
+			PLAN_JETPACK_SECURITY_T2_YEARLY,
+			PLAN_JETPACK_SECURITY_T2_MONTHLY,
 		],
 		purchase.product_slug
 	) &&
-	new Date( purchase.subscribed_date ) < new Date( '2021-10-07T00:00:00+00:00' );
+	new Date( purchase.subscribed_date ) >= new Date( '2021-10-07T00:00:00+00:00' );

--- a/projects/plugins/jetpack/_inc/client/lib/plans/constants.js
+++ b/projects/plugins/jetpack/_inc/client/lib/plans/constants.js
@@ -513,28 +513,3 @@ export function containsBackupRealtime( planClass ) {
 		'is-realtime-backup-plan',
 	].includes( planClass );
 }
-
-/**
- * Security plans no longer includes VideoPress as of Oct 7 2021 00:00 UTC.
- * We use this check to identify purchases of Security plans AFTER Oct 7 2021 00:00 UTC to EXCLUDE them from the
- * VideoPress feature.
- *
- * @param {*} purchase - The site purchase object.
- * @returns {boolean} True if Security plan purchased after Oct 7 2021 (VideoPress is NOT included).
- */
-export const isSecurityPlanExcludingVideoPress = purchase =>
-	purchase.active &&
-	includes(
-		[
-			PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
-			PLAN_JETPACK_SECURITY_DAILY,
-			PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
-			PLAN_JETPACK_SECURITY_REALTIME,
-			PLAN_JETPACK_SECURITY_T1_YEARLY,
-			PLAN_JETPACK_SECURITY_T1_MONTHLY,
-			PLAN_JETPACK_SECURITY_T2_YEARLY,
-			PLAN_JETPACK_SECURITY_T2_MONTHLY,
-		],
-		purchase.product_slug
-	) &&
-	new Date( purchase.subscribed_date ) >= new Date( '2021-10-07T00:00:00+00:00' );

--- a/projects/plugins/jetpack/_inc/client/performance/media.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/media.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { includes } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { ProgressBar } from '@automattic/components';
@@ -12,8 +11,6 @@ import { ProgressBar } from '@automattic/components';
  * Internal dependencies
  */
 import {
-	isVideoPressLegacySecurityPlan,
-	getPlanClass,
 	getJetpackProductUpsellByFeature,
 	FEATURE_VIDEOPRESS,
 	FEATURE_VIDEO_HOSTING_JETPACK,
@@ -30,9 +27,8 @@ import { isModuleFound as _isModuleFound } from 'state/search';
 import { hasConnectedOwner as hasConnectedOwnerSelector, isOfflineMode } from 'state/connection';
 import {
 	getSitePlan,
-	getSitePurchases,
 	getVideoPressStorageUsed,
-	hasActiveVideoPressPurchase,
+	hasActiveVideoPressFeature,
 	isFetchingSitePurchases,
 } from 'state/site';
 import CompactFormToggle from 'components/form/form-toggle/compact';
@@ -54,26 +50,19 @@ class Media extends React.Component {
 		}
 
 		const videoPress = this.props.module( 'videopress' );
-		const planClass = getPlanClass( this.props.sitePlan.product_slug );
 		const {
 			hasConnectedOwner,
-			hasVideoPressLegacySecurityPlan,
-			hasVideoPressPurchase,
+			hasVideoPressFeature,
 			isFetching,
 			isOffline,
 			upgradeUrl,
 			videoPressStorageUsed,
 		} = this.props;
 
-		const shouldDisplayStorage = hasVideoPressPurchase && null !== videoPressStorageUsed;
-
-		const hasUpgrade =
-			includes( [ 'is-premium-plan', 'is-business-plan', 'is-complete-plan' ], planClass ) ||
-			hasVideoPressLegacySecurityPlan ||
-			hasVideoPressPurchase;
+		const shouldDisplayStorage = hasVideoPressFeature && null !== videoPressStorageUsed;
 
 		const bannerText =
-			! hasVideoPressPurchase && null !== videoPressStorageUsed && 0 === videoPressStorageUsed
+			! hasVideoPressFeature && null !== videoPressStorageUsed && 0 === videoPressStorageUsed
 				? __(
 						'1 free video available. Upgrade now to unlock more videos and 1TB of storage.',
 						'jetpack'
@@ -139,7 +128,7 @@ class Media extends React.Component {
 
 		const videoPressForcedInactive = 'inactive' === this.props.getModuleOverride( 'videopress' );
 		const shouldDisplayBanner =
-			foundVideoPress && ! hasUpgrade && hasConnectedOwner && ! isOffline && ! isFetching;
+			foundVideoPress && ! hasVideoPressFeature && hasConnectedOwner && ! isOffline && ! isFetching;
 
 		return (
 			<SettingsCard
@@ -171,10 +160,7 @@ export default connect( state => {
 		module: module_name => getModule( state, module_name ),
 		isModuleFound: module_name => _isModuleFound( state, module_name ),
 		sitePlan: getSitePlan( state ),
-		hasVideoPressPurchase: hasActiveVideoPressPurchase( state ),
-		hasVideoPressLegacySecurityPlan: getSitePurchases( state ).find(
-			isVideoPressLegacySecurityPlan
-		),
+		hasVideoPressFeature: hasActiveVideoPressFeature( state ),
 		hasConnectedOwner: hasConnectedOwnerSelector( state ),
 		isOffline: isOfflineMode( state ),
 		isFetching: isFetchingSitePurchases( state ),

--- a/projects/plugins/jetpack/_inc/client/performance/media.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/media.jsx
@@ -28,6 +28,7 @@ import { hasConnectedOwner as hasConnectedOwnerSelector, isOfflineMode } from 's
 import {
 	getSitePlan,
 	getVideoPressStorageUsed,
+	hasActiveSiteFeature,
 	hasActiveVideoPressFeature,
 	isFetchingSitePurchases,
 } from 'state/site';
@@ -53,13 +54,15 @@ class Media extends React.Component {
 		const {
 			hasConnectedOwner,
 			hasVideoPressFeature,
+			hasVideoPressUnlimitedStorage,
 			isFetching,
 			isOffline,
 			upgradeUrl,
 			videoPressStorageUsed,
 		} = this.props;
 
-		const shouldDisplayStorage = hasVideoPressFeature && null !== videoPressStorageUsed;
+		const shouldDisplayStorage =
+			hasVideoPressFeature && ! hasVideoPressUnlimitedStorage && null !== videoPressStorageUsed;
 
 		const bannerText =
 			! hasVideoPressFeature && null !== videoPressStorageUsed && 0 === videoPressStorageUsed
@@ -161,6 +164,7 @@ export default connect( state => {
 		isModuleFound: module_name => _isModuleFound( state, module_name ),
 		sitePlan: getSitePlan( state ),
 		hasVideoPressFeature: hasActiveVideoPressFeature( state ),
+		hasVideoPressUnlimitedStorage: hasActiveSiteFeature( state, 'videopress-unlimited-storage' ),
 		hasConnectedOwner: hasConnectedOwnerSelector( state ),
 		isOffline: isOfflineMode( state ),
 		isFetching: isFetchingSitePurchases( state ),

--- a/projects/plugins/jetpack/_inc/client/performance/media.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/media.jsx
@@ -29,7 +29,6 @@ import {
 	getSitePlan,
 	getVideoPressStorageUsed,
 	hasActiveSiteFeature,
-	hasActiveVideoPressFeature,
 	isFetchingSitePurchases,
 } from 'state/site';
 import CompactFormToggle from 'components/form/form-toggle/compact';
@@ -163,7 +162,9 @@ export default connect( state => {
 		module: module_name => getModule( state, module_name ),
 		isModuleFound: module_name => _isModuleFound( state, module_name ),
 		sitePlan: getSitePlan( state ),
-		hasVideoPressFeature: hasActiveVideoPressFeature( state ),
+		hasVideoPressFeature:
+			hasActiveSiteFeature( state, 'videopress-1tb-storage' ) ||
+			hasActiveSiteFeature( state, 'videopress-unlimited-storage' ),
 		hasVideoPressUnlimitedStorage: hasActiveSiteFeature( state, 'videopress-unlimited-storage' ),
 		hasConnectedOwner: hasConnectedOwnerSelector( state ),
 		isOffline: isOfflineMode( state ),

--- a/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
@@ -3,7 +3,7 @@
  */
 import { _x } from '@wordpress/i18n';
 import { combineReducers } from 'redux';
-import { assign, difference, get, includes, isArray, isEmpty, mergeWith, union } from 'lodash';
+import { assign, difference, get, isArray, isEmpty, mergeWith, union } from 'lodash';
 
 /**
  * Internal dependencies
@@ -31,8 +31,6 @@ import {
 	JETPACK_RECOMMENDATIONS_SITE_DISCOUNT_VIEWED,
 } from 'state/action-types';
 import {
-	getPlanClass,
-	isVideoPressLegacySecurityPlan,
 	isJetpackPlanWithAntiSpam,
 	PLAN_JETPACK_SECURITY_T1_YEARLY,
 	PLAN_JETPACK_VIDEOPRESS,
@@ -42,13 +40,12 @@ import { getRewindStatus } from 'state/rewind';
 import { getSetting } from 'state/settings';
 import {
 	getSitePlan,
-	getSitePurchases,
 	hasActiveProductPurchase,
 	hasActiveSecurityPurchase,
 	hasActiveSiteFeature,
 	hasActiveAntiSpamPurchase,
-	hasActiveVideoPressPurchase,
 	hasSecurityComparableLegacyPlan,
+	hasActiveVideoPressFeature,
 } from 'state/site';
 import { hasConnectedOwner } from 'state/connection';
 import { isPluginActive } from 'state/site/plugins';
@@ -343,8 +340,6 @@ export const isProductSuggestionsAvailable = state => {
 };
 
 export const getProductSlugForStep = ( state, step ) => {
-	const planClass = getPlanClass( getSitePlan( state ).product_slug );
-
 	switch ( step ) {
 		case 'publicize':
 		case 'security-plan':
@@ -362,11 +357,7 @@ export const getProductSlugForStep = ( state, step ) => {
 			}
 			break;
 		case 'videopress':
-			if (
-				! includes( [ 'is-premium-plan', 'is-business-plan', 'is-complete-plan' ], planClass ) &&
-				! getSitePurchases( state ).find( isVideoPressLegacySecurityPlan ) &&
-				! hasActiveVideoPressPurchase( state )
-			) {
+			if ( ! hasActiveVideoPressFeature( state ) ) {
 				return PLAN_JETPACK_VIDEOPRESS;
 			}
 			break;

--- a/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
@@ -45,7 +45,6 @@ import {
 	hasActiveSiteFeature,
 	hasActiveAntiSpamPurchase,
 	hasSecurityComparableLegacyPlan,
-	hasActiveVideoPressFeature,
 } from 'state/site';
 import { hasConnectedOwner } from 'state/connection';
 import { isPluginActive } from 'state/site/plugins';
@@ -357,7 +356,10 @@ export const getProductSlugForStep = ( state, step ) => {
 			}
 			break;
 		case 'videopress':
-			if ( ! hasActiveVideoPressFeature( state ) ) {
+			if (
+				! hasActiveSiteFeature( state, 'videopress-1tb-storage' ) &&
+				! hasActiveSiteFeature( state, 'videopress-unlimited-storage' )
+			) {
 				return PLAN_JETPACK_VIDEOPRESS;
 			}
 			break;

--- a/projects/plugins/jetpack/_inc/client/state/site/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/site/reducer.js
@@ -13,10 +13,8 @@ import {
 	isJetpackProduct,
 	isJetpackSearch,
 	isJetpackSecurityBundle,
-	isJetpackVideoPress,
 	isJetpackAntiSpam,
 	isSecurityComparableJetpackLegacyPlan,
-	isSecurityPlanExcludingVideoPress,
 } from 'lib/plans/constants';
 import {
 	JETPACK_SITE_DATA_FETCH,
@@ -413,28 +411,15 @@ export function hasActiveSearchPurchase( state ) {
 }
 
 /**
- * Searches active products for an active VideoPress product.
- *
- * @param {*} state - Global state tree
- * @returns {boolean} True if the an active VideoPress plan was found, false otherwise.
- */
-export function getActiveVideoPressPurchase( state ) {
-	return find( getActiveProductPurchases( state ), product =>
-		isJetpackVideoPress( product.product_slug )
-	);
-}
-
-/**
- * Determines if the site has an active VideoPress feature and excludes the VideoPress feature from Security plans
- * purchased after a certain date.
+ * Determines if the site has an active VideoPress feature.
  *
  * @param {*} state - Global state tree
  * @returns {boolean} True if the site has an active VideoPress product purchase, false otherwise.
  */
 export function hasActiveVideoPressFeature( state ) {
 	return (
-		hasActiveSiteFeature( state, 'videopress' ) &&
-		! getSitePurchases( state ).find( isSecurityPlanExcludingVideoPress )
+		hasActiveSiteFeature( state, 'videopress-1tb-storage' ) ||
+		hasActiveSiteFeature( state, 'videopress-unlimited-storage' )
 	);
 }
 

--- a/projects/plugins/jetpack/_inc/client/state/site/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/site/reducer.js
@@ -16,6 +16,7 @@ import {
 	isJetpackVideoPress,
 	isJetpackAntiSpam,
 	isSecurityComparableJetpackLegacyPlan,
+	isSecurityPlanExcludingVideoPress,
 } from 'lib/plans/constants';
 import {
 	JETPACK_SITE_DATA_FETCH,
@@ -424,13 +425,17 @@ export function getActiveVideoPressPurchase( state ) {
 }
 
 /**
- * Determines if the site has an active VideoPress product purchase
+ * Determines if the site has an active VideoPress feature and excludes the VideoPress feature from Security plans
+ * purchased after a certain date.
  *
  * @param {*} state - Global state tree
  * @returns {boolean} True if the site has an active VideoPress product purchase, false otherwise.
  */
-export function hasActiveVideoPressPurchase( state ) {
-	return !! getActiveVideoPressPurchase( state );
+export function hasActiveVideoPressFeature( state ) {
+	return (
+		hasActiveSiteFeature( state, 'videopress' ) &&
+		! getSitePurchases( state ).find( isSecurityPlanExcludingVideoPress )
+	);
 }
 
 /**

--- a/projects/plugins/jetpack/_inc/client/state/site/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/site/reducer.js
@@ -411,19 +411,6 @@ export function hasActiveSearchPurchase( state ) {
 }
 
 /**
- * Determines if the site has an active VideoPress feature.
- *
- * @param {*} state - Global state tree
- * @returns {boolean} True if the site has an active VideoPress product purchase, false otherwise.
- */
-export function hasActiveVideoPressFeature( state ) {
-	return (
-		hasActiveSiteFeature( state, 'videopress-1tb-storage' ) ||
-		hasActiveSiteFeature( state, 'videopress-unlimited-storage' )
-	);
-}
-
-/**
  * Searches active products for an active Anti-Spam product.
  *
  * @param {*} state - Global state tree

--- a/projects/plugins/jetpack/changelog/refactor-use-wpcom-features-check
+++ b/projects/plugins/jetpack/changelog/refactor-use-wpcom-features-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Refactor to use hasActiveSiteFeature to centralize the source of truth to WPCOM_Features.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This purpose of this PR is to convert VideoPress plan checks into feature checks to help consolidate the source of truth on what plans have the VideoPress feature. (P2 primer: p58i-cef-p2) This is done by leveraging `hasActiveSiteFeature`.

This PR affects 3 places in the front end.

- Dashboard > At a Glance > Performance and Growth > VideoPress
- Settings > Performance > Media > VideoPress
- Dashboard > Recommendations (VideoPress is recommended after 2 weeks)

There should be no noticeable changes from production EXCEPT for one. Jetpack Complete (purchased after '2021-10-07') plans should now show the storage bar in At a Glance and in Performance. (Reference p1651177148184529-slack-CDLH4C1UZ)

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
- This PR leverages the new WPCOM_Features legacy feature support (D80783-code). The legacy features `videopress-unlimited-storage` and `videopress-1tb-storage` are defined in D80962-code and we no longer need to identify legacy Unlimited VideoPress purchases locally. As such, this PR removes:
  - isVideoPressLegacySecurityPlan
  - hasActiveVideoPressPurchase
  - getActiveVideoPressPurchase

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

# Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

## Testing the "At a Glance" and Performance Section
To test the At a Glance and Performance section, you will need these sites:

- Jetpack Free
- Jetpack Complete
- Jetpack Security
- Jetpack Security (purchased before Oct 7 2021)
  - Use Store Admin to adjust your purchase date.

At a Glance is here: /wp-admin/admin.php?page=jetpack#/dashboard
Performance is here: /wp-admin/admin.php?page=jetpack#/performance

The plans should match the images in the table below. Note, that in production (10.8) the storage used bar does not show for Jetpack Complete plans. This PR changes that. Jetpack Complete should show the storage used bar as shown in the picture below. p1651177148184529-slack-CDLH4C1UZ Additionally, in Jetpack 10.9, a new Video Privacy toggle was added to the Performance section.

Plan | At a Glance | Performance
--|--|--
All purchases that do NOT include VideoPress 1TB or Unlimited storage. This includes all plans EXCEPT Complete and VideoPress add-on | Disabled (default state) ![jetpack-free-glance-disabled-prod](https://user-images.githubusercontent.com/140841/166162587-3fba7012-fb26-406e-84a9-eb12fbccdf49.png) Enabled ![jetpack-free-glance-enabled-prod](https://user-images.githubusercontent.com/140841/166162610-955defac-950d-4bb4-ba2e-beb79282c298.png) | Disabled (default state) ![jetpack-free-performance-disabled-prod](https://user-images.githubusercontent.com/140841/166162501-93af9772-ee9a-4fd1-9a56-87a389b4f231.png) Enabled ![jetpack-free-performance-enabled-prod](https://user-images.githubusercontent.com/140841/166162509-31b1ad43-5c2e-4fa2-bbad-e2bac9992499.png)
All purchases that include VideoPress 1TB, including Complete & VideoPress add-on (purchased after 2021-10-07) | Enabled (default state) ![jetpack-vp-glance](https://user-images.githubusercontent.com/140841/166070439-5ef9a489-9867-4a3d-b635-2677320b9203.png) Disabled ![jetpack-vp-glance-disabled](https://user-images.githubusercontent.com/140841/166070887-22f91b7c-9d6c-47f1-87e1-95c979e049c5.png) | Enabled (default state) ![jetpack-complete-prod](https://user-images.githubusercontent.com/140841/166162375-86c8703d-3e19-4a67-8430-849f4cef3415.png) Disabled ![jetpack-complete-disabled-prod](https://user-images.githubusercontent.com/140841/166162379-6f074356-7da9-45bc-b836-6e5632d93782.png)
Legacy VideoPress Unlimited purchases do not show the storage bar. (Jetpack Complete, VideoPress, and Security plans purchased before 2021-10-07) | ![video-press-unlimited-ata](https://user-images.githubusercontent.com/140841/170349299-00f36373-61f1-4a80-a9b8-8016c8ae4f46.png) | ![video-press-unlimited-media](https://user-images.githubusercontent.com/140841/170349288-a8b95b8a-ffb6-4390-97d1-976ae634ace9.png)






## Testing the Recommendation Section

The VideoPress recommendation shows up 2 weeks after a site connects if VideoPress is not already enabled on that site. Making this tough to test. But it can be done!

If you have Jetpack Docker site that is older than 2 weeks, you can simply go to /wp-admin/admin.php?page=jetpack#/recommendations/videopress and confirm it works and matches production.

If you do not have a Jetpack site that is older than 2 weeks, you can "trick" the recommendation into appearing by following the testing instructions on this PR: https://github.com/Automattic/jetpack/pull/23678