### PR TITLE
RecordMeterBar Component: Adds a prop to display legend count after label

### DIFF
--- a/projects/js-packages/components/changelog/update-record-meter-bar-legend-format
+++ b/projects/js-packages/components/changelog/update-record-meter-bar-legend-format
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+added formatting prop to RecordMeterBar component legend

--- a/projects/js-packages/components/components/record-meter-bar/index.tsx
+++ b/projects/js-packages/components/components/record-meter-bar/index.tsx
@@ -83,7 +83,9 @@ const RecordMeterBar: React.FC< RecordMeterBarProps > = ( {
 								) }
 								{ showLegendLabelBeforeCount && (
 									<span>
-										<span className="record-meter-bar__legend--item-label">{ label }</span>
+										<span className="record-meter-bar__legend--item-label record-meter-bar__legend--item-label-first">
+											{ label }
+										</span>
 										<span className="record-meter-bar__legend--item-count">({ count })</span>
 									</span>
 								) }

--- a/projects/js-packages/components/components/record-meter-bar/index.tsx
+++ b/projects/js-packages/components/components/record-meter-bar/index.tsx
@@ -29,6 +29,10 @@ export type RecordMeterBarProps = {
 	 * The items to display in Record meter.
 	 */
 	items: Array< RecordMeterBarItem >;
+	/**
+	 * The formatting style for legend item display. If not provided, it defaults to showing legend label after count
+	 */
+	showLegendLabelBeforeCount: boolean;
 };
 
 /**
@@ -37,7 +41,11 @@ export type RecordMeterBarProps = {
  * @param {RecordMeterBarProps} props - Props
  * @returns {React.ReactElement} - JSX element
  */
-const RecordMeterBar: React.FC< RecordMeterBarProps > = ( { totalCount, items = [] } ) => {
+const RecordMeterBar: React.FC< RecordMeterBarProps > = ( {
+	totalCount,
+	items = [],
+	showLegendLabelBeforeCount = false,
+} ) => {
 	const total = useMemo( () => {
 		// If total count is not given, then compute it from items' count
 		return (
@@ -67,8 +75,18 @@ const RecordMeterBar: React.FC< RecordMeterBarProps > = ( { totalCount, items = 
 									className="record-meter-bar__legend--item-circle"
 									style={ { backgroundColor } }
 								/>
-								<span className="record-meter-bar__legend--item-count">{ count }</span>
-								<span className="record-meter-bar__legend--item-label">{ label }</span>
+								{ ! showLegendLabelBeforeCount && (
+									<span>
+										<span className="record-meter-bar__legend--item-count">{ count }</span>
+										<span className="record-meter-bar__legend--item-label">{ label }</span>
+									</span>
+								) }
+								{ showLegendLabelBeforeCount && (
+									<span>
+										<span className="record-meter-bar__legend--item-label">{ label }</span>
+										<span className="record-meter-bar__legend--item-count">({ count })</span>
+									</span>
+								) }
 							</li>
 						);
 					} ) }

--- a/projects/js-packages/components/components/record-meter-bar/stories/index.tsx
+++ b/projects/js-packages/components/components/record-meter-bar/stories/index.tsx
@@ -28,3 +28,9 @@ WithTotalCount.args = {
 	...DefaultArgs,
 	totalCount: 200,
 };
+
+export const LabelBeforeCount = Template.bind( {} );
+LabelBeforeCount.args = {
+	...DefaultArgs,
+	showLegendLabelBeforeCount: true,
+};

--- a/projects/js-packages/components/components/record-meter-bar/style.scss
+++ b/projects/js-packages/components/components/record-meter-bar/style.scss
@@ -13,7 +13,7 @@
 	&__legend {
 		&--items {
 			display: flex;
-			margin: 0px;
+			margin: 0;
 		}
 		&--item {
 			display: flex;

--- a/projects/js-packages/components/components/record-meter-bar/style.scss
+++ b/projects/js-packages/components/components/record-meter-bar/style.scss
@@ -1,35 +1,38 @@
 .record-meter-bar {
-    padding-block: 1em;
+	padding-block: 1em;
 
-    &__items {
-        height: 2rem;
-        display: flex;
-        border-radius: 1rem;
-        overflow: hidden;
-        margin-bottom: 2em;
-        background-color: var(--jp-gray-off);
-    }
+	&__items {
+		height: 2rem;
+		display: flex;
+		border-radius: 1rem;
+		overflow: hidden;
+		margin-bottom: 2em;
+		background-color: var(--jp-gray-off);
+	}
 
-    &__legend {
-        &--items {
-            display: flex;
-            margin: 0px;
-        }
-        &--item {
-            display: flex;
-            margin: 0px;
-            margin-inline-end: 1em;
-            align-items: center;
-        }
-        &--item-circle {
-            width: 1rem;
-            height: 1rem;
-            display: inline-block;
-            margin-inline-end: 0.4em;
-            border-radius: 100%;
-        }
-        &--item-count {
-            margin-inline-end: 0.4em;
-        }
-    }
+	&__legend {
+		&--items {
+			display: flex;
+			margin: 0px;
+		}
+		&--item {
+			display: flex;
+			margin: 0px;
+			margin-inline-end: 1em;
+			align-items: center;
+		}
+		&--item-circle {
+			width: 1rem;
+			height: 1rem;
+			display: inline-block;
+			margin-inline-end: 0.4em;
+			border-radius: 100%;
+		}
+		&--item-count {
+			margin-inline-end: 0.4em;
+		}
+		// &--item-label {
+		// 	margin-inline-end: 0.4em;
+		// }
+	}
 }

--- a/projects/js-packages/components/components/record-meter-bar/style.scss
+++ b/projects/js-packages/components/components/record-meter-bar/style.scss
@@ -17,7 +17,7 @@
 		}
 		&--item {
 			display: flex;
-			margin: 0px;
+			margin: 0;
 			margin-inline-end: 1em;
 			align-items: center;
 		}

--- a/projects/js-packages/components/components/record-meter-bar/style.scss
+++ b/projects/js-packages/components/components/record-meter-bar/style.scss
@@ -31,8 +31,8 @@
 		&--item-count {
 			margin-inline-end: 0.4em;
 		}
-		// &--item-label {
-		// 	margin-inline-end: 0.4em;
-		// }
+		&--item-label-first {
+			margin-inline-end: 0.4em;
+		}
 	}
 }


### PR DESCRIPTION
This PR alters the RecordMeterBar component to take an optional legend formatting prop. When passed in as true, the legend displays with the count after the label instead of before. 

![image](https://user-images.githubusercontent.com/30754158/170095129-6a8d3b4d-53e0-45b3-b202-08c14039c5a1.png)

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* Run `cd projects/js-packages/storybook && npm run storybook:dev` and confirm that you see RecordMeterBar component in Storybook.
* Under RecordMeterBar, choose the story 'Label Before Count'.

You can also run the unit tests for js-packages/components by running `jetpack test`.