### PR TITLE
Revert soft disconnection on deactivation

### DIFF
--- a/projects/js-packages/connection/changelog/update-jetpack-force-disconnect
+++ b/projects/js-packages/connection/changelog/update-jetpack-force-disconnect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Revert and make Jetpack hard disconnect on deactivation

--- a/projects/js-packages/connection/components/disconnect-dialog/steps/step-disconnect.jsx
+++ b/projects/js-packages/connection/components/disconnect-dialog/steps/step-disconnect.jsx
@@ -64,7 +64,7 @@ const StepDisconnect = props => {
 		if ( isDisconnecting ) {
 			buttonText = __( 'Disconnecting…', 'jetpack' );
 		} else if ( context === 'plugins' ) {
-			buttonText = __( 'Deactivate', 'jetpack' );
+			buttonText = __( 'Disconnect and Deactivate', 'jetpack' );
 		}
 
 		return (
@@ -157,9 +157,7 @@ const StepDisconnect = props => {
 							onClick={ handleStayConnectedClick }
 							className="jp-connection__disconnect-dialog__btn-dismiss"
 						>
-							{ context === 'plugins'
-								? __( 'Cancel', 'jetpack' )
-								: __( 'Stay connected', 'jetpack', /* dummy arg to avoid bad minification */ 0 ) }
+							{ __( 'Stay connected', 'jetpack' ) }
 						</Button>
 						{ renderDisconnectButton() }
 					</div>

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-benefits/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-benefits/index.jsx
@@ -11,7 +11,6 @@ import { createInterpolateElement } from '@wordpress/element';
 import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import PropTypes from 'prop-types';
 import './style.scss';
 
 /**
@@ -19,11 +18,10 @@ import './style.scss';
  *
  * @param {object} props - The component props.
  * @param {Array} props.siteBenefits - An array of site benefits.
- * @param {Array} props.context - Context in which the component will be used. disconnect or deactivate.
  * @returns {React.Component} - The JetpackBenefits component.
  */
 const JetpackBenefits = props => {
-	const { siteBenefits, context } = props;
+	const { siteBenefits } = props;
 
 	return (
 		<React.Fragment>
@@ -31,16 +29,10 @@ const JetpackBenefits = props => {
 				<React.Fragment>
 					<div className="jp-connection__disconnect-dialog__step-copy">
 						<p className="jp-connection__disconnect-dialog__large-text">
-							{ context === 'disconnect'
-								? __(
-										'Jetpack is currently powering features on your site. Once you disconnect Jetpack, these features will no longer be available and your site may no longer function the same way.',
-										'jetpack'
-								  )
-								: __(
-										'Jetpack is currently powering features on your site. Once you deactivate Jetpack, these features will no longer be available.',
-										'jetpack',
-										/* dummy arg to avoid bad minification */ 0
-								  ) }
+							{ __(
+								'Jetpack is currently powering features on your site. Once you disconnect Jetpack, these features will no longer be available and your site may no longer function the same way.',
+								'jetpack'
+							) }
 						</p>
 					</div>
 					<div className="jp-connection__disconnect-card__group">
@@ -115,17 +107,6 @@ const JetpackBenefits = props => {
 			) }
 		</React.Fragment>
 	);
-};
-
-JetpackBenefits.propTypes = {
-	/** An array of site benefits. */
-	siteBenefits: PropTypes.array,
-	/** Context in which the component will be used. disconnect or deactivate. */
-	context: PropTypes.oneOf( [ 'disconnect', 'deactivate' ] ),
-};
-
-JetpackBenefits.defaultProps = {
-	context: 'disconnect',
 };
 
 export default JetpackBenefits;

--- a/projects/plugins/jetpack/_inc/client/portals/plugin-deactivation.jsx
+++ b/projects/plugins/jetpack/_inc/client/portals/plugin-deactivation.jsx
@@ -34,6 +34,7 @@ import JetpackBenefits from '../components/jetpack-benefits';
  * @param {object} props - The props object for the component.
  * @param {string} props.apiRoot - Root URL for the API, which is required by the <DisconnectDialog/> component.
  * @param {string} props.apiNonce - Nonce value for the API, which is required by the <DisconnectDialog/> component.
+ * @param {object} props.connectedPlugins - An object of plugins that are using the Jetpack connection.
  * @param {Array} props.siteBenefits - An array of benefits provided by Jetpack.
  * @param {string} props.pluginUrl - The URL of the plugin directory.
  * @returns {React.Component} - The PluginDeactivation component.
@@ -42,8 +43,10 @@ const PluginDeactivation = props => {
 	const {
 		apiRoot,
 		apiNonce,
+		connectedPlugins,
 		siteBenefits,
 		connectionUserData,
+		fetchConnectedPlugins,
 		fetchSiteBenefits,
 		fetchUserConnectionData,
 	} = props;
@@ -51,13 +54,15 @@ const PluginDeactivation = props => {
 
 	useEffect( () => {
 		fetchSiteBenefits();
+		fetchConnectedPlugins();
 		fetchUserConnectionData();
-	}, [ fetchSiteBenefits, fetchUserConnectionData ] );
+	}, [ fetchSiteBenefits, fetchConnectedPlugins, fetchUserConnectionData ] );
 
 	// Modify the deactivation link.
 	const deactivationLink = document.querySelector( '#deactivate-jetpack, #deactivate-jetpack-dev' ); // ID set by WP on the deactivation link.
 
 	deactivationLink.setAttribute( 'title', __( 'Deactivate Jetpack', 'jetpack' ) );
+	deactivationLink.textContent = __( 'Disconnect and Deactivate', 'jetpack' );
 
 	useEffect( () => {
 		restApi.setApiRoot( apiRoot );
@@ -93,16 +98,15 @@ const PluginDeactivation = props => {
 	}, [ deactivationLink ] );
 
 	const disconnectStepComponent = siteBenefits ? (
-		<JetpackBenefits siteBenefits={ siteBenefits } context="deactivate" />
+		<JetpackBenefits siteBenefits={ siteBenefits } />
 	) : null;
 
 	return (
 		<PortalSidecar>
 			<DisconnectDialog
-				title={ __( 'Are you sure you want to deactivate?', 'jetpack' ) }
 				apiRoot={ apiRoot }
 				apiNonce={ apiNonce }
-				connectedPlugins={ [] } // We no longer disconnect Jetpack if other plugins are active, so no need to warn.
+				connectedPlugins={ connectedPlugins }
 				connectedUser={ {
 					ID: connectionUserData?.ID,
 					login: connectionUserData?.login,

--- a/projects/plugins/jetpack/changelog/update-jetpack-force-disconnect
+++ b/projects/plugins/jetpack/changelog/update-jetpack-force-disconnect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Revert soft disconnection on deactivation

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -2966,10 +2966,6 @@ p {
 	 * Disconnects from the Jetpack servers.
 	 * Forgets all connection details and tells the Jetpack servers to do the same.
 	 *
-	 * Will not disconnect if there are other plugins using the connection.
-	 *
-	 * @since 11.0 Do not disconnect if other plugins are using the connection.
-	 *
 	 * @static
 	 */
 	public static function disconnect() {
@@ -2978,7 +2974,9 @@ p {
 
 		// If the site is in an IDC because sync is not allowed,
 		// let's make sure to not disconnect the production site.
-		$connection->remove_connection( ! Identity_Crisis::validate_sync_error_idc_option() );
+		// For now, Jetpack plugin always disconnect the site and kills the connection of all other active plugins.
+		// We just need to remove the second parameter when we are ready to make this change.
+		$connection->remove_connection( ! Identity_Crisis::validate_sync_error_idc_option(), true );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We fear that not hard disconnecting Jetpack before making sure sync will clean the cache site properly might increase the number of situations in which we'll have out of date information on WPCOM that may lead to undesired behavior.

If we decide we want to push this change further, let's merge this PR.

All other PRs related to the deprecation of Soft disconnect are fine as they don't introduce any breaking changes.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-55t-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate and connect Jetpack and one additional jetpack plugin
* Go to Plugins
* Make sure the label of the link to deactivate Jetpack says "Disconnect and Deactivate"
* Click it
* Make sure the modal informs about the other active plugin that will lose connection
* Click Disconnect and Deactivate
* Make sure the remaining plugin was disconnected