### PR TITLE
Protect: polish interstitial page in medium viewport size

### DIFF
--- a/projects/js-packages/components/changelog/update-protect-interstial-md-size
+++ b/projects/js-packages/components/changelog/update-protect-interstial-md-size
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Protect: improve Dialog layout in medium viewport size

--- a/projects/js-packages/components/components/dialog/index.tsx
+++ b/projects/js-packages/components/components/dialog/index.tsx
@@ -28,27 +28,28 @@ type DialogProps = {
  * @returns {React.ReactNode}                 Rendered dialog
  */
 const Dialog: React.FC< DialogProps > = ( { primary, secondary, isTwoSections = false } ) => {
+	const [ isSmall, isLowerThanLarge ] = useBreakpointMatch( [ 'sm', 'lg' ], [ null, '<' ] );
+
 	/*
 	 * By convention, secondary section is not shown when:
-	 * - layout is two sections
+	 * - layout is a two-sections setup
 	 * - on mobile breakpoint (sm)
 	 */
-	const [ isSmallBreakpoint ] = useBreakpointMatch( 'sm' );
-	const hideSecondarySection = ! isTwoSections && isSmallBreakpoint;
+	const hideSecondarySection = ! isTwoSections && isSmall;
 
 	const classNames = classnames( {
 		[ styles[ 'one-section-style' ] ]: ! isTwoSections,
-		[ styles[ 'is-viewport-small' ] ]: isSmallBreakpoint,
+		[ styles[ 'is-viewport-small' ] ]: isSmall,
 	} );
 
 	return (
 		<Container className={ classNames } horizontalSpacing={ 0 } horizontalGap={ 0 } fluid>
 			{ ! hideSecondarySection && (
 				<>
-					<Col sm={ 4 } md={ 5 } lg={ 7 } className={ styles.primary }>
+					<Col sm={ 4 } md={ isLowerThanLarge ? 4 : 5 } lg={ 7 } className={ styles.primary }>
 						{ primary }
 					</Col>
-					<Col sm={ 4 } md={ 3 } lg={ 5 } className={ styles.secondary }>
+					<Col sm={ 4 } md={ isLowerThanLarge ? 4 : 3 } lg={ 5 } className={ styles.secondary }>
 						{ secondary }
 					</Col>
 				</>

--- a/projects/plugins/protect/changelog/update-protect-interstial-md-size
+++ b/projects/plugins/protect/changelog/update-protect-interstial-md-size
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Protect: improve Dialog layout in medium viewport size

--- a/projects/plugins/protect/src/js/components/interstitial/index.jsx
+++ b/projects/plugins/protect/src/js/components/interstitial/index.jsx
@@ -2,15 +2,16 @@
  * External dependencies
  */
 import React from 'react';
-import { Dialog, ProductOffer } from '@automattic/jetpack-components';
+import { Dialog, ProductOffer, useBreakpointMatch } from '@automattic/jetpack-components';
 
 /**
  * Internal dependencies
  */
 import ConnectedProductOffer from '../product-offer';
 import useProtectData from '../../hooks/use-protect-data';
+import styles from './styles.module.scss';
 
-const SecurityBundle = ( { onAdd, redirecting, rest } ) => {
+const SecurityBundle = ( { onAdd, redirecting, ...rest } ) => {
 	const { securityBundle } = useProtectData();
 	const {
 		name,
@@ -58,10 +59,19 @@ const SecurityBundle = ( { onAdd, redirecting, rest } ) => {
  * @returns {React.Component} Interstitial react component.
  */
 const Interstitial = ( { onSecurityAdd, securityJustAdded } ) => {
+	const [ isMediumSize ] = useBreakpointMatch( 'md' );
+	const mediaClassName = isMediumSize ? styles[ 'is-viewport-medium' ] : null;
+
 	return (
 		<Dialog
-			primary={ <ConnectedProductOffer isCard={ true } /> }
-			secondary={ <SecurityBundle onAdd={ onSecurityAdd } redirecting={ securityJustAdded } /> }
+			primary={ <ConnectedProductOffer className={ mediaClassName } isCard={ true } /> }
+			secondary={
+				<SecurityBundle
+					className={ mediaClassName }
+					onAdd={ onSecurityAdd }
+					redirecting={ securityJustAdded }
+				/>
+			}
 			isTwoSections={ true }
 		/>
 	);

--- a/projects/plugins/protect/src/js/components/interstitial/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/interstitial/styles.module.scss
@@ -1,0 +1,3 @@
+.is-viewport-medium {
+	padding: calc( var( --spacing-base ) * 6 ) calc( var( --spacing-base ) * 4 );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR reduces the padding in both sections of the Interstitial page when on medium viewport size.
Also, it sets up the Dialog layout depending on this breakpoint, from `5 | 3` to `4 | 4`

Disclaimer: there is still an issue that we need to tackle to make the UI better in different screen sizes.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Set up the Dialog grid depending on the viewport size.
* Tweak primary and secondary sections of Dialog in small and medium viewport sizes

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Protect dashboard
* Disconnect the site in case it's already connected
* Take a look at the interstitial page
* play with the viewport size. You'd like to use the mobile tool of our client
* Confirm the page looks better

before  | after
------|-------
<img width="921" alt="image" src="https://user-images.githubusercontent.com/77539/168844120-6e427f5a-7dcb-478e-a1a7-4be6763e1068.png"> | <img width="918" alt="image" src="https://user-images.githubusercontent.com/77539/168843763-5350de39-5bc2-40c5-80fd-7ad6a0e019de.png">
<img width="946" alt="image" src="https://user-images.githubusercontent.com/77539/168883562-8319bd51-8043-4676-bb56-01475866e884.png"> | <img width="947" alt="image" src="https://user-images.githubusercontent.com/77539/168883488-21741b26-10de-4cde-8daf-9dc0efdba24b.png"> 



