### PR TITLE
Social: Extract component to their own files

### DIFF
--- a/projects/plugins/social/changelog/add-jetpack-social-admin-design
+++ b/projects/plugins/social/changelog/add-jetpack-social-admin-design
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Moved components to their own files

--- a/projects/plugins/social/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/social/src/js/components/admin-page/index.jsx
@@ -2,105 +2,19 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, ToggleControl } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { AdminPage, AdminSectionHero, Container, Col } from '@automattic/jetpack-components';
-import { useSelect, useDispatch } from '@wordpress/data';
-import { ConnectScreen, CONNECTION_STORE_ID } from '@automattic/jetpack-connection';
-import React, { useCallback } from 'react';
+import { useSelect } from '@wordpress/data';
+import { CONNECTION_STORE_ID } from '@automattic/jetpack-connection';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-import { STORE_ID } from '../../store';
 import styles from './styles.module.scss';
-
-const ConnectionItem = props => {
-	const { connections } = window.jetpackSocialInitialState;
-
-	return props.connectionIds.map( connectionId => {
-		const connection = connections[ props.provider ][ connectionId ];
-		return (
-			<div key={ connectionId }>
-				<tr>
-					<th className={ styles.connectionRow }> { __( 'Name', 'jetpack-social' ) }</th>
-					<th className={ styles.connectionRow }>{ __( 'Image', 'jetpack-social' ) }</th>
-				</tr>
-				<tr>
-					<td className={ styles.connectionRow }>{ connection.external_display }</td>
-					<td className={ styles.connectionRow }>
-						{ connection.profile_picture && (
-							<img
-								alt="connection avatar"
-								src={ connection.profile_picture }
-								height="50px"
-								width="50px"
-							/>
-						) }
-					</td>
-				</tr>
-			</div>
-		);
-	} );
-};
-
-const ConnectionItems = () => {
-	const { connections } = window.jetpackSocialInitialState;
-
-	if ( ! connections ) {
-		return null;
-	}
-
-	const providers = Object.keys( connections );
-	return providers.map( provider => {
-		return (
-			<div key={ provider }>
-				<h2> { provider.charAt( 0 ).toUpperCase() + provider.slice( 1 ) } Connections</h2>
-				<table className={ styles.connectionTable }>
-					<ConnectionItem
-						connectionIds={ Object.keys( connections[ provider ] ) }
-						provider={ provider }
-					/>
-				</table>
-			</div>
-		);
-	} );
-};
-
-const ModuleToggle = () => {
-	const updateOptions = useDispatch( STORE_ID ).updateJetpackSettings;
-	const { isModuleEnabled, isUpdating } = useSelect( select => {
-		const store = select( STORE_ID );
-		return {
-			isModuleEnabled: store.isModuleEnabled(),
-			isUpdating: store.isUpdatingJetpackSettings(),
-		};
-	} );
-
-	const toggleModule = useCallback( () => {
-		const newOption = {
-			publicize_active: ! isModuleEnabled,
-		};
-		updateOptions( newOption );
-	}, [ isModuleEnabled, updateOptions ] );
-
-	const label = isModuleEnabled
-		? __( 'Jetpack Social is active', 'jetpack-social' )
-		: __(
-				'Jetpack Social is inactive',
-				'jetpack-social',
-				/* dummy arg to avoid bad minification */ 0
-		  );
-
-	return (
-		<ToggleControl
-			label={ __( 'Activate Jetpack Social', 'jetpack-social' ) }
-			help={ isUpdating ? __( 'Updating…', 'jetpack-social' ) : label }
-			disabled={ isUpdating }
-			checked={ isModuleEnabled }
-			onChange={ toggleModule }
-		/>
-	);
-};
+import ConnectionScreen from './../connection-screen';
+import ModuleToggle from './../module-toggle';
+import Connections from './../connections';
 
 const Admin = () => {
 	const connectionStatus = useSelect(
@@ -117,7 +31,7 @@ const Admin = () => {
 				<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 					<Col sm={ 4 } md={ 8 } lg={ 12 }>
 						{ showConnectionCard ? (
-							<ConnectionSection />
+							<ConnectionScreen />
 						) : (
 							<div>
 								<div className={ styles.manageConnectionsHeader }>
@@ -131,7 +45,7 @@ const Admin = () => {
 								</div>
 								<div className={ styles.publicizeConnectionsList }>
 									<ModuleToggle />
-									<ConnectionItems />
+									<Connections />
 								</div>
 							</div>
 						) }
@@ -143,51 +57,3 @@ const Admin = () => {
 };
 
 export default Admin;
-
-const ConnectionSection = () => {
-	const connectProps = useSelect( select => {
-		const store = select( STORE_ID );
-		return {
-			apiRoot: store.getAPIRootUrl(),
-			apiNonce: store.getAPINonce(),
-			registrationNonce: store.getRegistrationNonce(),
-		};
-	} );
-	return (
-		<ConnectScreen
-			buttonLabel={ __( 'Connect Jetpack Social', 'jetpack-social' ) }
-			pricingTitle={ __( 'Jetpack Social', 'jetpack-social' ) }
-			title={ __( 'Social Media Automation for WordPress Sites', 'jetpack-social' ) }
-			from="jetpack-social"
-			redirectUri="admin.php?page=jetpack-social"
-			{ ...connectProps }
-		>
-			<h3>
-				{ __(
-					'Share your site’s posts on several social media networks automatically when you publish a new post',
-					'jetpack-social'
-				) }
-			</h3>
-			<ul>
-				<li>
-					{ __(
-						'Reach your maximum potential audience, not just those who visit your site',
-						'jetpack-social'
-					) }
-				</li>
-				<li>
-					{ __(
-						'Be found by prospective readers or customers on their preferred social site or network',
-						'jetpack-social'
-					) }
-				</li>
-				<li>
-					{ __(
-						'Allow people who like your content to easily share it with their own followers, giving you even greater visibility',
-						'jetpack-social'
-					) }
-				</li>
-			</ul>
-		</ConnectScreen>
-	);
-};

--- a/projects/plugins/social/src/js/components/connection-screen/index.js
+++ b/projects/plugins/social/src/js/components/connection-screen/index.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { ConnectScreen } from '@automattic/jetpack-connection';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_ID } from '../../store';
+
+const ConnectionScreen = () => {
+	const connectProps = useSelect( select => {
+		const store = select( STORE_ID );
+		return {
+			apiRoot: store.getAPIRootUrl(),
+			apiNonce: store.getAPINonce(),
+			registrationNonce: store.getRegistrationNonce(),
+		};
+	} );
+	return (
+		<ConnectScreen
+			buttonLabel={ __( 'Connect Jetpack Social', 'jetpack-social' ) }
+			pricingTitle={ __( 'Jetpack Social', 'jetpack-social' ) }
+			title={ __( 'Social Media Automation for WordPress Sites', 'jetpack-social' ) }
+			from="jetpack-social"
+			redirectUri="admin.php?page=jetpack-social"
+			{ ...connectProps }
+		>
+			<h3>
+				{ __(
+					'Share your site’s posts on several social media networks automatically when you publish a new post',
+					'jetpack-social'
+				) }
+			</h3>
+			<ul>
+				<li>
+					{ __(
+						'Reach your maximum potential audience, not just those who visit your site',
+						'jetpack-social'
+					) }
+				</li>
+				<li>
+					{ __(
+						'Be found by prospective readers or customers on their preferred social site or network',
+						'jetpack-social'
+					) }
+				</li>
+				<li>
+					{ __(
+						'Allow people who like your content to easily share it with their own followers, giving you even greater visibility',
+						'jetpack-social'
+					) }
+				</li>
+			</ul>
+		</ConnectScreen>
+	);
+};
+
+export default ConnectionScreen;

--- a/projects/plugins/social/src/js/components/connections/index.js
+++ b/projects/plugins/social/src/js/components/connections/index.js
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import styles from './styles.module.scss';
+
+const ConnectionItem = props => {
+	const { connections } = window.jetpackSocialInitialState;
+
+	return props.connectionIds.map( connectionId => {
+		const connection = connections[ props.provider ][ connectionId ];
+		return (
+			<div key={ connectionId }>
+				<tr>
+					<th className={ styles.connectionRow }> { __( 'Name', 'jetpack-social' ) }</th>
+					<th className={ styles.connectionRow }>{ __( 'Image', 'jetpack-social' ) }</th>
+				</tr>
+				<tr>
+					<td className={ styles.connectionRow }>{ connection.external_display }</td>
+					<td className={ styles.connectionRow }>
+						{ connection.profile_picture && (
+							<img
+								alt="connection avatar"
+								src={ connection.profile_picture }
+								height="50px"
+								width="50px"
+							/>
+						) }
+					</td>
+				</tr>
+			</div>
+		);
+	} );
+};
+
+const Connections = () => {
+	const { connections } = window.jetpackSocialInitialState;
+
+	if ( ! connections ) {
+		return null;
+	}
+
+	const providers = Object.keys( connections );
+	return providers.map( provider => {
+		return (
+			<div key={ provider }>
+				<h2> { provider.charAt( 0 ).toUpperCase() + provider.slice( 1 ) } Connections</h2>
+				<table className={ styles.connectionTable }>
+					<ConnectionItem
+						connectionIds={ Object.keys( connections[ provider ] ) }
+						provider={ provider }
+					/>
+				</table>
+			</div>
+		);
+	} );
+};
+
+export default Connections;

--- a/projects/plugins/social/src/js/components/connections/styles.module.scss
+++ b/projects/plugins/social/src/js/components/connections/styles.module.scss
@@ -1,0 +1,15 @@
+.connectionTable {
+	font-family: arial, sans-serif;
+	border-collapse: collapse;
+	width: 100%;
+}
+
+.connectionRow {
+	border: 1px solid #dddddd;
+	text-align: left;
+	padding: 8px;
+}
+
+.publicizeConnectionsList {
+	margin: 40px;
+}

--- a/projects/plugins/social/src/js/components/module-toggle/index.js
+++ b/projects/plugins/social/src/js/components/module-toggle/index.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { ToggleControl } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import React, { useCallback } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_ID } from '../../store';
+
+const ModuleToggle = () => {
+	const updateOptions = useDispatch( STORE_ID ).updateJetpackSettings;
+	const { isModuleEnabled, isUpdating } = useSelect( select => {
+		const store = select( STORE_ID );
+		return {
+			isModuleEnabled: store.isModuleEnabled(),
+			isUpdating: store.isUpdatingJetpackSettings(),
+		};
+	} );
+
+	const toggleModule = useCallback( () => {
+		const newOption = {
+			publicize_active: ! isModuleEnabled,
+		};
+		updateOptions( newOption );
+	}, [ isModuleEnabled, updateOptions ] );
+
+	const label = isModuleEnabled
+		? __( 'Jetpack Social is active', 'jetpack-social' )
+		: __(
+				'Jetpack Social is inactive',
+				'jetpack-social',
+				/* dummy arg to avoid bad minification */ 0
+		  );
+
+	return (
+		<ToggleControl
+			label={ __( 'Activate Jetpack Social', 'jetpack-social' ) }
+			help={ isUpdating ? __( 'Updating…', 'jetpack-social' ) : label }
+			disabled={ isUpdating }
+			checked={ isModuleEnabled }
+			onChange={ toggleModule }
+		/>
+	);
+};
+
+export default ModuleToggle;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This is a very simple PR that moves some of the components in the Jetpack Social admin page to their own file. The main goal is to make future iterations easier to review.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Move some components to their own files.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Build the plugin files: `jetpack build plugins/social`
* Make sure the connection screen still displays properly and that you can connect.
* After connection, confirm that the module toggle works (use `jetpack docker wp option get jetpack_active_modules` to check for the Publicize module).
* Make sure social media connections show in the admin screen.
