### PR TITLE
Boost: New Screenshots and Readme reference

### DIFF
--- a/projects/plugins/boost/changelog/improve-boost-wordpress-org-screenshots
+++ b/projects/plugins/boost/changelog/improve-boost-wordpress-org-screenshots
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: screenshot reference in readme
+
+

--- a/projects/plugins/boost/readme.txt
+++ b/projects/plugins/boost/readme.txt
@@ -170,7 +170,8 @@ If you run into compatibility issues, please do let us know. You can drop us a l
 
 == Screenshots ==
 
-1. Manage your Jetpack Boost settings
+1. Jetpack Boost Critical CSS Generation
+2. Jetpack Boost Speed Improvement
 
 == Changelog ==
 ### 1.4.2 - 2022-04-11


### PR DESCRIPTION
The WordPress.org readme had an old screenshot. This PR adds reference to the new screenshots - added a before and after speed score screenshot.

#### Changes proposed in this Pull Request:
No changes to Boost code

#### Jetpack product discussion
Not applicable. Small change.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Check that the new screenshots appear on the listing and they have captions
