### PR TITLE
Assistant: Fix product price without intro offer  

### DIFF
--- a/projects/plugins/jetpack/_inc/client/recommendations/product-card-upsell/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/product-card-upsell/index.jsx
@@ -56,9 +56,9 @@ const ProductCardUpsellComponent = ( {
 		() => introOffers.find( ( { product_slug } ) => product_slug === slug ) || {},
 		[ slug, introOffers ]
 	);
-	// introOriginalPrice is the price before introductory offer. Defaults to `cost` is there's
-	// no such offer available.
-	const initialPrice = introOriginalPrice || cost;
+	// introOriginalPrice is the price per year before introductory offer. Defaults to `cost`
+	// (which is cost per month) if there's no such offer available.
+	const initialPrice = introOriginalPrice || cost * 12;
 	// introRawPrice is the price after introductory offer, but before any other discount.
 	const introPrice = introRawPrice || initialPrice;
 	// Apply special discount.

--- a/projects/plugins/jetpack/changelog/fix-assistant-no-intro-price
+++ b/projects/plugins/jetpack/changelog/fix-assistant-no-intro-price
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Assistant: Fix product price without intro offer


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR corrects the price shown in the Assistant product cards when no intro offer is available.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Context: p8oabR-QB-p2#comment-6247

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Update your currency to one that doesn't have an intro offer for Backup or Security, such as Turkish lira (TRY)
- Spin up a new JN site with this branch
- Complete the connection flow, getting Jetpack Free
- Visit `/wp-admin/admin.php?page=jetpack#/recommendations/product-suggestions`
- Check that for both Backup and Security, the prices matche what you see in the checkout page. Prices are shown by month in the former, and by year in the latter, so you'll have to divide/multiple by 12.