### PR TITLE
Assistant: Fix background image position

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-banner-image-position
+++ b/projects/plugins/jetpack/changelog/fix-banner-image-position
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed recommendation backgroud image possition that was covering the dismiss button.

--- a/projects/plugins/jetpack/scss/jetpack-recommendations-banner.scss
+++ b/projects/plugins/jetpack/scss/jetpack-recommendations-banner.scss
@@ -215,7 +215,7 @@
 
 	img {
 		position: absolute;
-		top: 15px;
+		top: 55px;
 		right: 0;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Assistant background image position is preventing the dismiss button from working.
Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* CSS change

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
* WP-Admin and see if you can dismiss the recommendations banner.
