### PR TITLE
WAF: Do not throw API exceptions for users who do not have API access

### DIFF
--- a/projects/packages/waf/changelog/allow-rules-api-401
+++ b/projects/packages/waf/changelog/allow-rules-api-401
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Allow the rules API to return 401 responses without throwing an exception.

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -302,8 +302,10 @@ class Waf_Runner {
 			'wpcom'
 		);
 
-		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			throw new \Exception( 'API connection failed.' );
+		$response_code = wp_remote_retrieve_response_code( $response );
+
+		if ( 200 !== $response_code ) {
+			throw new \Exception( 'API connection failed.', $response_code );
 		}
 
 		$rules_json = wp_remote_retrieve_body( $response );
@@ -332,11 +334,17 @@ class Waf_Runner {
 
 		self::initialize_filesystem();
 
-		$api_exception = null;
+		$api_exception       = null;
+		$throw_api_exception = true;
 		try {
 			$rules = self::get_rules_from_api();
 		} catch ( \Exception $e ) {
-			if ( $wp_filesystem->exists( self::RULES_FILE ) ) {
+			if ( 401 !== $e->getCode() ) {
+				// do not throw API exceptions for users who do not have access
+				$throw_api_exception = true;
+			}
+
+			if ( $wp_filesystem->exists( self::RULES_FILE ) && $throw_api_exception ) {
 				throw $e;
 			}
 
@@ -364,7 +372,7 @@ class Waf_Runner {
 			throw new \Exception( 'Failed writing rules file to: ' . self::RULES_FILE );
 		}
 
-		if ( null !== $api_exception ) {
+		if ( null !== $api_exception && $throw_api_exception ) {
 			throw $api_exception;
 		}
 	}

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -339,9 +339,9 @@ class Waf_Runner {
 		try {
 			$rules = self::get_rules_from_api();
 		} catch ( \Exception $e ) {
-			if ( 401 !== $e->getCode() ) {
+			if ( 401 === $e->getCode() ) {
 				// do not throw API exceptions for users who do not have access
-				$throw_api_exception = true;
+				$throw_api_exception = false;
 			}
 
 			if ( $wp_filesystem->exists( self::RULES_FILE ) && $throw_api_exception ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR prevents 401 responses from the rules.php API endpoint from throwing exceptions. Jetpack users without a plan that includes Scan still have access to the Firewall/WAF module, so a `401` in this case can be a valid and acceptable response.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Includes request response code in connection exception thrown in `get_rules_from_api()`.
* Adds a new `$throw_api_exception` that is set to `false` when the exception code is `401`, and then related exceptions are only thrown when `$throw_api_exception` evaluates as true.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

1201069996155217-as-1202234313419420/f

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a Jetpack site with a free plan.
* Activate, deactivate, then reactivate the WAF module from the settings screen.
* Validate that there are no errors.