### PR TITLE
Mailchimp block - improve loading state

### DIFF
--- a/projects/plugins/jetpack/changelog/update-center-spinner-for-mailchimp-block
+++ b/projects/plugins/jetpack/changelog/update-center-spinner-for-mailchimp-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+For Mailchimp block center spinner during loading block content.

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/edit.js
@@ -118,8 +118,10 @@ class MailchimpSubscribeEdit extends Component {
 		} = attributes;
 		const classPrefix = 'wp-block-jetpack-mailchimp';
 		const waiting = (
-			<Placeholder icon={ icon } notices={ notices }>
-				<Spinner />
+			<Placeholder icon={ icon } notices={ notices } className="wp-block-jetpack-mailchimp">
+				<div class="align-center">
+					<Spinner />
+				</div>
 			</Placeholder>
 		);
 		const placeholder = (

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/edit.js
@@ -118,7 +118,12 @@ class MailchimpSubscribeEdit extends Component {
 		} = attributes;
 		const classPrefix = 'wp-block-jetpack-mailchimp';
 		const waiting = (
-			<Placeholder icon={ icon } notices={ notices } className="wp-block-jetpack-mailchimp">
+			<Placeholder
+				icon={ icon }
+				notices={ notices }
+				className="wp-block-jetpack-mailchimp"
+				label={ __( 'Mailchimp', 'jetpack' ) }
+			>
 				<div class="align-center">
 					<Spinner />
 				</div>

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/editor.scss
@@ -42,6 +42,9 @@
 		.components-button {
 			margin-bottom: 0;
 		}
-	}
 
+		.align-center {
+			text-align: center;
+		}
+	}
 }


### PR DESCRIPTION
Fixes # https://github.com/Automattic/jetpack/issues/19390

#### Changes proposed in this Pull Request:
Center spinner inside block during loading

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
Create new post
Add new Mailchimp block
Verify if spinner is centered

<img width="658" alt="Screenshot 2022-06-10 at 14 00 48" src="https://user-images.githubusercontent.com/82798599/173063187-0f897cdf-c686-4da5-9809-8d01a3dca698.png">
