### PR TITLE
[Package] Backup - Removed double headline from connection screen

### DIFF
--- a/projects/packages/backup/changelog/remove-backup-connection-title-dup
+++ b/projects/packages/backup/changelog/remove-backup-connection-title-dup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Removed extra headline from connection screen.

--- a/projects/packages/backup/src/js/hooks/useConnection.js
+++ b/projects/packages/backup/src/js/hooks/useConnection.js
@@ -41,19 +41,16 @@ export default function useConnection() {
 				priceBefore={ price }
 				pricingIcon="data:image/svg+xml,%3Csvg width='32' height='32' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='m21.092 15.164.019-1.703v-.039c0-1.975-1.803-3.866-4.4-3.866-2.17 0-3.828 1.351-4.274 2.943l-.426 1.524-1.581-.065a2.92 2.92 0 0 0-.12-.002c-1.586 0-2.977 1.344-2.977 3.133 0 1.787 1.388 3.13 2.973 3.133H22.399c1.194 0 2.267-1.016 2.267-2.4 0-1.235-.865-2.19-1.897-2.368l-1.677-.29Zm-10.58-3.204a4.944 4.944 0 0 0-.201-.004c-2.75 0-4.978 2.298-4.978 5.133s2.229 5.133 4.978 5.133h12.088c2.357 0 4.267-1.97 4.267-4.4 0-2.18-1.538-3.99-3.556-4.339v-.06c0-3.24-2.865-5.867-6.4-5.867-2.983 0-5.49 1.871-6.199 4.404Z' fill='%23000'/%3E%3C/svg%3E"
 				pricingTitle={ __( 'Jetpack Backup', 'jetpack-backup-pkg' ) }
-				title={ __( 'The best real‑time WordPress backups', 'jetpack-backup-pkg' ) }
+				title={ __(
+					'Save every change and get back online quickly with one‑click restores.',
+					'jetpack-backup-pkg'
+				) }
 				apiRoot={ APIRoot }
 				apiNonce={ APINonce }
 				registrationNonce={ registrationNonce }
 				from="jetpack-backup"
 				redirectUri="admin.php?page=jetpack-backup"
 			>
-				<h3>
-					{ __(
-						'Save every change and get back online quickly with one‑click restores.',
-						'jetpack-backup-pkg'
-					) }
-				</h3>
 				<ul>
 					<li>{ __( 'Automated real-time backups', 'jetpack-backup-pkg' ) }</li>
 					<li>{ __( 'Easy one-click restores', 'jetpack-backup-pkg' ) }</li>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Removes a double headline from the connection screen.

<img width="1148" alt="Screen Shot 2022-06-10 at 11 00 57 AM" src="https://user-images.githubusercontent.com/1992658/173093996-e38adc0d-9a7b-4736-a2c3-468ea3eea88c.png">

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
> The two headlines with the same font size make it look like a weird sentence. Can you remove the first line? - @robertbpugh 

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add this build to an existing or new site and disconnect (or never connect) Jetpack to see the connection screen
* You can start up a Jurassic Ninja site with Jetpack Beta and pick this feature branch as the Jetpack Backup version
* Ensure the screen looks like the screenshot and doesn't have the 'The best real-time WordPress backups' line
