### PR TITLE
Boost: Update Cloud CSS timeout error message

### DIFF
--- a/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
+++ b/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
@@ -90,7 +90,7 @@ class Critical_CSS_State {
 	 */
 	private function check_for_timeout() {
 		if ( self::REQUESTING === $this->state && ( microtime( true ) - $this->created ) > HOUR_IN_SECONDS ) {
-			$this->set_as_failed( 'timeout' );
+			$this->set_as_failed( __( 'Timeout while waiting for Critical CSS from the Boost Service.', 'jetpack-boost' ) );
 		}
 	}
 

--- a/projects/plugins/boost/changelog/update-cloud-css-timeout-error
+++ b/projects/plugins/boost/changelog/update-cloud-css-timeout-error
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Updated descriptive Cloud CSS timeout error message.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR partially addresses #24115 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updated descriptive Cloud CSS timeout error message.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
NA

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Define a small timeout window by updating [HOUR_IN_SECONDS](https://github.com/Automattic/jetpack/blob/master/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php#L92)
* Update Cloud CSS to never generate CSS by updating [request_generate](https://github.com/Automattic/jetpack/blob/master/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS.php#L125)
* Visit Jetpack Boost plugin Dashboard
* Enable "Automatically Optimize CSS Loading" or click "Refresh"
* Wait for the timeout and ensure that the following message is displayed: "Timeout while waiting for Critical CSS from the Boost Service"
