### PR TITLE
 Protect: Re implement "Your results will be ready soon" layout

### DIFF
--- a/projects/js-packages/components/changelog/update-protect-update-admin-soon-section
+++ b/projects/js-packages/components/changelog/update-protect-update-admin-soon-section
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+JS Components: remove Dialog isCard property

--- a/projects/js-packages/components/components/dialog/index.tsx
+++ b/projects/js-packages/components/components/dialog/index.tsx
@@ -27,7 +27,6 @@ type DialogProps = {
  * @param {React.ReactNode} props.primary   - Primary-section content.
  * @param {React.ReactNode} props.secondary - Secondary-section content.
  * @param {boolean} props.isTwoSections     - Handle two sections layout when true.
- * @param {boolean} props.isCard            - Add card styles to the main container.
  * @param {object} props.containerProps     - Props to pass to the container component.
  * @returns {React.ReactNode}                 Rendered dialog
  */
@@ -35,7 +34,6 @@ const Dialog: React.FC< DialogProps > = ( {
 	primary,
 	secondary,
 	isTwoSections = false,
-	isCard,
 	...containerProps
 } ) => {
 	const [ isSmall, isLowerThanLarge ] = useBreakpointMatch( [ 'sm', 'lg' ], [ null, '<' ] );
@@ -48,7 +46,7 @@ const Dialog: React.FC< DialogProps > = ( {
 	const hideSecondarySection = ! isTwoSections && isSmall;
 
 	const classNames = classnames( {
-		[ styles[ 'one-section-style' ] ]: typeof isCard !== 'undefined' ? isCard : ! isTwoSections,
+		[ styles[ 'one-section-style' ] ]: ! isTwoSections,
 		[ styles[ 'is-viewport-small' ] ]: isSmall,
 	} );
 

--- a/projects/js-packages/components/components/dialog/stories/js-components.components.dialog.story.mdx
+++ b/projects/js-packages/components/components/dialog/stories/js-components.components.dialog.story.mdx
@@ -10,7 +10,7 @@ import styles from './style.module.scss';
 	title="JS Packages/Components/Dialog" component={ Dialog }
 />
 
-export const Template = ( { isTwoSections, isCard } ) => (
+export const Template = ( { isTwoSections } ) => (
 	<Dialog
 		primary= {
 			<div className={ styles.section }>
@@ -26,7 +26,6 @@ export const Template = ( { isTwoSections, isCard } ) => (
 			</div>
 		}
 		isTwoSections= { isTwoSections }
-		isCard={ isCard }
 	/>
 );
 
@@ -52,7 +51,6 @@ import Dialog from '@automattic/jetpack-components';
 	name="Readme"
 	args={ {
 		isTwoSections: true,
-		isCard: false,
 	} }
 >
 	{ Template.bind( {} ) }
@@ -94,11 +92,3 @@ Primary-section content.
 It handles two sections layout:
   - Add card styles to the main wrapper when it is not a two-sections layout.
   - When it's false, the secondary section won't show in Mobile.
-
-### isCard
-
-- Type: `boolean`.
-- Optional.
-- Default: `false`
-
-Add card styles to the main wrapper.

--- a/projects/plugins/protect/changelog/update-protect-update-admin-soon-section
+++ b/projects/plugins/protect/changelog/update-protect-update-admin-soon-section
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Protect: Re implement "Your results will be ready soon" layout

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -112,14 +112,14 @@ const ProtectAdminPage = () => {
 				<AdminSectionHero>
 					<SeventyFiveLayout
 						main={
-							<div className={ styles[ 'alert-section' ] }>
+							<div className={ styles[ 'main-content' ] }>
 								<AlertSVGIcon className={ styles[ 'alert-icon-wrapper' ] } />
 								<H3>{ __( 'We’re having problems scanning your site', 'jetpack-protect' ) }</H3>
 								<Text>{ displayErrorMessage }</Text>
 							</div>
 						}
 						secondary={
-							<div className={ styles[ 'alert-section-illustration' ] }>
+							<div className={ styles.illustration }>
 								<img src={ inProgressImage } alt="" />
 							</div>
 						}
@@ -136,21 +136,25 @@ const ProtectAdminPage = () => {
 		return (
 			<AdminPage moduleName={ __( 'Jetpack Protect', 'jetpack-protect' ) } header={ <Logo /> }>
 				<AdminSectionHero>
-					<Container horizontalSpacing={ 3 } horizontalGap={ 7 }>
-						<Col sm={ 4 } md={ 4 } lg={ 6 }>
-							<H3 mt={ 8 }>{ __( 'Your results will be ready soon', 'jetpack-protect' ) }</H3>
-							<Text>
-								{ __(
-									'We are scanning for security threats from our more than 22,000 listed vulnerabilities, powered by WPScan. This could take a few seconds.',
-									'jetpack-protect'
-								) }
-							</Text>
-						</Col>
-						<Col sm={ 0 } md={ 0 } lg={ 1 }></Col>
-						<Col sm={ 4 } md={ 3 } lg={ 5 }>
-							<img src={ inProgressImage } alt="" />
-						</Col>
-					</Container>
+					<SeventyFiveLayout
+						main={
+							<div className={ styles[ 'main-content' ] }>
+								<H3 mt={ 8 }>{ __( 'Your results will be ready soon', 'jetpack-protect' ) }</H3>
+								<Text>
+									{ __(
+										'We are scanning for security threats from our more than 22,000 listed vulnerabilities, powered by WPScan. This could take a few seconds.',
+										'jetpack-protect'
+									) }
+								</Text>
+							</div>
+						}
+						secondary={
+							<div className={ styles.illustration }>
+								<img src={ inProgressImage } alt="" />
+							</div>
+						}
+						preserveSecondaryOnMobile={ false }
+					/>
 				</AdminSectionHero>
 				<Footer />
 			</AdminPage>

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -139,7 +139,7 @@ const ProtectAdminPage = () => {
 					<SeventyFiveLayout
 						main={
 							<div className={ styles[ 'main-content' ] }>
-								<H3 mt={ 8 }>{ __( 'Your results will be ready soon', 'jetpack-protect' ) }</H3>
+								<H3>{ __( 'Your results will be ready soon', 'jetpack-protect' ) }</H3>
 								<Text>
 									{ __(
 										'We are scanning for security threats from our more than 22,000 listed vulnerabilities, powered by WPScan. This could take a few seconds.',

--- a/projects/plugins/protect/src/js/components/admin-page/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/admin-page/styles.module.scss
@@ -13,11 +13,11 @@
 }
 
 // Alert section
-.alert-section {
+.main-content {
 	padding: calc( var( --spacing-base ) * 7 ) 0;
 }
 
-.alert-section-illustration {
+.illustration {
 	display: flex;
 	align-items: center;
 	height: 100%;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Similarly to [this](https://github.com/Automattic/jetpack/pull/24434), this PR re-implements the "Your results will be ready soon" admin section layout.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*  Protect: Re implement "Your results will be ready soon" layout

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set Protect to show the "Your results will be ready soon" page
* Confirm the sections looks well, same that layout that the Admin error page, and aligned with the footer.

<img width="919" alt="image" src="https://user-images.githubusercontent.com/77539/170139662-ca7ccfff-568c-42f7-a8e3-1687cb212aa3.png">

<img width="845" alt="image" src="https://user-images.githubusercontent.com/77539/170139776-1831cb80-19eb-4a75-be46-98daa99b5416.png">


<img width="682" alt="image" src="https://user-images.githubusercontent.com/77539/170139707-d7ec11d6-f97a-41dc-a02d-5e382993f152.png">


