### PR TITLE
Search: Disable auto-collapsing the sidebar in Customberg

### DIFF
--- a/projects/packages/search/changelog/remove-customberg-sidebar-auto-collapse
+++ b/projects/packages/search/changelog/remove-customberg-sidebar-auto-collapse
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Search: Disable auto-collapsing the wp-admin sidebar within Customberg

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -68,7 +68,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-master": "0.13.x-dev"
+			"dev-master": "0.14.x-dev"
 		},
 		"version-constants": {
 			"::VERSION": "src/class-package.php"

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.13.4",
+	"version": "0.14.0-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.13.4';
+	const VERSION = '0.14.0-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/customberg/index.jsx
+++ b/projects/packages/search/src/customberg/index.jsx
@@ -10,19 +10,11 @@ import Layout from 'components/layout';
 import 'styles.scss';
 
 /**
- * Collapses wp-admin's sidebar menu for additional space.
- */
-function collapseWpAdminSidebar() {
-	document.body.classList.add( 'folded' );
-}
-
-/**
  * Initializes the widgets screen
  *
  * @param {string} id - Id of the root element to render the screen.
  */
 function initialize( id ) {
-	collapseWpAdminSidebar();
 	render( <Layout />, document.getElementById( id ) );
 }
 

--- a/projects/plugins/jetpack/changelog/remove-customberg-sidebar-auto-collapse
+++ b/projects/plugins/jetpack/changelog/remove-customberg-sidebar-auto-collapse
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -37,7 +37,7 @@
 		"automattic/jetpack-publicize": "0.3.x-dev",
 		"automattic/jetpack-redirect": "1.7.x-dev",
 		"automattic/jetpack-roles": "1.4.x-dev",
-		"automattic/jetpack-search": "0.13.x-dev",
+		"automattic/jetpack-search": "0.14.x-dev",
 		"automattic/jetpack-status": "1.13.x-dev",
 		"automattic/jetpack-sync": "1.33.x-dev",
 		"automattic/jetpack-waf": "0.6.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "594d60fb6350656d391f718f7a2b16f2",
+    "content-hash": "98459ec2205ea0f90c047772b07e2ca9",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1577,7 +1577,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "ff95c5de2b54e36f93995505ebf61c60376293ce"
+                "reference": "215cafebb20483ae996174b3054ef62a3c94a3a4"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -1600,7 +1600,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "0.13.x-dev"
+                    "dev-master": "0.14.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"

--- a/projects/plugins/search/changelog/remove-customberg-sidebar-auto-collapse
+++ b/projects/plugins/search/changelog/remove-customberg-sidebar-auto-collapse
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -9,7 +9,7 @@
 		"automattic/jetpack-config": "1.9.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
 		"automattic/jetpack-my-jetpack": "1.4.x-dev",
-		"automattic/jetpack-search": "0.13.x-dev",
+		"automattic/jetpack-search": "0.14.x-dev",
 		"automattic/jetpack-status": "^1.13",
 		"automattic/jetpack-sync": "1.33.x-dev"
 	},

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "85fa9a85c0812f951294c5c978d3ad11",
+    "content-hash": "f66368cfca96f5b15b8b789857bdcdad",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -903,7 +903,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "ff95c5de2b54e36f93995505ebf61c60376293ce"
+                "reference": "215cafebb20483ae996174b3054ef62a3c94a3a4"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -926,7 +926,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "0.13.x-dev"
+                    "dev-master": "0.14.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Disables auto-collapsing the wp-admin sidebar when opening Customberg.

#### Jetpack product discussion
p1HpG7-fTB-p2#comment-54345

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply this change to your site with a Jetpack Search subscription and with Instant Search enabled.
* Navigate to Customberg (`/wp-admin/admin.php?page=jetpack-search-configure`).
* Ensure that the wp-admin sidebar does not automatically collapse in desktop viewports.
