### PR TITLE
Lazy Images: run lazy-images setup filters to run on 'the_post'

### DIFF
--- a/projects/packages/lazy-images/changelog/update-lazy-images-filter-init
+++ b/projects/packages/lazy-images/changelog/update-lazy-images-filter-init
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Setup lazy-images filters to run on 'the_post' hook not 'wp_head' to fix a variety of issues.

--- a/projects/packages/lazy-images/src/lazy-images.php
+++ b/projects/packages/lazy-images/src/lazy-images.php
@@ -114,7 +114,7 @@ class Jetpack_Lazy_Images {
 			return;
 		}
 
-		add_action( 'wp_head', array( $this, 'setup_filters' ), 9999 ); // We don't really want to modify anything in <head> since it's mostly all metadata.
+		add_action( 'the_post', array( $this, 'setup_filters' ), 9999 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 
 		// Do not lazy load avatar in admin bar.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Change `Jetpack_Lazy_Images::__construct` to `setup_filters` on hook `the_post` rather than `wp_head`.
  -  [the_post](https://developer.wordpress.org/reference/hooks/the_post/) - "Fires once the post data has been set up." Which I think makes more sense than `wp_head` since Lazy Images modifies the posts contents.

This change hopes to resolve the following issues for Jetpack Lazy Images:

1. Not working for block themes, closes #24253
2. Not working for admin post views.
3. Not working for Latest Instagram Posts block #19086

Closes #15354

#### Jetpack product discussion

n/a

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

- For `#1` above, follow instructions in #24253
- For `#2`, you can then switch two theme Twenty Twenty and try viewing your test post as an admin to see that the Jetpack Lazy Images isn't running as expected (look for the `jetpack-lazy-image` class on images).
- For testing `#3`, you will need to add the Latest Instagram Posts block (requires connection). Observe pre/post patch behavior to confirm that patching results in Lazy Images running for the Instagram gallery images.
