### PR TITLE
changelogger: Recognize more non-feature-branch names

### DIFF
--- a/projects/packages/changelogger/changelog/add-changelogger-more-non-feature-branch-names
+++ b/projects/packages/changelogger/changelog/add-changelogger-more-non-feature-branch-names
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Recognize more branch names as non-feature-branches.

--- a/projects/packages/changelogger/src/AddCommand.php
+++ b/projects/packages/changelogger/src/AddCommand.php
@@ -136,11 +136,13 @@ EOF
 	 * @return string
 	 */
 	protected function getDefaultFilename( OutputInterface $output ) {
+		static $non_feature_branches = array( 'current', 'default', 'develop', 'latest', 'main', 'master', 'next', 'production', 'support', 'tip', 'trunk' );
+
 		try {
 			$process = Utils::runCommand( array( 'git', 'rev-parse', '--abbrev-ref', 'HEAD' ), $output, $this->getHelper( 'debug_formatter' ) );
 			if ( $process->isSuccessful() ) {
 				$ret = trim( $process->getOutput() );
-				if ( ! in_array( $ret, array( '', 'master', 'main', 'trunk' ), true ) ) {
+				if ( ! in_array( $ret, $non_feature_branches, true ) ) {
 					return strtr( $ret, array_fill_keys( array_keys( self::$badChars ), '-' ) );
 				}
 			}

--- a/projects/packages/changelogger/src/Application.php
+++ b/projects/packages/changelogger/src/Application.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 class Application extends SymfonyApplication {
 
-	const VERSION = '3.1.1';
+	const VERSION = '3.1.2-alpha';
 
 	/**
 	 * Constructor.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We were already recognizing 'main', 'master', and 'trunk'. Let's take
some more from those Composer itself recognizes: 'current', 'default',
'develop', 'latest', 'next', 'support', and 'tip'.

And let's throw 'production' in there too, I've seen that one somewhere.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try creating a branch with any of these names, then do `changelogger add`. It should suggest a date-based filename instead of using the branch name.
* Any other names people have been using?