### PR TITLE
 Protect: Add Jetpack Scan to footer promotion section

### DIFF
--- a/projects/plugins/protect/changelog/update-protect-add-scan-to-footer
+++ b/projects/plugins/protect/changelog/update-protect-add-scan-to-footer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Protect: Add Jetpack Scan to promotion section when site doesn't have Security bundle

--- a/projects/plugins/protect/src/js/components/footer/index.jsx
+++ b/projects/plugins/protect/src/js/components/footer/index.jsx
@@ -25,6 +25,8 @@ import useProtectData from '../../hooks/use-protect-data';
 
 const ProductPromotion = ( { onSecurityAdd, hasCheckoutStarted, hasSecurityBundle } ) => {
 	if ( ! hasSecurityBundle ) {
+		const getStartedUrl = getRedirectUrl( 'protect-footer-get-started-scan' );
+
 		return (
 			<div className={ styles.section }>
 				<Title>
@@ -37,7 +39,7 @@ const ProductPromotion = ( { onSecurityAdd, hasCheckoutStarted, hasSecurityBundl
 					) }
 				</Text>
 
-				<Button variant="external-link" weight="regular" href="#">
+				<Button variant="external-link" weight="regular" href={ getStartedUrl }>
 					{ __( 'Get Started', 'jetpack-protect' ) }
 				</Button>
 			</div>

--- a/projects/plugins/protect/src/js/components/footer/index.jsx
+++ b/projects/plugins/protect/src/js/components/footer/index.jsx
@@ -23,7 +23,7 @@ import useAnalyticsTracks from '../../hooks/use-analytics-tracks';
 import { SECURITY_BUNDLE } from '../admin-page';
 import useProtectData from '../../hooks/use-protect-data';
 
-const Upsell = ( { onSecurityAdd, hasCheckoutStarted, hasSecurityBundle } ) => {
+const ProductPromotion = ( { onSecurityAdd, hasCheckoutStarted, hasSecurityBundle } ) => {
 	if ( ! hasSecurityBundle ) {
 		return (
 			<div className={ styles.section }>
@@ -111,7 +111,7 @@ const Footer = () => {
 			<Col>
 				<Dialog
 					primary={
-						<Upsell
+						<ProductPromotion
 							onSecurityAdd={ getSecurityBundle }
 							hasCheckoutStarted={ hasCheckoutStarted }
 							hasSecurityBundle={ hasRequiredPlan }

--- a/projects/plugins/protect/src/js/components/footer/index.jsx
+++ b/projects/plugins/protect/src/js/components/footer/index.jsx
@@ -103,7 +103,7 @@ const Footer = () => {
 				<Container horizontalSpacing={ 0 } horizontalGap={ 0 } fluid={ true }>
 					<Col>
 						<IconsCard
-							products={ hasRequiredPlan ? [ 'backup', 'scan', 'anti-spam' ] : [ 'scan' ] }
+							products={ ! hasRequiredPlan ? [ 'backup', 'scan', 'anti-spam' ] : [ 'scan' ] }
 						/>
 					</Col>
 				</Container>
@@ -114,7 +114,7 @@ const Footer = () => {
 						<ProductPromotion
 							onSecurityAdd={ getSecurityBundle }
 							hasCheckoutStarted={ hasCheckoutStarted }
-							hasSecurityBundle={ hasRequiredPlan }
+							hasSecurityBundle={ ! hasRequiredPlan }
 						/>
 					}
 					secondary={ <FooterInfo /> }

--- a/projects/plugins/protect/src/js/components/footer/index.jsx
+++ b/projects/plugins/protect/src/js/components/footer/index.jsx
@@ -22,7 +22,7 @@ import styles from './styles.module.scss';
 import useAnalyticsTracks from '../../hooks/use-analytics-tracks';
 import { SECURITY_BUNDLE } from '../admin-page';
 
-const GetSecurityBundle = ( { onAdd, hasCheckoutStarted } ) => {
+const Upsell = ( { onAdd, hasCheckoutStarted } ) => {
 	return (
 		<div className={ styles.section }>
 			<Title>{ __( 'Comprehensive Site Security', 'jetpack-protect' ) }</Title>
@@ -85,10 +85,7 @@ const Footer = () => {
 			<Col>
 				<Dialog
 					primary={
-						<GetSecurityBundle
-							onAdd={ getSecurityBundle }
-							hasCheckoutStarted={ hasCheckoutStarted }
-						/>
+						<Upsell onAdd={ getSecurityBundle } hasCheckoutStarted={ hasCheckoutStarted } />
 					}
 					secondary={ <FooterInfo /> }
 					split={ true }

--- a/projects/plugins/protect/src/js/components/footer/index.jsx
+++ b/projects/plugins/protect/src/js/components/footer/index.jsx
@@ -21,8 +21,29 @@ import { useProductCheckoutWorkflow } from '@automattic/jetpack-connection';
 import styles from './styles.module.scss';
 import useAnalyticsTracks from '../../hooks/use-analytics-tracks';
 import { SECURITY_BUNDLE } from '../admin-page';
+import useProtectData from '../../hooks/use-protect-data';
 
-const Upsell = ( { onAdd, hasCheckoutStarted } ) => {
+const Upsell = ( { onSecurityAdd, hasCheckoutStarted, hasSecurityBundle } ) => {
+	if ( ! hasSecurityBundle ) {
+		return (
+			<div className={ styles.section }>
+				<Title>
+					{ __( 'Increase your site protection with Jetpack Scan', 'jetpack-protect' ) }
+				</Title>
+				<Text className={ styles.paragraphs }>
+					{ __(
+						'With your Jetpack Security bundle you have access to Jetpack Scan. Automatically scan your site from the Cloud, get email notifications and perform one-click fixes.',
+						'jetpack-protect'
+					) }
+				</Text>
+
+				<Button variant="external-link" weight="regular" href="#">
+					{ __( 'Get Started', 'jetpack-protect' ) }
+				</Button>
+			</div>
+		);
+	}
+
 	return (
 		<div className={ styles.section }>
 			<Title>{ __( 'Comprehensive Site Security', 'jetpack-protect' ) }</Title>
@@ -33,7 +54,7 @@ const Upsell = ( { onAdd, hasCheckoutStarted } ) => {
 				) }
 			</Text>
 
-			<Button variant="secondary" onClick={ onAdd } isLoading={ hasCheckoutStarted }>
+			<Button variant="secondary" onClick={ onSecurityAdd } isLoading={ hasCheckoutStarted }>
 				{ __( 'Get Jetpack Security', 'jetpack-protect' ) }
 			</Button>
 		</div>
@@ -73,19 +94,28 @@ const Footer = () => {
 		run
 	);
 
+	const { securityBundle } = useProtectData();
+	const { hasRequiredPlan } = securityBundle;
+
 	return (
 		<Container horizontalSpacing={ 8 } horizontalGap={ 0 }>
 			<Col className={ styles.icons }>
 				<Container horizontalSpacing={ 0 } horizontalGap={ 0 } fluid={ true }>
 					<Col>
-						<IconsCard products={ [ 'backup', 'scan', 'anti-spam' ] } />
+						<IconsCard
+							products={ hasRequiredPlan ? [ 'backup', 'scan', 'anti-spam' ] : [ 'scan' ] }
+						/>
 					</Col>
 				</Container>
 			</Col>
 			<Col>
 				<Dialog
 					primary={
-						<Upsell onAdd={ getSecurityBundle } hasCheckoutStarted={ hasCheckoutStarted } />
+						<Upsell
+							onSecurityAdd={ getSecurityBundle }
+							hasCheckoutStarted={ hasCheckoutStarted }
+							hasSecurityBundle={ hasRequiredPlan }
+						/>
 					}
 					secondary={ <FooterInfo /> }
 					split={ true }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

When the site already has the Security bundle product, we'd like to suggest the Jetpack Scan to customers. That's what this PR does.
Based on the site's plan data, it switches between offering the Security product or suggesting getting started to use Jetpack Scan.

~Disclaimer: the link to the Jetpack Scan is not defined.~ Set redirect URL with `protect-footer-get-started-scan`

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Protect: Add Jetpack Scan to promotion section when site has Security bundle

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In the Protect dashboard
* With a site without a Security plan, confirm you see the Security bundle suggestion
* With a site with a Security plan, confirm you see the Jetpack Scan suggestion

With security bundle | Without security bundle
------|------
<img width="699" alt="image" src="https://user-images.githubusercontent.com/77539/167037178-16829560-1a82-4c7a-8768-f3a3680142b9.png"> | <img width="654" alt="image" src="https://user-images.githubusercontent.com/77539/167037219-0be23edc-ec79-47d2-a882-ec4da632e452.png">




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202183658698204