### PR TITLE
add option to use checkout workflow

### DIFF
--- a/projects/js-packages/connection/changelog/update-use-checkout-flow-in-search
+++ b/projects/js-packages/connection/changelog/update-use-checkout-flow-in-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add option to use the checkout workflow from the ConnectionScreenRequirePlan component

--- a/projects/js-packages/connection/components/connect-screen/required-plan/index.jsx
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/index.jsx
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
  */
 import ConnectScreenRequiredPlanVisual from './visual';
 import useConnection from '../../use-connection';
+import useProductCheckoutWorkflow from '../../../hooks/use-product-checkout-workflow';
 
 /**
  * The Connection Screen Visual component for consumers that require a Plan.
@@ -33,6 +34,7 @@ const ConnectScreenRequiredPlan = props => {
 		pricingIcon,
 		pricingTitle,
 		pricingCurrencyCode,
+		wpcomProductSlug,
 	} = props;
 
 	const {
@@ -51,9 +53,17 @@ const ConnectScreenRequiredPlan = props => {
 		from,
 	} );
 
+	const productSlug = wpcomProductSlug ? wpcomProductSlug : '';
+
+	const { run, hasCheckoutStarted } = useProductCheckoutWorkflow( {
+		productSlug,
+		redirectUrl: redirectUri,
+	} );
+
 	const showConnectButton = ! isRegistered || ! isUserConnected;
 	const displayButtonError = Boolean( registrationError );
-	const buttonIsLoading = siteIsRegistering || userIsConnecting;
+	const buttonIsLoading = siteIsRegistering || userIsConnecting || hasCheckoutStarted;
+	const handleButtonClick = productSlug ? run : handleRegisterSite;
 
 	return (
 		<ConnectScreenRequiredPlanVisual
@@ -64,7 +74,7 @@ const ConnectScreenRequiredPlan = props => {
 			pricingIcon={ pricingIcon }
 			pricingTitle={ pricingTitle }
 			pricingCurrencyCode={ pricingCurrencyCode }
-			handleButtonClick={ handleRegisterSite }
+			handleButtonClick={ handleButtonClick }
 			showConnectButton={ showConnectButton }
 			displayButtonError={ displayButtonError }
 			buttonIsLoading={ buttonIsLoading }
@@ -101,6 +111,8 @@ ConnectScreenRequiredPlan.propTypes = {
 	priceAfter: PropTypes.number.isRequired,
 	/** The Currency code, eg 'USD'. */
 	pricingCurrencyCode: PropTypes.string,
+	/** The WordPress.com product slug. If informed, the connection/authorization flow will go through the Checkout page for this product'. */
+	wpcomProductSlug: PropTypes.string,
 };
 
 ConnectScreenRequiredPlan.defaultProps = {

--- a/projects/packages/search/changelog/update-use-checkout-flow-in-search
+++ b/projects/packages/search/changelog/update-use-checkout-flow-in-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use the Checkout wordflow to establish the connection and make the purchase

--- a/projects/packages/search/src/dashboard/components/pages/connection-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/connection-page.jsx
@@ -56,6 +56,7 @@ export default function ConnectionPage( { isLoading = false } ) {
 				registrationNonce={ registrationNonce }
 				from="jetpack-search"
 				redirectUri="admin.php?page=jetpack-search"
+				wpcomProductSlug="jetpack_search"
 			>
 				<SearchPromotionBlock />
 			</ConnectScreenRequiredPlan>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a JN site with Jetpack Beta
* Deactivate and DELETE Jetpack plugin
* Enable Jetpack Boost on this branch
* Connect Boost
* Go to My Jetpack
* Add Search
* You should:

- be redirected to `wordpress.com/checkout/SITE_SLUG/jetpack_search` with `unlinked=1` as one of the parameters
- then quicky redirected to authenticate the user
- redirected back to the checkout page
