### PR TITLE
Update boost/tsconfig to use js-tools/tsconfig.base.json

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1124,7 +1124,6 @@ importers:
       '@rollup/plugin-node-resolve': 13.0.6
       '@rollup/plugin-replace': 4.0.0
       '@rollup/plugin-typescript': 8.2.5
-      '@tsconfig/svelte': 2.0.1
       '@wordpress/components': 19.10.0
       '@wordpress/element': 4.6.0
       '@wordpress/i18n': 4.8.0
@@ -1170,7 +1169,6 @@ importers:
       '@rollup/plugin-node-resolve': 13.0.6_rollup@2.56.3
       '@rollup/plugin-replace': 4.0.0_rollup@2.56.3
       '@rollup/plugin-typescript': 8.2.5_d5b4c212067eb4489bd764c22d3b50b7
-      '@tsconfig/svelte': 2.0.1
       '@wordpress/i18n': 4.8.0
       node-wp-i18n: 1.2.6
       npm-run-all: 4.1.5
@@ -6786,10 +6784,6 @@ packages:
   /@trysound/sax/0.2.0:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
-
-  /@tsconfig/svelte/2.0.1:
-    resolution: {integrity: sha512-aqkICXbM1oX5FfgZd2qSSAGdyo/NRxjWCamxoyi3T8iVQnzGge19HhDYzZ6NrVOW7bhcWNSq9XexWFtMzbB24A==}
-    dev: true
 
   /@types/aria-query/4.2.2:
     resolution: {integrity: sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==}

--- a/projects/plugins/boost/changelog/update-boost-use-consistent-tsconfig
+++ b/projects/plugins/boost/changelog/update-boost-use-consistent-tsconfig
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated boost/tsconfig to use js-tools/tsconfig.base.json

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -25,7 +25,6 @@
 		"@rollup/plugin-node-resolve": "13.0.6",
 		"@rollup/plugin-replace": "4.0.0",
 		"@rollup/plugin-typescript": "8.2.5",
-		"@tsconfig/svelte": "2.0.1",
 		"@wordpress/i18n": "4.8.0",
 		"node-wp-i18n": "1.2.6",
 		"npm-run-all": "4.1.5",

--- a/projects/plugins/boost/tsconfig.json
+++ b/projects/plugins/boost/tsconfig.json
@@ -1,10 +1,15 @@
 {
-	"extends": "@tsconfig/svelte/tsconfig.json",
+	"extends": "jetpack-js-tools/tsconfig.base.json",
 	"include": [ "app/assets/src/js/**/*" ],
 	"exclude": [ "node_modules/*", "app/assets/dist/*", "tests/e2e/*" ],
 	"compilerOptions": {
 		"types": [ "svelte" ],
 		"typeRoots": [ "./node_modules/@types/", "./app/assets/src/js" ],
-		"lib": [ "dom", "es2018" ]
+		/**
+		 * Values from "@tsconfig/svelte/tsconfig.json"
+		 */
+		"importsNotUsedAsValues": "error",
+		"sourceMap": true,
+		"forceConsistentCasingInFileNames": true
 	}
 }

--- a/tools/js-tools/tsconfig.base.json
+++ b/tools/js-tools/tsconfig.base.json
@@ -4,6 +4,7 @@
 		"esModuleInterop": true,
 		"isolatedModules": true,
 		"jsx": "react-jsx",
+		"lib": [ "DOM", "ESNext" ],
 		"module": "esnext",
 		"moduleResolution": "node",
 		"noEmit": true,


### PR DESCRIPTION
In preparation for #24329 and to have a consistent TS type checking, we need to use a consistent TS configuration throughout the monorepo. Only Boost uses its own `tsconfig.json` which is different from other areas of the codebase.

#### Changes proposed in this Pull Request:

- This PR updates `plugins/boost/tsconfig.json` to use a consistent config by extending `js-tools/tsconfig.base.json` in order to have a consistent tsconfig throughout the monorepo. Previously, it extended [`@tsconfig/svelte/tsconfig.json`](https://unpkg.com/browse/@tsconfig/svelte@3.0.0/tsconfig.json).
- The new config retains the existing config though, by copying over the three different options from `@tsconfig/svelte/tsconfig.json`.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

* Run `jetpack build plugins/boost` and `jetpack build --all`
* Confirm that the build is successful.