### PR TITLE
webpack-config: Add a plugin to make module ids more deterministic

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -586,7 +586,7 @@ importers:
 
   projects/packages/assets:
     specifiers:
-      '@automattic/jetpack-webpack-config': workspace:* || ^1.1
+      '@automattic/jetpack-webpack-config': workspace:* || ^1.2
       '@wordpress/browserslist-config': 4.1.2
       jest: 28.1.0
       md5-es: 1.8.2
@@ -606,7 +606,7 @@ importers:
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
       '@automattic/jetpack-components': workspace:* || ^0.12
       '@automattic/jetpack-connection': workspace:* || ^0.18
-      '@automattic/jetpack-webpack-config': workspace:* || ^1.1
+      '@automattic/jetpack-webpack-config': workspace:* || ^1.2
       '@babel/core': 7.17.10
       '@babel/preset-env': 7.17.10
       '@babel/register': 7.17.7
@@ -653,7 +653,7 @@ importers:
     specifiers:
       '@automattic/jetpack-api': workspace:* || ^0.13
       '@automattic/jetpack-connection': workspace:* || ^0.18
-      '@automattic/jetpack-webpack-config': workspace:* || ^1.1
+      '@automattic/jetpack-webpack-config': workspace:* || ^1.2
       '@babel/core': 7.17.10
       '@babel/preset-env': 7.17.10
       '@babel/register': 7.17.7
@@ -696,7 +696,7 @@ importers:
   projects/packages/identity-crisis:
     specifiers:
       '@automattic/jetpack-idc': workspace:* || ^0.10
-      '@automattic/jetpack-webpack-config': workspace:* || ^1.1
+      '@automattic/jetpack-webpack-config': workspace:* || ^1.2
       '@babel/core': 7.17.10
       '@babel/preset-env': 7.17.10
       '@babel/register': 7.17.7
@@ -730,7 +730,7 @@ importers:
 
   projects/packages/jitm:
     specifiers:
-      '@automattic/jetpack-webpack-config': workspace:* || ^1.1
+      '@automattic/jetpack-webpack-config': workspace:* || ^1.2
       '@wordpress/browserslist-config': 4.1.2
       sass: 1.43.3
       sass-loader: 12.4.0
@@ -746,7 +746,7 @@ importers:
 
   projects/packages/lazy-images:
     specifiers:
-      '@automattic/jetpack-webpack-config': workspace:* || ^1.1
+      '@automattic/jetpack-webpack-config': workspace:* || ^1.2
       '@wordpress/browserslist-config': 4.1.2
       copy-webpack-plugin: 10.2.0
       intersection-observer: 0.12.0
@@ -769,7 +769,7 @@ importers:
       '@automattic/jetpack-components': workspace:* || ^0.12
       '@automattic/jetpack-connection': workspace:* || ^0.18
       '@automattic/jetpack-licensing': workspace:* || ^0.4
-      '@automattic/jetpack-webpack-config': workspace:* || ^1.1
+      '@automattic/jetpack-webpack-config': workspace:* || ^1.2
       '@babel/core': 7.17.10
       '@babel/preset-env': 7.17.10
       '@babel/register': 7.17.7
@@ -866,7 +866,7 @@ importers:
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
       '@automattic/jetpack-components': workspace:* || ^0.12
       '@automattic/jetpack-connection': workspace:* || ^0.18
-      '@automattic/jetpack-webpack-config': workspace:* || ^1.1
+      '@automattic/jetpack-webpack-config': workspace:* || ^1.2
       '@babel/core': 7.17.10
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.16.7
       '@babel/plugin-transform-react-jsx': 7.17.3
@@ -985,7 +985,7 @@ importers:
       '@automattic/jetpack-analytics': workspace:* || ^0.1
       '@automattic/jetpack-api': workspace:* || ^0.13
       '@automattic/jetpack-components': workspace:* || ^0.12
-      '@automattic/jetpack-webpack-config': workspace:* || ^1.1
+      '@automattic/jetpack-webpack-config': workspace:* || ^1.2
       '@babel/core': 7.17.10
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.16.7
       '@babel/plugin-transform-react-jsx': 7.17.3
@@ -1202,7 +1202,7 @@ importers:
       '@automattic/jetpack-licensing': workspace:* || ^0.4
       '@automattic/jetpack-partner-coupon': workspace:* || ^0.2
       '@automattic/jetpack-shared-extension-utils': workspace:* || ^0.4
-      '@automattic/jetpack-webpack-config': workspace:* || ^1.1
+      '@automattic/jetpack-webpack-config': workspace:* || ^1.2
       '@automattic/popup-monitor': 1.0.0
       '@automattic/remove-asset-webpack-plugin': workspace:* || ^1.0
       '@automattic/request-external-access': 1.0.0
@@ -1514,7 +1514,7 @@ importers:
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
       '@automattic/jetpack-components': workspace:* || ^0.12
       '@automattic/jetpack-connection': workspace:* || ^0.18
-      '@automattic/jetpack-webpack-config': workspace:* || ^1.1
+      '@automattic/jetpack-webpack-config': workspace:* || ^1.2
       '@babel/core': 7.17.10
       '@babel/preset-env': 7.17.10
       '@babel/register': 7.17.7
@@ -1590,7 +1590,7 @@ importers:
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
       '@automattic/jetpack-components': workspace:* || ^0.12
       '@automattic/jetpack-connection': workspace:* || ^0.18
-      '@automattic/jetpack-webpack-config': workspace:* || ^1.1
+      '@automattic/jetpack-webpack-config': workspace:* || ^1.2
       '@babel/core': 7.17.10
       '@babel/preset-env': 7.17.10
       '@babel/register': 7.17.7
@@ -1635,7 +1635,7 @@ importers:
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
       '@automattic/jetpack-components': workspace:* || ^0.12
       '@automattic/jetpack-connection': workspace:* || ^0.18
-      '@automattic/jetpack-webpack-config': workspace:* || ^1.1
+      '@automattic/jetpack-webpack-config': workspace:* || ^1.2
       '@babel/core': 7.17.10
       '@babel/preset-env': 7.17.10
       '@babel/register': 7.17.7

--- a/projects/js-packages/i18n-check-webpack-plugin/changelog/fix-webpack-deterministic-ids
+++ b/projects/js-packages/i18n-check-webpack-plugin/changelog/fix-webpack-deterministic-ids
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Update test snapshot.

--- a/projects/js-packages/i18n-check-webpack-plugin/tests/__snapshots__/build.test.js.snap
+++ b/projects/js-packages/i18n-check-webpack-plugin/tests/__snapshots__/build.test.js.snap
@@ -135,16 +135,16 @@ Object {
     Object {
       "errors": Array [
         Object {
-          "message": "string/main.js:1:75: msgid argument is not a string literal: __(t?\\"arr is set\\":\\"arr is not set\\",\\"domain\\")",
+          "message": "string/main.js:1:77: msgid argument is not a string literal: __(t?\\"arr is set\\":\\"arr is not set\\",\\"domain\\")",
         },
         Object {
-          "message": "string/main.js:1:185: msgid argument is not a string literal: __(t?\\"func is set\\":\\"func is not set\\",\\"domain\\")",
+          "message": "string/main.js:1:187: msgid argument is not a string literal: __(t?\\"func is set\\":\\"func is not set\\",\\"domain\\")",
         },
         Object {
-          "message": "string/main.js:1:372: msgid argument is not a string literal: __(t?\\"regex is set\\":\\"regex is not set\\",\\"domain\\")",
+          "message": "string/main.js:1:376: msgid argument is not a string literal: __(t?\\"regex is set\\":\\"regex is not set\\",\\"domain\\")",
         },
         Object {
-          "message": "string/main.js:1:486: msgid argument is not a string literal: __(t?\\"string is set\\":\\"string is not set\\",\\"domain\\")",
+          "message": "string/main.js:1:490: msgid argument is not a string literal: __(t?\\"string is set\\":\\"string is not set\\",\\"domain\\")",
         },
         Object {
           "message": "string/main.js: Optimization seems to have broken the following translation strings:
@@ -158,16 +158,16 @@ Object {
     Object {
       "errors": Array [
         Object {
-          "message": "regex/main.js:1:75: msgid argument is not a string literal: __(t?\\"arr is set\\":\\"arr is not set\\",\\"domain\\")",
+          "message": "regex/main.js:1:77: msgid argument is not a string literal: __(t?\\"arr is set\\":\\"arr is not set\\",\\"domain\\")",
         },
         Object {
-          "message": "regex/main.js:1:185: msgid argument is not a string literal: __(t?\\"func is set\\":\\"func is not set\\",\\"domain\\")",
+          "message": "regex/main.js:1:187: msgid argument is not a string literal: __(t?\\"func is set\\":\\"func is not set\\",\\"domain\\")",
         },
         Object {
-          "message": "regex/main.js:1:372: msgid argument is not a string literal: __(t?\\"regex is set\\":\\"regex is not set\\",\\"domain\\")",
+          "message": "regex/main.js:1:376: msgid argument is not a string literal: __(t?\\"regex is set\\":\\"regex is not set\\",\\"domain\\")",
         },
         Object {
-          "message": "regex/main.js:1:486: msgid argument is not a string literal: __(t?\\"string is set\\":\\"string is not set\\",\\"domain\\")",
+          "message": "regex/main.js:1:490: msgid argument is not a string literal: __(t?\\"string is set\\":\\"string is not set\\",\\"domain\\")",
         },
         Object {
           "message": "regex/main.js: Optimization seems to have broken the following translation strings:
@@ -181,16 +181,16 @@ Object {
     Object {
       "errors": Array [
         Object {
-          "message": "function/main.js:1:75: msgid argument is not a string literal: __(t?\\"arr is set\\":\\"arr is not set\\",\\"domain\\")",
+          "message": "function/main.js:1:77: msgid argument is not a string literal: __(t?\\"arr is set\\":\\"arr is not set\\",\\"domain\\")",
         },
         Object {
-          "message": "function/main.js:1:185: msgid argument is not a string literal: __(t?\\"func is set\\":\\"func is not set\\",\\"domain\\")",
+          "message": "function/main.js:1:187: msgid argument is not a string literal: __(t?\\"func is set\\":\\"func is not set\\",\\"domain\\")",
         },
         Object {
-          "message": "function/main.js:1:372: msgid argument is not a string literal: __(t?\\"regex is set\\":\\"regex is not set\\",\\"domain\\")",
+          "message": "function/main.js:1:376: msgid argument is not a string literal: __(t?\\"regex is set\\":\\"regex is not set\\",\\"domain\\")",
         },
         Object {
-          "message": "function/main.js:1:486: msgid argument is not a string literal: __(t?\\"string is set\\":\\"string is not set\\",\\"domain\\")",
+          "message": "function/main.js:1:490: msgid argument is not a string literal: __(t?\\"string is set\\":\\"string is not set\\",\\"domain\\")",
         },
         Object {
           "message": "function/main.js: Optimization seems to have broken the following translation strings:
@@ -204,16 +204,16 @@ Object {
     Object {
       "errors": Array [
         Object {
-          "message": "array/main.js:1:75: msgid argument is not a string literal: __(t?\\"arr is set\\":\\"arr is not set\\",\\"domain\\")",
+          "message": "array/main.js:1:77: msgid argument is not a string literal: __(t?\\"arr is set\\":\\"arr is not set\\",\\"domain\\")",
         },
         Object {
-          "message": "array/main.js:1:185: msgid argument is not a string literal: __(t?\\"func is set\\":\\"func is not set\\",\\"domain\\")",
+          "message": "array/main.js:1:187: msgid argument is not a string literal: __(t?\\"func is set\\":\\"func is not set\\",\\"domain\\")",
         },
         Object {
-          "message": "array/main.js:1:372: msgid argument is not a string literal: __(t?\\"regex is set\\":\\"regex is not set\\",\\"domain\\")",
+          "message": "array/main.js:1:376: msgid argument is not a string literal: __(t?\\"regex is set\\":\\"regex is not set\\",\\"domain\\")",
         },
         Object {
-          "message": "array/main.js:1:486: msgid argument is not a string literal: __(t?\\"string is set\\":\\"string is not set\\",\\"domain\\")",
+          "message": "array/main.js:1:490: msgid argument is not a string literal: __(t?\\"string is set\\":\\"string is not set\\",\\"domain\\")",
         },
         Object {
           "message": "array/main.js: Optimization seems to have broken the following translation strings:
@@ -227,16 +227,16 @@ Object {
     Object {
       "errors": Array [
         Object {
-          "message": "undefined/main.js:1:75: msgid argument is not a string literal: __(t?\\"arr is set\\":\\"arr is not set\\",\\"domain\\")",
+          "message": "undefined/main.js:1:77: msgid argument is not a string literal: __(t?\\"arr is set\\":\\"arr is not set\\",\\"domain\\")",
         },
         Object {
-          "message": "undefined/main.js:1:185: msgid argument is not a string literal: __(t?\\"func is set\\":\\"func is not set\\",\\"domain\\")",
+          "message": "undefined/main.js:1:187: msgid argument is not a string literal: __(t?\\"func is set\\":\\"func is not set\\",\\"domain\\")",
         },
         Object {
-          "message": "undefined/main.js:1:372: msgid argument is not a string literal: __(t?\\"regex is set\\":\\"regex is not set\\",\\"domain\\")",
+          "message": "undefined/main.js:1:376: msgid argument is not a string literal: __(t?\\"regex is set\\":\\"regex is not set\\",\\"domain\\")",
         },
         Object {
-          "message": "undefined/main.js:1:486: msgid argument is not a string literal: __(t?\\"string is set\\":\\"string is not set\\",\\"domain\\")",
+          "message": "undefined/main.js:1:490: msgid argument is not a string literal: __(t?\\"string is set\\":\\"string is not set\\",\\"domain\\")",
         },
         Object {
           "message": "undefined/main.js: Optimization seems to have broken the following translation strings:
@@ -257,19 +257,19 @@ Object {
   "errors": Array [
     Object {
       "compilerPath": "string",
-      "message": "string/main.js:1:75: msgid argument is not a string literal: __(t?\\"arr is set\\":\\"arr is not set\\",\\"domain\\")",
+      "message": "string/main.js:1:77: msgid argument is not a string literal: __(t?\\"arr is set\\":\\"arr is not set\\",\\"domain\\")",
     },
     Object {
       "compilerPath": "string",
-      "message": "string/main.js:1:185: msgid argument is not a string literal: __(t?\\"func is set\\":\\"func is not set\\",\\"domain\\")",
+      "message": "string/main.js:1:187: msgid argument is not a string literal: __(t?\\"func is set\\":\\"func is not set\\",\\"domain\\")",
     },
     Object {
       "compilerPath": "string",
-      "message": "string/main.js:1:372: msgid argument is not a string literal: __(t?\\"regex is set\\":\\"regex is not set\\",\\"domain\\")",
+      "message": "string/main.js:1:376: msgid argument is not a string literal: __(t?\\"regex is set\\":\\"regex is not set\\",\\"domain\\")",
     },
     Object {
       "compilerPath": "string",
-      "message": "string/main.js:1:486: msgid argument is not a string literal: __(t?\\"string is set\\":\\"string is not set\\",\\"domain\\")",
+      "message": "string/main.js:1:490: msgid argument is not a string literal: __(t?\\"string is set\\":\\"string is not set\\",\\"domain\\")",
     },
     Object {
       "compilerPath": "string",
@@ -279,19 +279,19 @@ Object {
     },
     Object {
       "compilerPath": "regex",
-      "message": "regex/main.js:1:75: msgid argument is not a string literal: __(t?\\"arr is set\\":\\"arr is not set\\",\\"domain\\")",
+      "message": "regex/main.js:1:77: msgid argument is not a string literal: __(t?\\"arr is set\\":\\"arr is not set\\",\\"domain\\")",
     },
     Object {
       "compilerPath": "regex",
-      "message": "regex/main.js:1:185: msgid argument is not a string literal: __(t?\\"func is set\\":\\"func is not set\\",\\"domain\\")",
+      "message": "regex/main.js:1:187: msgid argument is not a string literal: __(t?\\"func is set\\":\\"func is not set\\",\\"domain\\")",
     },
     Object {
       "compilerPath": "regex",
-      "message": "regex/main.js:1:372: msgid argument is not a string literal: __(t?\\"regex is set\\":\\"regex is not set\\",\\"domain\\")",
+      "message": "regex/main.js:1:376: msgid argument is not a string literal: __(t?\\"regex is set\\":\\"regex is not set\\",\\"domain\\")",
     },
     Object {
       "compilerPath": "regex",
-      "message": "regex/main.js:1:486: msgid argument is not a string literal: __(t?\\"string is set\\":\\"string is not set\\",\\"domain\\")",
+      "message": "regex/main.js:1:490: msgid argument is not a string literal: __(t?\\"string is set\\":\\"string is not set\\",\\"domain\\")",
     },
     Object {
       "compilerPath": "regex",
@@ -301,19 +301,19 @@ Object {
     },
     Object {
       "compilerPath": "function",
-      "message": "function/main.js:1:75: msgid argument is not a string literal: __(t?\\"arr is set\\":\\"arr is not set\\",\\"domain\\")",
+      "message": "function/main.js:1:77: msgid argument is not a string literal: __(t?\\"arr is set\\":\\"arr is not set\\",\\"domain\\")",
     },
     Object {
       "compilerPath": "function",
-      "message": "function/main.js:1:185: msgid argument is not a string literal: __(t?\\"func is set\\":\\"func is not set\\",\\"domain\\")",
+      "message": "function/main.js:1:187: msgid argument is not a string literal: __(t?\\"func is set\\":\\"func is not set\\",\\"domain\\")",
     },
     Object {
       "compilerPath": "function",
-      "message": "function/main.js:1:372: msgid argument is not a string literal: __(t?\\"regex is set\\":\\"regex is not set\\",\\"domain\\")",
+      "message": "function/main.js:1:376: msgid argument is not a string literal: __(t?\\"regex is set\\":\\"regex is not set\\",\\"domain\\")",
     },
     Object {
       "compilerPath": "function",
-      "message": "function/main.js:1:486: msgid argument is not a string literal: __(t?\\"string is set\\":\\"string is not set\\",\\"domain\\")",
+      "message": "function/main.js:1:490: msgid argument is not a string literal: __(t?\\"string is set\\":\\"string is not set\\",\\"domain\\")",
     },
     Object {
       "compilerPath": "function",
@@ -323,19 +323,19 @@ Object {
     },
     Object {
       "compilerPath": "array",
-      "message": "array/main.js:1:75: msgid argument is not a string literal: __(t?\\"arr is set\\":\\"arr is not set\\",\\"domain\\")",
+      "message": "array/main.js:1:77: msgid argument is not a string literal: __(t?\\"arr is set\\":\\"arr is not set\\",\\"domain\\")",
     },
     Object {
       "compilerPath": "array",
-      "message": "array/main.js:1:185: msgid argument is not a string literal: __(t?\\"func is set\\":\\"func is not set\\",\\"domain\\")",
+      "message": "array/main.js:1:187: msgid argument is not a string literal: __(t?\\"func is set\\":\\"func is not set\\",\\"domain\\")",
     },
     Object {
       "compilerPath": "array",
-      "message": "array/main.js:1:372: msgid argument is not a string literal: __(t?\\"regex is set\\":\\"regex is not set\\",\\"domain\\")",
+      "message": "array/main.js:1:376: msgid argument is not a string literal: __(t?\\"regex is set\\":\\"regex is not set\\",\\"domain\\")",
     },
     Object {
       "compilerPath": "array",
-      "message": "array/main.js:1:486: msgid argument is not a string literal: __(t?\\"string is set\\":\\"string is not set\\",\\"domain\\")",
+      "message": "array/main.js:1:490: msgid argument is not a string literal: __(t?\\"string is set\\":\\"string is not set\\",\\"domain\\")",
     },
     Object {
       "compilerPath": "array",
@@ -345,19 +345,19 @@ Object {
     },
     Object {
       "compilerPath": "undefined",
-      "message": "undefined/main.js:1:75: msgid argument is not a string literal: __(t?\\"arr is set\\":\\"arr is not set\\",\\"domain\\")",
+      "message": "undefined/main.js:1:77: msgid argument is not a string literal: __(t?\\"arr is set\\":\\"arr is not set\\",\\"domain\\")",
     },
     Object {
       "compilerPath": "undefined",
-      "message": "undefined/main.js:1:185: msgid argument is not a string literal: __(t?\\"func is set\\":\\"func is not set\\",\\"domain\\")",
+      "message": "undefined/main.js:1:187: msgid argument is not a string literal: __(t?\\"func is set\\":\\"func is not set\\",\\"domain\\")",
     },
     Object {
       "compilerPath": "undefined",
-      "message": "undefined/main.js:1:372: msgid argument is not a string literal: __(t?\\"regex is set\\":\\"regex is not set\\",\\"domain\\")",
+      "message": "undefined/main.js:1:376: msgid argument is not a string literal: __(t?\\"regex is set\\":\\"regex is not set\\",\\"domain\\")",
     },
     Object {
       "compilerPath": "undefined",
-      "message": "undefined/main.js:1:486: msgid argument is not a string literal: __(t?\\"string is set\\":\\"string is not set\\",\\"domain\\")",
+      "message": "undefined/main.js:1:490: msgid argument is not a string literal: __(t?\\"string is set\\":\\"string is not set\\",\\"domain\\")",
     },
     Object {
       "compilerPath": "undefined",

--- a/projects/js-packages/webpack-config/changelog/fix-webpack-deterministic-ids
+++ b/projects/js-packages/webpack-config/changelog/fix-webpack-deterministic-ids
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Add a plugin to make module IDs more deterministic with pnpm.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "1.1.11-alpha",
+	"version": "1.2.0-alpha",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/src/webpack.js
+++ b/projects/js-packages/webpack-config/src/webpack.js
@@ -11,6 +11,7 @@ const MiniCSSWithRTLPlugin = require( './webpack/mini-css-with-rtl' );
 const WebpackRTLPlugin = require( '@automattic/webpack-rtl-plugin' );
 const I18nLoaderWebpackPlugin = require( '@automattic/i18n-loader-webpack-plugin' );
 const I18nCheckWebpackPlugin = require( '@automattic/i18n-check-webpack-plugin' );
+const PnpmDeterministicModuleIdsPlugin = require( './webpack/pnpm-deterministic-ids.js' );
 
 const MyCssMinimizerPlugin = options => new CssMinimizerPlugin( options );
 
@@ -28,6 +29,7 @@ const optimization = {
 	minimize: isProduction,
 	minimizer: [ TerserPlugin(), MyCssMinimizerPlugin() ],
 	concatenateModules: false,
+	moduleIds: isProduction ? false : 'named',
 	emitOnErrors: true,
 };
 const resolve = {
@@ -107,9 +109,16 @@ const I18nCheckPlugin = options => {
 };
 I18nCheckPlugin.defaultFilter = i18nFilterFunction;
 
+const MyPnpmDeterministicModuleIdsPlugin = options => [
+	new PnpmDeterministicModuleIdsPlugin( options ),
+];
+
 const StandardPlugins = ( options = {} ) => {
 	if ( typeof options.I18nCheckPlugin === 'undefined' && isDevelopment ) {
 		options.I18nCheckPlugin = false;
+	}
+	if ( typeof options.PnpmDeterministicModuleIdsPlugin === 'undefined' && isDevelopment ) {
+		options.PnpmDeterministicModuleIdsPlugin = false;
 	}
 
 	return [
@@ -132,6 +141,9 @@ const StandardPlugins = ( options = {} ) => {
 			: DependencyExtractionPlugin( options.DependencyExtractionPlugin ) ),
 		...( options.I18nLoaderPlugin === false ? [] : I18nLoaderPlugin( options.I18nLoaderPlugin ) ),
 		...( options.I18nCheckPlugin === false ? [] : I18nCheckPlugin( options.I18nCheckPlugin ) ),
+		...( options.PnpmDeterministicModuleIdsPlugin === false
+			? []
+			: MyPnpmDeterministicModuleIdsPlugin( options.PnpmDeterministicModuleIdsPlugin ) ),
 	];
 };
 
@@ -166,6 +178,7 @@ module.exports = {
 	DependencyExtractionPlugin,
 	DuplicatePackageCheckerPlugin,
 	I18nLoaderPlugin,
+	PnpmDeterministicModuleIdsPlugin: MyPnpmDeterministicModuleIdsPlugin,
 	// Module rules and loaders.
 	TranspileRule,
 	CssRule,

--- a/projects/js-packages/webpack-config/src/webpack/pnpm-deterministic-ids.js
+++ b/projects/js-packages/webpack-config/src/webpack/pnpm-deterministic-ids.js
@@ -1,0 +1,85 @@
+/**
+ * Webpack plugin to make module IDs more deterministic when used with pnpm.
+ *
+ * Based on Webpack's DeterministicModuleIdsPlugin. This is the same except for the
+ * addition of `fixPnpmPaths`.
+ */
+
+const { compareModulesByPreOrderIndexOrIdentifier } = require( 'webpack/lib/util/comparators' );
+const {
+	getUsedModuleIds,
+	getFullModuleName,
+	assignDeterministicIds,
+} = require( 'webpack/lib/ids/IdHelpers' );
+
+const PNPM_PATH_REGEXP = /(?<=^|[|!])(?:\.\.\/)*node_modules\/\.pnpm\/[^/]*\/node_modules\/([^|!]+)/g;
+
+/**
+ * Replace pnpm store paths in an identifier.
+ *
+ * Pnpm's store paths contain the version number of the package, which means
+ * the identifier would change every time the package is updated. This strips
+ * those out of the identifier.
+ *
+ * This does mean that a bundle with multiple versions of a package might wind
+ * up with colliding identifiers, but Webpack already handles that.
+ *
+ * @param {string} identifier - Identifier.
+ * @returns {string} Transformed identifier.
+ */
+function fixPnpmPaths( identifier ) {
+	return identifier.replace( PNPM_PATH_REGEXP, '.pnpm/$1' );
+}
+
+/** @typedef {import("webpack/lib/Compiler")} Compiler */
+
+class PnpmDeterministicModuleIdsPlugin {
+	constructor( options ) {
+		this.options = options || {};
+	}
+
+	/**
+	 * Apply the plugin
+	 *
+	 * @param {Compiler} compiler - the compiler instance
+	 * @returns {void}
+	 */
+	apply( compiler ) {
+		compiler.hooks.compilation.tap( 'PnpmDeterministicModuleIdsPlugin', compilation => {
+			compilation.hooks.moduleIds.tap( 'PnpmDeterministicModuleIdsPlugin', modules => {
+				const chunkGraph = compilation.chunkGraph;
+				const context = this.options.context ? this.options.context : compiler.context;
+				const maxLength = this.options.maxLength || 3;
+
+				const usedIds = getUsedModuleIds( compilation );
+				assignDeterministicIds(
+					Array.from( modules ).filter( module => {
+						if ( ! module.needId ) {
+							return false;
+						}
+						if ( chunkGraph.getNumberOfModuleChunks( module ) === 0 ) {
+							return false;
+						}
+						return chunkGraph.getModuleId( module ) === null;
+					} ),
+					module => fixPnpmPaths( getFullModuleName( module, context, compiler.root ) ),
+					compareModulesByPreOrderIndexOrIdentifier( compilation.moduleGraph ),
+					( module, id ) => {
+						const size = usedIds.size;
+						usedIds.add( `${ id }` );
+						if ( size === usedIds.size ) {
+							return false;
+						}
+						chunkGraph.setModuleId( module, id );
+						return true;
+					},
+					[ Math.pow( 10, maxLength ) ],
+					10,
+					usedIds.size
+				);
+			} );
+		} );
+	}
+}
+
+module.exports = PnpmDeterministicModuleIdsPlugin;

--- a/projects/packages/assets/changelog/fix-webpack-deterministic-ids
+++ b/projects/packages/assets/changelog/fix-webpack-deterministic-ids
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/assets/package.json
+++ b/projects/packages/assets/package.json
@@ -12,7 +12,7 @@
 		"validate": "pnpm exec validate-es build/"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-webpack-config": "workspace:* || ^1.1",
+		"@automattic/jetpack-webpack-config": "workspace:* || ^1.2",
 		"@wordpress/browserslist-config": "4.1.2",
 		"md5-es": "1.8.2",
 		"jest": "28.1.0",

--- a/projects/packages/backup/changelog/fix-webpack-deterministic-ids
+++ b/projects/packages/backup/changelog/fix-webpack-deterministic-ids
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/backup/package.json
+++ b/projects/packages/backup/package.json
@@ -38,7 +38,7 @@
 	},
 	"devDependencies": {
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3",
-		"@automattic/jetpack-webpack-config": "workspace:* || ^1.1",
+		"@automattic/jetpack-webpack-config": "workspace:* || ^1.2",
 		"@babel/core": "7.17.10",
 		"@babel/preset-env": "7.17.10",
 		"@babel/register": "7.17.7",

--- a/projects/packages/connection-ui/changelog/fix-webpack-deterministic-ids
+++ b/projects/packages/connection-ui/changelog/fix-webpack-deterministic-ids
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/connection-ui/package.json
+++ b/projects/packages/connection-ui/package.json
@@ -24,7 +24,7 @@
 		"@wordpress/data": "6.7.0"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-webpack-config": "workspace:* || ^1.1",
+		"@automattic/jetpack-webpack-config": "workspace:* || ^1.2",
 		"@babel/core": "7.17.10",
 		"@babel/preset-env": "7.17.10",
 		"@babel/register": "7.17.7",

--- a/projects/packages/identity-crisis/changelog/fix-webpack-deterministic-ids
+++ b/projects/packages/identity-crisis/changelog/fix-webpack-deterministic-ids
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -23,7 +23,7 @@
 		"@wordpress/data": "6.7.0"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-webpack-config": "workspace:* || ^1.1",
+		"@automattic/jetpack-webpack-config": "workspace:* || ^1.2",
 		"@babel/core": "7.17.10",
 		"@babel/preset-env": "7.17.10",
 		"@babel/register": "7.17.7",

--- a/projects/packages/jitm/changelog/fix-webpack-deterministic-ids
+++ b/projects/packages/jitm/changelog/fix-webpack-deterministic-ids
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/jitm/package.json
+++ b/projects/packages/jitm/package.json
@@ -23,7 +23,7 @@
 	},
 	"browserslist": "extends @wordpress/browserslist-config",
 	"devDependencies": {
-		"@automattic/jetpack-webpack-config": "workspace:* || ^1.1",
+		"@automattic/jetpack-webpack-config": "workspace:* || ^1.2",
 		"@wordpress/browserslist-config": "4.1.2",
 		"sass": "1.43.3",
 		"sass-loader": "12.4.0",

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '2.2.15';
+	const PACKAGE_VERSION = '2.2.16-alpha';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/lazy-images/changelog/fix-webpack-deterministic-ids
+++ b/projects/packages/lazy-images/changelog/fix-webpack-deterministic-ids
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/lazy-images/package.json
+++ b/projects/packages/lazy-images/package.json
@@ -24,7 +24,7 @@
 		"validate": "pnpm exec validate-es dist/"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-webpack-config": "workspace:* || ^1.1",
+		"@automattic/jetpack-webpack-config": "workspace:* || ^1.2",
 		"@wordpress/browserslist-config": "4.1.2",
 		"copy-webpack-plugin": "10.2.0",
 		"intersection-observer": "0.12.0",

--- a/projects/packages/my-jetpack/changelog/fix-webpack-deterministic-ids
+++ b/projects/packages/my-jetpack/changelog/fix-webpack-deterministic-ids
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -43,7 +43,7 @@
 	],
 	"devDependencies": {
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3",
-		"@automattic/jetpack-webpack-config": "workspace:* || ^1.1",
+		"@automattic/jetpack-webpack-config": "workspace:* || ^1.2",
 		"@babel/core": "7.17.10",
 		"@babel/preset-env": "7.17.10",
 		"@babel/register": "7.17.7",

--- a/projects/packages/search/changelog/fix-webpack-deterministic-ids
+++ b/projects/packages/search/changelog/fix-webpack-deterministic-ids
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -68,7 +68,7 @@
 		"tiny-lru": "7.0.6"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-webpack-config": "workspace:* || ^1.1",
+		"@automattic/jetpack-webpack-config": "workspace:* || ^1.2",
 		"@babel/core": "7.17.10",
 		"@babel/plugin-proposal-nullish-coalescing-operator": "7.16.7",
 		"@babel/plugin-transform-react-jsx": "7.17.3",

--- a/projects/packages/wordads/changelog/fix-webpack-deterministic-ids
+++ b/projects/packages/wordads/changelog/fix-webpack-deterministic-ids
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -59,7 +59,7 @@
 		"tiny-lru": "7.0.6"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-webpack-config": "workspace:* || ^1.1",
+		"@automattic/jetpack-webpack-config": "workspace:* || ^1.2",
 		"@babel/core": "7.17.10",
 		"@babel/plugin-proposal-nullish-coalescing-operator": "7.16.7",
 		"@babel/plugin-transform-react-jsx": "7.17.3",

--- a/projects/plugins/jetpack/changelog/fix-webpack-deterministic-ids
+++ b/projects/plugins/jetpack/changelog/fix-webpack-deterministic-ids
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -128,7 +128,7 @@
 	"devDependencies": {
 		"@automattic/color-studio": "2.5.0",
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3",
-		"@automattic/jetpack-webpack-config": "workspace:* || ^1.1",
+		"@automattic/jetpack-webpack-config": "workspace:* || ^1.2",
 		"@automattic/remove-asset-webpack-plugin": "workspace:* || ^1.0",
 		"@babel/core": "7.17.10",
 		"@babel/plugin-proposal-nullish-coalescing-operator": "7.16.7",

--- a/projects/plugins/protect/changelog/fix-webpack-deterministic-ids
+++ b/projects/plugins/protect/changelog/fix-webpack-deterministic-ids
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/protect/package.json
+++ b/projects/plugins/protect/package.json
@@ -43,7 +43,7 @@
 		"react-dom": "17.0.2"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-webpack-config": "workspace:* || ^1.1",
+		"@automattic/jetpack-webpack-config": "workspace:* || ^1.2",
 		"@babel/core": "7.17.10",
 		"@babel/preset-env": "7.17.10",
 		"@babel/register": "7.17.7",

--- a/projects/plugins/social/changelog/fix-webpack-deterministic-ids
+++ b/projects/plugins/social/changelog/fix-webpack-deterministic-ids
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/social/package.json
+++ b/projects/plugins/social/package.json
@@ -36,7 +36,7 @@
 		"react-dom": "17.0.2"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-webpack-config": "workspace:* || ^1.1",
+		"@automattic/jetpack-webpack-config": "workspace:* || ^1.2",
 		"@babel/core": "7.17.10",
 		"@babel/preset-env": "7.17.10",
 		"@babel/register": "7.17.7",

--- a/projects/plugins/starter-plugin/changelog/fix-webpack-deterministic-ids
+++ b/projects/plugins/starter-plugin/changelog/fix-webpack-deterministic-ids
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/starter-plugin/package.json
+++ b/projects/plugins/starter-plugin/package.json
@@ -36,7 +36,7 @@
 		"react-dom": "17.0.2"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-webpack-config": "workspace:* || ^1.1",
+		"@automattic/jetpack-webpack-config": "workspace:* || ^1.2",
 		"@babel/core": "7.17.10",
 		"@babel/preset-env": "7.17.10",
 		"@babel/register": "7.17.7",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
In pnpm, the paths to packages in node_modules include the package's
version number. This winds up in the module ID used by webpack, which
causes the "deterministic" IDs it assigns in production mode to change
whenever a package is updated (it also changes the named IDs in
development mode, but we don't really care about that).

This new plugin is a simple modification of Webpack's deterministic ID
plugin that strips the version numbers from the identifier before
assigning the numeric ID.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Revert 731b3291c5cf7450db3f2994eba738a88122f6cc, keeping this PR's version of `projects/js-packages/i18n-check-webpack-plugin/tests/__snapshots__/build.test.js.snap`. That package's tests should still pass.