### PR TITLE
My Jetpack: Add Protect class

### DIFF
--- a/projects/packages/backup/changelog/update-my-jetpack-add-protect-product-data
+++ b/projects/packages/backup/changelog/update-my-jetpack-add-protect-product-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/backup/composer.json
+++ b/projects/packages/backup/composer.json
@@ -12,7 +12,7 @@
 		"automattic/jetpack-connection": "^1.40",
 		"automattic/jetpack-connection-ui": "^2.4",
 		"automattic/jetpack-identity-crisis": "^0.8",
-		"automattic/jetpack-my-jetpack": "^1.3",
+		"automattic/jetpack-my-jetpack": "^1.4",
 		"automattic/jetpack-sync": "^1.32",
 		"automattic/jetpack-status": "^1.13"
 	},

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-add-protect-product-data
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-add-protect-product-data
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+My Jetpack: Add Protect class

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -72,7 +72,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-master": "1.3.x-dev"
+			"dev-master": "1.4.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "1.3.1-alpha",
+	"version": "1.4.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -28,7 +28,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '1.3.1-alpha';
+	const PACKAGE_VERSION = '1.4.0-alpha';
 
 	/**
 	 * Initialize My Jetapack

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -30,6 +30,7 @@ class Products {
 			Products\Search::class,
 			Products\Videopress::class,
 			Products\Security::class,
+			Products\Protect::class,
 		);
 	}
 

--- a/projects/packages/my-jetpack/src/products/class-protect.php
+++ b/projects/packages/my-jetpack/src/products/class-protect.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Protect product
+ *
+ * @package my-jetpack
+ */
+
+namespace Automattic\Jetpack\My_Jetpack\Products;
+
+use Automattic\Jetpack\My_Jetpack\Product;
+
+/**
+ * Class responsible for handling the Protect product
+ */
+class Protect extends Product {
+
+	/**
+	 * The product slug
+	 *
+	 * @var string
+	 */
+	public static $slug = 'protect';
+
+	/**
+	 * The filename (id) of the plugin associated with this product.
+	 *
+	 * @var string
+	 */
+	public static $plugin_filename = array(
+		'jetpack-protect/jetpack-protect.php',
+		'protect/jetpack-protect.php',
+		'jetpack-protect-dev/jetpack-protect.php',
+	);
+
+	/**
+	 * The slug of the plugin associated with this product.
+	 *
+	 * @var string
+	 */
+	public static $plugin_slug = 'jetpack-protect';
+
+	/**
+	 * Whether this product requires a user connection
+	 *
+	 * @var string
+	 */
+	public static $requires_user_connection = false;
+
+	/**
+	 * Get the internationalized product name
+	 *
+	 * @return string
+	 */
+	public static function get_name() {
+		return __( 'Protect', 'jetpack-my-jetpack' );
+	}
+
+	/**
+	 * Get the internationalized product title
+	 *
+	 * @return string
+	 */
+	public static function get_title() {
+		return __( 'Jetpack Protect', 'jetpack-my-jetpack' );
+	}
+
+	/**
+	 * Get the internationalized product description
+	 *
+	 * @return string
+	 */
+	public static function get_description() {
+		return __( 'Protect your site and scan for security vulnerabilities.', 'jetpack-my-jetpack' );
+	}
+
+	/**
+	 * Get the internationalized product long description
+	 *
+	 * @return string
+	 */
+	public static function get_long_description() {
+		return __( 'Protect your site and scan for security vulnerabilities listed in our database.', 'jetpack-my-jetpack' );
+	}
+
+	/**
+	 * Get the internationalized features list
+	 *
+	 * @return array Protect features list
+	 */
+	public static function get_features() {
+		return array(
+			__( 'Over 20,000 listed vulnerabilities', 'jetpack-my-jetpack' ),
+			__( 'Daily automatic scans', 'jetpack-my-jetpack' ),
+			__( 'Check plugin and theme version status', 'jetpack-my-jetpack' ),
+			__( 'Easy to navigate and use', 'jetpack-my-jetpack' ),
+		);
+	}
+
+	/**
+	 * Get the product princing details
+	 *
+	 * @return array Pricing details
+	 */
+	public static function get_pricing_for_ui() {
+		return array(
+			'available' => true,
+			'is_free'   => true,
+		);
+	}
+
+	/**
+	 * Get the URL where the user manages the product
+	 *
+	 * @return ?string
+	 */
+	public static function get_manage_url() {
+		return admin_url( 'admin.php?page=jetpack-protect' );
+	}
+}

--- a/projects/plugins/backup/changelog/update-my-jetpack-add-protect-product-data
+++ b/projects/plugins/backup/changelog/update-my-jetpack-add-protect-product-data
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -235,7 +235,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "bc25fe4dc1a5db053d0dea48d3c26996385ecbbf"
+                "reference": "fa588c7b40d284d2c6f51979254853567dc73cc9"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -246,7 +246,7 @@
                 "automattic/jetpack-connection": "^1.40",
                 "automattic/jetpack-connection-ui": "^2.4",
                 "automattic/jetpack-identity-crisis": "^0.8",
-                "automattic/jetpack-my-jetpack": "^1.3",
+                "automattic/jetpack-my-jetpack": "^1.4",
                 "automattic/jetpack-status": "^1.13",
                 "automattic/jetpack-sync": "^1.32"
             },
@@ -801,7 +801,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "1850f7b082c85cddc144272e4e15f279ff0d0ca5"
+                "reference": "725ef878f070c99a8b213fb6398448427c398ffb"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -826,7 +826,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "1.4.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/update-my-jetpack-add-protect-product-data
+++ b/projects/plugins/boost/changelog/update-my-jetpack-add-protect-product-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -20,7 +20,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.9.x-dev",
 		"automattic/jetpack-connection": "1.40.x-dev",
-		"automattic/jetpack-my-jetpack": "1.3.x-dev",
+		"automattic/jetpack-my-jetpack": "1.4.x-dev",
 		"automattic/jetpack-device-detection": "1.4.x-dev",
 		"automattic/jetpack-lazy-images": "2.1.x-dev",
 		"tedivm/jshrink": "1.4.0"

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "63e29120da922d8de38599de1267a17e",
+    "content-hash": "e51fdcccc533391fd3f3206e338e3762",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -608,7 +608,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "1850f7b082c85cddc144272e4e15f279ff0d0ca5"
+                "reference": "725ef878f070c99a8b213fb6398448427c398ffb"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -633,7 +633,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "1.4.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/changelog/update-my-jetpack-add-protect-product-data
+++ b/projects/plugins/jetpack/changelog/update-my-jetpack-add-protect-product-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -31,7 +31,7 @@
 		"automattic/jetpack-lazy-images": "2.1.x-dev",
 		"automattic/jetpack-licensing": "1.7.x-dev",
 		"automattic/jetpack-logo": "1.5.x-dev",
-		"automattic/jetpack-my-jetpack": "1.3.x-dev",
+		"automattic/jetpack-my-jetpack": "1.4.x-dev",
 		"automattic/jetpack-partner": "1.7.x-dev",
 		"automattic/jetpack-plugins-installer": "0.1.x-dev",
 		"automattic/jetpack-publicize": "0.3.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "395d2685d38b328b367064eb458a68ef",
+    "content-hash": "934ab0e7c33f55305401b96b8b93701d",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -290,7 +290,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "bc25fe4dc1a5db053d0dea48d3c26996385ecbbf"
+                "reference": "fa588c7b40d284d2c6f51979254853567dc73cc9"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -301,7 +301,7 @@
                 "automattic/jetpack-connection": "^1.40",
                 "automattic/jetpack-connection-ui": "^2.4",
                 "automattic/jetpack-identity-crisis": "^0.8",
-                "automattic/jetpack-my-jetpack": "^1.3",
+                "automattic/jetpack-my-jetpack": "^1.4",
                 "automattic/jetpack-status": "^1.13",
                 "automattic/jetpack-sync": "^1.32"
             },
@@ -1173,7 +1173,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "1850f7b082c85cddc144272e4e15f279ff0d0ca5"
+                "reference": "725ef878f070c99a8b213fb6398448427c398ffb"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -1198,7 +1198,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "1.4.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/protect/changelog/update-my-jetpack-add-protect-product-data
+++ b/projects/plugins/protect/changelog/update-my-jetpack-add-protect-product-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/protect/composer.json
+++ b/projects/plugins/protect/composer.json
@@ -10,7 +10,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.9.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-my-jetpack": "1.3.x-dev",
+		"automattic/jetpack-my-jetpack": "1.4.x-dev",
 		"automattic/jetpack-plugins-installer": "0.1.x-dev",
 		"automattic/jetpack-sync": "1.32.x-dev"
 	},

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c5fa2bd37c1b6d3cad11486443a38589",
+    "content-hash": "516ae748f98add6b57113241075d671d",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -618,7 +618,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "1850f7b082c85cddc144272e4e15f279ff0d0ca5"
+                "reference": "725ef878f070c99a8b213fb6398448427c398ffb"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -643,7 +643,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "1.4.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/update-my-jetpack-add-protect-product-data
+++ b/projects/plugins/search/changelog/update-my-jetpack-add-protect-product-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -8,7 +8,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.9.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-my-jetpack": "1.3.x-dev",
+		"automattic/jetpack-my-jetpack": "1.4.x-dev",
 		"automattic/jetpack-search": "0.13.x-dev",
 		"automattic/jetpack-status": "^1.13",
 		"automattic/jetpack-sync": "1.32.x-dev"

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "90991d3de9424680d116f98dd2a5c970",
+    "content-hash": "cc223725291725ed2f87a83af3ff13b1",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -618,7 +618,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "1850f7b082c85cddc144272e4e15f279ff0d0ca5"
+                "reference": "725ef878f070c99a8b213fb6398448427c398ffb"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -643,7 +643,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "1.4.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/update-my-jetpack-add-protect-product-data
+++ b/projects/plugins/social/changelog/update-my-jetpack-add-protect-product-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -13,7 +13,7 @@
 		"automattic/jetpack-publicize": "0.3.x-dev",
 		"automattic/jetpack-options": "1.16.x-dev",
 		"automattic/jetpack-connection": "1.40.x-dev",
-		"automattic/jetpack-my-jetpack": "1.3.x-dev",
+		"automattic/jetpack-my-jetpack": "1.4.x-dev",
 		"automattic/jetpack-sync": "1.32.x-dev",
 		"automattic/jetpack-status": "1.13.x-dev"
 	},

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95269dc373103171bd80470e2fdd1176",
+    "content-hash": "41a7e9eb8940ff89b71757d2a39b7cfc",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -618,7 +618,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "1850f7b082c85cddc144272e4e15f279ff0d0ca5"
+                "reference": "725ef878f070c99a8b213fb6398448427c398ffb"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -643,7 +643,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "1.4.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/update-my-jetpack-add-protect-product-data
+++ b/projects/plugins/starter-plugin/changelog/update-my-jetpack-add-protect-product-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/starter-plugin/composer.json
+++ b/projects/plugins/starter-plugin/composer.json
@@ -10,7 +10,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.9.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-my-jetpack": "1.3.x-dev",
+		"automattic/jetpack-my-jetpack": "1.4.x-dev",
 		"automattic/jetpack-sync": "1.32.x-dev"
 	},
 	"require-dev": {

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b3f979a85129897e2838e7daa3b5b59",
+    "content-hash": "ba3b5d60e49581d4cb469872053cd568",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -618,7 +618,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "1850f7b082c85cddc144272e4e15f279ff0d0ca5"
+                "reference": "725ef878f070c99a8b213fb6398448427c398ffb"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -643,7 +643,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "1.4.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds the Protect class. It's a pretty basic implementation but useful to enhance when required. So far, it simply defines data about the product such as title, description, price, etc.
And since it's included in the products list, the data is available via the product endpoint and propagated to the client, too, in the My Jetpack global var.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: Add Protect class

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The easiest way to test the whole approach is to check whether the Protect data is available to the client, either looking at the global bar or using the `getProduct()` selector.

* Go to My Jetpack overview page
* Open the dev console
* Type the whole protect file path `myJetpackInitialState.products.items.protect`
* Confirm you see the data there
<img width="876" alt="image" src="https://user-images.githubusercontent.com/77539/168094349-7604b14e-5659-4ee2-8408-2d21222de017.png">

* Select the data by using the proper selector: `wp.data.select( 'my-jetpack' ).getProduct( 'protect' )`
* Same as above
