### PR TITLE
Comments: Google accounts no longer an identity provider

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-google-comments-provider
+++ b/projects/plugins/jetpack/changelog/remove-google-comments-provider
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Comments: update UI to reflect that Google accounts are no longer a sign-in option.

--- a/projects/plugins/jetpack/modules/comments.php
+++ b/projects/plugins/jetpack/modules/comments.php
@@ -1,14 +1,14 @@
 <?php
 /**
  * Module Name: Comments
- * Module Description: Let visitors use a WordPress.com, Twitter, Facebook, or Google account to comment
+ * Module Description: Let visitors use a WordPress.com, Twitter, or Facebook account to comment
  * First Introduced: 1.4
  * Sort Order: 20
  * Requires Connection: Yes
  * Auto Activate: No
  * Module Tags: Social
  * Feature: Engagement
- * Additional Search Queries: comments, comment, facebook, twitter, google, social
+ * Additional Search Queries: comments, comment, facebook, twitter, social
  *
  * @package automattic/jetpack
  */


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- From internal D78705-code, looks like Google accounts have been removed for the time being as a sign-in option for comments. The Comments module description has been updated to reflect that.
- Updated corresponding support doc: https://jetpack.com/support/comments/

#### Jetpack product discussion

- Internal: p7H4VZ-3uJ-p2#comment-10420
- Closes #24522

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

Proofread.