### PR TITLE
Protect: use weight Button prop to style the "learn more" footer link

### DIFF
--- a/projects/plugins/protect/changelog/update-protect-learn-more-link
+++ b/projects/plugins/protect/changelog/update-protect-learn-more-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Protect: use weight Button prop to style the "learn more" footer link

--- a/projects/plugins/protect/src/js/components/footer/index.jsx
+++ b/projects/plugins/protect/src/js/components/footer/index.jsx
@@ -52,11 +52,7 @@ const FooterInfo = () => {
 					'jetpack-protect'
 				) }
 			</Text>
-			<Button
-				variant="external-link"
-				href={ learnMoreUrl }
-				className={ styles[ 'learn-more-link' ] }
-			>
+			<Button variant="external-link" href={ learnMoreUrl } weight="regular">
 				{ __( 'Learn more', 'jetpack-protect' ) }
 			</Button>
 		</div>

--- a/projects/plugins/protect/src/js/components/footer/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/footer/styles.module.scss
@@ -9,10 +9,3 @@
 .paragraphs {
 	margin-bottom: calc( var(--spacing-base) * 3 );
 }
-
-// Todo: consider to tweak the styles straight at Button component level
-.learn-more-link {
-	&:global(.is-link) {
-		font-weight: 400;
-	}
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Protect: use weight Button prop to style the "learn more" footer link

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Protect dashboard
* Confirm the "Learn More" link looks ok ( `font-weight`: 400 )
<img width="1164" alt="Screen Shot 2022-05-02 at 8 32 34 PM" src="https://user-images.githubusercontent.com/77539/166342484-03385eda-f900-4501-83d3-6ccedd6007c7.png">




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202211721983865