### PR TITLE
Related posts: use latest core function to check block-based theme

### DIFF
--- a/projects/packages/blocks/changelog/fix-related-posts-fse
+++ b/projects/packages/blocks/changelog/fix-related-posts-fse
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Update method checking for block-based themes to use latest core function.

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -256,7 +256,8 @@ class Blocks {
 	 * @return bool True if the current theme is an FSE/Site Editor theme.
 	 */
 	public static function is_fse_theme() {
-		$is_fse_theme = function_exists( 'gutenberg_is_fse_theme' ) && gutenberg_is_fse_theme();
+		$is_fse_theme = wp_is_block_theme()
+			|| ( function_exists( 'gutenberg_is_fse_theme' ) && gutenberg_is_fse_theme() );
 
 		/**
 		 * Returns true if the current theme is an FSE/Site Editor theme.

--- a/projects/packages/blocks/tests/php/test-blocks.php
+++ b/projects/packages/blocks/tests/php/test-blocks.php
@@ -248,14 +248,27 @@ class Test_Blocks extends TestCase {
 	}
 
 	/**
-	 * Test that we can detect an FSE theme using the provided core function, gutenberg_is_fse_theme.
+	 * Test that we can detect an FSE theme using the provided gutenberg_is_fse_theme function.
 	 *
 	 * @since 9.8.0
 	 *
 	 * @covers Automattic\Jetpack\Blocks::is_standalone_block
 	 */
-	public function test_is_fse_theme_via_core_function() {
+	public function test_is_fse_theme_via_gutenberg_function() {
 		Functions\when( 'gutenberg_is_fse_theme' )->justReturn( true );
+
+		$this->assertTrue( Blocks::is_fse_theme() );
+	}
+
+	/**
+	 * Test that we can detect an FSE theme using the provided wp_is_block_theme function.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @covers Automattic\Jetpack\Blocks::is_standalone_block
+	 */
+	public function test_is_fse_theme_via_core_function() {
+		Functions\when( 'wp_is_block_theme' )->justReturn( true );
 
 		$this->assertTrue( Blocks::is_fse_theme() );
 	}

--- a/projects/packages/blocks/tests/php/test-blocks.php
+++ b/projects/packages/blocks/tests/php/test-blocks.php
@@ -225,7 +225,7 @@ class Test_Blocks extends TestCase {
 	 *
 	 * @since 9.8.0
 	 *
-	 * @covers Automattic\Jetpack\Blocks::is_standalone_block
+	 * @covers Automattic\Jetpack\Blocks::is_fse_theme
 	 */
 	public function test_is_not_fse_theme() {
 		$this->assertFalse( Blocks::is_fse_theme() );
@@ -236,7 +236,7 @@ class Test_Blocks extends TestCase {
 	 *
 	 * @since 9.8.0
 	 *
-	 * @covers Automattic\Jetpack\Blocks::is_standalone_block
+	 * @covers Automattic\Jetpack\Blocks::is_fse_theme
 	 */
 	public function test_is_fse_theme_via_filter() {
 		add_filter( 'jetpack_is_fse_theme', '__return_true' );
@@ -252,7 +252,7 @@ class Test_Blocks extends TestCase {
 	 *
 	 * @since 9.8.0
 	 *
-	 * @covers Automattic\Jetpack\Blocks::is_standalone_block
+	 * @covers Automattic\Jetpack\Blocks::is_fse_theme
 	 */
 	public function test_is_fse_theme_via_gutenberg_function() {
 		Functions\when( 'gutenberg_is_fse_theme' )->justReturn( true );

--- a/projects/packages/blocks/tests/php/test-blocks.php
+++ b/projects/packages/blocks/tests/php/test-blocks.php
@@ -261,19 +261,6 @@ class Test_Blocks extends TestCase {
 	}
 
 	/**
-	 * Test that we can detect an FSE theme using the provided wp_is_block_theme function.
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @covers Automattic\Jetpack\Blocks::is_standalone_block
-	 */
-	public function test_is_fse_theme_via_core_function() {
-		Functions\when( 'wp_is_block_theme' )->justReturn( true );
-
-		$this->assertTrue( Blocks::is_fse_theme() );
-	}
-
-	/**
 	 * Test that by default we are not running in a Jetpack plugin context.
 	 *
 	 * @since 9.6.0


### PR DESCRIPTION
Fixes #24619

#### Changes proposed in this Pull Request:

* We previously only relied on a function provided in Gutenberg, `gutenberg_is_fse_theme()`, to check whether a theme was a block-based theme. Now that the feature made its way to core, there is a Core function we can (and should) use instead: `wp_is_block_theme()`.

**Note**

I had originally added a new test, but I could not get it to work. I kept receiving this error:

```
1) Automattic\Jetpack\Test_Blocks::test_is_fse_theme_via_core_function
Patchwork\Exceptions\DefinedTooEarly: The file that defines wp_is_block_theme() was included earlier than Patchwork. This is likely a result of an improper setup; see readme for details.
```

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:

* Start with a site with some existing content.
* Go to Jetpack > Settings > Traffic and enable Related Posts.
* Go to Appearance > Themes and enable the Twenty Twenty Two theme.
* Go to Appearance > Editor, and pick the single post editor.
* Add the Related Posts Block somewhere in the template, and save your changes.
* Visit a single post.
* You should only see one set of related posts on the page.
