### PR TITLE
Track boost deactivation

### DIFF
--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -118,7 +118,6 @@ class Jetpack_Boost {
 	 */
 	public function deactivate() {
 		do_action( 'jetpack_boost_deactivate' );
-		Analytics::record_user_event( 'clear_cache' );
 		Analytics::record_user_event( 'deactivate_plugin' );
 		Admin::clear_dismissed_notices();
 	}

--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -119,6 +119,7 @@ class Jetpack_Boost {
 	public function deactivate() {
 		do_action( 'jetpack_boost_deactivate' );
 		Analytics::record_user_event( 'clear_cache' );
+		Analytics::record_user_event( 'deactivate_plugin' );
 		Admin::clear_dismissed_notices();
 	}
 

--- a/projects/plugins/boost/changelog/add-track-boost-deactivation
+++ b/projects/plugins/boost/changelog/add-track-boost-deactivation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+


### PR DESCRIPTION
Fixes 42-gh-Automattic/boost-shield-api

#### Changes proposed in this Pull Request:
* Track Boost deactivation

#### Jetpack product discussion
pbNhbs-2k2-p2#comment-7439

#### Does this pull request change what data or activity we track or use?
Yes, the plugin now tracks when it is deactivated.
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
* Activate Jetpack Boost
* Deactivate Jetpack Boost
* Search event name `jetpack_boost_deactivate_plugin` in tracks