### PR TITLE
WAF: Add support links and more information

### DIFF
--- a/projects/plugins/jetpack/_inc/client/security/style.scss
+++ b/projects/plugins/jetpack/_inc/client/security/style.scss
@@ -5,11 +5,17 @@
     &__badge {
         background-color: $green-primary;
         border-radius: 2px;
-        color: $white;
         font-size: 11px;
         line-height: 12px;
         margin-left: 9px;
         padding: 4px 5px;
+
+        &,
+        &:active,
+        &:focus,
+        &:hover {
+            color: $white;
+        }
     }
 
 }

--- a/projects/plugins/jetpack/_inc/client/security/waf.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/waf.jsx
@@ -257,12 +257,11 @@ export const Waf = class extends Component {
 					disableInOfflineMode
 					module={ this.props.getModule( 'waf' ) }
 					support={ {
-						text:
-							__(
-								'The Jetpack Firewall is a web application firewall designed to protect your WordPress site from malicious requests.',
-								'jetpack'
-							) || 'yeet',
-						link: getRedirectUrl( 'jetpack-support-waf' ) || 'yeet',
+						text: __(
+							'The Jetpack Firewall is a web application firewall designed to protect your WordPress site from malicious requests.',
+							'jetpack'
+						),
+						link: getRedirectUrl( 'jetpack-support-waf' ),
 					} }
 				>
 					<ModuleToggle

--- a/projects/plugins/jetpack/_inc/client/security/waf.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/waf.jsx
@@ -81,9 +81,14 @@ export const Waf = class extends Component {
 		const moduleHeader = (
 			<div className="waf__header">
 				<span>{ _x( 'Firewall', 'Settings header', 'jetpack' ) }</span>
-				<span className="waf__header__badge">
+				<a
+					href={ getRedirectUrl( 'jetpack-support-waf' ) }
+					target="_blank"
+					rel="noopener noreferrer"
+					className="waf__header__badge"
+				>
 					{ _x( 'Beta', 'Settings header badge', 'jetpack' ) }
-				</span>
+				</a>
 			</div>
 		);
 

--- a/projects/plugins/jetpack/_inc/client/security/waf.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/waf.jsx
@@ -248,7 +248,18 @@ export const Waf = class extends Component {
 				] ) }
 			>
 				<QueryWafSettings />
-				<SettingsGroup disableInOfflineMode module={ this.props.getModule( 'waf' ) }>
+				<SettingsGroup
+					disableInOfflineMode
+					module={ this.props.getModule( 'waf' ) }
+					support={ {
+						text:
+							__(
+								'The Jetpack Firewall is a web application firewall designed to protect your WordPress site from malicious requests.',
+								'jetpack'
+							) || 'yeet',
+						link: getRedirectUrl( 'jetpack-support-waf' ) || 'yeet',
+					} }
+				>
 					<ModuleToggle
 						slug="waf"
 						disabled={ unavailableInOfflineMode }

--- a/projects/plugins/jetpack/_inc/client/security/waf.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/waf.jsx
@@ -257,11 +257,8 @@ export const Waf = class extends Component {
 					disableInOfflineMode
 					module={ this.props.getModule( 'waf' ) }
 					support={ {
-						text: __(
-							'The Jetpack Firewall is a web application firewall designed to protect your WordPress site from malicious requests.',
-							'jetpack'
-						),
-						link: getRedirectUrl( 'jetpack-support-waf' ),
+						text: this.props.getModule( 'waf' ).long_description,
+						link: this.props.getModule( 'waf' ).learn_more_button,
 					} }
 				>
 					<ModuleToggle

--- a/projects/plugins/jetpack/changelog/add-support-links
+++ b/projects/plugins/jetpack/changelog/add-support-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add links to waf support documentation.

--- a/projects/plugins/jetpack/modules/module-info.php
+++ b/projects/plugins/jetpack/modules/module-info.php
@@ -889,3 +889,19 @@ function jetpack_more_info_google_fonts() {
 	esc_html_e( 'A selection of Google fonts for block enabled themes.  This feature is still being developed.', 'jetpack' );
 }
 add_action( 'jetpack_module_more_info_google-fonts', 'jetpack_more_info_google_fonts' );
+
+/**
+ * WAF support link.
+ */
+function jetpack_waf_more_link() {
+	echo esc_url( Redirect::get_url( 'jetpack-support-waf' ) );
+}
+add_action( 'jetpack_learn_more_button_waf', 'jetpack_waf_more_link' );
+
+/**
+ * WAF description.
+ */
+function jetpack_more_info_waf() {
+	esc_html_e( 'The Jetpack Firewall is a web application firewall designed to protect your WordPress site from malicious requests.', 'jetpack' );
+}
+add_action( 'jetpack_module_more_info_waf', 'jetpack_more_info_waf' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds links to the [Jetpack Firewall support page](https://jetpack.com/support/jetpack-firewall/) to the WAF settings group. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds the following support information to the settings group, with a link to the support page: "The Jetpack Firewall is a web application firewall designed to protect your WordPress site from malicious requests.
* Links the "Beta" badge to the support page.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

1201069996155217-as-1202326318206132/f

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `/wp-admin/admin.php?page=jetpack#/settings`
* Validate the Firewall's beta badge links to the support page.
* Validate the Firewall's settings group displays the additional information, and links to the support page.

#### Screenshots:

Existing additional info pattern used by backup:

<img width="1037" alt="Screen Shot 2022-06-04 at 9 33 54 AM" src="https://user-images.githubusercontent.com/10933065/172013363-80618a22-c29a-4d33-bcd9-aa41b983e583.png">

PR adds the same pattern to firewall:

<img width="1022" alt="Screen Shot 2022-06-04 at 9 35 12 AM" src="https://user-images.githubusercontent.com/10933065/172013387-fb1d1b37-62d0-4d90-a1de-37665d8ac625.png">