### PR TITLE
Protect: Add alert icon when having problem scanning the site

### DIFF
--- a/projects/plugins/protect/changelog/update-add-protect-error-icon
+++ b/projects/plugins/protect/changelog/update-add-protect-error-icon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add Alert icon to the error admin page

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -66,9 +66,7 @@ const ProtectAdminPage = () => {
 					<Container horizontalSpacing={ 3 } horizontalGap={ 7 }>
 						<Col sm={ 4 } md={ 4 } lg={ 6 }>
 							<AlertSVGIcon className={ styles[ 'alert-icon-wrapper' ] } />
-							<H3 mt={ 8 }>
-								{ __( 'We’re having problems scanning your site', 'jetpack-protect' ) }
-							</H3>
+							<H3>{ __( 'We’re having problems scanning your site', 'jetpack-protect' ) }</H3>
 							<Text>{ displayErrorMessage }</Text>
 						</Col>
 						<Col sm={ 0 } md={ 0 } lg={ 1 }></Col>

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -27,6 +27,8 @@ import useProtectData from '../../hooks/use-protect-data';
 import inProgressImage from './in-progress.png';
 import useAnalyticsTracks from '../../hooks/use-analytics-tracks';
 import Logo from '../logo';
+import AlertSVGIcon from '../alert-icon';
+import styles from './styles.module.scss';
 
 export const SECURITY_BUNDLE = 'jetpack_security_t1_yearly';
 
@@ -63,7 +65,7 @@ const ProtectAdminPage = () => {
 				<AdminSectionHero>
 					<Container horizontalSpacing={ 3 } horizontalGap={ 7 }>
 						<Col sm={ 4 } md={ 4 } lg={ 6 }>
-							ALERT ICON GOES HERE
+							<AlertSVGIcon className={ styles[ 'alert-icon-wrapper' ] } />
 							<H3 mt={ 8 }>
 								{ __( 'We’re having problems scanning your site', 'jetpack-protect' ) }
 							</H3>

--- a/projects/plugins/protect/src/js/components/admin-page/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/admin-page/styles.module.scss
@@ -1,3 +1,4 @@
 .alert-icon-wrapper {
+	margin-top: -4px;
 	margin-left: -40px; // the icon has a drop shadow that is 40px wide
 }

--- a/projects/plugins/protect/src/js/components/admin-page/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/admin-page/styles.module.scss
@@ -1,0 +1,3 @@
+.alert-icon-wrapper {
+	margin-left: -40px; // the icon has a drop shadow that is 40px wide
+}

--- a/projects/plugins/protect/src/js/components/alert-icon/index.jsx
+++ b/projects/plugins/protect/src/js/components/alert-icon/index.jsx
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { Path, SVG, Rect, G } from '@wordpress/components';
+
+/**
+ * Alert icon
+ *
+ * @param {object} props           - Props.
+ * @param {string} props.className - Optional component class name.
+ * @param {string} props.color     - Optional icon color. Defaults to '#D63638'.
+ * @returns { React.ReactNode }      The Alert Icon component.
+ */
+export default function AlertSVGIcon( { className, color = '#D63638' } ) {
+	return (
+		<SVG
+			className={ className }
+			width="127"
+			height="136"
+			viewBox="0 0 127 136"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<G filter="url(#filter0_d_2716_19567)">
+				<Path
+					fillRule="evenodd"
+					clipRule="evenodd"
+					d="M63.4061 36L86.8123 46.4057V61.9177C86.8123 75.141 78.1289 87.6611 65.8844 91.6107C64.2754 92.1298 62.5369 92.1297 60.9279 91.6107C48.6834 87.6611 40 75.141 40 61.9177V46.4057L63.4061 36Z"
+					fill={ color }
+				/>
+				<Rect x="59.8953" y="72.1666" width="7.02184" height="7" rx="3.5" fill="white" />
+				<Path
+					d="M59.9619 51.0626C59.9258 50.4868 60.383 50 60.9599 50H65.8524C66.4293 50 66.8866 50.4868 66.8505 51.0626L65.8056 67.7292C65.7725 68.2562 65.3355 68.6667 64.8075 68.6667H62.0048C61.4769 68.6667 61.0398 68.2562 61.0068 67.7292L59.9619 51.0626Z"
+					fill="white"
+				/>
+			</G>
+			<defs>
+				<filter
+					id="filter0_d_2716_19567"
+					x="0"
+					y="0"
+					width="126.812"
+					height="136"
+					filterUnits="userSpaceOnUse"
+					colorInterpolationFilters="sRGB"
+				>
+					<feFlood floodOpacity="0" result="BackgroundImageFix" />
+					<feColorMatrix
+						in="SourceAlpha"
+						type="matrix"
+						values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+						result="hardAlpha"
+					/>
+					<feOffset dy="4" />
+					<feGaussianBlur stdDeviation="20" />
+					<feComposite in2="hardAlpha" operator="out" />
+					<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.08 0" />
+					<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2716_19567" />
+					<feBlend
+						mode="normal"
+						in="SourceGraphic"
+						in2="effect1_dropShadow_2716_19567"
+						result="shape"
+					/>
+				</filter>
+			</defs>
+		</SVG>
+	);
+}

--- a/projects/plugins/protect/src/js/components/alert-icon/stories/index.jsx
+++ b/projects/plugins/protect/src/js/components/alert-icon/stories/index.jsx
@@ -1,0 +1,18 @@
+/* eslint-disable react/react-in-jsx-scope */
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import AlertIcon from '../index.jsx';
+
+export default {
+	title: 'Plugins/Protect/Alert Icon',
+	component: AlertIcon,
+};
+
+const FooterTemplate = args => <AlertIcon { ...args } />;
+export const Default = FooterTemplate.bind( {} );

--- a/projects/plugins/protect/src/js/components/alert-icon/stories/index.jsx
+++ b/projects/plugins/protect/src/js/components/alert-icon/stories/index.jsx
@@ -12,6 +12,13 @@ import AlertIcon from '../index.jsx';
 export default {
 	title: 'Plugins/Protect/Alert Icon',
 	component: AlertIcon,
+	argTypes: {
+		color: {
+			control: {
+				type: 'color',
+			},
+		},
+	},
 };
 
 const FooterTemplate = args => <AlertIcon { ...args } />;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds an SVG Alert icon when having problems scanning the site. It's a follow up of https://github.com/Automattic/jetpack/pull/24261

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use Storybook
* Take a look at the Alert Icon story: `http://localhost:50240/?path=/story/plugins-protect-alert-icon--default`
<img width="791" alt="Screen Shot 2022-05-06 at 11 03 18 AM" src="https://user-images.githubusercontent.com/77539/167148769-5d28aeb4-3bc4-42bf-a510-075eb5a19302.png">

* Take a look at Protect overview page

<img width="862" alt="image" src="https://user-images.githubusercontent.com/77539/167148930-eca5520c-e483-4499-966f-bcf148688e03.png">

<img width="677" alt="image" src="https://user-images.githubusercontent.com/77539/167148395-5dcf68c9-ce69-47c5-abe7-c7a952db7f91.png">




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202230774714214