### PR TITLE
Sharing: remove nonce field that was added in #24412

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-save-cpt-sharing
+++ b/projects/plugins/jetpack/changelog/fix-save-cpt-sharing
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Sharing: remove nonce field that was added but not used in previous PR.
+
+

--- a/projects/plugins/jetpack/modules/sharedaddy/sharedaddy.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharedaddy.php
@@ -222,7 +222,6 @@ function sharing_meta_box_content( $post ) {
 			<?php esc_html_e( 'Show sharing buttons.', 'jetpack' ); ?>
 		</label>
 		<input type="hidden" name="sharing_status_hidden" value="1" />
-		<?php wp_nonce_field( 'sharing-meta-box' ); ?>
 	</p>
 
 	<?php


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

I had added the field, but ended up not using because of saving issues (see c5611e64a3df43a73ef5878a9bb3758d9c80b232).

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start with a site with Jetpack connected and the sharing module active.
* Create a new CPT like so:
```php
add_action(
	'init',
	function () {
		register_post_type(
			'example_cpt',
			array(
				'label'               => __( 'Post Type', 'jeherve-cpt' ),
				'description'         => __( 'Post Type Description', 'jeherve-cpt' ),
				'labels'              => array(
					'name'          => _x( 'Post Types', 'Post Type General Name', 'jeherve-cpt' ),
					'singular_name' => _x( 'Post Type', 'Post Type Singular Name', 'jeherve-cpt' ),
				),
				'supports'            => array( 'title' ),
				'hierarchical'        => false,
				'public'              => true,
				'show_ui'             => true,
				'show_in_menu'        => true,
				'menu_position'       => 5,
				'show_in_admin_bar'   => true,
				'show_in_nav_menus'   => true,
				'can_export'          => true,
				'has_archive'         => true,
				'exclude_from_search' => false,
				'publicly_queryable'  => true,
				'capability_type'     => 'page',
			)
		);
	}
);
```
3. Go to that new post type's menu, and create a new post there.
4. Without that branch, you should get an error when trying to publish. With this branch, it should work.

