### PR TITLE
Fusion: Add blogging prompts to the site endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/fusion-update-sal-blogging-prompts
+++ b/projects/plugins/jetpack/changelog/fusion-update-sal-blogging-prompts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Fusion: Add blogging prompts settings to SAL

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -179,6 +179,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'anchor_podcast',
 		'is_difm_lite_in_progress',
 		'site_intent',
+		'blogging_prompts_settings',
 	);
 
 	/**
@@ -223,6 +224,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		// and defaults to `0000-00-00T00:00:00+00:00` from the Jetpack site.
 		// See https://github.com/Automattic/jetpack/blob/58638f46094b36f5df9cbc4570006544f0ad300c/sal/class.json-api-site-base.php#L387.
 		'created_at',
+		'blogging_prompts_settings',
 	);
 
 	/**
@@ -756,6 +758,11 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'site_intent':
 					$options[ $key ] = $site->get_site_intent();
+					break;
+				case 'blogging_prompts_settings':
+					if ( current_user_can( 'edit_posts' ) ) {
+						$options[ $key ] = $site->get_blogging_prompts_settings( get_current_user_id(), $site->blog_id );
+					}
 					break;
 			}
 		}

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -92,6 +92,14 @@ abstract class SAL_Site {
 	public function get_post_count() {
 		return (int) wp_count_posts( 'post' )->publish;
 	}
+	/**
+	 * Returns an array of blogging prompt settings.
+	 *
+	 * Data comes from .com since the fearture requires a .com connection to work.
+	 */
+	public function get_blogging_prompts_settings( $user_id, $blog_id ) {
+		return false;
+	}
 
 	/**
 	 * A prototype function for get_quota - currently returns null.

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -92,14 +92,6 @@ abstract class SAL_Site {
 	public function get_post_count() {
 		return (int) wp_count_posts( 'post' )->publish;
 	}
-	/**
-	 * Returns an array of blogging prompt settings.
-	 *
-	 * Data comes from .com since the fearture requires a .com connection to work.
-	 */
-	public function get_blogging_prompts_settings( $user_id, $blog_id ) {
-		return false;
-	}
 
 	/**
 	 * A prototype function for get_quota - currently returns null.
@@ -108,6 +100,18 @@ abstract class SAL_Site {
 	 */
 	public function get_quota() {
 		return null;
+	}
+
+	/**
+	 * Returns an array of blogging prompt settings.
+	 *
+	 * Data comes from .com since the fearture requires a .com connection to work.
+	 *
+	 * @param int $user_id the current user_id.
+	 * @param int $blog_id the blog id in this context.
+	 */
+	public function get_blogging_prompts_settings( $user_id, $blog_id ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
This PR brings the .com [D80390](D80390-code) in sync with the Jetpack. 


#### Changes proposed in this Pull Request:
- Make brings the changed over from 

#### Testing instructions:
* Since the data gets overwritten on the .com side we expect the to see no error on the jetpack side for this feature. 
* 1. Apply this patch. 
* 2. Make a request to the jetpack site. /v1.1/sites/yourjetpacksite.com 
* Note that there are no PHP error and the respons is as expected for the jetpack site. 

Related PR: D81425-code