### PR TITLE
VideoPress: fix validation error for core/video

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-vp-core-video-validation
+++ b/projects/plugins/jetpack/changelog/fix-vp-core-video-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: avoid validation errors for core video block usage.

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -271,6 +271,9 @@ const addVideoPressSupport = ( settings, name ) => {
 			},
 			src: {
 				type: 'string',
+				source: 'attribute',
+				selector: 'video',
+				attribute: 'src',
 			},
 			useAverageColor: {
 				type: 'boolean',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- For the block `attributesDefinition` VideoPress provides, add a selector for the `src` attribute.

If a video block does not have a VideoPress `guid`:

https://github.com/Automattic/jetpack/blob/f9674a61bea783593236c1ac87887ff59422736a/projects/plugins/jetpack/extensions/blocks/videopress/save.js#L42-L53

We send things back to the `core/video` save method - which should have a valid src to [save](https://github.com/WordPress/gutenberg/blob/5623107f40907061ce670d8cfe51641a1cd47bd9/packages/block-library/src/video/save.js#L24-L26).

#### Jetpack product discussion

Fixes #23953

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

Before patching, reproduce validation error:

- Disconnect and deactivate Jetpack plugin.
- Create/edit a post and add a core video block with a video of your choice.
- Reactivate and connect Jetpack.
- Open the test post for editing again and observe the browser console for a validation error such as:

```plain
Block validation: Block validation failed for `core/video`

Content generated by `save` function:
<figure class="wp-block-video"></figure>
```

- Patch with changes here, build Jetpack, and refresh the post editor again. The block should no longer fail validation.