### PR TITLE
WAF: Don't execute code if on WPCOM

### DIFF
--- a/projects/packages/waf/actions.php
+++ b/projects/packages/waf/actions.php
@@ -12,6 +12,10 @@ if ( ! function_exists( 'add_action' ) ) {
 	return;
 }
 
+if ( ! Waf_Runner::is_enabled() ) {
+	return;
+}
+
 /**
  * Triggers when the Jetpack plugin is updated
  */

--- a/projects/packages/waf/actions.php
+++ b/projects/packages/waf/actions.php
@@ -12,7 +12,7 @@ if ( ! function_exists( 'add_action' ) ) {
 	return;
 }
 
-if ( ! Waf_Runner::is_enabled() ) {
+if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 	return;
 }
 
@@ -27,10 +27,12 @@ add_action(
 /**
  * Cron to update the rules periodically.
  */
-add_action( 'jetpack_waf_rules_update_cron', array( __NAMESPACE__ . '\Waf_Runner', 'update_rules_cron' ) );
+if ( Waf_Runner::is_enabled() ) {
+	add_action( 'jetpack_waf_rules_update_cron', array( __NAMESPACE__ . '\Waf_Runner', 'update_rules_cron' ) );
 
-if ( ! wp_next_scheduled( 'jetpack_waf_rules_update_cron' ) ) {
-	wp_schedule_event( time(), 'twicedaily', 'jetpack_waf_rules_update_cron' );
+	if ( ! wp_next_scheduled( 'jetpack_waf_rules_update_cron' ) ) {
+		wp_schedule_event( time(), 'twicedaily', 'jetpack_waf_rules_update_cron' );
+	}
 }
 
 /**

--- a/projects/packages/waf/changelog/fix-waf-package-actions
+++ b/projects/packages/waf/changelog/fix-waf-package-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+fixed issue where code for the waf package was executed if the module was disabled


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This changes the actions file to return early if the waf module is disabled.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1651249885661069-slack-C029WFNV69M

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Disable the WAF module.
* Verify that the cron wasn't scheduled.
* Define the IS_WPCOM constant.
* Verify that no code from actions.php is executed when the constant is defined.