### PR TITLE
Recommendations: Use feature check for one click restores

### DIFF
--- a/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
@@ -44,8 +44,8 @@ import {
 	getSitePlan,
 	getSitePurchases,
 	hasActiveProductPurchase,
-	hasActiveScanPurchase,
 	hasActiveSecurityPurchase,
+	hasActiveSiteFeature,
 	hasActiveAntiSpamPurchase,
 	hasActiveVideoPressPurchase,
 	hasSecurityComparableLegacyPlan,
@@ -552,7 +552,7 @@ export const getSidebarCardSlug = state => {
 		return 'upsell';
 	}
 
-	if ( 'awaiting_credentials' === rewindState && ! hasActiveScanPurchase( state ) ) {
+	if ( 'awaiting_credentials' === rewindState && ! hasActiveSiteFeature( state, 'scan' ) ) {
 		return 'one-click-restores';
 	}
 

--- a/projects/plugins/jetpack/_inc/client/state/site/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/site/reducer.js
@@ -13,7 +13,6 @@ import {
 	isJetpackProduct,
 	isJetpackBackup,
 	isJetpackPlanWithBackup,
-	isJetpackScan,
 	isJetpackSearch,
 	isJetpackSecurityBundle,
 	isJetpackVideoPress,
@@ -384,16 +383,6 @@ export function getActiveBackupPurchase( state ) {
 
 export function hasActiveBackupPurchase( state ) {
 	return !! getActiveBackupPurchase( state );
-}
-
-export function getActiveScanPurchase( state ) {
-	return find( getActiveProductPurchases( state ), product =>
-		isJetpackScan( product.product_slug )
-	);
-}
-
-export function hasActiveScanPurchase( state ) {
-	return !! getActiveScanPurchase( state );
 }
 
 /**

--- a/projects/plugins/jetpack/changelog/update-scan-feature-check
+++ b/projects/plugins/jetpack/changelog/update-scan-feature-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Recommendations: Use feature check for one-click restores


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* No functional changes
* Replaces purchase check with a feature check to determine if the current site has Scan.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* [Create a jurassic ninja site](https://jurassic.ninja/specialops/) with a "Jetpack Backup (Real-time)" plan and Jetpack Beta with this branch being enabled.
* Connect to your site and chose a free plan
* Go through the recommendation steps until the last card.
* Make sure the sidebar card shows the one-click backups card 
<img width="315" alt="image" src="https://user-images.githubusercontent.com/1398304/165855543-4aa973b9-cfde-4ab4-bd53-2e9f7e0e96b6.png">
* Add a Scan plan to your site. It should now show the download app card.
