### PR TITLE
Remove deprecated external-link variant

### DIFF
--- a/projects/js-packages/components/changelog/update-external-link-instances
+++ b/projects/js-packages/components/changelog/update-external-link-instances
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+JS Components: remove deprecated external-link variant

--- a/projects/js-packages/components/components/button/index.tsx
+++ b/projects/js-packages/components/components/button/index.tsx
@@ -24,7 +24,7 @@ export const Button: React.FC< ButtonProps > = ( {
 	disabled,
 	isDestructive,
 	isLoading,
-	isExternalLink: isExternalLinkProp,
+	isExternalLink,
 	className: propsClassName,
 	text,
 	...componentProps
@@ -37,9 +37,6 @@ export const Button: React.FC< ButtonProps > = ( {
 		[ styles.regular ]: weight === 'regular',
 	} );
 
-	const isExternalLinkDeprecated = variant === 'external-link';
-	const isExternalLink = isExternalLinkProp || isExternalLinkDeprecated;
-
 	const externalIconSize = size === 'normal' ? 20 : 16;
 	const externalIcon = isExternalLink && (
 		<Icon size={ externalIconSize } icon={ external } className={ styles[ 'external-icon' ] } />
@@ -49,7 +46,7 @@ export const Button: React.FC< ButtonProps > = ( {
 	return (
 		<WPButton
 			target={ externalTarget }
-			variant={ isExternalLinkDeprecated ? 'link' : variant }
+			variant={ variant }
 			className={ className }
 			icon={ ! isExternalLink ? icon : undefined }
 			iconSize={ iconSize }

--- a/projects/js-packages/components/components/button/stories/index.tsx
+++ b/projects/js-packages/components/components/button/stories/index.tsx
@@ -6,11 +6,15 @@ import * as allIcons from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import Col from '../../layout/col';
+import Container from '../../layout/container';
+import Text, { H3 } from '../../text';
 import Button from '../index';
 import Doc from './Button.mdx';
+import styles from './style.module.scss';
 
 const { Icon: WPIcon, ...icons } = allIcons;
-const { check } = icons;
+const { check, cloud } = icons;
 
 const DisableVariant = {
 	variant: {
@@ -64,16 +68,28 @@ export default {
 	title: 'JS Packages/Components/Button',
 	component: Button,
 	argTypes: {
-		icon: {
-			control: {
-				type: 'select',
-				options: [ 'none', ...Object.keys( icons ) ],
-			},
-		},
 		variant: {
 			control: {
 				type: 'select',
 				options: [ 'primary', 'secondary', 'link' ],
+			},
+		},
+		size: {
+			control: {
+				type: 'select',
+				options: [ 'normal', 'small' ],
+			},
+		},
+		weight: {
+			control: {
+				type: 'select',
+				options: [ 'bold', 'regular' ],
+			},
+		},
+		icon: {
+			control: {
+				type: 'select',
+				options: [ 'none', ...Object.keys( icons ) ],
 			},
 		},
 	},
@@ -94,15 +110,15 @@ const DefaultTemplate = args => {
 
 export const _default = DefaultTemplate.bind( {} );
 _default.args = {
+	variant: 'primary',
 	size: 'normal',
 	weight: 'bold',
-	children: 'Once upon a time… a button story',
-	variant: 'primary',
+	icon: 'cloud',
 	isExternalLink: false,
 	isLoading: false,
 	disabled: false,
 	isDestructive: false,
-	icon: 'cloud',
+	children: 'Once upon a time… a button story',
 };
 
 const Template = args => <Button { ...args } />;
@@ -207,3 +223,130 @@ Loading.args = {
 	variant: 'primary',
 	isLoading: true,
 };
+
+export const VariantsAndProps = () => {
+	const variants = [ 'primary', 'secondary', 'link' ];
+	return (
+		<>
+			<Container>
+				<Col>
+					<H3>Variants & Props</H3>
+				</Col>
+				<Col>
+					<Text mb={ 3 }>
+						The following shows how the properties modify the appearance and/or behavior of the
+						button, in the different variants. Keep in mind that you cannot combine the variants but
+						you can combine the props. Use the { '' }
+						<a href="./?path=/story/js-packages-components-button--default">default story</a> to
+						play with the combinations.
+					</Text>
+				</Col>
+			</Container>
+			<Container className={ styles.container } horizontalGap={ 0 }>
+				<Col
+					className={ `${ styles[ 'row-instance' ] } ${ styles.header }` }
+					sm={ 4 }
+					md={ 2 }
+					lg={ 3 }
+				>
+					<Text size="body-extra-small">props / variants</Text>
+				</Col>
+
+				<Col sm={ 4 } md={ 2 } lg={ 3 }>
+					<Text size="body-extra-small" className={ styles.header }>
+						Primary
+					</Text>
+				</Col>
+
+				<Col sm={ 4 } md={ 2 } lg={ 3 }>
+					<Text size="body-extra-small" className={ styles.header }>
+						Secondary
+					</Text>
+				</Col>
+
+				<Col sm={ 4 } md={ 2 } lg={ 3 }>
+					<Text size="body-extra-small" className={ styles.header }>
+						Link
+					</Text>
+				</Col>
+
+				<Col className={ styles[ 'row-instance' ] } sm={ 4 } md={ 2 } lg={ 3 }>
+					<Text size="body-extra-small">no props</Text>
+				</Col>
+				{ variants.map( variant => (
+					<Col sm={ 4 } md={ 2 } lg={ 3 }>
+						<Button { ...ButtonPrimary.args } variant={ variant } />
+					</Col>
+				) ) }
+
+				<Col className={ styles[ 'row-instance' ] } sm={ 4 } md={ 2 } lg={ 3 }>
+					<Text size="body-extra-small">size: small</Text>
+				</Col>
+				{ variants.map( variant => (
+					<Col sm={ 4 } md={ 2 } lg={ 3 }>
+						<Button { ...ButtonPrimary.args } variant={ variant } size="small" />
+					</Col>
+				) ) }
+
+				<Col className={ styles[ 'row-instance' ] } sm={ 4 } md={ 2 } lg={ 3 }>
+					<Text size="body-extra-small">weight: regular</Text>
+				</Col>
+				{ variants.map( variant => (
+					<Col sm={ 4 } md={ 2 } lg={ 3 }>
+						<Button { ...ButtonPrimary.args } variant={ variant } weight="regular" />
+					</Col>
+				) ) }
+
+				<Col className={ styles[ 'row-instance' ] } sm={ 4 } md={ 2 } lg={ 3 }>
+					<Text size="body-extra-small">icon (cloud)</Text>
+				</Col>
+				{ variants.map( variant => (
+					<Col sm={ 4 } md={ 2 } lg={ 3 }>
+						<Button
+							{ ...ButtonPrimary.args }
+							variant={ variant }
+							icon={ <WPIcon icon={ cloud } /> }
+						/>
+					</Col>
+				) ) }
+
+				<Col className={ styles[ 'row-instance' ] } sm={ 4 } md={ 2 } lg={ 3 }>
+					<Text size="body-extra-small">disabled</Text>
+				</Col>
+				{ variants.map( variant => (
+					<Col sm={ 4 } md={ 2 } lg={ 3 }>
+						<Button { ...ButtonPrimary.args } variant={ variant } disabled />
+					</Col>
+				) ) }
+
+				<Col className={ styles[ 'row-instance' ] } sm={ 4 } md={ 2 } lg={ 3 }>
+					<Text size="body-extra-small">isDestructive</Text>
+				</Col>
+				{ variants.map( variant => (
+					<Col sm={ 4 } md={ 2 } lg={ 3 }>
+						<Button { ...ButtonPrimary.args } variant={ variant } isDestructive />
+					</Col>
+				) ) }
+
+				<Col className={ styles[ 'row-instance' ] } sm={ 4 } md={ 2 } lg={ 3 }>
+					<Text size="body-extra-small">isExternalLink</Text>
+				</Col>
+				{ variants.map( variant => (
+					<Col sm={ 4 } md={ 2 } lg={ 3 }>
+						<Button { ...ButtonPrimary.args } variant={ variant } isExternalLink />
+					</Col>
+				) ) }
+
+				<Col className={ styles[ 'row-instance' ] } sm={ 4 } md={ 2 } lg={ 3 }>
+					<Text size="body-extra-small">isLoading</Text>
+				</Col>
+				{ variants.map( variant => (
+					<Col sm={ 4 } md={ 2 } lg={ 3 }>
+						<Button { ...ButtonPrimary.args } variant={ variant } isLoading />
+					</Col>
+				) ) }
+			</Container>
+		</>
+	);
+};
+VariantsAndProps.storyName = 'Variants & Props';

--- a/projects/js-packages/components/components/button/stories/index.tsx
+++ b/projects/js-packages/components/components/button/stories/index.tsx
@@ -73,7 +73,7 @@ export default {
 		variant: {
 			control: {
 				type: 'select',
-				options: [ 'primary', 'secondary', 'link', 'external-link' ],
+				options: [ 'primary', 'secondary', 'link' ],
 			},
 		},
 	},
@@ -149,21 +149,6 @@ ButtonLink.args = {
 	size: 'normal',
 	children: 'Jetpack Button',
 	variant: 'link',
-};
-
-export const ButtonExternalLink = Template.bind( {} );
-ButtonExternalLink.argTypes = {
-	...DisableVariant,
-	...DisableDisabled,
-	...DisableIcon,
-	...DisableIsLoading,
-	...DisableIsDestructive,
-	...disableClassName,
-};
-ButtonExternalLink.args = {
-	size: 'normal',
-	children: 'Jetpack Button',
-	variant: 'external-link',
 };
 
 export const Icon = Template.bind( {} );

--- a/projects/js-packages/components/components/button/stories/style.module.scss
+++ b/projects/js-packages/components/components/button/stories/style.module.scss
@@ -1,0 +1,20 @@
+.container {
+	row-gap: 0;
+	column-gap: 0;
+	> div {
+		border-right: 1px dotted var( --jp-gray-10 );
+		border-bottom: 1px dotted var( --jp-gray-10 );
+		padding: calc( var( --spacing-base ) * 4 ) calc( var( --spacing-base ) * 2 );
+		align-items: center;
+
+		&:nth-child(4n) {
+			border-right: none;
+		}
+	}
+}
+
+
+.header {
+	font-weight: 600;
+	text-align: center;
+}

--- a/projects/js-packages/components/components/button/types.ts
+++ b/projects/js-packages/components/components/button/types.ts
@@ -17,7 +17,7 @@ type JetpackButtonBaseProps = {
 };
 
 type JetpackLinkProps = Omit< Button.AnchorProps, 'size' | 'variant' > & {
-	variant?: 'link' | 'external-link';
+	variant?: 'link';
 };
 
 type JetpackButtonProps = Omit< Button.ButtonProps, 'size' | 'variant' > & {

--- a/projects/packages/backup/changelog/update-external-link-instances
+++ b/projects/packages/backup/changelog/update-external-link-instances
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/backup/composer.json
+++ b/projects/packages/backup/composer.json
@@ -12,7 +12,7 @@
 		"automattic/jetpack-connection": "^1.40",
 		"automattic/jetpack-connection-ui": "^2.4",
 		"automattic/jetpack-identity-crisis": "^0.8",
-		"automattic/jetpack-my-jetpack": "^1.5",
+		"automattic/jetpack-my-jetpack": "^1.6",
 		"automattic/jetpack-sync": "^1.34",
 		"automattic/jetpack-status": "^1.13"
 	},

--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
@@ -107,8 +107,9 @@ function PlanSectionFooter( { purchases } ) {
 				<Button
 					onClick={ purchaseClickHandler }
 					href={ purchases.length ? getManageYourPlanUrl() : getPurchasePlanUrl() }
-					variant="external-link"
 					weight="regular"
+					variant="link"
+					isExternalLink={ true }
 				>
 					{ planLinkDescription }
 				</Button>

--- a/projects/packages/my-jetpack/changelog/update-external-link-instances
+++ b/projects/packages/my-jetpack/changelog/update-external-link-instances
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Replace deprecated external-link variation by using isExternalLink prop

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -72,7 +72,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-master": "1.5.x-dev"
+			"dev-master": "1.6.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "1.5.1-alpha",
+	"version": "1.6.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -28,7 +28,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '1.5.1-alpha';
+	const PACKAGE_VERSION = '1.6.0-alpha';
 
 	/**
 	 * Initialize My Jetapack

--- a/projects/plugins/backup/changelog/update-external-link-instances
+++ b/projects/plugins/backup/changelog/update-external-link-instances
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -235,7 +235,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "0fd14086464709bc3c6005fc6fff0f88150cdaa7"
+                "reference": "f8b936e9994f1966273b00a35976b94b612245bb"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -246,7 +246,7 @@
                 "automattic/jetpack-connection": "^1.40",
                 "automattic/jetpack-connection-ui": "^2.4",
                 "automattic/jetpack-identity-crisis": "^0.8",
-                "automattic/jetpack-my-jetpack": "^1.5",
+                "automattic/jetpack-my-jetpack": "^1.6",
                 "automattic/jetpack-status": "^1.13",
                 "automattic/jetpack-sync": "^1.34"
             },
@@ -801,7 +801,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "2037dc9cc15f93fa978682bf75a89a68fb4a5ee3"
+                "reference": "a8d2b0021ab98a8e548084b0ba261fb55367588f"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -826,7 +826,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.5.x-dev"
+                    "dev-master": "1.6.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/update-external-link-instances
+++ b/projects/plugins/boost/changelog/update-external-link-instances
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -20,7 +20,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.9.x-dev",
 		"automattic/jetpack-connection": "1.40.x-dev",
-		"automattic/jetpack-my-jetpack": "1.5.x-dev",
+		"automattic/jetpack-my-jetpack": "1.6.x-dev",
 		"automattic/jetpack-device-detection": "1.4.x-dev",
 		"automattic/jetpack-lazy-images": "2.1.x-dev",
 		"tedivm/jshrink": "1.4.0"

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a3d60ee95e33e60b86cd72b020332ed8",
+    "content-hash": "d5e6a2fc6c7681f558241aeda745d9cc",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -608,7 +608,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "2037dc9cc15f93fa978682bf75a89a68fb4a5ee3"
+                "reference": "a8d2b0021ab98a8e548084b0ba261fb55367588f"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -633,7 +633,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.5.x-dev"
+                    "dev-master": "1.6.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/changelog/update-external-link-instances
+++ b/projects/plugins/jetpack/changelog/update-external-link-instances
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -31,7 +31,7 @@
 		"automattic/jetpack-lazy-images": "2.1.x-dev",
 		"automattic/jetpack-licensing": "1.7.x-dev",
 		"automattic/jetpack-logo": "1.5.x-dev",
-		"automattic/jetpack-my-jetpack": "1.5.x-dev",
+		"automattic/jetpack-my-jetpack": "1.6.x-dev",
 		"automattic/jetpack-partner": "1.7.x-dev",
 		"automattic/jetpack-plugins-installer": "0.1.x-dev",
 		"automattic/jetpack-publicize": "0.5.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9e01ca9733b3ecac1f498d448ebece5a",
+    "content-hash": "fff6c8d0610883b5d4766726fcde77d1",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -290,7 +290,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "0fd14086464709bc3c6005fc6fff0f88150cdaa7"
+                "reference": "f8b936e9994f1966273b00a35976b94b612245bb"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -301,7 +301,7 @@
                 "automattic/jetpack-connection": "^1.40",
                 "automattic/jetpack-connection-ui": "^2.4",
                 "automattic/jetpack-identity-crisis": "^0.8",
-                "automattic/jetpack-my-jetpack": "^1.5",
+                "automattic/jetpack-my-jetpack": "^1.6",
                 "automattic/jetpack-status": "^1.13",
                 "automattic/jetpack-sync": "^1.34"
             },
@@ -1173,7 +1173,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "2037dc9cc15f93fa978682bf75a89a68fb4a5ee3"
+                "reference": "a8d2b0021ab98a8e548084b0ba261fb55367588f"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -1198,7 +1198,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.5.x-dev"
+                    "dev-master": "1.6.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/protect/changelog/update-external-link-instances
+++ b/projects/plugins/protect/changelog/update-external-link-instances
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Replace deprecated external-link variation by using isExternalLink prop

--- a/projects/plugins/protect/changelog/update-external-link-instances#2
+++ b/projects/plugins/protect/changelog/update-external-link-instances#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/protect/composer.json
+++ b/projects/plugins/protect/composer.json
@@ -10,7 +10,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.9.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-my-jetpack": "1.5.x-dev",
+		"automattic/jetpack-my-jetpack": "1.6.x-dev",
 		"automattic/jetpack-plugins-installer": "0.1.x-dev",
 		"automattic/jetpack-sync": "1.34.x-dev"
 	},

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "66801ee7a9c4f656d7d9f25b073b05cb",
+    "content-hash": "12783fcb5552eda518056df15d555dfd",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -618,7 +618,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "2037dc9cc15f93fa978682bf75a89a68fb4a5ee3"
+                "reference": "a8d2b0021ab98a8e548084b0ba261fb55367588f"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -643,7 +643,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.5.x-dev"
+                    "dev-master": "1.6.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/protect/src/js/components/footer/index.jsx
+++ b/projects/plugins/protect/src/js/components/footer/index.jsx
@@ -47,7 +47,7 @@ const ProductPromotion = () => {
 					) }
 				</Text>
 
-				<Button variant="external-link" weight="regular" href={ getStartedUrl }>
+				<Button variant="link" isExternalLink={ true } weight="regular" href={ getStartedUrl }>
 					{ __( 'Get Started', 'jetpack-protect' ) }
 				</Button>
 			</div>
@@ -84,7 +84,7 @@ const FooterInfo = () => {
 					'jetpack-protect'
 				) }
 			</Text>
-			<Button variant="external-link" href={ learnMoreUrl } weight="regular">
+			<Button variant="link" isExternalLink={ true } href={ learnMoreUrl } weight="regular">
 				{ __( 'Learn more', 'jetpack-protect' ) }
 			</Button>
 		</div>

--- a/projects/plugins/protect/src/js/components/vulnerabilities-list/list.jsx
+++ b/projects/plugins/protect/src/js/components/vulnerabilities-list/list.jsx
@@ -23,7 +23,9 @@ const VulAccordionItem = ( { id, name, version, title, icon, fixedIn } ) => {
 				}
 			</Text>
 			<Button
-				variant="external-link"
+				variant="link"
+				isExternalLink={ true }
+				weight="regular"
 				href={ getRedirectUrl( 'jetpack-protect-vul-info', { path: id } ) }
 			>
 				{ __( 'See more technical details of this vulnerability', 'jetpack-protect' ) }

--- a/projects/plugins/search/changelog/update-external-link-instances
+++ b/projects/plugins/search/changelog/update-external-link-instances
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -8,7 +8,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.9.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-my-jetpack": "1.5.x-dev",
+		"automattic/jetpack-my-jetpack": "1.6.x-dev",
 		"automattic/jetpack-search": "0.14.x-dev",
 		"automattic/jetpack-status": "^1.13",
 		"automattic/jetpack-sync": "1.34.x-dev"

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "20f02b27f6deec2ca4ae15b596f422ed",
+    "content-hash": "d74a3855a2765889e1c4bcbc0eb5334a",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -618,7 +618,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "2037dc9cc15f93fa978682bf75a89a68fb4a5ee3"
+                "reference": "a8d2b0021ab98a8e548084b0ba261fb55367588f"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -643,7 +643,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.5.x-dev"
+                    "dev-master": "1.6.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/update-external-link-instances
+++ b/projects/plugins/social/changelog/update-external-link-instances
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -13,7 +13,7 @@
 		"automattic/jetpack-publicize": "0.5.x-dev",
 		"automattic/jetpack-options": "1.16.x-dev",
 		"automattic/jetpack-connection": "1.40.x-dev",
-		"automattic/jetpack-my-jetpack": "1.5.x-dev",
+		"automattic/jetpack-my-jetpack": "1.6.x-dev",
 		"automattic/jetpack-sync": "1.34.x-dev",
 		"automattic/jetpack-status": "1.13.x-dev"
 	},

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "afcafd781e657dc843fd1f9b8b5309a1",
+    "content-hash": "b0dd78bb6be7ba28f0aeac8333fa2b95",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -618,7 +618,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "2037dc9cc15f93fa978682bf75a89a68fb4a5ee3"
+                "reference": "a8d2b0021ab98a8e548084b0ba261fb55367588f"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -643,7 +643,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.5.x-dev"
+                    "dev-master": "1.6.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/update-external-link-instances
+++ b/projects/plugins/starter-plugin/changelog/update-external-link-instances
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/starter-plugin/composer.json
+++ b/projects/plugins/starter-plugin/composer.json
@@ -10,7 +10,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.9.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-my-jetpack": "1.5.x-dev",
+		"automattic/jetpack-my-jetpack": "1.6.x-dev",
 		"automattic/jetpack-sync": "1.34.x-dev"
 	},
 	"require-dev": {

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fe433aca4f034cd5cc77d12590a2254f",
+    "content-hash": "d0589d26949b1fac2acf4777232495c4",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -618,7 +618,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "2037dc9cc15f93fa978682bf75a89a68fb4a5ee3"
+                "reference": "a8d2b0021ab98a8e548084b0ba261fb55367588f"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -643,7 +643,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "1.5.x-dev"
+                    "dev-master": "1.6.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We've defined the `external-link` variant as deprecated. This PR removes all instances were the variant is used, and replaced by the `isExternalLink` prop.


Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Clean the `external-link` variant from Button component
* Replace all Button instances with `external-link` variant by using the `isExternalLink` prop
* Add a new `Variants & Props` Button story


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Confirm the following external-link buttons look properly
  * My Jetpack / Plans section
<img width="628" alt="Screen Shot 2022-05-25 at 12 49 38 PM" src="https://user-images.githubusercontent.com/77539/170304398-68f7461a-57fd-4206-9880-e8b86f034b6f.png">

  * Protect
<img width="997" alt="Screen Shot 2022-05-25 at 12 47 50 PM" src="https://user-images.githubusercontent.com/77539/170304047-97d78460-3362-41de-b220-f4e8aa95d82a.png">

<img width="981" alt="Screen Shot 2022-05-25 at 12 48 10 PM" src="https://user-images.githubusercontent.com/77539/170304034-5cb7b784-2ed6-40a0-abe1-da92889e7516.png">

* Take a look a the [`Variants & Props`](http://localhost:50240/?path=/story/js-packages-components-button--variants-and-props) story

<img width="1316" alt="image" src="https://user-images.githubusercontent.com/77539/170303537-b4f78a74-20ed-4afc-bff6-a07b1be57626.png">





---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202332192030055