### PR TITLE
Protect: Update verbiage of CTA

### DIFF
--- a/projects/plugins/protect/changelog/update-protect-scan-cta
+++ b/projects/plugins/protect/changelog/update-protect-scan-cta
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Updates CTA wording to reduce confusion when user already has Jetpack Security Bundle which includes Jetpack Scan

--- a/projects/plugins/protect/src/js/components/footer/index.jsx
+++ b/projects/plugins/protect/src/js/components/footer/index.jsx
@@ -38,7 +38,7 @@ const ProductPromotion = () => {
 			<div className={ styles[ 'product-section' ] }>
 				<IconsCard products={ [ 'backup', 'scan', 'anti-spam' ] } />
 				<Title>
-					{ __( 'Increase your site protection with Jetpack Scan', 'jetpack-protect' ) }
+					{ __( 'Learn how Jetpack Scan increases your site protection', 'jetpack-protect' ) }
 				</Title>
 				<Text mb={ 3 }>
 					{ __(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR updates the Call To Action wording for a user who already has the Jetpack Security Bundle. The wording changes:

**Old:** Increase your site protection with Jetpack Scan
**New:** Learn how Jetpack Scan increases your site protection

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://wp.me/p1HpG7-g36#comment-54548

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up test site with Protect plugin and Security Bundle
* Notice the CTA at the bottom left of the page "Increase your site protection with Jetpack Scan"
* Checkout this branch
* Notice the CTA at the bottom left of the page now says "Learn how Jetpack Scan increases your site protection"
