### PR TITLE
JS Components: fix ProductOffer icons size

### DIFF
--- a/projects/js-packages/components/changelog/update-product-offer-fix-icons-size
+++ b/projects/js-packages/components/changelog/update-product-offer-fix-icons-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+JS Components: fix ProductOffer icons size

--- a/projects/js-packages/components/components/product-offer/index.jsx
+++ b/projects/js-packages/components/components/product-offer/index.jsx
@@ -40,14 +40,15 @@ function ProductOfferHeader( { title = __( 'Popular upgrade', 'jetpack' ) } ) {
  * @param {object} props         - Component props.
  * @param {Array} props.icon     - Custom icon slug.
  * @param {Array} props.products - List of supported products.
+ * @param {number} props.size    - Icon size.
  * @returns {React.Component}      Bundle product icons react component.
  */
-export function IconsCard( { products, icon } ) {
+export function IconsCard( { products, icon, size = 24 } ) {
 	if ( icon ) {
 		const CustomIcon = getIconBySlug( icon );
 		return (
 			<div className={ styles[ 'product-bundle-icons' ] }>
-				<CustomIcon size={ 32 } />
+				<CustomIcon size={ size } />
 			</div>
 		);
 	}
@@ -60,7 +61,7 @@ export function IconsCard( { products, icon } ) {
 
 				return (
 					<Fragment key={ index }>
-						<ProIcon size={ 24 } />
+						<ProIcon size={ size } />
 
 						{ index !== products.length - 1 && (
 							<Icon
@@ -142,6 +143,7 @@ const ProductOffer = ( {
 					slug={ slug }
 					icon={ icon }
 					products={ supportedProducts?.length ? supportedProducts : [ slug ] }
+					size={ 32 }
 				/>
 				<H3>{ title }</H3>
 				{ subTitle && <Title mb={ 3 }>{ subTitle }</Title> }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes the size of the icons of the ProductOffer card. Currently, the Icon size is not correct (24px).

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add a new `size` to IconsCard component (24px sa default)
* Define size of 32px for ProductOffer component

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Portect interstital, My Jetpack interstital pages, etc
* Confirm the icons are properly aligned
* <img width="1073" alt="image" src="https://user-images.githubusercontent.com/77539/170367240-c3ee9bf8-003e-4258-b025-3e811dcf3191.png">
* Confirm the icons size is right (32px)
<img width="450" alt="image" src="https://user-images.githubusercontent.com/77539/170367397-64b38fe1-a194-4e4d-8339-87dea40c8d9f.png">
* Connect the site
* Check the Protect footer. Confirm the size of the icons there are right (24px)
<img width="478" alt="image" src="https://user-images.githubusercontent.com/77539/170367826-4cc71687-c8fb-4e86-9920-77aeadd2774a.png">



