### PR TITLE
VideoPress: Fix video embeds in classic editor for themes with no $content_width set

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-videopress-add-default-width
+++ b/projects/plugins/jetpack/changelog/fix-videopress-add-default-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed VideoPress embeds in classic editor when theme has no $content_width set.

--- a/projects/plugins/jetpack/modules/videopress/editor-media-view.php
+++ b/projects/plugins/jetpack/modules/videopress/editor-media-view.php
@@ -41,7 +41,7 @@ function videopress_handle_editor_view_js() {
 		array(
 			'home_url_host'     => wp_parse_url( home_url(), PHP_URL_HOST ),
 			'min_content_width' => VIDEOPRESS_MIN_WIDTH,
-			'content_width'     => $content_width,
+			'content_width'     => isset( $content_width ) ? $content_width : 640,
 			'modal_labels'      => array(
 				'title'     => esc_html__( 'VideoPress Shortcode', 'jetpack' ),
 				'guid'      => esc_html__( 'Video ID', 'jetpack' ),


### PR DESCRIPTION
A bug was reported where VideoPress embeds were not loading in the classic editor. This was tracked down to some themes (Like Twenty Twenty Two) not setting the global `$content_width` variable. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Falls back to a default value of 640px for the editor video embed if not `$content_width` global exists.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Ensure VideoPress is enabled in Jetpack settings
* Install and activate the classic editor plugin
* Change your theme to Twenty Twenty Two.
* Add a video to a post, you should see it display with a 640px width.
* Change your theme to Twenty Twenty (This theme DOES set `$content_width`)
* Inserting a video should also display the video properly.
