### PR TITLE
Fix regex for matching existing `tk_ai` cookies

### DIFF
--- a/projects/packages/connection/changelog/update-old_cookie_regex
+++ b/projects/packages/connection/changelog/update-old_cookie_regex
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed old tk_ai regex to accurately match tk_ai ids.

--- a/projects/packages/connection/legacy/class-jetpack-tracks-client.php
+++ b/projects/packages/connection/legacy/class-jetpack-tracks-client.php
@@ -184,7 +184,7 @@ class Jetpack_Tracks_Client {
 		if ( ! isset( $anon_id ) ) {
 
 			// Did the browser send us a cookie?
-			if ( isset( $_COOKIE['tk_ai'] ) && preg_match( '#^[A-Za-z0-9+/=]{24}$#', $_COOKIE['tk_ai'] ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- This is validating.
+			if ( isset( $_COOKIE['tk_ai'] ) && preg_match( '#^[a-z]+:[A-Za-z0-9+/=]{24}$#', $_COOKIE['tk_ai'] ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- This is validating.
 				$anon_id = $_COOKIE['tk_ai']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- This is validating.
 			} else {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
Updates the regex used to see if a `tk_ai` cookie is valid. This should now match any id's that follow `<lower case product name>:<24 characted base 64 id>` (ex: `jetpack:I8XJISGzESHE1TIORR+g+A8c` or `woo:U9Lx7TjnsFTvC2bdzkgznFau`

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack discussion here: p1654803569461579-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start a fresh Wordpress site without activating Jetpack and install and activate WooCommerce
* Notice how a `tk_ai` cookie is generated for Woo ( under Devtools > Application > Cookies > your domain )
* Activate Jetpack (with this build) and navigate to a couple different pages within Wordpress
* The `tk_ai` cookie should remain as the `woo:....` cookie and not be overwritten by a `jetpack:...` cookie.
