### PR TITLE
Related Posts: avoid using strings in array_values

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-related-posts-fatals
+++ b/projects/plugins/jetpack/changelog/fix-related-posts-fatals
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Related Posts: avoid fatal errors when calling related posts with multiple exclusions.

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -528,7 +528,8 @@ EOT;
 			if ( is_string( $_GET[ $arg ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				$result = explode( ',', sanitize_text_field( wp_unslash( $_GET[ $arg ] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			} elseif ( is_array( $_GET[ $arg ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				$result = array_values( sanitize_text_field( wp_unslash( $_GET[ $arg ] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				$args   = array_map( 'sanitize_text_field', wp_unslash( $_GET[ $arg ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				$result = array_values( $args );
 			}
 
 			$result = array_unique( array_filter( array_map( 'absint', $result ) ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This should fix fatals introduced in #22201.

```
Uncaught TypeError: Argument 1 passed to Jetpack_RelatedPosts::action_frontend_init_ajax() must be of the type array, null given, called in wp-content/mu-plugins/related-posts/jetpack-related-posts.php on line 227 and defined
```

- Syncs r246829-wpcom
- D82022-code

#### Jetpack product discussion

* p1654219480093619-slack-CDLH4C1UZ

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start with a site that has lots of posts and related posts active.
* When viewing a single post, add the following query string to the URL: `?relatedposts=1&relatedposts_exclude%5B0%5D=exp&relatedposts_exclude%5B1%5D=%3D1`
* The page should load with no issues, and display related posts data.
