### PR TITLE
Removed the keepPlaceholderOnFocus property from RichText component

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-remove-keepPlaceholderOnFocus
+++ b/projects/plugins/jetpack/changelog/fix-remove-keepPlaceholderOnFocus
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Removed keepPlaceholderOnFocus property from donations form and dialogue blocks since the property was removed from Gutenberg.

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/components/participants-control.js
@@ -260,7 +260,6 @@ export function SpeakerEditControl( {
 				withoutInteractiveFormatting={ true }
 				onChange={ onChangeHandler }
 				placeholder={ __( 'Speaker', 'jetpack' ) }
-				keepPlaceholderOnFocus={ true }
 				onSplit={ () => {} }
 				onReplace={ replaceValue => {
 					setTimeout( () => transcriptRef?.current?.focus(), 10 );

--- a/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/dialogue/edit.js
@@ -261,7 +261,6 @@ export default function DialogueEdit( {
 				} }
 				onRemove={ onReplace ? () => onReplace( [] ) : undefined }
 				placeholder={ placeholder || __( 'Write dialogue…', 'jetpack' ) }
-				keepPlaceholderOnFocus={ true }
 			/>
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/donations/amount.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/amount.js
@@ -105,7 +105,6 @@ const Amount = ( {
 				<RichText
 					allowedFormats={ [] }
 					aria-label={ label }
-					keepPlaceholderOnFocus={ true }
 					multiline={ false }
 					onChange={ amount => setAmount( amount ) }
 					placeholder={ formatCurrency( defaultValue, currency, { symbol: '' } ) }


### PR DESCRIPTION
Since keepPlaceholderOnFocus property was removed from RichText Gutenberg component, this was causing console errors for Donations and Dialogue blocks.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #24268

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removed the usage of keepPlaceholderOnFocus from payment blocks.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On Atomic sites, use the Jetpack Beta plugin and switch to this branch
* On Simple Sites, apply D80285-code on your sandbox
* Go to wp-admin/post-new.php and add a Donation block
* Check that the placeholder is still displayed if the value from one of the amount fields is deleted.
* Additionally, on WPCOM side, we can also test the Dialogue block by adding a new Conversation block, and skipping the first step (upload).
* Make sure that the placeholder is still displayed in there too.