### PR TITLE
Boost: Add cloud css cron

### DIFF
--- a/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS.php
+++ b/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS.php
@@ -122,7 +122,7 @@ class Cloud_CSS implements Feature, Has_Endpoints {
 		$state->create_request( $source_providers->get_providers() );
 
 		$client    = new Cloud_CSS_Request();
-		$providers = $state->get_provider_urls( true );
+		$providers = $state->get_provider_urls_with_args();
 		$response  = $client->request_generate( $providers );
 
 		if ( is_wp_error( $response ) ) {

--- a/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS.php
+++ b/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS.php
@@ -44,6 +44,7 @@ class Cloud_CSS implements Feature, Has_Endpoints {
 
 		REST_API::register( $this->get_endpoints() );
 		Critical_CSS_Invalidator::init();
+		Cloud_CSS_Cron::init();
 
 		return true;
 	}
@@ -121,7 +122,7 @@ class Cloud_CSS implements Feature, Has_Endpoints {
 		$state->create_request( $source_providers->get_providers() );
 
 		$client    = new Cloud_CSS_Request();
-		$providers = $this->add_generation_args( $state->get_provider_urls() );
+		$providers = $state->get_provider_urls( true );
 		$response  = $client->request_generate( $providers );
 
 		if ( is_wp_error( $response ) ) {
@@ -163,18 +164,6 @@ class Cloud_CSS implements Feature, Has_Endpoints {
 		} catch ( \Exception $e ) {
 			return new \WP_Error( 'invalid_request', $e->getMessage(), array( 'status' => 400 ) );
 		}
-	}
-
-	/**
-	 * Add jb-generate-critical-css arg to each URL in the provider set.
-	 */
-	private function add_generation_args( $providers ) {
-		foreach ( $providers as &$urls ) {
-			foreach ( $urls as &$url ) {
-				$url = add_query_arg( 'jb-generate-critical-css', 'true', $url );
-			}
-		}
-		return $providers;
 	}
 
 	/**

--- a/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS.php
+++ b/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS.php
@@ -122,7 +122,7 @@ class Cloud_CSS implements Feature, Has_Endpoints {
 		$state->create_request( $source_providers->get_providers() );
 
 		$client    = new Cloud_CSS_Request();
-		$providers = $state->get_provider_urls_with_args();
+		$providers = $state->get_provider_urls();
 		$response  = $client->request_generate( $providers );
 
 		// Set a one off cron job one hour from now. This will resend the request in case it failed.

--- a/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS.php
+++ b/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS.php
@@ -125,6 +125,9 @@ class Cloud_CSS implements Feature, Has_Endpoints {
 		$providers = $state->get_provider_urls_with_args();
 		$response  = $client->request_generate( $providers );
 
+		// Set a one off cron job one hour from now. This will resend the request in case it failed.
+		Cloud_CSS_Cron::install( time() + HOUR_IN_SECONDS );
+
 		if ( is_wp_error( $response ) ) {
 			$state->set_as_failed( $response->get_error_message() );
 		}

--- a/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS_Cron.php
+++ b/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS_Cron.php
@@ -27,13 +27,13 @@ class Cloud_CSS_Cron {
 		/*
 		 * Run the scheduled job
 		 */
-		add_action( self::SCHEDULER_HOOK, array( self::class, 'run' ) );
+		add_action( self::SCHEDULER_HOOK, array( $cron, 'run' ) );
 	}
 
 	/**
 	 * Run the cron job.
 	 */
-	public static function run() {
+	public function run() {
 		$state = new Critical_CSS_State( 'cloud' );
 
 		if ( $state->is_fatal_error() ) {

--- a/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS_Cron.php
+++ b/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS_Cron.php
@@ -6,8 +6,7 @@ use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_State;
 
 class Cloud_CSS_Cron {
 
-	const SCHEDULER_HOOK     = 'jetpack_boost_check_cloud_css';
-	const SCHEDULER_INTERVAL = 'hourly';
+	const SCHEDULER_HOOK = 'jetpack_boost_check_cloud_css';
 
 	/**
 	 * Initiate the scheduler
@@ -17,23 +16,16 @@ class Cloud_CSS_Cron {
 	 * @return void
 	 */
 	public static function init() {
-		$cron = new self();
-
-		/*
-		 * If the cron-job is not scheduled, schedule it.
-		 */
-		$cron->install();
-
 		/*
 		 * Run the scheduled job
 		 */
-		add_action( self::SCHEDULER_HOOK, array( $cron, 'run' ) );
+		add_action( self::SCHEDULER_HOOK, array( self::class, 'run' ) );
 	}
 
 	/**
 	 * Run the cron job.
 	 */
-	public function run() {
+	public static function run() {
 		$state = new Critical_CSS_State( 'cloud' );
 
 		if ( $state->is_fatal_error() ) {
@@ -46,12 +38,14 @@ class Cloud_CSS_Cron {
 	/**
 	 * Add a cron-job to maintain cloud CSS
 	 *
+	 * @param int $when Timestamp of when to schedule the event.
 	 * @return void
 	 */
-	public function install() {
-		if ( ! wp_next_scheduled( self::SCHEDULER_HOOK ) ) {
-			wp_schedule_event( time(), self::SCHEDULER_INTERVAL, self::SCHEDULER_HOOK );
-		}
+	public static function install( $when ) {
+		// Remove any existing schedule
+		self::uninstall();
+
+		wp_schedule_single_event( $when, self::SCHEDULER_HOOK );
 	}
 
 	/**

--- a/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS_Cron.php
+++ b/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS_Cron.php
@@ -38,7 +38,7 @@ class Cloud_CSS_Cron {
 
 		if ( $state->is_fatal_error() ) {
 			$client    = new Cloud_CSS_Request();
-			$providers = $state->get_provider_urls( true );
+			$providers = $state->get_provider_urls_with_args();
 			$client->request_generate( $providers );
 		}
 	}

--- a/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS_Cron.php
+++ b/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS_Cron.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Features\Optimizations\Cloud_CSS;
+
+use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_State;
+
+class Cloud_CSS_Cron {
+
+	const SCHEDULER_HOOK     = 'jetpack_boost_check_cloud_css';
+	const SCHEDULER_INTERVAL = 'hourly';
+
+	/**
+	 * Initiate the scheduler
+	 *
+	 * Whenever Cloud CSS module is setup, it will call this method.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		$cron = new self();
+
+		/*
+		 * If the cron-job is not scheduled, schedule it.
+		 */
+		$cron->install();
+
+		/*
+		 * Run the scheduled job
+		 */
+		add_action( self::SCHEDULER_HOOK, array( self::class, 'run' ) );
+	}
+
+	/**
+	 * Run the cron job.
+	 */
+	public static function run() {
+		$state = new Critical_CSS_State( 'cloud' );
+
+		if ( $state->is_fatal_error() ) {
+			$client    = new Cloud_CSS_Request();
+			$providers = $state->get_provider_urls( true );
+			$client->request_generate( $providers );
+		}
+	}
+
+	/**
+	 * Add a cron-job to maintain cloud CSS
+	 *
+	 * @return void
+	 */
+	public function install() {
+		if ( ! wp_next_scheduled( self::SCHEDULER_HOOK ) ) {
+			wp_schedule_event( time(), self::SCHEDULER_INTERVAL, self::SCHEDULER_HOOK );
+		}
+	}
+
+	/**
+	 * Remove the cron-job
+	 */
+	public static function uninstall() {
+		wp_clear_scheduled_hook( self::SCHEDULER_HOOK );
+	}
+}

--- a/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS_Cron.php
+++ b/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS_Cron.php
@@ -30,7 +30,7 @@ class Cloud_CSS_Cron {
 
 		if ( $state->is_fatal_error() ) {
 			$client    = new Cloud_CSS_Request();
-			$providers = $state->get_provider_urls_with_args();
+			$providers = $state->get_provider_urls();
 			$client->request_generate( $providers );
 		}
 	}

--- a/projects/plugins/boost/app/lib/critical-css/Critical_CSS_Invalidator.php
+++ b/projects/plugins/boost/app/lib/critical-css/Critical_CSS_Invalidator.php
@@ -6,6 +6,8 @@
  */
 namespace Automattic\Jetpack_Boost\Lib\Critical_CSS;
 
+use Automattic\Jetpack_Boost\Features\Optimizations\Cloud_CSS\Cloud_CSS_Cron;
+
 class Critical_CSS_Invalidator {
 	/**
 	 * Register hooks.
@@ -24,6 +26,7 @@ class Critical_CSS_Invalidator {
 		$storage = new Critical_CSS_Storage();
 		$storage->clear();
 		Critical_CSS_State::reset();
+		Cloud_CSS_Cron::uninstall();
 	}
 
 	/**

--- a/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
+++ b/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
@@ -177,7 +177,8 @@ class Critical_CSS_State {
 	 * @param string $key Provider key.
 	 */
 	public function set_source_success( $key ) {
-		// Remove error data from previous attempts
+		// If this success was result of a retry by Cloud_CSS_Cron. This provider may contain error data from the
+		// original attempt. We have to remove that first.
 		$this->sources[ $key ]['error'] = null;
 
 		$this->set_source_status( $key, self::SUCCESS );

--- a/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
+++ b/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
@@ -109,13 +109,13 @@ class Critical_CSS_State {
 
 	public function maybe_set_status() {
 		if ( $this->get_total_providers_count() === $this->get_processed_providers_count() ) {
-
 			// Only consider the generation a success if at least one provider was successful
 			if ( $this->get_providers_success_count() > 0 ) {
 				$this->state = self::SUCCESS;
 			} else {
 				$this->state = self::FAIL;
 			}
+
 			$this->save();
 		}
 	}
@@ -397,24 +397,6 @@ class Critical_CSS_State {
 	 */
 	public function get_provider_urls() {
 		return $this->collate_column( 'urls' );
-	}
-
-	/**
-	 * Get the provider urls with added query parameter to indicate critical css generation.
-	 *
-	 * @return array
-	 */
-	public function get_provider_urls_with_args() {
-		$providers = $this->get_provider_urls();
-		$urls      = array();
-
-		foreach ( $providers as $provider => $provider_urls ) {
-			foreach ( $provider_urls as $url ) {
-				$urls[ $provider ][] = add_query_arg( 'jb-generate-critical-css', 'true', $url );
-			}
-		}
-
-		return $urls;
 	}
 
 	/**

--- a/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
+++ b/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
@@ -392,21 +392,28 @@ class Critical_CSS_State {
 	/**
 	 * Get the provider urls.
 	 *
-	 * @param bool $with_provider_keys Indicate whether to include generation query args
 	 * @return array
 	 */
-	public function get_provider_urls( $with_provider_keys = false ) {
-		$providers = $this->collate_column( 'urls' );
+	public function get_provider_urls() {
+		return $this->collate_column( 'urls' );
+	}
 
-		if ( $with_provider_keys ) {
-			foreach ( $providers as &$urls ) {
-				foreach ( $urls as &$url ) {
-					$url = add_query_arg( 'jb-generate-critical-css', 'true', $url );
-				}
+	/**
+	 * Get the provider urls with added query parameter to indicate critical css generation.
+	 *
+	 * @return array
+	 */
+	public function get_provider_urls_with_args() {
+		$providers = $this->get_provider_urls();
+		$urls      = array();
+
+		foreach ( $providers as $provider => $provider_urls ) {
+			foreach ( $provider_urls as $url ) {
+				$urls[ $provider ][] = add_query_arg( 'jb-generate-critical-css', 'true', $url );
 			}
 		}
 
-		return $providers;
+		return $urls;
 	}
 
 	/**

--- a/projects/plugins/boost/changelog/add-cloud-css-cron
+++ b/projects/plugins/boost/changelog/add-cloud-css-cron
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added cron job that checks if last attempt to cloud css failed and resends the request


### PR DESCRIPTION
Fixes 83-gh-Automattic/boost-shield-api

**Note:** Designed to be used alongside 48-gh-Automattic/boost-cloud

#### Changes proposed in this Pull Request:
* Added a cron job that periodically checks if the last cloud CSS failed.
* It will then resubmit the request for retry.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Check if the cron is registered. A plugin that might help: [Advanced Cron Manager]
* Produce some errors during the generation of cloud-css, perhaps using the Boost Dev Companion plugin.
* Disable the error generation on the Dev companion plugin
* Let WP run the cron job or force it using [Advanced Cron Manager].
* See if CCSS retried.


[Advanced Cron Manager]: https://wordpress.org/plugins/advanced-cron-manager/