### PR TITLE
Settings: Display upsells using feature checks

### DIFF
--- a/projects/plugins/jetpack/changelog/update-settings-plan-checks
+++ b/projects/plugins/jetpack/changelog/update-settings-plan-checks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Settings: Display upsells using feature checks


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- No functional changes, everything should work as before
- Moves from plan checks to feature checks to display the upsell nudges in Jetpack > Settings

#### Jetpack product discussion
p9dueE-4T6-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* [Spin up a JN site using this branch](https://jurassic.ninja/create/?jetpack-beta&branches.jetpack=update/settings-plan-checks).
* Set up Jetpack and start with a Free plan.
* Go to WP Admin > Jetpack > Settings.
* Make sure you see the following upsell nudges:

Feature | Settings
--- | ---
Anti-spam | <img width="1031" alt="antispam 1" src="https://user-images.githubusercontent.com/1233880/165951913-2d3dded0-13ef-4af5-a50a-7d008f6d82f8.png">
Google Analytics | <img width="1015" alt="google-analytics 1" src="https://user-images.githubusercontent.com/1233880/165951945-be84e9a4-e68f-405b-b8e3-24f46ec702dd.png">
Scan | <img width="1018" alt="scan 1" src="https://user-images.githubusercontent.com/1233880/165951980-12bcf720-e3cb-4f11-9e3e-ecbdc5689205.png">
Search | <img width="1020" alt="search 1" src="https://user-images.githubusercontent.com/1233880/165952000-d75530bd-7c3a-40a8-9cf4-b5708e482b90.png">
WordAds | <img width="1037" alt="wordads 1" src="https://user-images.githubusercontent.com/1233880/165952051-50c7e134-aff5-4053-93c8-79e27f1dfd94.png">

* Go to https://wordpress.com/plans and select your JN site.
* Purchase any of the products listed in the table below.
* Go to WP Admin > Jetpack > Settings.
* Make sure the settings no longer display an upsell nudge according to the table below.

Feature | Product | Settings
--- | --- | ---
Anti-spam | Backup, Security, Complete | <img width="1020" alt="antispam 2" src="https://user-images.githubusercontent.com/1233880/165952388-8bf4abcd-2f81-4a20-b803-cd76eaef0cdb.png">
Google Analytics | Security, Complete | <img width="1023" alt="google-analytics 2" src="https://user-images.githubusercontent.com/1233880/165953366-3cc45ef4-5dc0-4cd6-8096-293a5832042c.png">
Scan | Backup | <img width="1020" alt="scan 2" src="https://user-images.githubusercontent.com/1233880/165953455-91011aff-a2c1-449c-af13-2cbf945a6c6d.png">
Scan | Security, Complete | <img width="1018" alt="scan 3" src="https://user-images.githubusercontent.com/1233880/165953501-158b87b7-cbb3-4add-851a-afbcf8317106.png">
Search | Site search, Complete | <img width="1022" alt="search 2" src="https://user-images.githubusercontent.com/1233880/165953645-4bf7b4a3-d707-4935-9742-9c34053d3115.png">
WordAds | Security, Complete | <img width="1021" alt="wordads 2" src="https://user-images.githubusercontent.com/1233880/165953679-06f0c110-bc4a-488a-932c-fd060d1aab3a.png">

 