### PR TITLE
Social: Update the admin page's Learn more link

### DIFF
--- a/projects/plugins/social/changelog/update-social-learn-more
+++ b/projects/plugins/social/changelog/update-social-learn-more
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Admin page: Updated the support link and swapped to use an ExternalLink

--- a/projects/plugins/social/src/js/components/toggle-section/index.js
+++ b/projects/plugins/social/src/js/components/toggle-section/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
+import { ExternalLink } from '@wordpress/components';
 import { Button, Container, Text } from '@automattic/jetpack-components';
 
 /**
@@ -35,9 +36,9 @@ const ToggleSection = () => {
 						'jetpack-social'
 					) }
 					&nbsp;
-					<a href="https://wordpress.com/support/publicize/" target="_blank" rel="noreferrer">
+					<ExternalLink href="https://jetpack.com/support/publicize/">
 						{ __( 'Learn more', 'jetpack-social' ) }
-					</a>
+					</ExternalLink>
 				</Text>
 				{ connectionsAdminUrl && (
 					<Button

--- a/projects/plugins/social/src/js/components/toggle-section/index.js
+++ b/projects/plugins/social/src/js/components/toggle-section/index.js
@@ -36,7 +36,7 @@ const ToggleSection = () => {
 						'jetpack-social'
 					) }
 					&nbsp;
-					<ExternalLink href="https://jetpack.com/support/publicize/">
+					<ExternalLink href="https://jetpack.com/redirect/?source=social-plugin-publicize-support-admin-page">
 						{ __( 'Learn more', 'jetpack-social' ) }
 					</ExternalLink>
 				</Text>


### PR DESCRIPTION
The Learn more link on the admin page was pointing to WordPress.com and
it was suggested that we should indicate that it's an external link too.

#### Changes proposed in this Pull Request:
This change updates the URL and changes the link to an ExternalLink
component.

#### Jetpack product discussion
p1HpG7-g6I-p2#comment-54676

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Install/Activate the Jetpack Social plugin
* Connect it via the getting started link on the Social admin page
* When you return to the admin page, you should see the updated Learn more link
* Clicking it will take you to jetpack.com rather than wordpress.com

<img width="773" alt="image" src="https://user-images.githubusercontent.com/96462/170835678-a4e353e7-a00d-427b-b930-8a80bdce67d4.png">
