### PR TITLE
WAF: Add endpoint to update rules on demand

### DIFF
--- a/projects/packages/waf/changelog/add-waf-update-endpoint
+++ b/projects/packages/waf/changelog/add-waf-update-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added endpoint to update rules on demand

--- a/projects/packages/waf/src/class-waf-endpoints.php
+++ b/projects/packages/waf/src/class-waf-endpoints.php
@@ -47,6 +47,34 @@ class Waf_Endpoints {
 				'permission_callback' => __CLASS__ . '::waf_permissions_callback',
 			)
 		);
+		register_rest_route(
+			'jetpack/v4',
+			'/waf/update-rules',
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => __CLASS__ . '::update_rules',
+				'permission_callback' => __CLASS__ . '::waf_permissions_callback',
+			)
+		);
+	}
+
+	/**
+	 * Update rules endpoint
+	 */
+	public static function update_rules() {
+		$success = true;
+
+		try {
+			Waf_Runner::generate_rules();
+		} catch ( Exception $e ) {
+			$success = false;
+		}
+
+		return rest_ensure_response(
+			array(
+				'success' => $success,
+			)
+		);
 	}
 
 	/**

--- a/projects/packages/waf/src/class-waf-endpoints.php
+++ b/projects/packages/waf/src/class-waf-endpoints.php
@@ -63,16 +63,19 @@ class Waf_Endpoints {
 	 */
 	public static function update_rules() {
 		$success = true;
+		$message = 'Rules updated succesfully';
 
 		try {
 			Waf_Runner::generate_rules();
 		} catch ( Exception $e ) {
 			$success = false;
+			$message = $e->getMessage();
 		}
 
 		return rest_ensure_response(
 			array(
 				'success' => $success,
+				'message' => $message,
 			)
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This adds an endpoint that will be called after a plan that includes our WAF is bought so the customer can get updated rules.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1201069996155224-as-1202197114468148

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Call this endpoint for a site that has a scan subscription.
* Verify that the rules were updated.