### PR TITLE
Search: Record Meter. Sort records before passing to RecordMeterBar component

### DIFF
--- a/projects/packages/search/changelog/update-search-record-meter-sorting
+++ b/projects/packages/search/changelog/update-search-record-meter-sorting
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Search record meter: pass sorted records RecordMeterBart component
+Search record meter: pass sorted records to RecordMeterBar component

--- a/projects/packages/search/changelog/update-search-record-meter-sorting
+++ b/projects/packages/search/changelog/update-search-record-meter-sorting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search record meter: pass sorted records RecordMeterBart component

--- a/projects/packages/search/src/dashboard/components/record-meter/index.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/index.jsx
@@ -47,7 +47,6 @@ export default function RecordMeter( {
 						<RecordMeterBar
 							items={ recordInfo.data }
 							showLegendLabelBeforeCount={ true }
-							sortByCount={ 'descending' }
 							totalCount={ tierMaximumRecords }
 						/>
 						<NoticeBox

--- a/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
+++ b/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
@@ -108,8 +108,6 @@ export default function getRecordInfo( postCount, postTypeBreakdown, lastIndexed
  * @returns {object} containing included items with post type and count, and other items, split.
  */
 export function splitUsablePostTypes( postTypeBreakdown, numItems, maxPostTypeCount ) {
-	postTypeBreakdown.sort( ( a, b ) => ( a.data.count[ 0 ] < b.data.count[ 0 ] ? 1 : -1 ) );
-
 	const count = maxPostTypeCount <= numItems ? maxPostTypeCount : numItems;
 
 	return {


### PR DESCRIPTION
This PR removes the sorting from RecordMeterBar and instead sorts data before passing to the component. This ensures the 'other' category is always at the end, regardless of how large its count is. 

#### Changes proposed in this Pull Request:

* Removes passing of the sortByCount prop
* Sorts the records prior to combining into records and other

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* Go to `/wp-admin/admin.php?page=jetpack-search&features=record-meter` on your test site with Search enabled.
* Ensure that record counts are in descending order, with the largest count first. 
* Confirm that when there are more than 5 record types (usually achieved by adding custom post types) that the `other` category remains last on the record meter and legend, even if it has a larger count than other records. 
* Confirm that there is no `remaining` category displaying
![image](https://user-images.githubusercontent.com/30754158/173479371-712bed29-4315-4c58-8777-406f6a8e6448.png)

