### PR TITLE
Connection: include to define wp_generate_password if necessary

### DIFF
--- a/projects/packages/connection/changelog/fix-wp-generate-password-fatal
+++ b/projects/packages/connection/changelog/fix-wp-generate-password-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Include WordPress Core file if wp_generate_password is not defined yet when external request is being made.

--- a/projects/packages/connection/src/class-client.php
+++ b/projects/packages/connection/src/class-client.php
@@ -128,11 +128,12 @@ class Client {
 
 		$timestamp = time() + $time_diff;
 
-		if ( function_exists( 'wp_generate_password' ) ) {
-			$nonce = wp_generate_password( 10, false );
-		} else {
-			$nonce = substr( sha1( wp_rand( 0, 1000000 ) ), 0, 10 );
+		// When called very early, wp_generate_password sometimes isn't set yet.
+		if ( ! function_exists( '\wp_generate_password' ) ) {
+			include_once ABSPATH . WPINC . '/pluggable.php';
 		}
+
+		$nonce = wp_generate_password( 10, false );
 
 		// Kind of annoying.  Maybe refactor Jetpack_Signature to handle body-hashing.
 		if ( $body === null ) {


### PR DESCRIPTION
Fixes #23835

#### Changes proposed in this Pull Request:

This may not be the right approach, but may be a workaround for the problem described in #23835.

I worry a bit about trying to include a core file from the package directly, ideally we wouldn't have to do that. I don't know if that could ever be an issue.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

I wasn't able to reproduce the original issue, but this may be worth trying:

1. Install and connect Jetpack.
2. Go to Plugins > Add New
3. Install the Passwords Evolved plugin.
4. Click to activate it.
5. Check your logs to ensure no Fatal happened.
