### PR TITLE
Protect: request and expose to the client the Security bundle data

### DIFF
--- a/projects/plugins/protect/changelog/update-protect-pull-security-bundle-data
+++ b/projects/plugins/protect/changelog/update-protect-pull-security-bundle-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Protect: request and expose to the client the Security bundle data

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -15,6 +15,7 @@ use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
 use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
+use Automattic\Jetpack\My_Jetpack\Products as My_Jetpack_Products;
 use Automattic\Jetpack\Plugins_Installer;
 use Automattic\Jetpack\Protect\Site_Health;
 use Automattic\Jetpack\Protect\Status as Protect_Status;
@@ -167,6 +168,7 @@ class Jetpack_Protect {
 			'installedThemes'   => Sync_Functions::get_themes(),
 			'wpVersion'         => $wp_version,
 			'adminUrl'          => admin_url( 'admin.php?page=jetpack-protect' ),
+			'securityBundle'    => My_Jetpack_Products::get_product( 'security' ),
 		);
 	}
 	/**

--- a/projects/plugins/protect/src/js/hooks/use-protect-data/index.js
+++ b/projects/plugins/protect/src/js/hooks/use-protect-data/index.js
@@ -71,15 +71,21 @@ function normalizeCoreInformation( wpVersion, coreCheck ) {
  * @returns {object} The information available in Protect's initial state.
  */
 export default function useProtectData() {
-	const { installedPlugins, installedThemes, wpVersion, statusIsFetching, status } = useSelect(
-		select => ( {
-			installedPlugins: select( STORE_ID ).getInstalledPlugins(),
-			installedThemes: select( STORE_ID ).getInstalledThemes(),
-			wpVersion: select( STORE_ID ).getWpVersion(),
-			statusIsFetching: select( STORE_ID ).getStatusIsFetching(),
-			status: select( STORE_ID ).getStatus(),
-		} )
-	);
+	const {
+		installedPlugins,
+		installedThemes,
+		wpVersion,
+		statusIsFetching,
+		status,
+		securityBundle,
+	} = useSelect( select => ( {
+		installedPlugins: select( STORE_ID ).getInstalledPlugins(),
+		installedThemes: select( STORE_ID ).getInstalledThemes(),
+		wpVersion: select( STORE_ID ).getWpVersion(),
+		statusIsFetching: select( STORE_ID ).getStatusIsFetching(),
+		status: select( STORE_ID ).getStatus(),
+		securityBundle: select( STORE_ID ).getSecurityBundle(),
+	} ) );
 
 	const plugins = mergeInstalledAndCheckedLists( installedPlugins, status.plugins || {} );
 	const themes = mergeInstalledAndCheckedLists( installedThemes, status.themes || {} );
@@ -102,5 +108,6 @@ export default function useProtectData() {
 		plugins,
 		themes,
 		currentStatus,
+		securityBundle,
 	};
 }

--- a/projects/plugins/protect/src/js/state/actions.js
+++ b/projects/plugins/protect/src/js/state/actions.js
@@ -9,6 +9,7 @@ const SET_STATUS_IS_FETCHING = 'SET_STATUS_IS_FETCHING';
 const SET_INSTALLED_PLUGINS = 'SET_INSTALLED_PLUGINS';
 const SET_INSTALLED_THEMES = 'SET_INSTALLED_THEMES';
 const SET_WP_VERSION = 'SET_WP_VERSION';
+const SET_SECURITY_BUNDLE = 'SET_SECURITY_BUNDLE';
 
 const setStatus = status => {
 	return { type: SET_STATUS, status };
@@ -53,6 +54,10 @@ const setwpVersion = version => {
 	return { type: SET_WP_VERSION, version };
 };
 
+const setSecurityBundle = bundle => {
+	return { type: SET_SECURITY_BUNDLE, bundle };
+};
+
 const actions = {
 	setStatus,
 	refreshStatus,
@@ -60,6 +65,7 @@ const actions = {
 	setInstalledPlugins,
 	setInstalledThemes,
 	setwpVersion,
+	setSecurityBundle,
 };
 
 export {
@@ -68,5 +74,6 @@ export {
 	SET_INSTALLED_PLUGINS,
 	SET_INSTALLED_THEMES,
 	SET_WP_VERSION,
+	SET_SECURITY_BUNDLE,
 	actions as default,
 };

--- a/projects/plugins/protect/src/js/state/reducers.js
+++ b/projects/plugins/protect/src/js/state/reducers.js
@@ -12,6 +12,7 @@ import {
 	SET_INSTALLED_PLUGINS,
 	SET_INSTALLED_THEMES,
 	SET_WP_VERSION,
+	SET_SECURITY_BUNDLE,
 } from './actions';
 
 const status = ( state = {}, action ) => {
@@ -54,12 +55,21 @@ const wpVersion = ( state = {}, action ) => {
 	return state;
 };
 
+const securityBundle = ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SET_SECURITY_BUNDLE:
+			return action.bundle;
+	}
+	return state;
+};
+
 const reducers = combineReducers( {
 	status,
 	statusIsFetching,
 	installedPlugins,
 	installedThemes,
 	wpVersion,
+	securityBundle,
 } );
 
 export default reducers;

--- a/projects/plugins/protect/src/js/state/resolvers.js
+++ b/projects/plugins/protect/src/js/state/resolvers.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import actions from './actions';
+
+const resolvers = {
+	getSecurityBundle: {
+		isFulfilled: state => {
+			return Object.keys( state?.securityBundle ).length > 0;
+		},
+
+		fulfill: () => async ( { dispatch } ) => {
+			const response = await apiFetch( {
+				path: '/my-jetpack/v1/site/products/security',
+				method: 'GET',
+			} );
+
+			dispatch( actions.setSecurityBundle( response ) );
+		},
+	},
+};
+
+export default resolvers;

--- a/projects/plugins/protect/src/js/state/selectors.js
+++ b/projects/plugins/protect/src/js/state/selectors.js
@@ -4,6 +4,7 @@ const selectors = {
 	getStatus: state => state.status || {},
 	getStatusIsFetching: state => state.statusIsFetching || false,
 	getWpVersion: state => state.wpVersion || '',
+	getSecurityBundle: state => state.securityBundle || {},
 };
 
 export default selectors;

--- a/projects/plugins/protect/src/js/state/store.js
+++ b/projects/plugins/protect/src/js/state/store.js
@@ -4,6 +4,7 @@
 import reducer from './reducers';
 import actions from './actions';
 import selectors from './selectors';
+import resolvers from './resolvers';
 import storeHolder from './store-holder';
 import camelize from 'camelize';
 
@@ -18,6 +19,7 @@ function initStore() {
 		reducer,
 		actions,
 		selectors,
+		resolvers,
 		initialState: camelize( window.jetpackProtectInitialState ) || {},
 	} );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR exposes the Security bundle data to the client. For this:
* It requests the Security bundle product taking advantage of the My Jetpack Products class
* Exposes from the server-side to the client through `jetpackProtectInitialState` the global var.
* Propagate the data via the Protect Store.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Protect: request and expose to the client the Security bundle data

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* No UI changes here.
* Go to Protect plugin
* Open the dev console
* Get the protect data via the getSecurityBundle() selector
```
wp.data.select( 'jetpack-protect' ).getSecurityBundle()
```
<img width="531" alt="image" src="https://user-images.githubusercontent.com/77539/166992154-3d9e9830-5860-40b1-a749-96a5a5643223.png">



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202230042727404