### PR TITLE
Dashboard: update link to Protect features in disconnect modal.

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/jetpack-benefits/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-benefits/index.jsx
@@ -78,7 +78,7 @@ const JetpackBenefits = props => {
 								{
 									ExternalLink: (
 										<ExternalLink
-											href={ getRedirectUrl( 'jetpack-features-security' ) }
+											href={ getRedirectUrl( 'jetpack-features-brute-force' ) }
 											rel="noopener noreferrer"
 											target="_blank"
 										></ExternalLink>

--- a/projects/plugins/jetpack/changelog/fix-link-disconnect-protect
+++ b/projects/plugins/jetpack/changelog/fix-link-disconnect-protect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Dashboard: update link to Protect features in disconnect modal.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Update the link appearing when disconnecting Jetpack.

#### Jetpack product discussion

* Internal reference: p8oabR-Sc-p2#comment-6367

#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:

* Start from a connected Jetpack site.
* Go to Jetpack > Dashboard, and scroll down to the Connections area.
* In the disconnect modal, click on the link to Brute Force attack protection.
* You should be redirected to `https://jetpack.com/features/security/brute-force-attack-protection/`.
