### PR TITLE
My Jetpack: Update "Activate a license" link to send user to connection when not user connnected

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
@@ -96,7 +96,7 @@ function PlanSectionFooter( { purchases } ) {
 	let activateLicenceDescription = __( 'Activate a license', 'jetpack-my-jetpack' );
 	if ( ! isUserConnected ) {
 		activateLicenceDescription = __(
-			'Connect your user account to activate a license',
+			'Activate a license (requires a user connection)',
 			'jetpack-my-jetpack'
 		);
 	}

--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
@@ -13,6 +13,7 @@ import usePurchases from '../../hooks/use-purchases';
 import getManageYourPlanUrl from '../../utils/get-manage-your-plan-url';
 import getPurchasePlanUrl from '../../utils/get-purchase-plan-url';
 import styles from './style.module.scss';
+import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 
 /**
  * Basic plan section component.
@@ -63,6 +64,9 @@ function PlanSectionHeader( { purchases } ) {
  * @returns {object} PlanSectionFooter react component.
  */
 function PlanSectionFooter( { purchases } ) {
+	const { recordEvent } = useAnalytics();
+	const { isUserConnected } = useMyJetpackConnection();
+
 	let planLinkDescription = __( 'Purchase a plan', 'jetpack-my-jetpack' );
 	if ( purchases.length >= 1 ) {
 		planLinkDescription = _n(
@@ -72,8 +76,6 @@ function PlanSectionFooter( { purchases } ) {
 			'jetpack-my-jetpack'
 		);
 	}
-
-	const { recordEvent } = useAnalytics();
 
 	const purchaseClickHandler = useCallback( () => {
 		const event = purchases.length
@@ -98,7 +100,7 @@ function PlanSectionFooter( { purchases } ) {
 					{ planLinkDescription }
 				</Button>
 			</li>
-			{ window?.myJetpackInitialState?.loadAddLicenseScreen && (
+			{ window?.myJetpackInitialState?.loadAddLicenseScreen && isUserConnected && (
 				<li className={ styles[ 'actions-list-item' ] }>
 					<Button
 						onClick={ activateLicenseClickHandler }

--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
@@ -14,6 +14,7 @@ import getManageYourPlanUrl from '../../utils/get-manage-your-plan-url';
 import getPurchasePlanUrl from '../../utils/get-purchase-plan-url';
 import styles from './style.module.scss';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
+import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 
 /**
  * Basic plan section component.
@@ -84,9 +85,21 @@ function PlanSectionFooter( { purchases } ) {
 		recordEvent( event );
 	}, [ purchases, recordEvent ] );
 
+	const navigateToConnectionPage = useMyJetpackNavigate( '/connection' );
 	const activateLicenseClickHandler = useCallback( () => {
 		recordEvent( 'jetpack_myjetpack_activate_license_click' );
-	}, [ recordEvent ] );
+		if ( ! isUserConnected ) {
+			navigateToConnectionPage();
+		}
+	}, [ navigateToConnectionPage, isUserConnected, recordEvent ] );
+
+	let activateLicenceDescription = __( 'Activate a license', 'jetpack-my-jetpack' );
+	if ( ! isUserConnected ) {
+		activateLicenceDescription = __(
+			'Connect your user account to activate a license',
+			'jetpack-my-jetpack'
+		);
+	}
 
 	return (
 		<ul>
@@ -100,15 +113,19 @@ function PlanSectionFooter( { purchases } ) {
 					{ planLinkDescription }
 				</Button>
 			</li>
-			{ window?.myJetpackInitialState?.loadAddLicenseScreen && isUserConnected && (
+			{ window?.myJetpackInitialState?.loadAddLicenseScreen && (
 				<li className={ styles[ 'actions-list-item' ] }>
 					<Button
 						onClick={ activateLicenseClickHandler }
-						href={ `${ window?.myJetpackInitialState?.adminUrl }admin.php?page=my-jetpack#/add-license` }
+						href={
+							isUserConnected
+								? `${ window?.myJetpackInitialState?.adminUrl }admin.php?page=my-jetpack#/add-license`
+								: undefined
+						}
 						variant="link"
 						weight="regular"
 					>
-						{ __( 'Activate a license', 'jetpack-my-jetpack' ) }
+						{ activateLicenceDescription }
 					</Button>
 				</li>
 			) }

--- a/projects/packages/my-jetpack/changelog/Hide Activate a license link if there is no user connection since user connection is required
+++ b/projects/packages/my-jetpack/changelog/Hide Activate a license link if there is no user connection since user connection is required
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Hide Activate a license link if there is no user connection since user connection is required


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Updates the link for activating a license such that it will send users to the connection screen when there is no user connection.

We do this because activating a license requires a user connection. It _may_ be possible to make license activation not require a user connection, but that could lead to some weird flows.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

NA

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

 No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout branch
* Set `define( 'JETPACK_ENABLE_MY_JETPACK_LICENSE', true );`
* Connect your site but do not complete the user connection
* Go to "My Jetpack" page
* Ensure that you see a link prompting you to connect your site to activate a license
* Click that link
* Connect your site
* Click "Start for free" to return to your site
* Navigate to My Jetpack again. Yes, this is borked, but on a larger level which we need to fix for standalone plugins generally. See p9dueE-4VX-p2. My personal preference is probably that we just redirect users back to My Jetpack if they start the connection from within My Jetpack. Of note, we're still behind a feature flag for now.
* Ensure that link now only mentions activating a license
* Click link and ensure that you see the licensing activation UI

See the [video walkthrough](https://user-images.githubusercontent.com/1126811/168873231-4f99d8ca-94d4-4287-87da-aef05593d379.mov)

Here's a screenshot of the site connection only state:

<img width="1200" alt="Screen Shot 2022-05-17 at 12 23 28 PM" src="https://user-images.githubusercontent.com/1126811/168873704-76c10984-0d38-4ba5-a438-eefd05015a40.png">

