### PR TITLE
docker: Add PHP's intl module to the docker env

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -51,6 +51,7 @@ RUN \
 		php${PHP_VERSION}-curl \
 		php${PHP_VERSION}-gd \
 		php${PHP_VERSION}-imagick \
+		php${PHP_VERSION}-intl \
 		php${PHP_VERSION}-ldap \
 		php${PHP_VERSION}-mbstring \
 		php${PHP_VERSION}-mysql \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
While nothing we have requires it, it's a "nice to have" and WordPress's
site health screen complains if it's missing.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Once the "Build Docker" job here finishes, change [tools/docker/docker-compose.yml line 37](https://github.com/Automattic/jetpack/blob/add/docker-php-intl-module/tools/docker/docker-compose.yml#L37) to point to `ghcr.io/automattic/jetpack-wordpress-dev:pr-24249` and restart your docker env (`jetpack docker stop && jetpack docker up -d`). The Site Health screen in wp-admin should no longer complain about "One or more recommended modules are missing". 
