### PR TITLE
JS Components: add isExternalLink button property

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,7 +179,7 @@ importers:
       '@automattic/jetpack-analytics': workspace:* || ^0.1
       '@automattic/jetpack-api': workspace:* || ^0.13
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.14
+      '@automattic/jetpack-components': workspace:* || ^0.15
       '@automattic/jetpack-config': workspace:* || ^0.1
       '@babel/core': 7.17.10
       '@babel/preset-react': 7.16.7
@@ -292,7 +292,7 @@ importers:
       '@automattic/jetpack-analytics': workspace:* || ^0.1
       '@automattic/jetpack-api': workspace:* || ^0.13
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.14
+      '@automattic/jetpack-components': workspace:* || ^0.15
       '@babel/core': 7.17.10
       '@babel/preset-react': 7.16.7
       '@wordpress/base-styles': 4.4.0
@@ -334,7 +334,7 @@ importers:
     specifiers:
       '@automattic/jetpack-api': workspace:* || ^0.13
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.14
+      '@automattic/jetpack-components': workspace:* || ^0.15
       '@babel/core': 7.17.10
       '@babel/preset-react': 7.16.7
       '@wordpress/components': 19.10.0
@@ -369,7 +369,7 @@ importers:
     specifiers:
       '@automattic/jetpack-analytics': workspace:* || ^0.1
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.14
+      '@automattic/jetpack-components': workspace:* || ^0.15
       '@automattic/jetpack-connection': workspace:* || ^0.18
       '@babel/core': 7.17.10
       '@babel/preset-react': 7.16.7
@@ -405,7 +405,7 @@ importers:
   projects/js-packages/publicize-components:
     specifiers:
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.14
+      '@automattic/jetpack-components': workspace:* || ^0.15
       '@automattic/jetpack-shared-extension-utils': workspace:* || ^0.4
       '@automattic/jetpack-webpack-config': workspace:* || ^1.3
       '@babel/core': 7.17.10
@@ -511,7 +511,7 @@ importers:
 
   projects/js-packages/storybook:
     specifiers:
-      '@automattic/jetpack-components': workspace:* || ^0.14
+      '@automattic/jetpack-components': workspace:* || ^0.15
       '@babel/core': 7.17.10
       '@babel/plugin-syntax-jsx': 7.16.7
       '@babel/preset-react': 7.16.7
@@ -677,7 +677,7 @@ importers:
     specifiers:
       '@automattic/jetpack-api': workspace:* || ^0.13
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.14
+      '@automattic/jetpack-components': workspace:* || ^0.15
       '@automattic/jetpack-connection': workspace:* || ^0.18
       '@automattic/jetpack-webpack-config': workspace:* || ^1.3
       '@babel/core': 7.17.10
@@ -851,7 +851,7 @@ importers:
       '@automattic/jetpack-analytics': workspace:* || ^0.1
       '@automattic/jetpack-api': workspace:* || ^0.13
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.14
+      '@automattic/jetpack-components': workspace:* || ^0.15
       '@automattic/jetpack-connection': workspace:* || ^0.18
       '@automattic/jetpack-licensing': workspace:* || ^0.5
       '@automattic/jetpack-webpack-config': workspace:* || ^1.3
@@ -949,7 +949,7 @@ importers:
       '@automattic/jetpack-analytics': workspace:* || ^0.1
       '@automattic/jetpack-api': workspace:* || ^0.13
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.14
+      '@automattic/jetpack-components': workspace:* || ^0.15
       '@automattic/jetpack-connection': workspace:* || ^0.18
       '@automattic/jetpack-webpack-config': workspace:* || ^1.3
       '@babel/core': 7.17.10
@@ -1071,7 +1071,7 @@ importers:
       '@automattic/color-studio': 2.5.0
       '@automattic/jetpack-analytics': workspace:* || ^0.1
       '@automattic/jetpack-api': workspace:* || ^0.13
-      '@automattic/jetpack-components': workspace:* || ^0.14
+      '@automattic/jetpack-components': workspace:* || ^0.15
       '@automattic/jetpack-webpack-config': workspace:* || ^1.3
       '@babel/core': 7.17.10
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.16.7
@@ -1183,7 +1183,7 @@ importers:
   projects/plugins/boost:
     specifiers:
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.14
+      '@automattic/jetpack-components': workspace:* || ^0.15
       '@babel/core': 7.17.10
       '@babel/preset-env': 7.17.10
       '@babel/preset-react': 7.16.7
@@ -1280,7 +1280,7 @@ importers:
       '@automattic/jetpack-analytics': workspace:* || ^0.1
       '@automattic/jetpack-api': workspace:* || ^0.13
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.14
+      '@automattic/jetpack-components': workspace:* || ^0.15
       '@automattic/jetpack-connection': workspace:* || ^0.18
       '@automattic/jetpack-licensing': workspace:* || ^0.5
       '@automattic/jetpack-partner-coupon': workspace:* || ^0.2
@@ -1589,7 +1589,7 @@ importers:
     specifiers:
       '@automattic/jetpack-analytics': workspace:* || ^0.1
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.14
+      '@automattic/jetpack-components': workspace:* || ^0.15
       '@automattic/jetpack-connection': workspace:* || ^0.18
       '@automattic/jetpack-webpack-config': workspace:* || ^1.3
       '@babel/core': 7.17.10
@@ -1665,7 +1665,7 @@ importers:
   projects/plugins/social:
     specifiers:
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.14
+      '@automattic/jetpack-components': workspace:* || ^0.15
       '@automattic/jetpack-connection': workspace:* || ^0.18
       '@automattic/jetpack-webpack-config': workspace:* || ^1.3
       '@babel/core': 7.17.10
@@ -1714,7 +1714,7 @@ importers:
   projects/plugins/starter-plugin:
     specifiers:
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.14
+      '@automattic/jetpack-components': workspace:* || ^0.15
       '@automattic/jetpack-connection': workspace:* || ^0.18
       '@automattic/jetpack-webpack-config': workspace:* || ^1.3
       '@babel/core': 7.17.10

--- a/projects/js-packages/components/changelog/update-components-add-is-external-link-prop
+++ b/projects/js-packages/components/changelog/update-components-add-is-external-link-prop
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+JS Components: add isExternalLink button property

--- a/projects/js-packages/components/components/button/index.tsx
+++ b/projects/js-packages/components/components/button/index.tsx
@@ -38,6 +38,12 @@ export const Button: React.FC< ButtonProps > = ( {
 	} );
 
 	const isExternalLinkDeprecated = variant === 'external-link';
+	if ( isExternalLinkDeprecated ) {
+		const warning =
+			'The "external-link" variant is deprecated. Please use "isExternalLink" prop instead.';
+		console.warn( warning ); // eslint-disable-line no-console
+	}
+
 	const isExternalLink = isExternalLinkProp || isExternalLinkDeprecated;
 
 	const externalIconSize = size === 'normal' ? 20 : 16;

--- a/projects/js-packages/components/components/button/index.tsx
+++ b/projects/js-packages/components/components/button/index.tsx
@@ -24,6 +24,7 @@ export const Button: React.FC< ButtonProps > = ( {
 	disabled,
 	isDestructive,
 	isLoading,
+	isExternalLink: isExternalLinkProp,
 	className: propsClassName,
 	text,
 	...componentProps
@@ -36,7 +37,9 @@ export const Button: React.FC< ButtonProps > = ( {
 		[ styles.regular ]: weight === 'regular',
 	} );
 
-	const isExternalLink = variant === 'external-link';
+	const isExternalLinkDeprecated = variant === 'external-link';
+	const isExternalLink = isExternalLinkProp || isExternalLinkDeprecated;
+
 	const externalIconSize = size === 'normal' ? 20 : 16;
 	const externalIcon = isExternalLink && (
 		<Icon size={ externalIconSize } icon={ external } className={ styles[ 'external-icon' ] } />
@@ -46,7 +49,7 @@ export const Button: React.FC< ButtonProps > = ( {
 	return (
 		<WPButton
 			target={ externalTarget }
-			variant={ isExternalLink ? 'link' : variant }
+			variant={ isExternalLinkDeprecated ? 'link' : variant }
 			className={ className }
 			icon={ ! isExternalLink ? icon : undefined }
 			iconSize={ iconSize }

--- a/projects/js-packages/components/components/button/index.tsx
+++ b/projects/js-packages/components/components/button/index.tsx
@@ -38,12 +38,6 @@ export const Button: React.FC< ButtonProps > = ( {
 	} );
 
 	const isExternalLinkDeprecated = variant === 'external-link';
-	if ( isExternalLinkDeprecated ) {
-		const warning =
-			'The "external-link" variant is deprecated. Please use "isExternalLink" prop instead.';
-		console.warn( warning ); // eslint-disable-line no-console
-	}
-
 	const isExternalLink = isExternalLinkProp || isExternalLinkDeprecated;
 
 	const externalIconSize = size === 'normal' ? 20 : 16;

--- a/projects/js-packages/components/components/button/stories/index.tsx
+++ b/projects/js-packages/components/components/button/stories/index.tsx
@@ -73,7 +73,7 @@ export default {
 		variant: {
 			control: {
 				type: 'select',
-				options: [ 'primary', 'secondary', 'link' ],
+				options: [ 'primary', 'secondary', 'link', 'external-link' ],
 			},
 		},
 	},

--- a/projects/js-packages/components/components/button/stories/index.tsx
+++ b/projects/js-packages/components/components/button/stories/index.tsx
@@ -70,6 +70,12 @@ export default {
 				options: [ 'none', ...Object.keys( icons ) ],
 			},
 		},
+		variant: {
+			control: {
+				type: 'select',
+				options: [ 'primary', 'secondary', 'link' ],
+			},
+		},
 	},
 	parameters: {
 		backgrounds: {
@@ -92,6 +98,7 @@ _default.args = {
 	weight: 'bold',
 	children: 'Once upon a time… a button story',
 	variant: 'primary',
+	isExternalLink: false,
 	isLoading: false,
 	disabled: false,
 	isDestructive: false,

--- a/projects/js-packages/components/components/button/types.ts
+++ b/projects/js-packages/components/components/button/types.ts
@@ -10,6 +10,7 @@ type JetpackButtonBaseProps = {
 	disabled?: boolean;
 	isDestructive?: boolean;
 	isLoading?: boolean;
+	isExternalLink?: boolean;
 	size?: 'normal' | 'small';
 	text?: string;
 	weight?: 'bold' | 'regular';

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.14.0",
+	"version": "0.15.0-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/changelog/update-components-add-is-external-link-prop
+++ b/projects/js-packages/connection/changelog/update-components-add-is-external-link-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,13 +1,13 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.18.2",
+	"version": "0.18.3-alpha",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",
 	"dependencies": {
 		"@automattic/jetpack-analytics": "workspace:* || ^0.1",
 		"@automattic/jetpack-config": "workspace:* || ^0.1",
-		"@automattic/jetpack-components": "workspace:* || ^0.14",
+		"@automattic/jetpack-components": "workspace:* || ^0.15",
 		"@automattic/jetpack-api": "workspace:* || ^0.13",
 		"@wordpress/base-styles": "4.4.0",
 		"@wordpress/browserslist-config": "4.1.2",

--- a/projects/js-packages/idc/changelog/update-components-add-is-external-link-prop
+++ b/projects/js-packages/idc/changelog/update-components-add-is-external-link-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -8,7 +8,7 @@
 		"@automattic/jetpack-analytics": "workspace:* || ^0.1",
 		"@automattic/jetpack-api": "workspace:* || ^0.13",
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3",
-		"@automattic/jetpack-components": "workspace:* || ^0.14",
+		"@automattic/jetpack-components": "workspace:* || ^0.15",
 		"@wordpress/base-styles": "4.4.0",
 		"@wordpress/components": "19.10.0",
 		"@wordpress/compose": "5.6.0",

--- a/projects/js-packages/licensing/changelog/update-components-add-is-external-link-prop
+++ b/projects/js-packages/licensing/changelog/update-components-add-is-external-link-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.5.1",
+	"version": "0.5.2-alpha",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {
@@ -39,7 +39,7 @@
 	},
 	"dependencies": {
 		"@automattic/jetpack-api": "workspace:* || ^0.13",
-		"@automattic/jetpack-components": "workspace:* || ^0.14",
+		"@automattic/jetpack-components": "workspace:* || ^0.15",
 		"@wordpress/i18n": "4.8.0",
 		"@wordpress/element": "4.6.0",
 		"prop-types": "15.7.2",

--- a/projects/js-packages/partner-coupon/changelog/update-components-add-is-external-link-prop
+++ b/projects/js-packages/partner-coupon/changelog/update-components-add-is-external-link-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.14",
+	"version": "0.2.15-alpha",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {
@@ -35,7 +35,7 @@
 		"react-dom": "17.0.2"
 	},
 	"dependencies": {
-		"@automattic/jetpack-components": "workspace:* || ^0.14",
+		"@automattic/jetpack-components": "workspace:* || ^0.15",
 		"@automattic/jetpack-connection": "workspace:* || ^0.18",
 		"@wordpress/i18n": "4.8.0",
 		"classnames": "2.3.1",

--- a/projects/js-packages/publicize-components/changelog/update-components-add-is-external-link-prop
+++ b/projects/js-packages/publicize-components/changelog/update-components-add-is-external-link-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.1.0",
+	"version": "0.1.1-alpha",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {
@@ -19,7 +19,7 @@
 	},
 	"dependencies": {
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3",
-		"@automattic/jetpack-components": "workspace:* || ^0.14",
+		"@automattic/jetpack-components": "workspace:* || ^0.15",
 		"@automattic/jetpack-shared-extension-utils": "workspace:* || ^0.4",
 		"@wordpress/annotations": "2.8.0",
 		"@wordpress/components": "19.10.0",

--- a/projects/js-packages/storybook/changelog/update-components-add-is-external-link-prop
+++ b/projects/js-packages/storybook/changelog/update-components-add-is-external-link-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/js-packages/storybook/package.json
+++ b/projects/js-packages/storybook/package.json
@@ -21,7 +21,7 @@
 		"test-coverage": "jest tests/ --coverage --collectCoverageFrom='src/**/*.js' --coverageDirectory=\"$COVERAGE_DIR\" --coverageReporters=clover"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-components": "workspace:* || ^0.14",
+		"@automattic/jetpack-components": "workspace:* || ^0.15",
 		"@babel/core": "7.17.10",
 		"@babel/plugin-syntax-jsx": "7.16.7",
 		"@babel/preset-react": "7.16.7",

--- a/projects/packages/backup/changelog/update-components-add-is-external-link-prop
+++ b/projects/packages/backup/changelog/update-components-add-is-external-link-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/backup/package.json
+++ b/projects/packages/backup/package.json
@@ -26,7 +26,7 @@
 	],
 	"dependencies": {
 		"@automattic/jetpack-api": "workspace:* || ^0.13",
-		"@automattic/jetpack-components": "workspace:* || ^0.14",
+		"@automattic/jetpack-components": "workspace:* || ^0.15",
 		"@automattic/jetpack-connection": "workspace:* || ^0.18",
 		"@wordpress/api-fetch": "6.5.0",
 		"@wordpress/data": "6.8.0",

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.3.6';
+	const PACKAGE_VERSION = '1.3.7-alpha';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/my-jetpack/changelog/update-components-add-is-external-link-prop
+++ b/projects/packages/my-jetpack/changelog/update-components-add-is-external-link-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "1.5.0",
+	"version": "1.5.1-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {
@@ -25,7 +25,7 @@
 		"@automattic/format-currency": "1.0.1",
 		"@automattic/jetpack-analytics": "workspace:* || ^0.1",
 		"@automattic/jetpack-api": "workspace:* || ^0.13",
-		"@automattic/jetpack-components": "workspace:* || ^0.14",
+		"@automattic/jetpack-components": "workspace:* || ^0.15",
 		"@automattic/jetpack-connection": "workspace:* || ^0.18",
 		"@automattic/jetpack-licensing": "workspace:* || ^0.5",
 		"@wordpress/api-fetch": "6.5.0",

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -28,7 +28,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '1.5.0';
+	const PACKAGE_VERSION = '1.5.1-alpha';
 
 	/**
 	 * Initialize My Jetapack

--- a/projects/packages/search/changelog/update-components-add-is-external-link-prop
+++ b/projects/packages/search/changelog/update-components-add-is-external-link-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.14.1",
+	"version": "0.14.2-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {
@@ -42,7 +42,7 @@
 		"@automattic/jetpack-analytics": "workspace:* || ^0.1",
 		"@automattic/jetpack-api": "workspace:* || ^0.13",
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3",
-		"@automattic/jetpack-components": "workspace:* || ^0.14",
+		"@automattic/jetpack-components": "workspace:* || ^0.15",
 		"@automattic/jetpack-connection": "workspace:* || ^0.18",
 		"@wordpress/base-styles": "4.4.0",
 		"@wordpress/block-editor": "9.0.0",

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.14.1';
+	const VERSION = '0.14.2-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/wordads/changelog/update-components-add-is-external-link-prop
+++ b/projects/packages/wordads/changelog/update-components-add-is-external-link-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.2.3",
+	"version": "0.2.4-alpha",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",
@@ -34,7 +34,7 @@
 		"@automattic/color-studio": "2.5.0",
 		"@automattic/jetpack-analytics": "workspace:* || ^0.1",
 		"@automattic/jetpack-api": "workspace:* || ^0.13",
-		"@automattic/jetpack-components": "workspace:* || ^0.14",
+		"@automattic/jetpack-components": "workspace:* || ^0.15",
 		"@wordpress/base-styles": "4.4.0",
 		"@wordpress/block-editor": "9.0.0",
 		"@wordpress/data": "6.8.0",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.2.3';
+	const VERSION = '0.2.4-alpha';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/boost/changelog/update-components-add-is-external-link-prop
+++ b/projects/plugins/boost/changelog/update-components-add-is-external-link-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -15,7 +15,7 @@
 		"svelte-navigator": "3.1.5"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-components": "workspace:* || ^0.14",
+		"@automattic/jetpack-components": "workspace:* || ^0.15",
 		"@babel/core": "7.17.10",
 		"@babel/preset-env": "7.17.10",
 		"@babel/preset-react": "7.16.7",

--- a/projects/plugins/jetpack/changelog/update-components-add-is-external-link-prop
+++ b/projects/plugins/jetpack/changelog/update-components-add-is-external-link-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -51,7 +51,7 @@
 		"@automattic/format-currency": "1.0.1",
 		"@automattic/jetpack-analytics": "workspace:* || ^0.1",
 		"@automattic/jetpack-api": "workspace:* || ^0.13",
-		"@automattic/jetpack-components": "workspace:* || ^0.14",
+		"@automattic/jetpack-components": "workspace:* || ^0.15",
 		"@automattic/jetpack-connection": "workspace:* || ^0.18",
 		"@automattic/jetpack-licensing": "workspace:* || ^0.5",
 		"@automattic/jetpack-partner-coupon": "workspace:* || ^0.2",

--- a/projects/plugins/protect/changelog/update-components-add-is-external-link-prop
+++ b/projects/plugins/protect/changelog/update-components-add-is-external-link-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/protect/package.json
+++ b/projects/plugins/protect/package.json
@@ -26,7 +26,7 @@
 	],
 	"dependencies": {
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3",
-		"@automattic/jetpack-components": "workspace:* || ^0.14",
+		"@automattic/jetpack-components": "workspace:* || ^0.15",
 		"@automattic/jetpack-connection": "workspace:* || ^0.18",
 		"@automattic/jetpack-analytics": "workspace:* || ^0.1",
 		"@wordpress/api-fetch": "6.5.0",

--- a/projects/plugins/social/changelog/update-components-add-is-external-link-prop
+++ b/projects/plugins/social/changelog/update-components-add-is-external-link-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/social/package.json
+++ b/projects/plugins/social/package.json
@@ -26,7 +26,7 @@
 	],
 	"dependencies": {
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3",
-		"@automattic/jetpack-components": "workspace:* || ^0.14",
+		"@automattic/jetpack-components": "workspace:* || ^0.15",
 		"@automattic/jetpack-connection": "workspace:* || ^0.18",
 		"@wordpress/data": "6.8.0",
 		"@wordpress/date": "4.8.0",

--- a/projects/plugins/starter-plugin/changelog/update-components-add-is-external-link-prop
+++ b/projects/plugins/starter-plugin/changelog/update-components-add-is-external-link-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/starter-plugin/package.json
+++ b/projects/plugins/starter-plugin/package.json
@@ -26,7 +26,7 @@
 	],
 	"dependencies": {
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3",
-		"@automattic/jetpack-components": "workspace:* || ^0.14",
+		"@automattic/jetpack-components": "workspace:* || ^0.15",
 		"@automattic/jetpack-connection": "workspace:* || ^0.18",
 		"@wordpress/data": "6.8.0",
 		"@wordpress/element": "4.6.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds the `isExternalLink` property to the Button component to be able to get the external link behavior for all button variations. It overlaps with the `external-link` variant but does not generate conflicts in terms of usability or styles.
However, the `external-link` variation is considered deprecated in favor of `isExternalLink` property:

### API

```tsx
<Button
  variation="primary"
  isExternalLink={ true }
>
  Support page
</Button>
```

<img width="206" alt="image" src="https://user-images.githubusercontent.com/77539/169910634-4a2fa962-6493-4304-8ce9-5481316f94ba.png">

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use storybook
* Select the default story of Button component

https://user-images.githubusercontent.com/77539/169910715-60f25303-2fd1-4d1a-a8f0-28d635bae26f.mov



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202322888191964