### PR TITLE
git: pre-commit hook shouldn't check files twice

### DIFF
--- a/tools/js-tools/git-hooks/pre-commit-hook.js
+++ b/tools/js-tools/git-hooks/pre-commit-hook.js
@@ -149,6 +149,7 @@ const dirtyFiles = parseGitDiffToPathArray( [ '--diff-filter=ACMR' ] ).filter( B
 const jsFiles = gitFiles.filter( filterJsFiles );
 const phpFiles = gitFiles.filter( name => name.endsWith( '.php' ) );
 const phpcsFiles = phpFiles.filter( phpcsFilesToFilter );
+const phpcsChangedFiles = phpFiles.filter( file => ! phpcsFilesToFilter( file ) );
 
 /**
  * Filters out unstaged changes so we do not add an entire file without intention.
@@ -281,9 +282,15 @@ function runEslintFix( toFixFiles ) {
 		return;
 	}
 
-	spawnSync( 'pnpm', [ 'run', 'lint-file', '--', '--fix', ...toFixFiles ], {
-		stdio: 'inherit',
-	} );
+	const maxWarnings = isJetpackDraftMode() ? 100 : 0;
+
+	const eslintResult = spawnSync(
+		'pnpm',
+		[ 'run', 'lint-file', '--', `--max-warnings=${ maxWarnings }`, '--fix', ...toFixFiles ],
+		{
+			stdio: 'inherit',
+		}
+	);
 
 	// Unlike phpcbf, eslint seems to give no indication as to whether it did anything.
 	// It doesn't even print a summary of what it fixed. Sigh.
@@ -295,6 +302,12 @@ function runEslintFix( toFixFiles ) {
 		runPrettier( newDirty );
 		spawnSync( 'git', [ 'add', '-v', '--', ...newDirty ], { stdio: 'inherit' } );
 		console.log( chalk.yellow( 'JS issues detected and automatically fixed via eslint.' ) );
+	}
+
+	if ( eslintResult && eslintResult.status ) {
+		// If we get here, required files have failed eslint. Let's return early and avoid the duplicate information.
+		checkFailed();
+		exit( exitCode );
 	}
 }
 
@@ -471,6 +484,10 @@ dirtyFiles.forEach( file =>
 const jsOnlyFiles = jsFiles.filter( file => ! file.endsWith( '.json' ) );
 const eslintFiles = jsOnlyFiles.filter( filterEslintFiles );
 const eslintFixFiles = eslintFiles.filter( file => checkFileAgainstDirtyList( file, dirtyFiles ) );
+const eslintNoFixFiles = eslintFiles.filter(
+	file => ! checkFileAgainstDirtyList( file, dirtyFiles )
+);
+const eslintChangedFiles = jsOnlyFiles.filter( file => ! filterEslintFiles( file ) );
 
 const toPrettify = jsFiles.filter( file => checkFileAgainstDirtyList( file, dirtyFiles ) );
 toPrettify.forEach( file => console.log( `Prettier formatting staged file: ${ file }` ) );
@@ -483,10 +500,10 @@ if ( toPrettify.length ) {
 // linting should happen after formatting
 if ( eslintFiles.length > 0 ) {
 	runEslintFix( eslintFixFiles );
-	runEslint( eslintFiles );
+	runEslint( eslintNoFixFiles );
 }
-if ( jsOnlyFiles.length > 0 ) {
-	runEslintChanged( jsOnlyFiles );
+if ( eslintChangedFiles.length > 0 ) {
+	runEslintChanged( eslintChangedFiles );
 }
 
 // Start PHP work.
@@ -509,8 +526,8 @@ if ( phpcsFiles.length > 0 ) {
 	runPHPCbf();
 	runPHPCS();
 }
-if ( phpFiles.length > 0 ) {
-	runPHPCSChanged( phpFiles );
+if ( phpcsChangedFiles.length > 0 ) {
+	runPHPCSChanged( phpcsChangedFiles );
 }
 
 exit( exitCode );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We had been running non-excluded files through both `phpcs`/`eslint` and
`phpcs-changed`/`eslint-changed`. If we do the former there's no need
for the latter.

For that matter, `eslint --fix` will report any remaining problems and
exit with a proper code, so there's no need to run a file through both
`eslint --fix` and `eslint`. Unfortunately `phpcbf` isn't so helpful, so
we still have to run through `phpcs` after that one.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

PHP files:
* Make a change to a non-excluded PHP file. Commit. Output should indicate it was passed to phpcs, but phpcs-changed was not run.
  * i.e. you should see `> phpcs -p -s '--runtime-set' 'ignore_warnings_on_exit' '1' '<file>'` in the output, but not `> phpcs-changed -s --git '<file>'`
* Make a change to an excluded PHP file. Commit. Output should indicate it was passed to phpcs-changed, phpcs was not run.
  * Note that PHPCompatibility will still be run, i.e. `> phpcs -p -s '--standard=./.phpcs.config.xml,PHPCompatibilityWP' ...`. That's expected.
* Make a change to both an excluded and a non-excluded PHP file. Commit. Output should indicate that only the non-excluded file was passed to phpcs, and only the excluded file was passed to phpcs-changed.

JS files:
* Make a change to a non-excluded JS file. Commit. Output should indicate it was passed to eslint, but eslint-changed was not run.
* Make a change to an excluded JS file. Commit. Output should indicate it was passed to eslint-changed, eslint was not run.
* Make a change to both an excluded and a non-excluded JS file. Commit. Output should indicate that only the non-excluded file was passed to eslint, and only the excluded file was passed to eslint-changed.

JS fixes:
* Make a change introducing a fixable problem to a non-excluded JS file. Commit. Output should indicate it was passed to `eslint --fix` not `eslint` without `--fix`.
* Make a change introducing a non-fixable problem to a non-excluded JS file. Commit. Output should indicate it was passed to `eslint --fix` and the commit should be aborted.
* Make a change introducing a fixable problem to a non-excluded JS file. `git add` the file, then make another change, then `git commit`. Output should indicate it was not passed to `eslint --fix`, but `eslint` without `--fix` was run and aborted the commit.
