### PR TITLE
Search: fix fill color for gridicons in dark mode in Customberg

### DIFF
--- a/projects/packages/search/changelog/fix-customberg-post-type-icon
+++ b/projects/packages/search/changelog/fix-customberg-post-type-icon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: fix gridicon color in dark mode on Customberg

--- a/projects/packages/search/src/customberg/styles.scss
+++ b/projects/packages/search/src/customberg/styles.scss
@@ -20,4 +20,9 @@ html.wp-toolbar {
 	display: none;
 }
 
+// Fix fill color for gridicons in dark mode
+.jp-search-configure-app-wrapper .jetpack-instant-search__overlay--dark .gridicon {
+	fill: #fff;
+}
+
 @include wordpress-admin-schemes();

--- a/projects/packages/search/src/customberg/styles.scss
+++ b/projects/packages/search/src/customberg/styles.scss
@@ -22,7 +22,7 @@ html.wp-toolbar {
 
 // Fix fill color for gridicons in dark mode
 .jp-search-configure-app-wrapper .jetpack-instant-search__overlay--dark .gridicon {
-	fill: #fff;
+	fill: $white;
 }
 
 @include wordpress-admin-schemes();


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
In Customberg, when dark mode is activated for the minimal result type, the fill colour is wrong (grey). On the front end of the site, it is correct (white).

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* On a site with Instant Search, go to `/wp-admin/admin.php?page=jetpack-search-configure`.
* Set the result format to 'Minimal' and turn on dark mode in the settings. 
* Create a new page on your test site.
* Search for the new page in Customberg.
* Ensure that the icon for the page is white, not dark grey.

<img width="223" alt="Screen Shot 2022-06-08 at 16 39 39" src="https://user-images.githubusercontent.com/17325/172532965-c577f11b-13ed-4196-9065-51c0aced206e.png">

