### PR TITLE
jetpack: Reenable running of multisite tests in CI

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-multisite-tests
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-multisite-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Re-enable running of multisite tests. No plugin change.
+
+

--- a/projects/plugins/jetpack/tests/action-test-php.sh
+++ b/projects/plugins/jetpack/tests/action-test-php.sh
@@ -6,7 +6,7 @@ echo "::group::Jetpack tests"
 phpunit
 echo "::endgroup::"
 
-if [[ "$WP_BRANCH" == "master" ]]; then
+if [[ "$WP_BRANCH" == "trunk" ]]; then
 	echo "::group::Jetpack multisite tests"
 	WP_MULTISITE=1 phpunit -c tests/php.multisite.xml
 	echo "::endgroup::"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
When WordPress core renamed their main branch from "master" to "trunk",
first we didn't notice for several months. Then when we changed things
over in #24083, we overlooked changing the Jetpack test-running script
that was only running the multisite tests against WP "master" to run
against "trunk" instead.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/24661#pullrequestreview-1001648960

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the output of the "Tests / PHP Tests: PHP 8.0 WP trunk" job for "Jetpack multisite tests" being run.