### PR TITLE
Fix server side rendered blocks crashing in wpcom

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-server-side-rendered-blocks-crashing-in-wpcom
+++ b/projects/plugins/jetpack/changelog/fix-server-side-rendered-blocks-crashing-in-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+WPcom: fix crashing server-side rendered blocks

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -1181,6 +1181,10 @@ add_action( 'init', array( 'Jetpack_Widget_Conditions', 'init' ) );
 // 'init' happens too late to hook on block registration.
 global $pagenow;
 $current_url = ! empty( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
-if ( is_customize_preview() || 'widgets.php' === $pagenow || ( false !== strpos( $current_url, '/wp-json/wp/v2/block-renderer' ) ) ) {
+if ( is_customize_preview()
+	|| 'widgets.php' === $pagenow
+	|| ( false !== strpos( $current_url, '/wp-json/wp/v2/block-renderer' ) )
+	|| 1 === preg_match( '~^/wp/v2/sites/\d+/block-renderer~', $current_url )
+) {
 	Jetpack_Widget_Conditions::add_block_attributes_filter();
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/57493

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

A code in `widget-conditions.php` dynamically adds the "conditions” attribute for server-side rendered blocks. 

The current condition checks for `/wp-json/wp/v2/block-renderer`. However, the Calypso for simple sites accesses `/wp/v2/sites/$blog_id/block-renderer/` URL so the condition doesn’t catch it.

The PR adds a condition to check for the WP.com API endpoint too.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*
