### PR TITLE
Social: Add the editor sidebar

### DIFF
--- a/projects/plugins/social/changelog/add-jetpack-social-add-sidebar
+++ b/projects/plugins/social/changelog/add-jetpack-social-add-sidebar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Adds a placeholder sidebar in the block editor

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -82,6 +82,9 @@ class Jetpack_Social {
 		My_Jetpack_Initializer::init();
 
 		$this->manager = $connection_manager ? $connection_manager : new Connection_Manager();
+
+		// Add block editor assets
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_scripts' ) );
 	}
 
 	/**
@@ -136,6 +139,23 @@ class Jetpack_Social {
 			'connections'                      => $publicize->get_all_connections_for_user(), // TODO: Sanitize the array
 			'jetpackSocialConnectionsAdminUrl' => esc_url_raw( $publicize->publicize_connections_url( 'jetpack-social-connections-admin-page' ) ),
 		);
+	}
+
+	/**
+	 * Enqueue block editor scripts and styles.
+	 */
+	public function enqueue_block_editor_scripts() {
+		Assets::register_script(
+			'jetpack-social-editor',
+			'build/editor.js',
+			JETPACK_SOCIAL_PLUGIN_ROOT_FILE,
+			array(
+				'in_footer'  => true,
+				'textdomain' => 'jetpack-social',
+			)
+		);
+
+		Assets::enqueue_script( 'jetpack-social-editor' );
 	}
 
 	/**

--- a/projects/plugins/social/src/js/editor.js
+++ b/projects/plugins/social/src/js/editor.js
@@ -12,6 +12,7 @@ import { registerPlugin } from '@wordpress/plugins';
 import { dispatch } from '@wordpress/data';
 import { getQueryArg } from '@wordpress/url';
 import domReady from '@wordpress/dom-ready';
+import { JetpackLogo } from '@automattic/jetpack-components';
 
 /**
  * Open Jetpack Spcoal; sidebar by default when URL includes jetpackSidebarIsOpen=true.
@@ -30,9 +31,18 @@ const PublicizePanel = () => <span>This is a placeholder panel</span>;
 registerPlugin( 'jetpack-social', {
 	render: () => (
 		<PostTypeSupportCheck supportKeys="publicize">
-			<PluginSidebarMoreMenuItem target="jetpack-social">Jetpack Social</PluginSidebarMoreMenuItem>
+			<PluginSidebarMoreMenuItem
+				target="jetpack-social"
+				icon={ <JetpackLogo showText={ false } /> }
+			>
+				Jetpack Social
+			</PluginSidebarMoreMenuItem>
 
-			<PluginSidebar name="jetpack-social" title="Jetpack Social">
+			<PluginSidebar
+				name="jetpack-social"
+				title="Jetpack Social"
+				icon={ <JetpackLogo showText={ false } /> }
+			>
 				<PublicizePanel />
 			</PluginSidebar>
 

--- a/projects/plugins/social/src/js/editor.js
+++ b/projects/plugins/social/src/js/editor.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	PluginSidebar,
+	PluginSidebarMoreMenuItem,
+	PluginPrePublishPanel,
+} from '@wordpress/edit-post';
+import { PostTypeSupportCheck } from '@wordpress/editor';
+import { registerPlugin } from '@wordpress/plugins';
+import { dispatch } from '@wordpress/data';
+import { getQueryArg } from '@wordpress/url';
+import domReady from '@wordpress/dom-ready';
+
+/**
+ * Open Jetpack Spcoal; sidebar by default when URL includes jetpackSidebarIsOpen=true.
+ */
+domReady( () => {
+	if ( getQueryArg( window.location.search, 'jetpackSidebarIsOpen' ) === 'true' ) {
+		dispatch( 'core/interface' ).enableComplementaryArea(
+			'core/edit-post',
+			'jetpack-social-sidebar/jetpack-social'
+		);
+	}
+} );
+
+const PublicizePanel = () => <span>This is a placeholder panel</span>;
+
+registerPlugin( 'jetpack-social', {
+	render: () => (
+		<PostTypeSupportCheck supportKeys="publicize">
+			<PluginSidebarMoreMenuItem target="jetpack-social">Jetpack Social</PluginSidebarMoreMenuItem>
+
+			<PluginSidebar name="jetpack-social" title="Jetpack Social">
+				<PublicizePanel />
+			</PluginSidebar>
+
+			<PluginPrePublishPanel
+				initialOpen
+				id="publicize-title"
+				title={
+					<span id="publicize-defaults" key="publicize-title-span">
+						{ __( 'Share this post', 'jetpack-social' ) }
+					</span>
+				}
+			>
+				<PublicizePanel prePublish={ true } />
+			</PluginPrePublishPanel>
+		</PostTypeSupportCheck>
+	),
+} );

--- a/projects/plugins/social/webpack.config.js
+++ b/projects/plugins/social/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = [
 	{
 		entry: {
 			index: './src/js/index.js',
+			editor: './src/js/editor.js',
 		},
 		mode: jetpackWebpackConfig.mode,
 		devtool: jetpackWebpackConfig.isDevelopment ? 'source-map' : false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR adds the editor sidebar component, with a placeholder panel.

props: @danielpost 

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Build the Social plugin with `jetpack build plugins/social`
* Activate the plugin, and if necessary deactivate Jetpack
* Connect the site
* Start a new post in the block editor.
* You should see the Jetpack Social sidebar.

---
We need to work out if we want to not load the editor plugin if the module is disabled. We could handle that in the panel and display a warning that the module is disabled with a link to the admin page where once #24203 is merged, they can enable it.

Also the triangles in the Jetpack logo are transparent, so they show as the active colour when the sidebar is open. We might want to adapt the component to allow for a version where the triangles are always white. We may also want to use our social icon instead.

I don't think either of these are blockers to merging it. Let's do that and iterate on it.