### PR TITLE
Starter plugin: add activation and deactivation hooks

### DIFF
--- a/projects/plugins/starter-plugin/changelog/update-starter-plugin-hooks
+++ b/projects/plugins/starter-plugin/changelog/update-starter-plugin-hooks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add actiavtion and deactivation hooks

--- a/projects/plugins/starter-plugin/jetpack-starter-plugin.php
+++ b/projects/plugins/starter-plugin/jetpack-starter-plugin.php
@@ -86,5 +86,33 @@ if ( is_readable( $jetpack_autoloader ) ) {
 	return;
 }
 
+// Redirect to plugin page when the plugin is activated.
+add_action( 'activated_plugin', 'jetpack_starter_plugin_activation' );
+
+/**
+ * Redirects to plugin page when the plugin is activated
+ *
+ * @param string $plugin Path to the plugin file relative to the plugins directory.
+ */
+function jetpack_starter_plugin_activation( $plugin ) {
+	if ( JETPACK_STARTER_PLUGIN_ROOT_FILE_RELATIVE_PATH === $plugin ) {
+		wp_safe_redirect( esc_url( admin_url( 'admin.php?page=jetpack-starter-plugin' ) ) );
+		exit;
+	}
+}
+
+// Add "Settings" link to plugins page.
+add_filter(
+	'plugin_action_links_' . JETPACK_STARTER_PLUGIN_FOLDER . '/jetpack-starter-plugin.php',
+	function ( $actions ) {
+		$settings_link = '<a href="' . esc_url( admin_url( 'admin.php?page=jetpack-starter-plugin' ) ) . '">' . __( 'Settings', 'jetpack-starter-plugin' ) . '</a>';
+		array_unshift( $actions, $settings_link );
+
+		return $actions;
+	}
+);
+
+register_deactivation_hook( __FILE__, array( 'Jetpack_Starter_Plugin', 'plugin_deactivation' ) );
+
 // Main plugin class.
 new Jetpack_Starter_Plugin();

--- a/projects/plugins/starter-plugin/src/class-jetpack-starter-plugin.php
+++ b/projects/plugins/starter-plugin/src/class-jetpack-starter-plugin.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
 use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
 use Automattic\Jetpack\Sync\Data_Settings;
@@ -121,5 +122,18 @@ class Jetpack_Starter_Plugin {
 		?>
 			<div id="jetpack-starter-plugin-root"></div>
 		<?php
+	}
+
+	/**
+	 * Removes plugin from the connection manager
+	 * If it's the last plugin using the connection, the site will be disconnected.
+	 *
+	 * @access public
+	 * @static
+	 */
+	public static function plugin_deactivation() {
+		$manager = new Connection_Manager( 'jetpack-starter-plugin' );
+		$manager->disconnect_site_wpcom();
+		$manager->delete_all_connection_tokens();
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* add activation and deactivation hooks to the Starter plugin

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Generate a new plugin using `jetpack generate` CLI command
* Make sure to use the Starter plugin as a base when asked
* Check that all additions of this PR have been correctly replaced to the new plugin slug
* Build your new plugin
* Activate your new plugin
* Confirm you got redirected to the plugin's page
* Connect
* Go to Plugins
* Make sure the "Settings" link takes you to the plugin's page
* Deactivate the plugin
* Make sure the site got disconnected (if there was no other active plugin using the connection)
