### PR TITLE
Connection Screen: Connect site with product supporting check

### DIFF
--- a/projects/js-packages/connection/changelog/update-use-checkout-flow-in-search
+++ b/projects/js-packages/connection/changelog/update-use-checkout-flow-in-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add option to use the checkout workflow from the ConnectionScreenRequirePlan component

--- a/projects/js-packages/connection/components/connect-screen/required-plan/index.jsx
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/index.jsx
@@ -35,7 +35,7 @@ const ConnectScreenRequiredPlan = props => {
 		pricingTitle,
 		pricingCurrencyCode,
 		wpcomProductSlug,
-		supportsCheck,
+		checkSiteHasWpcomProduct,
 	} = props;
 
 	const {
@@ -59,7 +59,7 @@ const ConnectScreenRequiredPlan = props => {
 	const { run: handleCheckoutWorkflow, hasCheckoutStarted } = useProductCheckoutWorkflow( {
 		productSlug,
 		redirectUrl: redirectUri,
-		supportsCheck,
+		checkSiteHasWpcomProduct,
 		handleRegisterSite,
 	} );
 
@@ -116,6 +116,8 @@ ConnectScreenRequiredPlan.propTypes = {
 	pricingCurrencyCode: PropTypes.string,
 	/** The WordPress.com product slug. If informed, the connection/authorization flow will go through the Checkout page for this product'. */
 	wpcomProductSlug: PropTypes.string,
+	/** A callback that will be used to check whether the site already has the wpcomProductSlug. This will be checked after registration and the checkout will be skipped if it returns true. */
+	checkSiteHasWpcomProduct: PropTypes.func,
 };
 
 ConnectScreenRequiredPlan.defaultProps = {

--- a/projects/js-packages/connection/components/connect-screen/required-plan/index.jsx
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/index.jsx
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
  */
 import ConnectScreenRequiredPlanVisual from './visual';
 import useConnection from '../../use-connection';
+import useProductCheckoutWorkflow from '../../../hooks/use-product-checkout-workflow';
 
 /**
  * The Connection Screen Visual component for consumers that require a Plan.
@@ -33,6 +34,7 @@ const ConnectScreenRequiredPlan = props => {
 		pricingIcon,
 		pricingTitle,
 		pricingCurrencyCode,
+		wpcomProductSlug,
 	} = props;
 
 	const {
@@ -51,9 +53,17 @@ const ConnectScreenRequiredPlan = props => {
 		from,
 	} );
 
+	const productSlug = wpcomProductSlug ? wpcomProductSlug : '';
+
+	const { run, hasCheckoutStarted } = useProductCheckoutWorkflow( {
+		productSlug,
+		redirectUrl: redirectUri,
+	} );
+
 	const showConnectButton = ! isRegistered || ! isUserConnected;
 	const displayButtonError = Boolean( registrationError );
-	const buttonIsLoading = siteIsRegistering || userIsConnecting;
+	const buttonIsLoading = siteIsRegistering || userIsConnecting || hasCheckoutStarted;
+	const handleButtonClick = productSlug ? run : handleRegisterSite;
 
 	return (
 		<ConnectScreenRequiredPlanVisual
@@ -64,7 +74,7 @@ const ConnectScreenRequiredPlan = props => {
 			pricingIcon={ pricingIcon }
 			pricingTitle={ pricingTitle }
 			pricingCurrencyCode={ pricingCurrencyCode }
-			handleButtonClick={ handleRegisterSite }
+			handleButtonClick={ handleButtonClick }
 			showConnectButton={ showConnectButton }
 			displayButtonError={ displayButtonError }
 			buttonIsLoading={ buttonIsLoading }
@@ -101,6 +111,8 @@ ConnectScreenRequiredPlan.propTypes = {
 	priceAfter: PropTypes.number.isRequired,
 	/** The Currency code, eg 'USD'. */
 	pricingCurrencyCode: PropTypes.string,
+	/** The WordPress.com product slug. If informed, the connection/authorization flow will go through the Checkout page for this product'. */
+	wpcomProductSlug: PropTypes.string,
 };
 
 ConnectScreenRequiredPlan.defaultProps = {

--- a/projects/js-packages/connection/components/connect-screen/required-plan/index.jsx
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/index.jsx
@@ -114,7 +114,7 @@ ConnectScreenRequiredPlan.propTypes = {
 	priceAfter: PropTypes.number.isRequired,
 	/** The Currency code, eg 'USD'. */
 	pricingCurrencyCode: PropTypes.string,
-	/** The WordPress.com product slug. If informed, the connection/authorization flow will go through the Checkout page for this product'. */
+	/** The WordPress.com product slug. If specified, the connection/authorization flow will go through the Checkout page for this product'. */
 	wpcomProductSlug: PropTypes.string,
 	/** A callback that will be used to check whether the site already has the wpcomProductSlug. This will be checked after registration and the checkout will be skipped if it returns true. */
 	checkSiteHasWpcomProduct: PropTypes.func,

--- a/projects/js-packages/connection/components/connect-screen/required-plan/index.jsx
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/index.jsx
@@ -60,7 +60,7 @@ const ConnectScreenRequiredPlan = props => {
 		productSlug,
 		redirectUrl: redirectUri,
 		siteProductAvailabilityHandler,
-		handleRegisterSite,
+		from,
 	} );
 
 	const showConnectButton = ! isRegistered || ! isUserConnected;

--- a/projects/js-packages/connection/components/connect-screen/required-plan/index.jsx
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/index.jsx
@@ -66,7 +66,7 @@ const ConnectScreenRequiredPlan = props => {
 	const showConnectButton = ! isRegistered || ! isUserConnected;
 	const displayButtonError = Boolean( registrationError );
 	const buttonIsLoading = siteIsRegistering || userIsConnecting || hasCheckoutStarted;
-	const handleButtonClick = handleCheckoutWorkflow; //! productSlug ? handleCheckoutWorkflow : handleRegisterSite;
+	const handleButtonClick = productSlug ? handleCheckoutWorkflow : handleRegisterSite;
 
 	return (
 		<ConnectScreenRequiredPlanVisual

--- a/projects/js-packages/connection/components/connect-screen/required-plan/index.jsx
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/index.jsx
@@ -35,6 +35,7 @@ const ConnectScreenRequiredPlan = props => {
 		pricingTitle,
 		pricingCurrencyCode,
 		wpcomProductSlug,
+		supportsCheck,
 	} = props;
 
 	const {
@@ -55,15 +56,17 @@ const ConnectScreenRequiredPlan = props => {
 
 	const productSlug = wpcomProductSlug ? wpcomProductSlug : '';
 
-	const { run, hasCheckoutStarted } = useProductCheckoutWorkflow( {
+	const { run: handleCheckoutWorkflow, hasCheckoutStarted } = useProductCheckoutWorkflow( {
 		productSlug,
 		redirectUrl: redirectUri,
+		supportsCheck,
+		handleRegisterSite,
 	} );
 
 	const showConnectButton = ! isRegistered || ! isUserConnected;
 	const displayButtonError = Boolean( registrationError );
 	const buttonIsLoading = siteIsRegistering || userIsConnecting || hasCheckoutStarted;
-	const handleButtonClick = productSlug ? run : handleRegisterSite;
+	const handleButtonClick = handleCheckoutWorkflow; //! productSlug ? handleCheckoutWorkflow : handleRegisterSite;
 
 	return (
 		<ConnectScreenRequiredPlanVisual

--- a/projects/js-packages/connection/components/connect-screen/required-plan/index.jsx
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/index.jsx
@@ -35,7 +35,7 @@ const ConnectScreenRequiredPlan = props => {
 		pricingTitle,
 		pricingCurrencyCode,
 		wpcomProductSlug,
-		checkSiteHasWpcomProduct,
+		siteProductAvailabilityHandler,
 	} = props;
 
 	const {
@@ -59,7 +59,7 @@ const ConnectScreenRequiredPlan = props => {
 	const { run: handleCheckoutWorkflow, hasCheckoutStarted } = useProductCheckoutWorkflow( {
 		productSlug,
 		redirectUrl: redirectUri,
-		checkSiteHasWpcomProduct,
+		siteProductAvailabilityHandler,
 		handleRegisterSite,
 	} );
 

--- a/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
+++ b/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
@@ -60,12 +60,12 @@ export default function useProductCheckoutWorkflow( {
 	 */
 	const run = event => {
 		event && event.preventDefault();
+		setCheckoutStarted( true );
 
 		Promise.resolve( () => isRegistered && registerSite( { registrationNonce, redirectUrl } ) )
 			.then( () => supportsCheck && supportsCheck() )
 			.then( supportsProduct => {
 				if ( ! supportsProduct ) {
-					setCheckoutStarted( true );
 					window.location.href = checkoutProductUrl;
 				} else {
 					handleRegisterSite();

--- a/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
+++ b/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
@@ -50,11 +50,15 @@ export default function useProductCheckoutWorkflow( {
 	);
 
 	const handleAfterRegistration = () => {
-		if ( checkSiteHasWpcomProduct && checkSiteHasWpcomProduct() ) {
-			handleConnectUser();
-		} else {
-			return ( window.location.href = checkoutProductUrl );
-		}
+		Promise.resolve( checkSiteHasWpcomProduct && checkSiteHasWpcomProduct() ).then(
+			siteHasWpcomProduct => {
+				if ( siteHasWpcomProduct ) {
+					handleConnectUser();
+				} else {
+					return ( window.location.href = checkoutProductUrl );
+				}
+			}
+		);
 	};
 
 	/**
@@ -71,9 +75,7 @@ export default function useProductCheckoutWorkflow( {
 			return handleAfterRegistration();
 		}
 
-		registerSite( { registrationNonce, redirectUrl } ).then( () => {
-			handleAfterRegistration();
-		} );
+		registerSite( { registrationNonce, redirectUrl } ).then( handleAfterRegistration );
 	};
 
 	// Initialize/Setup the REST API.

--- a/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
+++ b/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
@@ -27,7 +27,7 @@ const {
  * @param {string} props.productSlug  - The WordPress product slug.
  * @param {string} props.redirectUrl  - The URI to redirect to after checkout.
  * @param {string} [props.siteSuffix] - The site suffix.
- * @param {Function} props.checkSiteHasWpcomProduct - The function used to check whether the site already has the requested product. This will be checked after registration and the checkout page will be skipped if it returns true.
+ * @param {Function} props.checkSiteHasWpcomProduct - The function used to check whether the site already has the requested product. This will be checked after registration and the checkout page will be skipped if the promise returned resloves true.
  * @returns {Function}				  - The useEffect hook.
  */
 export default function useProductCheckoutWorkflow( {
@@ -55,10 +55,9 @@ export default function useProductCheckoutWorkflow( {
 		return Promise.resolve( checkSiteHasWpcomProduct && checkSiteHasWpcomProduct() ).then(
 			siteHasWpcomProduct => {
 				if ( siteHasWpcomProduct ) {
-					handleConnectUser();
-				} else {
-					return ( window.location.href = checkoutProductUrl );
+					return handleConnectUser();
 				}
+				window.location.href = checkoutProductUrl;
 			}
 		);
 	};

--- a/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
+++ b/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
@@ -62,7 +62,7 @@ export default function useProductCheckoutWorkflow( {
 		event && event.preventDefault();
 		setCheckoutStarted( true );
 
-		Promise.resolve( () => isRegistered && registerSite( { registrationNonce, redirectUrl } ) )
+		Promise.resolve( () => isRegistered || registerSite( { registrationNonce, redirectUrl } ) )
 			.then( () => supportsCheck && supportsCheck() )
 			.then( supportsProduct => {
 				if ( ! supportsProduct ) {

--- a/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
+++ b/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
@@ -28,6 +28,7 @@ const {
  * @param {string} props.redirectUrl  - The URI to redirect to after checkout.
  * @param {string} [props.siteSuffix] - The site suffix.
  * @param {Function} props.siteProductAvailabilityHandler - The function used to check whether the site already has the requested product. This will be checked after registration and the checkout page will be skipped if the promise returned resloves true.
+ * @param {Function} props.from       - The plugin slug initiated the flow.
  * @returns {Function}				  - The useEffect hook.
  */
 export default function useProductCheckoutWorkflow( {
@@ -35,12 +36,14 @@ export default function useProductCheckoutWorkflow( {
 	redirectUrl,
 	siteSuffix = defaultSiteSuffix,
 	siteProductAvailabilityHandler = null,
+	from,
 } = {} ) {
 	const [ hasCheckoutStarted, setCheckoutStarted ] = useState( false );
 	const { registerSite } = useDispatch( STORE_ID );
 
 	const { isUserConnected, isRegistered, handleConnectUser } = useConnection( {
 		redirectUri: redirectUrl,
+		from,
 	} );
 
 	// Build the checkout URL.

--- a/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
+++ b/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
@@ -39,7 +39,9 @@ export default function useProductCheckoutWorkflow( {
 	const [ hasCheckoutStarted, setCheckoutStarted ] = useState( false );
 	const { registerSite } = useDispatch( STORE_ID );
 
-	const { isUserConnected, isRegistered, handleConnectUser } = useConnection();
+	const { isUserConnected, isRegistered, handleConnectUser } = useConnection( {
+		redirectUri: redirectUrl,
+	} );
 
 	// Build the checkout URL.
 	const checkoutProductUrl = getProductCheckoutUrl(
@@ -75,7 +77,7 @@ export default function useProductCheckoutWorkflow( {
 			return handleAfterRegistration();
 		}
 
-		registerSite( { registrationNonce, redirectUrl } ).then( handleAfterRegistration );
+		registerSite( { registrationNonce, redirectUri: redirectUrl } ).then( handleAfterRegistration );
 	};
 
 	// Initialize/Setup the REST API.

--- a/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
+++ b/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
@@ -27,14 +27,14 @@ const {
  * @param {string} props.productSlug  - The WordPress product slug.
  * @param {string} props.redirectUrl  - The URI to redirect to after checkout.
  * @param {string} [props.siteSuffix] - The site suffix.
- * @param {Function} props.checkSiteHasWpcomProduct - The function used to check whether the site already has the requested product. This will be checked after registration and the checkout page will be skipped if the promise returned resloves true.
+ * @param {Function} props.siteProductAvailabilityHandler - The function used to check whether the site already has the requested product. This will be checked after registration and the checkout page will be skipped if the promise returned resloves true.
  * @returns {Function}				  - The useEffect hook.
  */
 export default function useProductCheckoutWorkflow( {
 	productSlug,
 	redirectUrl,
 	siteSuffix = defaultSiteSuffix,
-	checkSiteHasWpcomProduct = null,
+	siteProductAvailabilityHandler = null,
 } = {} ) {
 	const [ hasCheckoutStarted, setCheckoutStarted ] = useState( false );
 	const { registerSite } = useDispatch( STORE_ID );
@@ -52,14 +52,14 @@ export default function useProductCheckoutWorkflow( {
 	);
 
 	const handleAfterRegistration = () => {
-		return Promise.resolve( checkSiteHasWpcomProduct && checkSiteHasWpcomProduct() ).then(
-			siteHasWpcomProduct => {
-				if ( siteHasWpcomProduct ) {
-					return handleConnectUser();
-				}
-				window.location.href = checkoutProductUrl;
+		return Promise.resolve(
+			siteProductAvailabilityHandler && siteProductAvailabilityHandler()
+		).then( siteHasWpcomProduct => {
+			if ( siteHasWpcomProduct ) {
+				return handleConnectUser();
 			}
-		);
+			window.location.href = checkoutProductUrl;
+		} );
 	};
 
 	/**

--- a/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
+++ b/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
@@ -62,7 +62,7 @@ export default function useProductCheckoutWorkflow( {
 		event && event.preventDefault();
 		setCheckoutStarted( true );
 
-		Promise.resolve( () => isRegistered || registerSite( { registrationNonce, redirectUrl } ) )
+		Promise.resolve( isRegistered || registerSite( { registrationNonce, redirectUrl } ) )
 			.then( () => supportsCheck && supportsCheck() )
 			.then( supportsProduct => {
 				if ( ! supportsProduct ) {

--- a/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
+++ b/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
@@ -52,7 +52,7 @@ export default function useProductCheckoutWorkflow( {
 	);
 
 	const handleAfterRegistration = () => {
-		Promise.resolve( checkSiteHasWpcomProduct && checkSiteHasWpcomProduct() ).then(
+		return Promise.resolve( checkSiteHasWpcomProduct && checkSiteHasWpcomProduct() ).then(
 			siteHasWpcomProduct => {
 				if ( siteHasWpcomProduct ) {
 					handleConnectUser();
@@ -77,7 +77,9 @@ export default function useProductCheckoutWorkflow( {
 			return handleAfterRegistration();
 		}
 
-		registerSite( { registrationNonce, redirectUri: redirectUrl } ).then( handleAfterRegistration );
+		return registerSite( { registrationNonce, redirectUri: redirectUrl } ).then(
+			handleAfterRegistration
+		);
 	};
 
 	// Initialize/Setup the REST API.

--- a/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
+++ b/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
@@ -61,24 +61,12 @@ export default function useProductCheckoutWorkflow( {
 	const run = event => {
 		event && event.preventDefault();
 
-		if ( isRegistered ) {
-			Promise.resolve( () => supportsCheck && supportsCheck() ).then( supportsProduct => {
-				if ( ! supportsProduct ) {
-					setCheckoutStarted( true );
-					window.location.href = checkoutProductUrl;
-				} else {
-					window.location.reload();
-				}
-			} );
-			return;
-		}
-
-		registerSite( { registrationNonce, redirectUrl } )
+		Promise.resolve( () => isRegistered && registerSite( { registrationNonce, redirectUrl } ) )
 			.then( () => supportsCheck && supportsCheck() )
 			.then( supportsProduct => {
 				if ( ! supportsProduct ) {
 					setCheckoutStarted( true );
-					window.location = checkoutProductUrl;
+					window.location.href = checkoutProductUrl;
 				} else {
 					handleRegisterSite();
 				}

--- a/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
+++ b/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
@@ -79,9 +79,7 @@ export default function useProductCheckoutWorkflow( {
 			return handleAfterRegistration();
 		}
 
-		return registerSite( { registrationNonce, redirectUri: redirectUrl } ).then(
-			handleAfterRegistration
-		);
+		registerSite( { registrationNonce, redirectUri: redirectUrl } ).then( handleAfterRegistration );
 	};
 
 	// Initialize/Setup the REST API.

--- a/projects/packages/search/changelog/update-use-checkout-flow-in-search
+++ b/projects/packages/search/changelog/update-use-checkout-flow-in-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use the Checkout wordflow to establish the connection and make the purchase

--- a/projects/packages/search/changelog/update-use-checkout-flow-in-search
+++ b/projects/packages/search/changelog/update-use-checkout-flow-in-search
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Use the Checkout wordflow to establish the connection and make the purchase
+Use the Checkout workflow to establish the connection and make the purchase

--- a/projects/packages/search/src/dashboard/components/pages/connection-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/connection-page.jsx
@@ -33,7 +33,7 @@ export default function ConnectionPage( { isLoading = false } ) {
 	const priceCurrencyCode = useSelect( select => select( STORE_ID ).getPriceCurrencyCode(), [] );
 	const registrationNonce = useSelect( select => select( STORE_ID ).getRegistrationNonce(), [] );
 	const { fetchSearchPlanInfo } = useDispatch( STORE_ID );
-	const supportsCheck = useCallback(
+	const checkSiteHasWpcomProduct = useCallback(
 		() => fetchSearchPlanInfo().then( response => response?.supports_search ),
 		[ fetchSearchPlanInfo ]
 	);
@@ -62,7 +62,7 @@ export default function ConnectionPage( { isLoading = false } ) {
 				from="jetpack-search"
 				redirectUri="admin.php?page=jetpack-search"
 				wpcomProductSlug="jetpack_search"
-				supportsCheck={ supportsCheck }
+				checkSiteHasWpcomProduct={ checkSiteHasWpcomProduct }
 			>
 				<SearchPromotionBlock />
 			</ConnectScreenRequiredPlan>

--- a/projects/packages/search/src/dashboard/components/pages/connection-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/connection-page.jsx
@@ -33,7 +33,7 @@ export default function ConnectionPage( { isLoading = false } ) {
 	const priceCurrencyCode = useSelect( select => select( STORE_ID ).getPriceCurrencyCode(), [] );
 	const registrationNonce = useSelect( select => select( STORE_ID ).getRegistrationNonce(), [] );
 	const { fetchSearchPlanInfo } = useDispatch( STORE_ID );
-	const checkSiteHasWpcomProduct = useCallback(
+	const checkSiteHasSearchProduct = useCallback(
 		() => fetchSearchPlanInfo().then( response => response?.supports_search ),
 		[ fetchSearchPlanInfo ]
 	);
@@ -62,7 +62,7 @@ export default function ConnectionPage( { isLoading = false } ) {
 				from="jetpack-search"
 				redirectUri="admin.php?page=jetpack-search"
 				wpcomProductSlug="jetpack_search"
-				checkSiteHasWpcomProduct={ checkSiteHasWpcomProduct }
+				siteProductAvailabilityHandler={ checkSiteHasSearchProduct }
 			>
 				<SearchPromotionBlock />
 			</ConnectScreenRequiredPlan>

--- a/projects/packages/search/src/dashboard/components/pages/connection-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/connection-page.jsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import { useSelect } from '@wordpress/data';
+import React, { useCallback } from 'react';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { Container, Col, AdminSectionHero, getRedirectUrl } from '@automattic/jetpack-components';
 import { ConnectScreenRequiredPlan } from '@automattic/jetpack-connection';
 import { __ } from '@wordpress/i18n';
@@ -32,6 +32,11 @@ export default function ConnectionPage( { isLoading = false } ) {
 	const priceAfter = useSelect( select => select( STORE_ID ).getPriceAfter(), [] );
 	const priceCurrencyCode = useSelect( select => select( STORE_ID ).getPriceCurrencyCode(), [] );
 	const registrationNonce = useSelect( select => select( STORE_ID ).getRegistrationNonce(), [] );
+	const { fetchSearchPlanInfo } = useDispatch( STORE_ID );
+	const supportsCheck = useCallback(
+		() => fetchSearchPlanInfo().then( response => response?.supports_search ),
+		[ fetchSearchPlanInfo ]
+	);
 
 	const isPageLoading = useSelect(
 		select =>
@@ -57,6 +62,7 @@ export default function ConnectionPage( { isLoading = false } ) {
 				from="jetpack-search"
 				redirectUri="admin.php?page=jetpack-search"
 				wpcomProductSlug="jetpack_search"
+				supportsCheck={ supportsCheck }
 			>
 				<SearchPromotionBlock />
 			</ConnectScreenRequiredPlan>

--- a/projects/packages/search/src/dashboard/components/pages/connection-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/connection-page.jsx
@@ -56,6 +56,7 @@ export default function ConnectionPage( { isLoading = false } ) {
 				registrationNonce={ registrationNonce }
 				from="jetpack-search"
 				redirectUri="admin.php?page=jetpack-search"
+				wpcomProductSlug="jetpack_search"
 			>
 				<SearchPromotionBlock />
 			</ConnectScreenRequiredPlan>

--- a/projects/packages/search/src/dashboard/components/pages/connection-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/connection-page.jsx
@@ -83,7 +83,7 @@ export default function ConnectionPage( { isLoading = false } ) {
 					{ __(
 						'Pricing will automatically adjust based on the number of records in your search index.',
 						'jetpack-search-pkg'
-					) }
+					) }{ ' ' }
 					<a
 						href={ getRedirectUrl( 'search-product-pricing' ) }
 						className="jp-search-dashboard-connection-footer__link"

--- a/projects/packages/search/src/dashboard/store/actions/site-plan.js
+++ b/projects/packages/search/src/dashboard/store/actions/site-plan.js
@@ -18,13 +18,13 @@ export function setSearchPlanInfo( options ) {
  * fetchSearchPlanInfo action
  *
  * @yields {object} - an action object.
- * @returns {object} - an action object.
+ * @returns {object} - an search plan object.
  */
 export function* fetchSearchPlanInfo() {
 	const response = yield {
 		type: FETCH_SEARCH_PLAN_INFO,
 	};
-	return Promise.resolve( response );
+	return response;
 }
 
 export default { setSearchPlanInfo, fetchSearchPlanInfo };

--- a/projects/packages/search/src/dashboard/store/actions/site-plan.js
+++ b/projects/packages/search/src/dashboard/store/actions/site-plan.js
@@ -1,5 +1,9 @@
+/**
+ * Internal dependencies
+ */
+import { fetchSearchPlanInfo } from '../controls';
+
 export const SET_SEARCH_PLAN_INFO = 'SET_SEARCH_PLAN_INFO';
-export const FETCH_SEARCH_PLAN_INFO = 'FETCH_SEARCH_PLAN_INFO';
 
 /**
  * Action to set plan info
@@ -12,19 +16,6 @@ export function setSearchPlanInfo( options ) {
 		type: 'SET_SEARCH_PLAN_INFO',
 		options,
 	};
-}
-
-/**
- * fetchSearchPlanInfo action
- *
- * @yields {object} - an action object.
- * @returns {object} - an search plan object.
- */
-export function* fetchSearchPlanInfo() {
-	const response = yield {
-		type: FETCH_SEARCH_PLAN_INFO,
-	};
-	return response;
 }
 
 export default { setSearchPlanInfo, fetchSearchPlanInfo };

--- a/projects/packages/search/src/dashboard/store/actions/site-plan.js
+++ b/projects/packages/search/src/dashboard/store/actions/site-plan.js
@@ -1,4 +1,5 @@
 export const SET_SEARCH_PLAN_INFO = 'SET_SEARCH_PLAN_INFO';
+export const FETCH_SEARCH_PLAN_INFO = 'FETCH_SEARCH_PLAN_INFO';
 
 /**
  * Action to set plan info
@@ -13,4 +14,17 @@ export function setSearchPlanInfo( options ) {
 	};
 }
 
-export default { setSearchPlanInfo };
+/**
+ * fetchSearchPlanInfo action
+ *
+ * @yields {object} - an action object.
+ * @returns {object} - an action object.
+ */
+export function* fetchSearchPlanInfo() {
+	const response = yield {
+		type: FETCH_SEARCH_PLAN_INFO,
+	};
+	return Promise.resolve( response );
+}
+
+export default { setSearchPlanInfo, fetchSearchPlanInfo };

--- a/projects/packages/search/src/dashboard/store/controls.js
+++ b/projects/packages/search/src/dashboard/store/controls.js
@@ -36,13 +36,15 @@ export const updateJetpackSettings = settings => {
 /**
  * fetchSearchPlanInfo action
  *
- * @returns {object} - an action object.
+ * @yields {object} - an action object.
+ * @returns {object} - an search plan object.
  */
-export const fetchSearchPlanInfo = () => {
-	return {
+export function* fetchSearchPlanInfo() {
+	const response = yield {
 		type: FETCH_SEARCH_PLAN_INFO,
 	};
-};
+	return response;
+}
 
 /**
  * fetchSearchStats action


### PR DESCRIPTION
Partly fixes #24398, #24289 and #23972

#### Changes proposed in this Pull Request:
Refactored the `ConnectScreenRequiredPlan` to allow consumers to pass in a function to check whether the site has a subscription or not after site registration and before user connecting. If site has an eligible plan, then we only connect user rather than redirecting user to the checkout page with parameter `unlinked=1`.

#### Jetpack product discussion
p9dueE-55u#comment-7971

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Create a JN site with Jetpack Beta Tester (**uncheck Jetpack please**)
- Activate Search plugin on branch `try/get-plan-before-connection` in Jetpack Beta Tester
- <strike>Run Calypso from your local from https://github.com/Automattic/wp-calypso/pull/63884 </strike>
- 

- Click `Get Jetpack Search` on page `/wp-admin/admin.php?page=jetpack-search`
- <strike>Replace `https://wordpress.com` with `http://calypso.localhost:3000` for the Authorization page, reload</strike>
- Click `Approve`
- Ensure you could purchase a search plan
- 

- Disconnect the site thru link on My Jetpack page
- Click `Get Jetpack Search`
- Replace `https://wordpress.com` with `http://calypso.localhost:3000` for the Authorization page, reload
- Click `Approve`
- Ensure you are only logged in but not redirected to purchase search product again
- 

- Remove the search subscription
- Disconnect the site thru link on My Jetpack page
- Add a `Complete` plan to site thru JP Cloud
- Click `Get Jetpack Search`
- <strike>Replace `https://wordpress.com` with `http://calypso.localhost:3000` for the Authorization page, reload</strike>
- Click `Approve`
- Ensure you are only logged in but not redirected to purchase search product again

![image](https://user-images.githubusercontent.com/1425433/169444429-2b6370bb-1921-4153-a558-763299ffc813.png)


Related: #23171 #23917 