### PR TITLE
Boost: Update connection usage

### DIFF
--- a/projects/plugins/boost/app/lib/class-connection.php
+++ b/projects/plugins/boost/app/lib/class-connection.php
@@ -68,8 +68,7 @@ class Connection {
 	 * Deactivate the connection on plugin disconnect.
 	 */
 	public function deactivate_disconnect() {
-		$this->manager->disconnect_site_wpcom();
-		$this->manager->delete_all_connection_tokens();
+		$this->manager->remove_connection();
 	}
 
 	/**
@@ -127,7 +126,7 @@ class Connection {
 			$is_connected = $this->manager->is_registered();
 		}
 
-		return $is_connected && $this->manager->is_plugin_enabled();
+		return $is_connected;
 	}
 
 	/**
@@ -136,8 +135,6 @@ class Connection {
 	 * @return true|\WP_Error The error object.
 	 */
 	public function register() {
-		$this->manager->enable_plugin();
-
 		if ( $this->is_connected() ) {
 			Analytics::record_user_event( 'connect_site' );
 
@@ -164,24 +161,6 @@ class Connection {
 
 		$this->manager->remove_connection();
 
-		// @todo: implement clearing of IDC options
-		// Jetpack_IDC::clear_all_idc_options();
-
-		// @todo: implement check of updating activated state?
-		// if ( $update_activated_state ) {
-		// Jetpack_Options::update_option( 'activated', 4 );
-		// }
-
-		// @todo: implement check of unique connection increment/decrement
-		// if ( $jetpack_unique_connection = Jetpack_Options::get_option( 'unique_connection' ) ) {
-		// ...
-		// }
-
-		// @todo: Delete all the sync related data. Since it could be taking up space.
-		// Sender::get_instance()->uninstall();
-
-		// @todo: Disable the Heartbeat cron
-		// Jetpack_Heartbeat::init()->deactivate();
 		return true;
 	}
 

--- a/projects/plugins/boost/changelog/boost-update-disconnection
+++ b/projects/plugins/boost/changelog/boost-update-disconnection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+update connection usage


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR updates the usage of the connection package using the proxy method instead of calling individual methods for each step of the disconnection routine.

The new methods make sure we fire the proper hooks and trigger stats and tracks events.

There should be no functional changes.

Also, do not enable plugin on connection (this is deprecated). As a suggestion, Boost could use the v4 REST endpoint provided by the connection package to establish the connection, no need to build its own server-side connection method.

I also deleted some `todo` comments:

```
// @todo: implement clearing of IDC options
// Jetpack_IDC::clear_all_idc_options();
```
If this is needed, it should be handled by the IDC package. I'm creating a task to check on that

```
// @todo: implement check of updating activated state?
// if ( $update_activated_state ) {
// Jetpack_Options::update_option( 'activated', 4 );
// }
```
This is jetpack plugin specific.

```
// @todo: implement check of unique connection increment/decrement
// if ( $jetpack_unique_connection = Jetpack_Options::get_option( 'unique_connection' ) ) {
// ...
// }
```
This is handled by the connection package already

```
// @todo: Delete all the sync related data. Since it could be taking up space.
// Sender::get_instance()->uninstall();
```
If this is needed, it should be handled by the Sync package. I'm creating a task to check on that

```
// @todo: Disable the Heartbeat cron
// Jetpack_Heartbeat::init()->deactivate();
```
If this is needed, it should be handled by the Connection package. I'm creating a task to check on that

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-4n9-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check connection and disconnection work as expected
