### PR TITLE
Jetpack Sync Config: Full Sync module in "must sync" settings

### DIFF
--- a/projects/packages/sync/changelog/update-must-sync-data-settings
+++ b/projects/packages/sync/changelog/update-must-sync-data-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+

--- a/projects/packages/sync/src/class-data-settings.php
+++ b/projects/packages/sync/src/class-data-settings.php
@@ -18,6 +18,7 @@ class Data_Settings {
 	const MUST_SYNC_DATA_SETTINGS = array(
 		'jetpack_sync_modules'            => array(
 			'Automattic\\Jetpack\\Sync\\Modules\\Callables',
+			'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync_Immediately', // enable Initial Sync on Site Connection.
 		),
 		'jetpack_sync_callable_whitelist' => array(
 			'site_url'       => array( 'Automattic\\Jetpack\\Connection\\Urls', 'site_url' ),

--- a/projects/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/projects/packages/sync/src/modules/class-full-sync-immediately.php
@@ -246,7 +246,10 @@ class Full_Sync_Immediately extends Module {
 		// Set default configuration, calculate totals, and save configuration if totals > 0.
 		$status = array();
 		foreach ( $full_sync_config as $name => $config ) {
-			$module          = Modules::get_module( $name );
+			$module = Modules::get_module( $name );
+			if ( ! $module ) {
+				continue;
+			}
 			$status[ $name ] = array(
 				'total'    => $module->total( $config ),
 				'sent'     => 0,

--- a/projects/packages/sync/tests/php/data-test-data-settings.php
+++ b/projects/packages/sync/tests/php/data-test-data-settings.php
@@ -33,6 +33,7 @@ class Data_Test_Data_Settings {
 					'Automattic\\Jetpack\\Sync\\Modules\\Options',
 					'Automattic\\Jetpack\\Sync\\Modules\\Plugins',
 					'Automattic\Jetpack\Sync\Modules\Callables',
+					'Automattic\Jetpack\Sync\Modules\Full_Sync_Immediately',
 				),
 				'jetpack_sync_options_whitelist'      => \Automattic\Jetpack\Sync\Defaults::$default_options_whitelist,
 				'jetpack_sync_options_contentless'    => \Automattic\Jetpack\Sync\Defaults::$default_options_contentless,
@@ -596,6 +597,7 @@ class Data_Test_Data_Settings {
 				'jetpack_sync_modules'                => array(
 					'Automattic\\Jetpack\\Sync\\Modules\\Constants',
 					'Automattic\\Jetpack\\Sync\\Modules\\Callables',
+					'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync_Immediately',
 					'Automattic\\Jetpack\\Sync\\Modules\\Options',
 				),
 				'jetpack_sync_options_whitelist'      => array(


### PR DESCRIPTION
Ensures that the Full Sync module is always present, no matter the plugin's (consumer) Sync related config.
Full Sync is required for the Initial Sync to trigger upon establishing a Site Connection.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\SyncData_Settings`: Adds `Full_Sync_Immediately` module  in `MUST_SYNC_DATA_SETTINGS`
* `Automattic\Jetpack\Sync\Modules\Full_Sync_Immediately`: Fixes a bug that prevented the Initial Sync to start successfully if `Users` Sync module was not loaded.

#### Jetpack product discussion
p9dueE-51L-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
TBD