### PR TITLE
JP CLI: add help text for jt-up command failures

### DIFF
--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -457,11 +457,26 @@ const execJtCmdHandler = argv => {
 	const jtResult = executor( argv, () => shellExecutor( argv, cmd, opts.concat( jtOpts ) ) );
 
 	if ( jtResult.status !== 0 ) {
-		console.warn(
-			chalk.yellow(
-				'Unable to establish Jurassic Tube connection. Is your Jetpack Docker container up? If not try: jetpack docker up -d'
-			)
+		// Try to check if the default named Jetpack container is up.
+		const dockerPs = spawnSync(
+			'docker',
+			[
+				"ps --filter 'name=jetpack_dev_wordpress' --filter 'status=running' --format='{{.ID}} {{.Names}}'",
+			],
+			{
+				encoding: 'utf8',
+				shell: true,
+			}
 		);
+
+		if ( dockerPs.status === 0 && dockerPs.stdout.length === 0 ) {
+			console.warn(
+				chalk.yellow(
+					'Unable to establish Jurassic Tube connection. Is your Jetpack Docker container up? If not, try: jetpack docker up -d'
+				)
+			);
+		}
+
 		process.exit( jtResult.status );
 	}
 

--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -475,9 +475,9 @@ const execJtCmdHandler = argv => {
 					'Unable to establish Jurassic Tube connection. Is your Jetpack Docker container up? If not, try: jetpack docker up -d'
 				)
 			);
-		}
 
-		process.exit( jtResult.status );
+			process.exit( jtResult.status );
+		}
 	}
 
 	checkProcessResult( jtResult );

--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -481,11 +481,14 @@ const execJtCmdHandler = argv => {
 	}
 
 	checkProcessResult( jtResult );
-	console.warn(
-		chalk.yellow(
-			'Remember! This is creating a tunnel to your local machine. Please use jetpack docker jt-down as soon as you are done with your testing.'
-		)
-	);
+
+	if ( arg !== 'jt-down' ) {
+		console.warn(
+			chalk.yellow(
+				'Remember! This is creating a tunnel to your local machine. Please use jetpack docker jt-down as soon as you are done with your testing.'
+			)
+		);
+	}
 };
 
 /**

--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -438,6 +438,14 @@ const execJtCmdHandler = argv => {
 		cmd = jtTunnelFile;
 		opts.push( 'break' );
 	} else if ( arg === 'jt-up' ) {
+		const dockerPs = spawnSync( 'docker', [ 'ps' ] );
+		if ( dockerPs.status !== 0 ) {
+			console.warn(
+				chalk.yellow( 'Docker status unreachable. Make sure that the Docker service has started.' )
+			);
+			process.exit( dockerPs.status );
+		}
+
 		cmd = jtTunnelFile;
 		console.warn(
 			chalk.yellow(
@@ -447,6 +455,16 @@ const execJtCmdHandler = argv => {
 	}
 
 	const jtResult = executor( argv, () => shellExecutor( argv, cmd, opts.concat( jtOpts ) ) );
+
+	if ( jtResult.status !== 0 ) {
+		console.warn(
+			chalk.yellow(
+				'Unable to establish Jurassic Tube connection. Is your Jetpack Docker container up? If not try: jetpack docker up -d'
+			)
+		);
+		process.exit( jtResult.status );
+	}
+
 	checkProcessResult( jtResult );
 	console.warn(
 		chalk.yellow(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Check to make sure Docker is running before executing `jt-up` command.
- When running `jt-up`, check to see if the default `jetpack_dev_wordpress*` container is up and running, if not print some help text.
- When running `jt-down`, don't show the "Remember! This is creating a tunnel..." message since we are disconnecting.

> Could we detect that Docker is not up yet and either bring it up or at least provide notice that jetpack docker up -d is needed.

I decided to go with just some help text here. The `jt-up` command could fail for other reasons aside from the container not being started, so trying to check for the container status or bring it up manually seems heavy-handed. We also don't know if people prefer running detached `-d` or not for example.

#### Jetpack product discussion

Closes #22540

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

- Before patching, without Docker running at all, try running `jetpack docker jt-up`. This should print a giant stack trace.
- After starting Docker, try running the command again, you should see something like:

```plain
Establishing the connection
Command exited with status 1
Command exited with status 1
```

- Close the Docker service, patch with changes in this PR.
- Again, try `jetpack docker jt-up` which should catch that the Docker service hasn't started.
- Start Docker, then try the command again which should print:

```plain
Establishing the connection
Command exited with status 1
Unable to establish Jurassic Tube connection. Is your Jetpack Docker container up? If not try: jetpack docker up -d
```

![Screen Shot 2022-05-19 at 2 20 11 PM](https://user-images.githubusercontent.com/15803018/169399568-803cfd24-36f9-4da5-ada7-51842fe33497.png)

