### PR TITLE
Add/protect cache timing

### DIFF
--- a/projects/plugins/protect/changelog/add-protect-cache-timing
+++ b/projects/plugins/protect/changelog/add-protect-cache-timing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Change expiration time of plugin cache

--- a/projects/plugins/protect/src/class-status.php
+++ b/projects/plugins/protect/src/class-status.php
@@ -43,14 +43,14 @@ class Status {
 	 *
 	 * @var int
 	 */
-	const OPTION_EXPIRES_AFTER = 43200; // 12 hours.
+	const OPTION_EXPIRES_AFTER = 3600; // 1 hour.
 
 	/**
 	 * Time in seconds that the cache for the initial empty response should last
 	 *
 	 * @var int
 	 */
-	const INITIAL_OPTION_EXPIRES_AFTER = 5 * MINUTE_IN_SECONDS;
+	const INITIAL_OPTION_EXPIRES_AFTER = 1 * MINUTE_IN_SECONDS;
 
 	/**
 	 * Memoization for the current status


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Reduces the expiration time of Protect cache. The full status report will be cached for an hour and the initial empty response will only be cached for a minute.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open up the Protect settings page and verify that the status page is showing.
* Open wp sh and write down the timestamp of the report.
* Wait an hour and open the Protect settings page again.
* Verify that the option was updated and the timestamp matches a new generation of the report.
