### PR TITLE
Assets: Format numbers filtered through ngettext

### DIFF
--- a/projects/packages/assets/changelog/fix-number-format-using-n
+++ b/projects/packages/assets/changelog/fix-number-format-using-n
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Assets: Format the number filtered through ngettext _n functions

--- a/projects/packages/assets/src/class-assets.php
+++ b/projects/packages/assets/src/class-assets.php
@@ -657,7 +657,7 @@ class Assets {
 	public static function filter_ngettext( $translation, $single, $plural, $number, $domain ) {
 		if ( $translation === $single || $translation === $plural ) {
 			// phpcs:ignore WordPress.WP.I18n
-			$translation = _n( $single, $plural, $number, self::$domain_map[ $domain ][0] );
+			$translation = _n( $single, $plural, number_format_i18n( $number ), self::$domain_map[ $domain ][0] );
 		}
 		return $translation;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

I kinda expected core's `_n` to handle the formatting of the numbers, but it seems that it might not. We have a filter through `ngettext` that might work here. Currently untested. 
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Fixes the formatting of translated text using `_n()`, such as 
![image](https://user-images.githubusercontent.com/7129409/170775018-0b371556-753d-42d8-8665-43370e152755.png)

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1653675252620949-slack-C0299DMPG

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Get over 1,000 subscribers! Or you can manually modify one of the numbers sent to `_n()` within extensions/blocks. 
