### PR TITLE
[Performance tests] Fix performance tests broken setup

### DIFF
--- a/.github/workflows/block-performance.yml
+++ b/.github/workflows/block-performance.yml
@@ -3,6 +3,10 @@ name: Jetpack block performance
 on:
   schedule:
     - cron:  '0 */12 * * *'
+  push:
+    branches:
+      - 'fix/perf-tests-setup-failure'
+
 
 jobs:
   block-performance:
@@ -12,10 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup tools for G
-        uses: ./.github/actions/tool-setup
+      - uses: actions/setup-node@v3
         with:
-          node: 14
+          node-version: 14
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/block-performance.yml
+++ b/.github/workflows/block-performance.yml
@@ -3,10 +3,6 @@ name: Jetpack block performance
 on:
   schedule:
     - cron:  '0 */12 * * *'
-  push:
-    branches:
-      - 'fix/perf-tests-setup-failure'
-
 
 jobs:
   block-performance:


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Changes to `.pnpmfile.cjs` introduced by #24355 broke the setup step in Block Performance tests job. Gutenberg requires node 14, and the changes introduce the use of logical OR assignment that's only available on Node >= 15. 
Since Gutenberg only needs Node, I replaced the `.github/actions/tool-setup` with `actions/checkout@v3`, thus skipping the `.pnpmfile.cjs`


#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- See run [6505198228](https://github.com/Automattic/jetpack/runs/6505198228?check_suite_focus=true)
