### PR TITLE
Security Settings: Use feature check in backup & scan

### DIFF
--- a/projects/plugins/jetpack/_inc/client/security/backups-scan.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/backups-scan.jsx
@@ -19,9 +19,9 @@ import { getRedirectUrl, numberFormat } from '@automattic/jetpack-components';
 import analytics from 'lib/analytics';
 import Banner from 'components/banner';
 import Card from 'components/card';
-import { getPlanClass, FEATURE_SECURITY_SCANNING_JETPACK } from 'lib/plans/constants';
+import { FEATURE_SECURITY_SCANNING_JETPACK } from 'lib/plans/constants';
 import { getVaultPressData, getVaultPressScanThreatCount } from 'state/at-a-glance';
-import { getSitePlan } from 'state/site';
+import { hasActiveSiteFeature } from 'state/site';
 import { isModuleActivated } from 'state/modules';
 import QueryRewindStatus from 'components/data/query-rewind-status';
 import SettingsCard from 'components/settings-card';
@@ -159,8 +159,7 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 					[ 'data', 'features', 'backups' ],
 					false
 				),
-				scanEnabled = get( this.props.vaultPressData, [ 'data', 'features', 'security' ], false ),
-				planClass = getPlanClass( this.props.sitePlan.product_slug );
+				scanEnabled = get( this.props.vaultPressData, [ 'data', 'features', 'security' ], false );
 			let cardText = '';
 
 			if ( this.props.isOfflineMode ) {
@@ -199,33 +198,21 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 				);
 			}
 
-			// Only return here if backups enabled and site on on free/personal plan, or if Jetpack Backup is in use.
-			// If they're on a higher plan, then they have access to scan as well, and need to set it up!
-			if (
-				backupsEnabled &&
-				includes(
-					[ 'is-free-plan', 'is-personal-plan', 'is-daily-backup-plan', 'is-realtime-backup-plan' ],
-					planClass
-				)
-			) {
+			// Only return here if backups are enabled and site doesn't have scan.
+			if ( backupsEnabled && ! this.props.hasScan ) {
 				return __( 'Your site is connected to VaultPress for backups.', 'jetpack' );
 			}
 
 			// Nothing is enabled. We can show upgrade/setup text now.
-			switch ( planClass ) {
-				case 'is-personal-plan':
-					cardText = __( "You have paid for backups but they're not yet active.", 'jetpack' );
-					cardText += ' ' + __( 'Click "Set Up" to finish installation.', 'jetpack' );
-					break;
-				case 'is-premium-plan':
-				case 'is-business-plan':
-					cardText = __(
-						'You have paid for backups and security scanning but they’re not yet active.',
-						'jetpack'
-					);
-					cardText += ' ' + __( 'Click "Set Up" to finish installation.', 'jetpack' );
-					break;
+			cardText = __( "You have paid for backups but they're not yet active.", 'jetpack' );
+			if ( this.props.hasScan ) {
+				cardText = __(
+					'You have paid for backups and security scanning but they’re not yet active.',
+					'jetpack'
+				);
 			}
+
+			cardText += ' ' + __( 'Click "Set Up" to finish installation.', 'jetpack' );
 
 			return cardText;
 		}
@@ -296,8 +283,8 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 
 export default connect( state => {
 	return {
-		sitePlan: getSitePlan( state ),
 		vaultPressData: getVaultPressData( state ),
+		hasScan: hasActiveSiteFeature( state, 'scan' ),
 		hasThreats: getVaultPressScanThreatCount( state ),
 		vaultPressActive: isModuleActivated( state, 'vaultpress' ),
 		showBackups: showBackups( state ),

--- a/projects/plugins/jetpack/changelog/update-scan-settings-plan-checks
+++ b/projects/plugins/jetpack/changelog/update-scan-settings-plan-checks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Security Settings: Use feature checks for backup and scan


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* No functional changes
* Updates plan checks with feature checks in Backup & Scan settings.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be p
resented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* [Create a jurassic ninja site](https://jurassic.ninja/specialops/) with Jetpack Beta with this branch being enabled.
* Connect to your site and chose a free plan
* Navigate to `/wp-admin/admin.php?page=jetpack#/security`
* On sites without Jetpack Backup or Scan, a prompt to upgrade should show.  <img width="701" alt="Screen Shot 2022-04-28 at 2 37 31 PM" src="https://user-images.githubusercontent.com/1398304/165849916-d8dbd10b-39dd-4812-ab8b-c7d2ece05aef.png">

* On sites with Jetpack Backup but not Scan, the card should refer to configuring only Jetpack Backup. <img width="605" alt="Screen Shot 2022-04-28 at 2 46 42 PM" src="https://user-images.githubusercontent.com/1398304/165852027-3dff104b-7874-41a2-9498-59e77cad3290.png">

* On sites with Scan, the card should refer to both Backup and Scan.
* Upgrade to a backup plan and verify the Backup and Scan settings are update.
* Upgrade to a scan plan and verify the Backup and Scan settings are updated.
<img width="639" alt="image" src="https://user-images.githubusercontent.com/1398304/165847222-f0ba67e0-a7e3-4823-bd73-a1899d194ce1.png">

