### PR TITLE
Remove recurring-payments button color

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-payment-button-outline
+++ b/projects/plugins/jetpack/changelog/fix-payment-button-outline
@@ -1,0 +1,6 @@
+Significance: patch
+Type: bugfix
+
+Removed hardcoded recurring-payments button color.
+
+Previously this was white. Removing it altogether means  that the outline button style works on white backgrounds.

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/view.scss
@@ -3,7 +3,3 @@
 .wp-block-jetpack-recurring-payments.aligncenter .wp-block-jetpack-button {
 	text-align: center;
 }
-
-.wp-block-jetpack-recurring-payments .wp-block-jetpack-button {
-	color: #ffffff;
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #24768

#### Changes proposed in this Pull Request:
The Payments Button button color was hardcoded to white (#fff). The
button itself's color could be overriden by using the editor controls
but the outline style just meant the button was invisible - white on
white backgrounds.

This has been fixed by removing the rule completely - I can't see why
it exists. Another approach would have been to use the currentColor
pseudo-color.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a site with a paid WPcom (or JP Security/Complete) plan using the 2022 theme
* Add a new post and insert a payment button
* Complete Stripe set-up
* Go back to the post and insert a second payment button, selecting the 'outline' style from the right hand bar
* The button disappear
* Publish and view the page
* The second button should be invisible
* Apply this patch
* Refresh the page, both buttons should be visible
* Refresh the editor, both buttons should be visible there too.

 before | after
--------|--------
![image](https://user-images.githubusercontent.com/93301/174853148-0122eb9a-6464-442b-9899-3fa30bca93a8.png) | ![image](https://user-images.githubusercontent.com/93301/174853234-abf9b6a8-4b8b-40a5-bd02-cfa417637c25.png)




