### PR TITLE
Status: Get site suffix from site URL on WoA sites

### DIFF
--- a/projects/packages/redirect/changelog/fix-get-site-suffix-subdirectory-woa-sites
+++ b/projects/packages/redirect/changelog/fix-get-site-suffix-subdirectory-woa-sites
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated a unit test due to a compability issue with a change in the Status package
+
+

--- a/projects/packages/redirect/tests/php/test-redirect.php
+++ b/projects/packages/redirect/tests/php/test-redirect.php
@@ -40,6 +40,8 @@ class RedirectTest extends TestCase {
 	 */
 	public function test_get_url() {
 		Functions\when( 'home_url' )->justReturn( 'https://example.org' );
+		Functions\when( 'get_current_blog_id' )->justReturn( 1 );
+		Functions\when( 'get_option' )->justReturn();
 
 		$url = Redirect::get_url( 'simple' );
 		$this->assertEquals( 'https://jetpack.com/redirect/?source=simple&site=example.org', $url );

--- a/projects/packages/status/changelog/fix-get-site-suffix-subdirectory-woa-sites
+++ b/projects/packages/status/changelog/fix-get-site-suffix-subdirectory-woa-sites
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed an issue that was setting a wrong site suffix for WoA sites. These changes doesn't affect self-hosted Jetpack sites.
+
+

--- a/projects/packages/status/src/class-status.php
+++ b/projects/packages/status/src/class-status.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack;
 
 use Automattic\Jetpack\Status\Cache;
+use Automattic\Jetpack\Status\Host;
 use WPCOM_Masterbar;
 
 /**
@@ -330,7 +331,19 @@ class Status {
 			return WPCOM_Masterbar::get_calypso_site_slug( get_current_blog_id() );
 		}
 
+		// Grab the 'site_url' option for WoA sites to avoid plugins to interfere with the site
+		// identifier (e.g. i18n plugins may change the main url to '<DOMAIN>/<LOCALE>', but we
+		// want to exclude the locale since it's not part of the site suffix).
+		if ( ( new Host() )->is_woa_site() ) {
+			$url = \site_url();
+		}
+
 		if ( empty( $url ) ) {
+			// WordPress can be installed in subdirectories (e.g. make.wordpress.org/plugins)
+			// where the 'site_url' option points to the root domain (e.g. make.wordpress.org)
+			// which could collide with another site in the same domain but with WordPress
+			// installed in a different subdirectory (e.g. make.wordpress.org/core). To avoid
+			// such collision, we identify the site with the 'home_url' option.
 			$url = \home_url();
 		}
 

--- a/projects/packages/status/tests/php/test-status.php
+++ b/projects/packages/status/tests/php/test-status.php
@@ -458,6 +458,7 @@ class Test_Status extends TestCase {
 	 */
 	public function test_jetpack_get_site_suffix( $site, $expected ) {
 		Functions\when( 'home_url' )->justReturn( $this->site_url );
+		Functions\when( 'get_option' )->justReturn();
 		$suffix = $this->status_obj->get_site_suffix( $site );
 
 		$this->assertSame( $expected, $suffix );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/61464

#### Changes proposed in this Pull Request:
Changes the `get_site_suffix` function to use the `site_url` option on WoA sites to avoid plugins from interfering with the site suffix, since there are some plugins like WPML that may change the main url to `<DOMAIN>/<LOCALE>` which breaks the navigation to Calypso.

#### Jetpack product discussion
p9F6qB-8EL-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

- Install and activate [Jetpack Beta](https://jetpack.com/download-jetpack-beta/) on a WoA site.
- Go to `/wp-admin/admin.php?page=jetpack-beta&plugin=jetpack` and switch to the branch of this PR.
- Add the code below to your WoA site to overwrite your `home_url` option with a fake locale path (*):
```
add_filter( 'home_url', function( $home_url ) {
	return $home_url . '/en';
} );
```
- Make sure that all links to Calypso (`wordpress.com`) in the sidebar don't include the `/en` locale path.


(*) Alternatively, you can test a real scenario if you install the WPML plugin (it's a paid plugin, so you cannot find it in the .org plugins repository) and change the settings as follows:
<img width="925" alt="Screen Shot 2022-05-09 at 14 00 55" src="https://user-images.githubusercontent.com/1233880/167405765-022fc088-a30e-473c-9a65-4c55e4731bb4.png">