### PR TITLE
docker: Clean up Dockerfile

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -10,6 +10,8 @@ ARG PNPM_VERSION
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
+WORKDIR /tmp
+
 # Install basic packages, including Apache.
 RUN \
 	export DEBIAN_FRONTEND=noninteractive \
@@ -32,7 +34,8 @@ RUN \
 		unzip \
 		vim \
 		zip \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get remove --purge --auto-remove -y software-properties-common \
+	&& rm -rf /var/lib/apt/lists/* ~/.launchpadlib
 
 # Enable mod_rewrite in Apache.
 RUN a2enmod rewrite
@@ -45,12 +48,9 @@ RUN \
 	&& apt-get install -y \
 		libapache2-mod-php${PHP_VERSION} \
 		php${PHP_VERSION} \
-		php${PHP_VERSION}-apcu \
 		php${PHP_VERSION}-bcmath \
 		php${PHP_VERSION}-cli \
 		php${PHP_VERSION}-curl \
-		php${PHP_VERSION}-gd \
-		php${PHP_VERSION}-imagick \
 		php${PHP_VERSION}-intl \
 		php${PHP_VERSION}-ldap \
 		php${PHP_VERSION}-mbstring \
@@ -63,6 +63,10 @@ RUN \
 		php${PHP_VERSION}-xml \
 		php${PHP_VERSION}-xsl \
 		php${PHP_VERSION}-zip \
+	&& apt-get install -y --no-install-recommends \
+		php${PHP_VERSION}-apcu \
+		php${PHP_VERSION}-gd \
+		php${PHP_VERSION}-imagick \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Install requested version of Composer.
@@ -85,7 +89,8 @@ RUN \
 # Install requested version of pnpm.
 RUN \
 	: "${PNPM_VERSION:?Build argument PNPM_VERSION needs to be set and non-empty.}" \
-	&& corepack enable && corepack prepare pnpm@$PNPM_VERSION --activate
+	&& npm install --global pnpm@$PNPM_VERSION \
+	&& rm -rf ~/.npm
 
 # Install wp-cli.
 RUN curl -o /usr/local/bin/wp -fSL https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar \
@@ -97,7 +102,7 @@ RUN mkdir /usr/local/src/psysh \
 	&& composer require psy/psysh:@stable \
 	&& mkdir ~/.wp-cli \
 	&& echo "require: /usr/local/src/psysh/vendor/autoload.php" > ~/.wp-cli/config.yml \
-	&& rm -rf ~/.cache ~/.config ~/.local ~/.subversion
+	&& rm -rf ~/.cache ~/.composer ~/.config ~/.local ~/.subversion
 
 # Copy a default config file for an apache host.
 COPY ./config/apache_default /etc/apache2/sites-available/000-default.conf


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The main change here is switching the pnpm install to `npm install -g`,
as `corepack` is apparently per user rather than global. Sigh.

Then I took the opportunity to clean up a few other things:

* Remove `software-properties-common` after using it, which gets rid of
  89 other unneeded packages (80M).
* Remove a random cache dir, `~/.launchpadlib` (2.2M).
* Avoid installing PHP 7.4 (through a recommendation on php-apcu-bc) and
  some other recommendations to save another 33 packages (89M, but some
  were shared with the first bullet).
* And another random cache dir, `~/.composer` (1.9M).

In total it brings the size from 704M down to 580M.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None, but it should fix Renovate on #24702, #24703, and #24704.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* The main thing is to load the new image with `docker run --rm -it --user 1000` and see that `pnpm --version` reports 7.1.1.