### PR TITLE
Codesniffer: allow the use of lowercase WordPress

### DIFF
--- a/projects/packages/codesniffer/Jetpack/ruleset.xml
+++ b/projects/packages/codesniffer/Jetpack/ruleset.xml
@@ -70,8 +70,8 @@
 	</rule>
 
 	<!-- This rule, while useful, is not one we'd want to run automatically in a pre-commit hook. -->
-	<rule ref="WordPress.WP.CapitalPDangit.Misspelled">
-		<exclude name="WordPress.WP.CapitalPDangit.Misspelled" />
+	<rule ref="WordPress.WP.CapitalPDangit" phpcbf-only="true">
+		<exclude name="WordPress.WP.CapitalPDangit" />
 	</rule>
 
 </ruleset>

--- a/projects/packages/codesniffer/Jetpack/ruleset.xml
+++ b/projects/packages/codesniffer/Jetpack/ruleset.xml
@@ -69,4 +69,9 @@
 		<exclude name="WordPress.DB.SlowDBQuery"/>
 	</rule>
 
+	<!-- This rule, while useful, is not one we'd want to run automatically in a pre-commit hook. -->
+	<rule ref="WordPress.WP.CapitalPDangit.Misspelled">
+		<exclude name="WordPress.WP.CapitalPDangit.Misspelled" />
+	</rule>
+
 </ruleset>

--- a/projects/packages/codesniffer/changelog/update-ruleset-wordpress
+++ b/projects/packages/codesniffer/changelog/update-ruleset-wordpress
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Rulesets: allow the use of lowercase WordPress.


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

While the rule is important, we currently attempt to autofix PHPCS errors in our pre-commit hook. When this happens and an array key is automatically renamed from wordpress to WordPress for example, we may inadvertently add errors via the automated tools.

Let's not do that.


#### Jetpack product discussion

Related discussion: p1652454457615319-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

* Branch off from this branch.
* Locally, edit an array in a PHP file to add a `'wordpress' => 'bar'` pair. You can do so [here](https://github.com/Automattic/jetpack/blob/e9eeab71ce1644416f6b94f1830742f48b8b7436/projects/plugins/jetpack/modules/custom-post-types/nova.php#L174) for example.
* save your changes, stage and commit.
* Ensure that `wordpress` wasn't automatically updated to `WordPress`.

