### PR TITLE
renovate: Add period in "Updated package dependencies." changelog entry

### DIFF
--- a/.github/files/renovate-post-upgrade.sh
+++ b/.github/files/renovate-post-upgrade.sh
@@ -56,7 +56,7 @@ for DIR in $(git -c core.quotepath=off diff --name-only HEAD | grep -E -v '(^|/)
 		ARGS+=( "--type=$CLTYPE" )
 	fi
 
-	ARGS+=( --entry="Updated package dependencies" )
+	ARGS+=( --entry="Updated package dependencies." )
 
 	CHANGES_DIR="$(jq -r '.extra.changelogger["changes-dir"] // "changelog"' composer.json)"
 	if [[ -d "$CHANGES_DIR" && "$(ls -- "$CHANGES_DIR")" ]]; then

--- a/projects/github-actions/repo-gardening/changelog/renovate-github-api-packages
+++ b/projects/github-actions/repo-gardening/changelog/renovate-github-api-packages
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/github-actions/repo-gardening/changelog/renovate-npm-moment-vulnerability
+++ b/projects/github-actions/repo-gardening/changelog/renovate-npm-moment-vulnerability
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/github-actions/required-review/changelog/renovate-github-api-packages
+++ b/projects/github-actions/required-review/changelog/renovate-github-api-packages
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-mdn-browser-compat-data-4.x
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-mdn-browser-compat-data-4.x
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/storybook/changelog/renovate-babel-monorepo
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-babel-monorepo#2
+++ b/projects/js-packages/storybook/changelog/renovate-babel-monorepo#2
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-babel-monorepo#3
+++ b/projects/js-packages/storybook/changelog/renovate-babel-monorepo#3
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/js-packages/storybook/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-postcss-8.x
+++ b/projects/js-packages/storybook/changelog/renovate-postcss-8.x
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-storybook-monorepo
+++ b/projects/js-packages/storybook/changelog/renovate-storybook-monorepo
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-typescript-4.x
+++ b/projects/js-packages/storybook/changelog/renovate-typescript-4.x
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-typescript-4.x#2
+++ b/projects/js-packages/storybook/changelog/renovate-typescript-4.x#2
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-webpack-5.x
+++ b/projects/js-packages/storybook/changelog/renovate-webpack-5.x
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#3
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#3
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#5
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#5
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#6
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#6
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#7
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#7
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#8
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#8
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo-2
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo-2
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/packages/backup/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/backup/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/packages/codesniffer/changelog/renovate-mediawiki-mediawiki-codesniffer-39.x
+++ b/projects/packages/codesniffer/changelog/renovate-mediawiki-mediawiki-codesniffer-39.x
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/packages/connection-ui/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/connection-ui/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/packages/wordads/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/wordads/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/always-use-jetpack-open-graph/changelog/renovate-lock-file-maintenance#2
+++ b/projects/plugins/always-use-jetpack-open-graph/changelog/renovate-lock-file-maintenance#2
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/beta/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/beta/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/beta/changelog/renovate-lock-file-maintenance#3
+++ b/projects/plugins/beta/changelog/renovate-lock-file-maintenance#3
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/boost/changelog/renovate-babel-monorepo
+++ b/projects/plugins/boost/changelog/renovate-babel-monorepo
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/boost/changelog/renovate-babel-monorepo#2
+++ b/projects/plugins/boost/changelog/renovate-babel-monorepo#2
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/boost/changelog/renovate-babel-monorepo#3
+++ b/projects/plugins/boost/changelog/renovate-babel-monorepo#3
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/boost/changelog/renovate-eslint-packages
+++ b/projects/plugins/boost/changelog/renovate-eslint-packages
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/boost/changelog/renovate-eslint-packages#2
+++ b/projects/plugins/boost/changelog/renovate-eslint-packages#2
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/boost/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/boost/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/boost/changelog/renovate-lock-file-maintenance#3
+++ b/projects/plugins/boost/changelog/renovate-lock-file-maintenance#3
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/boost/changelog/renovate-pin-dependencies
+++ b/projects/plugins/boost/changelog/renovate-pin-dependencies
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/boost/changelog/renovate-postcss-8.x
+++ b/projects/plugins/boost/changelog/renovate-postcss-8.x
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/boost/changelog/renovate-typescript-4.x
+++ b/projects/plugins/boost/changelog/renovate-typescript-4.x
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/boost/changelog/renovate-typescript-4.x#2
+++ b/projects/plugins/boost/changelog/renovate-typescript-4.x#2
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/boost/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/boost/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/boost/changelog/renovate-wordpress-monorepo#2
+++ b/projects/plugins/boost/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/boost/changelog/renovate-wordpress-monorepo#3
+++ b/projects/plugins/boost/changelog/renovate-wordpress-monorepo#3
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/boost/changelog/renovate-wordpress-monorepo#4
+++ b/projects/plugins/boost/changelog/renovate-wordpress-monorepo#4
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/boost/changelog/renovate-wordpress-monorepo-2
+++ b/projects/plugins/boost/changelog/renovate-wordpress-monorepo-2
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance#3
+++ b/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance#3
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-automattic-social-previews-1.x
+++ b/projects/plugins/jetpack/changelog/renovate-automattic-social-previews-1.x
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-typescript-4.x
+++ b/projects/plugins/jetpack/changelog/renovate-typescript-4.x
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/protect/changelog/renovate-babel-monorepo
+++ b/projects/plugins/protect/changelog/renovate-babel-monorepo
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/protect/changelog/renovate-babel-monorepo#2
+++ b/projects/plugins/protect/changelog/renovate-babel-monorepo#2
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/protect/changelog/renovate-lock-file-maintenance#2
+++ b/projects/plugins/protect/changelog/renovate-lock-file-maintenance#2
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/protect/changelog/renovate-webpack-5.x
+++ b/projects/plugins/protect/changelog/renovate-webpack-5.x
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/protect/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/protect/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/protect/changelog/renovate-wordpress-monorepo#2
+++ b/projects/plugins/protect/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/protect/changelog/renovate-wordpress-monorepo#3
+++ b/projects/plugins/protect/changelog/renovate-wordpress-monorepo#3
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/protect/changelog/renovate-wordpress-monorepo#4
+++ b/projects/plugins/protect/changelog/renovate-wordpress-monorepo#4
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/protect/changelog/renovate-wordpress-monorepo-2
+++ b/projects/plugins/protect/changelog/renovate-wordpress-monorepo-2
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/social/changelog/renovate-babel-monorepo
+++ b/projects/plugins/social/changelog/renovate-babel-monorepo
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/social/changelog/renovate-babel-monorepo#3
+++ b/projects/plugins/social/changelog/renovate-babel-monorepo#3
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/social/changelog/renovate-babel-monorepo#4
+++ b/projects/plugins/social/changelog/renovate-babel-monorepo#4
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/social/changelog/renovate-lock-file-maintenance#2
+++ b/projects/plugins/social/changelog/renovate-lock-file-maintenance#2
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/social/changelog/renovate-pin-dependencies#2
+++ b/projects/plugins/social/changelog/renovate-pin-dependencies#2
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/social/changelog/renovate-webpack-5.x
+++ b/projects/plugins/social/changelog/renovate-webpack-5.x
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/social/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/social/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/social/changelog/renovate-wordpress-monorepo#2
+++ b/projects/plugins/social/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/social/changelog/renovate-wordpress-monorepo#3
+++ b/projects/plugins/social/changelog/renovate-wordpress-monorepo#3
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/social/changelog/renovate-wordpress-monorepo#4
+++ b/projects/plugins/social/changelog/renovate-wordpress-monorepo#4
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/social/changelog/renovate-wordpress-monorepo-2
+++ b/projects/plugins/social/changelog/renovate-wordpress-monorepo-2
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo
+++ b/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo#2
+++ b/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo#2
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#2
+++ b/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#2
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-webpack-5.x
+++ b/projects/plugins/starter-plugin/changelog/renovate-webpack-5.x
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#2
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#3
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#3
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#4
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#4
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo-2
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo-2
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#3
+++ b/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#3
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#5
+++ b/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#5
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated package dependencies
+Updated package dependencies.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Renovate was setting the message without a period, while
check-intra-monorepo-deps.sh does it with. The two should match.

Also, fix the existing change entry files (the ones left after #24571)
that lack the period so future releases don't have duplicates in the
changelog.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1653943970547739/1653943619.413279-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Merge this, then keep an eye on future renovate PRs.