### PR TITLE
Sync: adjust the time variation for the delays test

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sync-delays-test
+++ b/projects/plugins/jetpack/changelog/fix-sync-delays-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix the inconsistent Sync Delays test.

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -372,7 +372,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 		remove_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ) );
 
-		$this->assertTrue( $this->sender->get_next_sync_time( 'sync' ) > time() + 9 );
+		$this->assertTrue( $this->sender->get_next_sync_time( 'sync' ) > time() + 8 );
 	}
 
 	public function test_default_value_for_max_execution_time() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Fix the inconsistent unit test `WP_Test_Jetpack_Sync_Sender::test_delays_next_send_if_exceeded_sync_wait_threshold()` by allowing more variation in the Sync timing.

#### Jetpack product discussion
1202427859356518-as-1202032023127869

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- make sure the PR tests pass
- re-run the PHP unit tests a few times to confirm the fix helped