### PR TITLE
Licensing: My Jetpack: Add and update entry points into licensing activation UI in My Jetpack

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -366,7 +366,7 @@ importers:
       '@automattic/jetpack-analytics': workspace:* || ^0.1
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
       '@automattic/jetpack-components': workspace:* || ^0.12
-      '@automattic/jetpack-connection': workspace:* || ^0.17
+      '@automattic/jetpack-connection': workspace:* || ^0.18
       '@babel/core': 7.17.9
       '@babel/preset-react': 7.16.7
       '@wordpress/base-styles': 4.4.0
@@ -605,7 +605,7 @@ importers:
       '@automattic/jetpack-api': workspace:* || ^0.13
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
       '@automattic/jetpack-components': workspace:* || ^0.12
-      '@automattic/jetpack-connection': workspace:* || ^0.17
+      '@automattic/jetpack-connection': workspace:* || ^0.18
       '@automattic/jetpack-webpack-config': workspace:* || ^1.1
       '@babel/core': 7.17.9
       '@babel/preset-env': 7.16.11
@@ -652,7 +652,7 @@ importers:
   projects/packages/connection-ui:
     specifiers:
       '@automattic/jetpack-api': workspace:* || ^0.13
-      '@automattic/jetpack-connection': workspace:* || ^0.17
+      '@automattic/jetpack-connection': workspace:* || ^0.18
       '@automattic/jetpack-webpack-config': workspace:* || ^1.1
       '@babel/core': 7.17.9
       '@babel/preset-env': 7.16.11
@@ -767,7 +767,7 @@ importers:
       '@automattic/jetpack-api': workspace:* || ^0.13
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
       '@automattic/jetpack-components': workspace:* || ^0.12
-      '@automattic/jetpack-connection': workspace:* || ^0.17
+      '@automattic/jetpack-connection': workspace:* || ^0.18
       '@automattic/jetpack-licensing': workspace:* || ^0.4
       '@automattic/jetpack-webpack-config': workspace:* || ^1.1
       '@babel/core': 7.17.9
@@ -863,7 +863,7 @@ importers:
       '@automattic/jetpack-api': workspace:* || ^0.13
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
       '@automattic/jetpack-components': workspace:* || ^0.12
-      '@automattic/jetpack-connection': workspace:* || ^0.17
+      '@automattic/jetpack-connection': workspace:* || ^0.18
       '@automattic/jetpack-webpack-config': workspace:* || ^1.1
       '@babel/core': 7.17.9
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.16.7
@@ -1196,7 +1196,7 @@ importers:
       '@automattic/jetpack-api': workspace:* || ^0.13
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
       '@automattic/jetpack-components': workspace:* || ^0.12
-      '@automattic/jetpack-connection': workspace:* || ^0.17
+      '@automattic/jetpack-connection': workspace:* || ^0.18
       '@automattic/jetpack-licensing': workspace:* || ^0.4
       '@automattic/jetpack-partner-coupon': workspace:* || ^0.2
       '@automattic/jetpack-shared-extension-utils': workspace:* || ^0.4
@@ -1511,7 +1511,7 @@ importers:
       '@automattic/jetpack-analytics': workspace:* || ^0.1
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
       '@automattic/jetpack-components': workspace:* || ^0.12
-      '@automattic/jetpack-connection': workspace:* || ^0.17
+      '@automattic/jetpack-connection': workspace:* || ^0.18
       '@automattic/jetpack-webpack-config': workspace:* || ^1.1
       '@babel/core': 7.17.9
       '@babel/preset-env': 7.16.11
@@ -1587,7 +1587,7 @@ importers:
     specifiers:
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
       '@automattic/jetpack-components': workspace:* || ^0.12
-      '@automattic/jetpack-connection': workspace:* || ^0.17
+      '@automattic/jetpack-connection': workspace:* || ^0.18
       '@automattic/jetpack-webpack-config': workspace:* || ^1.1
       '@babel/core': 7.17.9
       '@babel/preset-env': 7.16.11
@@ -1632,7 +1632,7 @@ importers:
     specifiers:
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
       '@automattic/jetpack-components': workspace:* || ^0.12
-      '@automattic/jetpack-connection': workspace:* || ^0.17
+      '@automattic/jetpack-connection': workspace:* || ^0.18
       '@automattic/jetpack-webpack-config': workspace:* || ^1.1
       '@babel/core': 7.17.9
       '@babel/preset-env': 7.16.11

--- a/projects/js-packages/connection/changelog/update-licensing-to-my-jetpack
+++ b/projects/js-packages/connection/changelog/update-licensing-to-my-jetpack
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Updated references to old licensing activation UI to licensing activation UI in My Jetpack

--- a/projects/js-packages/connection/components/connection-status-card/index.jsx
+++ b/projects/js-packages/connection/components/connection-status-card/index.jsx
@@ -3,10 +3,9 @@
  */
 import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
 import PropTypes from 'prop-types';
 import restApi from '@automattic/jetpack-api';
-import { H3, Text } from '@automattic/jetpack-components';
+import { Button, H3, Text } from '@automattic/jetpack-components';
 import { useSelect, useDispatch } from '@wordpress/data';
 
 /**

--- a/projects/js-packages/connection/components/connection-status-card/index.jsx
+++ b/projects/js-packages/connection/components/connection-status-card/index.jsx
@@ -131,6 +131,7 @@ const ConnectionStatusCard = props => {
 					{ __( 'Site connected.', 'jetpack' ) }&nbsp;
 					<Button
 						variant="link"
+						weight="regular"
 						onClick={ openDisconnectDialog }
 						className="jp-connection__disconnect-dialog__link"
 					>

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.17.13-alpha",
+	"version": "0.18.0-alpha",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/partner-coupon/changelog/update-licensing-to-my-jetpack
+++ b/projects/js-packages/partner-coupon/changelog/update-licensing-to-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -36,7 +36,7 @@
 	},
 	"dependencies": {
 		"@automattic/jetpack-components": "workspace:* || ^0.12",
-		"@automattic/jetpack-connection": "workspace:* || ^0.17",
+		"@automattic/jetpack-connection": "workspace:* || ^0.18",
 		"@wordpress/i18n": "4.7.0",
 		"classnames": "2.3.1",
 		"prop-types": "15.7.2"

--- a/projects/packages/backup/changelog/update-licensing-to-my-jetpack
+++ b/projects/packages/backup/changelog/update-licensing-to-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/backup/changelog/update-licensing-to-my-jetpack#2
+++ b/projects/packages/backup/changelog/update-licensing-to-my-jetpack#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/backup/composer.json
+++ b/projects/packages/backup/composer.json
@@ -12,7 +12,7 @@
 		"automattic/jetpack-connection": "^1.40",
 		"automattic/jetpack-connection-ui": "^2.4",
 		"automattic/jetpack-identity-crisis": "^0.8",
-		"automattic/jetpack-my-jetpack": "^1.2",
+		"automattic/jetpack-my-jetpack": "^1.3",
 		"automattic/jetpack-sync": "^1.31",
 		"automattic/jetpack-status": "^1.13"
 	},

--- a/projects/packages/backup/package.json
+++ b/projects/packages/backup/package.json
@@ -27,7 +27,7 @@
 	"dependencies": {
 		"@automattic/jetpack-api": "workspace:* || ^0.13",
 		"@automattic/jetpack-components": "workspace:* || ^0.12",
-		"@automattic/jetpack-connection": "workspace:* || ^0.17",
+		"@automattic/jetpack-connection": "workspace:* || ^0.18",
 		"@wordpress/api-fetch": "6.4.0",
 		"@wordpress/data": "6.7.0",
 		"@wordpress/element": "4.5.0",

--- a/projects/packages/connection-ui/changelog/update-licensing-to-my-jetpack
+++ b/projects/packages/connection-ui/changelog/update-licensing-to-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/connection-ui/package.json
+++ b/projects/packages/connection-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-connection-manager-ui",
-	"version": "2.4.2",
+	"version": "2.4.3-alpha",
 	"description": "Jetpack Connection Manager UI",
 	"main": "_inc/admin.jsx",
 	"repository": {
@@ -20,7 +20,7 @@
 	"browserslist": "extends @wordpress/browserslist-config",
 	"dependencies": {
 		"@automattic/jetpack-api": "workspace:* || ^0.13",
-		"@automattic/jetpack-connection": "workspace:* || ^0.17",
+		"@automattic/jetpack-connection": "workspace:* || ^0.18",
 		"@wordpress/data": "6.7.0"
 	},
 	"devDependencies": {

--- a/projects/packages/my-jetpack/_inc/components/add-license-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/add-license-screen/index.jsx
@@ -26,9 +26,18 @@ export default function AddLicenseScreen() {
 
 	const { recordEvent } = useAnalytics();
 
-	const onClickGoBack = useCallback( () => {
-		recordEvent( 'jetpack_myjetpack_license_activation_back_link_click' );
-	}, [ recordEvent ] );
+	const onClickGoBack = useCallback(
+		event => {
+			recordEvent( 'jetpack_myjetpack_license_activation_back_link_click' );
+
+			if ( -1 !== document.referrer.indexOf( window.location.host ) ) {
+				// Prevent default here to minimize page change within the My Jetpack app.
+				event.preventDefault();
+				history.back();
+			}
+		},
+		[ recordEvent ]
+	);
 
 	return (
 		<AdminPage showHeader={ false } showBackground={ false }>

--- a/projects/packages/my-jetpack/_inc/components/add-license-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/add-license-screen/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { AdminPage, Container, Col } from '@automattic/jetpack-components';
 
 /**
@@ -10,6 +10,7 @@ import { AdminPage, Container, Col } from '@automattic/jetpack-components';
 import { ActivationScreen } from '@automattic/jetpack-licensing';
 import GoBackLink from '../go-back-link';
 import restApi from '@automattic/jetpack-api';
+import useAnalytics from '../../hooks/use-analytics';
 
 /**
  * The AddLicenseScreen component of the My Jetpack app.
@@ -23,11 +24,17 @@ export default function AddLicenseScreen() {
 		restApi.setApiNonce( apiNonce );
 	}, [] );
 
+	const { recordEvent } = useAnalytics();
+
+	const onClickGoBack = useCallback( () => {
+		recordEvent( 'jetpack_myjetpack_license_activation_back_link_click' );
+	}, [ recordEvent ] );
+
 	return (
 		<AdminPage showHeader={ false } showBackground={ false }>
 			<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 				<Col>
-					<GoBackLink onClick={ null } />
+					<GoBackLink onClick={ onClickGoBack } />
 				</Col>
 				<Col>
 					<ActivationScreen

--- a/projects/packages/my-jetpack/_inc/components/add-license-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/add-license-screen/index.jsx
@@ -30,7 +30,7 @@ export default function AddLicenseScreen() {
 		event => {
 			recordEvent( 'jetpack_myjetpack_license_activation_back_link_click' );
 
-			if ( -1 !== document.referrer.indexOf( window.location.host ) ) {
+			if ( document.referrer.includes( window.location.host ) ) {
 				// Prevent default here to minimize page change within the My Jetpack app.
 				event.preventDefault();
 				history.back();

--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
@@ -3,8 +3,7 @@
  */
 import React, { useCallback } from 'react';
 import { __, _n } from '@wordpress/i18n';
-import { ExternalLink } from '@wordpress/components';
-import { Text, H3, Title } from '@automattic/jetpack-components';
+import { Text, H3, Title, Button } from '@automattic/jetpack-components';
 
 /**
  * Internal dependencies
@@ -76,7 +75,14 @@ function PlanSectionFooter( { purchases } ) {
 
 	const { recordEvent } = useAnalytics();
 
-	const clickHandler = useCallback( () => {
+	const purchaseClickHandler = useCallback( () => {
+		const event = purchases.length
+			? 'jetpack_myjetpack_plans_manage_click'
+			: 'jetpack_myjetpack_plans_purchase_click';
+		recordEvent( event );
+	}, [ purchases, recordEvent ] );
+
+	const activateLicenseClickHandler = useCallback( () => {
 		const event = purchases.length
 			? 'jetpack_myjetpack_plans_manage_click'
 			: 'jetpack_myjetpack_plans_purchase_click';
@@ -84,15 +90,29 @@ function PlanSectionFooter( { purchases } ) {
 	}, [ purchases, recordEvent ] );
 
 	return (
-		<Text
-			component={ ExternalLink }
-			className={ styles[ 'external-link' ] }
-			onClick={ clickHandler }
-			href={ purchases.length ? getManageYourPlanUrl() : getPurchasePlanUrl() }
-			variant="body"
-		>
-			{ planLinkDescription }
-		</Text>
+		<ul>
+			<li>
+				<Button
+					onClick={ purchaseClickHandler }
+					href={ purchases.length ? getManageYourPlanUrl() : getPurchasePlanUrl() }
+					variant="external-link"
+				>
+					{ planLinkDescription }
+				</Button>
+			</li>
+			{ window?.myJetpackInitialState?.loadAddLicenseScreen && (
+				<li>
+					<Button
+						component={ <Button variant="link" /> }
+						onClick={ activateLicenseClickHandler }
+						href={ `${ window?.myJetpackInitialState?.adminUrl }admin.php?page=my-jetpack#/add-license` }
+						variant="link"
+					>
+						{ __( 'Activate a license', 'jetpack-my-jetpack' ) }
+					</Button>
+				</li>
+			) }
+		</ul>
 	);
 }
 

--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
@@ -93,6 +93,7 @@ function PlanSectionFooter( { purchases } ) {
 					onClick={ purchaseClickHandler }
 					href={ purchases.length ? getManageYourPlanUrl() : getPurchasePlanUrl() }
 					variant="external-link"
+					weight="regular"
 				>
 					{ planLinkDescription }
 				</Button>
@@ -104,6 +105,7 @@ function PlanSectionFooter( { purchases } ) {
 						onClick={ activateLicenseClickHandler }
 						href={ `${ window?.myJetpackInitialState?.adminUrl }admin.php?page=my-jetpack#/add-license` }
 						variant="link"
+						weight="regular"
 					>
 						{ __( 'Activate a license', 'jetpack-my-jetpack' ) }
 					</Button>

--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
@@ -90,7 +90,7 @@ function PlanSectionFooter( { purchases } ) {
 	}, [ purchases, recordEvent ] );
 
 	return (
-		<ul>
+		<ul className={ styles[ 'actions-list' ] }>
 			<li>
 				<Button
 					onClick={ purchaseClickHandler }

--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
@@ -87,8 +87,8 @@ function PlanSectionFooter( { purchases } ) {
 	}, [ recordEvent ] );
 
 	return (
-		<ul className={ styles[ 'actions-list' ] }>
-			<li>
+		<ul>
+			<li className={ styles[ 'actions-list-item' ] }>
 				<Button
 					onClick={ purchaseClickHandler }
 					href={ purchases.length ? getManageYourPlanUrl() : getPurchasePlanUrl() }
@@ -99,9 +99,8 @@ function PlanSectionFooter( { purchases } ) {
 				</Button>
 			</li>
 			{ window?.myJetpackInitialState?.loadAddLicenseScreen && (
-				<li>
+				<li className={ styles[ 'actions-list-item' ] }>
 					<Button
-						component={ <Button variant="link" /> }
 						onClick={ activateLicenseClickHandler }
 						href={ `${ window?.myJetpackInitialState?.adminUrl }admin.php?page=my-jetpack#/add-license` }
 						variant="link"

--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
@@ -83,11 +83,8 @@ function PlanSectionFooter( { purchases } ) {
 	}, [ purchases, recordEvent ] );
 
 	const activateLicenseClickHandler = useCallback( () => {
-		const event = purchases.length
-			? 'jetpack_myjetpack_plans_manage_click'
-			: 'jetpack_myjetpack_plans_purchase_click';
-		recordEvent( event );
-	}, [ purchases, recordEvent ] );
+		recordEvent( 'jetpack_myjetpack_activate_license_click' );
+	}, [ recordEvent ] );
 
 	return (
 		<ul className={ styles[ 'actions-list' ] }>

--- a/projects/packages/my-jetpack/_inc/components/plans-section/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/style.module.scss
@@ -7,3 +7,10 @@
 .expire-date {
 	margin-bottom: calc( var(--spacing-base ) * 3 );
 }
+
+.actions-list {
+	li {
+		line-height: 24px;
+		margin: 0 0 8px 0;
+	}
+}

--- a/projects/packages/my-jetpack/_inc/components/plans-section/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/style.module.scss
@@ -10,7 +10,7 @@
 
 .actions-list {
 	li {
-		line-height: 24px;
-		margin: 0 0 8px 0;
+		line-height: calc( var( --spacing-base ) * 3 );
+		margin: 0 0 var( --spacing-base ) 0;
 	}
 }

--- a/projects/packages/my-jetpack/_inc/components/plans-section/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/style.module.scss
@@ -7,11 +7,3 @@
 .expire-date {
 	margin-bottom: calc( var(--spacing-base ) * 3 );
 }
-
-.external-link {
-	font-size: var( --font-body );
-	&:hover {
-		color: var( --jp-black );
-		text-decoration-thickness: var( --jp-underline-thickness );
-	}
-}

--- a/projects/packages/my-jetpack/_inc/components/plans-section/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/style.module.scss
@@ -8,9 +8,7 @@
 	margin-bottom: calc( var(--spacing-base ) * 3 );
 }
 
-.actions-list {
-	li {
-		line-height: calc( var( --spacing-base ) * 3 );
-		margin: 0 0 var( --spacing-base ) 0;
-	}
+.actions-list-item {
+	line-height: calc( var( --spacing-base ) * 3 );
+	margin: 0 0 var( --spacing-base ) 0;
 }

--- a/projects/packages/my-jetpack/changelog/update-licensing-to-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/update-licensing-to-my-jetpack
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Updated references to old licensing activation UI to licensing activation UI in My Jetpack

--- a/projects/packages/my-jetpack/changelog/update-licensing-to-my-jetpack#2
+++ b/projects/packages/my-jetpack/changelog/update-licensing-to-my-jetpack#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -72,7 +72,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-master": "1.2.x-dev"
+			"dev-master": "1.3.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "1.2.2-alpha",
+	"version": "1.3.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -26,7 +26,7 @@
 		"@automattic/jetpack-analytics": "workspace:* || ^0.1",
 		"@automattic/jetpack-api": "workspace:* || ^0.13",
 		"@automattic/jetpack-components": "workspace:* || ^0.12",
-		"@automattic/jetpack-connection": "workspace:* || ^0.17",
+		"@automattic/jetpack-connection": "workspace:* || ^0.18",
 		"@automattic/jetpack-licensing": "workspace:* || ^0.4",
 		"@wordpress/api-fetch": "6.4.0",
 		"@wordpress/components": "19.9.0",

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -28,7 +28,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '1.2.2-alpha';
+	const PACKAGE_VERSION = '1.3.0-alpha';
 
 	/**
 	 * Initialize My Jetapack

--- a/projects/packages/search/changelog/update-licensing-to-my-jetpack
+++ b/projects/packages/search/changelog/update-licensing-to-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -43,7 +43,7 @@
 		"@automattic/jetpack-api": "workspace:* || ^0.13",
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3",
 		"@automattic/jetpack-components": "workspace:* || ^0.12",
-		"@automattic/jetpack-connection": "workspace:* || ^0.17",
+		"@automattic/jetpack-connection": "workspace:* || ^0.18",
 		"@wordpress/base-styles": "4.4.0",
 		"@wordpress/block-editor": "8.6.0",
 		"@wordpress/data": "6.7.0",

--- a/projects/plugins/backup/changelog/update-licensing-to-my-jetpack
+++ b/projects/plugins/backup/changelog/update-licensing-to-my-jetpack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -235,7 +235,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "0b01d5ecb343023c7542615941bb114d7914c003"
+                "reference": "f72ce4df88a224f63b24087bf3a36cc119a0166d"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -246,7 +246,7 @@
                 "automattic/jetpack-connection": "^1.40",
                 "automattic/jetpack-connection-ui": "^2.4",
                 "automattic/jetpack-identity-crisis": "^0.8",
-                "automattic/jetpack-my-jetpack": "^1.2",
+                "automattic/jetpack-my-jetpack": "^1.3",
                 "automattic/jetpack-status": "^1.13",
                 "automattic/jetpack-sync": "^1.31"
             },
@@ -795,7 +795,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "6d639a693079b82ec70c988619f352fc39f785d7"
+                "reference": "1850f7b082c85cddc144272e4e15f279ff0d0ca5"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -820,7 +820,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.3.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/update-licensing-to-my-jetpack
+++ b/projects/plugins/boost/changelog/update-licensing-to-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -20,7 +20,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.8.x-dev",
 		"automattic/jetpack-connection": "1.40.x-dev",
-		"automattic/jetpack-my-jetpack": "1.2.x-dev",
+		"automattic/jetpack-my-jetpack": "1.3.x-dev",
 		"automattic/jetpack-device-detection": "1.4.x-dev",
 		"automattic/jetpack-lazy-images": "2.1.x-dev",
 		"tedivm/jshrink": "1.4.0"

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5ade76c8f9ad2840babb362b95ae2fe1",
+    "content-hash": "2727566f137c6605bcf04050bb1a20a6",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -602,7 +602,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "6d639a693079b82ec70c988619f352fc39f785d7"
+                "reference": "1850f7b082c85cddc144272e4e15f279ff0d0ca5"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -627,7 +627,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.3.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
@@ -415,7 +415,7 @@ class MyPlanHeader extends React.Component {
 						) }
 						{ 'header' === position ? (
 							<Button
-								href={ siteAdminUrl + 'admin.php?page=jetpack#/license/activation' }
+								href={ siteAdminUrl + 'admin.php?page=my-jetpack#/add-license' }
 								onClick={ this.trackLicenseActivationClick }
 								primary
 							>

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
@@ -415,7 +415,11 @@ class MyPlanHeader extends React.Component {
 						) }
 						{ 'header' === position ? (
 							<Button
-								href={ siteAdminUrl + 'admin.php?page=my-jetpack#/add-license' }
+								href={
+									! window.Initial_State?.useMyJetpackLicensingUI
+										? siteAdminUrl + 'admin.php?page=jetpack#/license/activation'
+										: siteAdminUrl + 'admin.php?page=my-jetpack#/add-license'
+								}
 								onClick={ this.trackLicenseActivationClick }
 								primary
 							>

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -212,6 +212,7 @@ class Jetpack_Redux_State_Helper {
 			'newRecommendations'          => Jetpack_Recommendations::get_new_conditional_recommendations(),
 			// Check if WooCommerce plugin is active (based on https://docs.woocommerce.com/document/create-a-plugin/).
 			'isWooCommerceActive'         => in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', Jetpack::get_active_plugins() ), true ),
+			'useMyJetpackLicensingUI'     => My_Jetpack_Initializer::is_licensing_ui_enabled(),
 		);
 	}
 

--- a/projects/plugins/jetpack/changelog/update-licensing-to-my-jetpack
+++ b/projects/plugins/jetpack/changelog/update-licensing-to-my-jetpack
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Updates entrypoints in to My Jetpack licensing activation

--- a/projects/plugins/jetpack/changelog/update-licensing-to-my-jetpack#2
+++ b/projects/plugins/jetpack/changelog/update-licensing-to-my-jetpack#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/update-licensing-to-my-jetpack#3
+++ b/projects/plugins/jetpack/changelog/update-licensing-to-my-jetpack#3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -31,7 +31,7 @@
 		"automattic/jetpack-lazy-images": "2.1.x-dev",
 		"automattic/jetpack-licensing": "1.7.x-dev",
 		"automattic/jetpack-logo": "1.5.x-dev",
-		"automattic/jetpack-my-jetpack": "1.2.x-dev",
+		"automattic/jetpack-my-jetpack": "1.3.x-dev",
 		"automattic/jetpack-partner": "1.7.x-dev",
 		"automattic/jetpack-plugins-installer": "0.1.x-dev",
 		"automattic/jetpack-publicize": "0.2.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b80144071339c925d0f88411fc7b5cb1",
+    "content-hash": "e430206f348dc726208e18c1a25d3d9c",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -290,7 +290,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "0b01d5ecb343023c7542615941bb114d7914c003"
+                "reference": "f72ce4df88a224f63b24087bf3a36cc119a0166d"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -301,7 +301,7 @@
                 "automattic/jetpack-connection": "^1.40",
                 "automattic/jetpack-connection-ui": "^2.4",
                 "automattic/jetpack-identity-crisis": "^0.8",
-                "automattic/jetpack-my-jetpack": "^1.2",
+                "automattic/jetpack-my-jetpack": "^1.3",
                 "automattic/jetpack-status": "^1.13",
                 "automattic/jetpack-sync": "^1.31"
             },
@@ -1167,7 +1167,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "6d639a693079b82ec70c988619f352fc39f785d7"
+                "reference": "1850f7b082c85cddc144272e4e15f279ff0d0ca5"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -1192,7 +1192,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.3.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -52,7 +52,7 @@
 		"@automattic/jetpack-analytics": "workspace:* || ^0.1",
 		"@automattic/jetpack-api": "workspace:* || ^0.13",
 		"@automattic/jetpack-components": "workspace:* || ^0.12",
-		"@automattic/jetpack-connection": "workspace:* || ^0.17",
+		"@automattic/jetpack-connection": "workspace:* || ^0.18",
 		"@automattic/jetpack-licensing": "workspace:* || ^0.4",
 		"@automattic/jetpack-partner-coupon": "workspace:* || ^0.2",
 		"@automattic/jetpack-shared-extension-utils": "workspace:* || ^0.4",

--- a/projects/plugins/protect/changelog/update-licensing-to-my-jetpack
+++ b/projects/plugins/protect/changelog/update-licensing-to-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/protect/changelog/update-licensing-to-my-jetpack#2
+++ b/projects/plugins/protect/changelog/update-licensing-to-my-jetpack#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/protect/composer.json
+++ b/projects/plugins/protect/composer.json
@@ -10,7 +10,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.8.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-my-jetpack": "1.2.x-dev",
+		"automattic/jetpack-my-jetpack": "1.3.x-dev",
 		"automattic/jetpack-plugins-installer": "0.1.x-dev",
 		"automattic/jetpack-sync": "1.31.x-dev"
 	},

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "20304e3fcc559c60dbabcee8195769c3",
+    "content-hash": "6a649b44b5c38fccc0c7ed37c5356d2d",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -612,7 +612,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "6d639a693079b82ec70c988619f352fc39f785d7"
+                "reference": "1850f7b082c85cddc144272e4e15f279ff0d0ca5"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -637,7 +637,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.3.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/protect/package.json
+++ b/projects/plugins/protect/package.json
@@ -27,7 +27,7 @@
 	"dependencies": {
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3",
 		"@automattic/jetpack-components": "workspace:* || ^0.12",
-		"@automattic/jetpack-connection": "workspace:* || ^0.17",
+		"@automattic/jetpack-connection": "workspace:* || ^0.18",
 		"@automattic/jetpack-analytics": "workspace:* || ^0.1",
 		"@wordpress/api-fetch": "6.4.0",
 		"@wordpress/components": "19.9.0",

--- a/projects/plugins/search/changelog/update-licensing-to-my-jetpack
+++ b/projects/plugins/search/changelog/update-licensing-to-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -8,7 +8,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.8.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-my-jetpack": "1.2.x-dev",
+		"automattic/jetpack-my-jetpack": "1.3.x-dev",
 		"automattic/jetpack-search": "0.13.x-dev",
 		"automattic/jetpack-status": "^1.13",
 		"automattic/jetpack-sync": "1.31.x-dev"

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "91720448f2b9a8454798797bf0625b36",
+    "content-hash": "c9f2833874005f5704c53d9d2360b459",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -612,7 +612,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "6d639a693079b82ec70c988619f352fc39f785d7"
+                "reference": "1850f7b082c85cddc144272e4e15f279ff0d0ca5"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -637,7 +637,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.3.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/update-licensing-to-my-jetpack
+++ b/projects/plugins/social/changelog/update-licensing-to-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/social/changelog/update-licensing-to-my-jetpack#2
+++ b/projects/plugins/social/changelog/update-licensing-to-my-jetpack#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -13,7 +13,7 @@
 		"automattic/jetpack-publicize": "0.2.x-dev",
 		"automattic/jetpack-options": "1.16.x-dev",
 		"automattic/jetpack-connection": "1.40.x-dev",
-		"automattic/jetpack-my-jetpack": "1.2.x-dev",
+		"automattic/jetpack-my-jetpack": "1.3.x-dev",
 		"automattic/jetpack-sync": "1.31.x-dev",
 		"automattic/jetpack-status": "1.13.x-dev"
 	},

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ed70acaafe02e241c99ee07dc41d6bbc",
+    "content-hash": "c84d16af26677b103d0b9809b6de84e5",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -612,7 +612,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "6d639a693079b82ec70c988619f352fc39f785d7"
+                "reference": "1850f7b082c85cddc144272e4e15f279ff0d0ca5"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -637,7 +637,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.3.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/package.json
+++ b/projects/plugins/social/package.json
@@ -27,7 +27,7 @@
 	"dependencies": {
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3",
 		"@automattic/jetpack-components": "workspace:* || ^0.12",
-		"@automattic/jetpack-connection": "workspace:* || ^0.17",
+		"@automattic/jetpack-connection": "workspace:* || ^0.18",
 		"@wordpress/data": "6.7.0",
 		"@wordpress/element": "4.5.0",
 		"@wordpress/date": "4.7.0",

--- a/projects/plugins/starter-plugin/changelog/update-licensing-to-my-jetpack
+++ b/projects/plugins/starter-plugin/changelog/update-licensing-to-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-licensing-to-my-jetpack#2
+++ b/projects/plugins/starter-plugin/changelog/update-licensing-to-my-jetpack#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/starter-plugin/composer.json
+++ b/projects/plugins/starter-plugin/composer.json
@@ -10,7 +10,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.8.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-my-jetpack": "1.2.x-dev",
+		"automattic/jetpack-my-jetpack": "1.3.x-dev",
 		"automattic/jetpack-sync": "1.31.x-dev"
 	},
 	"require-dev": {

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d1b736b90519bb8bc090fdcbb218de8a",
+    "content-hash": "7c2c7bb5d4495dfb0dd9de7c3f757b5d",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -612,7 +612,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "6d639a693079b82ec70c988619f352fc39f785d7"
+                "reference": "1850f7b082c85cddc144272e4e15f279ff0d0ca5"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -637,7 +637,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.3.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/package.json
+++ b/projects/plugins/starter-plugin/package.json
@@ -27,7 +27,7 @@
 	"dependencies": {
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3",
 		"@automattic/jetpack-components": "workspace:* || ^0.12",
-		"@automattic/jetpack-connection": "workspace:* || ^0.17",
+		"@automattic/jetpack-connection": "workspace:* || ^0.18",
 		"@wordpress/data": "6.7.0",
 		"@wordpress/element": "4.5.0",
 		"@wordpress/date": "4.7.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Now that the licensing activation UI can also be loaded in My Jetpack, we can being transition entry points to point to My Jetpack. This PR does that, while also checking for the licensing activation UI feature flag
* As part of this work, this PR updates the links in the primary My Jetpack page to use the button component in `@automattic/jetpack-components` which results in a thicker underline on hover. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

NA

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Yes. There is a new Tracks event that is added here for users that click the back button within the licensing activation UI. `jetpack_myjetpack_license_activation_back_link_click`

Though, I do not think this is significant enough to need to update documentation. 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout PR
* `jetpack build plugins/jetpack`
* Go to Jetpack > Dashboard > My Plan
* Click "Activate a Product" button
* Ensure that you stay in the Jetpack plugin UI the URL does not have My Jetpack
* Enable licensing activation UI feature flag with `define( 'JETPACK_ENABLE_MY_JETPACK_LICENSE', true );`
* Go to Jetpack > Dashboard > My Plan
* Click "Activate a Product" button
* Ensure that you end up in the licensing activation UI in My Jetpack (url should have my-jetpack in it
* Click "Back" button
* Ensure that you end back up at the My Plan page
* Go to "My Jetpack"
* Ensure that you are user connected
* Ensure that "Activate a license" link shows in bottom left
* Click that link
* Ensure that you end up in licensing activation UI within my Jetpack
* Click "Back" button
* Ensure that you end back up on My Jetpack

See [video](https://user-images.githubusercontent.com/1126811/165997924-c9b8ddc0-313a-41fc-bf78-e784fabbe4b7.mov)

https://user-images.githubusercontent.com/1126811/165997924-c9b8ddc0-313a-41fc-bf78-e784fabbe4b7.mov


