### PR TITLE
VideoPress: Removing strict comparison to fix average color param

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-videopress-average-color
+++ b/projects/plugins/jetpack/changelog/fix-videopress-average-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Removing strict comparison to fix average color param

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
@@ -658,11 +658,13 @@ class VideoPress_Player {
 				case 'controls':
 				case 'playsinline':
 				case 'useAverageColor':
-					if ( in_array( $value, array( 1, 'true' ), true ) ) {
+					// phpcs:disable WordPress.PHP.StrictInArray.MissingTrueStrict -- strict comparison will break this feature
+					if ( in_array( $value, array( 1, 'true' ) ) ) {
 						$videopress_options[ $option ] = true;
-					} elseif ( in_array( $value, array( 0, 'false' ), true ) ) {
+					} elseif ( in_array( $value, array( 0, 'false' ) ) ) {
 						$videopress_options[ $option ] = false;
 					}
+					// phpcs:enable
 					break;
 				case 'defaultlangcode':
 					$option = 'defaultLangCode';


### PR DESCRIPTION
Fixes #24605

#### Changes proposed in this Pull Request:

* This PR removes strict comparison added to the 'useAverageColor' case check from [this PR](https://github.com/Automattic/jetpack/pull/24351). The strict comparison caused the parameter to stop working.
* Adding this fix then enabled the new 'useAverageColor' shortcode parameter introduced in [this PR](https://github.com/Automattic/jetpack/pull/24330) to work.

#### Jetpack product discussion

p1654074457350269-slack-C9W0QF6KA

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* To test, follow the testing instructions in [this PR](https://github.com/Automattic/jetpack/pull/24330).
* The new parameter, when added via a shortcode, should result in the changes mentioned (the seekbar should change color depending on the video background).
