### PR TITLE
WAF: Change the way we check if the module is enabled

### DIFF
--- a/projects/packages/waf/changelog/fix-waf-is-enabled
+++ b/projects/packages/waf/changelog/fix-waf-is-enabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+fixed the way we check if the waf module is enabled

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -91,7 +91,12 @@ class Waf_Runner {
 		if ( defined( 'ABSPATH' ) ) {
 			// We can't use the Modules class here because it returns an empty array since this function runs earlier than most of the Jetpack setup: https://github.com/Automattic/jetpack/commit/e8b77065ba947f531a1d7e0fd48fcc1781e5bb1b#diff-6cac390ffca47817d6b7787b21008ee3a0d650287812d3c0ab85a3a12ae1e5d1R245
 			$active_modules = Jetpack_Options::get_option( 'active_modules' );
-			return in_array( 'waf', $active_modules, true );
+
+			if ( ! empty( $active_modules ) ) {
+				return in_array( 'waf', $active_modules, true );
+			}
+
+			return false;
 		}
 
 		return true;

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -89,6 +89,7 @@ class Waf_Runner {
 		// if ABSPATH is defined, then WordPress has already been instantiated,
 		// so we can check to see if the waf module is activated.
 		if ( defined( 'ABSPATH' ) ) {
+			// We can't use the Modules class here because it returns an empty array since this function runs earlier than most of the Jetpack setup: https://github.com/Automattic/jetpack/commit/e8b77065ba947f531a1d7e0fd48fcc1781e5bb1b#diff-6cac390ffca47817d6b7787b21008ee3a0d650287812d3c0ab85a3a12ae1e5d1R245
 			$active_modules = Jetpack_Options::get_option( 'active_modules' );
 			return in_array( 'waf', $active_modules, true );
 		}

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\Waf;
 
 use Automattic\Jetpack\Connection\Client;
-use Automattic\Jetpack\Modules;
 use Jetpack_Options;
 
 /**
@@ -90,7 +89,8 @@ class Waf_Runner {
 		// if ABSPATH is defined, then WordPress has already been instantiated,
 		// so we can check to see if the waf module is activated.
 		if ( defined( 'ABSPATH' ) ) {
-			return ( new Modules() )->is_active( 'waf' );
+			$active_modules = Jetpack_Options::get_option( 'active_modules' );
+			return in_array( 'waf', $active_modules, true );
 		}
 
 		return true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This fixes the way we check if the module is enabled.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch on a test site with a scan subscription.
* Activate the WAF module.
* Verify that the rules are being executed.
