### PR TITLE
Search: Redirect & enable after plugin activation

### DIFF
--- a/projects/plugins/search/changelog/add-dashboard-redirect-after-search-plugin-activation
+++ b/projects/plugins/search/changelog/add-dashboard-redirect-after-search-plugin-activation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search: After plugin activation, automatically redirect to the Search dashboard while enabling the search module and instant search if eligible

--- a/projects/plugins/search/jetpack-search.php
+++ b/projects/plugins/search/jetpack-search.php
@@ -24,6 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Constant definitions.
 define( 'JETPACK_SEARCH_PLUGIN__DIR', plugin_dir_path( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__FILE', __FILE__ );
+define( 'JETPACK_SEARCH_PLUGIN__FILE_RELATIVE_PATH', plugin_basename( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__SLUG', 'jetpack-search' );
 define( 'JETPACK_SEARCH_PLUGIN__VERSION', '0.1.0-alpha' );
 

--- a/projects/plugins/search/jetpack-search.php
+++ b/projects/plugins/search/jetpack-search.php
@@ -23,6 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // Constant definitions.
 define( 'JETPACK_SEARCH_PLUGIN__DIR', plugin_dir_path( __FILE__ ) );
+define( 'JETPACK_SEARCH_PLUGIN__FILE', __FILE__ );
 define( 'JETPACK_SEARCH_PLUGIN__SLUG', 'jetpack-search' );
 define( 'JETPACK_SEARCH_PLUGIN__VERSION', '0.1.0-alpha' );
 

--- a/projects/plugins/search/src/class-jetpack-search-plugin.php
+++ b/projects/plugins/search/src/class-jetpack-search-plugin.php
@@ -12,7 +12,6 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
 use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
 use Automattic\Jetpack\Search\Module_Control as Search_Module_Control;
-use Automattic\Jetpack\Search\Options as Search_Options;
 
 /**
  * Class to bootstrap Jetpack Search Plugin
@@ -20,8 +19,6 @@ use Automattic\Jetpack\Search\Options as Search_Options;
  * @package automattic/jetpack-search
  */
 class Jetpack_Search_Plugin {
-	const ACTIVATION_OPTION_NAME = Search_Options::OPTION_PREFIX . 'plugin_is_activated';
-
 	/**
 	 * Register hooks to initialize the plugin
 	 */

--- a/projects/plugins/search/src/class-jetpack-search-plugin.php
+++ b/projects/plugins/search/src/class-jetpack-search-plugin.php
@@ -28,8 +28,7 @@ class Jetpack_Search_Plugin {
 	public static function bootstrap() {
 		add_action( 'plugins_loaded', array( self::class, 'ensure_dependencies_configured' ), 1 );
 		add_action( 'plugins_loaded', array( self::class, 'initialize' ) );
-		register_activation_hook( JETPACK_SEARCH_PLUGIN__FILE, array( self::class, 'handle_plugin_activation' ) );
-		add_action( 'admin_init', array( self::class, 'redirect_on_activation' ) );
+		add_action( 'activated_plugin', array( self::class, 'handle_plugin_activation' ) );
 	}
 
 	/**
@@ -65,9 +64,11 @@ class Jetpack_Search_Plugin {
 	}
 
 	/**
-	 * Activation hook.
+	 * Redirects to the Search Dashboard when the Search plugin is activated.
+	 *
+	 * @param string $plugin Path to the plugin file relative to the plugins directory.
 	 */
-	public static function handle_plugin_activation() {
+	public static function handle_plugin_activation( $plugin ) {
 		// If site is already connected, enable the search module and enable instant search.
 		if ( ( new Connection_Manager() )->is_connected() ) {
 			$controller        = new Search_Module_Control();
@@ -78,17 +79,9 @@ class Jetpack_Search_Plugin {
 			}
 		}
 
-		// Used for redirecting to the search dashboard following plugin activation.
-		add_option( self::ACTIVATION_OPTION_NAME, true );
-	}
-
-	/**
-	 * Runs after the plugin activation hook for page redirection.
-	 */
-	public static function redirect_on_activation() {
-		if ( get_option( self::ACTIVATION_OPTION_NAME ) ) {
-			delete_option( self::ACTIVATION_OPTION_NAME );
-			wp_safe_redirect( admin_url( 'admin.php?page=jetpack-search' ) );
+		if ( JETPACK_SEARCH_PLUGIN__FILE_RELATIVE_PATH === $plugin ) {
+			wp_safe_redirect( esc_url( admin_url( 'admin.php?page=jetpack-search' ) ) );
+			exit;
 		}
 	}
 }

--- a/projects/plugins/search/src/class-jetpack-search-plugin.php
+++ b/projects/plugins/search/src/class-jetpack-search-plugin.php
@@ -73,7 +73,7 @@ class Jetpack_Search_Plugin {
 			$controller        = new Search_Module_Control();
 			$activation_result = $controller->activate();
 
-			if ( ! is_wp_error( $activation_result ) && true === $activation_result ) {
+			if ( true === $activation_result ) {
 				$controller->enable_instant_search();
 			}
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #24286.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Automatically redirect to the search dashboard upon standalone plugin activation.
* Automatically enable the Search module and Instant Search when eligible upon plugin activation.

<!-- #### Jetpack product discussion -->
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Apply this change to your test site without a Jetpack Search subscription with the Jetpack Search plugin disabled (or uninstalled).
* Activate the Jetpack Search subscription.
* Ensure that you're redirected to the Search Dashboard with an active pre-connection page.
* Purchase a search subscription.
* Navigate to the Search Dashboard and disable both the Search module and Instant Search.
* Navigate to the wp-admin plugin page and disable the Search plugin.
* Re-enable the Search plugin.
* Ensure you're redirected to the Search Dashboard and that the Search module and Instant Search have been automatically re-enabled.
