### PR TITLE
Form block: ensure it can be used in 404 templates in FSE.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-contact-form-fse
+++ b/projects/plugins/jetpack/changelog/fix-contact-form-fse
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Form Block: ensure the block can be used is a 404 template in a block-based theme.


### PR DESCRIPTION
See #22749

#### Changes proposed in this Pull Request:

In this PR, I'll add handling for form blocks inserted in custom templates when using a block-based theme. See the original issue for more information.

**Note**

This PR only adds handling for blocks in the 404 template so far. I'm struggling a bit to figure out if we need to handle other use-cases. I would think that in other cases, the form is able to pull a post ID on the page (like the home page ID on a home template, or the first post in an archive template), but looking at the comment on the original issue, I seem to be wrong since folks can run into the problem even when inserting the block into a home template. This requires more investigation.

Maybe folks are having home, or index templates that have no query loops, just some static content, but they do not set a specific page as the static front page, instead they add their static content right into a home template?

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start with a site running Jetpack, with the Contact Form module active.
* Go to Appearance > Themes and enable a block-based theme like Twenty Twenty Two.
* Go to Appearance > Editor, and using the selector at the top-center of the editor, select "Browse all templates", and then the 404 template.
* Add a form block to that template, and save your changes.
* Load a page on your site that will load that template, for example by adding some gibberish to your home URL.
* The form should be displayed properly.
* You should be able to submit the form with no issues.
