### PR TITLE
Remove claim of support for Node 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"jetpack-js-tools": "workspace:*"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/github-actions/repo-gardening/changelog/remove-claim-of-support-for-node-14
+++ b/projects/github-actions/repo-gardening/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/github-actions/repo-gardening/package.json
+++ b/projects/github-actions/repo-gardening/package.json
@@ -27,7 +27,7 @@
 		"build": "ncc build src/index.js -o dist --source-map --license licenses.txt"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/github-actions/required-review/changelog/remove-claim-of-support-for-node-14
+++ b/projects/github-actions/required-review/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/github-actions/required-review/package.json
+++ b/projects/github-actions/required-review/package.json
@@ -19,7 +19,7 @@
 		"build": "ncc build src/main.js -o dist --source-map --license licenses.txt"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/js-packages/analytics/changelog/remove-claim-of-support-for-node-14
+++ b/projects/js-packages/analytics/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/js-packages/analytics/package.json
+++ b/projects/js-packages/analytics/package.json
@@ -20,7 +20,7 @@
 		"test": "NODE_ENV=test NODE_PATH=tests:. js-test-runner --jsdom 'glob:./test/*.@(jsx|js)'"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/js-packages/api/changelog/remove-claim-of-support-for-node-14
+++ b/projects/js-packages/api/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/js-packages/api/package.json
+++ b/projects/js-packages/api/package.json
@@ -23,7 +23,7 @@
 		"test": "NODE_ENV=test NODE_PATH=tests:. js-test-runner --jsdom --initfile=test-main.jsx 'glob:./test/*.jsx'"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/js-packages/babel-plugin-replace-textdomain/changelog/remove-claim-of-support-for-node-14
+++ b/projects/js-packages/babel-plugin-replace-textdomain/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/js-packages/babel-plugin-replace-textdomain/package.json
+++ b/projects/js-packages/babel-plugin-replace-textdomain/package.json
@@ -26,7 +26,7 @@
 		"jest": "28.1.0"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	},

--- a/projects/js-packages/base-styles/changelog/remove-claim-of-support-for-node-14
+++ b/projects/js-packages/base-styles/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/js-packages/base-styles/package.json
+++ b/projects/js-packages/base-styles/package.json
@@ -23,7 +23,7 @@
 		"@wordpress/base-styles": "4.5.0"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/js-packages/components/changelog/remove-claim-of-support-for-node-14
+++ b/projects/js-packages/components/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -57,7 +57,7 @@
 		"test": "NODE_ENV=test NODE_PATH=tests:. js-test-runner --jsdom --initfile=test-main.jsx 'glob:./!(node_modules)/**/test/*.[jt]sx'"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/js-packages/config/changelog/remove-claim-of-support-for-node-14
+++ b/projects/js-packages/config/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/js-packages/config/package.json
+++ b/projects/js-packages/config/package.json
@@ -22,7 +22,7 @@
 		"nyc": "15.1.0"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	},

--- a/projects/js-packages/connection/changelog/remove-claim-of-support-for-node-14
+++ b/projects/js-packages/connection/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -45,7 +45,7 @@
 		"test": "NODE_ENV=test NODE_PATH=tests:. js-test-runner --jsdom --initfile=test-main.jsx 'glob:./!(node_modules)/**/test/*.jsx'"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/js-packages/eslint-changed/changelog/remove-claim-of-support-for-node-14
+++ b/projects/js-packages/eslint-changed/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/js-packages/eslint-changed/package.json
+++ b/projects/js-packages/eslint-changed/package.json
@@ -33,7 +33,7 @@
 		"eslint": ">=7.0.0"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/js-packages/eslint-config-target-es/changelog/remove-claim-of-support-for-node-14
+++ b/projects/js-packages/eslint-config-target-es/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/js-packages/eslint-config-target-es/package.json
+++ b/projects/js-packages/eslint-config-target-es/package.json
@@ -34,7 +34,7 @@
 		"eslint-plugin-es": "^4.1.0"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	},

--- a/projects/js-packages/i18n-check-webpack-plugin/changelog/remove-claim-of-support-for-node-14
+++ b/projects/js-packages/i18n-check-webpack-plugin/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/js-packages/i18n-check-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-check-webpack-plugin/package.json
@@ -31,7 +31,7 @@
 		"webpack": "^5.0.0"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	},

--- a/projects/js-packages/i18n-loader-webpack-plugin/changelog/remove-claim-of-support-for-node-14
+++ b/projects/js-packages/i18n-loader-webpack-plugin/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/js-packages/i18n-loader-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/package.json
@@ -31,7 +31,7 @@
 		"webpack": "^5.29.0"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	},

--- a/projects/js-packages/idc/changelog/remove-claim-of-support-for-node-14
+++ b/projects/js-packages/idc/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -43,7 +43,7 @@
 		"test": "NODE_ENV=test NODE_PATH=tests:. js-test-runner --jsdom --initfile=test-main.jsx 'glob:./!(node_modules)/**/test/*.jsx'"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/js-packages/licensing/changelog/remove-claim-of-support-for-node-14
+++ b/projects/js-packages/licensing/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -28,7 +28,7 @@
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	},

--- a/projects/js-packages/partner-coupon/changelog/remove-claim-of-support-for-node-14
+++ b/projects/js-packages/partner-coupon/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -42,7 +42,7 @@
 		"prop-types": "15.7.2"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	},

--- a/projects/js-packages/publicize-components/changelog/remove-claim-of-support-for-node-14
+++ b/projects/js-packages/publicize-components/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -56,7 +56,7 @@
 		"react-dom": "17.0.2"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	},

--- a/projects/js-packages/remove-asset-webpack-plugin/changelog/remove-claim-of-support-for-node-14
+++ b/projects/js-packages/remove-asset-webpack-plugin/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/js-packages/remove-asset-webpack-plugin/package.json
+++ b/projects/js-packages/remove-asset-webpack-plugin/package.json
@@ -29,7 +29,7 @@
 		"webpack": "^5.8.0"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	},

--- a/projects/js-packages/shared-extension-utils/changelog/remove-claim-of-support-for-node-14
+++ b/projects/js-packages/shared-extension-utils/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -31,7 +31,7 @@
 		"react": "17.0.2"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	},

--- a/projects/js-packages/storybook/changelog/remove-claim-of-support-for-node-14
+++ b/projects/js-packages/storybook/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/js-packages/storybook/package.json
+++ b/projects/js-packages/storybook/package.json
@@ -66,7 +66,7 @@
 		"webpack-cli": "4.9.1"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/js-packages/webpack-config/changelog/remove-claim-of-support-for-node-14
+++ b/projects/js-packages/webpack-config/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -68,7 +68,7 @@
 		"./babel/preset": "./src/babel-preset.js"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/packages/admin-ui/changelog/remove-claim-of-support-for-node-14
+++ b/projects/packages/admin-ui/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/packages/admin-ui/package.json
+++ b/projects/packages/admin-ui/package.json
@@ -22,7 +22,7 @@
 	},
 	"devDependencies": {},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/packages/assets/changelog/remove-claim-of-support-for-node-14
+++ b/projects/packages/assets/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/packages/assets/package.json
+++ b/projects/packages/assets/package.json
@@ -20,7 +20,7 @@
 		"webpack-cli": "4.9.1"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/packages/backup/changelog/remove-claim-of-support-for-node-14
+++ b/projects/packages/backup/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/packages/backup/package.json
+++ b/projects/packages/backup/package.json
@@ -51,7 +51,7 @@
 		"webpack-cli": "4.9.1"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/packages/connection-ui/changelog/remove-claim-of-support-for-node-14
+++ b/projects/packages/connection-ui/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/packages/connection-ui/package.json
+++ b/projects/packages/connection-ui/package.json
@@ -42,7 +42,7 @@
 		"webpack-cli": "4.9.1"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/packages/connection/changelog/remove-claim-of-support-for-node-14
+++ b/projects/packages/connection/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/packages/connection/package.json
+++ b/projects/packages/connection/package.json
@@ -30,7 +30,7 @@
 		"webpack-cli": "4.9.1"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/packages/google-fonts-provider/changelog/remove-claim-of-support-for-node-14
+++ b/projects/packages/google-fonts-provider/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/packages/google-fonts-provider/package.json
+++ b/projects/packages/google-fonts-provider/package.json
@@ -23,7 +23,7 @@
 	},
 	"devDependencies": {},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/packages/identity-crisis/changelog/remove-claim-of-support-for-node-14
+++ b/projects/packages/identity-crisis/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -38,7 +38,7 @@
 		"webpack-cli": "4.9.1"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/packages/jitm/changelog/remove-claim-of-support-for-node-14
+++ b/projects/packages/jitm/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/packages/jitm/package.json
+++ b/projects/packages/jitm/package.json
@@ -31,7 +31,7 @@
 		"webpack-cli": "4.9.1"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/packages/lazy-images/changelog/remove-claim-of-support-for-node-14
+++ b/projects/packages/lazy-images/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/packages/lazy-images/package.json
+++ b/projects/packages/lazy-images/package.json
@@ -32,7 +32,7 @@
 		"webpack-cli": "4.9.1"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/packages/my-jetpack/changelog/remove-claim-of-support-for-node-14
+++ b/projects/packages/my-jetpack/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -73,7 +73,7 @@
 		"webpack-cli": "4.9.1"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/packages/plans/changelog/remove-claim-of-support-for-node-14
+++ b/projects/packages/plans/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/packages/plans/package.json
+++ b/projects/packages/plans/package.json
@@ -23,7 +23,7 @@
 	},
 	"devDependencies": {},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/packages/publicize/changelog/remove-claim-of-support-for-node-14
+++ b/projects/packages/publicize/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -23,7 +23,7 @@
 	},
 	"devDependencies": {},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/packages/search/changelog/remove-claim-of-support-for-node-14
+++ b/projects/packages/search/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -33,7 +33,7 @@
 	},
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/search/#readme",
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	},

--- a/projects/packages/wordads/changelog/remove-claim-of-support-for-node-14
+++ b/projects/packages/wordads/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -89,7 +89,7 @@
 		"webpack-cli": "4.9.1"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	},

--- a/projects/plugins/boost/changelog/remove-claim-of-support-for-node-14
+++ b/projects/plugins/boost/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -74,7 +74,7 @@
 	},
 	"homepage": "https://jetpack.com/boost/",
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/plugins/boost/tests/e2e/package.json
+++ b/projects/plugins/boost/tests/e2e/package.json
@@ -36,7 +36,7 @@
 		"jetpack-e2e-commons": "*"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	},

--- a/projects/plugins/jetpack/changelog/remove-claim-of-support-for-node-14
+++ b/projects/plugins/jetpack/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -169,7 +169,7 @@
 		"react-dom": "17.0.2"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/plugins/jetpack/tests/e2e/package.json
+++ b/projects/plugins/jetpack/tests/e2e/package.json
@@ -43,7 +43,7 @@
 		"jetpack-e2e-commons": "*"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	},

--- a/projects/plugins/protect/changelog/remove-claim-of-support-for-node-14
+++ b/projects/plugins/protect/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/plugins/protect/package.json
+++ b/projects/plugins/protect/package.json
@@ -56,7 +56,7 @@
 		"webpack-cli": "4.9.1"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/plugins/search/changelog/remove-claim-of-support-for-node-14
+++ b/projects/plugins/search/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/plugins/search/package.json
+++ b/projects/plugins/search/package.json
@@ -20,7 +20,7 @@
 		"clean": "true"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/plugins/search/tests/e2e/package.json
+++ b/projects/plugins/search/tests/e2e/package.json
@@ -35,7 +35,7 @@
 		"jetpack-e2e-commons": "*"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	},

--- a/projects/plugins/social/changelog/remove-claim-of-support-for-node-14
+++ b/projects/plugins/social/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/plugins/social/package.json
+++ b/projects/plugins/social/package.json
@@ -59,7 +59,7 @@
 		"webpack-cli": "4.9.1"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/projects/plugins/starter-plugin/changelog/remove-claim-of-support-for-node-14
+++ b/projects/plugins/starter-plugin/changelog/remove-claim-of-support-for-node-14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
+
+

--- a/projects/plugins/starter-plugin/package.json
+++ b/projects/plugins/starter-plugin/package.json
@@ -49,7 +49,7 @@
 		"webpack-cli": "4.9.1"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -48,7 +48,7 @@
 		"jest-extended": "2.0.0"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/tools/cli/skeletons/common/package.json
+++ b/tools/cli/skeletons/common/package.json
@@ -22,7 +22,7 @@
 	},
 	"devDependencies": {},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/tools/e2e-commons/package.json
+++ b/tools/e2e-commons/package.json
@@ -36,7 +36,7 @@
 		"yargs": "17.4.0"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	},

--- a/tools/js-test-runner/package.json
+++ b/tools/js-test-runner/package.json
@@ -42,7 +42,7 @@
 		"typescript": "4.7.2"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}

--- a/tools/js-tools/package.json
+++ b/tools/js-tools/package.json
@@ -54,7 +54,7 @@
 		"yaml": "1.10.2"
 	},
 	"engines": {
-		"node": "^14.18.3 || ^16.13.2",
+		"node": "^16.13.2",
 		"pnpm": "^7.1.1",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This was added back in #20990 for Gutenberg Mobile. We never really
tested that things still worked in Node 14.

Now Gutenberg Mobile has dropped the need for the monorepo to claim Node
14 support, so let's drop it.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/wordpress-mobile/gutenberg-mobile/pull/4871#issuecomment-1142117428

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Nothing should change here.