### PR TITLE
VideoPress: Add useAverageColor param to wpvideo shortcode 

### DIFF
--- a/projects/plugins/jetpack/changelog/add-videopress-average-color-in-wpvideo
+++ b/projects/plugins/jetpack/changelog/add-videopress-average-color-in-wpvideo
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+VideoPress: add useAverageColor to wpvideo shortcode to support automatic seekbar color.

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
@@ -646,6 +646,7 @@ class VideoPress_Player {
 				case 'muted':
 				case 'controls':
 				case 'playsinline':
+				case 'useAverageColor':
 					if ( in_array( $value, array( 1, 'true' ) ) ) {
 						$videopress_options[ $option ] = true;
 					} elseif ( in_array( $value, array( 0, 'false' ) ) ) {

--- a/projects/plugins/jetpack/modules/videopress/shortcode.php
+++ b/projects/plugins/jetpack/modules/videopress/shortcode.php
@@ -85,6 +85,7 @@ class VideoPress_Shortcode {
 			'muted'           => false, // Whether the video should start without sound.
 			'controls'        => true,  // Whether the video should display controls.
 			'playsinline'     => false, // Whether the video should be allowed to play inline (for browsers that support this).
+			'useaveragecolor' => false, // Whether the video should use the seekbar automatic average color.
 		);
 
 		$attr = shortcode_atts( $defaults, $attr, 'videopress' );
@@ -146,6 +147,7 @@ class VideoPress_Shortcode {
 				'muted'           => $attr['muted'],
 				'controls'        => $attr['controls'],
 				'playsinline'     => $attr['playsinline'],
+				'useAverageColor' => (bool) $attr['useaveragecolor'], // The casing is intentional, shortcode params are lowercase, but player expects useAverageColor
 			// accessible via the `videopress_shortcode_options` filter.
 			)
 		);


### PR DESCRIPTION
Fixes Automattic/greenhouse#1050

#### Changes proposed in this Pull Request:

This PR adds support for the "useAverageColor" param in wpvideo shortcode, in order to use the automatic seekbar color for the VideoPress player.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* On a JP site with VideoPress enabled, apply this patch.
* In your media library, find a VideoPress video and copy the GUID.
* Create a new post `/wp-admin/post-new.php`
* Add a /shortcode block
* `[wpvideo <replace with your guid> useAverageColor=true]`
* Save and preview
* Play the video
* ✅ The seekbar should change its color automatically during video playback.
* In the post edit, remove useAverageColor or set it to false
* Save and preview
* Play the video
* ✅ The seekbar should not change its color anymore.