### PR TITLE
Fix bug preventing images in payment buttons

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-payment-block-regex
+++ b/projects/plugins/jetpack/changelog/fix-payment-block-regex
@@ -1,0 +1,6 @@
+Significance: patch
+Type: bugfix
+
+Use an ungreedy regex when substituting the payment URL. This fixes a bug
+where the button content could be removed if it included a literal " -
+such as when the button includes an inline image.

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -312,7 +312,7 @@ class Jetpack_Memberships {
 			$content       = str_replace( 'recurring-payments-id', $block_id, $content );
 			$content       = str_replace( 'wp-block-jetpack-recurring-payments', 'wp-block-jetpack-recurring-payments wp-block-button', $content );
 			$subscribe_url = $this->get_subscription_url( $plan_id );
-			return preg_replace( '/(href=".*")/', 'href="' . $subscribe_url . '"', $content );
+			return preg_replace( '/(href=".*")/U', 'href="' . $subscribe_url . '"', $content );
 		}
 
 		return $this->deprecated_render_button_v1( $attributes, $plan_id );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #24662

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->


Inline images didn't work in payment buttons - the image wasn't rendered
at all, and neither was any accompanying text.

This was happening due to a small bug introduced in #23487 where the
regular expression wasn't just replacing the href attribute and the "
surrounding it's values, but all of the content between the " opening
the href value and the last " in the user-supplied content.

This change fixes it by using an ungreedy regex, which should mean just
the href attribute and it's delimiters are matched.

The generated HTML on the front-end should have been 

```
<div class="wp-block-jetpack-recurring-payments wp-block-button">
  <div class="wp-block-jetpack-button wp-block-button" style="">
    <a 
        class="wp-block-button__link has-background has-electric-grass-gradient-background"
        style="" 
        data-id-attr="recurring-payments-138" 
        id="recurring-payments-138" 
        href="http://deansas.example/?p=530&#038;recurring_payments=138" 
        target="_blank" 
        role="button" 
        rel="noopener noreferrer"
    >
        t e
        <img class="wp-image-363" style="width: 150px;" src="http://deansas.example/wp-content/uploads/2022/02/corridor-scaled.jpg" alt="">
    </a>
  </div>
</div>
```

but instead it was

```
<div class="wp-block-jetpack-recurring-payments wp-block-button">
  <div class="wp-block-jetpack-button wp-block-button" style="">
    <a 
        class="wp-block-button__link has-background has-electric-grass-gradient-background" 
        style=""
        data-id-attr="recurring-payments-138" 
        id="recurring-payments-138" 
        href="P4C8E-1M-p2?blog=195073678&plan=138&lang=en_US&pid=530&redirect=http%3A%2F%2Fdeansas.example">
    </a>
  </div>
</div>
```
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a new post
2. Insert a new Payment button block
3. Follow any on-screen prompts to upgrade your WP/JP plan, connect Stripe, etc
4. Add an inline image inside the Payment Button
5. Publish the Post
6. View the post, any content inside the button before and including the image will not appear
7. Apply this patch to your sandbox / local JN site
8. Refresh the post, it should now display as the Gutenberg preview does

Before | After
-------|------
![image](https://user-images.githubusercontent.com/93301/172479812-394f2aa0-9295-4350-aaf0-f5709d205e47.png) | ![image](https://user-images.githubusercontent.com/93301/172479916-b0c84a0c-6e94-41f8-b9bd-b158aa4653e4.png)

