### PR TITLE
Protect: use data provided by My Jetpack to render Product offer

### DIFF
--- a/projects/plugins/protect/changelog/update-protect-remove-product-mock-data
+++ b/projects/plugins/protect/changelog/update-protect-remove-product-mock-data
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Protect: use data provided by My Jetpack to render Product offer

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -169,6 +169,7 @@ class Jetpack_Protect {
 			'wpVersion'         => $wp_version,
 			'adminUrl'          => admin_url( 'admin.php?page=jetpack-protect' ),
 			'securityBundle'    => My_Jetpack_Products::get_product( 'security' ),
+			'productData'       => My_Jetpack_Products::get_product( 'protect' ),
 		);
 	}
 	/**

--- a/projects/plugins/protect/src/js/components/interstitial/stories/mock.js
+++ b/projects/plugins/protect/src/js/components/interstitial/stories/mock.js
@@ -589,4 +589,32 @@ export const jetpackProtectInitialState = {
 		post_activation_url: '',
 		class: 'Automattic\\Jetpack\\My_Jetpack\\Products\\Security',
 	},
+	productData: {
+		slug: 'protect',
+		name: 'Protect',
+		title: 'Jetpack Protect',
+		description: 'Protect your site and scan for security vulnerabilities.',
+		longDescription:
+			'Protect your site and scan for security vulnerabilities listed in our database.',
+		features: [
+			'Over 20,000 listed vulnerabilities',
+			'Daily automatic scans',
+			'Check plugin and theme version status',
+			'Easy to navigate and use',
+		],
+		status: 'active',
+		pricingForUi: {
+			available: true,
+			isFree: true,
+		},
+		isBundle: false,
+		isUpgradableByBundle: false,
+		supportedProducts: [],
+		wpcomProductSlug: null,
+		requiresUserConnection: false,
+		hasRequiredPlan: true,
+		manageUrl: 'http://localhost/wp-admin/admin.php?page=jetpack-protect',
+		postActivationUrl: 'http://localhost/wp-admin/admin.php?page=jetpack-protect',
+		class: 'Automattic\\Jetpack\\My_Jetpack\\Products\\Protect',
+	},
 };

--- a/projects/plugins/protect/src/js/components/product-offer/index.jsx
+++ b/projects/plugins/protect/src/js/components/product-offer/index.jsx
@@ -7,20 +7,10 @@ import { __ } from '@wordpress/i18n';
 import { ProductOffer } from '@automattic/jetpack-components';
 import { useConnection } from '@automattic/jetpack-connection';
 
-const PROTECT_PRODUCT_MOCK = {
-	slug: 'protect',
-	title: __( 'Protect', 'jetpack-protect' ),
-	description: __(
-		'Protect your site and scan for security vulnerabilities listed in our database.',
-		'jetpack-protect'
-	),
-	features: [
-		__( 'Over 20,000 listed vulnerabilities', 'jetpack-protect' ),
-		__( 'Daily automatic scans', 'jetpack-protect' ),
-		__( 'Check plugin and theme version status', 'jetpack-protect' ),
-		__( 'Easy to navigate and use', 'jetpack-protect' ),
-	],
-};
+/**
+ * Internal dependencies
+ */
+import useProtectData from '../../hooks/use-protect-data';
 
 /**
  * Product Detail component.
@@ -35,6 +25,9 @@ const ConnectedProductOffer = ( { onAdd, ...rest } ) => {
 		skipUserConnection: true,
 	} );
 
+	const { productData } = useProtectData();
+	const { slug, title, longDescription, features, pricingForUi } = productData;
+
 	const onAddHandler = useCallback( () => {
 		if ( onAdd ) {
 			onAdd();
@@ -45,11 +38,11 @@ const ConnectedProductOffer = ( { onAdd, ...rest } ) => {
 
 	return (
 		<ProductOffer
-			slug={ PROTECT_PRODUCT_MOCK.slug }
-			title={ PROTECT_PRODUCT_MOCK.title }
-			description={ PROTECT_PRODUCT_MOCK.description }
-			features={ PROTECT_PRODUCT_MOCK.features }
-			pricing={ { isFree: true } }
+			slug={ slug }
+			title={ title }
+			description={ longDescription }
+			features={ features }
+			pricing={ pricingForUi }
 			isBundle={ false }
 			onAdd={ onAddHandler }
 			buttonText={ __( 'Get started with Jetpack Protect', 'jetpack-protect' ) }

--- a/projects/plugins/protect/src/js/components/product-offer/stories/index.jsx
+++ b/projects/plugins/protect/src/js/components/product-offer/stories/index.jsx
@@ -8,6 +8,11 @@ import React from 'react';
  * Internal dependencies
  */
 import ConnectedProductOffer from '../index.jsx';
+import { initStore } from '../../../state/store';
+import { jetpackProtectInitialState } from '../../interstitial/stories/mock.js';
+
+window.jetpackProtectInitialState = jetpackProtectInitialState;
+initStore();
 
 export default {
 	title: 'Plugins/Protect/Product Offer',

--- a/projects/plugins/protect/src/js/hooks/use-protect-data/index.js
+++ b/projects/plugins/protect/src/js/hooks/use-protect-data/index.js
@@ -83,6 +83,7 @@ export default function useProtectData() {
 		statusIsFetching,
 		status,
 		securityBundle,
+		productData,
 	} = useSelect( select => ( {
 		installedPlugins: select( STORE_ID ).getInstalledPlugins(),
 		installedThemes: select( STORE_ID ).getInstalledThemes(),
@@ -90,6 +91,7 @@ export default function useProtectData() {
 		statusIsFetching: select( STORE_ID ).getStatusIsFetching(),
 		status: select( STORE_ID ).getStatus(),
 		securityBundle: select( STORE_ID ).getSecurityBundle(),
+		productData: select( STORE_ID ).getProductData(),
 	} ) );
 
 	const plugins = mergeInstalledAndCheckedLists( installedPlugins, status.plugins || {} );
@@ -117,5 +119,6 @@ export default function useProtectData() {
 		currentStatus,
 		hasUncheckedItems,
 		securityBundle,
+		productData,
 	};
 }

--- a/projects/plugins/protect/src/js/state/actions.js
+++ b/projects/plugins/protect/src/js/state/actions.js
@@ -10,6 +10,7 @@ const SET_INSTALLED_PLUGINS = 'SET_INSTALLED_PLUGINS';
 const SET_INSTALLED_THEMES = 'SET_INSTALLED_THEMES';
 const SET_WP_VERSION = 'SET_WP_VERSION';
 const SET_SECURITY_BUNDLE = 'SET_SECURITY_BUNDLE';
+const SET_PRODUCT_DATA = 'SET_PRODUCT_DATA';
 
 const setStatus = status => {
 	return { type: SET_STATUS, status };
@@ -58,6 +59,10 @@ const setSecurityBundle = bundle => {
 	return { type: SET_SECURITY_BUNDLE, bundle };
 };
 
+const setProductData = productData => {
+	return { type: SET_PRODUCT_DATA, productData };
+};
+
 const actions = {
 	setStatus,
 	refreshStatus,
@@ -66,6 +71,7 @@ const actions = {
 	setInstalledThemes,
 	setwpVersion,
 	setSecurityBundle,
+	setProductData,
 };
 
 export {

--- a/projects/plugins/protect/src/js/state/reducers.js
+++ b/projects/plugins/protect/src/js/state/reducers.js
@@ -63,6 +63,14 @@ const securityBundle = ( state = {}, action ) => {
 	return state;
 };
 
+const productData = ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SET_SECURITY_BUNDLE:
+			return action.productData;
+	}
+	return state;
+};
+
 const reducers = combineReducers( {
 	status,
 	statusIsFetching,
@@ -70,6 +78,7 @@ const reducers = combineReducers( {
 	installedThemes,
 	wpVersion,
 	securityBundle,
+	productData,
 } );
 
 export default reducers;

--- a/projects/plugins/protect/src/js/state/selectors.js
+++ b/projects/plugins/protect/src/js/state/selectors.js
@@ -5,7 +5,7 @@ const selectors = {
 	getStatusIsFetching: state => state.statusIsFetching || false,
 	getWpVersion: state => state.wpVersion || '',
 	getSecurityBundle: state => state.securityBundle || {},
-	getProduct: state => state.productData || {},
+	getProductData: state => state.productData || {},
 };
 
 export default selectors;

--- a/projects/plugins/protect/src/js/state/selectors.js
+++ b/projects/plugins/protect/src/js/state/selectors.js
@@ -5,6 +5,7 @@ const selectors = {
 	getStatusIsFetching: state => state.statusIsFetching || false,
 	getWpVersion: state => state.wpVersion || '',
 	getSecurityBundle: state => state.securityBundle || {},
+	getProduct: state => state.productData || {},
 };
 
 export default selectors;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR takes advantage of the data provided by My Jetpack to remove the mock product data.

This is a follow-up of https://github.com/Automattic/jetpack/pull/24347.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Protect: use data provided by My Jetpack to render Product offer

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Should not be any visual change in the UI, but anyway:

**Using storybook**
* Go to [Plugins / Protect / Product Offer story](http://localhost:50240/?path=/story/plugins-protect-product-offer--default)
* Confirm the data shown by the component is right
<img width="1016" alt="image" src="https://user-images.githubusercontent.com/77539/168180855-252f956b-c526-4c81-ac22-f2ad2170acc7.png">


**Using Protect plugin page**
* Disconnect the site
* Go to Protect plugin page
* Confirm the data shown there is right
<img width="727" alt="image" src="https://user-images.githubusercontent.com/77539/168180831-3aeaf823-6775-478b-affb-e5ac2f9a566b.png">

* Open the dev console
* Get the protect data using the selector:
```
wp.data.select( 'jetpack-protect' ).getProductData()
```
<img width="649" alt="image" src="https://user-images.githubusercontent.com/77539/168180957-43d9039c-ccf9-4fbf-94fb-710fda2be550.png">




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202270682245411