### PR TITLE
jetpack: Use jest for remaining tests

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1341,7 +1341,6 @@ importers:
       autoprefixer: 10.4.2
       babel-jest: 28.1.0
       bounding-client-rect: 1.0.5
-      chai: 4.3.4
       classnames: 2.3.1
       clipboard: 2.0.6
       component-uid: 0.0.2
@@ -1361,7 +1360,6 @@ importers:
       jest: 28.1.0
       jest-environment-jsdom: 28.1.0
       jest-enzyme: 7.1.2
-      jetpack-js-test-runner: workspace:*
       jsdom: 19.0.0
       lodash: 4.17.21
       mapbox-gl: 1.13.0
@@ -1493,7 +1491,6 @@ importers:
       '@wordpress/token-list': 2.9.0
       autoprefixer: 10.4.2_postcss@8.4.13
       babel-jest: 28.1.0_@babel+core@7.17.10
-      chai: 4.3.4
       concurrently: 6.0.2
       enzyme: 3.11.0
       enzyme-to-json: 3.6.2_enzyme@3.11.0
@@ -1502,7 +1499,6 @@ importers:
       jest: 28.1.0
       jest-environment-jsdom: 28.1.0
       jest-enzyme: 7.1.2_x3fx6ski7nqiropha7uejbvcbi
-      jetpack-js-test-runner: link:../../../tools/js-test-runner
       lodash: 4.17.21
       postcss: 8.4.13
       postcss-loader: 6.2.0_yokl3cbwhadljnh75p6ymh6bce
@@ -9249,6 +9245,7 @@ packages:
 
   /assertion-error/1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
+    dev: false
 
   /assign-symbols/1.0.0:
     resolution: {integrity: sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=}
@@ -9953,6 +9950,7 @@ packages:
       get-func-name: 2.0.0
       pathval: 1.1.1
       type-detect: 4.0.8
+    dev: false
 
   /chalk/1.1.3:
     resolution: {integrity: sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=}
@@ -10026,6 +10024,7 @@ packages:
 
   /check-error/1.0.2:
     resolution: {integrity: sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=}
+    dev: false
 
   /cheerio-select/1.6.0:
     resolution: {integrity: sha512-eq0GdBvxVFbqWgmCm7M3XGs1I8oLy/nExUnh6oLqmBditPO9AqQJrkslDpMun/hZ0yyTs8L0m85OHp4ho6Qm9g==}
@@ -10994,6 +10993,7 @@ packages:
     engines: {node: '>=0.12'}
     dependencies:
       type-detect: 4.0.8
+    dev: false
 
   /deep-equal-ident/1.1.1:
     resolution: {integrity: sha1-BvS4nlNxDNbOpKd4HHqVZkLejck=}
@@ -13087,6 +13087,7 @@ packages:
 
   /get-func-name/2.0.0:
     resolution: {integrity: sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=}
+    dev: false
 
   /get-intrinsic/1.1.1:
     resolution: {integrity: sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==}
@@ -16783,6 +16784,7 @@ packages:
 
   /pathval/1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+    dev: false
 
   /pbf/3.2.1:
     resolution: {integrity: sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==}

--- a/projects/plugins/jetpack/changelog/update-jetpack-remaining-tests-to-jest
+++ b/projects/plugins/jetpack/changelog/update-jetpack-remaining-tests-to-jest
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update remaining tests to use Jest (and to be run in CI). No change to the plugin.
+
+

--- a/projects/plugins/jetpack/modules/.eslintrc.js
+++ b/projects/plugins/jetpack/modules/.eslintrc.js
@@ -43,4 +43,10 @@ module.exports = {
 		'no-undef': 1,
 		'no-extra-boolean-cast': 1,
 	},
+	overrides: [
+		{
+			files: [ '**/test/*.[jt]s?(x)' ],
+			extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
+		},
+	],
 };

--- a/projects/plugins/jetpack/modules/videopress/js/test/test-gutenberg-video-upload.js
+++ b/projects/plugins/jetpack/modules/videopress/js/test/test-gutenberg-video-upload.js
@@ -1,10 +1,10 @@
-import { expect } from 'chai';
+import { jest } from '@jest/globals';
 
 let apiFetchOriginal = null;
 let apiFetchMiddlewares = [];
 
 describe( 'gutenberg-video-upload', () => {
-	before( () => {
+	beforeAll( () => {
 		apiFetchOriginal = window.wp ? window.wp.apiFetch : undefined;
 
 		delete window.videoPressUploadTrack;
@@ -19,7 +19,7 @@ describe( 'gutenberg-video-upload', () => {
 		require( '../gutenberg-video-upload' );
 	} );
 
-	after( () => {
+	afterAll( () => {
 		if ( apiFetchOriginal ) {
 			window.wp.apiFetch = apiFetchOriginal;
 		}
@@ -29,17 +29,13 @@ describe( 'gutenberg-video-upload', () => {
 
 	describe( 'apiFetch middleware', () => {
 		it( 'installs one middleware', () => {
-			expect( apiFetchMiddlewares.length ).to.equal( 1 );
-			expect( typeof apiFetchMiddlewares[ 0 ] ).to.equal( 'function' );
+			expect( apiFetchMiddlewares ).toHaveLength( 1 );
+			expect( typeof apiFetchMiddlewares[ 0 ] ).toBe( 'function' );
 		} );
 
-		it( 'does not process the request body for irrelevant requests', done => {
-			expect( typeof apiFetchMiddlewares[ 0 ] ).to.equal( 'function' );
+		it( 'does not process the request body for irrelevant requests', async () => {
+			expect( typeof apiFetchMiddlewares[ 0 ] ).toBe( 'function' );
 			const middleware = apiFetchMiddlewares[ 0 ];
-
-			const next = () => {
-				done();
-			};
 
 			const options = {
 				path: '/foo',
@@ -47,7 +43,11 @@ describe( 'gutenberg-video-upload', () => {
 				method: 'POST',
 			};
 
-			middleware( options, next );
+			const response = {};
+			const next = jest.fn().mockReturnValue( Promise.resolve( response ) );
+			await expect( middleware( options, next ) ).resolves.toBe( response );
+			expect( next ).toHaveBeenCalledTimes( 1 );
+			expect( next ).toHaveBeenCalledWith( options );
 		} );
 	} );
 } );

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -39,8 +39,6 @@
 		"test-client": "NODE_PATH=tests:_inc/client jest --config=tests/jest.config.client.js",
 		"test-extensions": "TZ=UTC jest --config=tests/jest.config.extensions.js",
 		"test-gui": "NODE_PATH=tests:_inc/client jest --config=tests/jest.config.gui.js",
-		"test-lib": "NODE_ENV=test NODE_PATH=tests:_inc/client js-test-runner --jsdom glob:_inc/client/lib/**/test/*.js",
-		"test-modules": "NODE_ENV=test NODE_PATH=tests:_inc/client js-test-runner --jsdom glob:modules/**/test-*.js",
 		"watch": "concurrently --names client-js,client-css,masterbar,extensions,widget-visibility 'webpack watch --config ./tools/webpack.config.js' 'webpack watch --config ./tools/webpack.config.css.js' 'webpack watch --config ./tools/webpack.config.masterbar.js' 'webpack watch --config ./tools/webpack.config.extensions.js' 'webpack watch --config ./tools/webpack.config.widget-visibility.js'"
 	},
 	"browserslist": [
@@ -144,7 +142,6 @@
 		"@wordpress/token-list": "2.9.0",
 		"autoprefixer": "10.4.2",
 		"babel-jest": "28.1.0",
-		"chai": "4.3.4",
 		"concurrently": "6.0.2",
 		"enzyme": "3.11.0",
 		"enzyme-to-json": "3.6.2",
@@ -153,7 +150,6 @@
 		"jest": "28.1.0",
 		"jest-environment-jsdom": "28.1.0",
 		"jest-enzyme": "7.1.2",
-		"jetpack-js-test-runner": "workspace:*",
 		"lodash": "4.17.21",
 		"postcss": "8.4.13",
 		"postcss-loader": "6.2.0",

--- a/projects/plugins/jetpack/tests/jest.config.client.js
+++ b/projects/plugins/jetpack/tests/jest.config.client.js
@@ -2,6 +2,6 @@ const baseConfig = require( './jest.config.base.js' );
 
 module.exports = {
 	...baseConfig,
-	roots: [ '<rootDir>/_inc/client/state/' ],
+	roots: [ '<rootDir>/_inc/client/state/', '<rootDir>/_inc/client/lib/', '<rootDir>/modules/' ],
 	coverageDirectory: 'coverage/client',
 };

--- a/projects/plugins/jetpack/tools/webpack.config.js
+++ b/projects/plugins/jetpack/tools/webpack.config.js
@@ -94,7 +94,7 @@ const supportedModules = [
 const moduleSources = [
 	...glob.sync( '_inc/*.js' ),
 	...glob.sync( `modules/@(${ supportedModules.join( '|' ) })/**/*.js` ),
-].filter( name => ! name.endsWith( '.min.js' ) && ! /\/test-[^/]\.js$/.test( name ) );
+].filter( name => ! name.endsWith( '.min.js' ) && name.indexOf( '/test/' ) < 0 );
 
 // Library definitions for certain modules.
 const libraryDefs = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
After previous PRs, two package.json scripts were left using
js-test-runner. Neither was being run in CI; one had only one test, and
one had none at all.

Both of these are now merged into the "client" tests. Note that module
tests are now expected to be named with the usual `**/test/*.[jt]s?(x)`
pattern, rather than the strange `**/test-*.js` it had been using
before. The one existing test already matched both patterns.

And, as usual, linting is set up for the tests that didn't already have
it.

Jetpack no longer uses js-test-runner, mocha, sinon, or chai. We still
need to remove use of enzyme in favor of testing-library, but I'll leave
that for a later PR.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Working towards p4TIVU-a8r-p2#comment-11500

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?