### PR TITLE
Protect: Add new Debug Helper module and fix a bug

### DIFF
--- a/projects/plugins/debug-helper/changelog/add-protect-helper-module
+++ b/projects/plugins/debug-helper/changelog/add-protect-helper-module
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add Protect helper module

--- a/projects/plugins/debug-helper/modules/class-protect-helper.php
+++ b/projects/plugins/debug-helper/modules/class-protect-helper.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Jetpack Protect helper class.
+ *
+ * @package automattic/jetpack-debug-helper
+ */
+
+/**
+ * Helps debug Protect
+ */
+class Protect_Helper {
+
+	/**
+	 * Options.
+	 */
+	const STORED_OPTIONS_KEY = 'protect_helper_option_name';
+
+	/**
+	 * Construction.
+	 */
+	public function __construct() {
+		add_action( 'admin_menu', array( $this, 'register_submenu_page' ), 1000 );
+
+		add_action( 'admin_post_protect_helper_store_options', array( $this, 'admin_post_store_current_options' ) );
+
+		if ( isset( $_GET['show_notice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			add_action( 'admin_notices', array( $this, 'display_notice' ) );
+		}
+
+		$settings = self::get_stored_settings();
+		if ( $settings['overwrite_status'] ) {
+			// Display a notice when this module overwrites Protect Status.
+			add_action( 'admin_notices', array( $this, 'display_protect_overwritten_notice' ) );
+		}
+
+	}
+
+	/**
+	 * Add submenu item.
+	 */
+	public function register_submenu_page() {
+		add_submenu_page(
+			'jetpack-debug-tools',
+			'Protect Helper',
+			'Protect Helper',
+			'manage_options',
+			'protect-helper',
+			array( $this, 'render_ui' ),
+			99
+		);
+	}
+
+	/**
+	 * Renders the UI.
+	 */
+	public function render_ui() {
+		$settings = $this->get_stored_settings();
+		?>
+		<h1>Protect Helper</h1>
+
+		<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post">
+
+		<table class="form-table" role="presentation">
+		<tbody>
+		<tr>
+			<th scope="row">Overwrite Protect Status</th>
+			<td>
+				<fieldset><legend class="screen-reader-text"><span>If enable, Protet status fetched from the server will be ignored and the rules below will define the current status.</span></legend>
+				<label><input type="radio" name="overwrite_status" value="1" <?php echo ( $settings['overwrite_status'] ? 'checked="checked"' : '' ); ?>> enabled</label><br>
+				<label><input type="radio" name="overwrite_status" value="0" <?php echo ( ! $settings['overwrite_status'] ? 'checked="checked"' : '' ); ?>> disabled</label><br>
+				</fieldset>
+			</td>
+		</tr>
+		<tr>
+			<th scope="row"><label for="idc_siteurl">Status</label></th>
+			<td>
+				<select name="status">
+					<option value="empty" <?php selected( 'empty', $settings['status'] ); ?>>Empty - When the initial scan did not run yet</option>
+					<option value="incomplete" <?php selected( 'incomplete', $settings['status'] ); ?>>Incomplete - When we have results, but some extensions were not scanned</option>
+					<option value="complete" <?php selected( 'complete', $settings['status'] ); ?>>Complete - When we have results for all extensions</option>
+				</select>
+			</td>
+		</tr>
+		<tr>
+			<th scope="row">Vulnerabilities</th>
+			<td>
+				<label><input type="checkbox" name="vuls_for_core" <?php echo ( $settings['vuls_for_core'] ? 'checked="checked"' : '' ); ?>> Add vulnerabilities to core</label><br>
+				<label><input type="checkbox" name="vuls_for_plugins" <?php echo ( $settings['vuls_for_plugins'] ? 'checked="checked"' : '' ); ?>> Add vulnerabilities to Plugins</label><br>
+				<label><input type="checkbox" name="vuls_for_themes" <?php echo ( $settings['vuls_for_themes'] ? 'checked="checked"' : '' ); ?>> Add vulnerabilities to Themes</label><br>
+			</td>
+		</tr>
+
+		</tbody>
+		</table>
+
+		<input type="hidden" name="action" value="protect_helper_store_options">
+		<?php wp_nonce_field( 'protect-helper-store-options' ); ?>
+		<input type="submit" value="Store these options" class="button button-primary">
+		</form>
+
+		<?php
+	}
+
+	/**
+	 * Retrieves the stored IDC options.
+	 *
+	 * @return array
+	 */
+	public static function get_stored_settings() {
+		return wp_parse_args(
+			get_option( self::STORED_OPTIONS_KEY ),
+			array(
+				'overwrite_status' => false,
+				'status'           => 'empty',
+				'vuls_for_core'    => false,
+				'vuls_for_plugins' => false,
+				'vuls_for_themes'  => false,
+			)
+		);
+	}
+
+	/**
+	 * Store options.
+	 */
+	public function admin_post_store_current_options() {
+		check_admin_referer( 'protect-helper-store-options' );
+
+		update_option(
+			self::STORED_OPTIONS_KEY,
+			array(
+				'overwrite_status' => isset( $_POST['overwrite_status'] ) ? filter_var( wp_unslash( $_POST['overwrite_status'] ) ) : null,
+				'status'           => isset( $_POST['status'] ) ? filter_var( wp_unslash( $_POST['status'] ) ) : null,
+				'vuls_for_core'    => isset( $_POST['vuls_for_core'] ) ? true : false,
+				'vuls_for_plugins' => isset( $_POST['vuls_for_plugins'] ) ? true : false,
+				'vuls_for_themes'  => isset( $_POST['vuls_for_themes'] ) ? true : false,
+			)
+		);
+
+		$this->notice_type = 'stored_success';
+		$this->admin_post_redirect_referrer();
+	}
+
+	/**
+	 * Just redirects back to the referrer. Keeping it DRY.
+	 */
+	public function admin_post_redirect_referrer() {
+		if ( wp_get_referer() ) {
+			wp_safe_redirect(
+				add_query_arg(
+					array(
+						'show_notice' => $this->notice_type,
+					),
+					wp_get_referer()
+				)
+			);
+		} else {
+			wp_safe_redirect( get_home_url() );
+		}
+	}
+
+	/**
+	 * Display a notice if necessary.
+	 */
+	public function display_notice() {
+		?>
+		<div class="notice notice-success is-dismissible">
+			<p>Settings have been saved!</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Display a notice when Sync is disabled by this module.
+	 */
+	public function display_protect_overwritten_notice() {
+		echo '<div class="notice notice-warning"><p>Jetpack Protect Status is being overwritten by the Jetpack Debug Helper plugin.</p></div>';
+
+	}
+
+}
+
+add_action(
+	'plugins_loaded',
+	function () {
+		new Protect_Helper();
+	},
+	1000
+);
+

--- a/projects/plugins/debug-helper/modules/class-protect-helper.php
+++ b/projects/plugins/debug-helper/modules/class-protect-helper.php
@@ -78,7 +78,7 @@ class Protect_Helper {
 			<th scope="row">Overwrite Protect Status</th>
 			<td>
 				<fieldset>
-					<p>If enable, Protet status fetched from the server will be ignored and the rules below will define the current status.</p>
+					<p>If enabled, the Protect status fetched from the server will be ignored and the rules below will define the current status.</p>
 					<label><input type="radio" name="overwrite_status" value="1" <?php echo ( $settings['overwrite_status'] ? 'checked="checked"' : '' ); ?>> enabled</label><br>
 					<label><input type="radio" name="overwrite_status" value="0" <?php echo ( ! $settings['overwrite_status'] ? 'checked="checked"' : '' ); ?>> disabled</label><br>
 				</fieldset>

--- a/projects/plugins/debug-helper/modules/class-protect-helper.php
+++ b/projects/plugins/debug-helper/modules/class-protect-helper.php
@@ -98,7 +98,7 @@ class Protect_Helper {
 		<tr>
 			<th scope="row">Vulnerabilities</th>
 			<td>
-				<label><input type="checkbox" name="vuls_for_core" <?php echo ( $settings['vuls_for_core'] ? 'checked="checked"' : '' ); ?>> Add vulnerabilities to core</label><br>
+				<label><input type="checkbox" name="vuls_for_core" <?php echo ( $settings['vuls_for_core'] ? 'checked="checked"' : '' ); ?>> Add vulnerabilities to Core</label><br>
 				<label><input type="checkbox" name="vuls_for_plugins" <?php echo ( $settings['vuls_for_plugins'] ? 'checked="checked"' : '' ); ?>> Add vulnerabilities to Plugins</label><br>
 				<label><input type="checkbox" name="vuls_for_themes" <?php echo ( $settings['vuls_for_themes'] ? 'checked="checked"' : '' ); ?>> Add vulnerabilities to Themes</label><br>
 			</td>

--- a/projects/plugins/debug-helper/modules/class-protect-helper.php
+++ b/projects/plugins/debug-helper/modules/class-protect-helper.php
@@ -73,38 +73,38 @@ class Protect_Helper {
 		<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post">
 
 		<table class="form-table" role="presentation">
-		<tbody>
-		<tr>
-			<th scope="row">Overwrite Protect Status</th>
-			<td>
-				<fieldset>
-					<p>If enabled, the Protect status fetched from the server will be ignored and the rules below will define the current status.</p>
-					<label><input type="radio" name="overwrite_status" value="1" <?php echo ( $settings['overwrite_status'] ? 'checked="checked"' : '' ); ?>> enabled</label><br>
-					<label><input type="radio" name="overwrite_status" value="0" <?php echo ( ! $settings['overwrite_status'] ? 'checked="checked"' : '' ); ?>> disabled</label><br>
-				</fieldset>
-			</td>
-		</tr>
-		<tr>
-			<th scope="row"><label for="idc_siteurl">Status</label></th>
-			<td>
-				<select name="status">
-					<option value="empty" <?php selected( 'empty', $settings['status'] ); ?>>Empty - When the initial scan did not run yet</option>
-					<option value="error" <?php selected( 'error', $settings['status'] ); ?>>Error - When there's an error fetching the status</option>
-					<option value="incomplete" <?php selected( 'incomplete', $settings['status'] ); ?>>Incomplete - When we have results, but some extensions were not scanned</option>
-					<option value="complete" <?php selected( 'complete', $settings['status'] ); ?>>Complete - When we have results for all extensions</option>
-				</select>
-			</td>
-		</tr>
-		<tr>
-			<th scope="row">Vulnerabilities</th>
-			<td>
-				<label><input type="checkbox" name="vuls_for_core" <?php echo ( $settings['vuls_for_core'] ? 'checked="checked"' : '' ); ?>> Add vulnerabilities to Core</label><br>
-				<label><input type="checkbox" name="vuls_for_plugins" <?php echo ( $settings['vuls_for_plugins'] ? 'checked="checked"' : '' ); ?>> Add vulnerabilities to Plugins</label><br>
-				<label><input type="checkbox" name="vuls_for_themes" <?php echo ( $settings['vuls_for_themes'] ? 'checked="checked"' : '' ); ?>> Add vulnerabilities to Themes</label><br>
-			</td>
-		</tr>
+			<tbody>
+				<tr>
+					<th scope="row">Overwrite Protect Status</th>
+					<td>
+						<fieldset>
+							<p>If enabled, the Protect status fetched from the server will be ignored and the rules below will define the current status.</p>
+							<label><input type="radio" name="overwrite_status" value="1" <?php echo ( $settings['overwrite_status'] ? 'checked="checked"' : '' ); ?>> enabled</label><br>
+							<label><input type="radio" name="overwrite_status" value="0" <?php echo ( ! $settings['overwrite_status'] ? 'checked="checked"' : '' ); ?>> disabled</label><br>
+						</fieldset>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="idc_siteurl">Status</label></th>
+					<td>
+						<select name="status">
+							<option value="empty" <?php selected( 'empty', $settings['status'] ); ?>>Empty - When the initial scan did not run yet</option>
+							<option value="error" <?php selected( 'error', $settings['status'] ); ?>>Error - When there's an error fetching the status</option>
+							<option value="incomplete" <?php selected( 'incomplete', $settings['status'] ); ?>>Incomplete - When we have results, but some extensions were not scanned</option>
+							<option value="complete" <?php selected( 'complete', $settings['status'] ); ?>>Complete - When we have results for all extensions</option>
+						</select>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row">Vulnerabilities</th>
+					<td>
+						<label><input type="checkbox" name="vuls_for_core" <?php echo ( $settings['vuls_for_core'] ? 'checked="checked"' : '' ); ?>> Add vulnerabilities to Core</label><br>
+						<label><input type="checkbox" name="vuls_for_plugins" <?php echo ( $settings['vuls_for_plugins'] ? 'checked="checked"' : '' ); ?>> Add vulnerabilities to Plugins</label><br>
+						<label><input type="checkbox" name="vuls_for_themes" <?php echo ( $settings['vuls_for_themes'] ? 'checked="checked"' : '' ); ?>> Add vulnerabilities to Themes</label><br>
+					</td>
+				</tr>
 
-		</tbody>
+			</tbody>
 		</table>
 
 		<input type="hidden" name="action" value="protect_helper_store_options">

--- a/projects/plugins/debug-helper/modules/class-protect-helper.php
+++ b/projects/plugins/debug-helper/modules/class-protect-helper.php
@@ -5,6 +5,9 @@
  * @package automattic/jetpack-debug-helper
  */
 
+use Automattic\Jetpack\Plugins_Installer;
+use Automattic\Jetpack\Sync\Functions as Sync_Functions;
+
 /**
  * Helps debug Protect
  */
@@ -31,6 +34,15 @@ class Protect_Helper {
 		if ( $settings['overwrite_status'] ) {
 			// Display a notice when this module overwrites Protect Status.
 			add_action( 'admin_notices', array( $this, 'display_protect_overwritten_notice' ) );
+
+			$option_name      = Automattic\Jetpack\Protect\Status::OPTION_NAME;
+			$option_time_name = Automattic\Jetpack\Protect\Status::OPTION_TIMESTAMP_NAME;
+			add_filter( "option_$option_name", array( $this, 'get_mock_response' ) );
+			add_filter( "option_$option_time_name", array( $this, 'filter_option_time' ) );
+
+			if ( 'error' === $settings['status'] ) {
+				add_filter( 'pre_http_request', array( $this, 'filter_status_fetch' ), 10, 3 );
+			}
 		}
 
 	}
@@ -65,9 +77,10 @@ class Protect_Helper {
 		<tr>
 			<th scope="row">Overwrite Protect Status</th>
 			<td>
-				<fieldset><legend class="screen-reader-text"><span>If enable, Protet status fetched from the server will be ignored and the rules below will define the current status.</span></legend>
-				<label><input type="radio" name="overwrite_status" value="1" <?php echo ( $settings['overwrite_status'] ? 'checked="checked"' : '' ); ?>> enabled</label><br>
-				<label><input type="radio" name="overwrite_status" value="0" <?php echo ( ! $settings['overwrite_status'] ? 'checked="checked"' : '' ); ?>> disabled</label><br>
+				<fieldset>
+					<p>If enable, Protet status fetched from the server will be ignored and the rules below will define the current status.</p>
+					<label><input type="radio" name="overwrite_status" value="1" <?php echo ( $settings['overwrite_status'] ? 'checked="checked"' : '' ); ?>> enabled</label><br>
+					<label><input type="radio" name="overwrite_status" value="0" <?php echo ( ! $settings['overwrite_status'] ? 'checked="checked"' : '' ); ?>> disabled</label><br>
 				</fieldset>
 			</td>
 		</tr>
@@ -76,6 +89,7 @@ class Protect_Helper {
 			<td>
 				<select name="status">
 					<option value="empty" <?php selected( 'empty', $settings['status'] ); ?>>Empty - When the initial scan did not run yet</option>
+					<option value="error" <?php selected( 'error', $settings['status'] ); ?>>Error - When there's an error fetching the status</option>
 					<option value="incomplete" <?php selected( 'incomplete', $settings['status'] ); ?>>Incomplete - When we have results, but some extensions were not scanned</option>
 					<option value="complete" <?php selected( 'complete', $settings['status'] ); ?>>Complete - When we have results for all extensions</option>
 				</select>
@@ -177,6 +191,157 @@ class Protect_Helper {
 
 	}
 
+	/**
+	 * Gets a mock api response
+	 */
+	public function get_mock_response() {
+		$settings = $this->get_stored_settings();
+		$response = (object) array(
+			'last_checked'                => '',
+			'num_vulnerabilities'         => 0,
+			'num_plugins_vulnerabilities' => 0,
+			'num_themes_vulnerabilities'  => 0,
+			'status'                      => 'scheduled',
+		);
+		if ( 'empty' === $settings['status'] ) {
+			return $response;
+		}
+
+		global $wp_version;
+
+		$response->last_checked = gmdate( 'Y-m-d H:i:s', time() - 1000 );
+		$installed_plugins      = Plugins_Installer::get_plugins();
+		$installed_themes       = Sync_Functions::get_themes();
+
+		$response->core    = (object) array(
+			'version'         => $wp_version,
+			'vulnerabilities' => $this->get_vulnerabilities( 'core' ),
+		);
+		$response->themes  = new StdClass();
+		$response->plugins = new StdClass();
+		$skipped_plugin    = false;
+
+		foreach ( $installed_plugins as $plugin_slug => $plugin ) {
+			if ( ! $skipped_plugin && 'incomplete' === $settings['status'] ) {
+				$skipped_plugin = true;
+				continue;
+			}
+			$response->plugins->{ $plugin_slug } = (object) array(
+				'version'         => $plugin['Version'],
+				'vulnerabilities' => $this->get_vulnerabilities( 'plugins' ),
+			);
+		}
+		foreach ( $installed_themes as $theme_slug => $theme ) {
+			$response->themes->{ $theme_slug } = (object) array(
+				'version'         => $theme['Version'],
+				'vulnerabilities' => $this->get_vulnerabilities( 'themes' ),
+			);
+		}
+
+		if ( $settings['vuls_for_core'] ) {
+			$response->num_vulnerabilities += 2;
+		}
+		if ( $settings['vuls_for_plugins'] ) {
+			$response->num_vulnerabilities         += 2;
+			$response->num_plugins_vulnerabilities += 2;
+		}
+		if ( $settings['vuls_for_themes'] ) {
+			$response->num_vulnerabilities        += 2;
+			$response->num_themes_vulnerabilities += 2;
+		}
+
+		return $response;
+
+	}
+
+	/**
+	 * Get random fake vulnerability ID
+	 *
+	 * @return string
+	 */
+	public function get_random_id() {
+		$random1 = wp_generate_password( 8, false, false );
+		$random2 = wp_generate_password( 6, false, false );
+		return $random1 . '-1a32-446d-be3d-RANDOM' . $random2;
+	}
+
+	/**
+	 * Gets a fake list of vulnerabilities
+	 *
+	 * @param string  $type Core, plugins or themes.
+	 * @param integer $how_many Number of vulnerabilities to return.
+	 * @return array
+	 */
+	public function get_vulnerabilities( $type, $how_many = 2 ) {
+		static $current_index = 0;
+		static $done          = array(
+			'plugins' => false,
+			'themes'  => false,
+			'core'    => false,
+		);
+		$settings             = $this->get_stored_settings();
+		$vuls                 = array();
+		if ( ! $settings[ 'vuls_for_' . $type ] || $done[ $type ] ) {
+			return $vuls;
+		}
+
+		$done[ $type ] = true;
+
+		$ids = array(
+			'1fd6742e-1a32-446d-be3d-7cce44f8f416',
+			'1ac912c1-5e29-41ac-8f76-a062de254c09',
+			'6e61b246-5af1-4a4f-9ca8-a8c87eb2e499',
+			'36e3817f-7fcc-4a97-9ea2-e5e3b01f93a1',
+			'd442acac-4394-45e4-b6bb-adf4a40960fb',
+			'0c980e1c-d4dc-4b96-b0ce-282289674f55',
+			'5abdae02-215f-4df8-a0e8-c1c1b2eafa4b',
+			'0b58b722-e75a-4dc2-b63b-35375f475344',
+			'd3ef5644-1044-492f-ac23-ea90b32f1e77',
+			'ce716e4f-60f8-42e3-8891-a38e7948b970',
+			'be165b4b-cddb-46ec-8863-4d44e4d53045',
+			'72400eb2-b055-4431-aa02-8247a07ee8d4',
+		);
+		for ( $i = 1; $i <= $how_many; $i++ ) {
+			$id     = $current_index < count( $ids ) ? $ids[ $current_index ] : $this->get_random_id();
+			$vuls[] = array(
+				'id'       => $id,
+				'title'    => 'Sample Vulnerability number ' . $i . ' with a long title',
+				'fixed_in' => '3.14.2',
+			);
+			$current_index ++;
+		}
+
+		return $vuls;
+
+	}
+
+	/**
+	 * Filter the cache expire date and make sure it always look like it's not expired, except on status = error
+	 *
+	 * @return int
+	 */
+	public function filter_option_time() {
+		$settings = $this->get_stored_settings();
+		if ( 'error' === $settings['status'] ) {
+			return time() - 100;
+		}
+		return time() + 100;
+	}
+
+	/**
+	 * Forces the request for the Protect Status API ro return an error
+	 *
+	 * @param false|array|WP_Error $preempt The original response.
+	 * @param array                $parsed_args The request args.
+	 * @param string               $url The request URL.
+	 * @return mixed WP_Error if it's a request to Protect status API
+	 */
+	public function filter_status_fetch( $preempt, $parsed_args, $url ) {
+		if ( strpos( $url, Automattic\Jetpack\Protect\Status::get_api_url() ) !== false ) {
+			return new WP_Error( 'error' );
+		}
+		return $preempt;
+	}
 }
 
 add_action(

--- a/projects/plugins/debug-helper/plugin.php
+++ b/projects/plugins/debug-helper/plugin.php
@@ -79,6 +79,11 @@ $jetpack_dev_debug_modules = array(
 		'name'        => 'Jetpack Modules Debug Helper',
 		'description' => '',
 	),
+	'protect-helper'     => array(
+		'file'        => 'class-protect-helper.php',
+		'name'        => 'Jetpack Protect Helper',
+		'description' => 'Allows you to force different results for the Jetpack Protect plugin to make it easier to develop it.',
+	),
 );
 
 require_once __DIR__ . '/class-admin.php';

--- a/projects/plugins/protect/README.md
+++ b/projects/plugins/protect/README.md
@@ -7,40 +7,14 @@ Jetpack Protect plugin
 
 ## Developing
 
-Jetpack Protect is currently under development and we have 2 constants that let us work in the plugin while we are still building the service in WPCOM.
+Use the [Jetpack Debug Helper plugin](https://github.com/Automattic/jetpack/tree/trunk/projects/plugins/debug-helper) to force Protect into different statuses. The plugin will allow you to emulate different responses from the server so you can work on all the different statuses the plugin support.
+
+If you want to force Protect to always fetch data from the server you can use the constant below:
 
 `JETPACK_PROTECT_DEV__BYPASS_CACHE` - will ignore the cached results and will always request fresh data from WPCOM servers.
 
-`JETPACK_PROTECT_DEV__API_RESPONSE_TYPE` - will let you ask WPCOM servers to send a specific response to your requests:
+Be aware that a request to the server will be made in all admin pages! Use it only for debugging.
 
-Since the service is still under development, WPCOM is still responding with sample, hardcoded, data. You can choose which response type you want to get by passing one of the following parameters:
-
-* complete_green: Response will include all plugins and zero vulnerabitlies
-* incomplete_green: Response will miss one plugin and have zero vulnerabilities
-* complete: Response will include all plugins and 2 of them will have vulnerabilities
-* incomplete: Response will miss one plugin and 2 of them will have vulnerabilities
-* empty: Response as if the first check was not performed yet
-* error: Response as if there was an error checking vulnerabilities
-
-Example:
-
-```
-define( 'JETPACK_PROTECT_DEV__BYPASS_CACHE', true );
-define( 'JETPACK_PROTECT_DEV__API_RESPONSE_TYPE', 'complete' );
-```
-
-`JETPACK_PROTECT_DEV__API_CORE_VULS` - will let you ask WPCOM servers to respond with found vulnerabilities for WordPress core. The value should be an integer with the number of vulnerabilities you want to get. Default is zero.
-
-### Troubleshooting
-
-Jetpack Protect and the dev API endpoint on WPCOM relies on Sync. Protect needs to send the list of installed themes and plugins to our servers so we know what to check for.
-
-Sometimes in our dev environment we might run into situations where information is not synced immediately (because of plugin dance, etc).
-
-If you run in a situation where you are only getting empty responses from our testing endpoint, even though you have many plugins and themes installed and chose the right `response_type` in the constants described above, try the following:
-
-* Delete this transient: `wp transient delete jetpack_sync_callables_await`
-* Install or uninstall a plugin and/or a theme to make sure the list changes
 
 ## Contribute
 

--- a/projects/plugins/protect/changelog/add-protect-helper-module
+++ b/projects/plugins/protect/changelog/add-protect-helper-module
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed bug that would not display Core vulnerabilities, remove legacy code and documentation and add new docs on the debug helper plugin.

--- a/projects/plugins/protect/src/class-status.php
+++ b/projects/plugins/protect/src/class-status.php
@@ -208,12 +208,6 @@ class Status {
 
 		$api_url = sprintf( self::REST_API_BASE, $blog_id );
 
-		if ( defined( 'JETPACK_PROTECT_DEV__API_RESPONSE_TYPE' ) && is_string( JETPACK_PROTECT_DEV__API_RESPONSE_TYPE ) ) {
-			$api_url = add_query_arg( array( 'response_type' => JETPACK_PROTECT_DEV__API_RESPONSE_TYPE ), $api_url );
-		}
-		if ( defined( 'JETPACK_PROTECT_DEV__API_CORE_VULS' ) && is_int( JETPACK_PROTECT_DEV__API_CORE_VULS ) ) {
-			$api_url = add_query_arg( array( 'core_vuls' => JETPACK_PROTECT_DEV__API_CORE_VULS ), $api_url );
-		}
 		return $api_url;
 	}
 

--- a/projects/plugins/protect/src/js/hooks/use-protect-data/index.js
+++ b/projects/plugins/protect/src/js/hooks/use-protect-data/index.js
@@ -97,7 +97,7 @@ export default function useProtectData() {
 		installedThemes,
 		status.themes || {}
 	).map( theme => ( { ...theme, type: 'theme' } ) );
-	const core = normalizeCoreInformation( wpVersion, status.wordpress );
+	const core = normalizeCoreInformation( wpVersion, status.core );
 
 	let currentStatus = 'error';
 	if ( true === statusIsFetching ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds a new module to the Jetpack Debugger plugin that allows you to set different statuses for the Protect plugin. This is very handy when developing the plugin, since you need a way to simulate the different responses the API might return.

While working on this, I discovered a small bug in the plugin, that would keep Core vuls from showing up.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Create new Protect Helper debug module
* Fix a bug in Protect plugin keeping the core vulnerabilities from showing up

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack Debug and activate the "Protect Helper" module
* Go to Jetpack Debug > Protect helper
* See if you can understand what this screen does
* Play with the options there
* Visit Jetpack Protect page and make sure the page content follows what you are configuring in the Protect Helper plugin



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202476778482733