### PR TITLE
codesniffer: Fix dev dep on WPCS

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -61,7 +61,7 @@
             "dist": {
                 "type": "path",
                 "url": "projects/packages/codesniffer",
-                "reference": "51829660678dddaafa5c6c1397da13cf6fbc2c44"
+                "reference": "9cbcac7a0228a2893e25b10b46b2702d6ed6d357"
             },
             "require": {
                 "automattic/vipwpcs": "^2.3",
@@ -73,7 +73,7 @@
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.1",
-                "wp-coding-standards/wpcs": "dev-develop#7b39722c38cbf2fe64c55be7154ee6f1807d304c as 2.3.1",
+                "wp-coding-standards/wpcs": "2022-02-07 as 2.3.1",
                 "yoast/phpunit-polyfills": "1.0.3"
             },
             "type": "phpcodesniffer-standard",

--- a/projects/packages/codesniffer/changelog/fix-codesniffer-composer-dev-deps
+++ b/projects/packages/codesniffer/changelog/fix-codesniffer-composer-dev-deps
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix dev dep on WPCS to point at our fork rather than their dev-develop. Even though we're depending on a specific old commit, Composer gets confused now that their dev-develop depends on newer PHPCS than we can currently use. No change to the package itself.
+
+

--- a/projects/packages/codesniffer/composer.json
+++ b/projects/packages/codesniffer/composer.json
@@ -13,7 +13,7 @@
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.1",
-		"wp-coding-standards/wpcs": "dev-develop#7b39722c38cbf2fe64c55be7154ee6f1807d304c as 2.3.1",
+		"wp-coding-standards/wpcs": "2022-02-07 as 2.3.1",
 		"yoast/phpunit-polyfills": "1.0.3"
 	},
 	"autoload": {
@@ -45,6 +45,10 @@
 			"options": {
 				"monorepo": true
 			}
+		},
+		{
+			"type": "vcs",
+			"url": "https://github.com/Automattic/WordPress-Coding-Standards"
 		}
 	],
 	"minimum-stability": "dev",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
For a while now we've been depending on a particular commit of WPCS that
works with PHP 8. We had been doing that as `dev-develop#<sha>`, which
Composer only halfway supports.

Now that WPCS has updated their dev-develop to depend on phpcs 3.7,
Composer is getting confused because it's still trying to apply the
composer.json metadata from the tip of dev-develop rather than the sha
we're pointing to.

Since we already have a fork from #24627, let's go ahead and use that
here too to avoid the problem. Hopefully someday WPCS will finally do a
release...

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1655129609166099-slack-C034JEXD1RD

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy again?