### PR TITLE
Payment Blocks: Only attempt to auto-select a product if it exists

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-payment-blocks-unable-to-autocreate-products-when-stripe-disconnected
+++ b/projects/plugins/jetpack/changelog/fix-payment-blocks-unable-to-autocreate-products-when-stripe-disconnected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Make sure payment blocks only attempt to auto-select a product if it exists.

--- a/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
@@ -91,8 +91,11 @@ const shouldCreateDefaultProduct = response =>
 	response.connected_account_id;
 
 const setDefaultProductIfNeeded = ( selectedProductId, setSelectedProductId, select ) => {
-	if ( ! selectedProductId ) {
-		const defaultProductId = select.getProductsNoResolver()[ 0 ].id;
+	if ( selectedProductId ) {
+		return;
+	}
+	const defaultProductId = select.getProductsNoResolver()[ 0 ]?.id;
+	if ( defaultProductId ) {
 		setSelectedProductId( defaultProductId );
 	}
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/63723

#### Changes proposed in this Pull Request:

* Make sure payment blocks only attempt to auto-select a product if it exists.

When inserted, the Payment Button block (and by extension the Premium Content block as well) automatically selects the latest product, or creates one if none exists.

If the site is not connected to Stripe, the block should not attempt to auto-select a product, but a recent change introduced a regression where this attempt happens anyway, trying to grab a product ID from an empty list, which caused a fatal error in the block's execution.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a Pro site with no products and Stripe disconnected.
* Insert a Payment Button block.
* Make sure it is created without errors.
* Make sure a default product is automatically created and assigned to the block.
