### PR TITLE
Add Jetpack Search team to CODEOWNERS for projects/plugins/search

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,9 @@
 /projects/packages/search @Automattic/jetpack-search
 /projects/packages/search/src/wpes @Automattic/prometheus
 
+# Plugins
+/projects/plugins/search @Automattic/jetpack-search
+
 # Other bits of the Codebase
 /projects/plugins/jetpack/_inc/lib/debugger/ @kraftbj
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Add Jetpack Search team to CODEOWNERS for projects/plugins/search so we're automatically prompted for review when the plugin changes.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Check that the changes follow the correct format for CODEOWNERS. Github automatically validates it and you can see the result of the validation here:

https://github.com/Automattic/jetpack/pull/24575/files