### PR TITLE
Lazy Images: do not lazy-load images in RSS feeds

### DIFF
--- a/projects/packages/lazy-images/changelog/2022-05-23-13-59-05-035657
+++ b/projects/packages/lazy-images/changelog/2022-05-23-13-59-05-035657
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Do not lazy-load images when in RSS feeds.

--- a/projects/packages/lazy-images/src/lazy-images.php
+++ b/projects/packages/lazy-images/src/lazy-images.php
@@ -133,6 +133,11 @@ class Jetpack_Lazy_Images {
 	 * @return void
 	 */
 	public function setup_filters() {
+		// Do not lazy-load images in RSS feeds.
+		if ( is_feed() ) {
+			return;
+		}
+
 		add_filter( 'the_content', array( $this, 'add_image_placeholders' ), PHP_INT_MAX ); // Run this later, so other content filters have run, including image_add_wh on WP.com.
 		add_filter( 'post_thumbnail_html', array( $this, 'add_image_placeholders' ), PHP_INT_MAX );
 		add_filter( 'get_avatar', array( $this, 'add_image_placeholders' ), PHP_INT_MAX );


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

Let's short-circuit early in RSS feeds, we do not need to be lazy loading images there.

References:
- Follow-up from #24277
- https://github.com/Automattic/newspack-plugin/pull/1658

#### Jetpack product discussion

- p1653313484308279-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start with a Jetpack site where you've activated the Lazy Load feature under Jetpack > Settings > Performance.
* Publish a few posts with some featured images set for each post.
* Install ["Shoyu RSS/Atom Feed Preview" chrome extension"](https://chrome.google.com/webstore/detail/shoyu-rssatom-feed-previe/ilicaedjojicckapfpfdoakbehjpfkah) to preview a feed (other RSS viewers seem to handle the lazy-loaded images)
* Preview a site's feed (`site.com/feed`)
* Ensure that the featured images appear.

