### PR TITLE
My Jetpack: Search flow plan B - Added exception for the Search checkout flow

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -59,7 +59,10 @@ export default function ProductInterstitial( {
 		recordEvent( 'jetpack_myjetpack_product_interstitial_add_link_click', { product: bundle } );
 	}, [ recordEvent, bundle ] );
 
-	const { isUserConnected } = useMyJetpackConnection();
+	// Search exception 1/2: Search checkout flow won't work with the unlinked=1 approach.
+	const from = 'search' === slug ? 'jetpack-search' : 'my-jetpack';
+
+	const { isUserConnected, handleConnectUser } = useMyJetpackConnection( { from } );
 
 	const navigateToMyJetpackOverviewPage = useMyJetpackNavigate( '/' );
 
@@ -81,10 +84,15 @@ export default function ProductInterstitial( {
 				return navigateToMyJetpackOverviewPage();
 			}
 
+			// Search exception 2/2: Search checkout flow won't work with the unlinked=1 approach. We rely on the redirect in calypso instead.
+			if ( 'search' === slug && ! isUserConnected && needsPurchase ) {
+				return handleConnectUser();
+			}
+
 			// Redirect to the checkout page.
 			window.location.href = getProductCheckoutUrl( wpcomProductSlug, isUserConnected );
 		} );
-	}, [ navigateToMyJetpackOverviewPage, activate, isUserConnected, slug ] );
+	}, [ navigateToMyJetpackOverviewPage, activate, isUserConnected, handleConnectUser, slug ] );
 
 	const onClickGoBack = useCallback( () => {
 		if ( slug ) {

--- a/projects/packages/my-jetpack/_inc/hooks/use-my-jetpack-connection/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-my-jetpack-connection/index.js
@@ -8,12 +8,14 @@ import { useConnection } from '@automattic/jetpack-connection';
 /**
  * React custom hook to get the site purchases data.
  *
+ * @param {object} args - Connection parameters
+ * @param {string} args.from - Identifier of the source of the connection/purchase flow.
  * @returns {object} site purchases data
  */
-export default function useMyJetpackConnection() {
+export default function useMyJetpackConnection( { from } = {} ) {
 	const { apiRoot, apiNonce } = myJetpackRest;
 	const { topJetpackMenuItemUrl } = myJetpackInitialState;
-	const connectionData = useConnection( { apiRoot, apiNonce } );
+	const connectionData = useConnection( { apiRoot, apiNonce, from } );
 
 	// Alias: https://github.com/Automattic/jetpack/blob/master/projects/packages/connection/src/class-rest-connector.php/#L315
 	const isSiteConnected = connectionData.isRegistered;

--- a/projects/packages/my-jetpack/changelog/update-search-exception-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/update-search-exception-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Added exception for the Search checkout flow


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Search flow is special and isn't working like the others. If we send the user to the checkout page with `unlinked=1`, the flow breaks.

If we are not able to fix the checkout page, we'll need this PR to add an exception to My Jetpack

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-55u-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate Boost and Search on this branch
* Set up Boost
* Go to My Jetpack
* Click to Purchase Search
* Make sure you are redirected to authentication and then to the checkout page