### PR TITLE
JS Connection: fix building product checkout URL in useProductCheckoutWorkflow() custom hook

### DIFF
--- a/projects/js-packages/connection/changelog/update-js-connection-fix-building-checkout-url
+++ b/projects/js-packages/connection/changelog/update-js-connection-fix-building-checkout-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+JS Connection: fix builinfg the product checkout URL in useProductCheckoutWorkflow() custom hook

--- a/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
+++ b/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
@@ -43,8 +43,8 @@ export default function useProductCheckoutWorkflow( {
 	// Build the checkout URL.
 	const checkoutProductUrl = getProductCheckoutUrl(
 		productSlug,
-		redirectUrl,
 		siteSuffix,
+		redirectUrl,
 		isUserConnected
 	);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This fixes an issue that happens when building the product checkout URL in the useProductCheckoutWorkflow() custom hook. It's a matter of arguments order 🤦 Here is the [getProductCheckoutUrl](https://github.com/Automattic/jetpack/tree/447d52ed5ac151a93c4243ffc7201ed2f2a78827/projects/js-packages/components/tools/get-product-checkout-url
) doc.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* JS Connection: fix building product checkout URL in useProductCheckoutWorkflow() custom hook

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the URL in the Protect footer button
