### PR TITLE
My Jetpack: compute Search plugin price based on prices tier

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-improve-search-product-data
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-improve-search-product-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+My Jetpack: compute Search plugin price based on price tier

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "1.3.0",
+	"version": "1.3.1-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -28,7 +28,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '1.3.0';
+	const PACKAGE_VERSION = '1.3.1-alpha';
 
 	/**
 	 * Initialize My Jetapack

--- a/projects/packages/my-jetpack/src/class-wpcom-products.php
+++ b/projects/packages/my-jetpack/src/class-wpcom-products.php
@@ -171,6 +171,18 @@ class Wpcom_Products {
 			'discount_price' => $discount_price,
 		);
 
+		return self::populate_with_discount( $product, $pricing, $discount_price );
+	}
+
+	/**
+	 * Populate the pricing array with the discount information.
+	 *
+	 * @param {object} $product - The product object.
+	 * @param {object} $pricing - The pricing array.
+	 * @param {float}  $price   - The price to be discounted.
+	 * @return {object} The pricing array with the discount information.
+	 */
+	public static function populate_with_discount( $product, $pricing, $price ) {
 		// Check whether the product has a coupon.
 		if ( ! isset( $product->sale_coupon ) ) {
 			return $pricing;
@@ -189,8 +201,8 @@ class Wpcom_Products {
 		// Populate response with coupon discount.
 		$pricing['coupon_discount'] = $coupon_discount;
 
-		// Apply coupon discount to discount price.
-		$pricing['discount_price'] = $discount_price * ( 100 - $coupon_discount ) / 100;
+		// Apply coupon discount to the price.
+		$pricing['discount_price'] = $price * ( 100 - $coupon_discount ) / 100;
 
 		return $pricing;
 	}

--- a/projects/packages/my-jetpack/src/class-wpcom-products.php
+++ b/projects/packages/my-jetpack/src/class-wpcom-products.php
@@ -184,11 +184,13 @@ class Wpcom_Products {
 			return $pricing;
 		}
 
+		$coupon_discount = intval( $coupon->discount );
+
 		// Populate response with coupon discount.
-		$pricing['coupon_discount'] = $coupon->discount;
+		$pricing['coupon_discount'] = $coupon_discount;
 
 		// Apply coupon discount to discount price.
-		$pricing['discount_price'] = $discount_price * ( 100 - $coupon->discount ) / 100;
+		$pricing['discount_price'] = $discount_price * ( 100 - $coupon_discount ) / 100;
 
 		return $pricing;
 	}

--- a/projects/packages/my-jetpack/src/products/class-search-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-search-stats.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Get search stats for use in the wp-admin dashboard.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\My_Jetpack\Products;
+
+use Automattic\Jetpack\Connection\Client;
+use Jetpack_Options;
+
+/**
+ * Search stats (e.g. post count, post type breakdown)
+ */
+class Search_Stats {
+	const CACHE_EXPIRY             = 5 * MINUTE_IN_SECONDS;
+	const CACHE_GROUP              = 'jetpack_search';
+	const COUNT_ESTIMATE_CACHE_KEY = 'count_estimate';
+
+	/**
+	 * Get stats from the WordPress.com API for the current blog ID.
+	 */
+	public function get_stats_from_wpcom() {
+		$blog_id = Jetpack_Options::get_option( 'id' );
+
+		if ( ! is_numeric( $blog_id ) ) {
+			return null;
+		}
+
+		$response = Client::wpcom_json_api_request_as_blog(
+			'/sites/' . (int) $blog_id . '/jetpack-search/stats',
+			'2',
+			array(),
+			null,
+			'wpcom'
+		);
+
+		return $response;
+	}
+
+	/**
+	 * Estimate record counts via a local database query.
+	 */
+	public static function estimate_count() {
+		$cached_value = wp_cache_get( self::COUNT_ESTIMATE_CACHE_KEY, self::CACHE_GROUP );
+		if ( false !== $cached_value ) {
+			return $cached_value;
+		}
+
+		global $wpdb;
+		$indexable_statuses     = get_post_stati( array( 'public' => true ) );
+		$unindexable_post_types = array_merge(
+			// Explicitly exclude various post types registered by plugins.
+			array(
+				'elementor_library', // Used by Elementor.
+				'jp_sitemap', // Used by Jetpack.
+				'product_variation', // Used by Woocommerce.
+				'redirect_rule', // Used by the Safe Redirect plugin.
+				'reply', // Used by bbpress.
+				'scheduled-action', // Used by Woocommerce.
+			),
+			get_post_types(
+				array(
+					'exclude_from_search' => true,
+					'public'              => false,
+				),
+				'names',
+				'or'
+			)
+		);
+
+		$prep_for_query = function ( $string ) use ( $wpdb ) {
+			// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.QuotedSimplePlaceholder -- This is used to sanitize post type names.
+			return $wpdb->prepare( "'%s'", $string );
+		};
+
+		$statuses_list   = implode( ',', array_map( $prep_for_query, $indexable_statuses ) );
+		$post_types_list = implode( ',', array_map( $prep_for_query, $unindexable_post_types ) );
+
+		$count = (int) $wpdb->get_var(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- This is properly prepared, but the query is constructed using variables.
+			"SELECT COUNT(ID) FROM {$wpdb->posts} WHERE post_status IN ($statuses_list) AND post_type NOT IN ($post_types_list)"
+		);
+
+		wp_cache_set( self::COUNT_ESTIMATE_CACHE_KEY, $count, self::CACHE_GROUP, self::CACHE_EXPIRY );
+		return $count;
+	}
+}

--- a/projects/packages/my-jetpack/src/products/class-search-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-search-stats.php
@@ -2,7 +2,7 @@
 /**
  * Get search stats for use in the wp-admin dashboard.
  *
- * @package automattic/jetpack-search
+ * @package my-jetpack
  */
 
 namespace Automattic\Jetpack\My_Jetpack\Products;

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -134,7 +134,7 @@ class Search extends Hybrid_Product {
 			}
 		}
 
-		// Computhe the minimum price.
+		// Compute the minimum price.
 		$minimum_price = $price_tier->minimum_price / 100;
 
 		// Re define the display price based on the tier.

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -17,7 +17,6 @@ use WP_Error;
  * Class responsible for handling the Search product
  */
 class Search extends Hybrid_Product {
-
 	/**
 	 * The product slug
 	 *
@@ -106,12 +105,51 @@ class Search extends Hybrid_Product {
 	 * @return array Pricing details
 	 */
 	public static function get_pricing_for_ui() {
-		return array_merge(
+		// Basic pricing info.
+		$pricing = array_merge(
 			array(
 				'available'          => true,
 				'wpcom_product_slug' => static::get_wpcom_product_slug(),
 			),
 			Wpcom_Products::get_product_pricing( static::get_wpcom_product_slug() )
+		);
+
+		$record_count = intval( Search_Stats::estimate_count() );
+
+		// Check whether the price is available.
+		// Bail early return the pricing info if not.
+		$product = Wpcom_Products::get_product( static::get_wpcom_product_slug() );
+		if ( ! isset( $product->price_tier_list ) ) {
+			return $pricing;
+		}
+
+		// Sort the tiers.
+		$price_tier_list = $product->price_tier_list;
+		array_multisort( array_column( $price_tier_list, 'maximum_units' ), SORT_ASC, $price_tier_list );
+
+		// Pick the first tier that is less than or equal to the record count.
+		foreach ( $product->price_tier_list as $price_tier ) {
+			if ( $record_count <= $price_tier->maximum_units ) {
+				break;
+			}
+		}
+
+		// Computhe the minimum price.
+		$minimum_price = $price_tier->minimum_price / 100;
+
+		// Re define the display price based on the tier.
+		$pricing = Wpcom_Products::populate_with_discount( $product, $pricing, $minimum_price );
+
+		// 1. Flat fee in the same tier, so for search, `minimum_price == maximum_price`.
+		// 2. `maximum_units` is empty on the highest tier, so the logic displays the highest or the highest matching tier.
+		return array_merge(
+			$pricing,
+			array(
+				'minimum_units'   => $price_tier->minimum_units,
+				'maximum_units'   => $price_tier->maximum_units,
+				'estimated_count' => $record_count,
+				'full_price'      => $minimum_price, // reset the full price to the minimum price.
+			)
 		);
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We are not considering the price tier when computing the price for the Search plugin. This PR takes it over.

Some considerations:
* I've copied [the class](https://github.com/Automattic/jetpack/blob/master/projects/packages/search/src/class-stats.php) to compute the record count from the Search package.
* The data to use to compute the price is based on what the `/sites/$site/products` returns on the response body
* The endpoint mentioned above does not contain `introductory_offer` but contains the `sale_coupon` data. We use this data (the same [approach that we use in the Search plugin](https://github.com/Automattic/jetpack/blob/17079078398c920c0bfc222b5020954ab0dbfd6a/projects/packages/search/src/class-product.php#L111-L123))

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: compute Search plugin price based on prices tier

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My jetpack overview
* Test with a site without the Search product
* Confirm that the price shown in the UI is consistent with the record_count

0 / 100 | 101 / 1000 | 1001 / 10000 | 10001 / 100000 | 100000 / 1000000
------|------|------|-------|-------
<img width="421" alt="image" src="https://user-images.githubusercontent.com/77539/167920337-f1220d85-83ec-4edd-baf5-38b9979b4a62.png"> | <img width="427" alt="image" src="https://user-images.githubusercontent.com/77539/167920216-12dd8588-3c3a-4dd1-bfcc-e31a1b562ed7.png"> | <img width="431" alt="image" src="https://user-images.githubusercontent.com/77539/167920694-5c4993d7-67d9-45b2-8004-91a508e066a7.png"> | <img width="429" alt="image" src="https://user-images.githubusercontent.com/77539/167920913-ed17a66d-cc50-4483-9943-c04d8b563a3a.png"> | <img width="421" alt="image" src="https://user-images.githubusercontent.com/77539/167921099-6fd4d79d-a2aa-41d9-949b-c0262f5413c6.png">

You can take a look at the data populated by the client.
* Open the dev console
* run `wp.data.select( 'my-jetpack' ).getProduct( 'search' ).pricingForUi`

<img width="323" alt="image" src="https://user-images.githubusercontent.com/77539/167921342-21b92428-cd93-4443-be30-49e041f57f1b.png">

The image below shows the data for the higher tier
