### PR TITLE
jetpack-live-branches: Only display plugins for the current repo

### DIFF
--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jetpack Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.20
+// @version      1.21
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @grant        GM_xmlhttpRequest
 // @connect      jurassic.ninja
@@ -17,6 +17,18 @@
 	const $ = jQuery.noConflict();
 	doit();
 
+	/**
+	 * Determine the current repo.
+	 *
+	 * Currently looks at the URL, expecting it to match a `@match` pattern from the script header.
+	 *
+	 * @returns {string|null} Repo name.
+	 */
+	function determineRepo() {
+		const m = location.pathname.match( /^\/([^/]+\/[^/]+)\/pull\// );
+		return m && m[ 1 ] ? decodeURIComponent( m[ 1 ] ) : null;
+	}
+
 	/** Function. */
 	function doit() {
 		const host = 'https://jurassic.ninja';
@@ -24,6 +36,7 @@
 		const currentBranch = jQuery( '.head-ref:first' ).text();
 		const branchIsForked = currentBranch.includes( ':' );
 		const branchStatus = $( '.gh-header-meta .State' ).text().trim();
+		const repo = determineRepo();
 
 		if ( branchStatus === 'Merged' ) {
 			const contents = `
@@ -43,6 +56,11 @@
 				markdownBody,
 				"<p><strong>This branch can't be tested live because it comes from a forked version of this repo.</strong></p>"
 			);
+		} else if ( ! repo ) {
+			appendHtml(
+				markdownBody,
+				'<p><strong>Cannot determine the repository for this PR.</strong></p>'
+			);
 		} else {
 			dofetch( `${ host }/wp-json/jurassic.ninja/jetpack-beta/plugins` )
 				.then( body => {
@@ -54,13 +72,18 @@
 						);
 						Object.keys( body.data ).forEach( k => {
 							const data = body.data[ k ];
-							plugins.push( {
-								name: `branches.${ k }`,
-								value: currentBranch,
-								label: encodeHtmlEntities( data.name ),
-								checked: data.labels && data.labels.some( l => labels.has( l ) ),
-							} );
+							if ( data.repo === repo ) {
+								plugins.push( {
+									name: `branches.${ k }`,
+									value: currentBranch,
+									label: encodeHtmlEntities( data.name ),
+									checked: data.labels && data.labels.some( l => labels.has( l ) ),
+								} );
+							}
 						} );
+						if ( ! plugins.length ) {
+							throw new Error( `No plugins are configured for ${ repo }` );
+						}
 						plugins.sort( ( a, b ) => a.label.localeCompare( b.label ) );
 					} else if ( body.code === 'rest_no_route' ) {
 						plugins.push( {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
WooCommerce has indicated interest in using our Beta plugin
infrastructure (pdqwkG-eT-p2). If that goes through, the JN endpoint
queried here will almost certainly start returning their plugin too.

It will seldom work to try to load the WooCommerce plugin for the
Jetpack monorepo branch, as that's unlikely to exist unless someone is
specifically creating the same-named branch in both repos. So let's
filter the plugins displayed by the returned "repo" field.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pdqwkG-eT-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You can probably go to https://github.com/Automattic/jetpack/raw/update/live-branches-check-repo/tools/jetpack-live-branches/jetpack-live-branches.user.js to install this version of the script. Then, for now, make sure all the plugins still show in the list.

