### PR TITLE
Widget Visibility: avoid PHP warnings when loading widgets.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-notice-widget-visibility-1135
+++ b/projects/plugins/jetpack/changelog/fix-notice-widget-visibility-1135
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Widget Visibility: avoid PHP warnings when loading widgets in some scenarios.

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -1127,6 +1127,10 @@ class Jetpack_Widget_Conditions {
 				$opts      = $wp_registered_widgets[ $widget ];
 				$instances = get_option( $opts['callback'][0]->option_name );
 
+				if ( ! is_array( $instances ) || empty( $instances ) ) {
+					continue;
+				}
+
 				// Going through each instance of the widget.
 				foreach ( $instances as $number => $instance ) {
 					if (


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

In some scenarios (maybe with some other plugins impacting widgets), one can run into the following warning:

```
Warning: Invalid argument supplied for foreach() in /var/www/wp-content/mu-plugins/jetpack-10.9/modules/widget-visibility/widget-conditions.php on line 1135
```

Let's try to avoid that.

#### Jetpack product discussion

Internal references:

- pcfWIW-Rj-p2#comment-2430
- p1653037254767549-slack-CDD9LQRSN


#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* I'm not super clear on how to reproduce the original warning, but I would recommend enabling the Widget Visibility feature and ensuring it still works properly.
* Note that you need to use a theme that supports widgets to be able to use the feature. Twenty Twenty is a good example.
