### PR TITLE
Social: Added proxy end-point to call wpcom's /sites/%d/shares-count

### DIFF
--- a/projects/packages/publicize/changelog/add-social-shares-endpoint
+++ b/projects/packages/publicize/changelog/add-social-shares-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added a proxy end-point to get the shares count for Publicize.

--- a/projects/packages/publicize/composer.json
+++ b/projects/packages/publicize/composer.json
@@ -51,7 +51,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.6.x-dev"
+			"dev-trunk": "0.7.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.6.1-alpha",
+	"version": "0.7.0-alpha",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -99,8 +99,17 @@ class REST_Controller {
 	 */
 	public function get_publicize_shares_count() {
 		$blog_id  = $this->get_blog_id();
-		$path     = sprintf( '/sites/%d/shares-count', absint( $blog_id ) );
-		$response = Client::wpcom_json_api_request_as_user( $path, '2', array(), null, 'wpcom' );
+		$response = Client::wpcom_json_api_request_as_blog(
+			sprintf( 'sites/%d/shares-count', absint( $blog_id ) ),
+			'2',
+			array(
+				'headers' => array( 'content-type' => 'application/json' ),
+				'method'  => 'GET',
+			),
+			null,
+			'wpcom'
+		);
+
 		return rest_ensure_response( $this->make_proper_response( $response ) );
 	}
 

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -50,6 +50,16 @@ class REST_Controller {
 				'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
 			)
 		);
+
+		register_rest_route(
+			'jetpack/v4',
+			'/publicize/shares-count',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_publicize_shares_count' ),
+				'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
+			)
+		);
 	}
 
 	/**
@@ -78,6 +88,18 @@ class REST_Controller {
 	public function get_publicize_connections() {
 		$blog_id  = $this->get_blog_id();
 		$path     = sprintf( '/sites/%d/publicize/connections', absint( $blog_id ) );
+		$response = Client::wpcom_json_api_request_as_user( $path, '2', array(), null, 'wpcom' );
+		return rest_ensure_response( $this->make_proper_response( $response ) );
+	}
+
+	/**
+	 * Gets the publicize shares count for the site.
+	 *
+	 * GET `jetpack/v4/publicize/shares-count`
+	 */
+	public function get_publicize_shares_count() {
+		$blog_id  = $this->get_blog_id();
+		$path     = sprintf( '/sites/%d/shares-count', absint( $blog_id ) );
 		$response = Client::wpcom_json_api_request_as_user( $path, '2', array(), null, 'wpcom' );
 		return rest_ensure_response( $this->make_proper_response( $response ) );
 	}

--- a/projects/plugins/jetpack/changelog/add-social-shares-endpoint
+++ b/projects/plugins/jetpack/changelog/add-social-shares-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -34,7 +34,7 @@
 		"automattic/jetpack-my-jetpack": "1.7.x-dev",
 		"automattic/jetpack-partner": "1.7.x-dev",
 		"automattic/jetpack-plugins-installer": "0.1.x-dev",
-		"automattic/jetpack-publicize": "0.6.x-dev",
+		"automattic/jetpack-publicize": "0.7.x-dev",
 		"automattic/jetpack-redirect": "1.7.x-dev",
 		"automattic/jetpack-roles": "1.4.x-dev",
 		"automattic/jetpack-search": "0.15.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "529317732f037002a0c0ee39049b5626",
+    "content-hash": "7d3760572913ec09acaded90e6ec754c",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1415,7 +1415,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/publicize",
-                "reference": "e6921456ede0a7ef1c103656167628fbcc5ad005"
+                "reference": "0b943a41f2072a6fe85404f6ce6c6c1af40784ba"
             },
             "require": {
                 "automattic/jetpack-autoloader": "^2.11",
@@ -1436,7 +1436,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.6.x-dev"
+                    "dev-trunk": "0.7.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/add-social-shares-endpoint
+++ b/projects/plugins/social/changelog/add-social-shares-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -10,7 +10,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.9.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-publicize": "0.6.x-dev",
+		"automattic/jetpack-publicize": "0.7.x-dev",
 		"automattic/jetpack-options": "1.16.x-dev",
 		"automattic/jetpack-connection": "1.41.x-dev",
 		"automattic/jetpack-my-jetpack": "1.7.x-dev",

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "62cd8fa38f8bed0de93cfbfa532ef78d",
+    "content-hash": "b59fa81ae69e37887404e154bf46f35b",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -844,7 +844,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/publicize",
-                "reference": "e6921456ede0a7ef1c103656167628fbcc5ad005"
+                "reference": "0b943a41f2072a6fe85404f6ce6c6c1af40784ba"
             },
             "require": {
                 "automattic/jetpack-autoloader": "^2.11",
@@ -865,7 +865,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.6.x-dev"
+                    "dev-trunk": "0.7.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
We have created an end-point on wpcom that will shares count aggregated by publicize service, along with a total. The end-point added in this PR enables Jetpack Social and Jetpack plugin call to call wpcom through a proxy. 

<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Added an end-point to the Publicize package to proxy through to wpcom's `/sites/%d/shares-count` endpoint

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox D82708-code and make `JETPACK__SANDBOX_DOMAIN` in `wp-config.php` to point to your sandbox
* Make a curl request to  `curl 'http://sidtest.jurassic.tube/wp-json/jetpack/v4/publicize/shares-count'`. Make sure to replace <your-cookie-here> with a valid cookie and make sure you get a successful response.

```
curl 'http://sidtest.jurassic.tube/wp-json/jetpack/v4/publicize/shares-count' \
  -H 'Accept: application/json, */*;q=0.1' \
  -H 'Accept-Language: en-GB,en-US;q=0.9,en;q=0.8' \
  -H 'Connection: keep-alive' \
  -H 'Cookie: wordpress_test_cookie=<your-cookie-here>' \
  -H 'Referer: http://sidtest.jurassic.tube/wp-admin/admin.php?page=jetpack-social' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36' \
  -H 'X-WP-Nonce: b45c08e895' \
  --compressed \
  --insecure
  ```