### PR TITLE
Publicize: Add a Jetpack Publicize connections endpoint.

### DIFF
--- a/projects/packages/publicize/changelog/add-publicize-test-connections-endpoint
+++ b/projects/packages/publicize/changelog/add-publicize-test-connections-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Created a new jetpack/v4/publicize/connections endpoint

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -27,5 +27,7 @@ class Publicize_Setup {
 			$publicize_ui = new Publicize_UI();
 
 		}
+
+		add_action( 'rest_api_init', array( new REST_Controller(), 'register_rest_routes' ) );
 	}
 }

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * The Publicize Rest Controller class.
+ * Registers the REST routes for Publicize.
+ *
+ * @package automattic/jetpack-publicize
+ */
+
+namespace Automattic\Jetpack\Publicize;
+
+use Automattic\Jetpack\Connection\Client;
+use Jetpack_Options;
+use WP_Error;
+use WP_REST_Server;
+
+/**
+ * Registers the REST routes for Search.
+ */
+class REST_Controller {
+	/**
+	 * Whether it's run on WPCOM.
+	 *
+	 * @var bool
+	 */
+	protected $is_wpcom;
+
+	/**
+	 * Constructor
+	 *
+	 * @param bool $is_wpcom - Whether it's run on WPCOM.
+	 */
+	public function __construct( $is_wpcom = false ) {
+		$this->is_wpcom = $is_wpcom;
+	}
+
+	/**
+	 * Registers the REST routes for Search.
+	 *
+	 * @access public
+	 * @static
+	 */
+	public function register_rest_routes() {
+		register_rest_route(
+			'jetpack/v4',
+			'/publicize/connections',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_publicize_connections' ),
+				'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
+			)
+		);
+	}
+
+	/**
+	 * Only administrators can access the API.
+	 *
+	 * @return bool|WP_Error True if a blog token was used to sign the request, WP_Error otherwise.
+	 */
+	public function require_admin_privilege_callback() {
+		if ( current_user_can( 'manage_options' ) ) {
+			return true;
+		}
+
+		$error_msg = esc_html__(
+			'You are not allowed to perform this action.',
+			'jetpack-publicize-pkg'
+		);
+
+		return new WP_Error( 'rest_forbidden', $error_msg, array( 'status' => rest_authorization_required_code() ) );
+	}
+
+	/**
+	 * Gets the current Publicize connections for the site.
+	 *
+	 * GET `jetpack/v4/publicize/connections`
+	 */
+	public function get_publicize_connections() {
+		$blog_id  = $this->get_blog_id();
+		$path     = sprintf( '/sites/%d/publicize/connections', absint( $blog_id ) );
+		$response = Client::wpcom_json_api_request_as_user( $path, '2', array(), null, 'wpcom' );
+		return rest_ensure_response( $this->make_proper_response( $response ) );
+	}
+
+	/**
+	 * Forward remote response to client with error handling.
+	 *
+	 * @param array|WP_Error $response - Response from WPCOM.
+	 */
+	protected function make_proper_response( $response ) {
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
+		$status_code = wp_remote_retrieve_response_code( $response );
+
+		if ( 200 === $status_code ) {
+			return $body;
+		}
+
+		return new WP_Error(
+			isset( $body['error'] ) ? 'remote-error-' . $body['error'] : 'remote-error',
+			isset( $body['message'] ) ? $body['message'] : 'unknown remote error',
+			array( 'status' => $status_code )
+		);
+	}
+
+	/**
+	 * Get blog id
+	 */
+	protected function get_blog_id() {
+		return $this->is_wpcom ? get_current_blog_id() : Jetpack_Options::get_option( 'id' );
+	}
+
+}

--- a/projects/plugins/jetpack/changelog/add-publicize-test-connections-endpoint
+++ b/projects/plugins/jetpack/changelog/add-publicize-test-connections-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Added the Publicize API endpoint URL to the initial state.

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -673,7 +673,6 @@ class Jetpack_Gutenberg {
 			);
 			$blog_id                   = get_current_blog_id();
 			$is_current_user_connected = true;
-			$publicize_connection_url  = '/wpcom/v2/publicize/connection-test-results';
 		} else {
 			$user_data                 = Jetpack_Tracks_Client::get_connected_user_tracks_identity();
 			$blog_id                   = Jetpack_Options::get_option( 'id', 0 );
@@ -711,7 +710,6 @@ class Jetpack_Gutenberg {
 					 * @param bool true Enable Pocket Casts block variation in block editor context. Defaults to false.
 					 */
 					'pocket_casts_enabled'      => apply_filters( 'jetpack_block_editor_pocket_casts_feature', false ),
-					'publicize_connection_url'  => $publicize_connection_url,
 				),
 				'siteFragment'     => $status->get_site_suffix(),
 				'adminUrl'         => esc_url( admin_url() ),

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -673,6 +673,7 @@ class Jetpack_Gutenberg {
 			);
 			$blog_id                   = get_current_blog_id();
 			$is_current_user_connected = true;
+			$publicize_connection_url  = '/wpcom/v2/publicize/connection-test-results';
 		} else {
 			$user_data                 = Jetpack_Tracks_Client::get_connected_user_tracks_identity();
 			$blog_id                   = Jetpack_Options::get_option( 'id', 0 );
@@ -710,6 +711,7 @@ class Jetpack_Gutenberg {
 					 * @param bool true Enable Pocket Casts block variation in block editor context. Defaults to false.
 					 */
 					'pocket_casts_enabled'      => apply_filters( 'jetpack_block_editor_pocket_casts_feature', false ),
+					'publicize_connection_url'  => $publicize_connection_url,
 				),
 				'siteFragment'     => $status->get_site_suffix(),
 				'adminUrl'         => esc_url( admin_url() ),

--- a/projects/plugins/jetpack/extensions/plugins/publicize/store/effects.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/store/effects.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { flatMap, throttle } from 'lodash';
+import { getJetpackData } from '@automattic/jetpack-shared-extension-utils';
 import apiFetch from '@wordpress/api-fetch';
 import { serialize } from '@wordpress/blocks';
 import { select, dispatch } from '@wordpress/data';
@@ -19,7 +20,10 @@ import { SUPPORTED_CONTAINER_BLOCKS } from '../components/twitter';
  */
 export async function refreshConnectionTestResults() {
 	try {
-		const results = await apiFetch( { path: '/wpcom/v2/publicize/connection-test-results' } );
+		const results = await apiFetch( {
+			path:
+				getJetpackData()?.jetpack?.publicize_connection_url ?? '/jetpack/v4/publicize/connections',
+		} );
 
 		// Combine current connections with new connections.
 		const prevConnections = select( 'jetpack/publicize' ).getConnections();

--- a/projects/plugins/jetpack/extensions/plugins/publicize/store/effects.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/store/effects.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { flatMap, throttle } from 'lodash';
-import { getJetpackData } from '@automattic/jetpack-shared-extension-utils';
 import apiFetch from '@wordpress/api-fetch';
 import { serialize } from '@wordpress/blocks';
 import { select, dispatch } from '@wordpress/data';
@@ -20,10 +19,7 @@ import { SUPPORTED_CONTAINER_BLOCKS } from '../components/twitter';
  */
 export async function refreshConnectionTestResults() {
 	try {
-		const results = await apiFetch( {
-			path:
-				getJetpackData()?.jetpack?.publicize_connection_url ?? '/jetpack/v4/publicize/connections',
-		} );
+		const results = await apiFetch( { path: '/jetpack/v4/publicize/connections' } );
 
 		// Combine current connections with new connections.
 		const prevConnections = select( 'jetpack/publicize' ).getConnections();


### PR DESCRIPTION
This adds a new endpoint, that proxies a request to WPCOM in order to
retrive the Publicize connections. It also makes a change to the initial
state, so that on WPCOM we call the API directly. It might be better to
just have an `isWPCOM` boolean so that it's more useful.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*
