### PR TITLE
Social: Update the editor plugin menu icon

### DIFF
--- a/projects/plugins/social/changelog/update-social-sidebar-icon
+++ b/projects/plugins/social/changelog/update-social-sidebar-icon
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Editor: Updated the sidebar menu icon to be the Social one

--- a/projects/plugins/social/src/js/editor.js
+++ b/projects/plugins/social/src/js/editor.js
@@ -12,7 +12,7 @@ import { registerPlugin } from '@wordpress/plugins';
 import { dispatch } from '@wordpress/data';
 import { getQueryArg } from '@wordpress/url';
 import domReady from '@wordpress/dom-ready';
-import { JetpackLogo } from '@automattic/jetpack-components';
+import { SocialIcon } from '@automattic/jetpack-components';
 
 /**
  * Internal dependencies
@@ -35,18 +35,11 @@ domReady( () => {
 registerPlugin( 'jetpack-social', {
 	render: () => (
 		<PostTypeSupportCheck supportKeys="publicize">
-			<PluginSidebarMoreMenuItem
-				target="jetpack-social"
-				icon={ <JetpackLogo showText={ false } /> }
-			>
+			<PluginSidebarMoreMenuItem target="jetpack-social" icon={ <SocialIcon /> }>
 				Jetpack Social
 			</PluginSidebarMoreMenuItem>
 
-			<PluginSidebar
-				name="jetpack-social"
-				title="Jetpack Social"
-				icon={ <JetpackLogo showText={ false } /> }
-			>
+			<PluginSidebar name="jetpack-social" title="Jetpack Social" icon={ <SocialIcon /> }>
 				<PublicizePanel />
 			</PluginSidebar>
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR updates the editor plugin menu to use the new Social icon rather
than the Jetpack logo.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Activate the Social plugin and connect it.
* Load the block editor
* Observe that the icon for the sidebar is the Jetpack Social megaphone

<img width="275" alt="image" src="https://user-images.githubusercontent.com/96462/170518069-b91e7e68-0975-4aaf-844e-9c0bdf7841e3.png">
