### PR TITLE
[Boost] - Fix for blue outline on settings and connection page

### DIFF
--- a/projects/plugins/boost/app/assets/src/css/main/dashboard.scss
+++ b/projects/plugins/boost/app/assets/src/css/main/dashboard.scss
@@ -18,6 +18,10 @@
   	overflow-x: hidden;
 }
 
+*:focus-visible {
+	outline: none;
+}
+
 .jb-section {
 	padding-top: $padding;
 	padding-bottom: $padding;

--- a/projects/plugins/boost/changelog/style fixes
+++ b/projects/plugins/boost/changelog/style fixes
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: minor scss improvement
+
+


### PR DESCRIPTION
Fixes #24379 - Blue outline on first load of plugin

#### Changes proposed in this Pull Request:
This removes the blue outline on first load. It looks to be driven by tabindex-1 being added to the element (adding a focus) which could be a svelte kit issue or a general WordPress issue.

It doesn't look like this impacts the accessibility use of the plugin itself as it was highlighting titles rather than interactive elements (like next buttons)

#### Jetpack product discussion
Minor change. Small discussion in slack.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
In trunk when you first load the plugin blue outlines appear for a moment and then vanish when the focus has gone. This branch fixes it through CSS.

<img width="1456" alt="Screenshot 2022-05-16 at 12 29 41" src="https://user-images.githubusercontent.com/4077604/168591749-b2795348-ed9a-4b00-83a0-01a135f2a63c.png">


* Either the settings page or the connection page
* With chrome developer tools open, right click and "Empty Cache and Hard Reload"
* A blue outline appears

It may even appear on normal refresh for you, but forcing a hard reload causes it to appear for me.
