### PR TITLE
Search: Record Meter. Replaces localStorage with sessionStorage

### DIFF
--- a/projects/packages/search/changelog/update-search-record-meter-session-storage
+++ b/projects/packages/search/changelog/update-search-record-meter-session-storage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Record Meter: switch noticebox persistence storage from localStorage to sessionStorage

--- a/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
@@ -84,8 +84,8 @@ export function NoticeBox( props ) {
 	const NOTICES = getNotices( props.tierMaximumRecords );
 	const [ showNotice, setShowNotice ] = useState( true );
 
-	// deal with localStorage for ensuring dismissed notice boxs are not re-displayed
-	const dismissedNoticesString = localStorage.getItem( DISMISSED_NOTICES ) ?? '';
+	// deal with sessionStorage for ensuring dismissed notice boxs are not re-displayed
+	const dismissedNoticesString = sessionStorage.getItem( DISMISSED_NOTICES ) ?? '';
 
 	const DATA_NOT_VALID = '1',
 		HAS_NOT_BEEN_INDEXED = '2',
@@ -134,7 +134,7 @@ export function NoticeBox( props ) {
 	const dismissNoticeBox = () => {
 		setShowNotice( false );
 		if ( ! dismissedNoticesString.includes( notice.id ) ) {
-			localStorage.setItem( DISMISSED_NOTICES, dismissedNoticesString + notice.id );
+			sessionStorage.setItem( DISMISSED_NOTICES, dismissedNoticesString + notice.id );
 		}
 	};
 


### PR DESCRIPTION
This tiny PR switches the notice box dismissal/persistence from using localStorage to using sessionStorage

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* On a site with an active Jetpack Search subscription, go to /wp-admin/admin.php?page=jetpack-search&features=record-meter and check there is currently no notice box displaying. 

* toggle off/on the different states `hasBeenIndexed` `hasValidData` and 'hasItems` to trigger the different notices. Note that `hasValidData` being false should resolve a red notice box instead:

| toggle the states in inspector  | red noticed when `hasValidData` is false |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/30754158/161786542-3a6e9a2c-ec79-40dd-9102-c9f729877bda.png)  | ![image](https://user-images.githubusercontent.com/30754158/161787716-b9a5ad54-7ce9-4f17-8324-a47ff3e634df.png)  |

* Try dismissing the notice box using the 'X' in the top right corner of the notice box. It should disappear. When the window is refreshed, dismissed notice should persist. However, other notices should still be able to be displayed (until they too are dismissed)

* When the session is ended (eg. cleared, or in a different browser etc) the notices should once again display. 

