### PR TITLE
Wpvideo shortcode: fix useAverageColor parameter handling for "false"

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-wpvideo-shortcode-useaveragecolor
+++ b/projects/plugins/jetpack/changelog/fix-wpvideo-shortcode-useaveragecolor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+VideoPress: make sure "false" will be casted as false for useaveragecolor

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
@@ -658,10 +658,9 @@ class VideoPress_Player {
 				case 'controls':
 				case 'playsinline':
 				case 'useAverageColor':
-					// phpcs:disable WordPress.PHP.StrictInArray.MissingTrueStrict -- strict comparison will break this feature
-					if ( in_array( $value, array( 1, 'true' ) ) ) {
+					if ( in_array( $value, array( true, 1, 'true' ), true ) ) {
 						$videopress_options[ $option ] = true;
-					} elseif ( in_array( $value, array( 0, 'false' ) ) ) {
+					} elseif ( in_array( $value, array( false, 0, 'false' ), true ) ) {
 						$videopress_options[ $option ] = false;
 					}
 					// phpcs:enable

--- a/projects/plugins/jetpack/modules/videopress/shortcode.php
+++ b/projects/plugins/jetpack/modules/videopress/shortcode.php
@@ -130,6 +130,11 @@ class VideoPress_Shortcode {
 			$attr['width'] --;
 		}
 
+		// Make sure "false" being passed as useaveragecolor will be actually false.
+		if ( is_string( $attr['useaveragecolor'] ) && 'false' === strtolower( $attr['useaveragecolor'] ) ) {
+			$attr['useaveragecolor'] = false;
+		}
+
 		/**
 		 * Filter the default VideoPress shortcode options.
 		 *


### PR DESCRIPTION
Fixes #24614

#### Changes proposed in this Pull Request:
This PR changes "false" to false for wpvideo's useaveragecolor shortcode param, so the param could be properly casted to boolean.
It also adds strict checks in shortcode attributes to remove phpcs ignore.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* On a Jetpack site with VideoPress enabled
* Go to your media library and upload a new video or find an existing one already uploaded to VideoPress
* Copy the video GUID
* Create a new post
* Add a /shortcode block
* `[wpvideo <your_guid> useAverageColor=true]`
* Save and preview
* ✅ The seekbar should change color while playing the video
* Go back to the editor
* Change useAverageColor to "false" `[wpvideo <your_guid> useAverageColor=false]`
* Save and preview
* ✅ The seekbar should not change color while playing the video
* Use the same test procedure for 0 and 1 (0 => should be same as false, 1 => should be same as true)
