### PR TITLE
SEO Tools: fix custom SEO description for Woo shop page

### DIFF
--- a/projects/plugins/jetpack/changelog/update-seo-woo-og-desc
+++ b/projects/plugins/jetpack/changelog/update-seo-woo-og-desc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+SEO Tools: allow WooCommerce to use custom SEO description for the shop page.

--- a/projects/plugins/jetpack/modules/seo-tools/class-jetpack-seo.php
+++ b/projects/plugins/jetpack/modules/seo-tools/class-jetpack-seo.php
@@ -91,6 +91,13 @@ class Jetpack_SEO {
 		$post_custom_description = Jetpack_SEO_Posts::get_post_custom_description( get_post() );
 		$front_page_meta         = Jetpack_SEO_Utils::get_front_page_meta_description();
 
+		if ( class_exists( 'woocommerce' ) && is_post_type_archive( 'product' ) ) {
+			$shop_page_id = get_option( 'woocommerce_shop_page_id' );
+			if ( $shop_page_id ) {
+				$post_custom_description = Jetpack_SEO_Posts::get_post_custom_description( get_post( $shop_page_id ) );
+			}
+		}
+
 		if ( is_front_page() && ! empty( $front_page_meta ) ) {
 			$tags['og:description'] = $front_page_meta;
 		} else {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

When on the WooCommerce Shop page, utilize the Jetpack custom SEO description if one has been set.

The query loop for the Shop page (archive) was giving the wrong post ID with the existing use of just `get_post()`.

#### Jetpack product discussion

Fixes #18071

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

- Before pulling down changes, make sure you have WooCommerce and Jetpack plugins activated.
- Jetpack should have the Sharing or Publicize module active.
- Have/add one or two products in your Woo shop.
- Open your set Woo Shop page for editing, and add a custom Jetpack SEO description then save.
- View the Shop page on the frontend, and inspect the source for the meta tag with the `og:description`. This should be the default set by Woo: "This is where you can browse products in this store."
- Pull down changes in this PR.
- Refresh the Shop page and observe that the `og:description` is updated to reflect the custom SEO description.