### PR TITLE
WAF: Update messaging for sites without latest rules access

### DIFF
--- a/projects/plugins/jetpack/_inc/client/security/style.scss
+++ b/projects/plugins/jetpack/_inc/client/security/style.scss
@@ -46,6 +46,11 @@
         margin-left: 8px;
     }
 
+    &__upgrade-popover {
+        vertical-align: middle;
+        margin-left: 8px;
+    }
+
 }
 
 .waf__enhanced-protection {

--- a/projects/plugins/jetpack/_inc/client/security/waf.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/waf.jsx
@@ -229,7 +229,21 @@ export const Waf = class extends Component {
 		const upgradeBanner = (
 			<JetpackBanner
 				callToAction={ __( 'Upgrade', 'jetpack' ) }
-				title={ __( 'Upgrade your protection for latest rules access', 'jetpack' ) }
+				title={
+					<>
+						{ __( 'Your site is not receiving the latest updates to Firewall rules', 'jetpack' ) }
+						<InfoPopover
+							position="right"
+							screenReaderText={ __( 'Learn more', 'jetpack' ) }
+							className="waf__settings__upgrade-popover"
+						>
+							{ __(
+								'Upgrade your protection to keep your site secure from the latest malicious requests with up-to-date firewall rules.',
+								'jetpack'
+							) }
+						</InfoPopover>
+					</>
+				}
 				eventFeature="scan"
 				plan={ getJetpackProductUpsellByFeature( FEATURE_SECURITY_SCANNING_JETPACK ) }
 				feature="jetpack_scan"

--- a/projects/plugins/jetpack/changelog/update-waf-upgrade-messaging
+++ b/projects/plugins/jetpack/changelog/update-waf-upgrade-messaging
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Update messaging around sites without latest firewall rules access.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR updates the description shown to users who do not have an active plan that provides access to the latest Firewall rules, in an attempt to better inform users about their access to firewall rules and the value of upgrading their Jetpack plan to include access to said rules.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates wording of notice to users without a plan that includes access to latest firewall rules.
* Adds an `<InfoNotice />` with additional information firewall rules.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pbuNQi-33j-p2

1201069996155217-as-1202326318206132/f

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `/wp-admin/admin.php?page=jetpack#/settings` on a free Jetpack site
* Validate that the rules notice is displayed per the screenshot below:

<img width="1017" alt="Screen Shot 2022-06-04 at 12 38 19 PM" src="https://user-images.githubusercontent.com/10933065/172021195-432ae678-7dbd-4462-985e-b064842f62b6.png">

