### PR TITLE
My Jetpack: Add from and redirectUri args to connection

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connection-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-screen/index.jsx
@@ -69,6 +69,7 @@ const ConnectionScreen = () => {
 						apiNonce={ apiNonce }
 						images={ [ connectImage ] }
 						footer={ <ConnectionScreenFooter /> }
+						from="my-jetpack-connection-route"
 					>
 						<ul>
 							<li>{ __( 'Receive instant downtime alerts', 'jetpack-my-jetpack' ) }</li>

--- a/projects/packages/my-jetpack/_inc/components/connection-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-screen/index.jsx
@@ -69,7 +69,8 @@ const ConnectionScreen = () => {
 						apiNonce={ apiNonce }
 						images={ [ connectImage ] }
 						footer={ <ConnectionScreenFooter /> }
-						from="my-jetpack-connection-route"
+						from="my-jetpack"
+						redirectUri="admin.php?page=my-jetpack"
 					>
 						<ul>
 							<li>{ __( 'Receive instant downtime alerts', 'jetpack-my-jetpack' ) }</li>

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-connection-add-from
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-connection-add-from
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Adds from arg to connection screen in My Jetpack so that we can begin tracking connections originating from My Jetpack


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Begins attributing connections coming from My Jetpack by adding the `from` prop
* Adds `redirectUri` arg to support the ability to redirect the user back to My Jetpack after the user connection. Note the word prepare, because it'll require a patch on WPCOM to actually do the redirect back.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Related to #24251. I want to redirect users back to My Jetpack after connection when that user's connection originates from My Jetpack. To do that, we need to now the `from` and `redirectUri`.

But, more importantly, we need the `from` to attribute the connection.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Yes. But, I don't believe in a meaningful way that requires privacy updates. 

It begins adding `my-jetpack` as the `from` arg in the connection URL when the user originates a connection from My Jetpack. We already track this `from` arg elsewhere though.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Checkout branch
- Click a connection button
- Do not complete the user connection
- Go to My Jetpack
- Click on a link to add user connection
- Click the black button to actually connect your site
- Ensure that `from=my-jetpack` exists in the URL that you are redirected to
- Ensure that you see something like `admin.php%253Fpage%253Dmy-jetpack` in the URL

If you'd like, you can test this functionally with this PR over in Calypso: https://github.com/Automattic/wp-calypso/pull/63397