### PR TITLE
Social: Fix spacing on admin page

### DIFF
--- a/projects/plugins/social/changelog/fix-jetpack-social-admin-page-spacing
+++ b/projects/plugins/social/changelog/fix-jetpack-social-admin-page-spacing
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed some spacing issues in a non-released plugin
+
+

--- a/projects/plugins/social/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/social/src/js/components/admin-page/index.jsx
@@ -20,6 +20,7 @@ import Logo from './../logo';
 import Header from './../header';
 import ToggleSection from './../toggle-section';
 import InfoSection from './../info-section';
+import './styles.module.scss';
 
 const Admin = () => {
 	const { isUserConnected, isRegistered } = useConnection();

--- a/projects/plugins/social/src/js/components/admin-page/styles.module.scss
+++ b/projects/plugins/social/src/js/components/admin-page/styles.module.scss
@@ -1,0 +1,4 @@
+// This is a temporary fix because `<Container>` is missing this.
+* {
+	box-sizing: border-box;
+}

--- a/projects/plugins/social/src/js/components/info-section/styles.module.scss
+++ b/projects/plugins/social/src/js/components/info-section/styles.module.scss
@@ -5,11 +5,11 @@
 		grid-column: 2 / span 6;
 		display: grid;
 		grid-template-columns: auto 1fr auto 1fr;
-		column-gap: var( --vertical-spacing-lg );
-		row-gap: var( --vertical-spacing-lg );
+		column-gap: calc( var( --spacing-base ) * 3 );
+		row-gap: calc( var( --spacing-base ) * 3 );
 
 		> * + * {
-			margin-top: var( --vertical-spacing-sm );
+			margin-top: calc( var( --spacing-base ) * 2 );
 		}
 
 		@supports ( display: grid ) {
@@ -31,7 +31,7 @@
 .number {
 	display: block;
 	color: var( --jp-black );
-	margin: var( --vertical-spacing-lg ) 0 var( --vertical-spacing-sm );
+	margin: calc( var( --spacing-base ) * 3 ) 0 calc( var( --spacing-base ) * 2 );
 
 	@media ( min-width: 600px ) {
 		margin: 0;

--- a/projects/plugins/social/src/js/components/toggle-section/styles.module.scss
+++ b/projects/plugins/social/src/js/components/toggle-section/styles.module.scss
@@ -1,13 +1,13 @@
 .column {
-	grid-column: span 12;
+	grid-column: 1 / -1;
 	display: grid;
 	grid-template-columns: auto 1fr;
 	grid-template-rows: repeat( 2, auto );
-	column-gap: var( --vertical-spacing-lg );
-	row-gap: var( --vertical-spacing-sm );
+	column-gap: calc( var( --spacing-base ) * 3 );
+	row-gap: calc( var( --spacing-base ) * 2 );
 
 	> * + * {
-		margin-top: var( --vertical-spacing-sm );
+		margin-top: calc( var( --spacing-base ) * 2 );
 	}
 
 	@supports ( display: grid ) {
@@ -21,7 +21,7 @@
 	}
 
 	@media ( min-width: 960px ) {
-		column-gap: calc( var( --vertical-spacing-lg ) * 2 );
+		column-gap: calc( var( --spacing-base ) * 6 );
 		grid-column: 3 / span 8;
 	}
 }
@@ -56,7 +56,7 @@
 }
 
 .button {
-	margin-top: var( --vertical-spacing-sm );
+	margin-top: calc( var( --spacing-base ) * 2 );
 	grid-column: span 2;
 	justify-self: flex-start;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In https://github.com/Automattic/jetpack/pull/24479, some spacing variables were removed that we were using in the Jetpack Social admin page. This PR adds alternatives to fix the layout spacing.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Replace missing variables with alternatives
* Add box-sizing to the container to prevent mobile overflow.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1653636502671999-slack-C02JJ910CNL

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the admin page.
* Ensure all the elements have proper spacing.
* Resize it to tablet and mobile spacing, and ensure the layout doesn't overflow.
* Repeat these steps on the connections screen.