### PR TITLE
Subscriptions: fix mistake in pending message

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subs-typo-message
+++ b/projects/plugins/jetpack/changelog/fix-subs-typo-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscriptions: fix typo in confirmation message.

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -245,7 +245,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 						printf(
 							wp_kses(
 								/* translators: 1: Link to Subscription Management page https://subscribe.wordpress.com/, 2: Description of this link */
-								__( 'You subscribed this site before but you have not clicked the confirmation link yet. Please check your inbox. <br /> Otherwise, you can manage your preferences at <a href="%1$s" title="%2$s" target="_blank" rel="noopener noreferrer">subscribe.wordpress.com</a>.', 'jetpack' ),
+								__( 'You subscribed to this site before but you have not clicked the confirmation link yet. Please check your inbox. <br /> Otherwise, you can manage your preferences at <a href="%1$s" title="%2$s" target="_blank" rel="noopener noreferrer">subscribe.wordpress.com</a>.', 'jetpack' ),
 								self::$allowed_html_tags_for_message
 							),
 							'https://subscribe.wordpress.com/',


### PR DESCRIPTION
Fixes #24287

#### Changes proposed in this Pull Request:

* Fix mistake in confirmation message.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start from a site that's connected to WordPress.com, and where you have enabled the Subscriptions feature.
* In Appearance > Themes, switch to a non-block theme like Twenty Twenty.
* Go to Appearance > Widgets and add a blog subscriptions widget.
* On the frontend of your site, use a test email to subscribe your testing site.
* Confirm your subscription.
* Go back to the frontend of your site, and try to subscribe again using that same email address.
* See the error message with the new wording.

