### PR TITLE
Search: Record meter display & naming changes

### DIFF
--- a/projects/packages/search/changelog/update-search-record-meter-update-naming
+++ b/projects/packages/search/changelog/update-search-record-meter-update-naming
@@ -1,5 +1,5 @@
 Significance: patch
 Type: changed
-Comment: very minor/insignificant change
+Comment: Record Meter: update title and fix display issues
 
 

--- a/projects/packages/search/changelog/update-search-record-meter-update-naming
+++ b/projects/packages/search/changelog/update-search-record-meter-update-naming
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: very minor/insignificant change
+
+

--- a/projects/packages/search/src/dashboard/components/record-meter/index.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/index.jsx
@@ -39,7 +39,7 @@ export default function RecordMeter( {
 		<div className="jp-search-record-meter jp-search-dashboard-wrap" data-testid="record-meter">
 			<div className="jp-search-dashboard-row">
 				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
-				<div className="jp-search-record-meter__title lg-col-span-8 md-col-span-6 sm-col-span-4">
+				<div className="jp-search-record-meter__content lg-col-span-8 md-col-span-6 sm-col-span-4">
 					<h2>
 						{
 							/* translators: Your Search Index is a breakdown of the site's indexed post type content,

--- a/projects/packages/search/src/dashboard/components/record-meter/index.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/index.jsx
@@ -40,6 +40,8 @@ export default function RecordMeter( {
 			<div className="jp-search-dashboard-row">
 				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
 				<div className="jp-search-record-meter__title lg-col-span-8 md-col-span-6 sm-col-span-4">
+					/* translators: Your Search Index is a breakdown of the site's indexed post type content,
+					such as the number of indexed posts, pages etc. */
 					<h2>{ __( 'Your Search Index', 'jetpack-search-pkg' ) }</h2>
 					<div>
 						<RecordCount

--- a/projects/packages/search/src/dashboard/components/record-meter/index.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/index.jsx
@@ -40,9 +40,15 @@ export default function RecordMeter( {
 			<div className="jp-search-dashboard-row">
 				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
 				<div className="jp-search-record-meter__title lg-col-span-8 md-col-span-6 sm-col-span-4">
-					/* translators: Your Search Index is a breakdown of the site's indexed post type content,
-					such as the number of indexed posts, pages etc. */
-					<h2>{ __( 'Your Search Index', 'jetpack-search-pkg' ) }</h2>
+					<h2>
+						{
+							/* translators: Your Search Index is a breakdown of the site's indexed post type content,
+					such as the number of indexed posts, pages etc. */ __(
+								'Your Search Index',
+								'jetpack-search-pkg'
+							)
+						}
+					</h2>
 					<div>
 						<RecordCount
 							recordCount={ recordInfo.recordCount }

--- a/projects/packages/search/src/dashboard/components/record-meter/index.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/index.jsx
@@ -40,7 +40,7 @@ export default function RecordMeter( {
 			<div className="jp-search-dashboard-row">
 				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
 				<div className="jp-search-record-meter__title lg-col-span-8 md-col-span-6 sm-col-span-4">
-					<h2>{ __( 'Your search records', 'jetpack-search-pkg' ) }</h2>
+					<h2>{ __( 'Your Search Index', 'jetpack-search-pkg' ) }</h2>
 					<div>
 						<RecordCount
 							recordCount={ recordInfo.recordCount }

--- a/projects/packages/search/src/dashboard/components/record-meter/index.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/index.jsx
@@ -42,7 +42,7 @@ export default function RecordMeter( {
 				<div className="jp-search-record-meter__content lg-col-span-8 md-col-span-6 sm-col-span-4">
 					<h2>
 						{
-							/* translators: Your Search Index is a breakdown of the site's indexed post type content,
+							/* translators: 'Your search index' is a breakdown of the site's indexed post type content,
 					such as the number of indexed posts, pages etc. */ __(
 								'Your search index',
 								'jetpack-search-pkg'

--- a/projects/packages/search/src/dashboard/components/record-meter/index.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/index.jsx
@@ -44,7 +44,7 @@ export default function RecordMeter( {
 						{
 							/* translators: Your Search Index is a breakdown of the site's indexed post type content,
 					such as the number of indexed posts, pages etc. */ __(
-								'Your Search Index',
+								'Your search index',
 								'jetpack-search-pkg'
 							)
 						}

--- a/projects/packages/search/src/dashboard/components/record-meter/style.scss
+++ b/projects/packages/search/src/dashboard/components/record-meter/style.scss
@@ -100,6 +100,10 @@ ul.jp-search-chart-legend {
 	padding: 64px 0;
 }
 
-.jp-search-record-meter__title h2 {
+.jp-search-record-meter__content h2 {
 	margin-top: 0;
+}
+
+.jp-search-record-meter__content {
+	width: 100%; // fixes overflow issues on firefox
 }


### PR DESCRIPTION
This very small PR makes four tiny changes to the Record Meter display.

Fixes https://github.com/Automattic/jetpack/issues/24424

#### Changes proposed in this Pull Request:
1. Updates the record meter heading `Your search records` to instead be `Your Search Index` 
2. Add one line of CSS to fix firefox displaying overflow content which doesn't resize along with screen resize
3. Change one CSS class name from `jp-search-record-meter__title` to `jp-search-record-meter__content` to be more accurately descriptive of the container it pertains to. 
4. Adds a translator comment for some additional context

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions
* Go to `/wp-admin/admin.php?page=jetpack-search&features=record-meter` on your test site with Search enabled.
* Check that the title is now `Your Search Index` instead of `Your search records`
* Open the above link in Firefox on a web browser, and resize the display smaller to check the text, record meter, legend box, and notice boxes all scale down to fit the viewport, and don't hang off the edge. Optionally, do the same on Firefox for mobile. 

![image](https://user-images.githubusercontent.com/30754158/170285958-fda6b0c4-bb07-4f22-a7a6-950d87fdb080.png)

![Screen Capture on 2022-05-25 at 15-29-58](https://user-images.githubusercontent.com/30754158/170286886-8131e550-cc52-4362-ba14-ac04d181e480.gif)

