### PR TITLE
Infinite Scroll: Show GA option when site has GA support

### DIFF
--- a/projects/plugins/jetpack/changelog/update-IS-GA
+++ b/projects/plugins/jetpack/changelog/update-IS-GA
@@ -1,0 +1,4 @@
+Significance: major
+Type: compat
+
+Check for Google Analytics feature support to track infinite scroll requests

--- a/projects/plugins/jetpack/modules/infinite-scroll.php
+++ b/projects/plugins/jetpack/modules/infinite-scroll.php
@@ -76,6 +76,10 @@ class Jetpack_Infinite_Scroll_Extras {
 	 * @action admin_init
 	 */
 	public function action_admin_init() {
+		if ( ! Jetpack_Plan::supports( 'google-analytics' ) ) {
+			return;
+		}
+
 		add_settings_field( $this->option_name_google_analytics, '<span id="infinite-scroll-google-analytics">' . __( 'Use Google Analytics with Infinite Scroll', 'jetpack' ) . '</span>', array( $this, 'setting_google_analytics' ), 'reading' );
 		register_setting( 'reading', $this->option_name_google_analytics, array( $this, 'sanitize_boolean_value' ) );
 	}
@@ -166,8 +170,8 @@ class Jetpack_Infinite_Scroll_Extras {
 			$settings['stats'] .= '-jetpack';
 		}
 
-		// Check if Google Analytics tracking is requested
-		$settings['google_analytics'] = (bool) Jetpack_Options::get_option_and_ensure_autoload( $this->option_name_google_analytics, 0 );
+		// Check if Google Analytics tracking is requested.
+		$settings['google_analytics'] = Jetpack_Plan::supports( 'google-analytics' ) && Jetpack_Options::get_option_and_ensure_autoload( $this->option_name_google_analytics, 0 );
 
 		return $settings;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #24532

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds feature checks for Google Analytics to Infinite Scroll GA settings.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install an Infinite Scroll-compatible theme (Twenty Thirteen for example).
* Enable Infinite Scroll in Jetpack settings by searching for it.
* Go to Settings > Reading and see if the Google Analytics option is available.
* On the front-end, bring up the browser console and check `infiniteScroll.settings.google_analytics` to be false`.
