### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,8 +11,15 @@ concurrency:
   group: codeql-analysis-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/autobuild to send a status report
     name: Analyze
     runs-on: ubuntu-latest
     timeout-minutes: 7  # 2021-01-18: Successful runs seem to take 3-5 minutes

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -18,6 +18,9 @@ jobs:
 
   ### Job to categorize changed files. Other jobs depend on this to know when they should run.
   changed_files:
+    permissions:
+      contents: read  # for dorny/paths-filter to fetch a list of changed files
+      pull-requests: read  # for dorny/paths-filter to read pull requests
     name: detect changed files
     runs-on: ubuntu-latest
     timeout-minutes: 1  # 2021-01-18: Successful runs seem to take a few seconds

--- a/.github/workflows/phpcompatibility-dev.yml
+++ b/.github/workflows/phpcompatibility-dev.yml
@@ -15,6 +15,9 @@ env:
 
 jobs:
   changed_files:
+    permissions:
+      contents: read  # for dorny/paths-filter to fetch a list of changed files
+      pull-requests: read  # for dorny/paths-filter to read pull requests
     name: detect changed files
     runs-on: ubuntu-latest
     timeout-minutes: 1  # 2021-01-18: Successful runs seem to take a few seconds.

--- a/.github/workflows/renovate-cleanup.yml
+++ b/.github/workflows/renovate-cleanup.yml
@@ -6,6 +6,9 @@ on:
 env:
   COMPOSER_ROOT_VERSION: "dev-trunk"
 
+permissions:
+  contents: read
+
 jobs:
   cleanup:
     name: Close old PRs

--- a/.github/workflows/slack-workflow-failed.yml
+++ b/.github/workflows/slack-workflow-failed.yml
@@ -10,8 +10,13 @@ on:
       - PR is up-to-date
     branches: [ 'trunk', '*/branch-*' ]
 
+permissions:
+  contents: read
+
 jobs:
   notify:
+    permissions:
+      contents: none
     name: Notify failure
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,8 +4,14 @@ on:
   schedule:
     - cron: '30 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     timeout-minutes: 1  # 2021-01-18: Successful runs seem to take a few seconds
     steps:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
