### PR TITLE
Protect: update Admin page layout composition

### DIFF
--- a/projects/js-packages/components/changelog/update-protect-iterate-over-admin-page
+++ b/projects/js-packages/components/changelog/update-protect-iterate-over-admin-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+JS Components: Add isCard prop to Dialog component

--- a/projects/js-packages/components/components/dialog/index.tsx
+++ b/projects/js-packages/components/components/dialog/index.tsx
@@ -16,6 +16,8 @@ type DialogProps = {
 	primary: React.ReactNode;
 	secondary?: React.ReactNode;
 	isTwoSections?: boolean;
+	isCard?: boolean;
+	containerProps: object;
 };
 
 /**
@@ -25,9 +27,17 @@ type DialogProps = {
  * @param {React.ReactNode} props.primary   - Primary-section content.
  * @param {React.ReactNode} props.secondary - Secondary-section content.
  * @param {boolean} props.isTwoSections     - Handle two sections layout when true.
+ * @param {boolean} props.isCard            - Add card styles to the main container.
+ * @param {object} props.containerProps     - Props to pass to the container component.
  * @returns {React.ReactNode}                 Rendered dialog
  */
-const Dialog: React.FC< DialogProps > = ( { primary, secondary, isTwoSections = false } ) => {
+const Dialog: React.FC< DialogProps > = ( {
+	primary,
+	secondary,
+	isTwoSections = false,
+	isCard,
+	...containerProps
+} ) => {
 	const [ isSmall, isLowerThanLarge ] = useBreakpointMatch( [ 'sm', 'lg' ], [ null, '<' ] );
 
 	/*
@@ -38,12 +48,18 @@ const Dialog: React.FC< DialogProps > = ( { primary, secondary, isTwoSections = 
 	const hideSecondarySection = ! isTwoSections && isSmall;
 
 	const classNames = classnames( {
-		[ styles[ 'one-section-style' ] ]: ! isTwoSections,
+		[ styles[ 'one-section-style' ] ]: typeof isCard !== 'undefined' ? isCard : ! isTwoSections,
 		[ styles[ 'is-viewport-small' ] ]: isSmall,
 	} );
 
 	return (
-		<Container className={ classNames } horizontalSpacing={ 0 } horizontalGap={ 0 } fluid>
+		<Container
+			className={ classNames }
+			horizontalSpacing={ 0 }
+			horizontalGap={ 0 }
+			fluid={ false }
+			{ ...containerProps }
+		>
 			{ ! hideSecondarySection && (
 				<>
 					<Col sm={ 4 } md={ isLowerThanLarge ? 4 : 5 } lg={ 7 } className={ styles.primary }>

--- a/projects/js-packages/components/components/dialog/stories/js-components.components.dialog.story.mdx
+++ b/projects/js-packages/components/components/dialog/stories/js-components.components.dialog.story.mdx
@@ -10,7 +10,7 @@ import styles from './style.module.scss';
 	title="JS Packages/Components/Dialog" component={ Dialog }
 />
 
-export const Template = ( { isTwoSections } ) => (
+export const Template = ( { isTwoSections, isCard } ) => (
 	<Dialog
 		primary= {
 			<div className={ styles.section }>
@@ -26,6 +26,7 @@ export const Template = ( { isTwoSections } ) => (
 			</div>
 		}
 		isTwoSections= { isTwoSections }
+		isCard={ isCard }
 	/>
 );
 
@@ -51,6 +52,7 @@ import Dialog from '@automattic/jetpack-components';
 	name="Readme"
 	args={ {
 		isTwoSections: true,
+		isCard: false,
 	} }
 >
 	{ Template.bind( {} ) }
@@ -83,7 +85,6 @@ Primary-section content.
 
 Primary-section content.
 
-
 ### isTwoSections
 
 - Type: `boolean`.
@@ -93,3 +94,11 @@ Primary-section content.
 It handles two sections layout:
   - Add card styles to the main wrapper when it is not a two-sections layout.
   - When it's false, the secondary section won't show in Mobile.
+
+### isCard
+
+- Type: `boolean`.
+- Optional.
+- Default: `false`
+
+Add card styles to the main wrapper.

--- a/projects/plugins/protect/changelog/update-protect-iterate-over-admin-page
+++ b/projects/plugins/protect/changelog/update-protect-iterate-over-admin-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Protect: re implement Admin page by using Dialog component

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { useEffect } from 'react';
+import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 
@@ -12,7 +13,7 @@ import {
 	Col,
 	H3,
 	Text,
-	Dialog,
+	useBreakpointMatch,
 } from '@automattic/jetpack-components';
 import { useProductCheckoutWorkflow, useConnection } from '@automattic/jetpack-connection';
 
@@ -32,6 +33,37 @@ import AlertSVGIcon from '../alert-icon';
 import styles from './styles.module.scss';
 
 export const SECURITY_BUNDLE = 'jetpack_security_t1_yearly';
+
+export const SeventyFiveLayout = ( { main, secondary, preserveSecondaryOnMobile = false } ) => {
+	const [ isSmall, isLowerThanLarge ] = useBreakpointMatch( [ 'sm', 'lg' ], [ null, '<' ] );
+
+	const classNames = classnames( {
+		[ styles[ 'is-viewport-small' ] ]: isSmall,
+	} );
+
+	/*
+	 * By convention, secondary section is not shown when:
+	 * - preserveSecondaryOnMobile is false
+	 * - on mobile breakpoint (sm)
+	 */
+	const hideSecondarySection = ! preserveSecondaryOnMobile && isSmall;
+
+	return (
+		<Container className={ classNames } horizontalSpacing={ 0 } horizontalGap={ 0 } fluid={ false }>
+			{ ! hideSecondarySection && (
+				<>
+					<Col sm={ 4 } md={ isLowerThanLarge ? 4 : 5 } lg={ 7 } className={ styles.main }>
+						{ main }
+					</Col>
+					<Col sm={ 4 } md={ isLowerThanLarge ? 4 : 3 } lg={ 5 } className={ styles.secondary }>
+						{ secondary }
+					</Col>
+				</>
+			) }
+			{ hideSecondarySection && <Col>{ main }</Col> }
+		</Container>
+	);
+};
 
 const InterstitialPage = ( { run, hasCheckoutStarted } ) => {
 	return (
@@ -64,17 +96,16 @@ const ProtectAdminPage = () => {
 		return (
 			<AdminPage moduleName={ __( 'Jetpack Protect', 'jetpack-protect' ) } header={ <Logo /> }>
 				<AdminSectionHero>
-					<Dialog
-						primary={
-							<div className={ styles.primary }>
+					<SeventyFiveLayout
+						main={
+							<div className={ styles[ 'alert-section' ] }>
 								<AlertSVGIcon className={ styles[ 'alert-icon-wrapper' ] } />
 								<H3>{ __( 'We’re having problems scanning your site', 'jetpack-protect' ) }</H3>
 								<Text>{ displayErrorMessage }</Text>
 							</div>
 						}
 						secondary={ <img src={ inProgressImage } alt="" /> }
-						isTwoSections={ false }
-						isCard={ false }
+						preserveSecondaryOnMobile={ false }
 					/>
 				</AdminSectionHero>
 				<Footer />

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -104,7 +104,11 @@ const ProtectAdminPage = () => {
 								<Text>{ displayErrorMessage }</Text>
 							</div>
 						}
-						secondary={ <img src={ inProgressImage } alt="" /> }
+						secondary={
+							<div className={ styles[ 'alert-section-illustration' ] }>
+								<img src={ inProgressImage } alt="" />
+							</div>
+						}
 						preserveSecondaryOnMobile={ false }
 					/>
 				</AdminSectionHero>

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -34,6 +34,20 @@ import styles from './styles.module.scss';
 
 export const SECURITY_BUNDLE = 'jetpack_security_t1_yearly';
 
+/**
+ * SeventyFive layout meta component
+ * The component name references to
+ * the sections disposition of the layout.
+ * FiftyFifty, 75, thus 7|5 means the cols numbers
+ * for main and secondary sections respectively,
+ * in large lg viewport size.
+ *
+ * @param {object} props                            - Component props
+ * @param {React.ReactNode} props.main              - Main section component
+ * @param {React.ReactNode} props.secondary         - Secondary section component
+ * @param {boolean} props.preserveSecondaryOnMobile - Whether to show secondary section on mobile
+ * @returns {React.ReactNode} 					    - React meta-component
+ */
 export const SeventyFiveLayout = ( { main, secondary, preserveSecondaryOnMobile = false } ) => {
 	const [ isSmall ] = useBreakpointMatch( [ 'sm', 'lg' ], [ null, '<' ] );
 

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -52,8 +52,12 @@ export const SeventyFiveLayout = ( { main, secondary, preserveSecondaryOnMobile 
 		<Container className={ classNames } horizontalSpacing={ 0 } horizontalGap={ 0 } fluid={ false }>
 			{ ! hideSecondarySection && (
 				<>
-					<div className={ styles.main }>{ main }</div>
-					<div className={ styles.secondary }>{ secondary }</div>
+					<Col sm={ 4 } md={ 4 } className={ styles.main }>
+						{ main }
+					</Col>
+					<Col sm={ 4 } md={ 4 } className={ styles.secondary }>
+						{ secondary }
+					</Col>
 				</>
 			) }
 			{ hideSecondarySection && <Col>{ main }</Col> }

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -35,7 +35,7 @@ import styles from './styles.module.scss';
 export const SECURITY_BUNDLE = 'jetpack_security_t1_yearly';
 
 export const SeventyFiveLayout = ( { main, secondary, preserveSecondaryOnMobile = false } ) => {
-	const [ isSmall, isLowerThanLarge ] = useBreakpointMatch( [ 'sm', 'lg' ], [ null, '<' ] );
+	const [ isSmall ] = useBreakpointMatch( [ 'sm', 'lg' ], [ null, '<' ] );
 
 	const classNames = classnames( {
 		[ styles[ 'is-viewport-small' ] ]: isSmall,
@@ -52,12 +52,8 @@ export const SeventyFiveLayout = ( { main, secondary, preserveSecondaryOnMobile 
 		<Container className={ classNames } horizontalSpacing={ 0 } horizontalGap={ 0 } fluid={ false }>
 			{ ! hideSecondarySection && (
 				<>
-					<Col sm={ 4 } md={ isLowerThanLarge ? 4 : 5 } lg={ 7 } className={ styles.main }>
-						{ main }
-					</Col>
-					<Col sm={ 4 } md={ isLowerThanLarge ? 4 : 3 } lg={ 5 } className={ styles.secondary }>
-						{ secondary }
-					</Col>
+					<div className={ styles.main }>{ main }</div>
+					<div className={ styles.secondary }>{ secondary }</div>
 				</>
 			) }
 			{ hideSecondarySection && <Col>{ main }</Col> }

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -12,6 +12,7 @@ import {
 	Col,
 	H3,
 	Text,
+	Dialog,
 } from '@automattic/jetpack-components';
 import { useProductCheckoutWorkflow, useConnection } from '@automattic/jetpack-connection';
 
@@ -63,17 +64,18 @@ const ProtectAdminPage = () => {
 		return (
 			<AdminPage moduleName={ __( 'Jetpack Protect', 'jetpack-protect' ) } header={ <Logo /> }>
 				<AdminSectionHero>
-					<Container horizontalSpacing={ 3 } horizontalGap={ 7 }>
-						<Col sm={ 4 } md={ 4 } lg={ 6 }>
-							<AlertSVGIcon className={ styles[ 'alert-icon-wrapper' ] } />
-							<H3>{ __( 'We’re having problems scanning your site', 'jetpack-protect' ) }</H3>
-							<Text>{ displayErrorMessage }</Text>
-						</Col>
-						<Col sm={ 0 } md={ 0 } lg={ 1 }></Col>
-						<Col sm={ 4 } md={ 3 } lg={ 5 }>
-							<img src={ inProgressImage } alt="" />
-						</Col>
-					</Container>
+					<Dialog
+						primary={
+							<div className={ styles.primary }>
+								<AlertSVGIcon className={ styles[ 'alert-icon-wrapper' ] } />
+								<H3>{ __( 'We’re having problems scanning your site', 'jetpack-protect' ) }</H3>
+								<Text>{ displayErrorMessage }</Text>
+							</div>
+						}
+						secondary={ <img src={ inProgressImage } alt="" /> }
+						isTwoSections={ false }
+						isCard={ false }
+					/>
 				</AdminSectionHero>
 				<Footer />
 			</AdminPage>

--- a/projects/plugins/protect/src/js/components/admin-page/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/admin-page/styles.module.scss
@@ -1,10 +1,15 @@
 // seventy-five layout
-.main {
-	grid-column: 1 / span 6;
-}
+// Handle large lg size from here,
+// adding a gap on one column
+// in between main and secondary sections.
+@media ( min-width: 960px ) {
+	.main {
+		grid-column: 1 / span 6;
+	}
 
-.secondary {
-	grid-column: 8 / span 5;
+	.secondary {
+		grid-column: 8 / span 5;
+	}
 }
 
 // Alert section

--- a/projects/plugins/protect/src/js/components/admin-page/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/admin-page/styles.module.scss
@@ -1,3 +1,13 @@
+// seventy-five layout
+.main {
+	grid-column: 1 / span 6;
+}
+
+.secondary {
+	grid-column: 8 / span 5;
+}
+
+// Alert section
 .alert-section {
 	padding: calc( var( --spacing-base ) * 7 ) 0;
 }

--- a/projects/plugins/protect/src/js/components/admin-page/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/admin-page/styles.module.scss
@@ -1,8 +1,3 @@
 .primary {
 	padding: calc( var( --spacing-base ) * 7 ) 0;
 }
-
-.alert-icon-wrapper {
-	margin-top: -4px;
-	margin-left: -40px; // the icon has a drop shadow that is 40px wide
-}

--- a/projects/plugins/protect/src/js/components/admin-page/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/admin-page/styles.module.scss
@@ -1,3 +1,7 @@
+.primary {
+	padding: calc( var( --spacing-base ) * 7 ) 0;
+}
+
 .alert-icon-wrapper {
 	margin-top: -4px;
 	margin-left: -40px; // the icon has a drop shadow that is 40px wide

--- a/projects/plugins/protect/src/js/components/admin-page/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/admin-page/styles.module.scss
@@ -1,11 +1,11 @@
-.main,
-.secondary {
-	display: flex;
+.alert-section {
+	padding: calc( var( --spacing-base ) * 7 ) 0;
 }
 
-// Fit images in secondary section.
-.secondary {
+.alert-section-illustration {
+	display: flex;
 	align-items: center;
+	height: 100%;
 	img {
 		// let's fit images
 		object-fit: cover;
@@ -19,8 +19,4 @@
 	.main {
 		margin-bottom: calc( var( --spacing-base ) * 3 );
 	}
-}
-
-.alert-section {
-	padding: calc( var( --spacing-base ) * 7 ) 0;
 }

--- a/projects/plugins/protect/src/js/components/admin-page/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/admin-page/styles.module.scss
@@ -1,3 +1,26 @@
-.primary {
+.main,
+.secondary {
+	display: flex;
+}
+
+// Fit images in secondary section.
+.secondary {
+	align-items: center;
+	img {
+		// let's fit images
+		object-fit: cover;
+		width: 100%;
+	}
+}
+
+// Viewport breakpoints.
+.is-viewport-small {
+	// Add spacing between main and secondary in "sm" viewport size
+	.main {
+		margin-bottom: calc( var( --spacing-base ) * 3 );
+	}
+}
+
+.alert-section {
 	padding: calc( var( --spacing-base ) * 7 ) 0;
 }

--- a/projects/plugins/protect/src/js/components/alert-icon/index.jsx
+++ b/projects/plugins/protect/src/js/components/alert-icon/index.jsx
@@ -5,6 +5,11 @@ import React from 'react';
 import { Path, SVG, Rect, G } from '@wordpress/components';
 
 /**
+ * Internal dependencies
+ */
+import styles from './styles.module.scss';
+
+/**
  * Alert icon
  *
  * @param {object} props           - Props.
@@ -14,57 +19,63 @@ import { Path, SVG, Rect, G } from '@wordpress/components';
  */
 export default function AlertSVGIcon( { className, color = '#D63638' } ) {
 	return (
-		<SVG
-			className={ className }
-			width="127"
-			height="136"
-			viewBox="0 0 127 136"
-			fill="none"
-			xmlns="http://www.w3.org/2000/svg"
-		>
-			<G filter="url(#filter0_d_2716_19567)">
-				<Path
-					fillRule="evenodd"
-					clipRule="evenodd"
-					d="M63.4061 36L86.8123 46.4057V61.9177C86.8123 75.141 78.1289 87.6611 65.8844 91.6107C64.2754 92.1298 62.5369 92.1297 60.9279 91.6107C48.6834 87.6611 40 75.141 40 61.9177V46.4057L63.4061 36Z"
-					fill={ color }
-				/>
-				<Rect x="59.8953" y="72.1666" width="7.02184" height="7" rx="3.5" fill="white" />
-				<Path
-					d="M59.9619 51.0626C59.9258 50.4868 60.383 50 60.9599 50H65.8524C66.4293 50 66.8866 50.4868 66.8505 51.0626L65.8056 67.7292C65.7725 68.2562 65.3355 68.6667 64.8075 68.6667H62.0048C61.4769 68.6667 61.0398 68.2562 61.0068 67.7292L59.9619 51.0626Z"
-					fill="white"
-				/>
-			</G>
-			<defs>
-				<filter
-					id="filter0_d_2716_19567"
-					x="0"
-					y="0"
-					width="126.812"
-					height="136"
-					filterUnits="userSpaceOnUse"
-					colorInterpolationFilters="sRGB"
-				>
-					<feFlood floodOpacity="0" result="BackgroundImageFix" />
-					<feColorMatrix
-						in="SourceAlpha"
-						type="matrix"
-						values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
-						result="hardAlpha"
+		<div className={ styles.container }>
+			<SVG
+				className={ className }
+				width="127"
+				height="136"
+				viewBox="0 0 127 136"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<G filter="url(#filter0_d_2716_19567)">
+					<Path
+						fillRule="evenodd"
+						clipRule="evenodd"
+						d="M63.4061 36L86.8123 46.4057V61.9177C86.8123 75.141 78.1289 87.6611 65.8844 91.6107C64.2754 92.1298 62.5369 92.1297 60.9279 91.6107C48.6834 87.6611 40 75.141 40 61.9177V46.4057L63.4061 36Z"
+						fill={ color }
 					/>
-					<feOffset dy="4" />
-					<feGaussianBlur stdDeviation="20" />
-					<feComposite in2="hardAlpha" operator="out" />
-					<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.08 0" />
-					<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2716_19567" />
-					<feBlend
-						mode="normal"
-						in="SourceGraphic"
-						in2="effect1_dropShadow_2716_19567"
-						result="shape"
+					<Rect x="59.8953" y="72.1666" width="7.02184" height="7" rx="3.5" fill="white" />
+					<Path
+						d="M59.9619 51.0626C59.9258 50.4868 60.383 50 60.9599 50H65.8524C66.4293 50 66.8866 50.4868 66.8505 51.0626L65.8056 67.7292C65.7725 68.2562 65.3355 68.6667 64.8075 68.6667H62.0048C61.4769 68.6667 61.0398 68.2562 61.0068 67.7292L59.9619 51.0626Z"
+						fill="white"
 					/>
-				</filter>
-			</defs>
-		</SVG>
+				</G>
+				<defs>
+					<filter
+						id="filter0_d_2716_19567"
+						x="0"
+						y="0"
+						width="126.812"
+						height="136"
+						filterUnits="userSpaceOnUse"
+						colorInterpolationFilters="sRGB"
+					>
+						<feFlood floodOpacity="0" result="BackgroundImageFix" />
+						<feColorMatrix
+							in="SourceAlpha"
+							type="matrix"
+							values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+							result="hardAlpha"
+						/>
+						<feOffset dy="4" />
+						<feGaussianBlur stdDeviation="20" />
+						<feComposite in2="hardAlpha" operator="out" />
+						<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.08 0" />
+						<feBlend
+							mode="normal"
+							in2="BackgroundImageFix"
+							result="effect1_dropShadow_2716_19567"
+						/>
+						<feBlend
+							mode="normal"
+							in="SourceGraphic"
+							in2="effect1_dropShadow_2716_19567"
+							result="shape"
+						/>
+					</filter>
+				</defs>
+			</SVG>
+		</div>
 	);
 }

--- a/projects/plugins/protect/src/js/components/alert-icon/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/alert-icon/styles.module.scss
@@ -1,0 +1,11 @@
+.container {
+	width: 48px;
+	height: 56px;
+	margin-bottom: calc( var( --spacing-base ) * 8 );
+
+	> SVG {
+		position: relative;
+		top: -36px;
+		left: -40px;
+	}
+}

--- a/projects/plugins/protect/src/js/components/alert-icon/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/alert-icon/styles.module.scss
@@ -3,7 +3,7 @@
 	height: 56px;
 	margin-bottom: calc( var( --spacing-base ) * 8 );
 
-	> SVG {
+	> svg {
 		position: relative;
 		top: -36px;
 		left: -40px;

--- a/projects/plugins/protect/src/js/components/footer/index.jsx
+++ b/projects/plugins/protect/src/js/components/footer/index.jsx
@@ -12,6 +12,7 @@ import { useProductCheckoutWorkflow } from '@automattic/jetpack-connection';
 import useAnalyticsTracks from '../../hooks/use-analytics-tracks';
 import { SECURITY_BUNDLE, SeventyFiveLayout } from '../admin-page';
 import useProtectData from '../../hooks/use-protect-data';
+import styles from './styles.module.scss';
 
 const ProductPromotion = () => {
 	const { adminUrl } = window.jetpackProtectInitialState || {};
@@ -34,7 +35,7 @@ const ProductPromotion = () => {
 		const getStartedUrl = getRedirectUrl( 'protect-footer-get-started-scan' );
 
 		return (
-			<>
+			<div className={ styles[ 'product-section' ] }>
 				<IconsCard products={ [ 'backup', 'scan', 'anti-spam' ] } />
 				<Title>
 					{ __( 'Increase your site protection with Jetpack Scan', 'jetpack-protect' ) }
@@ -49,12 +50,12 @@ const ProductPromotion = () => {
 				<Button variant="external-link" weight="regular" href={ getStartedUrl }>
 					{ __( 'Get Started', 'jetpack-protect' ) }
 				</Button>
-			</>
+			</div>
 		);
 	}
 
 	return (
-		<>
+		<div className={ styles[ 'product-section' ] }>
 			<IconsCard products={ [ 'scan' ] } />
 			<Title>{ __( 'Comprehensive Site Security', 'jetpack-protect' ) }</Title>
 			<Text mb={ 3 }>
@@ -67,7 +68,7 @@ const ProductPromotion = () => {
 			<Button variant="secondary" onClick={ getSecurityBundle } isLoading={ hasCheckoutStarted }>
 				{ __( 'Get Jetpack Security', 'jetpack-protect' ) }
 			</Button>
-		</>
+		</div>
 	);
 };
 
@@ -75,7 +76,7 @@ const FooterInfo = () => {
 	const learnMoreUrl = getRedirectUrl( 'jetpack-protect-footer-learn-more' );
 
 	return (
-		<>
+		<div className={ styles[ 'info-section' ] }>
 			<Title>{ __( 'Over 22,000 listed vulnerabilities', 'jetpack-protect' ) }</Title>
 			<Text mb={ 3 }>
 				{ __(
@@ -86,7 +87,7 @@ const FooterInfo = () => {
 			<Button variant="external-link" href={ learnMoreUrl } weight="regular">
 				{ __( 'Learn more', 'jetpack-protect' ) }
 			</Button>
-		</>
+		</div>
 	);
 };
 

--- a/projects/plugins/protect/src/js/components/footer/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/footer/styles.module.scss
@@ -1,0 +1,7 @@
+.product-section {
+	margin-top: calc( var( --spacing-base ) * 7 );
+}
+
+.info-section {
+	margin-top: calc( var( --spacing-base ) * 14 );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR iterates over the Admin page to re-implement the layout composition.
Currently, there is a not very well usage of the Layout in the AdminPage and Footer components.
To deal with this, I've introduced a new SeventyFiveLayout component which takes over to render properly the main and secondary sections. This component tries to achive the layout defined by designers folks.

<img width="740" alt="image" src="https://user-images.githubusercontent.com/77539/169900021-ded9548b-cd97-4dd8-baf7-7f86a78eb57c.png">

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* JS Components: Add isCard property to Dialog component
* Protect: Re implement Error admin page by using Dialog component
* Protect: Tweak Alert icon

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Protect
* Set up your testing site to see the error page
* Confirm the layout looks good

In the image below, there are two SeventyFiveLayout components.

<img width="1080" alt="image" src="https://user-images.githubusercontent.com/77539/169900554-7c7aa3b5-c2c4-495a-a262-c91695266270.png">

Try to active the grid by using the dev tool. Both instances, the error message and the footer are properly algined.
the gap bwteen the tow sections, in `lg` bteakpoint, is 1 colum width.

<img width="507" alt="Screen Shot 2022-05-23 at 5 32 34 PM" src="https://user-images.githubusercontent.com/77539/169901284-d1e58074-871c-4e46-b72a-fee0bb3e9807.png">

It changes the box-model for `md` and `sm` breakpoints too

<img width="867" alt="image" src="https://user-images.githubusercontent.com/77539/169901386-44102bfc-796f-490e-965e-e3d6d3226a38.png">

<img width="563" alt="image" src="https://user-images.githubusercontent.com/77539/169901426-8568f7b5-7f4c-4ef8-930a-165b065a4d5c.png">

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202306181281607