### PR TITLE
Protect Add error screen

### DIFF
--- a/projects/plugins/protect/README.md
+++ b/projects/plugins/protect/README.md
@@ -20,6 +20,7 @@ Since the service is still under development, WPCOM is still responding with sam
 * complete: Response will include all plugins and 2 of them will have vulnerabilities
 * incomplete: Response will miss one plugin and 2 of them will have vulnerabilities
 * empty: Response as if the first check was not performed yet
+* error: Response as if there was an error checking vulnerabilities
 
 Example:
 

--- a/projects/plugins/protect/changelog/protect-error-screen
+++ b/projects/plugins/protect/changelog/protect-error-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Handle error in the UI

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -4,6 +4,7 @@
 import React, { useEffect } from 'react';
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
+
 import {
 	AdminPage,
 	AdminSectionHero,
@@ -46,10 +47,38 @@ const InterstitialPage = ( { run, hasCheckoutStarted } ) => {
 };
 
 const ProtectAdminPage = () => {
-	const { lastChecked } = useProtectData();
-
+	const { lastChecked, currentStatus, errorCode, errorMessage } = useProtectData();
 	// Track view for Protect admin page.
 	useAnalyticsTracks( { pageViewEventName: 'protect_admin' } );
+
+	// Error
+	if ( 'error' === currentStatus ) {
+		let displayErrorMessage = errorMessage
+			? `${ errorMessage } (${ errorCode }).`
+			: __( 'We are having problems scanning your site.', 'jetpack-protect' );
+		displayErrorMessage += ' ' + __( 'Try again in a few minutes.', 'jetpack-protect' );
+
+		return (
+			<AdminPage moduleName={ __( 'Jetpack Protect', 'jetpack-protect' ) } header={ <Logo /> }>
+				<AdminSectionHero>
+					<Container horizontalSpacing={ 3 } horizontalGap={ 7 }>
+						<Col sm={ 4 } md={ 4 } lg={ 6 }>
+							ALERT ICON GOES HERE
+							<H3 mt={ 8 }>
+								{ __( 'We’re having problems scanning your site', 'jetpack-protect' ) }
+							</H3>
+							<Text>{ displayErrorMessage }</Text>
+						</Col>
+						<Col sm={ 0 } md={ 0 } lg={ 1 }></Col>
+						<Col sm={ 4 } md={ 3 } lg={ 5 }>
+							<img src={ inProgressImage } alt="" />
+						</Col>
+					</Container>
+				</AdminSectionHero>
+				<Footer />
+			</AdminPage>
+		);
+	}
 
 	// When there's no information yet. Usually when the plugin was just activated
 	if ( ! lastChecked ) {

--- a/projects/plugins/protect/src/js/hooks/use-protect-data/index.js
+++ b/projects/plugins/protect/src/js/hooks/use-protect-data/index.js
@@ -86,7 +86,7 @@ export default function useProtectData() {
 	const core = normalizeCoreInformation( wpVersion, status.wordpress );
 
 	let currentStatus = 'error';
-	if ( statusIsFetching ) {
+	if ( true === statusIsFetching ) {
 		currentStatus = 'loading';
 	} else if ( status.status ) {
 		currentStatus = status.status;
@@ -98,6 +98,8 @@ export default function useProtectData() {
 		numPluginsVulnerabilities: status.numPluginsVulnerabilities || 0,
 		numThemesVulnerabilities: status.numThemesVulnerabilities || 0,
 		lastChecked: status.lastChecked || null,
+		errorCode: status.errorCode || null,
+		errorMessage: status.errorMessage || null,
 		core,
 		plugins,
 		themes,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

This PR handles error in the UI.

It will display error messages in cases there are erros checking for vulnerabilities

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-51o-p2#comment-7864

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

There are two different error situations:

1. Error fetching data from the API. In this case, the remote site was not able to communicate with WPCOM to get results.
2. WPCOM response says there was an error checking for vulnerabilities.

Testing situation 1
* Connect Protect
* Sandbox your site
* Do not log in to your sandbox, meaning your sandbox will be offline and your site won't be able to communicate with it
* Check the error message at Protect page. It should match the error message we define in `Status::fetch_from_server()`

Testing situation 2
* Connect Protect
* Set the response_type to `error`
* Verify the error message.
* The error message is defined in wpcom and is set in the initial state