### PR TITLE
Search: don't open modal if only sort parameter is set

### DIFF
--- a/projects/packages/search/changelog/fix-sort-triggers-search-overlay
+++ b/projects/packages/search/changelog/fix-sort-triggers-search-overlay
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Search: don't open modal if only sort parameter is set

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -68,7 +68,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-master": "0.14.x-dev"
+			"dev-master": "0.15.x-dev"
 		},
 		"version-constants": {
 			"::VERSION": "src/class-package.php"

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.14.3-alpha",
+	"version": "0.15.0-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.14.3-alpha';
+	const VERSION = '0.15.0-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/instant-search/store/selectors.js
+++ b/projects/packages/search/src/instant-search/store/selectors.js
@@ -116,12 +116,7 @@ function hasStaticFilters( state ) {
  * @returns {object} hasActiveQuery - true if any search-related query value has been defined.
  */
 export function hasActiveQuery( state ) {
-	return (
-		getSearchQuery( state ) !== null ||
-		hasFilters( state ) ||
-		hasStaticFilters( state ) ||
-		state.sort !== null
-	);
+	return getSearchQuery( state ) !== null || hasFilters( state ) || hasStaticFilters( state );
 }
 
 /**

--- a/projects/packages/search/src/instant-search/store/test/selectors.test.js
+++ b/projects/packages/search/src/instant-search/store/test/selectors.test.js
@@ -63,10 +63,10 @@ describe( 'hasActiveQuery', () => {
 			hasActiveQuery( { searchQuery: null, filters: {}, staticFilters: {}, sort: null } )
 		).toEqual( false );
 	} );
-	test( 'returns true if there is a defined sort value', () => {
+	test( 'returns false if there is a defined sort value only', () => {
 		expect(
 			hasActiveQuery( { searchQuery: null, filters: {}, staticFilters: {}, sort: 'relevance' } )
-		).toEqual( true );
+		).toEqual( false );
 		expect(
 			hasActiveQuery( { searchQuery: null, filters: {}, staticFilters: {}, sort: null } )
 		).toEqual( false );

--- a/projects/plugins/jetpack/changelog/fix-sort-triggers-search-overlay
+++ b/projects/plugins/jetpack/changelog/fix-sort-triggers-search-overlay
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -37,7 +37,7 @@
 		"automattic/jetpack-publicize": "0.5.x-dev",
 		"automattic/jetpack-redirect": "1.7.x-dev",
 		"automattic/jetpack-roles": "1.4.x-dev",
-		"automattic/jetpack-search": "0.14.x-dev",
+		"automattic/jetpack-search": "0.15.x-dev",
 		"automattic/jetpack-status": "1.13.x-dev",
 		"automattic/jetpack-sync": "1.35.x-dev",
 		"automattic/jetpack-waf": "0.6.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "79532a3e70a2163ff18d69fa3dcee1ae",
+    "content-hash": "f34cd78e795a226eaab1ad83463a974d",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1577,7 +1577,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "215cafebb20483ae996174b3054ef62a3c94a3a4"
+                "reference": "975e20cf57e20fd24eba20100dcf5fc9dc3af2cb"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -1600,7 +1600,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "0.14.x-dev"
+                    "dev-master": "0.15.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"

--- a/projects/plugins/search/changelog/fix-sort-triggers-search-overlay
+++ b/projects/plugins/search/changelog/fix-sort-triggers-search-overlay
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -9,7 +9,7 @@
 		"automattic/jetpack-config": "1.9.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
 		"automattic/jetpack-my-jetpack": "1.6.x-dev",
-		"automattic/jetpack-search": "0.14.x-dev",
+		"automattic/jetpack-search": "0.15.x-dev",
 		"automattic/jetpack-status": "^1.13",
 		"automattic/jetpack-sync": "1.35.x-dev"
 	},

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2aa42f2845b4e2d75d84251ce4ae3c6e",
+    "content-hash": "5df75a41cd2b9ac960e09250deb1d6cc",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -903,7 +903,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "215cafebb20483ae996174b3054ef62a3c94a3a4"
+                "reference": "975e20cf57e20fd24eba20100dcf5fc9dc3af2cb"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -926,7 +926,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-master": "0.14.x-dev"
+                    "dev-master": "0.15.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/24498.

#### Changes proposed in this Pull Request:
A `sort` param alone should probably not trigger the search modal to open.

This PR requires either a search query or filters to be defined before opening the modal.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. On a test site with Instant Search enabled, visit `/?orderby=date`. Ensure the modal does not open.
2. Now visit `/?s=&orderby=date`. Ensure the modal _does_ open.