### PR TITLE
Stats: remove unnecessary type attribute from style element.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-stats-smiley-css
+++ b/projects/plugins/jetpack/changelog/update-stats-smiley-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Stats: remove unnecessary type attribute from style element.

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -892,7 +892,7 @@ function stats_convert_post_title( $matches ) {
  */
 function stats_hide_smile_css() {
 	?>
-<style type='text/css'>img#wpstats{display:none}</style>
+<style>img#wpstats{display:none}</style>
 	<?php
 }
 


### PR DESCRIPTION
Fixes #24423

#### Changes proposed in this Pull Request:

* Remove a `type` attribute that's not really necessary anymore, it was really only useful with HTML4.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start from a site connected to WordPress.com with the Stats feature active.
* Open the site in an incognito window.
* You should not see any smiley face in the footer of your site.
