### PR TITLE
Social: use isExternalLink for the media connections button

### DIFF
--- a/projects/plugins/social/changelog/update-protect-use-is-external-link-prop
+++ b/projects/plugins/social/changelog/update-protect-use-is-external-link-prop
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Social: use isExternalLink for the media connections button

--- a/projects/plugins/social/src/js/components/toggle-section/index.js
+++ b/projects/plugins/social/src/js/components/toggle-section/index.js
@@ -4,7 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { Button, Container, Text } from '@automattic/jetpack-components';
-import { Icon, external } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -44,12 +43,12 @@ const ToggleSection = () => {
 					<Button
 						className={ styles.button }
 						variant="primary"
+						isExternalLink={ true }
 						href={ connectionsAdminUrl }
 						disabled={ isUpdating || ! isModuleEnabled }
 						target="_blank"
 					>
 						{ __( 'Manage social media connections', 'jetpack-social' ) }
-						<Icon size={ 24 } icon={ external } className={ styles[ 'external-icon' ] } />
 					</Button>
 				) }
 			</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR implements the external link style for the media connections button via the new isExternalLink button property.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Social plugin dashboard
* confirm the media connections button looks and works as expected
* You may like to confirm the component property is there, too.

dashboard | components inspector
------|------
<img width="568" alt="image" src="https://user-images.githubusercontent.com/77539/170239793-ff0f623a-d5cf-4033-9bb8-5b8eb4c6d97f.png"> | <img width="767" alt="Screen Shot 2022-05-25 at 7 17 36 AM" src="https://user-images.githubusercontent.com/77539/170239976-78f57f0e-df8d-4133-812b-01d753ad56df.png">
