### PR TITLE
Update "Confirmation request" email default body

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscriptions-confirmation-request-email-default-body
+++ b/projects/plugins/jetpack/changelog/update-subscriptions-confirmation-request-email-default-body
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Email subscriptions: Update the default body of the "Confirmation request" email

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -574,8 +574,12 @@ class Jetpack_Subscriptions {
 	 * Get default settings for the Subscriptions module.
 	 */
 	public function get_default_settings() {
+		$site_url = get_home_url();
+		$base_url = basename( $site_url );
+
 		return array(
-			'invitation'     => __( "Howdy.\n\nYou recently followed this blog's posts. This means you will receive each new post by email.\n\nTo activate, click confirm below. If you believe this is an error, ignore this message and we'll never bother you again.", 'jetpack' ),
+			/* translators: Both %1$s and %2$s is site address */
+			'invitation'     => sprintf( __( "Howdy,\nYou recently subscribed to <a href='%1\$s'>%2\$s</a> and we need to verify the email you provided. Once you confirm below, you'll be able to receive and read new posts.\n\nIf you believe this is an error, ignore this message and nothing more will happen.", 'jetpack' ), $site_url, $base_url ),
 			'comment_follow' => __( "Howdy.\n\nYou recently followed one of my posts. This means you will receive an email when new comments are posted.\n\nTo activate, click confirm below. If you believe this is an error, ignore this message and we'll never bother you again.", 'jetpack' ),
 		);
 	}

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -574,12 +574,12 @@ class Jetpack_Subscriptions {
 	 * Get default settings for the Subscriptions module.
 	 */
 	public function get_default_settings() {
-		$site_url = get_home_url();
-		$base_url = basename( $site_url );
+		$site_url    = get_home_url();
+		$display_url = preg_replace( '(^https?://)', '', untrailingslashit( $site_url ) );
 
 		return array(
 			/* translators: Both %1$s and %2$s is site address */
-			'invitation'     => sprintf( __( "Howdy,\nYou recently subscribed to <a href='%1\$s'>%2\$s</a> and we need to verify the email you provided. Once you confirm below, you'll be able to receive and read new posts.\n\nIf you believe this is an error, ignore this message and nothing more will happen.", 'jetpack' ), $site_url, $base_url ),
+			'invitation'     => sprintf( __( "Howdy,\nYou recently subscribed to <a href='%1\$s'>%2\$s</a> and we need to verify the email you provided. Once you confirm below, you'll be able to receive and read new posts.\n\nIf you believe this is an error, ignore this message and nothing more will happen.", 'jetpack' ), $site_url, $display_url ),
 			'comment_follow' => __( "Howdy.\n\nYou recently followed one of my posts. This means you will receive an email when new comments are posted.\n\nTo activate, click confirm below. If you believe this is an error, ignore this message and we'll never bother you again.", 'jetpack' ),
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The proposed change updates the default "Blog follow email text" setting (in `wp-admin/options-reading.php`). The new default copy is used in the "Confirmation Request" email template:

![Markup on 2022-05-17 at 15:28:31](https://user-images.githubusercontent.com/25105483/168822291-d4b0a8f4-b6d3-4023-a334-9a5be1ba3296.png)

Before:
![Markup on 2022-05-17 at 15:31:51](https://user-images.githubusercontent.com/25105483/168822948-37c5a867-b642-49e9-b938-d758a166520c.png)

After:
![Markup on 2022-05-17 at 15:06:02](https://user-images.githubusercontent.com/25105483/168821687-5e79b3e6-ddb0-4fc1-9d82-7a4f46b083cf.png)

#### Jetpack product discussion
- related Slack discussion: p1652335378623919-slack-C02TCEHP3HA
- related WPCOM patch: D80915-code

#### Does this pull request change what data or activity we track or use?
No, it does not.

#### Testing instructions:

Make sure the Subscriptions are enabled:
![Markup on 2022-05-17 at 17:46:38](https://user-images.githubusercontent.com/25105483/168853766-ae7f9f33-7ac3-411a-9761-7e43b88eb4fb.png)

1. Apply the PR
2. Navigate to `wp-admin/options-reading.php` settings page and make sure the new default text is displayed
3. If you replaced the default text with a custom one before, the proposed change won't have any effect on that custom text


