### PR TITLE
Fix Contact form CSV export

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-contact-form-csv-export
+++ b/projects/plugins/jetpack/changelog/fix-contact-form-csv-export
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Contact Form: ensure the option to export forms to a csv file works with the upcoming version of WordPress, 6.0.

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -161,7 +161,7 @@ class Grunion_Contact_Form_Plugin {
 
 		// Export to CSV feature
 		if ( is_admin() ) {
-			add_action( 'admin_init', array( $this, 'download_feedback_as_csv' ) );
+			add_action( 'admin_post_feedback_export', array( $this, 'download_feedback_as_csv' ) );
 			add_action( 'admin_footer-edit.php', array( $this, 'export_form' ) );
 		}
 		add_action( 'admin_menu', array( $this, 'admin_menu' ) );


### PR DESCRIPTION
Fixes #24170

#### Changes proposed in this Pull Request:
Because of [a change in Core WordPress](https://github.com/WordPress/wordpress-develop/commit/99fd93c7dff9d3669f25f5f13a2358e65c14bde9), admin_post actions are now enforced. This PR changes a hook from `admin_init` to `admin_post_feedback_export` to prevent the page die-ing with 400.

#### Jetpack product discussion
See: p1651226424159739/1651215033.747819-slack-C01A60HCGUA

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
1. Go to My Site > Feedback
2. Click on Download button
3. CSV Export should be generated.