### PR TITLE
Gridicon: add info-outline icon to available subset of icons

### DIFF
--- a/projects/js-packages/components/changelog/add-info-outline-gridicon
+++ b/projects/js-packages/components/changelog/add-info-outline-gridicon
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Gridicon: added info-outline gridicon to the available subset of icons

--- a/projects/js-packages/components/components/gridicon/index.jsx
+++ b/projects/js-packages/components/components/gridicon/index.jsx
@@ -57,7 +57,7 @@ class Gridicon extends Component {
 			case 'gridicons-comment':
 				return <title>{ __( 'Matching comment.', 'jetpack' ) }</title>;
 			case 'gridicons-cross':
-				return <title>{ __( 'Close search results', 'jetpack' ) }</title>;
+				return <title>{ __( 'Close.', 'jetpack' ) }</title>;
 			case 'gridicons-filter':
 				return <title>{ __( 'Toggle search filters.', 'jetpack' ) }</title>;
 			case 'gridicons-folder':

--- a/projects/js-packages/components/components/gridicon/index.jsx
+++ b/projects/js-packages/components/components/gridicon/index.jsx
@@ -25,6 +25,7 @@ class Gridicon extends Component {
 			'gridicons-cart',
 			'gridicons-folder',
 			'gridicons-info',
+			'gridicons-info-outline',
 			'gridicons-posts',
 			'gridicons-star-outline',
 			'gridicons-star',
@@ -159,6 +160,12 @@ class Gridicon extends Component {
 				return (
 					<g>
 						<path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z" />
+					</g>
+				);
+			case 'gridicons-info-outline':
+				return (
+					<g>
+						<path d="M13 9h-2V7h2v2zm0 2h-2v6h2v-6zm-1-7c-4.411 0-8 3.589-8 8s3.589 8 8 8 8-3.589 8-8-3.589-8-8-8m0-2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2z"></path>
 					</g>
 				);
 			case 'gridicons-jetpack-search':

--- a/projects/js-packages/components/components/gridicon/index.jsx
+++ b/projects/js-packages/components/components/gridicon/index.jsx
@@ -62,6 +62,9 @@ class Gridicon extends Component {
 				return <title>{ __( 'Toggle search filters.', 'jetpack' ) }</title>;
 			case 'gridicons-folder':
 				return <title>{ __( 'Category', 'jetpack' ) }</title>;
+			case 'gridicons-info':
+			case 'gridicons-info-outline':
+				return <title>{ __( 'Information.', 'jetpack' ) }</title>;
 			case 'gridicons-image-multiple':
 				return <title>{ __( 'Has multiple images.', 'jetpack' ) }</title>;
 			case 'gridicons-image':

--- a/projects/js-packages/components/components/gridicon/stories/index.jsx
+++ b/projects/js-packages/components/components/gridicon/stories/index.jsx
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import Gridicon from '../index.jsx';
+
+export default {
+	title: 'JS Packages/Components/Gridicon',
+	component: Gridicon,
+};
+
+// Export additional stories using pre-defined values
+const Template = args => <Gridicon { ...args } />;
+
+// Export Default story
+export const _default = Template.bind( {} );
+
+export const InfoOutline = Template.bind( {} );
+InfoOutline.args = {
+	icon: 'info-outline',
+};


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The Jetpack Search Record Meter designs specify the use of the `info-outline` icon. This icon is not currently included in our limited subset of icons.

This PR adds `info-outline` to our Gridicon component.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions

1. Build Storybook with `cd projects/js-packages/storybook && pnpm run storybook:build`.
2. Open Storybook locally from `projects/js-packages/storybook/docs/index.html`.
3. In Storybook, navigate to JS Packages > Gridicon > Info Outline. Check that the rendered icon looks like this:

<img width="147" alt="Screen Shot 2022-05-11 at 17 07 24" src="https://user-images.githubusercontent.com/17325/167773176-52d9e283-847a-4f59-a655-c2ff0015c631.png">


