### PR TITLE
Publicize: Replace the initial settings form in the Classic Editor

### DIFF
--- a/projects/packages/publicize/changelog/update-publicize-settings-link
+++ b/projects/packages/publicize/changelog/update-publicize-settings-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Classic Editor: Replaced the initial settings form with the Jetpack redirect link

--- a/projects/packages/publicize/src/class-publicize-ui.php
+++ b/projects/packages/publicize/src/class-publicize-ui.php
@@ -560,7 +560,7 @@ jQuery( function($) {
 				$publicize_form = $this->get_metabox_form_disconnected( $available_services );
 				?>
 				<strong><?php esc_html_e( 'Not Connected', 'jetpack-publicize-pkg' ); ?></strong>
-				<a href="#" id="publicize-disconnected-form-show"><?php esc_html_e( 'Edit', 'jetpack-publicize-pkg' ); ?></a><br />
+				<a href="<?php echo esc_url( $this->publicize->publicize_connections_url( 'jetpack-social-connections-classic-editor' ) ); ?>" rel="noopener noreferrer" target="_blank"><?php esc_html_e( 'Settings', 'jetpack-publicize-pkg' ); ?></a><br />
 				<?php
 
 			endif;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

In the classic editor when there is no Publicize connections, we
currently display some links to authenticate directly with the networks,
but they redirect back to a deprecated options page which only exists
within Jetpack.

This change replaces that form with the Jetpack redirect link that will
take the user to the appropriate connections page on Calypso/Jetpack
Cloud.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Install the Jetpack plugin and enable Publicize or install Jetpack Social
* Install the Classic Editor plugin
* Start a new post
* Without this change, clicking on the 'Edit' link next to the 'No Connections' message will display the form with links for each network
* With this change there will be a Settings link, which will take you to Jetpack Cloud or Calypso, as appropriate.

##### Before
<img width="281" alt="image (1)" src="https://user-images.githubusercontent.com/96462/170558911-a753d69f-fd01-4767-8a18-59a2555a4ea4.png">

##### After
<img width="281" alt="image" src="https://user-images.githubusercontent.com/96462/170558758-51c1b727-1ce9-4869-8e59-e242de43b8a9.png">
