### PR TITLE
Social: Prevent the editor extension loading with Jetpack active

### DIFF
--- a/projects/plugins/social/changelog/remove-social-sidebar-with-jetpack
+++ b/projects/plugins/social/changelog/remove-social-sidebar-with-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Editor plugin: Prevent it from loading with Jetpack active

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -165,7 +165,7 @@ class Jetpack_Social {
 	 * Enqueue block editor scripts and styles.
 	 */
 	public function enqueue_block_editor_scripts() {
-		if ( ! ( new Modules() )->is_active( self::JETPACK_PUBLICIZE_MODULE_SLUG ) ) {
+		if ( ! ( new Modules() )->is_active( self::JETPACK_PUBLICIZE_MODULE_SLUG ) || class_exists( 'Jetpack' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The rest of the plugin is compatible with Jetpack. The module can be
toggled from both plugins, and the Publicize is only loaded once, so the
Classic editor works correctly.

But we were loading the editor extension, so with both plugins you have
both sidebars. This change prevents the Social one from loading when
Jetpack is active.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Activate and connect Jetpack Social
* Activate Jetpack
* Load the block editor
* Without this change there will be the Jetpack and Social sidebars
* With this change, there should only be the Jetpack sidebar

##### Before
<img width="281" alt="image" src="https://user-images.githubusercontent.com/96462/170533229-e49bd41c-5088-41b0-8864-b7fa48c9b9fe.png">

##### After
<img width="281" alt="image" src="https://user-images.githubusercontent.com/96462/170532863-ba1fdb31-1e6c-4e1f-89e2-bdd30f4dcb14.png">

