### PR TITLE
Protect: Convert UTC timestamp to local timestamp

### DIFF
--- a/projects/plugins/protect/changelog/add-protect-last-checked-local-timezone
+++ b/projects/plugins/protect/changelog/add-protect-last-checked-local-timezone
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Convert last_checked date from UTC to local configured timezone

--- a/projects/plugins/protect/src/class-status.php
+++ b/projects/plugins/protect/src/class-status.php
@@ -75,7 +75,9 @@ class Status {
 			$status = self::get_from_options();
 		}
 
-		$status->last_checked = get_date_from_gmt( $status->last_checked );
+		if ( isset( $status->last_checked ) ) {
+			$status->last_checked = get_date_from_gmt( $status->last_checked );
+		}
 
 		if ( is_wp_error( $status ) ) {
 			$status = array(

--- a/projects/plugins/protect/src/class-status.php
+++ b/projects/plugins/protect/src/class-status.php
@@ -75,6 +75,8 @@ class Status {
 			$status = self::get_from_options();
 		}
 
+		$status->last_checked = get_date_from_gmt( $status->last_checked );
+
 		if ( is_wp_error( $status ) ) {
 			$status = array(
 				'error'         => true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Converts the last_checked date that comes from the API from UTC to the local configured timezone.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1201069996155224-as-1202326318206100

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Configure your test site to use UTC as the timezone.
* Gerenate the Protect report and verify that the timestamp is not being shifted.
* Change the configured timezone and verify that the date is being shifted accordingly.