### PR TITLE
Admin menu: Avoid usage of pseudorandom numbers in tests

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-admin-menu-tests-wp6
+++ b/projects/plugins/jetpack/changelog/fix-admin-menu-tests-wp6
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Makes the Admin_Menu tests compatible with WordPress 6.0
+
+

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -92,11 +92,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->reregister_menu_items();
 
-		$this->assertSame(
-			array_keys( $menu ),
-			array( 2, '3.86682', 4, 5, 10, 15, 20, 25, 30, 50, 51, 58, 59, 60, 65, 70, 75, 80 ),
-			'Admin menu should not have unexpected top menu items.'
-		);
+		$this->assertCount( 18, $menu, 'Admin menu should not have unexpected top menu items.' );
 
 		$this->assertEquals( static::$submenu_data[''], $submenu[''], 'Submenu items without parent should stay the same.' );
 	}
@@ -208,7 +204,9 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_stats_menu();
 
-		$this->assertSame( 'https://wordpress.com/stats/day/' . static::$domain, $menu['3.86682'][2] );
+		$menu_items = array_values( $menu );
+
+		$this->assertSame( 'https://wordpress.com/stats/day/' . static::$domain, $menu_items[1][2] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -204,9 +204,14 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_stats_menu();
 
+		// Ignore position keys, since the key used for the Stats menu contains a pseudorandom number
+		// that we shouldn't hardcode. The only thing that matters is that the menu should be in the
+		// 3rd position regardless of the key.
+		// @see https://core.trac.wordpress.org/ticket/40927
+		ksort( $menu );
 		$menu_items = array_values( $menu );
 
-		$this->assertSame( 'https://wordpress.com/stats/day/' . static::$domain, $menu_items[4][2] );
+		$this->assertSame( 'https://wordpress.com/stats/day/' . static::$domain, $menu_items[2][2] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -206,7 +206,7 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 
 		$menu_items = array_values( $menu );
 
-		$this->assertSame( 'https://wordpress.com/stats/day/' . static::$domain, $menu_items[1][2] );
+		$this->assertSame( 'https://wordpress.com/stats/day/' . static::$domain, $menu_items[4][2] );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

WordPress 6.0 will change how menus are positioned when there is a collision between items that are supposed to be in the same position: https://core.trac.wordpress.org/ticket/40927

In such cases, WordPress generates a pseudorandom number to be used as the position key in order to guarantee there are no duplicated keys. However, the logic for generating that number has changed in WordPress 6.0.

We had a couple of tests that relied on such number, so to avoid failures in these tests in WordPress 6.0 this PR adapts their implementation to don't rely in it.

Originally reported by @david-binda in D79094-code.

#### Jetpack product discussion
* See #24082

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

Make sure tests pass.