### PR TITLE
When a VideoPress Upload completes, start polling for a guid.

### DIFF
--- a/projects/plugins/jetpack/changelog/change-videopress-uploader-poll-completion
+++ b/projects/plugins/jetpack/changelog/change-videopress-uploader-poll-completion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+VideoPress Uploader: Poll upload completion status.

--- a/projects/plugins/jetpack/extensions/blocks/videopress/resumable-upload/use-uploader.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/resumable-upload/use-uploader.js
@@ -45,7 +45,7 @@ export const getJWT = function ( key ) {
 
 const jwtsForKeys = {};
 
-const startPolling = () => {
+const completionPolling = () => {
 	let polling = false;
 	let timerId = null;
 	const cleanup = () => {
@@ -110,7 +110,7 @@ export const resumableUploader = ( { onUploadUuidRetrieved, onError, onProgress,
 	return ( file, data ) => {
 		const upload = new tus.Upload( file, {
 			onError: function ( msg ) {
-				startPolling().cleanup();
+				completionPolling().cleanup();
 				onError && onError( msg );
 			},
 			onProgress: onProgress,
@@ -137,7 +137,7 @@ export const resumableUploader = ( { onUploadUuidRetrieved, onError, onProgress,
 				const mediaId = res.getHeader( MEDIA_ID_HEADER );
 				const src = res.getHeader( SRC_URL_HEADER );
 				if ( guid && mediaId && src ) {
-					startPolling().cleanup();
+					completionPolling().cleanup();
 					onSuccess && onSuccess( { mediaId: Number( mediaId ), guid, src } );
 					return;
 				}
@@ -196,7 +196,7 @@ export const resumableUploader = ( { onUploadUuidRetrieved, onError, onProgress,
 				if ( [ 'OPTIONS', 'GET', 'HEAD', 'DELETE', 'PUT', 'PATCH' ].indexOf( method ) >= 0 ) {
 					const url = new URL( req._url );
 					const maybeUploadkey = extractUploadKeyForUrl( url );
-					startPolling().start( upload.url, onSuccess, onError );
+					completionPolling().start( upload.url, onSuccess, onError );
 					if ( jwtsForKeys[ maybeUploadkey ] ) {
 						req.setHeader( 'x-videopress-upload-token', jwtsForKeys[ maybeUploadkey ] );
 					} else if ( 'HEAD' === method ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adapt Jetpack video upload block to async upload completion on the server side.
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* When upload is about to complete, start polling for a guid in addition to waiting for a response from the final chunk

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test On a jetpack site using this branch
* Upload some progressively bigger files
* Uploads complete smoothly
