### PR TITLE
storybook: Test that deps match projects.js

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -466,8 +466,8 @@ importers:
       '@wordpress/postcss-plugins-preset': 3.6.0
       babel-loader: 8.2.4
       babel-plugin-inline-json-import: 0.3.2
-      concurrently: 6.0.2
       css-loader: 6.5.1
+      jest: 27.3.1
       postcss: 8.3.11
       postcss-loader: 6.2.0
       react: 17.0.2
@@ -508,8 +508,8 @@ importers:
       '@wordpress/postcss-plugins-preset': 3.6.0_postcss@8.3.11
       babel-loader: 8.2.4_609d5772f83284a93f69f48cce82773c
       babel-plugin-inline-json-import: 0.3.2
-      concurrently: 6.0.2
       css-loader: 6.5.1_webpack@5.65.0
+      jest: 27.3.1
       postcss: 8.3.11
       postcss-loader: 6.2.0_postcss@8.3.11+webpack@5.65.0
       react: 17.0.2

--- a/projects/js-packages/storybook/.gitattributes
+++ b/projects/js-packages/storybook/.gitattributes
@@ -8,6 +8,7 @@ node_modules      export-ignore
 /package.json     production-exclude
 /src/**           production-exclude
 /storybook/**     production-exclude
+/tests/**         production-exclude
 
 # Files to include in the mirror repo
 /docs/**          production-include

--- a/projects/js-packages/storybook/changelog/fix-storybook-test-deps
+++ b/projects/js-packages/storybook/changelog/fix-storybook-test-deps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Test that projects in `storybook/projects.js` are listed as extra build dependencies in composer.json.

--- a/projects/js-packages/storybook/composer.json
+++ b/projects/js-packages/storybook/composer.json
@@ -14,7 +14,9 @@
 		]
 	},
 	"scripts": {
-		"build-development": "pnpm run storybook:build"
+		"build-development": "pnpm run storybook:build",
+		"test-js": "pnpm run test",
+		"test-coverage": "pnpm run test-coverage"
 	},
 	"repositories": [
 		{
@@ -30,11 +32,11 @@
 	"extra": {
 		"dependencies": {
 			"build": [
-				"js-packages/base-styles",
 				"js-packages/components",
 				"js-packages/connection",
 				"js-packages/idc",
-				"packages/my-jetpack"
+				"packages/my-jetpack",
+				"plugins/protect"
 			]
 		},
 		"mirror-repo": "Automattic/jetpack-storybook"

--- a/projects/js-packages/storybook/package.json
+++ b/projects/js-packages/storybook/package.json
@@ -15,13 +15,10 @@
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic",
 	"scripts": {
-		"build": "echo 'Not implemented.'",
-		"build-js": "echo 'Not implemented.'",
-		"build-production": "echo 'Not implemented.'",
-		"build-production-js": "echo 'Not implemented.'",
 		"storybook:build": "build-storybook -s ./public -c ./storybook -o ./docs",
-		"dev:packages": "echo 'TODO dev:packages'",
-		"storybook:dev": "concurrently \"pnpm run dev:packages\" \"start-storybook -c ./storybook -p 50240 -s ./public\""
+		"storybook:dev": "start-storybook -c ./storybook -p 50240 -s ./public",
+		"test": "jest tests/",
+		"test-coverage": "jest tests/ --coverage --collectCoverageFrom='src/**/*.js' --coverageDirectory=\"$COVERAGE_DIR\" --coverageReporters=clover"
 	},
 	"devDependencies": {
 		"@automattic/jetpack-components": "workspace:* || ^0.11",
@@ -52,8 +49,8 @@
 		"@wordpress/postcss-plugins-preset": "3.6.0",
 		"babel-loader": "8.2.4",
 		"babel-plugin-inline-json-import": "0.3.2",
-		"concurrently": "6.0.2",
 		"css-loader": "6.5.1",
+		"jest": "27.3.1",
 		"postcss": "8.3.11",
 		"postcss-loader": "6.2.0",
 		"react": "17.0.2",

--- a/projects/js-packages/storybook/tests/deps.test.js
+++ b/projects/js-packages/storybook/tests/deps.test.js
@@ -1,0 +1,23 @@
+const fs = require( 'fs/promises' );
+const path = require( 'path' );
+
+test( 'Dependencies in composer.json (.extra.dependencies.build) match paths in storybook/projects.js', async () => {
+	const monorepoBaseDir = path.resolve( __dirname, '../../../..' );
+	const projects = require( '../storybook/projects.js' ).map( p =>
+		path.relative( monorepoBaseDir, p )
+	);
+	const projectsJsDeps = new Set();
+	for ( const project of projects ) {
+		const m = project.match( /^projects\/([^/]+\/[^/]+)/ );
+		if ( m ) {
+			projectsJsDeps.add( m[ 1 ] );
+		}
+	}
+
+	const composerJson = JSON.parse(
+		await fs.readFile( path.join( __dirname, '../composer.json' ), { encoding: 'utf8' } )
+	);
+	const composerJsonDeps = new Set( composerJson.extra?.dependencies?.build );
+
+	expect( composerJsonDeps ).toEqual( projectsJsDeps );
+} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We have a comment at the top of projects.js asking that people keep the
list in sync with the list of dependencies in composer.json, but it
seems this is easy to miss. Let's also add a test checking for the
match.

For example, #23780 missed updating composer.json when adding to the
list, and since the dependency was missing #24078 didn't know to try
rebuilding storybook when plugins/protect was changed, which allowed it
to be merged and break the build in master (necessitating #24160).

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1651176382871569-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy? Did the new test run?
* Adjust composer.json and/or projects.js. Does the test fail if they don't match?