### PR TITLE
Search: Remove search widget cta on uneligible themes

### DIFF
--- a/projects/plugins/jetpack/_inc/client/performance/search.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/search.jsx
@@ -20,6 +20,7 @@ import { ModuleToggle } from 'components/module-toggle';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
+import { currentThemeSupports } from 'state/initial-state';
 
 const SEARCH_DESCRIPTION = __(
 	'Incredibly powerful and customizable, Jetpack Search helps your visitors instantly find the right content – right when they need it.',
@@ -119,6 +120,7 @@ function Search( props ) {
 				) }
 			</SettingsGroup>
 			{ ! props.isLoading &&
+				props.isWidgetsSupported &&
 				( props.hasClassicSearch || props.hasInstantSearch ) &&
 				isModuleEnabled &&
 				! isInstantSearchEnabled && (
@@ -153,5 +155,6 @@ export default connect( state => {
 			! isSettingActivated( state, 'search' ) &&
 			! isUpdatingSetting( state, 'search' ) &&
 			false === hasUpdatedSetting( state, 'search' ),
+		isWidgetsSupported: currentThemeSupports( state, 'widgets' ),
 	};
 } )( withModuleSettingsFormHelpers( Search ) );

--- a/projects/plugins/jetpack/_inc/client/performance/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/performance/test/component.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import Search  from '../search';
+import { buildInitialState } from './fixtures';
+import { render, screen, within } from 'test/test-utils';
+
+describe.only( 'Performance tab', () => {
+	it( "shows Jetpack Search Widget button if theme supports it", () => {
+		render( <Search />, {
+			initialState: buildInitialState( { themeSupportsWidgets: true } ),
+		} );
+
+		expect( screen.getByText( 'Add Jetpack Search Widget' ) ).to.be.not.null;
+	} );
+
+	it( "hides Jetpack Search Widget button if theme does not support it", () => {
+		render( <Search />, {
+			initialState: buildInitialState( { themeSupportsWidgets: false } ),
+		} );
+
+		expect( screen.queryByText( 'Add Jetpack Search Widget' ) ).to.be.null;
+	} );
+} );

--- a/projects/plugins/jetpack/_inc/client/performance/test/fixtures.js
+++ b/projects/plugins/jetpack/_inc/client/performance/test/fixtures.js
@@ -1,0 +1,79 @@
+function siteDataFixture( ) {
+	return {
+		requests: {
+			isFetchingSiteDiscount: false,
+			isFetchingSitePurchases: false
+		},
+		data: {
+			site: {
+				features: {
+					active: [ 'search' ]
+				}
+			}
+		},
+	};
+}
+
+/**
+ * Build an object that can be used as a Redux store initial state.
+ *
+ * @param {object} options
+ * @param {boolean} options.themeSupportsWidgets – whether the current theme supports widgets
+ * @returns {object} – initial Redux state
+ */
+export function buildInitialState( {
+	themeSupportsWidgets= false,
+} = {} ) {
+	return {
+		jetpack: {
+			initialState: {
+				userData: {
+					currentUser: {
+						permissions: {
+							manage_modules: true
+						}
+					},
+				},
+				themeData: {
+					support: {
+						widgets: themeSupportsWidgets,
+					},
+				},
+			},
+			modules: {
+				items: {}
+			},
+			dashboard: {
+				requests: {
+					checkingAkismetKey: true
+				}
+			},
+			connection: {
+				status: {
+					siteConnected: {
+						offlineMode: {
+							isActive: false,
+						},
+						isActive: true
+					},
+				},
+				user: {
+					currentUser: {
+						isConnected: true,
+					},
+				},
+			},
+			settings: {
+				items: {
+					search: true
+				},
+				requests: {
+					settingsSent: {
+						search: true
+					}
+				}
+			},
+			siteData: siteDataFixture(),
+		},
+	};
+}

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -184,6 +184,7 @@ class Jetpack_Redux_State_Helper {
 				'hasUpdate' => (bool) get_theme_update_available( $current_theme ),
 				'support'   => array(
 					'infinite-scroll' => current_theme_supports( 'infinite-scroll' ) || in_array( $current_theme->get_stylesheet(), $inf_scr_support_themes, true ),
+					'widgets'         => current_theme_supports( 'widgets' ),
 					'webfonts'        => WP_Theme_JSON_Resolver::theme_has_support() && function_exists( 'wp_register_webfont_provider' ) && function_exists( 'wp_register_webfonts' ),
 				),
 			),

--- a/projects/plugins/jetpack/changelog/fix-remove-search-widget-cta-on-uneligible-themes
+++ b/projects/plugins/jetpack/changelog/fix-remove-search-widget-cta-on-uneligible-themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Remove search widget CTA on uneligible themes

--- a/projects/plugins/jetpack/tests/php/_inc/lib/test-class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/test-class-jetpack-redux-state-helper.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Redux State Helper unit tests.
+ *
+ * @package automattic/jetpack
+ */
+
+jetpack_require_lib( 'admin-pages/class-jetpack-redux-state-helper' );
+
+/**
+ * Class for testing the Jetpack_Redux_State_Helper class.
+ *
+ * @coversDefaultClass Jetpack_Redux_State_Helper
+ */
+class WP_Test_Jetpack_Redux_State_Helper extends WP_UnitTestCase {
+	/**
+	 * Tests whether get_initial_state() signals that the theme supports widgets.
+	 *
+	 * @covers ::get_initial_state
+	 */
+	public function test_theme_support_widgets() {
+		add_theme_support( 'widgets' );
+
+		$redux_state = Jetpack_Redux_State_Helper::get_initial_state();
+		$this->assertSame( true, $redux_state['themeData']['support']['widgets'] );
+	}
+
+	/**
+	 * Tests whether get_initial_state() signals that the theme does not support widgets.
+	 *
+	 * @covers ::get_initial_state
+	 */
+	public function test_theme_do_not_support_widgets() {
+		_remove_theme_support( 'widgets' );
+
+		$redux_state = Jetpack_Redux_State_Helper::get_initial_state();
+		$this->assertSame( false, $redux_state['themeData']['support']['widgets'] );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/_inc/lib/test-class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/test-class-jetpack-redux-state-helper.php
@@ -14,6 +14,33 @@ jetpack_require_lib( 'admin-pages/class-jetpack-redux-state-helper' );
  */
 class WP_Test_Jetpack_Redux_State_Helper extends WP_UnitTestCase {
 	/**
+	 * Theme features.
+	 *
+	 * @var array
+	 */
+	private $theme_features;
+
+	/**
+	 * Saving the original theme features.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		global $_wp_theme_features;
+		$this->theme_features = $_wp_theme_features;
+	}
+
+	/**
+	 * Restoring the original theme features.
+	 */
+	public function tear_down() {
+		global $_wp_theme_features;
+
+		$_wp_theme_features = $this->theme_features;
+		parent::tear_down();
+	}
+
+	/**
 	 * Tests whether get_initial_state() signals that the theme supports widgets.
 	 *
 	 * @covers ::get_initial_state


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/60362

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes search widget CTA in "WP Admin -> Jetpack -> Settings -> Performance  -> Search" on uneligible themes. Before the change, the search widget was displayed regardless of widget support in the currently used theme.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

##### Theme that supports widgets

* Log in to WP Admin
* Ensure that the site uses a theme that supports widgets eg. "Blask"
* Go to "Jetpack -> Settings" and then open the "Performance" tab
* Enable "search" and disable "instant search experience"
* Validate that the "Add Jetpack Search Widget" button exists in the "Search" panel

![theme-with-widgets](https://user-images.githubusercontent.com/727413/168759908-0120e40b-a681-4501-957b-ae8627abff0d.png)

##### Theme that does not support widgets

* Log in to WP Admin
* Ensure that the site uses a theme that doesn't support widgets eg. "Twenty Twenty-Two" or "Blockbase"
* Go to "Jetpack -> Settings" and then open the "Performance" tab
* Enable "search" and disable "instant search experience"
* Validate that the "Add Jetpack Search Widget" button does not exist in the "Search" panel

![theme-without-widgets](https://user-images.githubusercontent.com/727413/168759935-0769fab6-7561-49a3-b50f-037b57d0e098.png)

