### PR TITLE
Publicize: Fix the default connection state filter

### DIFF
--- a/projects/packages/publicize/changelog/fix-publicize-default-filter
+++ b/projects/packages/publicize/changelog/fix-publicize-default-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Post field: Allow for the filter which could make the connections default to disabled.

--- a/projects/packages/publicize/src/class-connections-post-field.php
+++ b/projects/packages/publicize/src/class-connections-post-field.php
@@ -214,21 +214,19 @@ class Connections_Post_Field {
 	 * @return Filtered $post
 	 */
 	public function rest_pre_insert( $post, $request ) {
-		if ( ! isset( $request['jetpack_publicize_connections'] ) ) {
-			return $post;
-		}
+		$request_connections = ! empty( $request['jetpack_publicize_connections'] ) ? $request['jetpack_publicize_connections'] : array();
 
 		$permission_check = $this->permission_check( empty( $post->ID ) ? 0 : $post->ID );
 		if ( is_wp_error( $permission_check ) ) {
 			return $permission_check;
 		}
 		// memoize.
-		$this->get_meta_to_update( $request['jetpack_publicize_connections'], isset( $post->ID ) ? $post->ID : 0 );
+		$this->get_meta_to_update( $request_connections, isset( $post->ID ) ? $post->ID : 0 );
 
 		if ( isset( $post->ID ) ) {
 			// Set the meta before we mark the post as published so that publicize works as expected.
 			// If this is not the case post end up on social media when they are marked as skipped.
-			$this->update( $request['jetpack_publicize_connections'], $post );
+			$this->update( $request_connections, $post );
 		}
 
 		return $post;
@@ -247,10 +245,6 @@ class Connections_Post_Field {
 			// An existing post was edited - no need to update
 			// our cache - we started out knowing the correct
 			// post ID.
-			return;
-		}
-
-		if ( ! isset( $request['jetpack_publicize_connections'] ) ) {
 			return;
 		}
 

--- a/projects/packages/publicize/tests/php/test-connections-post-field.php
+++ b/projects/packages/publicize/tests/php/test-connections-post-field.php
@@ -336,4 +336,24 @@ class Test_Connections_Post_Field  extends TestCase {
 			$this->assertSame( 'facebook' !== $connection->service_name, $connection->enabled );
 		}
 	}
+
+	/**
+	 * Test that connections are skipped when the publicize_checkbox_default filter is used.
+	 */
+	public function test_default_checkbox_filter() {
+		$filter_func = function ( $default ) {
+			return false;
+		};
+
+		add_filter( 'publicize_checkbox_default', $filter_func );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d', $this->draft_id ) );
+		$this->server->dispatch( $request );
+
+		foreach ( self::$connection_ids as $unique_id ) {
+			$skip_key = $this->publicize->POST_SKIP . $unique_id;
+			$this->assertNotEmpty( get_post_meta( $this->draft_id, $skip_key, true ) );
+		}
+
+		remove_filter( 'publicize_checkbox_default', $filter_func );
+	}
 }

--- a/projects/packages/publicize/tests/php/test-connections-post-field.php
+++ b/projects/packages/publicize/tests/php/test-connections-post-field.php
@@ -338,9 +338,22 @@ class Test_Connections_Post_Field  extends TestCase {
 	}
 
 	/**
-	 * Test that connections are skipped when the publicize_checkbox_default filter is used.
+	 * Test that connections are enabled when the publicize_checkbox_default filter isn't used.
 	 */
 	public function test_default_checkbox_filter() {
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d', $this->draft_id ) );
+		$this->server->dispatch( $request );
+
+		foreach ( self::$connection_ids as $unique_id ) {
+			$skip_key = $this->publicize->POST_SKIP . $unique_id;
+			$this->assertEmpty( get_post_meta( $this->draft_id, $skip_key, true ) );
+		}
+	}
+
+	/**
+	 * Test that connections are skipped when the publicize_checkbox_default filter is used.
+	 */
+	public function test_default_checkbox_filter_disabled() {
 		// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$filter_func = function ( $default ) {
 			return false;

--- a/projects/packages/publicize/tests/php/test-connections-post-field.php
+++ b/projects/packages/publicize/tests/php/test-connections-post-field.php
@@ -341,6 +341,7 @@ class Test_Connections_Post_Field  extends TestCase {
 	 * Test that connections are skipped when the publicize_checkbox_default filter is used.
 	 */
 	public function test_default_checkbox_filter() {
+		// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$filter_func = function ( $default ) {
 			return false;
 		};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #24059

#### Changes proposed in this Pull Request:
The REST post field assumes that the default value for connections is to be enabled. If the `publicize_checkbox_default` filter is used to make it `false` then it breaks this logic and meta isn't stored against the post to skip the connections when Publicize runs.

This PR removes the checks for `jetpack_publicize_connections` being empty as the post is saved, and ensures that the appropriate meta is stored against the post.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Setup Publicize on a site
* Add `add_filter( 'publicize_checkbox_default', '__return_false' );` somewhere that will be loaded.
* Without this PR when a post is published it will still be shared to any connections
* With it, the connection state should be respected.

Run the automated tests:

In the `packages/publicize` directory, run:

```
composer phpunit -- --filter=Test_Connections_Post_Field
```

