### PR TITLE
Protect: Prevent Navigation Items From Touching Navigation Icons

### DIFF
--- a/projects/plugins/protect/changelog/fix-protect-navigation-icon-spacing
+++ b/projects/plugins/protect/changelog/fix-protect-navigation-icon-spacing
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Added spacing between navigation label and icon.
+Adjust spacing and overflow properties of the navigation labels to improve display of long names.

--- a/projects/plugins/protect/changelog/fix-protect-navigation-icon-spacing
+++ b/projects/plugins/protect/changelog/fix-protect-navigation-icon-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Added spacing between navigation label and icon.

--- a/projects/plugins/protect/src/js/components/navigation/label.jsx
+++ b/projects/plugins/protect/src/js/components/navigation/label.jsx
@@ -16,7 +16,7 @@ const ItemLabel = ( { icon, children, className } ) => {
 	return (
 		<Text className={ classNames( styles[ 'navigation-item-label' ], className ) }>
 			{ icon && <Icon icon={ icon } className={ styles[ 'navigation-item-icon' ] } size={ 28 } /> }
-			{ children }
+			<span className={ styles[ 'navigation-item-label-content' ] }>{ children }</span>
 		</Text>
 	);
 };

--- a/projects/plugins/protect/src/js/components/navigation/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/navigation/styles.module.scss
@@ -50,6 +50,7 @@
 	&-label {
 		display: flex;
 		align-items: center;
+		padding-right: var(--spacing-base); // 8px
 	}
 
 	// .navigation-item-icon

--- a/projects/plugins/protect/src/js/components/navigation/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/navigation/styles.module.scss
@@ -51,6 +51,14 @@
 		display: flex;
 		align-items: center;
 		padding-right: var(--spacing-base); // 8px
+		overflow-x: hidden;
+	}
+
+	// .navigation-item-label-content
+	&-label-text {
+		display: block;
+		overflow-x: hidden;
+		text-overflow: ellipsis;
 	}
 
 	// .navigation-item-icon


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds 8px of padding between the navigation label and icon, to prevent them from getting too close when the label is very long.
* Adds a `<span>` with `overflow-x: hidden` and `text-overflow: ellipsis` inside the navigation label, to prevent long names from overflowing outside of the container. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

1202232924268038-as-1202326318206113

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Boot up this PR and visit the Protect admin page.
* Either install a plugin with a long name, or use dev tools to insert your own in the navigation.
* Validate that the navigation label does not touch the icon, regardless of the character count.
* Validate that the navigation label does not overflow, regardless of the character count.

#### Screenshots:

Before/After:

<img width="299" alt="Screen Shot 2022-05-25 at 11 31 51 AM" src="https://user-images.githubusercontent.com/10933065/170328009-6a65d803-0ae7-4c68-b190-7294d1df606a.png">

<img width="304" alt="Screen Shot 2022-05-25 at 11 32 07 AM" src="https://user-images.githubusercontent.com/10933065/170328044-8f03ab13-8e1e-444f-a1c2-a23477a15cb1.png">

Before:

<img width="369" alt="Screen Shot 2022-05-25 at 12 09 02 PM" src="https://user-images.githubusercontent.com/10933065/170336667-885e830b-c586-4556-87e0-0f920372b1b3.png">

After:

<img width="353" alt="Screen Shot 2022-05-25 at 12 09 09 PM" src="https://user-images.githubusercontent.com/10933065/170336702-506e971e-d14d-48f7-9b30-0bae97ee4873.png">