### PR TITLE
jetpack: Clean up some JS tests

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/jetpack-product-card/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-product-card/test/component.js
@@ -4,7 +4,7 @@ import { getCurrencyObject } from '@automattic/format-currency';
 
 import JetpackProductCard from '../index';
 import analytics from 'lib/analytics';
-import { fireEvent, render, screen, getNodeText } from 'test/test-utils';
+import { fireEvent, render, screen, getAllByText, getNodeText } from 'test/test-utils';
 import sinon from "sinon";
 
 describe( 'Jetpack Product Card', () => {
@@ -40,10 +40,10 @@ describe( 'Jetpack Product Card', () => {
 		
 		const priceObject = getCurrencyObject( mockAttributes.price, mockAttributes.currencyCode );
 
-		expect( container.getAllByText( priceObject.symbol ) ).to.exist;
-		expect( container.getAllByText( priceObject.integer ) ).to.exist;
-		expect( container.getAllByText( priceObject.fraction ) ).to.exist;
-		expect( container.getAllByText( mockAttributes.billingDescription ) ).to.exist;
+		expect( getAllByText( container, priceObject.symbol ) ).to.exist;
+		expect( getAllByText( container, priceObject.integer ) ).to.exist;
+		expect( getAllByText( container, priceObject.fraction ) ).to.exist;
+		expect( getAllByText( container, mockAttributes.billingDescription ) ).to.exist;
 	} );
 
 	it( 'discounted price is shown', () => {
@@ -53,16 +53,16 @@ describe( 'Jetpack Product Card', () => {
 		// Show original price.
 		const originalPriceObject = getCurrencyObject( mockAttributes.price, mockAttributes.currencyCode );
 
-		expect( container.getAllByText( originalPriceObject.symbol ) ).to.exist;
-		expect( container.getAllByText( originalPriceObject.integer ) ).to.exist;
-		expect( container.getAllByText( originalPriceObject.fraction ) ).to.exist;
+		expect( getAllByText( container, originalPriceObject.symbol ) ).to.exist;
+		expect( getAllByText( container, originalPriceObject.integer ) ).to.exist;
+		expect( getAllByText( container, originalPriceObject.fraction ) ).to.exist;
 		
 		// Show discounted price.
 		const discountedPriceObject = getCurrencyObject( discountedPrice, mockAttributes.currencyCode );
 
-		expect( container.getAllByText( discountedPriceObject.symbol ) ).to.exist;
-		expect( container.getAllByText( discountedPriceObject.integer ) ).to.exist;
-		expect( container.getAllByText( discountedPriceObject.fraction ) ).to.exist;
+		expect( getAllByText( container, discountedPriceObject.symbol ) ).to.exist;
+		expect( getAllByText( container, discountedPriceObject.integer ) ).to.exist;
+		expect( getAllByText( container, discountedPriceObject.fraction ) ).to.exist;
 	} );
 
 	it( 'cta is shown', () => {

--- a/projects/plugins/jetpack/_inc/client/performance/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/performance/test/component.js
@@ -5,7 +5,7 @@ import Search  from '../search';
 import { buildInitialState } from './fixtures';
 import { render, screen, within } from 'test/test-utils';
 
-describe.only( 'Performance tab', () => {
+describe( 'Performance tab', () => {
 	it( "shows Jetpack Search Widget button if theme supports it", () => {
 		render( <Search />, {
 			initialState: buildInitialState( { themeSupportsWidgets: true } ),

--- a/projects/plugins/jetpack/_inc/client/product-descriptions/product-description/test/fixtures.js
+++ b/projects/plugins/jetpack/_inc/client/product-descriptions/product-description/test/fixtures.js
@@ -131,6 +131,7 @@ export function buildInitialState() {
 			settings: {
 				items: [],
 			},
+			introOffers: {},
 		},
 	};
 }

--- a/projects/plugins/jetpack/changelog/fix-some-jetpack-js-tests
+++ b/projects/plugins/jetpack/changelog/fix-some-jetpack-js-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix some tests. No change to the plugin.
+
+

--- a/projects/plugins/jetpack/extensions/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/.eslintrc.js
@@ -44,4 +44,10 @@ module.exports = {
 			},
 		],
 	},
+	overrides: [
+		{
+			files: [ '**/test/*.[jt]s?(x)' ],
+			extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
+		},
+	],
 };

--- a/projects/plugins/jetpack/extensions/blocks/calendly/test/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/test/.eslintrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-};

--- a/projects/plugins/jetpack/extensions/blocks/gathering-tweetstorms/test/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/blocks/gathering-tweetstorms/test/.eslintrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-};

--- a/projects/plugins/jetpack/extensions/blocks/google-calendar/test/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/blocks/google-calendar/test/.eslintrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-};

--- a/projects/plugins/jetpack/extensions/blocks/markdown/test/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/blocks/markdown/test/.eslintrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-};

--- a/projects/plugins/jetpack/extensions/blocks/opentable/test/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/blocks/opentable/test/.eslintrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-};

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/test/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/test/.eslintrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-};

--- a/projects/plugins/jetpack/extensions/blocks/rating-star/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/rating-star/test/edit.js
@@ -33,7 +33,7 @@ describe( 'Rating', () => {
 		expect( setRatingMock ).toBeCalledWith( defaultProps.id );
 	} );
 
-	test.only( 'fires keydown event handler callbacks', async () => {
+	test( 'fires keydown event handler callbacks', async () => {
 		const user = userEvent.setup();
 		render( <Rating { ...defaultProps } /> );
 		await user.type( screen.getByRole( 'button' ), '{enter}' );

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/.eslintrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-};

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/test/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/test/.eslintrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-};

--- a/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/test/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/test/.eslintrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-};

--- a/projects/plugins/jetpack/extensions/shared/test/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/shared/test/.eslintrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-};

--- a/projects/plugins/jetpack/extensions/shared/test/block-fixtures.js
+++ b/projects/plugins/jetpack/extensions/shared/test/block-fixtures.js
@@ -11,6 +11,8 @@ import { parse as grammarParse } from '@wordpress/block-serialization-default-pa
 console.warn = jest.fn();
 console.error = jest.fn();
 console.info = jest.fn();
+console.groupCollapsed = jest.fn();
+console.groupEnd = jest.fn();
 /* eslint-enable no-console */
 
 let FIXTURES_DIR;
@@ -86,6 +88,8 @@ export default function runBlockFixtureTests( blockName, blocks, fixturesPath ) 
 					console.warn.mockReset();
 					console.error.mockReset();
 					console.info.mockReset();
+					console.groupCollapsed.mockReset();
+					console.groupEnd.mockReset();
 					/* eslint-enable no-console */
 				}
 

--- a/projects/plugins/jetpack/extensions/shared/use-autosave-and-redirect/index.js
+++ b/projects/plugins/jetpack/extensions/shared/use-autosave-and-redirect/index.js
@@ -26,7 +26,7 @@ export default function useAutosaveAndRedirect( redirectUrl, onRedirect = noop )
 	const isPostEditor = Object.keys( currentPost ).length > 0;
 
 	const isWidgetEditor = useSelect( select => {
-		if ( window.wp.customize ) {
+		if ( window.wp?.customize ) {
 			return true;
 		}
 

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -36,7 +36,7 @@
 		"fixtures:test": "jest validate.js",
 		"test-adminpage": "pnpm run test-client && pnpm run test-gui",
 		"test-client": "NODE_ENV=test NODE_PATH=tests:_inc/client js-test-runner glob:_inc/client/state/**/test/*.js",
-		"test-extensions": "jest extensions",
+		"test-extensions": "TZ=UTC jest extensions",
 		"test-gui": "NODE_ENV=test NODE_PATH=tests:_inc/client js-test-runner --jsdom --initfile=_inc/client/test/init.js _inc/client/test/main.js glob:_inc/client/**/test/component.js",
 		"test-lib": "NODE_ENV=test NODE_PATH=tests:_inc/client js-test-runner --jsdom glob:_inc/client/lib/**/test/*.js",
 		"test-modules": "NODE_ENV=test NODE_PATH=tests:_inc/client js-test-runner --jsdom glob:modules/**/test-*.js",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* GUI tests weren't even running since May 18 because #24386 added a
  `describe.only`. Fixing that then necessitated fixing some tests that
  had gotten broken since.
* Remove another `test.only` in `extensions/blocks/rating-star/test/edit.js`.
  At least this one only affected that test instead of everything.
* Set `TZ=UTC` for extension tests, otherwise one fails locally if your
  timezone is different.
* Mock `console.groupCollapsed` and `console.groupEnd` in block tests.
  `@wordpress/blocks` calls those and produces some spurious output.
* Fix a test in `extensions/shared/use-autosave-and-redirect/index.js`
  that was producing a big annoying backtrace (but not failing the
  test).
* Remove redundant `extensions/blocks/**/test/.eslintrc.js` in favor of
  an override in `extensions/.eslintrc.js`.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?
* Check the output for the Jetpack `[test-adminpage]` tests. In the section for "test-gui" (look for [this](https://github.com/Automattic/jetpack/runs/6757715108?check_suite_focus=true#step:9:1572)) it should report 190 passing, not [just 2](https://github.com/Automattic/jetpack/runs/6757715108?check_suite_focus=true#step:9:1593).
* Check the output for the Jetpack `[test-extensions]` tests. Stuff like [this](https://github.com/Automattic/jetpack/runs/6757715108?check_suite_focus=true#step:9:1632) and [this](https://github.com/Automattic/jetpack/runs/6757715108?check_suite_focus=true#step:9:1745) should no longer be present.
* Remove these lines https://github.com/Automattic/jetpack/blob/19992e36463b6b12981ea5857785484b0deca243/projects/plugins/jetpack/.eslintignore#L12-L13 then run `pnpm lint-file projects/plugins/jetpack/extensions`. You should see some "jest/" errors reported in some of the files (along with a ton of prettier errors and such)