### PR TITLE
Search: handle tiers without a record limit in Record Meter

### DIFF
--- a/projects/packages/search/changelog/fix-record-meter-1m-plus-records
+++ b/projects/packages/search/changelog/fix-record-meter-1m-plus-records
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: handle tiers without a record limit in Record Meter

--- a/projects/packages/search/src/dashboard/components/record-meter/index.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/index.jsx
@@ -41,26 +41,24 @@ export default function RecordMeter( {
 				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
 				<div className="jp-search-record-meter__title lg-col-span-8 md-col-span-6 sm-col-span-4">
 					<h2>{ __( 'Your search records', 'jetpack-search-pkg' ) }</h2>
-					{ tierMaximumRecords && (
-						<div>
-							<RecordCount
-								recordCount={ recordInfo.recordCount }
-								planRecordLimit={ tierMaximumRecords }
-							/>
-							<BarChart
-								data={ recordInfo.data }
-								isValid={ recordInfo.isValid }
-								postTypeBreakdown={ postTypeBreakdown }
-							/>
-							<NoticeBox
-								recordCount={ recordInfo.recordCount }
-								planRecordLimit={ tierMaximumRecords }
-								hasBeenIndexed={ recordInfo.hasBeenIndexed }
-								hasValidData={ recordInfo.hasValidData }
-								hasItems={ recordInfo.hasItems }
-							></NoticeBox>
-						</div>
-					) }
+					<div>
+						<RecordCount
+							recordCount={ recordInfo.recordCount }
+							planRecordLimit={ tierMaximumRecords }
+						/>
+						<BarChart
+							data={ recordInfo.data }
+							isValid={ recordInfo.isValid }
+							postTypeBreakdown={ postTypeBreakdown }
+						/>
+						<NoticeBox
+							recordCount={ recordInfo.recordCount }
+							planRecordLimit={ tierMaximumRecords }
+							hasBeenIndexed={ recordInfo.hasBeenIndexed }
+							hasValidData={ recordInfo.hasValidData }
+							hasItems={ recordInfo.hasItems }
+						></NoticeBox>
+					</div>
 				</div>
 				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
 			</div>

--- a/projects/packages/search/src/dashboard/components/record-meter/index.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/index.jsx
@@ -44,7 +44,7 @@ export default function RecordMeter( {
 					<div>
 						<RecordCount
 							recordCount={ recordInfo.recordCount }
-							planRecordLimit={ tierMaximumRecords }
+							tierMaximumRecords={ tierMaximumRecords }
 						/>
 						<BarChart
 							data={ recordInfo.data }
@@ -53,7 +53,7 @@ export default function RecordMeter( {
 						/>
 						<NoticeBox
 							recordCount={ recordInfo.recordCount }
-							planRecordLimit={ tierMaximumRecords }
+							tierMaximumRecords={ tierMaximumRecords }
 							hasBeenIndexed={ recordInfo.hasBeenIndexed }
 							hasValidData={ recordInfo.hasValidData }
 							hasItems={ recordInfo.hasItems }

--- a/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
+++ b/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
@@ -94,7 +94,7 @@ export default function getRecordInfo(
 		}
 
 		// if there is remaining unused space in tier, add filler spacing to chart
-		if ( tierMaximumRecords - currentCount > 0 ) {
+		if ( typeof tierMaximumRecords === 'number' && tierMaximumRecords - currentCount > 0 ) {
 			recordInfo.push( {
 				data: createData(
 					tierMaximumRecords - currentCount,

--- a/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
+++ b/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
@@ -160,7 +160,7 @@ export function combineOtherCount( otherItems ) {
  *
  * @param {object} data - data object with the count for the post type item
  * @param {string} color - color code to be used for the chart item
- * @param {string} name - capitalized name of post type for the label
+ * @param {string} name - name of post type for the label
  * @returns {object} chart ready data with data, label and background color.
  */
 export function createData( data, color, name ) {

--- a/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
+++ b/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
@@ -110,7 +110,6 @@ export default function getRecordInfo(
 
 	return {
 		data: recordInfo,
-		tier: tierMaximumRecords,
 		recordCount: currentCount,
 		hasBeenIndexed,
 		hasValidData,

--- a/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
@@ -14,7 +14,7 @@ import NoticeAction from 'components/notice/notice-action.jsx';
 const CLOSE_TO_LIMIT_PERCENT = 0.8;
 const DISMISSED_NOTICES = 'jetpack-search-dismissed-notices';
 
-const getNotices = ( planRecordLimit = null ) => {
+const getNotices = ( tierMaximumRecords = null ) => {
 	return {
 		1: {
 			id: 1,
@@ -43,7 +43,7 @@ const getNotices = ( planRecordLimit = null ) => {
 					'You recently surpassed %d records and will be automatically upgraded to the next billing tier',
 					'jetpack-search-pkg'
 				),
-				planRecordLimit
+				tierMaximumRecords
 			),
 			link: {
 				text: __( 'learn more', 'jetpack-search-pkg' ),
@@ -58,7 +58,7 @@ const getNotices = ( planRecordLimit = null ) => {
 					"You're close to the max amount of records for this billing tier. Once you hit %s indexed records, you'll automatically be billed for the next tier",
 					'jetpack-search-pkg'
 				),
-				planRecordLimit
+				tierMaximumRecords
 			),
 			link: {
 				text: __( 'learn more', 'jetpack-search-pkg' ),
@@ -81,7 +81,7 @@ const getNotices = ( planRecordLimit = null ) => {
  */
 export function NoticeBox( props ) {
 	const activeNoticeIds = [];
-	const NOTICES = getNotices( props.planRecordLimit );
+	const NOTICES = getNotices( props.tierMaximumRecords );
 	const [ showNotice, setShowNotice ] = useState( true );
 
 	// deal with localStorage for ensuring dismissed notice boxs are not re-displayed
@@ -109,13 +109,15 @@ export function NoticeBox( props ) {
 		activeNoticeIds.push( NO_INDEXABLE_ITEMS );
 
 	// check if over limit
-	props.recordCount > props.planRecordLimit &&
+	typeof props.tierMaximumRecords === 'number' &&
+		props.recordCount > props.tierMaximumRecords &&
 		! dismissedNoticesString.includes( OVER_RECORD_LIMIT ) &&
 		activeNoticeIds.push( OVER_RECORD_LIMIT );
 
 	// check if close to reaching limit
-	props.recordCount > props.planRecordLimit * CLOSE_TO_LIMIT_PERCENT &&
-		props.recordCount < props.planRecordLimit &&
+	typeof props.tierMaximumRecords === 'number' &&
+		props.recordCount > props.tierMaximumRecords * CLOSE_TO_LIMIT_PERCENT &&
+		props.recordCount < props.tierMaximumRecords &&
 		! dismissedNoticesString.includes( CLOSE_TO_LIMIT ) &&
 		activeNoticeIds.push( CLOSE_TO_LIMIT );
 

--- a/projects/packages/search/src/dashboard/components/record-meter/record-count.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/record-count.jsx
@@ -16,7 +16,7 @@ import { createInterpolateElement } from '@wordpress/element';
  * @returns {React.Component} record count component.
  */
 export function RecordCount( props ) {
-	if ( ! props.recordCount || ! props.planRecordLimit ) {
+	if ( ! props.recordCount ) {
 		return null;
 	}
 
@@ -24,24 +24,39 @@ export function RecordCount( props ) {
 		typeof props.recordCount === 'number' ? props.recordCount?.toLocaleString() : props.recordCount;
 
 	const recordLimit =
-		typeof props.planRecordLimit === 'number'
-			? props.planRecordLimit?.toLocaleString()
-			: props.planRecordLimit;
+		typeof props.tierMaximumRecords === 'number'
+			? props.tierMaximumRecords?.toLocaleString()
+			: props.tierMaximumRecords;
 
-	const message = createInterpolateElement(
-		sprintf(
-			// translators: %1$s: site's current record count, %2$s: record limit of the current plan
-			__(
-				'<s>%1$s</s> records indexed out of the <s>%2$s</s> allotted for your current plan',
-				'jetpack-search-pkg'
+	let message;
+
+	if ( recordLimit ) {
+		message = createInterpolateElement(
+			sprintf(
+				// translators: %1$s: site's current record count, %2$s: record limit of the current plan
+				__(
+					'<s>%1$s</s> records indexed out of the <s>%2$s</s> allotted for your current plan',
+					'jetpack-search-pkg'
+				),
+				recordCount,
+				recordLimit
 			),
-			recordCount,
-			recordLimit
-		),
-		{
-			s: <strong />,
-		}
-	);
+			{
+				s: <strong />,
+			}
+		);
+	} else {
+		message = createInterpolateElement(
+			sprintf(
+				// translators: %1$s: site's current record count, %2$s: record limit of the current plan
+				__( '<s>%1$s</s> records indexed', 'jetpack-search-pkg' ),
+				recordCount
+			),
+			{
+				s: <strong />,
+			}
+		);
+	}
 
 	return (
 		<div data-testid="record-count" className="jp-search-record-count">

--- a/projects/packages/search/src/dashboard/components/record-meter/test/index.test.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/test/index.test.jsx
@@ -22,7 +22,7 @@ describe( 'load the app', () => {
 	test( 'container renders', () => {
 		render( <RecordMeter /> );
 
-		const recordmetercontainer = screen.queryByTestId( 'record-meter' );
-		expect( recordmetercontainer ).toBeInTheDocument();
+		const container = screen.queryByTestId( 'record-meter' );
+		expect( container ).toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/search/src/dashboard/components/record-meter/test/notice-box.test.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/test/notice-box.test.jsx
@@ -19,7 +19,7 @@ describe( 'with notices to display', () => {
 		render(
 			<NoticeBox
 				recordCount={ 20 }
-				planRecordLimit={ 100 }
+				tierMaximumRecords={ 100 }
 				hasBeenIndexed={ false }
 				hasValidData={ true }
 				hasItems={ true }
@@ -32,7 +32,7 @@ describe( 'with notices to display', () => {
 		render(
 			<NoticeBox
 				recordCount={ 20 }
-				planRecordLimit={ 100 }
+				tierMaximumRecords={ 100 }
 				hasBeenIndexed={ true }
 				hasValidData={ false }
 				hasItems={ true }
@@ -46,7 +46,7 @@ describe( 'with notices to display', () => {
 		render(
 			<NoticeBox
 				recordCount={ 20 }
-				planRecordLimit={ 100 }
+				tierMaximumRecords={ 100 }
 				hasBeenIndexed={ true }
 				hasValidData={ true }
 				hasItems={ false }
@@ -60,7 +60,7 @@ describe( 'with notices to display', () => {
 		render(
 			<NoticeBox
 				recordCount={ 120 }
-				planRecordLimit={ 100 }
+				tierMaximumRecords={ 100 }
 				hasBeenIndexed={ true }
 				hasValidData={ true }
 				hasItems={ true }
@@ -74,7 +74,7 @@ describe( 'with notices to display', () => {
 		render(
 			<NoticeBox
 				recordCount={ 95 }
-				planRecordLimit={ 100 }
+				tierMaximumRecords={ 100 }
 				hasBeenIndexed={ true }
 				hasValidData={ true }
 				hasItems={ true }
@@ -89,7 +89,7 @@ test( "with no notices to display, notice box container doesn't render", () => {
 	render(
 		<NoticeBox
 			recordCount={ 20 }
-			planRecordLimit={ 100 }
+			tierMaximumRecords={ 100 }
 			hasBeenIndexed={ true }
 			hasValidData={ true }
 			hasItems={ true }

--- a/projects/packages/search/src/dashboard/components/record-meter/test/record-count.test.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/test/record-count.test.jsx
@@ -16,7 +16,7 @@ import { RecordCount } from 'components/record-meter/record-count';
 
 describe( 'record count', () => {
 	test( 'outputs correct record counts', () => {
-		render( <RecordCount recordCount={ 20 } planRecordLimit={ 100 } /> );
+		render( <RecordCount recordCount={ 20 } tierMaximumRecords={ 100 } /> );
 
 		expect( screen.getByText( /20/i ) ).toBeInTheDocument();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/24168.

#### Changes proposed in this Pull Request:
In our top pricing tier (1m records+), there is no maximum record limit. In this situation, it isn't possible to show how many records are remaining in the current tier.

This PR makes sure that the record meter still renders if there is no tier maximum. Previously, the meter was not rendered at all if the tier maximum was `null`.

New behaviour without a tier record limit:

<img width="870" alt="Screen Shot 2022-05-06 at 13 33 11" src="https://user-images.githubusercontent.com/17325/167052382-3a4a0bf0-3da5-4e68-b8d7-ee74807ce73b.png">

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Go to `/wp-admin/admin.php?page=jetpack-search&features=record-meter` on your test site with Search enabled.
* The easiest way to trigger this behaviour is to edit `projects/packages/search/src/dashboard/components/dashboard/index.jsx`. Look for the rendering of `<RecordMeter>` and set the value of the `tierMaximumRecords` prop to `null`.
