### PR TITLE
Fix/videopress disabled existing video block error

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-videopress-disabled-existing-video-block-error
+++ b/projects/plugins/jetpack/changelog/fix-videopress-disabled-existing-video-block-error
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Its a bugfix to a feature that isn't released yet
+
+

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
@@ -811,14 +811,16 @@ const VpBlock = props => {
 		scripts = [];
 	}
 
-	const videopresAjaxURLBlob = new Blob(
-		[ `var videopressAjax = { ajaxUrl: '${ window.videopressAjax.ajaxUrl }' };` ],
-		{
-			type: 'text/javascript',
-		}
-	);
+	if ( window.videopressAjax ) {
+		const videopresAjaxURLBlob = new Blob(
+			[ `var videopressAjax = { ajaxUrl: '${ window.videopressAjax.ajaxUrl }' };` ],
+			{
+				type: 'text/javascript',
+			}
+		);
 
-	scripts.push( URL.createObjectURL( videopresAjaxURLBlob ), window.videopressAjax.bridgeUrl );
+		scripts.push( URL.createObjectURL( videopresAjaxURLBlob ), window.videopressAjax.bridgeUrl );
+	}
 
 	return (
 		<figure { ...blockProps }>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #24144 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Checks for the `videopressAjax` variable before trying to access any of its properties

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
nope

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a site with VideoPress enabled, add a `/video` block to a post, upload or select an existing video from the media library. Publish the post.
* Disable VideoPress at Jetpack -> Settings -> Performance
* Re-open the post in the editor, you SHOULD NOT see the `Block has encountered an error...` message
