### PR TITLE
Storybook: fix styles defined by the ThemeProvider

### DIFF
--- a/projects/js-packages/components/changelog/update-js-components-theme-provider-handling
+++ b/projects/js-packages/components/changelog/update-js-components-theme-provider-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix styles defined by the ThemeProvider in the storybook stories

--- a/projects/js-packages/components/components/theme-provider/Readme.md
+++ b/projects/js-packages/components/components/theme-provider/Readme.md
@@ -1,0 +1,49 @@
+= ThemeProvider
+
+ThemeProvider is a React component that, at the moment, defines and sets CSS variables to a wrapper element to make them accessible by the children components.
+Usually, you'd like to provide the styles by wrappig your App component:
+
+```jsx
+import { ThemeProvider } from '@automattic/jetpack-components';
+
+function MyComponent() {
+	return (
+		<ThemeProvider>
+			<div style={ { color: var( --jp-green ) } }>Jetpack</div>
+		</ThemeProvider>
+	);
+}
+```
+
+Unlike other more complex implementations that use React context to share data, the CSS vars are defined in the DOM element, and consequently, propagated to child DOM elements.
+
+## API
+
+### Children
+
+ReactNode children to be wrapped by the ThemeProvider element.
+
+### targetDom
+
+Optional target DOM element to set the styles. By default, they are set in a new wrapper element created by the provider.
+But when targetDom is defined, the styles are set straight into the given target, thus, the wrapper is not created.
+
+When defining it, it's up to you the proper target to store the styles.
+
+The following example stores the styles at the top of the page, in the body.
+
+```jsx
+import { ThemeProvider } from '@automattic/jetpack-components';
+
+function MyComponent() {
+	return (
+		<ThemeProvider targetDom={ document.body }>
+			<div style={ { color: var( --jp-green ) } }>Jetpack</div>
+		</ThemeProvider>
+	);
+}
+```
+
+### id
+
+Pass an id to register the ThemeProvider instance to avoid redefining the styles every time that a ThemeProvider instance is created, avoiding unneeded redefinitions of the styles.

--- a/projects/js-packages/components/components/theme-provider/index.jsx
+++ b/projects/js-packages/components/components/theme-provider/index.jsx
@@ -76,36 +76,55 @@ export const spacing = {
 	'--spacing-base': '8px',
 };
 
-const setup = root => {
-	const tokens = { ...typography, ...colors, ...borders, ...spacing };
+const globalThemeInstances = {};
 
+const setup = ( root, id ) => {
+	const tokens = { ...typography, ...colors, ...borders, ...spacing };
 	for ( const key in tokens ) {
 		root.style.setProperty( key, tokens[ key ] );
 	}
+
+	if ( ! id ) {
+		return;
+	}
+
+	// Register theme provider instance.
+	globalThemeInstances[ id ] = {
+		provided: true,
+		root,
+	};
 };
 
 /**
  * ThemeProvider React component.
  *
  * @param {object} props           - Component properties.
- * @param {object} props.children  - Component children.
+ * @param {object} props.id        - An optional id to register and identify the provider instance.
  * @param {object} props.targetDom - Target DOM element to store theme styles. Optional.
+ * @param {object} props.children  - Component children.
  * @returns {React.ReactNode}        ThemeProvider component.
  */
-const ThemeProvider = ( { children = null, targetDom } ) => {
+const ThemeProvider = ( { children = null, targetDom, id } ) => {
 	const themeWrapperRef = useRef();
 
+	// Check whether the theme provider instance is already registered.
+	const isAlreadyProvided = globalThemeInstances?.[ id ]?.provided;
+
 	useLayoutEffect( () => {
+		if ( isAlreadyProvided ) {
+			return;
+		}
+
 		if ( targetDom ) {
-			return setup( targetDom );
+			return setup( targetDom, id );
 		}
 
 		if ( ! themeWrapperRef?.current ) {
 			return;
 		}
 
-		setup( themeWrapperRef.current );
-	}, [ targetDom, themeWrapperRef ] );
+		setup( themeWrapperRef.current, id );
+	}, [ targetDom, themeWrapperRef, isAlreadyProvided, id ] );
 
 	return <div ref={ themeWrapperRef }>{ children }</div>;
 };

--- a/projects/js-packages/components/components/theme-provider/index.jsx
+++ b/projects/js-packages/components/components/theme-provider/index.jsx
@@ -87,20 +87,25 @@ const setup = root => {
 /**
  * ThemeProvider React component.
  *
- * @param {object} props          - Component propwerties.
- * @param {object} props.children - Component children.
- * @returns {React.ReactNode}       ThemeProvider component.
+ * @param {object} props           - Component properties.
+ * @param {object} props.children  - Component children.
+ * @param {object} props.targetDom - Target DOM element to store theme styles. Optional.
+ * @returns {React.ReactNode}        ThemeProvider component.
  */
-const ThemeProvider = ( { children = null } ) => {
+const ThemeProvider = ( { children = null, targetDom } ) => {
 	const themeWrapperRef = useRef();
 
 	useLayoutEffect( () => {
+		if ( targetDom ) {
+			return setup( targetDom );
+		}
+
 		if ( ! themeWrapperRef?.current ) {
 			return;
 		}
 
 		setup( themeWrapperRef.current );
-	}, [ themeWrapperRef ] );
+	}, [ targetDom, themeWrapperRef ] );
 
 	return <div ref={ themeWrapperRef }>{ children }</div>;
 };

--- a/projects/js-packages/components/components/theme-provider/index.jsx
+++ b/projects/js-packages/components/components/theme-provider/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useLayoutEffect } from 'react';
+import React, { useLayoutEffect, useRef } from 'react';
 
 export const typography = {
 	// Headline
@@ -76,8 +76,7 @@ export const spacing = {
 	'--spacing-base': '8px',
 };
 
-const setup = () => {
-	const root = document.getElementById( 'jetpack-theme-provider' );
+const setup = root => {
 	const tokens = { ...typography, ...colors, ...borders, ...spacing };
 
 	for ( const key in tokens ) {
@@ -85,12 +84,25 @@ const setup = () => {
 	}
 };
 
+/**
+ * ThemeProvider React component.
+ *
+ * @param {object} props          - Component propwerties.
+ * @param {object} props.children - Component children.
+ * @returns {React.ReactNode}       ThemeProvider component.
+ */
 const ThemeProvider = ( { children = null } ) => {
-	useLayoutEffect( () => {
-		setup();
-	}, [] );
+	const themeWrapperRef = useRef();
 
-	return <div id="jetpack-theme-provider">{ children }</div>;
+	useLayoutEffect( () => {
+		if ( ! themeWrapperRef?.current ) {
+			return;
+		}
+
+		setup( themeWrapperRef.current );
+	}, [ themeWrapperRef ] );
+
+	return <div ref={ themeWrapperRef }>{ children }</div>;
 };
 
 export default ThemeProvider;

--- a/projects/js-packages/components/components/theme-provider/index.jsx
+++ b/projects/js-packages/components/components/theme-provider/index.jsx
@@ -126,6 +126,11 @@ const ThemeProvider = ( { children = null, targetDom, id } ) => {
 		setup( themeWrapperRef.current, id );
 	}, [ targetDom, themeWrapperRef, isAlreadyProvided, id ] );
 
+	// Do not wrap when the DOM element target is defined.
+	if ( targetDom ) {
+		return children;
+	}
+
 	return <div ref={ themeWrapperRef }>{ children }</div>;
 };
 

--- a/projects/js-packages/components/components/theme-provider/stories/index.jsx
+++ b/projects/js-packages/components/components/theme-provider/stories/index.jsx
@@ -50,13 +50,6 @@ function getContrast( hexcolor ) {
 
 export default {
 	title: 'JS Packages/Components/Theme Provider',
-	decorators: [
-		Story => (
-			<ThemeProvider>
-				<Story />
-			</ThemeProvider>
-		),
-	],
 };
 
 const noop = () => {};
@@ -148,3 +141,20 @@ export const Colors = () => (
 		) ) }
 	</div>
 );
+
+const Template = args => (
+	<ThemeProvider { ...args }>
+		<div
+			style={ {
+				color: 'var( --jp-white )',
+				backgroundColor: 'var( --jp-pink )',
+				fontSize: 'var( --font-title-small )',
+				padding: 'var( --spacing-base ) calc( var( --spacing-base ) * 2 )',
+				borderRadius: 'var( --jp-border-radius )',
+			} }
+		>
+			Pink Jetpack Show
+		</div>
+	</ThemeProvider>
+);
+export const BasicUsage = Template.bind( {} );

--- a/projects/js-packages/storybook/changelog/update-js-components-theme-provider-handling
+++ b/projects/js-packages/storybook/changelog/update-js-components-theme-provider-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix styles defined by the ThemeProvider in the storybook stories

--- a/projects/js-packages/storybook/storybook/preview.js
+++ b/projects/js-packages/storybook/storybook/preview.js
@@ -42,7 +42,7 @@ export const parameters = {
 
 export const decorators = [
 	Story => (
-		<ThemeProvider>
+		<ThemeProvider id="storybook-stories" targetDom={ document.body }>
 			<Story />
 		</ThemeProvider>
 	),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes the visual issues produced by the ThemeProvider in the stories.

## The underlying problem

### Element ID of the wrapper element

Although creating more than one instance per page of the ThemeProvider isn't encouraged, it's still doable. When it happens, the implementation malfunctions in how styles (style variables) are defined/injected by the provider. Basically, the component will create a new wrapper element per instance, with the same element ID attribute.
Even more, it will try to inject the styles querying the element by ID, which ends up setting the style only for the first match of the provider wrapper element.

Visually, it decorates only the first story. For instance, the Button story:

<img width="794" alt="Screen Shot 2022-05-26 at 3 37 12 PM" src="https://user-images.githubusercontent.com/77539/170554482-dd9aa652-6a38-4ee4-977b-e7f2160fd380.png">

Using the inspector, when searching by `jetpack-theme-provider` five elements are found. However, the first element is the only that has the CSS variables:

<img width="610" alt="Screen Shot 2022-05-26 at 3 41 47 PM" src="https://user-images.githubusercontent.com/77539/170555183-79eebda0-b9f0-49e1-8be4-28d19c427919.png">

Taking a look at the code, the problem is:
* It defines the id statically. (`<div id="jetpack-theme-provider">`)
* It searches the root by the ID (`const root = document.getElementById( 'jetpack-theme-provider' )`)

```jsx
const setup = () => {
	const root = document.getElementById( 'jetpack-theme-provider' );
	// ...
};

const ThemeProvider = ( { children = null } ) => {
	// ...
	return <div id="jetpack-theme-provider">{ children }</div>;
};
```

The solution for it suggested here is:
* Do not set element id statically
* Instead of that, use a reference to get the target to inject the CSS vars (root)

### targetDom

This PR also introduces the ability to define imperatively the target element to set the styles. This is how the Storybook is fixed, defining the document.body as the target to use.

### performance enhancement
Finally, it's possible to register the ThemeProvider instance in order to avoid re-definitions the styles again and again.

The storybook decorates the story in the following way:

```jsx
<ThemeProvider id="storybook-stories" targetDom={ document.body }>
	<Story />
</ThemeProvider>
```

The result of this is the ThemeProvider will define the CSS variables once among all instances. if we add a `console.count()` when the CSS var is injected:

```jsx
const setup = () => {
	// ...
	for ( const key in tokens ) {
		console.count( 'ThemeProvider: setting CSS property' );
		// ...
	}
};
````

We can see how the styles are re-defined again and again:

https://user-images.githubusercontent.com/77539/170557980-31701077-cdb2-4c1a-854c-948dc1ce796e.mov

With these changes, all styles are injected once:


https://user-images.githubusercontent.com/77539/170558260-9d8e9aa3-a4a8-433a-b8aa-f08d21b0ab4f.mov

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Improve ThemeProvider component: Add `targetDom` and `id`.
* Add ThemeProvider doc
* Fix Storiesbook stories when providing styles by ThemeProvider

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* Confirm ThemeProvider works as expected for MyJetpack, Protect, etc
* Use Storybook: Confirm all stories work properly. Some examples:

before | after
------|------
<img width="1022" alt="image" src="https://user-images.githubusercontent.com/77539/170559177-9aa8c81c-1903-4bb9-95bc-0979a4382bb8.png"> | <img width="1055" alt="image" src="https://user-images.githubusercontent.com/77539/170558976-3172a52e-51d5-4f78-8661-144c3efda9d2.png">
<img width="1043" alt="image" src="https://user-images.githubusercontent.com/77539/170559316-3cd79954-74a9-41e0-a4ed-8f6650d1f052.png"> | <img width="1041" alt="image" src="https://user-images.githubusercontent.com/77539/170559360-d4146f7d-b243-488c-a60a-084ee7167603.png">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202332192030070