### PR TITLE
renovate: Log GitHub API rate limits pre- and post-run

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           TOKEN: ${{ secrets.RENOVATE_TOKEN }}
         run: |
-          curl --header "Authorization: Bearer $TOKEN" https://api.github.com/rate_limit
+          curl --no-progress-meter --header "Authorization: Bearer $TOKEN" https://api.github.com/rate_limit
       - uses: renovatebot/github-action@v32.7.5
         with:
           configurationFile: /tmp/monorepo/.github/renovate-config.js
@@ -44,4 +44,4 @@ jobs:
           TOKEN: ${{ secrets.RENOVATE_TOKEN }}
         run: |
           echo "Note any difference between this number and the one from the previous step may also include API uses from elsewhere that happened to occur at the same time."
-          curl --header "Authorization: Bearer $TOKEN" https://api.github.com/rate_limit
+          curl --no-progress-meter --header "Authorization: Bearer $TOKEN" https://api.github.com/rate_limit

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -27,6 +27,11 @@ jobs:
         with:
           path: monorepo
       - run: mv monorepo /tmp/monorepo
+      - name: Check rate limit pre-run
+        env:
+          TOKEN: ${{ secrets.RENOVATE_TOKEN }}
+        run: |
+          curl --header "Authorization: Bearer $TOKEN" https://api.github.com/rate_limit
       - uses: renovatebot/github-action@v32.7.5
         with:
           configurationFile: /tmp/monorepo/.github/renovate-config.js
@@ -34,3 +39,9 @@ jobs:
         env:
           LOG_LEVEL: ${{ github.event.inputs.logLevel || 'debug' }}
           RENOVATE_DRY_RUN: ${{ github.event_name == 'push' || github.event.inputs.dryRun }}
+      - name: Check rate limit post-run
+        env:
+          TOKEN: ${{ secrets.RENOVATE_TOKEN }}
+        run: |
+          echo "Note any difference between this number and the one from the previous step may also include API uses from elsewhere that happened to occur at the same time."
+          curl --header "Authorization: Bearer $TOKEN" https://api.github.com/rate_limit


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Yesterday a run failed because the token hit the 5000/hr rate limit.
Let's track the rate limit on each run to see whether it seems the token
is chronically near the limit or if that was a fluke.

Note hitting the /rate_limit endpoint doesn't itself count towards the
rate limit.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1652358268639879-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Look at the dry run at https://github.com/Automattic/jetpack/runs/6406008517?check_suite_focus=true