### PR TITLE
Search: record meter, show the same notice box message for not indexed and no records.

### DIFF
--- a/projects/packages/search/changelog/update-search-record-meter-notice-box-fix
+++ b/projects/packages/search/changelog/update-search-record-meter-notice-box-fix
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-updated notice box content when site is not indexed
+Record Meter: updated notice box content when site is not indexed

--- a/projects/packages/search/changelog/update-search-record-meter-notice-box-fix
+++ b/projects/packages/search/changelog/update-search-record-meter-notice-box-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+updated notice box content when site is not indexed

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.15.2",
+	"version": "0.15.3-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.15.2';
+	const VERSION = '0.15.3-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
@@ -22,25 +22,15 @@ const getNotices = ( tierMaximumRecords = null ) => {
 		},
 		2: {
 			id: 2,
-			header: __( 'Your content has not yet been indexed for Search', 'jetpack-search-pkg' ),
+			header: __( "We weren't yet able to locate any content for Search", 'jetpack-search-pkg' ),
 			message: __(
-				'If you have recently set up Search, please allow a little time for indexing to complete.',
+				"This can happen if you don't have any posts or pages yet. If you have recently set up Search, please allow a little time for indexing to complete.",
 				'jetpack-search-pkg'
 			),
 		},
+
 		3: {
 			id: 3,
-			header: __(
-				"We weren't able to locate any content for Search to index",
-				'jetpack-search-pkg'
-			),
-			message: __(
-				"This can happen if you don't have any posts or pages yet.",
-				'jetpack-search-pkg'
-			),
-		},
-		4: {
-			id: 4,
 			header: __(
 				"You're close to the maximum records for this billing tier",
 				'jetpack-search-pkg'
@@ -83,8 +73,8 @@ export function NoticeBox( props ) {
 
 	const DATA_NOT_VALID = '1',
 		HAS_NOT_BEEN_INDEXED = '2',
-		NO_INDEXABLE_ITEMS = '3',
-		CLOSE_TO_LIMIT = '4';
+		NO_INDEXABLE_ITEMS = '2',
+		CLOSE_TO_LIMIT = '3';
 
 	// check if data is valid
 	props.hasValidData === false &&

--- a/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
@@ -22,9 +22,9 @@ const getNotices = ( tierMaximumRecords = null ) => {
 		},
 		2: {
 			id: 2,
-			header: __( "We weren't yet able to locate any content for Search", 'jetpack-search-pkg' ),
+			header: __( "We weren't able to locate any content for Search", 'jetpack-search-pkg' ),
 			message: __(
-				"This can happen if you don't have any posts or pages yet. If you have recently set up Search, please allow a little time for indexing to complete.",
+				'If you have recently set up Search, please allow a little time for indexing to complete.',
 				'jetpack-search-pkg'
 			),
 		},

--- a/projects/packages/search/src/dashboard/components/record-meter/test/notice-box.test.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/test/notice-box.test.jsx
@@ -32,7 +32,7 @@ describe( 'with notices to display', () => {
 			></NoticeBox>
 		);
 
-		expect( screen.getByText( /index your content/i ) ).toBeVisible();
+		expect( screen.getByText( /locate any content/i ) ).toBeVisible();
 	} );
 
 	test( 'unable to locate content notice is displayed', () => {

--- a/projects/packages/search/src/dashboard/components/record-meter/test/notice-box.test.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/test/notice-box.test.jsx
@@ -8,7 +8,7 @@ import { NoticeBox } from 'components/record-meter/notice-box';
 import React from 'react';
 
 describe( 'with notices to display', () => {
-	test( 'not-indexed notice is displayed', () => {
+	test( 'unable to locate content notice is displayed when not yet indexed', () => {
 		render(
 			<NoticeBox
 				recordCount={ 20 }
@@ -18,7 +18,7 @@ describe( 'with notices to display', () => {
 				hasItems={ true }
 			></NoticeBox>
 		);
-		expect( screen.getByText( /not yet been indexed/i ) ).toBeVisible();
+		expect( screen.getByText( /locate any content/i ) ).toBeVisible();
 	} );
 
 	test( 'unable to access data notice is displayed', () => {
@@ -32,10 +32,10 @@ describe( 'with notices to display', () => {
 			></NoticeBox>
 		);
 
-		expect( screen.getByText( /locate any content/i ) ).toBeVisible();
+		expect( screen.getByText( /index your content/i ) ).toBeVisible();
 	} );
 
-	test( 'unable to locate content notice is displayed', () => {
+	test( 'unable to locate content notice is displayed when there are no items', () => {
 		render(
 			<NoticeBox
 				recordCount={ 20 }


### PR DESCRIPTION
This PR updates the record meter notice box to display the same message regardless of whether the site has not been indexed, or has no indexable records/posts on it. 

This is because due to the current API status, the last indexed date is not returning as we would expect, so we don't have a good way to know whether there are no records, or they haven't been indexed yet. To get around this for the time being, we've adjusted both notice cases to display the same (more neutral) notice. 

#### Changes proposed in this Pull Request:

Changes made to the notice box text, and unit tests,  to display the same message: "We weren't able to locate any content for Search If you have recently set up Search, please allow a little time for indexing to complete." in both the case of not being indexed yet, as well as when there are no records. 

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:


* Go to` /wp-admin/admin.php?page=jetpack-search&features=record-meter` on your test site with Search enabled.
* Trigger the different notice box behaviours by toggling off/on the two altered states `hasBeenIndexed` and 'hasItems` to trigger the different notices using a React tools browser inspector. Or alternatively, test on a testing site once when Search is first added and has not been indexed, then again a little later once it has been indexed by deleting all existing posts/pages from the site.  
* Ensure that in both cases (not indexed, and with no products) the notice box is the same, and says "We weren't able to locate any content for Search If you have recently set up Search, please allow a little time for indexing to complete."

![image](https://user-images.githubusercontent.com/30754158/174527876-fa8a0b4f-cae2-40bc-af57-b3880458e5d1.png)

