### PR TITLE
JS Components: rename split Dialog property. Handle layout on mobile.

### DIFF
--- a/projects/js-packages/components/changelog/update-dialog-component-api
+++ b/projects/js-packages/components/changelog/update-dialog-component-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+JS Components: iterate over Dialog component

--- a/projects/js-packages/components/components/dialog/index.tsx
+++ b/projects/js-packages/components/components/dialog/index.tsx
@@ -14,7 +14,7 @@ import Col from '../layout/col';
 type DialogProps = {
 	primary: React.ReactNode;
 	secondary: React.ReactNode;
-	split?: boolean;
+	twoColumns?: boolean;
 };
 
 /**
@@ -23,12 +23,12 @@ type DialogProps = {
  * @param {object} props                    - React component props.
  * @param {React.ReactNode} props.primary   - Primary content.
  * @param {React.ReactNode} props.secondary - Secondary content.
- * @param {boolean} props.split			    - Split the sections.
+ * @param {boolean} props.twoColumns        - Whether to display the dialog in two columns.
  * @returns {React.ReactNode}                 Rendered dialog
  */
-const Dialog: React.FC< DialogProps > = ( { primary, secondary, split = false } ) => {
+const Dialog: React.FC< DialogProps > = ( { primary, secondary, twoColumns = false } ) => {
 	const classNames = classnames( {
-		[ styles.container ]: ! split,
+		[ styles[ 'one-column-style' ] ]: ! twoColumns,
 	} );
 
 	return (

--- a/projects/js-packages/components/components/dialog/index.tsx
+++ b/projects/js-packages/components/components/dialog/index.tsx
@@ -14,7 +14,7 @@ import useBreakpointMatch from '../layout/use-breakpoint-match';
 
 type DialogProps = {
 	primary: React.ReactNode;
-	secondary: React.ReactNode;
+	secondary?: React.ReactNode;
 	isTwoSections?: boolean;
 };
 
@@ -22,8 +22,8 @@ type DialogProps = {
  * Dialog component.
  *
  * @param {object} props                    - React component props.
- * @param {React.ReactNode} props.primary   - Primary content.
- * @param {React.ReactNode} props.secondary - Secondary content.
+ * @param {React.ReactNode} props.primary   - Primary-section content.
+ * @param {React.ReactNode} props.secondary - Secondary-section content.
  * @param {boolean} props.isTwoSections     - Handle two sections layout when true.
  * @returns {React.ReactNode}                 Rendered dialog
  */

--- a/projects/js-packages/components/components/dialog/index.tsx
+++ b/projects/js-packages/components/components/dialog/index.tsx
@@ -32,8 +32,13 @@ const Dialog: React.FC< DialogProps > = ( { primary, secondary, isTwoSections = 
 		[ styles[ 'one-section-style' ] ]: ! isTwoSections,
 	} );
 
-	// By convention, secondary section is not shown on mobile (`sm` breakpoint).
-	const [ hideSecondarySection ] = useBreakpointMatch( 'sm' );
+	/*
+	 * By convention, secondary section is not shown when:
+	 * - layout is two sections
+	 * - on mobile breakpoint (sm)
+	 */
+	const [ isSmallBreakpoint ] = useBreakpointMatch( 'sm' );
+	const hideSecondarySection = ! isTwoSections && isSmallBreakpoint;
 
 	return (
 		<Container className={ classNames } horizontalSpacing={ 0 } horizontalGap={ 0 } fluid>

--- a/projects/js-packages/components/components/dialog/index.tsx
+++ b/projects/js-packages/components/components/dialog/index.tsx
@@ -10,11 +10,12 @@ import classnames from 'classnames';
 import styles from './style.module.scss';
 import Container from '../layout/container';
 import Col from '../layout/col';
+import useBreakpointMatch from '../layout/use-breakpoint-match';
 
 type DialogProps = {
 	primary: React.ReactNode;
 	secondary: React.ReactNode;
-	twoColumns?: boolean;
+	isTwoSections?: boolean;
 };
 
 /**
@@ -23,22 +24,30 @@ type DialogProps = {
  * @param {object} props                    - React component props.
  * @param {React.ReactNode} props.primary   - Primary content.
  * @param {React.ReactNode} props.secondary - Secondary content.
- * @param {boolean} props.twoColumns        - Whether to display the dialog in two columns.
+ * @param {boolean} props.isTwoSections     - Handle two sections layout when true.
  * @returns {React.ReactNode}                 Rendered dialog
  */
-const Dialog: React.FC< DialogProps > = ( { primary, secondary, twoColumns = false } ) => {
+const Dialog: React.FC< DialogProps > = ( { primary, secondary, isTwoSections = false } ) => {
 	const classNames = classnames( {
-		[ styles[ 'one-column-style' ] ]: ! twoColumns,
+		[ styles[ 'one-section-style' ] ]: ! isTwoSections,
 	} );
+
+	// By convention, secondary section is not shown on mobile (`sm` breakpoint).
+	const [ hideSecondarySection ] = useBreakpointMatch( 'sm' );
 
 	return (
 		<Container className={ classNames } horizontalSpacing={ 0 } horizontalGap={ 0 } fluid>
-			<Col sm={ 4 } md={ 5 } lg={ 7 } className={ styles.primary }>
-				{ primary }
-			</Col>
-			<Col sm={ 4 } md={ 3 } lg={ 5 } className={ styles.secondary }>
-				{ secondary }
-			</Col>
+			{ ! hideSecondarySection && (
+				<>
+					<Col sm={ 4 } md={ 5 } lg={ 7 } className={ styles.primary }>
+						{ primary }
+					</Col>
+					<Col sm={ 4 } md={ 3 } lg={ 5 } className={ styles.secondary }>
+						{ secondary }
+					</Col>
+				</>
+			) }
+			{ hideSecondarySection && <Col>{ primary }</Col> }
 		</Container>
 	);
 };

--- a/projects/js-packages/components/components/dialog/stories/index.tsx
+++ b/projects/js-packages/components/components/dialog/stories/index.tsx
@@ -30,7 +30,7 @@ export default {
 				disable: true,
 			},
 		},
-		twoColumns: {
+		isTwoSections: {
 			table: {
 				disable: true,
 			},
@@ -52,7 +52,7 @@ _default.args = {
 			<h3>4 | 3 | 5</h3>
 		</div>
 	),
-	twoColumns: true,
+	isTwoSections: true,
 };
 
 export const InterstitialJetpackBoost = Template.bind( {} );
@@ -81,7 +81,7 @@ InterstitialJetpackBoost.args = {
 		/>
 	),
 	secondary: <img src={ BoostImage } alt="Boost" />,
-	twoColumns: false,
+	isTwoSections: false,
 };
 
 export const InterstitialJetpackBackup = Template.bind( {} );
@@ -136,5 +136,5 @@ InterstitialJetpackBackup.args = {
 			addProductUrl={ '' }
 		/>
 	),
-	twoColumns: true,
+	isTwoSections: true,
 };

--- a/projects/js-packages/components/components/dialog/stories/index.tsx
+++ b/projects/js-packages/components/components/dialog/stories/index.tsx
@@ -39,9 +39,9 @@ export default {
 
 const Template = args => <Dialog { ...args } />;
 
-export const InterstitialJetpackBoost = Template.bind( {} );
-InterstitialJetpackBoost.parameters = {};
-InterstitialJetpackBoost.args = {
+export const JetpackBoost = Template.bind( {} );
+JetpackBoost.parameters = {};
+JetpackBoost.args = {
 	primary: (
 		<ProductOffer
 			slug="boost"
@@ -68,9 +68,9 @@ InterstitialJetpackBoost.args = {
 	isTwoSections: false,
 };
 
-export const InterstitialJetpackBackup = Template.bind( {} );
-InterstitialJetpackBackup.parameters = {};
-InterstitialJetpackBackup.args = {
+export const JetpackBackup = Template.bind( {} );
+JetpackBackup.parameters = {};
+JetpackBackup.args = {
 	primary: (
 		<ProductOffer
 			slug={ 'backup' }

--- a/projects/js-packages/components/components/dialog/stories/index.tsx
+++ b/projects/js-packages/components/components/dialog/stories/index.tsx
@@ -30,7 +30,7 @@ export default {
 				disable: true,
 			},
 		},
-		split: {
+		twoColumns: {
 			table: {
 				disable: true,
 			},
@@ -52,7 +52,7 @@ _default.args = {
 			<h3>4 | 3 | 5</h3>
 		</div>
 	),
-	split: true,
+	twoColumns: true,
 };
 
 export const InterstitialJetpackBoost = Template.bind( {} );
@@ -81,7 +81,7 @@ InterstitialJetpackBoost.args = {
 		/>
 	),
 	secondary: <img src={ BoostImage } alt="Boost" />,
-	split: false,
+	twoColumns: false,
 };
 
 export const InterstitialJetpackBackup = Template.bind( {} );
@@ -136,5 +136,5 @@ InterstitialJetpackBackup.args = {
 			addProductUrl={ '' }
 		/>
 	),
-	split: true,
+	twoColumns: true,
 };

--- a/projects/js-packages/components/components/dialog/stories/index.tsx
+++ b/projects/js-packages/components/components/dialog/stories/index.tsx
@@ -8,9 +8,8 @@ import React from 'react';
  * Internal dependencies
  */
 import ProductOffer from '../../product-offer';
-import Dialog from '../';
+import Dialog from '..';
 import BoostImage from './boost.png';
-import styles from './style.module.scss';
 
 export default {
 	title: 'JS Packages/Components/Dialog',
@@ -39,21 +38,6 @@ export default {
 };
 
 const Template = args => <Dialog { ...args } />;
-
-export const _default = Template.bind( {} );
-_default.args = {
-	primary: (
-		<div className={ styles.primary }>
-			<h3>4 | 5 | 7</h3>
-		</div>
-	),
-	secondary: (
-		<div className={ styles.secondary }>
-			<h3>4 | 3 | 5</h3>
-		</div>
-	),
-	isTwoSections: true,
-};
 
 export const InterstitialJetpackBoost = Template.bind( {} );
 InterstitialJetpackBoost.parameters = {};

--- a/projects/js-packages/components/components/dialog/stories/index.tsx
+++ b/projects/js-packages/components/components/dialog/stories/index.tsx
@@ -73,17 +73,22 @@ InterstitialJetpackBackup.parameters = {};
 InterstitialJetpackBackup.args = {
 	primary: (
 		<ProductOffer
-			slug="boost"
-			name="Boost"
-			title="Jepack Boost"
-			description="Jetpack Boost gives your site the same performance advantages as the world’s leading websites, no developer required."
+			slug={ 'backup' }
+			name={ 'Backup' }
+			title={ 'Jepack Backup' }
+			description={
+				'Never lose a word, image, page, or time worrying about your site with automated backups & one-click restores.'
+			}
 			features={ [
-				'Check your site performance',
-				'Enable improvements in one click',
-				'Standalone free plugin for those focused on speed',
+				'Real-time cloud backups',
+				'10GB of backup storage',
+				'30-day archive & activity log',
+				'One-click restores',
 			] }
 			pricing={ {
-				isFree: true,
+				currency: 'USD',
+				price: 24.92,
+				offPrice: 12.42,
 			} }
 			isCard={ true }
 			className={ '' }

--- a/projects/js-packages/components/components/dialog/stories/js-components.components.dialog.story.mdx
+++ b/projects/js-packages/components/components/dialog/stories/js-components.components.dialog.story.mdx
@@ -1,0 +1,95 @@
+import { Meta, Source, Story, Canvas } from '@storybook/addon-docs';
+import { Preview } from "@storybook/addon-docs/blocks";
+import dedent from 'ts-dedent';
+import Dialog from '../index';
+import ProductOffer from '../../product-offer';
+import BoostImage from './boost.png';
+import styles from './style.module.scss';
+
+<Meta
+	title="JS Packages/Components/Dialog" component={ Dialog }
+/>
+
+export const Template = ( { isTwoSections } ) => (
+	<Dialog
+		primary= {
+			<div className={ styles.section }>
+				<div>Primary</div>
+				<strong>4 | 5 | 7</strong>
+			</div>
+		}
+		secondary= {
+			<div className={ styles.section }>
+				<div>Secondary</div>
+				<strong>4 | 3 | 5</strong>
+				<div>isTwoSections: <strong>{ isTwoSections ? 'yes' : 'no' }</strong></div>
+			</div>
+		}
+		isTwoSections= { isTwoSections }
+	/>
+);
+
+# Dialog
+
+Render a two-sections layout simple composition, built based on the primary <a href="?path=/docs/js-packages-components-layout--default">Layout component</a>.
+
+<Source
+  language='jsx'
+  code={dedent`
+import Dialog from '@automattic/jetpack-components';
+// ...
+	
+<Dialog
+  primary={ <PrimaryComponent /> }
+  secondary={ <SecondaryComponent /> }
+  isTwoSections={ true }
+/>
+`}
+/>
+
+<Story
+	name="1. Basic"
+	args={ {
+		isTwoSections: true,
+	} }
+>
+	{ Template.bind( {} ) }
+</Story>
+
+The cols number for each section depends on the viewport width. The following table shows how they are defined:
+
+ &nbsp; | Small (sm) | Medium (md) | Large (lg) 
+------|------|------|-----
+primary | 4 | 5 | 7
+secondary | 4 | 3 | 5
+
+Finally, when the Dialog is defined as not a two-sections layout (<a href="#istwosections">isTwoSections property</a>), the secondary section won't show in Mobile (sm breakpoint).
+
+## API
+
+The components accepts the following properties:
+
+
+### primary
+
+- Type: `React.ReactNode`, `string`.
+
+Primary-section content.
+
+### secondary
+
+- Type: `React.ReactNode`, `string`.
+- Optional.
+
+Primary-section content.
+
+
+### isTwoSections
+
+- Type: `boolean`.
+- Optional.
+- Default: `false`
+
+It handles two sections layout:
+  - Add card styles to the main wrapper when it is not a two-sections layout.
+  - When it's false, the secondary section won't show in Mobile.

--- a/projects/js-packages/components/components/dialog/stories/js-components.components.dialog.story.mdx
+++ b/projects/js-packages/components/components/dialog/stories/js-components.components.dialog.story.mdx
@@ -48,7 +48,7 @@ import Dialog from '@automattic/jetpack-components';
 />
 
 <Story
-	name="1. Basic"
+	name="Readme"
 	args={ {
 		isTwoSections: true,
 	} }

--- a/projects/js-packages/components/components/dialog/stories/style.module.scss
+++ b/projects/js-packages/components/components/dialog/stories/style.module.scss
@@ -1,12 +1,21 @@
-.primary,
-.secondary {
-	width: 100%;
-	background-color: #AFF;
-	padding: 64px;
-	border: 1px solid #a4e;
-	box-sizing: border-box;
-	display: flex;
-	justify-content: center;
-	align-items: center;
 
+.section {
+	display: flex;
+	padding: calc( var( --spacing-base ) * 6 ) 0;
+	border: 1px dotted var( --jp-green-60 );
+	box-sizing: border-box;
+	align-items: center;
+	color: var( --jp-white );
+	flex-wrap: nowrap;
+    flex-direction: column;
+	justify-content: space-between;
+	height: calc( var( --spacing-base ) * 20 );
+	flex-grow: 2;
+	background: repeating-linear-gradient(
+		-45deg,
+		var( --jp-green-50 ),
+		var( --jp-green-50 ) 20px,
+		var( --jp-green-60 ) 20px,
+		var( --jp-green-60 ) 40px
+	);
 }

--- a/projects/js-packages/components/components/dialog/style.module.scss
+++ b/projects/js-packages/components/components/dialog/style.module.scss
@@ -1,4 +1,4 @@
-.one-column-style {
+.one-section-style {
 	--product-card-shadow: rgb(0 0 0 / 3%);
 	background-color: var( --jp-white );
 	border: 1px solid var( --jp-gray );
@@ -18,6 +18,7 @@
 	}
 }
 
+// Fit images in secondary section.
 .secondary {
 	align-items: center;
 	img {

--- a/projects/js-packages/components/components/dialog/style.module.scss
+++ b/projects/js-packages/components/components/dialog/style.module.scss
@@ -1,5 +1,4 @@
-.container {
-	// Card main wrapper
+.one-column-style {
 	--product-card-shadow: rgb(0 0 0 / 3%);
 	background-color: var( --jp-white );
 	border: 1px solid var( --jp-gray );

--- a/projects/js-packages/components/components/text/stories/Text-MDX-Documentation.mdx
+++ b/projects/js-packages/components/components/text/stories/Text-MDX-Documentation.mdx
@@ -1,4 +1,4 @@
-import { Meta, Source, Story, Canvas } from '@storybook/addon-docs';
+import { Meta, Source, Story } from '@storybook/addon-docs';
 import dedent from 'ts-dedent';
 import Text, { BOX_MODEL_VALUES, H2, H3, Title } from '../index';
 

--- a/projects/plugins/protect/changelog/update-dialog-component-api
+++ b/projects/plugins/protect/changelog/update-dialog-component-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+JS Components: iterate over Dialog component

--- a/projects/plugins/protect/src/js/components/footer/index.jsx
+++ b/projects/plugins/protect/src/js/components/footer/index.jsx
@@ -120,7 +120,7 @@ const Footer = () => {
 						/>
 					}
 					secondary={ <FooterInfo /> }
-					split={ true }
+					isTwoSections={ true }
 				/>
 			</Col>
 		</Container>

--- a/projects/plugins/protect/src/js/components/interstitial/index.jsx
+++ b/projects/plugins/protect/src/js/components/interstitial/index.jsx
@@ -62,7 +62,7 @@ const Interstitial = ( { onSecurityAdd, securityJustAdded } ) => {
 		<Dialog
 			primary={ <ConnectedProductOffer isCard={ true } /> }
 			secondary={ <SecurityBundle onAdd={ onSecurityAdd } redirecting={ securityJustAdded } /> }
-			split={ true }
+			isTwoSections={ true }
 		/>
 	);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR iterates over the Dialog component.

1. Rename the `split` property by `isTwoSections`.
    It's more aligned with the design terminology.
3. Start to handle layout on mobile.
    Taking advantage of the new `useBreakpointsMatch()` hook, it shows or hides the `secondary` section when the Dialog is in one-section mode. Next issues will be addressed in follow-up PRs
4. General Dialog stories improvements.
5. Defines `secondary` Dialog property as optional.

Some points to keep in mind:

* most of the changes are about Dialog stories.  Not a big deal.
* `<Dialog />` component is used only by the Protect plugin, reducing the probability of adding breaking changes.


There is still stuff to tweak in mobile: margins, padding, etc. It's going to be handled in a follow-up PR.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* JS Components: rename `split` Dialog property.
* Handle layout on mobile.
* Improve Dialog stories
* Update Protect plugin with these changes

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Using Storybook
* Check the Dialog stories.
  * Documentation
  * Check how it does work when resizing the viewport


https://user-images.githubusercontent.com/77539/168491053-dd29939d-e68f-44c1-9f78-78c82e4d3964.mov

**Protect Plugins**
The Dialog is used by the Interstitial and the Footer component of Protect plugin. Take a look at both pages.
Confirm no changes here.

Disclaimer: The Storybook doesn't show the story properly for some reason. Please do a hard refresh to show the story ok.

Interstitial | Footer
------|------
<img width="1002" alt="image" src="https://user-images.githubusercontent.com/77539/168491189-12a87fd4-1366-4c36-a7e7-d54b23f67876.png"> | <img width="1164" alt="image" src="https://user-images.githubusercontent.com/77539/168491214-4bb2f354-5fb4-44e4-8efb-cbd293a49701.png">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202279494116122