### PR TITLE
RecordMeterBar Component: Adds a prop to sort items by count value

### DIFF
--- a/projects/js-packages/components/changelog/update-record-meter-bar-component-add-sorting
+++ b/projects/js-packages/components/changelog/update-record-meter-bar-component-add-sorting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+adds sort by descending prop to recordmeterbar component

--- a/projects/js-packages/components/changelog/update-record-meter-bar-component-add-sorting
+++ b/projects/js-packages/components/changelog/update-record-meter-bar-component-add-sorting
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-adds sort by descending prop to recordmeterbar component
+Add sortByCount prop to RecordMeterBar component

--- a/projects/js-packages/components/components/record-meter-bar/index.tsx
+++ b/projects/js-packages/components/components/record-meter-bar/index.tsx
@@ -30,6 +30,10 @@ export type RecordMeterBarProps = {
 	 * The formatting style for legend item display. If not provided, it defaults to showing legend label after count
 	 */
 	showLegendLabelBeforeCount?: boolean;
+	/**
+	 * The sort style for legend item. If not provided, it defaults to no sorting.
+	 */
+	sortByCount?: 'ascending' | 'descending';
 };
 
 /**
@@ -42,6 +46,7 @@ const RecordMeterBar: React.FC< RecordMeterBarProps > = ( {
 	totalCount,
 	items = [],
 	showLegendLabelBeforeCount = false,
+	sortByCount,
 } ) => {
 	const total = useMemo( () => {
 		// If total count is not given, then compute it from items' count
@@ -53,10 +58,20 @@ const RecordMeterBar: React.FC< RecordMeterBarProps > = ( {
 		);
 	}, [ items, totalCount ] );
 
+	const itemsToRender = useMemo( () => {
+		if ( sortByCount ) {
+			// create a new array because .sort() updates the array in place.
+			return [ ...items ].sort( ( a, z ) => {
+				return 'ascending' === sortByCount ? a.count - z.count : z.count - a.count;
+			} );
+		}
+		return items;
+	}, [ items, sortByCount ] );
+
 	return (
 		<div className="record-meter-bar">
 			<div className="record-meter-bar__items">
-				{ items.map( ( { count, label, backgroundColor } ) => {
+				{ itemsToRender.map( ( { count, label, backgroundColor } ) => {
 					const widthPercent = ( ( count / total ) * 100 ).toPrecision( 2 );
 					return (
 						<div key={ label } style={ { backgroundColor, flexBasis: `${ widthPercent }%` } }></div>
@@ -65,7 +80,7 @@ const RecordMeterBar: React.FC< RecordMeterBarProps > = ( {
 			</div>
 			<div className="record-meter-bar__legend">
 				<ul className="record-meter-bar__legend--items">
-					{ items.map( ( { count, label, backgroundColor } ) => {
+					{ itemsToRender.map( ( { count, label, backgroundColor } ) => {
 						return (
 							<li key={ label } className="record-meter-bar__legend--item">
 								<div

--- a/projects/js-packages/components/components/record-meter-bar/stories/index.tsx
+++ b/projects/js-packages/components/components/record-meter-bar/stories/index.tsx
@@ -3,6 +3,11 @@ import RecordMeterBar, { RecordMeterBarProps } from '../index';
 export default {
 	title: 'JS Packages/Components/RecordMeterBar',
 	component: RecordMeterBar,
+	argTypes: {
+		sortByCount: {
+			control: { type: 'select', options: [ undefined, 'ascending', 'descending' ] },
+		},
+	},
 };
 
 const Template = args => <RecordMeterBar { ...args } />;


### PR DESCRIPTION
This PR alters the RecordMeterBar component to take an optional legend formatting prop. When passed in as true, the legend displays with the count after the label instead of before. 

![image](https://user-images.githubusercontent.com/30754158/170512923-de3bb3d8-b115-419f-a43c-3d61ef853569.png)

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* Run `cd projects/js-packages/storybook && npm run storybook:dev` and confirm that you see RecordMeterBar component in Storybook.
* Under RecordMeterBar, choose the story 'Default' and try changing 'sortByCount' under 'Controls'.
* Confirm that sort is updated in ascending or descending order.

You can also run the unit tests for js-packages/components by running `jetpack test`.