### PR TITLE
My Plan: Use feature check for search card

### DIFF
--- a/projects/plugins/jetpack/_inc/client/my-plan/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/my-plan/index.jsx
@@ -13,7 +13,6 @@ import {
 	getAvailableFeatures,
 	getSitePlan,
 	getSitePurchases,
-	hasActiveSearchPurchase,
 } from 'state/site';
 import QuerySite from 'components/data/query-site';
 import { getSiteConnectionStatus } from 'state/connection';
@@ -45,7 +44,6 @@ export function MyPlan( props ) {
 			<MyPlanBody
 				activeFeatures={ activeFeatures }
 				availableFeatures={ availableFeatures }
-				hasActiveSearchPurchase={ props.hasActiveSearchPurchase }
 				plan={ sitePlan }
 				rewindStatus={ props.rewindStatus }
 				siteAdminUrl={ props.siteAdminUrl }
@@ -61,7 +59,6 @@ export default connect( state => {
 		activeProducts: getActiveProductPurchases( state ),
 		availableFeatures: getAvailableFeatures( state ),
 		getSiteConnectionStatus: () => getSiteConnectionStatus( state ),
-		hasActiveSearchPurchase: hasActiveSearchPurchase( state ),
 		purchases: getSitePurchases( state ),
 		sitePlan: getSitePlan( state ),
 	};

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
@@ -29,6 +29,7 @@ import {
 } from 'state/modules';
 import { updateSettings } from 'state/settings/actions';
 import { getSetting, isUpdatingSetting } from 'state/settings/reducer';
+import { hasActiveSiteFeature } from 'state/site';
 import QuerySitePlugins from 'components/data/query-site-plugins';
 import { showBackups } from 'state/initial-state';
 
@@ -301,7 +302,7 @@ class MyPlanBody extends React.Component {
 						{ 'is-personal-plan' === planClass && getRewindVaultPressCard() }
 						{ 'is-premium-plan' === planClass && getRewindVaultPressCard() }
 						{ 'is-business-plan' === planClass && getRewindVaultPressCard() }
-						{ this.props.hasActiveSearchPurchase && getSearchCard() }
+						{ this.props.hasInstantSearch && getSearchCard() }
 						<div className="jp-landing__plan-features-card">
 							<div className="jp-landing__plan-features-img">
 								<img
@@ -575,7 +576,7 @@ class MyPlanBody extends React.Component {
 				planCard = (
 					<div className="jp-landing__plan-features">
 						{ jetpackBackupCard }
-						{ this.props.hasActiveSearchPurchase && getSearchCard() }
+						{ this.props.hasInstantSearch && getSearchCard() }
 						<div className="jp-landing__plan-features-card">
 							<div className="jp-landing__plan-features-img">
 								<img
@@ -794,6 +795,7 @@ class MyPlanBody extends React.Component {
 export default connect(
 	state => {
 		return {
+			hasInstantSearch: hasActiveSiteFeature( state, 'instant-search' ),
 			isFetchingPluginsData: isFetchingPluginsData( state ),
 			isPluginActive: plugin_slug => isPluginActive( state, plugin_slug ),
 			isPluginInstalled: plugin_slug => isPluginInstalled( state, plugin_slug ),

--- a/projects/plugins/jetpack/changelog/update-search-purchase
+++ b/projects/plugins/jetpack/changelog/update-search-purchase
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+My Plan: Use feature check for search card


### PR DESCRIPTION


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* No functional changes
* Uses a feature check to show the search card under "My Plan"

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `/wp-admin/admin.php?page=jetpack#/my-plan` on your Jetpack test site.
* On a site with a jetpack search upgrade, make sure the page includes a search card: 
<img width="503" alt="image" src="https://user-images.githubusercontent.com/1398304/165859981-7e79c48d-c58b-4662-94eb-9aa3f8219f57.png">
* On a site without Jetpack search the card shouldn't show up.
