### PR TITLE
[Boost] External links updated in plugin

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { getRedirectUrl } from '@automattic/jetpack-components';
 	import { __ } from '@wordpress/i18n';
 	import TemplatedString from '../../../elements/TemplatedString.svelte';
 	import {
@@ -12,6 +13,10 @@
 	import CriticalCssMeta from '../elements/CriticalCssMeta.svelte';
 	import Module from '../elements/Module.svelte';
 	import PremiumCTA from '../elements/PremiumCTA.svelte';
+
+	const criticalCssLink = getRedirectUrl( 'jetpack-boost-critical-css' );
+	const deferJsLink = getRedirectUrl( 'jetpack-boost-defer-js' );
+	const lazyLoadlink = getRedirectUrl( 'jetpack-boost-lazy-load' );
 
 	// svelte-ignore unused-export-let - Ignored values supplied by svelte-navigator.
 	export let location, navigate;
@@ -32,7 +37,7 @@
 					`Move important styling information to the start of the page, which helps pages display your content sooner, so your users don’t have to wait for the entire page to load. Commonly referred to as <link>Critical CSS</link>.`,
 					'jetpack-boost'
 				)}
-				vars={externalLinkTemplateVar( 'https://web.dev/extract-critical-css/' )}
+				vars={externalLinkTemplateVar( criticalCssLink )}
 			/>
 		</p>
 
@@ -58,7 +63,7 @@
 					`Move important styling information to the start of the page, which helps pages display your content sooner, so your users don’t have to wait for the entire page to load. Commonly referred to as <link>critical CSS</link> which now generates automatically.`,
 					'jetpack-boost'
 				)}
-				vars={externalLinkTemplateVar( 'https://web.dev/extract-critical-css/' )}
+				vars={externalLinkTemplateVar( criticalCssLink )}
 			/>
 		</p>
 		<div slot="meta" class="jb-feature-toggle__meta">
@@ -76,7 +81,7 @@
 					`Run non-essential JavaScript after the page has loaded so that styles and images can load more quickly. Read more on <link>web.dev</link>.`,
 					'jetpack-boost'
 				)}
-				vars={externalLinkTemplateVar( 'https://web.dev/efficiently-load-third-party-javascript/' )}
+				vars={externalLinkTemplateVar( deferJsLink )}
 			/>
 		</p>
 	</Module>
@@ -89,7 +94,7 @@
 					`Improve page loading speed by only loading images when they are required. Read more on <link>web.dev</link>.`,
 					'jetpack-boost'
 				)}
-				vars={externalLinkTemplateVar( 'https://web.dev/browser-level-image-lazy-loading/' )}
+				vars={externalLinkTemplateVar( lazyLoadlink )}
 			/>
 		</p>
 	</Module>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Tips.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Tips.svelte
@@ -1,7 +1,11 @@
 <script>
+	import { getRedirectUrl } from '@automattic/jetpack-components';
 	import { __ } from '@wordpress/i18n';
 	import TemplatedString from '../../../elements/TemplatedString.svelte';
 	import externalLinkTemplateVar from '../../../utils/external-link-template-var';
+
+	const pingdomLink = getRedirectUrl( 'jetpack-boost-pingdom' );
+	const whySpeedLink = getRedirectUrl( 'jetpack-boost-why-speed' );
 </script>
 
 <div class="jb-section jb-section--alt">
@@ -19,9 +23,7 @@
 								`Pages that take over 3 seconds to load have 4x the bounce rate of pages that load in 2 seconds or less. (source: <link>Pingdom</link>).`,
 								'jetpack-boost'
 							)}
-							vars={externalLinkTemplateVar(
-								'https://royal.pingdom.com/page-load-time-really-affect-bounce-rate/'
-							)}
+							vars={externalLinkTemplateVar( pingdomLink )}
 						/>
 					</div>
 				</div>
@@ -33,7 +35,7 @@
 								`A one-second delay in loading times can reduce conversion rates by 20%. (source: <link>Google</link>).`,
 								'jetpack-boost'
 							)}
-							vars={externalLinkTemplateVar( 'https://web.dev/why-speed-matters/' )}
+							vars={externalLinkTemplateVar( whySpeedLink )}
 						/>
 					</div>
 				</div>

--- a/projects/plugins/boost/changelog/external links through redirect service
+++ b/projects/plugins/boost/changelog/external links through redirect service
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated external links in the plugin

--- a/projects/plugins/boost/readme.txt
+++ b/projects/plugins/boost/readme.txt
@@ -39,15 +39,15 @@ Currently the plugin has 3 performance modules available:
 
 1. *Optimize CSS Loading* generates Critical CSS for your homepage, posts and pages. This can allow your content to show up on the screen much faster, particularly for viewers using mobile devices.
 
-   Read more about critical CSS generation at [web.dev](https://web.dev/extract-critical-css/)
+   Read more about critical CSS generation at [web.dev](https://jetpack.com/redirect/?source=jetpack-boost-critical-css)
 
 2. *Defer Non-Essential Javascript* moves some tasks to after the page loads, so that important visual information can be seen sooner and your website loads quicker.
 
-   Read more about deferring javascript at [web.dev](https://web.dev/efficiently-load-third-party-javascript/)
+   Read more about deferring javascript at [web.dev](https://jetpack.com/redirect/?source=jetpack-boost-defer-js)
 
 3. *Lazy Image Loading* only loads the images the user can see. As the user scrolls, images are loaded just before they show up on the page. This simple optimization makes websites faster and saves bandwidth for your host and your customers.
 
-   Read more about lazy image loading at [web.dev](https://web.dev/lazy-loading-images/)
+   Read more about lazy image loading at [web.dev](https://jetpack.com/redirect/?source=jetpack-boost-lazy-load)
 
  Google PageSpeed API is used to measure the performance score of a site. It's important to look at the Page Speed score because Core Web Vitals are going to be used as a ranking factor in search engines which means improving your SERP listing and increase your website visitors.
 
@@ -93,7 +93,7 @@ The “Optimize CSS Loading” feature identifies the most important CSS rules y
 
 Web Vitals are the measurements that Google uses to better understand the user experience on a website. By improving Web Vitals scores you're also improving the user experience on your site.
 
-You can read more about Web Vitals on [web.dev](https://web.dev/vitals/)
+You can read more about Web Vitals on [web.dev](https://jetpack.com/redirect/?source=jetpack-boost-vitals)
 
 = How does Jetpack Boost plugin improve Core Web Vitals? =
 
@@ -119,10 +119,10 @@ Jetpack Boost includes a tool for measuring your site’s Speed Score - we encou
 
 Every site is different and so performance benefits for each module may vary from site to site. That's why we recommend that you measure the performance improvements on your site by enabling the performance modules one by one. There are many tools out there that you can use for free to measure performance improvements:
 
-* [WebPageTest.org](https://www.webpagetest.org/easy)
-* [web.dev/measure](https://web.dev/measure/)
-* [PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/)
-* [GTMetrix](https://gtmetrix.com/)
+* [WebPageTest.org](https://jetpack.com/redirect/?source=jetpack-boost-webpagetest)
+* [web.dev/measure](https://jetpack.com/redirect/?source=jetpack-boost-measure)
+* [PageSpeed Insights](https://jetpack.com/redirect/?source=jetpack-boost-pagespeed)
+* [GTMetrix](https://jetpack.com/redirect/?source=jetpack-boost-gtmetrix)
 
 Google PageSpeed measurements are built-in the Jetpack Boost dashboard.
 


### PR DESCRIPTION
### Description

This PR updates the external links to run through the redirect system as per the FG `/jetpack-redirects/`. The `readme.txt` links have also been updated with hard coded links through the redirect system.

### Testing instructions
- Go to `/wp-admin/admin.php?page=jetpack-boost`
- Click the links in the modules (3 links) and in the tips sections (2 links)
- These will route via the Jetpack redirect system to the same destination as before
- The `readme.txt` links need to be checked by copying them into a browser (until the plugin is deployed) 
- I also tested that the changes didn't break the toggles or speed test
- I also checked that the click event was recorded on logstash 

#### Does this pull request change what data or activity we track or use?
Since the links are now going through the Jetpack redirect service we'll be able to see the number of times the link is clicked as well as be able to change where the destination URL is if we ever need to.