### PR TITLE
Search: Sync search options

### DIFF
--- a/projects/packages/backup/changelog/add-sync-search-options
+++ b/projects/packages/backup/changelog/add-sync-search-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/backup/composer.json
+++ b/projects/packages/backup/composer.json
@@ -13,7 +13,7 @@
 		"automattic/jetpack-connection-ui": "^2.4",
 		"automattic/jetpack-identity-crisis": "^0.8",
 		"automattic/jetpack-my-jetpack": "^1.3",
-		"automattic/jetpack-sync": "^1.31",
+		"automattic/jetpack-sync": "^1.32",
 		"automattic/jetpack-status": "^1.13"
 	},
 	"require-dev": {

--- a/projects/packages/search/changelog/add-sync-search-options
+++ b/projects/packages/search/changelog/add-sync-search-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search: refactored Settings to expose the settings array for sync

--- a/projects/packages/search/src/class-settings.php
+++ b/projects/packages/search/src/class-settings.php
@@ -16,6 +16,23 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Class to initialize search settings on the site.
  */
 class Settings {
+	/**
+	 * This contains significant code overlap with `customizer/class-customizer.php`.
+	 * The settings are synced to WPCOM thru `sync/src/modules/class-search.php`.
+	 *
+	 * @var array
+	 */
+	public static $settings = array(
+		array( Options::OPTION_PREFIX . 'color_theme', 'string', 'light' ),
+		array( Options::OPTION_PREFIX . 'result_format', 'string', 'minimal' ),
+		array( Options::OPTION_PREFIX . 'default_sort', 'string', 'relevance' ),
+		array( Options::OPTION_PREFIX . 'overlay_trigger', 'string', 'results' ),
+		array( Options::OPTION_PREFIX . 'excluded_post_types', 'string', '' ),
+		array( Options::OPTION_PREFIX . 'highlight_color', 'string', '#FFC' ),
+		array( Options::OPTION_PREFIX . 'enable_sort', 'boolean', true ),
+		array( Options::OPTION_PREFIX . 'inf_scroll', 'boolean', true ),
+		array( Options::OPTION_PREFIX . 'show_powered_by', 'boolean', true ),
+	);
 
 	/**
 	 * Class initialization.
@@ -31,20 +48,7 @@ class Settings {
 	 * @since 9.x.x
 	 */
 	public function settings_register() {
-		// NOTE: This contains significant code overlap with class-jetpack-search-customize.
-		$setting_prefix = Options::OPTION_PREFIX;
-		$settings       = array(
-			array( $setting_prefix . 'color_theme', 'string', 'light' ),
-			array( $setting_prefix . 'result_format', 'string', 'minimal' ),
-			array( $setting_prefix . 'default_sort', 'string', 'relevance' ),
-			array( $setting_prefix . 'overlay_trigger', 'string', 'results' ),
-			array( $setting_prefix . 'excluded_post_types', 'string', '' ),
-			array( $setting_prefix . 'highlight_color', 'string', '#FFC' ),
-			array( $setting_prefix . 'enable_sort', 'boolean', true ),
-			array( $setting_prefix . 'inf_scroll', 'boolean', true ),
-			array( $setting_prefix . 'show_powered_by', 'boolean', true ),
-		);
-		foreach ( $settings as $value ) {
+		foreach ( static::$settings as $value ) {
 			register_setting(
 				'options',
 				$value[0],

--- a/projects/packages/search/src/class-settings.php
+++ b/projects/packages/search/src/class-settings.php
@@ -18,7 +18,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Settings {
 	/**
 	 * This contains significant code overlap with `customizer/class-customizer.php`.
-	 * The settings are synced to WPCOM thru `sync/src/modules/class-search.php`.
+	 *
+	 * 1. The settings are synced to WPCOM thru `sync/src/modules/class-search.php`.
+	 * 2. Ensure to add new options to WPCOM whitelist if need to be synced following `PCYsg-sBM-p2`.
 	 *
 	 * @var array
 	 */

--- a/projects/packages/search/src/class-settings.php
+++ b/projects/packages/search/src/class-settings.php
@@ -21,6 +21,7 @@ class Settings {
 	 *
 	 * 1. The settings are synced to WPCOM thru `sync/src/modules/class-search.php`.
 	 * 2. Ensure to add new options to WPCOM whitelist if need to be synced following `PCYsg-sBM-p2`.
+	 * 3. If the list of available values change say there is a new sorting method added, the sanitizing code in WPCOM should be updated as well.
 	 *
 	 * @var array
 	 */

--- a/projects/packages/search/src/class-settings.php
+++ b/projects/packages/search/src/class-settings.php
@@ -15,9 +15,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Class to initialize search settings on the site.
  *
- * 1. The settings are synced to WPCOM thru `sync/src/modules/class-search.php`.
- * 2. Ensure to add new options to WPCOM whitelist if need to be synced following `PCYsg-sBM-p2`.
- * 3. If the list of available values change say there is a new sorting method added, the sanitizing code in WPCOM should be updated as well.
+ * 1. Settings are synced to WPCOM according to `Automattic\Jetpack\Sync\Modules\Search::$options_to_sync`.
+ * 2. All synced options must also be explicitly whitelisted and sanitized on WPCOM; see `PCYsg-sBM-p2`.
  */
 class Settings {
 

--- a/projects/packages/search/src/class-settings.php
+++ b/projects/packages/search/src/class-settings.php
@@ -14,8 +14,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Class to initialize search settings on the site.
+ *
+ * 1. The settings are synced to WPCOM thru `sync/src/modules/class-search.php`.
+ * 2. Ensure to add new options to WPCOM whitelist if need to be synced following `PCYsg-sBM-p2`.
+ * 3. If the list of available values change say there is a new sorting method added, the sanitizing code in WPCOM should be updated as well.
  */
-class Settings {
 	/**
 	 * This contains significant code overlap with `customizer/class-customizer.php`.
 	 *
@@ -25,17 +28,7 @@ class Settings {
 	 *
 	 * @var array
 	 */
-	public static $settings = array(
-		array( Options::OPTION_PREFIX . 'color_theme', 'string', 'light' ),
-		array( Options::OPTION_PREFIX . 'result_format', 'string', 'minimal' ),
-		array( Options::OPTION_PREFIX . 'default_sort', 'string', 'relevance' ),
-		array( Options::OPTION_PREFIX . 'overlay_trigger', 'string', 'results' ),
-		array( Options::OPTION_PREFIX . 'excluded_post_types', 'string', '' ),
-		array( Options::OPTION_PREFIX . 'highlight_color', 'string', '#FFC' ),
-		array( Options::OPTION_PREFIX . 'enable_sort', 'boolean', true ),
-		array( Options::OPTION_PREFIX . 'inf_scroll', 'boolean', true ),
-		array( Options::OPTION_PREFIX . 'show_powered_by', 'boolean', true ),
-	);
+class Settings {
 
 	/**
 	 * Class initialization.
@@ -51,7 +44,20 @@ class Settings {
 	 * @since 9.x.x
 	 */
 	public function settings_register() {
-		foreach ( static::$settings as $value ) {
+		// NOTE: This contains significant code overlap with class-jetpack-search-customize.
+		$setting_prefix = Options::OPTION_PREFIX;
+		$settings       = array(
+			array( $setting_prefix . 'color_theme', 'string', 'light' ),
+			array( $setting_prefix . 'result_format', 'string', 'minimal' ),
+			array( $setting_prefix . 'default_sort', 'string', 'relevance' ),
+			array( $setting_prefix . 'overlay_trigger', 'string', 'results' ),
+			array( $setting_prefix . 'excluded_post_types', 'string', '' ),
+			array( $setting_prefix . 'highlight_color', 'string', '#FFC' ),
+			array( $setting_prefix . 'enable_sort', 'boolean', true ),
+			array( $setting_prefix . 'inf_scroll', 'boolean', true ),
+			array( $setting_prefix . 'show_powered_by', 'boolean', true ),
+		);
+		foreach ( $settings as $value ) {
 			register_setting(
 				'options',
 				$value[0],

--- a/projects/packages/search/src/class-settings.php
+++ b/projects/packages/search/src/class-settings.php
@@ -19,15 +19,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * 2. Ensure to add new options to WPCOM whitelist if need to be synced following `PCYsg-sBM-p2`.
  * 3. If the list of available values change say there is a new sorting method added, the sanitizing code in WPCOM should be updated as well.
  */
-	/**
-	 * This contains significant code overlap with `customizer/class-customizer.php`.
-	 *
-	 * 1. The settings are synced to WPCOM thru `sync/src/modules/class-search.php`.
-	 * 2. Ensure to add new options to WPCOM whitelist if need to be synced following `PCYsg-sBM-p2`.
-	 * 3. If the list of available values change say there is a new sorting method added, the sanitizing code in WPCOM should be updated as well.
-	 *
-	 * @var array
-	 */
 class Settings {
 
 	/**

--- a/projects/packages/sync/changelog/add-sync-search-options
+++ b/projects/packages/sync/changelog/add-sync-search-options
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search: add search options to option whitelist

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -55,7 +55,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-master": "1.31.x-dev"
+			"dev-master": "1.32.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -173,6 +173,16 @@ class Defaults {
 		'wpcom_publish_comments_with_markdown',
 		'wpcom_publish_posts_with_markdown',
 		'videopress_private_enabled_for_site',
+		'jetpack_search_color_theme',
+		'jetpack_search_result_format',
+		'jetpack_search_default_sort',
+		'jetpack_search_overlay_trigger',
+		'jetpack_search_excluded_post_types',
+		'jetpack_search_highlight_color',
+		'jetpack_search_enable_sort',
+		'jetpack_search_inf_scroll',
+		'jetpack_search_show_powered_by',
+		'instant_search_enabled',
 	);
 
 	/**

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -173,16 +173,6 @@ class Defaults {
 		'wpcom_publish_comments_with_markdown',
 		'wpcom_publish_posts_with_markdown',
 		'videopress_private_enabled_for_site',
-		'jetpack_search_color_theme',
-		'jetpack_search_result_format',
-		'jetpack_search_default_sort',
-		'jetpack_search_overlay_trigger',
-		'jetpack_search_excluded_post_types',
-		'jetpack_search_highlight_color',
-		'jetpack_search_enable_sort',
-		'jetpack_search_inf_scroll',
-		'jetpack_search_show_powered_by',
-		'instant_search_enabled',
 	);
 
 	/**

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.31.1';
+	const PACKAGE_VERSION = '1.32.0-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/sync/src/modules/class-search.php
+++ b/projects/packages/sync/src/modules/class-search.php
@@ -1795,7 +1795,7 @@ class Search extends Module {
 	 * @return array List of option keys that get synced.
 	 */
 	public static function get_all_option_keys() {
-		return array_column( \Automattic\Jetpack\Search\Settings::$settings, 0 );
+		return property_exists( '\Automattic\Jetpack\Search\Settings', 'settings' ) ? array_column( \Automattic\Jetpack\Search\Settings::$settings, 0 ) : array();
 	}
 
 	/**

--- a/projects/packages/sync/src/modules/class-search.php
+++ b/projects/packages/sync/src/modules/class-search.php
@@ -45,6 +45,8 @@ class Search extends Module {
 	public function __construct() {
 		// Post meta whitelists.
 		add_filter( 'jetpack_sync_post_meta_whitelist', array( $this, 'add_search_post_meta_whitelist' ), 10 );
+		// Add options
+		add_filter( 'jetpack_sync_options_whitelist', array( $this, 'add_search_options_whitelist' ) );
 	}
 
 	/**
@@ -1724,6 +1726,16 @@ class Search extends Module {
 		return array_merge( $list, $this->get_all_postmeta_keys() );
 	}
 
+	/**
+	 * Add Search options to the options whitelist.
+	 *
+	 * @param array $list Existing options whitelist.
+	 * @return array Updated options whitelist.
+	 */
+	public function add_search_options_whitelist( $list ) {
+		return array_merge( $list, $this->get_all_option_keys() );
+	}
+
 	//
 	// Indexing functions for wp.com.
 
@@ -1773,6 +1785,17 @@ class Search extends Module {
 	 */
 	public static function get_all_postmeta_keys() {
 		return array_keys( self::$postmeta_to_sync );
+	}
+
+	/**
+	 * Get all option keys that get synced.
+	 *
+	 * @access public
+	 *
+	 * @return array List of option keys that get synced.
+	 */
+	public static function get_all_option_keys() {
+		return array_column( \Automattic\Jetpack\Search\Settings::$settings, 0 );
 	}
 
 	/**

--- a/projects/packages/sync/src/modules/class-search.php
+++ b/projects/packages/sync/src/modules/class-search.php
@@ -46,7 +46,7 @@ class Search extends Module {
 		// Post meta whitelists.
 		add_filter( 'jetpack_sync_post_meta_whitelist', array( $this, 'add_search_post_meta_whitelist' ), 10 );
 		// Add options
-		add_filter( 'jetpack_sync_options_whitelist', array( $this, 'add_search_options_whitelist' ) );
+		add_filter( 'jetpack_sync_options_whitelist', array( $this, 'add_search_options_whitelist' ), 10 );
 	}
 
 	/**

--- a/projects/packages/sync/src/modules/class-search.php
+++ b/projects/packages/sync/src/modules/class-search.php
@@ -1702,6 +1702,27 @@ class Search extends Module {
 
 	); // end taxonomies.
 
+	/**
+	 * List of options to sync
+	 *
+	 * @access private
+	 * @static
+	 *
+	 * @var array
+	 */
+	private static $options_to_sync = array(
+		'jetpack_search_color_theme',
+		'jetpack_search_result_format',
+		'jetpack_search_default_sort',
+		'jetpack_search_overlay_trigger',
+		'jetpack_search_excluded_post_types',
+		'jetpack_search_highlight_color',
+		'jetpack_search_enable_sort',
+		'jetpack_search_inf_scroll',
+		'jetpack_search_show_powered_by',
+		'instant_search_enabled',
+	); // end options.
+
 	/*
 	 * Taxonomies we know don't sync.
 	 * See also sync/src/class-defaults.php
@@ -1795,7 +1816,7 @@ class Search extends Module {
 	 * @return array List of option keys that get synced.
 	 */
 	public static function get_all_option_keys() {
-		return property_exists( '\Automattic\Jetpack\Search\Settings', 'settings' ) ? array_column( \Automattic\Jetpack\Search\Settings::$settings, 0 ) : array();
+		return self::$options_to_sync;
 	}
 
 	/**

--- a/projects/plugins/backup/changelog/add-sync-search-options
+++ b/projects/plugins/backup/changelog/add-sync-search-options
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -235,7 +235,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "f72ce4df88a224f63b24087bf3a36cc119a0166d"
+                "reference": "92e629ee292cfce252315f6977c0b8573ea0f7c0"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -248,7 +248,7 @@
                 "automattic/jetpack-identity-crisis": "^0.8",
                 "automattic/jetpack-my-jetpack": "^1.3",
                 "automattic/jetpack-status": "^1.13",
-                "automattic/jetpack-sync": "^1.31"
+                "automattic/jetpack-sync": "^1.32"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.1",
@@ -1131,7 +1131,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "e638ec9a22f5b6035959668f9a831b0002ff1f41"
+                "reference": "cc8164374248973872980e5d4e14d696de6d9c5b"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.40",
@@ -1158,7 +1158,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.31.x-dev"
+                    "dev-master": "1.32.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/add-sync-search-options
+++ b/projects/plugins/jetpack/changelog/add-sync-search-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -39,7 +39,7 @@
 		"automattic/jetpack-roles": "1.4.x-dev",
 		"automattic/jetpack-search": "0.13.x-dev",
 		"automattic/jetpack-status": "1.13.x-dev",
-		"automattic/jetpack-sync": "1.31.x-dev",
+		"automattic/jetpack-sync": "1.32.x-dev",
 		"automattic/jetpack-waf": "0.5.x-dev",
 		"automattic/jetpack-wordads": "0.2.x-dev",
 		"nojimage/twitter-text-php": "3.1.2"

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e430206f348dc726208e18c1a25d3d9c",
+    "content-hash": "29b34f6e19e5eaa9e76805f42636c0d6",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -290,7 +290,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "f72ce4df88a224f63b24087bf3a36cc119a0166d"
+                "reference": "92e629ee292cfce252315f6977c0b8573ea0f7c0"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -303,7 +303,7 @@
                 "automattic/jetpack-identity-crisis": "^0.8",
                 "automattic/jetpack-my-jetpack": "^1.3",
                 "automattic/jetpack-status": "^1.13",
-                "automattic/jetpack-sync": "^1.31"
+                "automattic/jetpack-sync": "^1.32"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.1",
@@ -1697,7 +1697,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "e638ec9a22f5b6035959668f9a831b0002ff1f41"
+                "reference": "cc8164374248973872980e5d4e14d696de6d9c5b"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.40",
@@ -1724,7 +1724,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.31.x-dev"
+                    "dev-master": "1.32.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/changelog/add-sync-search-options
+++ b/projects/plugins/protect/changelog/add-sync-search-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/protect/composer.json
+++ b/projects/plugins/protect/composer.json
@@ -12,7 +12,7 @@
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
 		"automattic/jetpack-my-jetpack": "1.3.x-dev",
 		"automattic/jetpack-plugins-installer": "0.1.x-dev",
-		"automattic/jetpack-sync": "1.31.x-dev"
+		"automattic/jetpack-sync": "1.32.x-dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.0.3",

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6a649b44b5c38fccc0c7ed37c5356d2d",
+    "content-hash": "7fffd3986509d010d7d11682e3f800f6",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -948,7 +948,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "e638ec9a22f5b6035959668f9a831b0002ff1f41"
+                "reference": "cc8164374248973872980e5d4e14d696de6d9c5b"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.40",
@@ -975,7 +975,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.31.x-dev"
+                    "dev-master": "1.32.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/changelog/add-sync-search-options
+++ b/projects/plugins/search/changelog/add-sync-search-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -11,7 +11,7 @@
 		"automattic/jetpack-my-jetpack": "1.3.x-dev",
 		"automattic/jetpack-search": "0.13.x-dev",
 		"automattic/jetpack-status": "^1.13",
-		"automattic/jetpack-sync": "1.31.x-dev"
+		"automattic/jetpack-sync": "1.32.x-dev"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.1",

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c9f2833874005f5704c53d9d2360b459",
+    "content-hash": "7a1275a39c39cf84bbedad6640ce2644",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1027,7 +1027,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "e638ec9a22f5b6035959668f9a831b0002ff1f41"
+                "reference": "cc8164374248973872980e5d4e14d696de6d9c5b"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.40",
@@ -1054,7 +1054,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.31.x-dev"
+                    "dev-master": "1.32.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/add-sync-search-options
+++ b/projects/plugins/social/changelog/add-sync-search-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -14,7 +14,7 @@
 		"automattic/jetpack-options": "1.16.x-dev",
 		"automattic/jetpack-connection": "1.40.x-dev",
 		"automattic/jetpack-my-jetpack": "1.3.x-dev",
-		"automattic/jetpack-sync": "1.31.x-dev",
+		"automattic/jetpack-sync": "1.32.x-dev",
 		"automattic/jetpack-status": "1.13.x-dev"
 	},
 	"require-dev": {

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c84d16af26677b103d0b9809b6de84e5",
+    "content-hash": "5adf878d3bd56fc0dfef2335084b5660",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1047,7 +1047,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "e638ec9a22f5b6035959668f9a831b0002ff1f41"
+                "reference": "cc8164374248973872980e5d4e14d696de6d9c5b"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.40",
@@ -1074,7 +1074,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.31.x-dev"
+                    "dev-master": "1.32.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/starter-plugin/changelog/add-sync-search-options
+++ b/projects/plugins/starter-plugin/changelog/add-sync-search-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/starter-plugin/composer.json
+++ b/projects/plugins/starter-plugin/composer.json
@@ -11,7 +11,7 @@
 		"automattic/jetpack-config": "1.8.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
 		"automattic/jetpack-my-jetpack": "1.3.x-dev",
-		"automattic/jetpack-sync": "1.31.x-dev"
+		"automattic/jetpack-sync": "1.32.x-dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.0.3",

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7c2c7bb5d4495dfb0dd9de7c3f757b5d",
+    "content-hash": "6565df3dbbe4fc0e36746bb4fa8e7791",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -948,7 +948,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "e638ec9a22f5b6035959668f9a831b0002ff1f41"
+                "reference": "cc8164374248973872980e5d4e14d696de6d9c5b"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.40",
@@ -975,7 +975,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.31.x-dev"
+                    "dev-master": "1.32.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
Fixes #23779 

#### Changes proposed in this Pull Request:
Sync Jetpack Search options to WPCOM for future usage, e.g. excluding post types from index etc. Depends on `D79774-code`. Options includes:

```
jetpack_search_color_theme
jetpack_search_result_format
jetpack_search_default_sort
jetpack_search_overlay_trigger
jetpack_search_excluded_post_types
jetpack_search_highlight_color
jetpack_search_enable_sort
jetpack_search_inf_scroll
jetpack_search_show_powered_by
instant_search_enabled
```

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Sandbox Jetpack and `jptools.wordpress.com`
* Apply patch `D79774-code` to WPCOM sandbox
* Schedule a full sync from jptools for a site with JP Search subscription
* Run `gpr select * from wp_{blog_id}_options where option_name like '%_search_%'` from sandbox wpsh
* Ensure Jetpack Search options described above are synced
* Change a setting from the above list thru Customberg or Customizer
* Ensure it's updated in the cached DB in a while 