### PR TITLE
cli: Remove js-test-runner from js-package skeleton

### DIFF
--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -439,21 +439,20 @@ function createPackageJson( packageJson, answers ) {
 			'./action-types': './src/state/action-types',
 		};
 		packageJson.scripts = {
-			test:
-				"NODE_ENV=test NODE_PATH=tests:. js-test-runner --jsdom --initfile=test-main.jsx 'glob:./!(node_modules)/**/test/*.@(jsx|js)'",
+			test: 'jest tests',
+			'test-coverage':
+				'jest tests --coverage --collectCoverageFrom=\'src/**/*.js\' --coverageDirectory="$COVERAGE_DIR" --coverageReporters=clover',
 		};
-		packageJson.devDependencies = { 'jetpack-js-test-runner': 'workspace:*' };
 
-		// Since `createComposerJson()` adds a use of `nyc`, we need to depend on it here too.
-		// Look for which version is currently in use.
+		// Extract the version of jest currently in use for the dependency.
 		const yamlFile = yaml.load(
 			fs.readFileSync( new URL( '../../../pnpm-lock.yaml', import.meta.url ), 'utf8' )
 		);
-		const nycVersion = Object.keys( yamlFile.packages ).reduce( ( value, cur ) => {
-			const ver = cur.match( /^\/nyc\/([^_]+)/ )?.[ 1 ];
+		const jestVersion = Object.keys( yamlFile.packages ).reduce( ( value, cur ) => {
+			const ver = cur.match( /^\/jest\/([^_]+)/ )?.[ 1 ];
 			return ! value || ( ver && semver.gt( ver, value ) ) ? ver : value;
 		}, null );
-		packageJson.devDependencies.nyc = nycVersion || '*';
+		packageJson.devDependencies.jest = jestVersion || '*';
 	}
 }
 
@@ -518,7 +517,7 @@ async function createComposerJson( composerJson, answers ) {
 		case 'js-package':
 			composerJson.scripts = {
 				'test-js': [ 'pnpm run test' ],
-				'test-coverage': [ 'pnpm nyc --report-dir="$COVERAGE_DIR" pnpm run test' ],
+				'test-coverage': [ 'pnpm run test-coverage' ],
 			};
 	}
 }

--- a/tools/cli/skeletons/js-packages/.nycrc
+++ b/tools/cli/skeletons/js-packages/.nycrc
@@ -1,5 +1,0 @@
-{
-	"extensions": [".js", ".jsx"],
-	"exclude": "**/test/*.jsx",
-	"reporter": "clover"
-}

--- a/tools/cli/skeletons/js-packages/src/index.js
+++ b/tools/cli/skeletons/js-packages/src/index.js
@@ -1,0 +1,2 @@
+// Put your code in this `src/` folder!
+// Feel free to delete or rename this file.

--- a/tools/cli/skeletons/js-packages/test-main.jsx
+++ b/tools/cli/skeletons/js-packages/test-main.jsx
@@ -1,4 +1,0 @@
-import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
-import Enzyme from 'enzyme';
-
-Enzyme.configure( { adapter: new Adapter() } );

--- a/tools/cli/skeletons/js-packages/tests/.eslintrc.cjs
+++ b/tools/cli/skeletons/js-packages/tests/.eslintrc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
+};

--- a/tools/cli/skeletons/js-packages/tests/index.test.js
+++ b/tools/cli/skeletons/js-packages/tests/index.test.js
@@ -1,0 +1,8 @@
+// We recommend using `jest` for testing. If you're testing React code, we recommend `@testing-library/react` and related packages.
+// Please match the versions used elsewhere in the monorepo.
+//
+// Please don't add new uses of `mocha`, `chai`, `sinon`, `enzyme`, `js-test-runner`, and so on. We're trying to standardize on one testing framework.
+//
+// The default setup is to have files named like "name.test.js" (or .jsx, .ts, or .tsx) in this `tests/` directory.
+// But you could instead put them in `src/`, or put files like "name.js" (or .jsx, .ts, or .tsx) in `__tests__` directories somewhere.
+// In those cases you might want to adapt the eslintrc to apply the "jest" preset to those files accordingly.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Following Calypso's lead, let's start standardizing on `jest` and
`@testing-library` for JS testing. And a good way to start that is to
update the `jetpack generate` CLI command to stop including
`js-test-runner` in the generated skeleton.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p4TIVU-a8r-p2#comment-11500

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try generating a js-package and see that it looks right.