### PR TITLE
Jetpack CLI: add example of a change entry for the 'add' command

### DIFF
--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -412,9 +412,14 @@ async function changelogArgs( argv ) {
 		argv.args.push( ...argv.pass );
 	}
 
-	// Check for required command specific arguements.
+	// Check for required command specific arguments.
 	switch ( argv.args[ 0 ] ) {
 		case 'add':
+			console.log(
+				"When writing your changelog entry, please use the format 'Subject: change description.'\n" +
+					'Here is an example of a good changelog entry:\n' +
+					'  Sitemaps: ensure that the Home URL is slashed on subdirectory websites.\n'
+			);
 			if ( ( argv.s && argv.t && argv.e ) || argv.auto ) {
 				argv.args.push( '--no-interaction' );
 			} else if ( argv.s || argv.t || argv.e ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* When running `jetpack chaneglog add`, print an example of a good changelog entry.

#### Jetpack product discussion

Internal: p9dueE-4R7-p2#comment-7754

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* After patching, make a change to one of the project files (e.g. Jetpack), then try running `jetpack changelog add`.
* You should see the help text printed as such:

![Screen Shot 2022-05-09 at 12 04 54 PM](https://user-images.githubusercontent.com/15803018/167470507-1c9120eb-bddc-474d-8c0d-db01cbe18cec.png)

