### PR TITLE
Search: Fix left padding for upsell page

### DIFF
--- a/projects/packages/search/changelog/fix-search-upsell-left-padding
+++ b/projects/packages/search/changelog/fix-search-upsell-left-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: Fix left padding for upsell page

--- a/projects/packages/search/src/dashboard/components/dashboard/upsell-page.scss
+++ b/projects/packages/search/src/dashboard/components/dashboard/upsell-page.scss
@@ -4,4 +4,9 @@
 	h1 {
 		line-height: 1.2;
 	}
+
+	// Targets AdminPage component, which uses obfuscated CSS names.
+	> div {
+		margin-left: 0;
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #24284.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Adds styling shim to fix incorrect left padding for the search upsell page on mobile viewports.

<!-- #### Jetpack product discussion -->
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this change to your connected Jetpack site **without a Jetpack Search subscription**.
* Activate either Jetpack or Jetpack Search plugins.
* Navigate to the Search dashboard in a mobile viewport (`/wp-admin/admin.php?page=jetpack-search`).
* Ensure that there is sufficient left padding.

<img width="758" alt="Screen Shot 2022-05-06 at 6 03 30 PM" src="https://user-images.githubusercontent.com/4044428/167231791-5e3e828a-2656-4059-b3f0-b3755c48cdfd.png">
<img width="488" alt="Screen Shot 2022-05-06 at 6 03 18 PM" src="https://user-images.githubusercontent.com/4044428/167231793-c1a5ed95-d6ad-4f45-b3b3-80ab898a1c58.png">

