### PR TITLE
Sharing: avoid fatal errors when email process called outside ajax

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sharing-email-fatal
+++ b/projects/plugins/jetpack/changelog/fix-sharing-email-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sharing: avoid Fatal errors when email sharing process is called  without clicking on the button.

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
@@ -934,6 +934,9 @@ class Share_Email extends Sharing_Source {
 
 		if ( $is_ajax ) {
 			wp_send_json_success();
+		} else {
+			wp_safe_redirect( get_permalink( $post->ID ) . '?shared=email&msg=fail' );
+			exit;
 		}
 
 		wp_die();


### PR DESCRIPTION
Fixes #24764

#### Changes proposed in this Pull Request:

We've updated the email sharing button to use mailto in #24040. In the process, we've updated the email process but fail to account for use-cases when an email sharing URL is called manually, by a bot for example, instead of just clicking on the button in a WordPress context.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Go to Jetpack > Settings > Sharing and enable sharing buttons
* Go to Settings > Sharing and add the email button to the active sharing button.
* Load a post page on your site's frontend.
* Add `?share=email` to the end of the URL.
* The page should reload, with the query string `?shared=email&msg=fail`, instead of the Fatal that was triggered before.
