### PR TITLE
Add allow="clipboard-write" in VideoPress iframe embed to fix clipboard API in Chrome

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-videopress-copy-button-chrome
+++ b/projects/plugins/jetpack/changelog/fix-videopress-copy-button-chrome
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+VideoPress: add "allow='clipboard-write'" in iframe for embed in order to fix the Clipboard API on Chrome

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
@@ -693,7 +693,7 @@ class VideoPress_Player {
 				. "' width='" . esc_attr( $videopress_options['width'] )
 				. "' height='" . esc_attr( $videopress_options['height'] )
 				. "' src='" . esc_attr( $iframe_url )
-				. "' frameborder='0' allowfullscreen></iframe>"
+				. "' frameborder='0' allowfullscreen allow='clipboard-write'></iframe>"
 				. "<script src='" . esc_attr( $js_url ) . "'></script>";
 
 		} else {


### PR DESCRIPTION
Related  to Automattic/greenhouse#1199

#### Changes proposed in this Pull Request:
Copy button in the share modal is not working in Chrome because of an allow policy.
This PR adds allow="clipboard-write" to the generated iframe in order to fix that.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* On a Jetpack site with VideoPress enabled
* Apply this patch
* Use Google Chrome
* Go to your media library and get the GUID of a VideoPress video (or upload a new one)
* Create a new post
* Add a /shortcode block
* `[wpvideo <your_guid>]`
* Save and preview
* ✅ The generated iframe should contain 'allow="clipboard-write"' as attribute
* ✅ The copy buttons in the share menu should work on Chrome

