### PR TITLE
Protect: Introduce `Navigation` dropdown mode

### DIFF
--- a/projects/plugins/protect/changelog/update-protect-small-viewport-list-navigation
+++ b/projects/plugins/protect/changelog/update-protect-small-viewport-list-navigation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Protect: Add Navigation dropdown mode and use it for small/medium screens

--- a/projects/plugins/protect/src/js/components/navigation/group.jsx
+++ b/projects/plugins/protect/src/js/components/navigation/group.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useContext } from 'react';
 import { Button } from '@automattic/jetpack-components';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -10,12 +10,15 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import styles from './styles.module.scss';
 import ItemLabel from './label';
+import { NavigationContext } from './use-menu-navigation';
 
 const MAX_ITEMS = 8;
 
 const NavigationGroup = ( { icon, label, children } ) => {
 	const [ collapsed, setCollapsed ] = useState( true );
-	const needsTruncate = Array.isArray( children ) && children?.length >= MAX_ITEMS;
+	const { mode } = useContext( NavigationContext );
+	const needsTruncate =
+		Array.isArray( children ) && children?.length >= MAX_ITEMS && mode === 'list';
 	const content = needsTruncate && collapsed ? children.slice( 0, MAX_ITEMS ) : children;
 	const totalHideItems = needsTruncate ? children?.length - MAX_ITEMS : 0;
 

--- a/projects/plugins/protect/src/js/components/navigation/index.jsx
+++ b/projects/plugins/protect/src/js/components/navigation/index.jsx
@@ -1,8 +1,10 @@
 /**
  * External dependencies
  */
-import React from 'react';
-
+import React, { useState, useRef, useCallback } from 'react';
+import { Popover } from '@wordpress/components';
+import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
+import { Text } from '@automattic/jetpack-components';
 /**
  * Internal dependencies
  */
@@ -10,15 +12,63 @@ import styles from './styles.module.scss';
 import NavigationItem from './item';
 import NavigationGroup from './group';
 import useMenuNavigation, { NavigationContext } from './use-menu-navigation';
+import classNames from 'classnames';
 
-const Navigation = ( { children, selected, onSelect } ) => {
-	const data = useMenuNavigation( { selected, onSelect } );
+const NavigationList = ( { children } ) => (
+	<ul className={ styles.navigation } role="menu">
+		{ children }
+	</ul>
+);
+
+const NavigationDropdown = ( { children, data } ) => {
+	const ref = useRef();
+	const [ listOpen, setListOpen ] = useState( false );
+	const item = data?.items?.find( navItem => navItem?.id === data?.selectedItem ) ?? {};
+	const { label, icon } = item;
+
+	const handleOpen = useCallback( () => {
+		setListOpen( open => ! open );
+	}, [] );
 
 	return (
-		<NavigationContext.Provider value={ data }>
-			<ul className={ styles.navigation } role="menu">
-				{ children }
-			</ul>
+		<button className={ styles[ 'navigation-dropdown-button' ] } onClick={ handleOpen } ref={ ref }>
+			<div className={ styles[ 'navigation-dropdown-label' ] }>
+				{ icon && <Icon icon={ icon } className={ styles[ 'navigation-dropdown-icon' ] } /> }
+				<Text>{ label }</Text>
+			</div>
+			<Icon icon={ listOpen ? chevronUp : chevronDown } size={ 32 } />
+			<Popover
+				position="bottom center"
+				anchorRef={ ref?.current }
+				className={ classNames( {
+					[ styles[ 'navigation-dropdown-open' ] ]: listOpen,
+					[ styles[ 'navigation-dropdown-closed' ] ]: ! listOpen,
+				} ) }
+			>
+				<div style={ { width: ref?.current?.getBoundingClientRect?.()?.width } }>{ children }</div>
+			</Popover>
+		</button>
+	);
+};
+
+const getNavigationComponent = mode => {
+	switch ( mode ) {
+		case 'list':
+			return NavigationList;
+		case 'dropdown':
+			return NavigationDropdown;
+		default:
+			return NavigationList;
+	}
+};
+
+const Navigation = ( { children, selected, onSelect, mode = 'list' } ) => {
+	const data = useMenuNavigation( { selected, onSelect } );
+	const Component = getNavigationComponent( mode );
+
+	return (
+		<NavigationContext.Provider value={ { ...data, mode } }>
+			<Component data={ data }>{ children }</Component>
 		</NavigationContext.Provider>
 	);
 };

--- a/projects/plugins/protect/src/js/components/navigation/item.jsx
+++ b/projects/plugins/protect/src/js/components/navigation/item.jsx
@@ -69,7 +69,7 @@ const NavigationItem = ( {
 	);
 
 	useEffect( () => {
-		registerItem( { id, disabled } );
+		registerItem( { id, disabled, label, icon } );
 		// eslint-disable-next-line
 	}, [] );
 

--- a/projects/plugins/protect/src/js/components/navigation/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/navigation/styles.module.scss
@@ -100,10 +100,42 @@
 
 	&-truncate {
 		padding: calc( var(--spacing-base) * 2 ); // 16px;
+		display: flex;
+		justify-content: flex-start;
 	}
 }
 
 .popover-text {
 	width: 250px;
 	padding: calc( var(--spacing-base) * 2 ); // 16px
+}
+
+.navigation-dropdown {
+	&-button {
+		display: flex;
+		border: 1px solid var(--jp-gray-10);
+		border-radius: var(--jp-border-radius);
+		padding: calc( var(--spacing-base) * 2 ); // 16px;
+		background-color: var(--jp-white);
+		justify-content: space-between;
+		align-items: center;
+		width: 100%;
+	}
+
+	&-label {
+		display: flex;
+		justify-content: flex-start;
+	}
+
+	&-icon {
+		margin-right: var(--spacing-base);
+	}
+
+	&-open {
+		display: block;
+	}
+
+	&-closed {
+		display: none;
+	}
 }

--- a/projects/plugins/protect/src/js/components/navigation/use-menu-navigation.js
+++ b/projects/plugins/protect/src/js/components/navigation/use-menu-navigation.js
@@ -88,6 +88,7 @@ const useMenuNavigation = ( { selected, onSelect } ) => {
 		handleFocusItem,
 		registerRef,
 		registerItem,
+		items,
 	};
 };
 

--- a/projects/plugins/protect/src/js/components/vulnerabilities-list/index.jsx
+++ b/projects/plugins/protect/src/js/components/vulnerabilities-list/index.jsx
@@ -17,7 +17,7 @@ const VulnerabilitiesList = () => {
 	const { item, list, selected, setSelected } = useVulsList();
 
 	return (
-		<Container fluid>
+		<Container fluid horizontalSpacing={ 0 } horizontalGap={ 5 }>
 			<Col lg={ 4 }>
 				<VulnerabilitiesNavigation selected={ selected } onSelect={ setSelected } />
 			</Col>

--- a/projects/plugins/protect/src/js/components/vulnerabilities-list/navigation.jsx
+++ b/projects/plugins/protect/src/js/components/vulnerabilities-list/navigation.jsx
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { wordpress, plugins as pluginsIcon, warning, color } from '@wordpress/icons';
+import { useBreakpointMatch } from '@automattic/jetpack-components';
 
 /**
  * Internal dependencies
@@ -12,8 +13,14 @@ import useProtectData from '../../hooks/use-protect-data';
 
 const VulnerabilitiesNavigation = ( { selected, onSelect } ) => {
 	const { plugins, themes, numVulnerabilities, numCoreVulnerabilities } = useProtectData();
+	const [ isSmallOrLarge ] = useBreakpointMatch( 'lg', '<' );
+
 	return (
-		<Navigation selected={ selected } onSelect={ onSelect }>
+		<Navigation
+			selected={ selected }
+			onSelect={ onSelect }
+			mode={ isSmallOrLarge ? 'dropdown' : 'list' }
+		>
 			<NavigationItem
 				initial
 				id="all"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Add a new mode for `Navigation` component and use it in `small/medium` viewports.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Introduce `dropdown` mode at `Navigation`.
* Use `dropdown` mode in `small/medium` viewports.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start `Protect`.
* Navigate to `Protect` admin page.
* Reduce the viewport and interact with navigation dropdown.

#### Demo


https://user-images.githubusercontent.com/1663717/168929300-2098a260-d0da-469a-bb90-84dff6639cd1.mp4