### PR TITLE
Do not hard disconnect Jetpack on deactivation

### DIFF
--- a/projects/js-packages/connection/changelog/update-jetpack-soft-deactivation
+++ b/projects/js-packages/connection/changelog/update-jetpack-soft-deactivation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Do not hard disconnect Jetpack on deactivation

--- a/projects/js-packages/connection/components/disconnect-dialog/steps/step-disconnect.jsx
+++ b/projects/js-packages/connection/components/disconnect-dialog/steps/step-disconnect.jsx
@@ -64,7 +64,7 @@ const StepDisconnect = props => {
 		if ( isDisconnecting ) {
 			buttonText = __( 'Disconnecting…', 'jetpack' );
 		} else if ( context === 'plugins' ) {
-			buttonText = __( 'Disconnect and Deactivate', 'jetpack' );
+			buttonText = __( 'Deactivate', 'jetpack' );
 		}
 
 		return (
@@ -157,7 +157,9 @@ const StepDisconnect = props => {
 							onClick={ handleStayConnectedClick }
 							className="jp-connection__disconnect-dialog__btn-dismiss"
 						>
-							{ __( 'Stay connected', 'jetpack' ) }
+							{ context === 'plugins'
+								? __( 'Cancel', 'jetpack' )
+								: __( 'Stay connected', 'jetpack', /* dummy arg to avoid bad minification */ 0 ) }
 						</Button>
 						{ renderDisconnectButton() }
 					</div>

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-benefits/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-benefits/index.jsx
@@ -11,6 +11,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { getRedirectUrl } from '@automattic/jetpack-components';
+import PropTypes from 'prop-types';
 import './style.scss';
 
 /**
@@ -18,10 +19,11 @@ import './style.scss';
  *
  * @param {object} props - The component props.
  * @param {Array} props.siteBenefits - An array of site benefits.
+ * @param {Array} props.context - Context in which the component will be used. disconnect or deactivate.
  * @returns {React.Component} - The JetpackBenefits component.
  */
 const JetpackBenefits = props => {
-	const { siteBenefits } = props;
+	const { siteBenefits, context } = props;
 
 	return (
 		<React.Fragment>
@@ -29,10 +31,16 @@ const JetpackBenefits = props => {
 				<React.Fragment>
 					<div className="jp-connection__disconnect-dialog__step-copy">
 						<p className="jp-connection__disconnect-dialog__large-text">
-							{ __(
-								'Jetpack is currently powering features on your site. Once you disconnect Jetpack, these features will no longer be available and your site may no longer function the same way.',
-								'jetpack'
-							) }
+							{ context === 'disconnect'
+								? __(
+										'Jetpack is currently powering features on your site. Once you disconnect Jetpack, these features will no longer be available and your site may no longer function the same way.',
+										'jetpack'
+								  )
+								: __(
+										'Jetpack is currently powering features on your site. Once you deactivate Jetpack, these features will no longer be available.',
+										'jetpack',
+										/* dummy arg to avoid bad minification */ 0
+								  ) }
 						</p>
 					</div>
 					<div className="jp-connection__disconnect-card__group">
@@ -107,6 +115,17 @@ const JetpackBenefits = props => {
 			) }
 		</React.Fragment>
 	);
+};
+
+JetpackBenefits.propTypes = {
+	/** An array of site benefits. */
+	siteBenefits: PropTypes.array,
+	/** Context in which the component will be used. disconnect or deactivate. */
+	context: PropTypes.oneOf( [ 'disconnect', 'deactivate' ] ),
+};
+
+JetpackBenefits.defaultProps = {
+	context: 'disconnect',
 };
 
 export default JetpackBenefits;

--- a/projects/plugins/jetpack/_inc/client/portals/plugin-deactivation.jsx
+++ b/projects/plugins/jetpack/_inc/client/portals/plugin-deactivation.jsx
@@ -34,7 +34,6 @@ import JetpackBenefits from '../components/jetpack-benefits';
  * @param {object} props - The props object for the component.
  * @param {string} props.apiRoot - Root URL for the API, which is required by the <DisconnectDialog/> component.
  * @param {string} props.apiNonce - Nonce value for the API, which is required by the <DisconnectDialog/> component.
- * @param {object} props.connectedPlugins - An object of plugins that are using the Jetpack connection.
  * @param {Array} props.siteBenefits - An array of benefits provided by Jetpack.
  * @param {string} props.pluginUrl - The URL of the plugin directory.
  * @returns {React.Component} - The PluginDeactivation component.
@@ -43,10 +42,8 @@ const PluginDeactivation = props => {
 	const {
 		apiRoot,
 		apiNonce,
-		connectedPlugins,
 		siteBenefits,
 		connectionUserData,
-		fetchConnectedPlugins,
 		fetchSiteBenefits,
 		fetchUserConnectionData,
 	} = props;
@@ -54,15 +51,13 @@ const PluginDeactivation = props => {
 
 	useEffect( () => {
 		fetchSiteBenefits();
-		fetchConnectedPlugins();
 		fetchUserConnectionData();
-	}, [ fetchSiteBenefits, fetchConnectedPlugins, fetchUserConnectionData ] );
+	}, [ fetchSiteBenefits, fetchUserConnectionData ] );
 
 	// Modify the deactivation link.
 	const deactivationLink = document.querySelector( '#deactivate-jetpack, #deactivate-jetpack-dev' ); // ID set by WP on the deactivation link.
 
 	deactivationLink.setAttribute( 'title', __( 'Deactivate Jetpack', 'jetpack' ) );
-	deactivationLink.textContent = __( 'Disconnect and Deactivate', 'jetpack' );
 
 	useEffect( () => {
 		restApi.setApiRoot( apiRoot );
@@ -98,15 +93,16 @@ const PluginDeactivation = props => {
 	}, [ deactivationLink ] );
 
 	const disconnectStepComponent = siteBenefits ? (
-		<JetpackBenefits siteBenefits={ siteBenefits } />
+		<JetpackBenefits siteBenefits={ siteBenefits } context="deactivate" />
 	) : null;
 
 	return (
 		<PortalSidecar>
 			<DisconnectDialog
+				title={ __( 'Are you sure you want to deactivate?', 'jetpack' ) }
 				apiRoot={ apiRoot }
 				apiNonce={ apiNonce }
-				connectedPlugins={ connectedPlugins }
+				connectedPlugins={ [] } // We no longer disconnect Jetpack if other plugins are active, so no need to warn.
 				connectedUser={ {
 					ID: connectionUserData?.ID,
 					login: connectionUserData?.login,

--- a/projects/plugins/jetpack/changelog/update-jetpack-soft-deactivation
+++ b/projects/plugins/jetpack/changelog/update-jetpack-soft-deactivation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Do not hard disconnect Jetpack on deactivation

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -2974,7 +2974,10 @@ p {
 
 		// If the site is in an IDC because sync is not allowed,
 		// let's make sure to not disconnect the production site.
-		$connection->disconnect_site( ! Identity_Crisis::validate_sync_error_idc_option() );
+		if ( ! Identity_Crisis::validate_sync_error_idc_option() ) {
+			$connection->disconnect_site_wpcom();
+		}
+		$connection->delete_all_connection_tokens();
 	}
 
 	/**


### PR DESCRIPTION
This reverts commit https://github.com/Automattic/jetpack/commit/14de12accb24de15c01deee738ca6c9b04a2c5df.

and brings back https://github.com/Automattic/jetpack/pull/23957

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Do not hard disconnect Jetpack on plugin deactivation

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-4n9-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Connect Jetpack
* Activate a secondary plugin like Boost and/or Backup
* Go to Plugins
* Confirm the link to deactivate Jetpack says only "Deactivate" (and not 'Disconnect and Deactivate')
* Click Deactivate
* Confirm the dialog shows information about the active features you have and no mention to other plugins
* Test with different Jetpack modules active
* Make sure disconnecting from the Jetpack Dashboard still works and shows the survey