### PR TITLE
Custom CSS: Adding a check for WoA sites to prevent duplicate menu items

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-customcss-menu-woa
+++ b/projects/plugins/jetpack/changelog/fix-customcss-menu-woa
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Custom CSS: Add WoA check to prevent duplicate menu item on plan-less sites.

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -8,6 +8,7 @@
 use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
 use Automattic\Jetpack\Partner_Coupon as Jetpack_Partner_Coupon;
 use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Status\Host;
 
 /**
  * Build the Jetpack admin menu as a whole.
@@ -131,7 +132,7 @@ class Jetpack_Admin {
 
 		// If the site is a WoA site and the custom-css feature is not available, return.
 		// See https://github.com/Automattic/jetpack/pull/19965 for more on how this menu item is dealt with on WoA sites.
-		if ( jetpack_is_atomic_site() && ! ( in_array( 'custom-css', Jetpack::get_available_modules(), true ) ) ) {
+		if ( ( new Host() )->is_woa_site() && ! ( in_array( 'custom-css', Jetpack::get_available_modules(), true ) ) ) {
 			return;
 		} elseif ( class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'custom-css' ) ) { // If the Custom CSS module is enabled, add the Additional CSS menu item and link to the Customizer.
 			// Add in our legacy page to support old bookmarks and such.

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -8,6 +8,7 @@
 use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
 use Automattic\Jetpack\Partner_Coupon as Jetpack_Partner_Coupon;
 use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Status\Host;
 
 /**
  * Build the Jetpack admin menu as a whole.
@@ -129,8 +130,11 @@ class Jetpack_Admin {
 	 */
 	public static function additional_css_menu() {
 
-		// If the Custom CSS module is enabled, add the Additional CSS menu item and link to the Customizer.
-		if ( class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'custom-css' ) ) {
+		// If the site is a WoA site and the custom-css feature is not enabled, return.
+		// See https://github.com/Automattic/jetpack/pull/19965 for more on how this menu item is dealt with on WoA sites.
+		if ( ( new Host() )->is_woa_site() && ! Jetpack::is_module_active( 'custom-css' ) ) {
+			return;
+		} elseif ( class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'custom-css' ) ) { // If the Custom CSS module is enabled, add the Additional CSS menu item and link to the Customizer.
 			// Add in our legacy page to support old bookmarks and such.
 			add_submenu_page( null, __( 'CSS', 'jetpack' ), __( 'Additional CSS', 'jetpack' ), 'edit_theme_options', 'editcss', array( __CLASS__, 'customizer_redirect' ) );
 

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -8,7 +8,6 @@
 use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
 use Automattic\Jetpack\Partner_Coupon as Jetpack_Partner_Coupon;
 use Automattic\Jetpack\Status;
-use Automattic\Jetpack\Status\Host;
 
 /**
  * Build the Jetpack admin menu as a whole.
@@ -130,9 +129,9 @@ class Jetpack_Admin {
 	 */
 	public static function additional_css_menu() {
 
-		// If the site is a WoA site and the custom-css feature is not enabled, return.
+		// If the site is a WoA site and the custom-css feature is not available, return.
 		// See https://github.com/Automattic/jetpack/pull/19965 for more on how this menu item is dealt with on WoA sites.
-		if ( ( new Host() )->is_woa_site() && ! Jetpack::is_module_active( 'custom-css' ) ) {
+		if ( jetpack_is_atomic_site() && ! ( in_array( 'custom-css', Jetpack::get_available_modules(), true ) ) ) {
 			return;
 		} elseif ( class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'custom-css' ) ) { // If the Custom CSS module is enabled, add the Additional CSS menu item and link to the Customizer.
 			// Add in our legacy page to support old bookmarks and such.


### PR DESCRIPTION
Fixes the issue [mentioned here](https://github.com/Automattic/jetpack/pull/23670#issuecomment-1145133771).

#### Changes proposed in this Pull Request:

* More specifically, this PR introduces a check to see if a site is WoA - if it is and doesn't have the Custom CSS feature available, the Additional CSS menu item isn't added (not via Jetpack anyway - [this is handled independently](https://github.com/Automattic/jetpack/pull/19965)). 
* This fixes a regression introduced in [this PR](https://github.com/Automattic/jetpack/pull/23670), affecting WoA sites without a plan, where duplicate Additional CSS menu items appeared.

#### Jetpack product discussion

See link above.

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* To test, Create a WoA ephemeral site (internal testing only).
* First test by removing the plan that enabled the site to be WoA - you should notice duplicate Additional CSS menu items under 'Appearance'.
* I tested this by editing the `additional_css_menu` function in class.jetpack-admin.php directly for the site.
* Other ways to test this branch could include following steps similar to [what was mentioned here](https://github.com/Automattic/jetpack/pull/19965).
* Testing scenarios include enabling the Custom CSS feature while there is a Pro plan, then removing the plan. Then, re-add a Pro plan and disable the feature, and remove the plan again - testing the menu item each time. What you should expect to see is the following:
  * Plan: Additional CSS menu item both if the Custom CSS feature is enabled, and not.
    * When the Custom CSS feature is not enabled in this case, the menu item should lead to the Jetpack > Settings > Writing dashboard, highlighting the Custom CSS card. This behaviour should be the same on self-hosted Jetpack sites.
  * No plan: Additional CSS menu (leads to a Customizer nudge to purchase a Pro plan). This exists both if the Custom CSS feature was enabled before removing plan, and if it was disabled.

#### Additional questions / issues

* Prior to this feature being added, clicking on the 'Additional CSS' menu item resulted in a few PHP warnings in the debug log. Some of those (not all) still exist - in particular three similar to this - `PHP Warning:  Attempt to read property "title" on null in /var/www/html/wp-includes/class-wp-customize-nav-menus.php on line 523`. This is related to passing 'null' in `add_submenu_page` (which itself is in `additional_css_menu` in `class.jetpack-admin.php`, twice), and that only exists for legacy support. Do we really need this legacy fallback at this stage - or are those PHP warnings fine to leave?