### PR TITLE
GitHub Actions: Updating autotagger.yml to act on a push to trunk as well as master

### DIFF
--- a/.github/files/gh-autotagger/workflows/autotagger.yml
+++ b/.github/files/gh-autotagger/workflows/autotagger.yml
@@ -2,7 +2,7 @@ name: Auto-tagger
 
 on:
   push:
-    branches: [ 'master' ]
+    branches: [ 'master', 'trunk' ]
 
 jobs:
   tag:

--- a/.github/files/gh-autotagger/workflows/autotagger.yml
+++ b/.github/files/gh-autotagger/workflows/autotagger.yml
@@ -2,7 +2,9 @@ name: Auto-tagger
 
 on:
   push:
-    branches: [ 'master', 'trunk' ]
+    branches:
+      - master
+      - trunk
 
 jobs:
   tag:


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* In preparation for renaming 'master' to 'trunk' in the Jetpack monorepo and mirror repos, this PR adds a trunk branch to the branches on which the `autotagger.yml` file will check for pushes to. Once merged, this will change the `.github/workflows/autotagger.yml` files in each of the mirror repositories to match.
* This should allow for a seamless change when the 'master' branch is renamed.

#### Jetpack product discussion

p9dueE-59T-p2 

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* No actual testing for this one before merging, other than checking that the 'trunk' addition is added to the `autotagger.yml` file correctly.
* After merging and after the action to push to mirror repos has run, check in the mirror repos to make sure the `autotagger.yml` file has been updated (for example in [jetpack-changelogger](https://github.com/Automattic/jetpack-changelogger/blob/master/.github/workflows/autotagger.yml), and [jetpack-backup](https://github.com/Automattic/jetpack-backup/blob/master/.github/workflows/autotagger.yml) to name two at random).
