### PR TITLE
Search: update formatting in plugin README

### DIFF
--- a/projects/plugins/search/changelog/update-search-readme-formatting
+++ b/projects/plugins/search/changelog/update-search-readme-formatting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: update plugin README

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -60,7 +60,7 @@
 	},
 	"config": {
 		"sort-packages": true,
-		"autoloader-suffix": "b462338fb66be23595d68a93345c9e3d_jetpack_searchⓥ1_0_0",
+		"autoloader-suffix": "b462338fb66be23595d68a93345c9e3d_jetpack_searchⓥ1_0_1_alpha",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true,

--- a/projects/plugins/search/jetpack-search.php
+++ b/projects/plugins/search/jetpack-search.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Search
  * Plugin URI: https://jetpack.com/search/
  * Description: A cloud-powered replacement for WordPress' search.
- * Version: 1.0.0
+ * Version: 1.0.1-alpha
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later
@@ -26,7 +26,7 @@ define( 'JETPACK_SEARCH_PLUGIN__DIR', plugin_dir_path( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__FILE', __FILE__ );
 define( 'JETPACK_SEARCH_PLUGIN__FILE_RELATIVE_PATH', plugin_basename( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__SLUG', 'jetpack-search' );
-define( 'JETPACK_SEARCH_PLUGIN__VERSION', '1.0.0' );
+define( 'JETPACK_SEARCH_PLUGIN__VERSION', '1.0.1-alpha' );
 
 defined( 'JETPACK_CLIENT__AUTH_LOCATION' ) || define( 'JETPACK_CLIENT__AUTH_LOCATION', 'header' );
 

--- a/projects/plugins/search/readme.txt
+++ b/projects/plugins/search/readme.txt
@@ -35,16 +35,17 @@ People on eCommerce sites are 2x more likely to purchase something when they sea
 Jetpack Search is a completely customizable WordPress site search plugin, so your visitors get a search experience that blends in seamlessly with your site design.
 
 **WHY CHOOSE JETPACK SEARCH?**
-- Highly relevant search results organized by modern ranking algorithms
-- Boosted and prioritized results based on your site’s search stats
-- Instant search and filtering without reloading the page
-- Site search filters and facets (by categories, tags, dates, custom taxonomies, and post types)
-- Improved theme compatibility for both mobile and desktop
-- Real-time indexing, so your search index is updated within minutes of changes to your site
-- Integrates seamlessly with WooCommerce
-- Support for all languages, and advanced language analysis for 29 languages
-- Highlighted search terms on comments and post content
-- Fast and accurate spelling correction
+
+* Highly relevant search results organized by modern ranking algorithms
+* Boosted and prioritized results based on your site’s search stats
+* Instant search and filtering without reloading the page
+* Site search filters and facets (by categories, tags, dates, custom taxonomies, and post types)
+* Improved theme compatibility for both mobile and desktop
+* Real-time indexing, so your search index is updated within minutes of changes to your site
+* Integrates seamlessly with WooCommerce
+* Support for all languages, and advanced language analysis for 29 languages
+* Highlighted search terms on comments and post content
+* Fast and accurate spelling correction
 
 **WITH 💚 BY JETPACK**
 This is just the start!

--- a/projects/plugins/search/readme.txt
+++ b/projects/plugins/search/readme.txt
@@ -35,16 +35,16 @@ People on eCommerce sites are 2x more likely to purchase something when they sea
 Jetpack Search is a completely customizable WordPress site search plugin, so your visitors get a search experience that blends in seamlessly with your site design.
 
 **WHY CHOOSE JETPACK SEARCH?**
-Highly relevant search results organized by modern ranking algorithms
-Boosted and prioritized results based on your site’s search stats
-Instant search and filtering without reloading the page
-Site search filters and facets (by categories, tags, dates, custom taxonomies, and post types)
-Improved theme compatibility for both mobile and desktop
-Real-time indexing, so your search index is updated within minutes of changes to your site
-Integrates seamlessly with WooCommerce
-Support for all languages, and advanced language analysis for 29 languages
-Highlighted search terms on comments and post content
-Fast and accurate spelling correction
+- Highly relevant search results organized by modern ranking algorithms
+- Boosted and prioritized results based on your site’s search stats
+- Instant search and filtering without reloading the page
+- Site search filters and facets (by categories, tags, dates, custom taxonomies, and post types)
+- Improved theme compatibility for both mobile and desktop
+- Real-time indexing, so your search index is updated within minutes of changes to your site
+- Integrates seamlessly with WooCommerce
+- Support for all languages, and advanced language analysis for 29 languages
+- Highlighted search terms on comments and post content
+- Fast and accurate spelling correction
 
 **WITH 💚 BY JETPACK**
 This is just the start!
@@ -99,7 +99,7 @@ Yes, visitors can filter search results by tags, categories, dates, custom taxon
 
 = Where can I get a Jetpack Search subscription? =
 
-You can purchase a Search subscription directly through this plugin or via the [Jetpack website](https://jetpack.com/search/)
+You can purchase a Search subscription directly through this plugin or via the [Jetpack website](https://jetpack.com/search/).
 
 == Screenshots ==
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Our plugin README has a section called 'Why install Jetpack Search?' which currently looks like this (see https://wordpress.org/plugins/jetpack-search/):

<img width="684" alt="Screen Shot 2022-05-31 at 11 42 34" src="https://user-images.githubusercontent.com/17325/171068593-09a04333-015c-4c4d-9226-3ad5a9953cf6.png">

This PR marks up that section as a list for easier reading.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Paste the Markdown into your favourite Markdown editor (like [Gist](https://gist.github.com)) and make sure the 'Why install Jetpack Search?' section shows up as a list.