### PR TITLE
WAF: Change the run.php hook to plugins_loaded

### DIFF
--- a/projects/packages/waf/actions.php
+++ b/projects/packages/waf/actions.php
@@ -61,7 +61,7 @@ if ( Waf_Runner::is_enabled() ) {
  * @return void
  */
 add_action(
-	'plugin_loaded',
+	'plugins_loaded',
 	function () {
 		require_once __DIR__ . '/run.php';
 	}

--- a/projects/packages/waf/changelog/fix-waf-run-hook
+++ b/projects/packages/waf/changelog/fix-waf-run-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+fixed the hook we're using for run.php


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This changes the hook we're using for the WAF run.php file to plugins_loaded. This ensures we're not going to run before Jetpack is loaded which is needed to use the Modules class to verify if the package is enabled or not.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch on a test site with a scan subscription.
* Activate the WAF module.
* Verify that the rules are being executed.
