### PR TITLE
Protect: Flush cache on plugin deactivation

### DIFF
--- a/projects/plugins/protect/changelog/update-clear-protect-cache-deactivation
+++ b/projects/plugins/protect/changelog/update-clear-protect-cache-deactivation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Flush cache on plugin deactivation

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -193,6 +193,8 @@ class Jetpack_Protect {
 		$manager = new Connection_Manager( 'jetpack-protect' );
 		$manager->disconnect_site_wpcom();
 		$manager->delete_all_connection_tokens();
+
+		Protect_Status::delete_option();
 	}
 
 	/**

--- a/projects/plugins/protect/src/class-status.php
+++ b/projects/plugins/protect/src/class-status.php
@@ -259,4 +259,14 @@ class Status {
 		update_option( self::OPTION_TIMESTAMP_NAME, time() );
 	}
 
+	/**
+	 * Delete the cached status and its timestamp
+	 *
+	 * @return void
+	 */
+	public static function delete_option() {
+		delete_option( self::OPTION_NAME );
+		delete_option( self::OPTION_TIMESTAMP_NAME );
+	}
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Flush cache on plugin deactivation

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate and connect Protect
* Make sure the option is populated: `wp option get jetpack_protect_status`
* Deactivate the plugin
* Make sure the option was deleted


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202210952011303