### PR TITLE
Latest Instagram Posts block: lazy load the images

### DIFF
--- a/projects/plugins/jetpack/changelog/update-lazy-load-instagram-block-images
+++ b/projects/plugins/jetpack/changelog/update-lazy-load-instagram-block-images
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Latest Instagram Posts block: lazy load the images.

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/instagram-gallery.php
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/instagram-gallery.php
@@ -116,6 +116,7 @@ function render_block( $attributes, $content ) { // phpcs:ignore VariableAnalysi
 				<img
 					alt="<?php echo esc_attr( $image->title ? $image->title : $image->link ); ?>"
 					src="<?php echo esc_url( $image->url ); ?>"
+					loading="lazy"
 				/>
 			</a>
 		<?php endforeach; ?>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Add the `loading=lazy` attribute to the images fetched by the block.

Note: unfortunately I don't see width/height dimensions returned by the current Instagram API implementation we use, it'd be nice to have this for the images to prevent reflow.

#### Jetpack product discussion

Alongside #24277 this closes #19086

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

- Pre-patch, add a Instagram Latest Posts block to a test post (requires connection). Place a large spacer block above the Instagram one to test the lazy load aspect. Inspect the HTML of the block images to see that they don't contain the `lazy` attribute.
- Post-patch, you should be able to see the `lazy` attribute, and if you inspect the network tab the images should load in lazily on page scroll.
