### PR TITLE
Fix/product description price

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/jetpack-product-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-product-card/index.jsx
@@ -4,7 +4,7 @@
 import React, { useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { getCurrencyObject } from '@automattic/format-currency';
+import { ProductPrice } from '@automattic/jetpack-components';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -19,22 +19,6 @@ import Gridicon from 'components/gridicon';
  */
 import './style.scss';
 
-const formatPrice = ( price, currencyCode, isOldPrice = false ) => {
-	const priceObject = getCurrencyObject( price, currencyCode );
-	const classes = classNames( {
-		'jp-product-card__raw-price': true,
-		'jp-product-card__raw-price--is-old-price': isOldPrice,
-	} );
-
-	return (
-		<div className={ classes }>
-			<sup className="jp-product-card__currency-symbol">{ priceObject.symbol }</sup>
-			<span className="jp-product-card__price-integer">{ priceObject.integer }</span>
-			<sup className="jp-product-card__price-fraction">{ priceObject.fraction }</sup>
-		</div>
-	);
-};
-
 const JetpackProductCard = props => {
 	const {
 		icon,
@@ -44,7 +28,7 @@ const JetpackProductCard = props => {
 		features,
 		currencyCode,
 		price,
-		discount,
+		discountedPrice,
 		billingDescription,
 		callToAction,
 		checkoutText,
@@ -53,8 +37,6 @@ const JetpackProductCard = props => {
 		illustrationPath,
 	} = props;
 
-	const discountedPrice = ( price * ( 100 - discount ) ) / 100;
-	const isDiscounted = discount > 0;
 	const hasMedia = !! illustrationPath;
 	const hasCta = !! callToAction;
 
@@ -107,10 +89,14 @@ const JetpackProductCard = props => {
 				) }
 
 				<div className="jp-product-card__price">
-					{ formatPrice( price, currencyCode, !! isDiscounted ) }
-					{ !! isDiscounted && formatPrice( discountedPrice, currencyCode ) }
+					<ProductPrice
+						currency={ currencyCode }
+						price={ price }
+						offPrice={ discountedPrice }
+						showNotOffPrice={ !! discountedPrice }
+						leyend={ billingDescription }
+					/>
 				</div>
-				<span className="jp-product-card__price-description">{ billingDescription }</span>
 
 				<Button className={ buttonClasses } href={ checkoutUrl } onClick={ onClick }>
 					{ checkoutText }
@@ -137,12 +123,12 @@ JetpackProductCard.propTypes = {
 	checkoutUrl: PropTypes.string.isRequired,
 	title: PropTypes.string.isRequired,
 	price: PropTypes.number.isRequired,
+	discountedPrice: PropTypes.number,
 	currencyCode: PropTypes.string.isRequired,
 	billingDescription: PropTypes.string.isRequired,
 	productSlug: PropTypes.string.isRequired,
 	description: PropTypes.string,
 	features: PropTypes.array,
-	discount: PropTypes.number,
 	icon: PropTypes.element,
 	callToAction: PropTypes.string,
 	priority: PropTypes.string,
@@ -150,9 +136,7 @@ JetpackProductCard.propTypes = {
 };
 
 JetpackProductCard.defaultProps = {
-	arePromotionsActive: false,
 	description: '',
-	discount: 0,
 	features: [],
 	priority: 'primary',
 	showIllustration: '',

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-product-card/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-product-card/style.scss
@@ -77,67 +77,44 @@
 }
 
 .jp-product-card__price {
-	display: flex;
-	flex-wrap: wrap;
-	flex-direction: row;
-	margin-top: auto;
-	color: $black;
-}
+	// Price item
+	> div > p {
+		margin-inline-end: 0.75rem !important;
 
-.jp-product-card__raw-price {
-	display: flex;
-	margin: 0 22px 0 0;
-	font-size: $font-headline-medium;
-}
+		font-size: 3.375rem;
+		font-weight: 700;
+		line-height: 0.7;
 
-.jp-product-card__raw-price--is-old-price {
-	position: relative;
-	color: $studio-gray-20;
+		// Currency symbol
+		sup:first-of-type {
+			font-size: 1.5rem;
+			margin-top: -0.25rem;
+		}
 
-	&::after {
-		content: " ";
-		display: block;
-		width: 100%;
-		height: 3px;
-		background: #c9356e;
-		border-radius: 5px;
-		position: absolute;
-		top: 50%;
-		margin-top: -2px;
-		pointer-events: none;
+		// Fraction
+		sup:last-of-type {
+			font-size: 0.75rem;
+			margin-top: -0.75rem;
+		}
+
+		// Final price
+		&:last-child {
+			color: var( --jp-gray-100 );
+		}
 	}
-}
 
-.jp-product-card__currency-symbol {
-	padding-right: 1px;
-	font-size: .5em;
-	line-height: 1.4;
-}
+	// Billing timeframe
+	> p {
+		margin-top: 0.5rem;
 
-.jp-product-card__price-integer {
-	font-size: inherit;
-	font-weight: $bold;
-	line-height: 1;
-}
-
-.jp-product-card__price-fraction {
-	padding-left: 1px;
-	font-size: 0.35em;
-	font-weight: $bold;
-	line-height: 1.7;
-}
-
-.jp-product-card__price-description {
-	display: block;
-	font-size: $font-body-small;
-	color: $studio-gray-40;
-	margin-bottom: 32px;
-	letter-spacing: 0.2px;
+		font-size: 0.875rem;
+	}
 }
 
 .jp-product-card__checkout {
 	align-self: flex-start;
 	font-size: rem( 16px );
+	margin-top: 2rem;
 	padding-left: 60px;
 	padding-right: 60px;
 	text-align: center;
@@ -154,9 +131,7 @@
 			color: $white;
 		}
 		&:focus {
-			box-shadow:
-				0 0 0 1px $white,
-				0 0 0 3px $black;
+			box-shadow: 0 0 0 1px $white, 0 0 0 3px $black;
 		}
 	}
 
@@ -173,9 +148,7 @@
 			color: $white;
 		}
 		&:focus {
-			box-shadow:
-				0 0 0 1px $white,
-				0 0 0 3px $black;
+			box-shadow: 0 0 0 1px $white, 0 0 0 3px $black;
 		}
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-product-card/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-product-card/test/component.js
@@ -42,30 +42,32 @@ describe( 'Jetpack Product Card', () => {
 	} );
 
 	it( 'price is shown', () => {
-		const { container } = render( <JetpackProductCard { ...mockAttributes } /> );
+		render( <JetpackProductCard { ...mockAttributes } /> );
+		
 		const priceObject = getCurrencyObject( mockAttributes.price, mockAttributes.currencyCode );
 
-		expect( getNodeText( container.querySelector( '.jp-product-card__currency-symbol' ) ) ).to.be.equal( priceObject.symbol );
-		expect( getNodeText( container.querySelector( '.jp-product-card__price-integer' ) ) ).to.be.equal( priceObject.integer );
-		expect( getNodeText( container.querySelector( '.jp-product-card__price-fraction' ) ) ).to.be.equal( priceObject.fraction );
+		expect( screen.getAllByText( priceObject.symbol ) ).to.exist;
+		expect( screen.getAllByText( priceObject.integer ) ).to.exist;
+		expect( screen.getAllByText( priceObject.fraction ) ).to.exist;
 		expect( screen.getAllByText( mockAttributes.billingDescription ) ).to.exist;
 	} );
 
 	it( 'discounted price is shown', () => {
-		const discount = 50;
-		const { container } = render( <JetpackProductCard { ...mockAttributes } discount={ discount }/> );
+		const discountedPrice = mockAttributes.price / 2;
+		
+		render( <JetpackProductCard { ...mockAttributes } discountedPrice={ discountedPrice }/> );
 
 		// Show original price.
 		const originalPriceObject = getCurrencyObject( mockAttributes.price, mockAttributes.currencyCode );
-		expect( getNodeText( container.querySelector( '.jp-product-card__raw-price.jp-product-card__raw-price--is-old-price .jp-product-card__currency-symbol' ) ) ).to.be.equal( originalPriceObject.symbol );
-		expect( getNodeText( container.querySelector( '.jp-product-card__raw-price.jp-product-card__raw-price--is-old-price .jp-product-card__price-integer' ) ) ).to.be.equal( originalPriceObject.integer );
-		expect( getNodeText( container.querySelector( '.jp-product-card__raw-price.jp-product-card__raw-price--is-old-price .jp-product-card__price-fraction' ) ) ).to.be.equal( originalPriceObject.fraction );
-
+		expect( screen.getAllByText( originalPriceObject.symbol ) ).to.exist;
+		expect( screen.getAllByText( originalPriceObject.integer ) ).to.exist;
+		expect( screen.getAllByText( originalPriceObject.fraction ) ).to.exist;
+		
 		// Show discounted price.
-		const discountedPriceObject = getCurrencyObject( ( mockAttributes.price * ( 100 - discount ) / 100 ), mockAttributes.currencyCode );
-		expect( getNodeText( container.querySelector( '.jp-product-card__raw-price:not( .jp-product-card__raw-price--is-old-price ) .jp-product-card__currency-symbol' ) ) ).to.be.equal( discountedPriceObject.symbol );
-		expect( getNodeText( container.querySelector( '.jp-product-card__raw-price:not( .jp-product-card__raw-price--is-old-price ) .jp-product-card__price-integer' ) ) ).to.be.equal( discountedPriceObject.integer );
-		expect( getNodeText( container.querySelector( '.jp-product-card__raw-price:not( .jp-product-card__raw-price--is-old-price ) .jp-product-card__price-fraction' ) ) ).to.be.equal( discountedPriceObject.fraction );
+		const discountedPriceObject = getCurrencyObject( discountedPrice, mockAttributes.currencyCode );
+		expect( screen.getAllByText( discountedPriceObject.symbol ) ).to.exist;
+		expect( screen.getAllByText( discountedPriceObject.integer ) ).to.exist;
+		expect( screen.getAllByText( discountedPriceObject.fraction ) ).to.exist;
 	} );
 
 	it( 'cta is shown', () => {

--- a/projects/plugins/jetpack/_inc/client/product-descriptions/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/product-descriptions/index.jsx
@@ -10,10 +10,12 @@ import { isEmpty } from 'lodash';
 /**
  * Internal dependencies
  */
+import QueryIntroOffers from 'components/data/query-intro-offers';
 import QueryProducts from 'components/data/query-products';
 import { JetpackLoadingIcon } from 'components/jetpack-loading-icon';
+import { isFetchingIntroOffers } from 'state/intro-offers';
 import { isFetchingProducts as isFetchingProductsSelector } from 'state/products';
-import { arePromotionsActive, getProductsForPurchase } from 'state/initial-state';
+import { getProductsForPurchase } from 'state/initial-state';
 import { PRODUCT_DESCRIPTION_PRODUCTS as SUPPORTED_PRODUCTS } from './constants';
 import ProductDescription from './product-description';
 
@@ -23,8 +25,8 @@ import ProductDescription from './product-description';
 import './style.scss';
 
 const ProductDescriptions = props => {
-	const { isFetchingProducts, products } = props;
-	const isLoading = isFetchingProducts || isEmpty( products );
+	const { isFetchingProducts, isFetchingOffers, products } = props;
+	const isLoading = isFetchingProducts || isFetchingOffers || isEmpty( products );
 	const routes = [];
 
 	if ( ! isLoading ) {
@@ -41,7 +43,7 @@ const ProductDescriptions = props => {
 
 			routes.push(
 				<Route key={ key } path={ `/product/${ key }` }>
-					<ProductDescription product={ product } arePromotionsActive={ arePromotionsActive } />
+					<ProductDescription product={ product } />
 				</Route>
 			);
 		} );
@@ -50,6 +52,8 @@ const ProductDescriptions = props => {
 	return (
 		<>
 			<QueryProducts />
+			<QueryIntroOffers />
+
 			{ isLoading ? (
 				<div className="jp-product-descriptions__loading">
 					<JetpackLoadingIcon />
@@ -65,11 +69,11 @@ ProductDescriptions.propTypes = {
 	// From connect HoC.
 	products: PropTypes.object,
 	isFetchingProducts: PropTypes.bool,
-	arePromotionsActive: PropTypes.bool,
+	isFetchingOffers: PropTypes.bool,
 };
 
 export default connect( state => ( {
-	arePromotionsActive: arePromotionsActive( state ),
 	isFetchingProducts: isFetchingProductsSelector( state ),
+	isFetchingOffers: isFetchingIntroOffers( state ),
 	products: getProductsForPurchase( state ),
 } ) )( ProductDescriptions );

--- a/projects/plugins/jetpack/changelog/fix-product-description-price
+++ b/projects/plugins/jetpack/changelog/fix-product-description-price
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack: Correct prices in product descriptions


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR corrects prices in the product description page of the Jetpack plugin. It didn't take introductory offers into account, but a hardcoded discount.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Context: 1201210512993648-as-1202290412337989

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Prerequisites**
- Visit https://cloud.jetpack.com/pricing to see the correct prices

**To see the issue**
- Spin up a connected test site with no subscriptions
- Visit `/wp-admin/admin.php?page=jetpack#/product/backup`
- Notice that prices don't match what's in production
<img width="1008" alt="Screen Shot 2022-05-20 at 12 43 15 PM" src="https://user-images.githubusercontent.com/1620183/169588646-400a0807-5269-406e-bf4d-a49e9fd51e63.png">

**To see the fix**
- Spin up a connected test site with no subscriptions, which runs this branch
- Visit `/wp-admin/admin.php?page=jetpack#/product/backup`
- Notice that prices match what's in production
<img width="1008" alt="Screen Shot 2022-05-20 at 2 06 16 PM" src="https://user-images.githubusercontent.com/1620183/169588890-1c64ddfb-2c4e-4480-9670-6dfe964f856d.png">


