### PR TITLE
Publicize: add calypso redirect URLs #

### DIFF
--- a/projects/packages/publicize/changelog/update-publicize-calpyso-redirect-url
+++ b/projects/packages/publicize/changelog/update-publicize-calpyso-redirect-url
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added redirect links for Jetpack cloud.

--- a/projects/packages/publicize/composer.json
+++ b/projects/packages/publicize/composer.json
@@ -49,7 +49,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-master": "0.1.x-dev"
+			"dev-master": "0.2.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.1.1-alpha",
+	"version": "0.2.0-alpha",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1433,13 +1433,21 @@ abstract class Publicize_Base {
 		}
 		return str_replace( $search, $replace, $string );
 	}
-}
 
-/**
- * Get Calypso URL for Publicize connections.
- *
- * @return string
- */
-function publicize_calypso_url() {
-	return Redirect::get_url( 'calypso-marketing-connections', array( 'site' => ( new Status() )->get_site_suffix() ) );
+	/**
+	 * Get Calypso URL for Publicize connections.
+	 *
+	 * @param string $source The idenfitier of the place the function is called from.
+	 * @return string
+	 */
+	public function publicize_calypso_url( $source = null ) {
+		switch ( $source ) {
+			case 'jetpack-social-connections-admin-page':
+				return Redirect::get_url( 'jetpack-social-connections-admin-page', array( 'site' => ( new Status() )->get_site_suffix() ) );
+			case 'jetpack-social-connections-classic-editor':
+				return Redirect::get_url( 'jetpack-social-connections-classic-editor', array( 'site' => ( new Status() )->get_site_suffix() ) );
+			default:
+				return Redirect::get_url( 'calypso-marketing-connections', array( 'site' => ( new Status() )->get_site_suffix() ) );
+		}
+	}
 }

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1453,6 +1453,6 @@ abstract class Publicize_Base {
  * @return string
  */
 function publicize_calypso_url() {
-	_deprecated_function( __METHOD__, 'jetpack-10.9', 'Publicize::publicize_connections_url' );
+	_deprecated_function( __METHOD__, '$$next-version$$', 'Publicize::publicize_connections_url' );
 	return Redirect::get_url( 'calypso-marketing-connections', array( 'site' => ( new Status() )->get_site_suffix() ) );
 }

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1441,13 +1441,8 @@ abstract class Publicize_Base {
 	 * @return string
 	 */
 	public function publicize_calypso_url( $source = null ) {
-		switch ( $source ) {
-			case 'jetpack-social-connections-admin-page':
-				return Redirect::get_url( 'jetpack-social-connections-admin-page', array( 'site' => ( new Status() )->get_site_suffix() ) );
-			case 'jetpack-social-connections-classic-editor':
-				return Redirect::get_url( 'jetpack-social-connections-classic-editor', array( 'site' => ( new Status() )->get_site_suffix() ) );
-			default:
-				return Redirect::get_url( 'calypso-marketing-connections', array( 'site' => ( new Status() )->get_site_suffix() ) );
-		}
+		$allowed_sources = array( 'jetpack-social-connections-admin-page', 'jetpack-social-connections-classic-editor', 'calypso-marketing-connections' );
+		$source          = in_array( $source, $allowed_sources, true ) ? $source : 'calypso-marketing-connections';
+		return Redirect::get_url( $source, array( 'site' => ( new Status() )->get_site_suffix() ) );
 	}
 }

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1440,7 +1440,7 @@ abstract class Publicize_Base {
 	 * @param string $source The idenfitier of the place the function is called from.
 	 * @return string
 	 */
-	public function publicize_connections_url( $source = null ) {
+	public function publicize_connections_url( $source = 'calypso-marketing-connections' ) {
 		$allowed_sources = array( 'jetpack-social-connections-admin-page', 'jetpack-social-connections-classic-editor', 'calypso-marketing-connections' );
 		$source          = in_array( $source, $allowed_sources, true ) ? $source : 'calypso-marketing-connections';
 		return Redirect::get_url( $source, array( 'site' => ( new Status() )->get_site_suffix() ) );

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1446,3 +1446,13 @@ abstract class Publicize_Base {
 		return Redirect::get_url( $source, array( 'site' => ( new Status() )->get_site_suffix() ) );
 	}
 }
+
+/**
+ * Get Calypso URL for Publicize connections.
+ *
+ * @return string
+ */
+function publicize_calypso_url() {
+	_deprecated_function( __METHOD__, 'jetpack-10.9', 'Publicize_Base::publicize_calypso_url' );
+	return Redirect::get_url( 'calypso-marketing-connections', array( 'site' => ( new Status() )->get_site_suffix() ) );
+}

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1440,7 +1440,7 @@ abstract class Publicize_Base {
 	 * @param string $source The idenfitier of the place the function is called from.
 	 * @return string
 	 */
-	public function publicize_calypso_url( $source = null ) {
+	public function publicize_connections_url( $source = null ) {
 		$allowed_sources = array( 'jetpack-social-connections-admin-page', 'jetpack-social-connections-classic-editor', 'calypso-marketing-connections' );
 		$source          = in_array( $source, $allowed_sources, true ) ? $source : 'calypso-marketing-connections';
 		return Redirect::get_url( $source, array( 'site' => ( new Status() )->get_site_suffix() ) );
@@ -1453,6 +1453,6 @@ abstract class Publicize_Base {
  * @return string
  */
 function publicize_calypso_url() {
-	_deprecated_function( __METHOD__, 'jetpack-10.9', 'Publicize_Base::publicize_calypso_url' );
+	_deprecated_function( __METHOD__, 'jetpack-10.9', 'Publicize::publicize_connections_url' );
 	return Redirect::get_url( 'calypso-marketing-connections', array( 'site' => ( new Status() )->get_site_suffix() ) );
 }

--- a/projects/packages/publicize/src/class-publicize-ui.php
+++ b/projects/packages/publicize/src/class-publicize-ui.php
@@ -41,7 +41,7 @@ class Publicize_UI {
 	 * Initialize UI-related functionality.
 	 */
 	public function init() {
-		$this->publicize_settings_url = publicize_calypso_url();
+		$this->publicize_settings_url = $this->publicize->publicize_calypso_url();
 
 		// Show only to users with the capability required to manage their Publicize connections.
 		if ( ! $this->publicize->current_user_can_access_publicize_data() ) {
@@ -130,12 +130,12 @@ class Publicize_UI {
 						),
 					)
 				),
-				esc_url( publicize_calypso_url() )
+				esc_url( $this->publicize->publicize_calypso_url() )
 			);
 			?>
 		</h4>
 
-		<a href="<?php echo esc_url( publicize_calypso_url() ); ?>" class="button button-primary jptracks" data-jptracks-name='legacy_publicize_settings'><?php esc_html_e( 'Publicize Settings', 'jetpack-publicize-pkg' ); ?></a>
+		<a href="<?php echo esc_url( $this->publicize->publicize_calypso_url() ); ?>" class="button button-primary jptracks" data-jptracks-name='legacy_publicize_settings'><?php esc_html_e( 'Publicize Settings', 'jetpack-publicize-pkg' ); ?></a>
 		<?php
 	}
 
@@ -527,7 +527,7 @@ jQuery( function($) {
 							?>
 							<a
 								class="publicize-external-link"
-								href="<?php echo esc_url( publicize_calypso_url() ); ?>"
+								href="<?php echo esc_url( $this->publicize->publicize_calypso_url() ); ?>"
 								target="_blank"
 							>
 								<span class="publicize-external-link__text"><?php esc_html_e( 'Go to Sharing settings', 'jetpack-publicize-pkg' ); ?></span>
@@ -554,9 +554,8 @@ jQuery( function($) {
 				?>
 					<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- labels are already escaped above ?>
 					<span id="publicize-defaults"><?php echo join( ', ', $labels ); ?></span>
-					<a href="#" id="publicize-form-edit"><?php esc_html_e( 'Edit', 'jetpack-publicize-pkg' ); ?></a>&nbsp;<a href="<?php echo esc_url( $this->publicize_settings_url ); ?>" rel="noopener noreferrer" target="_blank"><?php esc_html_e( 'Settings', 'jetpack-publicize-pkg' ); ?></a><br />
-				<?php
-
+					<a href="#" id="publicize-form-edit"><?php esc_html_e( 'Edit', 'jetpack-publicize-pkg' ); ?></a>&nbsp;<a href="<?php echo esc_url( $this->publicize->publicize_calypso_url( 'jetpack-social-connections-classic-editor' ) ); ?>" rel="noopener noreferrer" target="_blank"><?php esc_html_e( 'Settings', 'jetpack-publicize-pkg' ); ?></a><br />				
+					<?php
 			else :
 				$publicize_form = $this->get_metabox_form_disconnected( $available_services );
 				?>

--- a/projects/packages/publicize/src/class-publicize-ui.php
+++ b/projects/packages/publicize/src/class-publicize-ui.php
@@ -41,7 +41,7 @@ class Publicize_UI {
 	 * Initialize UI-related functionality.
 	 */
 	public function init() {
-		$this->publicize_settings_url = $this->publicize->publicize_calypso_url();
+		$this->publicize_settings_url = $this->publicize->publicize_connections_url();
 
 		// Show only to users with the capability required to manage their Publicize connections.
 		if ( ! $this->publicize->current_user_can_access_publicize_data() ) {
@@ -130,12 +130,12 @@ class Publicize_UI {
 						),
 					)
 				),
-				esc_url( $this->publicize->publicize_calypso_url() )
+				esc_url( $this->publicize->publicize_connections_url() )
 			);
 			?>
 		</h4>
 
-		<a href="<?php echo esc_url( $this->publicize->publicize_calypso_url() ); ?>" class="button button-primary jptracks" data-jptracks-name='legacy_publicize_settings'><?php esc_html_e( 'Publicize Settings', 'jetpack-publicize-pkg' ); ?></a>
+		<a href="<?php echo esc_url( $this->publicize->publicize_connections_url() ); ?>" class="button button-primary jptracks" data-jptracks-name='legacy_publicize_settings'><?php esc_html_e( 'Publicize Settings', 'jetpack-publicize-pkg' ); ?></a>
 		<?php
 	}
 
@@ -527,7 +527,7 @@ jQuery( function($) {
 							?>
 							<a
 								class="publicize-external-link"
-								href="<?php echo esc_url( $this->publicize->publicize_calypso_url() ); ?>"
+								href="<?php echo esc_url( $this->publicize->publicize_connections_url() ); ?>"
 								target="_blank"
 							>
 								<span class="publicize-external-link__text"><?php esc_html_e( 'Go to Sharing settings', 'jetpack-publicize-pkg' ); ?></span>
@@ -554,7 +554,7 @@ jQuery( function($) {
 				?>
 					<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- labels are already escaped above ?>
 					<span id="publicize-defaults"><?php echo join( ', ', $labels ); ?></span>
-					<a href="#" id="publicize-form-edit"><?php esc_html_e( 'Edit', 'jetpack-publicize-pkg' ); ?></a>&nbsp;<a href="<?php echo esc_url( $this->publicize->publicize_calypso_url( 'jetpack-social-connections-classic-editor' ) ); ?>" rel="noopener noreferrer" target="_blank"><?php esc_html_e( 'Settings', 'jetpack-publicize-pkg' ); ?></a><br />				
+					<a href="#" id="publicize-form-edit"><?php esc_html_e( 'Edit', 'jetpack-publicize-pkg' ); ?></a>&nbsp;<a href="<?php echo esc_url( $this->publicize->publicize_connections_url( 'jetpack-social-connections-classic-editor' ) ); ?>" rel="noopener noreferrer" target="_blank"><?php esc_html_e( 'Settings', 'jetpack-publicize-pkg' ); ?></a><br />				
 					<?php
 			else :
 				$publicize_form = $this->get_metabox_form_disconnected( $available_services );

--- a/projects/plugins/jetpack/changelog/update-publicize-calpyso-redirect-url
+++ b/projects/plugins/jetpack/changelog/update-publicize-calpyso-redirect-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -34,7 +34,7 @@
 		"automattic/jetpack-my-jetpack": "1.2.x-dev",
 		"automattic/jetpack-partner": "1.7.x-dev",
 		"automattic/jetpack-plugins-installer": "0.1.x-dev",
-		"automattic/jetpack-publicize": "0.1.x-dev",
+		"automattic/jetpack-publicize": "0.2.x-dev",
 		"automattic/jetpack-redirect": "1.7.x-dev",
 		"automattic/jetpack-roles": "1.4.x-dev",
 		"automattic/jetpack-search": "0.13.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6ee1dc0d962c324d93ffd1a817534b88",
+    "content-hash": "f9c728cc3656b55be76468558dec050f",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1409,7 +1409,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/publicize",
-                "reference": "4ea6133419a087e31cbe33f27ea5831a156a800c"
+                "reference": "cfaba9cf7436d9dde3865dc8f74d51e87edaa52c"
             },
             "require": {
                 "automattic/jetpack-autoloader": "^2.11",
@@ -1429,7 +1429,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "0.1.x-dev"
+                    "dev-master": "0.2.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/modules/publicize/publicize.php
+++ b/projects/plugins/jetpack/modules/publicize/publicize.php
@@ -1446,6 +1446,18 @@ abstract class Publicize_Base {
 		}
 		return str_replace( $search, $replace, $string );
 	}
+
+	/**
+	 * Get Calypso URL for Publicize connections.
+	 *
+	 * @param string $source The idenfitier of the place the function is called from.
+	 * @return string
+	 */
+	public function publicize_calypso_url( $source = null ) {
+		$allowed_sources = array( 'jetpack-social-connections-admin-page', 'jetpack-social-connections-classic-editor', 'calypso-marketing-connections' );
+		$source          = in_array( $source, $allowed_sources, true ) ? $source : 'calypso-marketing-connections';
+		return Redirect::get_url( $source, array( 'site' => ( new Status() )->get_site_suffix() ) );
+	}
 }
 
 /**
@@ -1454,5 +1466,6 @@ abstract class Publicize_Base {
  * @return string
  */
 function publicize_calypso_url() {
+	_deprecated_function( __METHOD__, 'jetpack-10.9', 'Publicize_Base::publicize_calypso_url' );
 	return Redirect::get_url( 'calypso-marketing-connections', array( 'site' => ( new Status() )->get_site_suffix() ) );
 }

--- a/projects/plugins/jetpack/modules/publicize/publicize.php
+++ b/projects/plugins/jetpack/modules/publicize/publicize.php
@@ -1453,7 +1453,7 @@ abstract class Publicize_Base {
 	 * @param string $source The idenfitier of the place the function is called from.
 	 * @return string
 	 */
-	public function publicize_calypso_url( $source = null ) {
+	public function publicize_connections_url( $source = null ) {
 		$allowed_sources = array( 'jetpack-social-connections-admin-page', 'jetpack-social-connections-classic-editor', 'calypso-marketing-connections' );
 		$source          = in_array( $source, $allowed_sources, true ) ? $source : 'calypso-marketing-connections';
 		return Redirect::get_url( $source, array( 'site' => ( new Status() )->get_site_suffix() ) );
@@ -1466,6 +1466,6 @@ abstract class Publicize_Base {
  * @return string
  */
 function publicize_calypso_url() {
-	_deprecated_function( __METHOD__, 'jetpack-10.9', 'Publicize::publicize_calypso_url' );
+	_deprecated_function( __METHOD__, 'jetpack-10.9', 'Publicize::publicize_connections_url' );
 	return Redirect::get_url( 'calypso-marketing-connections', array( 'site' => ( new Status() )->get_site_suffix() ) );
 }

--- a/projects/plugins/jetpack/modules/publicize/publicize.php
+++ b/projects/plugins/jetpack/modules/publicize/publicize.php
@@ -1466,6 +1466,6 @@ abstract class Publicize_Base {
  * @return string
  */
 function publicize_calypso_url() {
-	_deprecated_function( __METHOD__, 'jetpack-10.9', 'Publicize_Base::publicize_calypso_url' );
+	_deprecated_function( __METHOD__, 'jetpack-10.9', 'Publicize::publicize_calypso_url' );
 	return Redirect::get_url( 'calypso-marketing-connections', array( 'site' => ( new Status() )->get_site_suffix() ) );
 }

--- a/projects/plugins/jetpack/modules/publicize/publicize.php
+++ b/projects/plugins/jetpack/modules/publicize/publicize.php
@@ -1453,7 +1453,7 @@ abstract class Publicize_Base {
 	 * @param string $source The idenfitier of the place the function is called from.
 	 * @return string
 	 */
-	public function publicize_connections_url( $source = null ) {
+	public function publicize_connections_url( $source = 'calypso-marketing-connections' ) {
 		$allowed_sources = array( 'jetpack-social-connections-admin-page', 'jetpack-social-connections-classic-editor', 'calypso-marketing-connections' );
 		$source          = in_array( $source, $allowed_sources, true ) ? $source : 'calypso-marketing-connections';
 		return Redirect::get_url( $source, array( 'site' => ( new Status() )->get_site_suffix() ) );

--- a/projects/plugins/jetpack/modules/publicize/publicize.php
+++ b/projects/plugins/jetpack/modules/publicize/publicize.php
@@ -1466,6 +1466,6 @@ abstract class Publicize_Base {
  * @return string
  */
 function publicize_calypso_url() {
-	_deprecated_function( __METHOD__, 'jetpack-10.9', 'Publicize::publicize_connections_url' );
+	_deprecated_function( __METHOD__, '$$next-version$$', 'Publicize::publicize_connections_url' );
 	return Redirect::get_url( 'calypso-marketing-connections', array( 'site' => ( new Status() )->get_site_suffix() ) );
 }

--- a/projects/plugins/jetpack/modules/publicize/ui.php
+++ b/projects/plugins/jetpack/modules/publicize/ui.php
@@ -39,7 +39,7 @@ class Publicize_UI {
 	 * Initialize UI-related functionality.
 	 */
 	public function init() {
-		$this->publicize_settings_url = $this->publicize->publicize_calypso_url();
+		$this->publicize_settings_url = $this->publicize->publicize_connections_url();
 
 		// Show only to users with the capability required to manage their Publicize connections.
 		if ( ! $this->publicize->current_user_can_access_publicize_data() ) {
@@ -126,12 +126,12 @@ class Publicize_UI {
 						),
 					)
 				),
-				esc_url( $this->publicize->publicize_calypso_url() )
+				esc_url( $this->publicize->publicize_connections_url() )
 			);
 			?>
 		</h4>
 
-		<a href="<?php echo esc_url( $this->publicize->publicize_calypso_url() ); ?>" class="button button-primary jptracks" data-jptracks-name='legacy_publicize_settings'><?php esc_html_e( 'Publicize Settings', 'jetpack' ); ?></a>
+		<a href="<?php echo esc_url( $this->publicize->publicize_connections_url() ); ?>" class="button button-primary jptracks" data-jptracks-name='legacy_publicize_settings'><?php esc_html_e( 'Publicize Settings', 'jetpack' ); ?></a>
 		<?php
 	}
 
@@ -517,7 +517,7 @@ jQuery( function($) {
 							?>
 							<a
 								class="publicize-external-link"
-								href="<?php echo esc_url( $this->publicize->publicize_calypso_url() ); ?>"
+								href="<?php echo esc_url( $this->publicize->publicize_connections_url() ); ?>"
 								target="_blank"
 							>
 								<span class="publicize-external-link__text"><?php esc_html_e( 'Go to Sharing settings', 'jetpack' ); ?></span>
@@ -544,7 +544,7 @@ jQuery( function($) {
 				?>
 					<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- labels are already escaped above ?>
 					<span id="publicize-defaults"><?php echo join( ', ', $labels ); ?></span>
-					<a href="#" id="publicize-form-edit"><?php esc_html_e( 'Edit', 'jetpack' ); ?></a>&nbsp;<a href="<?php echo esc_url( $this->publicize->publicize_calypso_url( 'jetpack-social-connections-classic-editor' ) ); ?>" rel="noopener noreferrer" target="_blank"><?php esc_html_e( 'Settings', 'jetpack' ); ?></a><br />
+					<a href="#" id="publicize-form-edit"><?php esc_html_e( 'Edit', 'jetpack' ); ?></a>&nbsp;<a href="<?php echo esc_url( $this->publicize->publicize_connections_url( 'jetpack-social-connections-classic-editor' ) ); ?>" rel="noopener noreferrer" target="_blank"><?php esc_html_e( 'Settings', 'jetpack' ); ?></a><br />
 				<?php
 
 			else :

--- a/projects/plugins/jetpack/modules/publicize/ui.php
+++ b/projects/plugins/jetpack/modules/publicize/ui.php
@@ -39,7 +39,7 @@ class Publicize_UI {
 	 * Initialize UI-related functionality.
 	 */
 	public function init() {
-		$this->publicize_settings_url = publicize_calypso_url();
+		$this->publicize_settings_url = $this->publicize->publicize_calypso_url();
 
 		// Show only to users with the capability required to manage their Publicize connections.
 		if ( ! $this->publicize->current_user_can_access_publicize_data() ) {
@@ -126,12 +126,12 @@ class Publicize_UI {
 						),
 					)
 				),
-				esc_url( publicize_calypso_url() )
+				esc_url( $this->publicize->publicize_calypso_url() )
 			);
 			?>
 		</h4>
 
-		<a href="<?php echo esc_url( publicize_calypso_url() ); ?>" class="button button-primary jptracks" data-jptracks-name='legacy_publicize_settings'><?php esc_html_e( 'Publicize Settings', 'jetpack' ); ?></a>
+		<a href="<?php echo esc_url( $this->publicize->publicize_calypso_url() ); ?>" class="button button-primary jptracks" data-jptracks-name='legacy_publicize_settings'><?php esc_html_e( 'Publicize Settings', 'jetpack' ); ?></a>
 		<?php
 	}
 
@@ -517,7 +517,7 @@ jQuery( function($) {
 							?>
 							<a
 								class="publicize-external-link"
-								href="<?php echo esc_url( publicize_calypso_url() ); ?>"
+								href="<?php echo esc_url( $this->publicize->publicize_calypso_url() ); ?>"
 								target="_blank"
 							>
 								<span class="publicize-external-link__text"><?php esc_html_e( 'Go to Sharing settings', 'jetpack' ); ?></span>
@@ -544,7 +544,7 @@ jQuery( function($) {
 				?>
 					<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- labels are already escaped above ?>
 					<span id="publicize-defaults"><?php echo join( ', ', $labels ); ?></span>
-					<a href="#" id="publicize-form-edit"><?php esc_html_e( 'Edit', 'jetpack' ); ?></a>&nbsp;<a href="<?php echo esc_url( $this->publicize_settings_url ); ?>" rel="noopener noreferrer" target="_blank"><?php esc_html_e( 'Settings', 'jetpack' ); ?></a><br />
+					<a href="#" id="publicize-form-edit"><?php esc_html_e( 'Edit', 'jetpack' ); ?></a>&nbsp;<a href="<?php echo esc_url( $this->publicize->publicize_calypso_url( 'jetpack-social-connections-classic-editor' ) ); ?>" rel="noopener noreferrer" target="_blank"><?php esc_html_e( 'Settings', 'jetpack' ); ?></a><br />
 				<?php
 
 			else :

--- a/projects/plugins/social/changelog/update-publicize-calpyso-redirect-url
+++ b/projects/plugins/social/changelog/update-publicize-calpyso-redirect-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -10,7 +10,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.8.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-publicize": "0.1.x-dev",
+		"automattic/jetpack-publicize": "0.2.x-dev",
 		"automattic/jetpack-options": "1.16.x-dev",
 		"automattic/jetpack-connection": "1.40.x-dev",
 		"automattic/jetpack-my-jetpack": "1.2.x-dev",

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "33213f6976ee81fcd37ac2e467abedf1",
+    "content-hash": "ed70acaafe02e241c99ee07dc41d6bbc",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -838,7 +838,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/publicize",
-                "reference": "4ea6133419a087e31cbe33f27ea5831a156a800c"
+                "reference": "cfaba9cf7436d9dde3865dc8f74d51e87edaa52c"
             },
             "require": {
                 "automattic/jetpack-autoloader": "^2.11",
@@ -858,7 +858,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "0.1.x-dev"
+                    "dev-master": "0.2.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Broken down from https://github.com/Automattic/jetpack/pull/24172
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Moved the standalone function publicize_calypso_url into the Publicize Base class. This was done because the method publicize_calypso_url will be called from the Jetpack Social plugin using the global $publicize object.
* publicize_calypso_url, now accepts a param called $source, which will determine the redirect URL. If the source is `jetpack-social-connections-classic-editor` or `jetpack-social-connections-admin-page`, the user will be redirected to Jetpack Cloud, if they only have the Jetpack Social plugin enabled and the Jetpack plugin is disabled. 
* The above change has been done in the Publicize files of the Jetpack plugin modules directory as well as the Publicize package. Jetpack the plugin and Jetpack Social use the package, whereas **WPCOM still uses the Publicize files of the Jetpack plugin modules directory**.


#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Checkout this branch, and install Jetpack and Jetpack Social. 
- Add a Publicize connection
- Install the classic editor plugin and in the create post screen, click on the settings link next to your publicize connection. You should be taken to Calypso.  
  
<img width="274" alt="Screenshot 2022-05-02 at 6 56 05 PM" src="https://user-images.githubusercontent.com/6594561/166241348-d251e57f-444c-41aa-b648-d095f5b199f2.png">

- Repeat the above step, after deactivating Jetpack the plugin, you will be taken to Jetpack Cloud. 

- Activate the Jetpack plugin and deactivate the classic editor. From the create post screen on the block editor, click on "Connect an account". You will be taken to Calypso. 
<img width="278" alt="Screenshot 2022-05-02 at 6 55 06 PM" src="https://user-images.githubusercontent.com/6594561/166241520-f5527f4b-4662-4d59-85ec-8c20c05ce7d6.png">


For WPCOM/Atomic

- Add a publicize connection on a simple wordpress.com site. 
- Make sure the connection is listed correctly in the block editor and you're redirected to calypso, when you click on "Connect an account"
- Transfer it to atomic by making it a WoA developer site
- SSH on to the machine's code and set the JETPACK__SANDBOX_DOMAIN to point to your sandbox. 
- Install the classic editor plugin and try clicking on settings link next to your publicize connection, you will be taken to Calypso.
