### PR TITLE
Boost: Update pricing on connection

### DIFF
--- a/projects/plugins/boost/app/admin/class-admin.php
+++ b/projects/plugins/boost/app/admin/class-admin.php
@@ -27,21 +27,9 @@ class Admin {
 	const MENU_SLUG = 'jetpack-boost';
 
 	/**
-	 * Nonce action for setting the statuses of rating and score prompts.
-	 */
-	const SET_SHOW_RATING_PROMPT_NONCE = 'set_show_rating_prompt';
-	const SET_SHOW_SCORE_PROMPT_NONCE  = 'set_show_score_prompt';
-
-	/**
 	 * Option to store options that have been dismissed.
 	 */
 	const DISMISSED_NOTICE_OPTION = 'jb-dismissed-notices';
-
-	/**
-	 * Name of option to store status of show/hide rating and score prompts
-	 */
-	const SHOW_RATING_PROMPT_OPTION = 'jb_show_rating_prompt';
-	const SHOW_SCORE_PROMPT_OPTION  = 'jb_show_score_prompt';
 
 	/**
 	 * Main plugin instance.
@@ -57,17 +45,26 @@ class Admin {
 	 */
 	private $speed_score;
 
+	/**
+	 * Configuration constants.
+	 *
+	 * @param Config $config
+	 */
+	private $config;
+
+
 	public function __construct( Optimizations $modules ) {
 		$this->modules     = $modules;
 		$this->speed_score = new Speed_Score( $modules );
 		Environment_Change_Detector::init();
 		Premium_Pricing::init();
 
+		$this->config = new Config;
+		$this->config->init();
+
 		add_action( 'init', array( new Analytics(), 'init' ) );
 		add_filter( 'plugin_action_links_' . JETPACK_BOOST_PLUGIN_BASE, array( $this, 'plugin_page_settings_link' ) );
 		add_action( 'admin_notices', array( $this, 'show_notices' ) );
-		add_action( 'wp_ajax_set_show_rating_prompt', array( $this, 'handle_set_show_rating_prompt' ) );
-		add_action( 'wp_ajax_set_show_score_prompt', array( $this, 'handle_set_show_score_prompt' ) );
 		add_filter( 'jetpack_boost_js_constants', array( $this, 'add_js_constants' ) );
 
 		$this->handle_get_parameters();
@@ -127,45 +124,10 @@ class Admin {
 			true
 		);
 
-		$optimizations = ( new Optimizations() )->get_status();
-		// Prepare configuration constants for JavaScript.
-		$constants = array(
-			'version'             => JETPACK_BOOST_VERSION,
-			'api'                 => array(
-				'namespace' => JETPACK_BOOST_REST_NAMESPACE,
-				'prefix'    => JETPACK_BOOST_REST_PREFIX,
-			),
-			'optimizations'       => $optimizations,
-			'locale'              => get_locale(),
-			'site'                => array(
-				'domain'    => ( new Status() )->get_site_suffix(),
-				'url'       => get_home_url(),
-				'online'    => ! ( new Status() )->is_offline_mode(),
-				'assetPath' => plugins_url( $internal_path, JETPACK_BOOST_PATH ),
-			),
-			'shownAdminNoticeIds' => $this->get_shown_admin_notice_ids(),
-			'preferences'         => array(
-				'showRatingPrompt' => $this->get_show_rating_prompt(),
-				'showScorePrompt'  => $this->get_show_score_prompt(),
-				'prioritySupport'  => Premium_Features::has_feature( Premium_Features::PRIORITY_SUPPORT ),
-			),
-
-			/**
-			 * A bit of necessary magic,
-			 * Explained more in the Nonce class.
-			 *
-			 * Nonces are automatically generated when registering routes.
-			 */
-			'nonces'              => Nonce::get_generated_nonces(),
-		);
-
-		// Give each module an opportunity to define extra constants.
-		$constants = apply_filters( 'jetpack_boost_js_constants', $constants );
-
 		wp_localize_script(
 			$admin_js_handle,
 			'Jetpack_Boost',
-			$constants
+			$this->config->constants()
 		);
 
 		wp_set_script_translations( $admin_js_handle, 'jetpack-boost' );
@@ -203,12 +165,17 @@ class Admin {
 	}
 
 	/**
-	 * Check for permissions.
-	 *
-	 * @return bool
+	 * Get the list of dismissed notices.
 	 */
-	public function check_for_permissions() {
-		return current_user_can( 'manage_options' );
+	public static function get_dismissed_notices() {
+		return \get_option( self::DISMISSED_NOTICE_OPTION, array() );
+	}
+
+	/**
+	 * Delete the option tracking which admin notices have been dismissed during deactivation.
+	 */
+	public static function clear_dismissed_notices() {
+		\delete_option( self::DISMISSED_NOTICE_OPTION );
 	}
 
 	/**
@@ -221,7 +188,7 @@ class Admin {
 		$notices          = $this->get_admin_notices();
 
 		// Filter out any that have been dismissed, unless newer than the dismissal.
-		$dismissed_notices = \get_option( self::DISMISSED_NOTICE_OPTION, array() );
+		$dismissed_notices = self::get_dismissed_notices();
 		$notices           = array_filter(
 			$notices,
 			function ( $notice ) use ( $dismissed_notices ) {
@@ -243,27 +210,11 @@ class Admin {
 	}
 
 	/**
-	 * Returns an array of notice ids (i.e.: jetpack-boost-notice-[slug]) for all
-	 * visible admin notices.
-	 *
-	 * @return array List of notice ids.
-	 */
-	private function get_shown_admin_notice_ids() {
-		$notices = $this->get_admin_notices();
-		$ids     = array();
-		foreach ( $notices as $notice ) {
-			$ids[] = $notice->get_id();
-		}
-
-		return $ids;
-	}
-
-	/**
 	 * Returns a list of admin notices to show. Asks each module to provide admin notices the user needs to see.
 	 *
 	 * @return \Automattic\Jetpack_Boost\Admin\Admin_Notice[]
 	 */
-	public function get_admin_notices() {
+	public static function get_admin_notices() {
 		return apply_filters( 'jetpack_boost_admin_notices', array() );
 	}
 
@@ -279,7 +230,7 @@ class Admin {
 		if ( is_admin() && ! empty( $_GET['jb-dismiss-notice'] ) ) {
 			$slug = sanitize_title( wp_unslash( $_GET['jb-dismiss-notice'] ) );
 
-			$dismissed_notices = \get_option( self::DISMISSED_NOTICE_OPTION, array() );
+			$dismissed_notices = self::get_dismissed_notices();
 
 			if ( ! in_array( $slug, $dismissed_notices, true ) ) {
 				$dismissed_notices[] = $slug;
@@ -291,94 +242,12 @@ class Admin {
 	// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 	/**
-	 * Handle the ajax request to set show-rating-prompt status.
-	 */
-	public function handle_set_show_rating_prompt() {
-		if ( check_ajax_referer( self::SET_SHOW_RATING_PROMPT_NONCE, 'nonce' ) && $this->check_for_permissions() ) {
-			$response = array(
-				'status' => 'ok',
-			);
-
-			$is_enabled = isset( $_POST['value'] ) && 'true' === $_POST['value'] ? '1' : '0';
-			\update_option( self::SHOW_RATING_PROMPT_OPTION, $is_enabled );
-
-			wp_send_json( $response );
-		} else {
-			$error = new \WP_Error( 'authorization', __( 'You do not have permission to take this action.', 'jetpack-boost' ) );
-			wp_send_json_error( $error, 403 );
-		}
-	}
-
-	/**
-	 * Get the value of show_rating_prompt.
-	 *
-	 * This determines if there should be a prompt after speed score improvements. Initially the value is set to true by
-	 * default. Once the user clicks on the rating button, it is switched to false.
-	 *
-	 * @return bool
-	 */
-	public function get_show_rating_prompt() {
-		return \get_option( self::SHOW_RATING_PROMPT_OPTION, '1' ) === '1';
-	}
-
-	/**
-	 * Handle the ajax request to set show-rating-prompt status.
-	 */
-	public function handle_set_show_score_prompt() {
-		if ( check_ajax_referer( self::SET_SHOW_SCORE_PROMPT_NONCE, 'nonce' ) && $this->check_for_permissions() ) {
-			$response = array(
-				'status' => 'ok',
-			);
-
-			$is_enabled = isset( $_POST['value'] ) && 'true' === $_POST['value'] ? '1' : '0';
-			\update_option( self::SHOW_SCORE_PROMPT_OPTION, $is_enabled );
-
-			wp_send_json( $response );
-		} else {
-			$error = new \WP_Error( 'authorization', __( 'You do not have permission to take this action.', 'jetpack-boost' ) );
-			wp_send_json_error( $error, 403 );
-		}
-	}
-
-	/**
-	 * Get the value of show_score_prompt.
-	 *
-	 * This determines if there should be a prompt after speed score worsens. Initially the value is set to true by
-	 * default. Once the user clicks on the support button, it is switched to false.
-	 *
-	 * @return bool
-	 */
-	public function get_show_score_prompt() {
-		return \get_option( self::SHOW_SCORE_PROMPT_OPTION, '1' ) === '1';
-	}
-
-	/**
-	 * Delete the option tracking which admin notices have been dismissed during deactivation.
-	 */
-	public static function clear_dismissed_notices() {
-		\delete_option( self::DISMISSED_NOTICE_OPTION );
-	}
-
-	/**
-	 * Clear the status of show_rating_prompt
-	 */
-	public static function clear_show_rating_prompt() {
-		\delete_option( self::SHOW_RATING_PROMPT_OPTION );
-	}
-
-	/**
-	 * Clear the status of show_score_prompt
-	 */
-	public static function clear_show_score_prompt() {
-		\delete_option( self::SHOW_SCORE_PROMPT_OPTION );
-	}
-	/**
 	 * Clear a specific admin notice.
 	 *
 	 * @param string $notice_slug The notice slug.
 	 */
 	public static function clear_dismissed_notice( $notice_slug ) {
-		$dismissed_notices = \get_option( self::DISMISSED_NOTICE_OPTION, array() );
+		$dismissed_notices = self::get_dismissed_notices();
 
 		if ( in_array( $notice_slug, $dismissed_notices, true ) ) {
 			array_splice( $dismissed_notices, array_search( $notice_slug, $dismissed_notices, true ), 1 );
@@ -396,8 +265,8 @@ class Admin {
 	 */
 	public function add_js_constants( $constants ) {
 		// Information about the current status of Critical CSS / generation.
-		$constants['showRatingPromptNonce'] = wp_create_nonce( self::SET_SHOW_RATING_PROMPT_NONCE );
-		$constants['showScorePromptNonce']  = wp_create_nonce( self::SET_SHOW_SCORE_PROMPT_NONCE );
+		$constants['showRatingPromptNonce'] = wp_create_nonce( Config::SET_SHOW_RATING_PROMPT_NONCE );
+		$constants['showScorePromptNonce']  = wp_create_nonce( Config::SET_SHOW_SCORE_PROMPT_NONCE );
 
 		return $constants;
 	}

--- a/projects/plugins/boost/app/admin/class-admin.php
+++ b/projects/plugins/boost/app/admin/class-admin.php
@@ -9,7 +9,6 @@
 namespace Automattic\Jetpack_Boost\Admin;
 
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
-use Automattic\Jetpack\Status;
 use Automattic\Jetpack_Boost\Features\Optimizations\Optimizations;
 use Automattic\Jetpack_Boost\Features\Speed_Score\Speed_Score;
 use Automattic\Jetpack_Boost\Jetpack_Boost;
@@ -17,7 +16,6 @@ use Automattic\Jetpack_Boost\Lib\Analytics;
 use Automattic\Jetpack_Boost\Lib\Environment_Change_Detector;
 use Automattic\Jetpack_Boost\Lib\Premium_Features;
 use Automattic\Jetpack_Boost\Lib\Premium_Pricing;
-use Automattic\Jetpack_Boost\REST_API\Permissions\Nonce;
 
 class Admin {
 
@@ -52,14 +50,13 @@ class Admin {
 	 */
 	private $config;
 
-
 	public function __construct( Optimizations $modules ) {
 		$this->modules     = $modules;
 		$this->speed_score = new Speed_Score( $modules );
 		Environment_Change_Detector::init();
 		Premium_Pricing::init();
 
-		$this->config = new Config;
+		$this->config = new Config();
 		$this->config->init();
 
 		add_action( 'init', array( new Analytics(), 'init' ) );

--- a/projects/plugins/boost/app/admin/class-config.php
+++ b/projects/plugins/boost/app/admin/class-config.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Admin;
+
+use Automattic\Jetpack\Status;
+use Automattic\Jetpack_Boost\Features\Optimizations\Optimizations;
+use Automattic\Jetpack_Boost\Lib\Premium_Features;
+use Automattic\Jetpack_Boost\REST_API\Permissions\Nonce;
+
+/**
+ * Handle the configuration constants.
+ *
+ * This is a global state of Jetpack Boost and passed on to the front-end.
+ */
+class Config {
+	/**
+	 * Nonce action for setting the statuses of rating and score prompts.
+	 */
+	const SET_SHOW_RATING_PROMPT_NONCE = 'set_show_rating_prompt';
+	const SET_SHOW_SCORE_PROMPT_NONCE  = 'set_show_score_prompt';
+
+	/**
+	 * Name of option to store status of show/hide rating and score prompts
+	 */
+	const SHOW_RATING_PROMPT_OPTION = 'jb_show_rating_prompt';
+	const SHOW_SCORE_PROMPT_OPTION  = 'jb_show_score_prompt';
+
+	public function init() {
+		add_action( 'wp_ajax_set_show_rating_prompt', array( $this, 'handle_set_show_rating_prompt' ) );
+		add_action( 'wp_ajax_set_show_score_prompt', array( $this, 'handle_set_show_score_prompt' ) );
+	}
+
+	public function constants() {
+		$optimizations = ( new Optimizations() )->get_status();
+		$internal_path = apply_filters( 'jetpack_boost_asset_internal_path', 'app/assets/dist/' );
+
+		$constants = array(
+			'version'             => JETPACK_BOOST_VERSION,
+			'api'                 => array(
+				'namespace' => JETPACK_BOOST_REST_NAMESPACE,
+				'prefix'    => JETPACK_BOOST_REST_PREFIX,
+			),
+			'optimizations'       => $optimizations,
+			'locale'              => get_locale(),
+			'site'                => array(
+				'domain'    => ( new Status() )->get_site_suffix(),
+				'url'       => get_home_url(),
+				'online'    => ! ( new Status() )->is_offline_mode(),
+				'assetPath' => plugins_url( $internal_path, JETPACK_BOOST_PATH ),
+			),
+			'shownAdminNoticeIds' => $this->get_shown_admin_notice_ids(),
+			'preferences'         => array(
+				'showRatingPrompt' => $this->get_show_rating_prompt(),
+				'showScorePrompt'  => $this->get_show_score_prompt(),
+				'prioritySupport'  => Premium_Features::has_feature( Premium_Features::PRIORITY_SUPPORT ),
+			),
+
+			/**
+			 * A bit of necessary magic,
+			 * Explained more in the Nonce class.
+			 *
+			 * Nonces are automatically generated when registering routes.
+			 */
+			'nonces'              => Nonce::get_generated_nonces(),
+		);
+
+		// Give each module an opportunity to define extra constants.
+		return apply_filters( 'jetpack_boost_js_constants', $constants );
+	}
+
+	/**
+	 * Returns an array of notice ids (i.e.: jetpack-boost-notice-[slug]) for all
+	 * visible admin notices.
+	 *
+	 * @return array List of notice ids.
+	 */
+	private function get_shown_admin_notice_ids() {
+		$notices = Admin::get_admin_notices();
+		$ids     = array();
+		foreach ( $notices as $notice ) {
+			$ids[] = $notice->get_id();
+		}
+
+		return $ids;
+	}
+
+	/**
+	 * Get the value of show_rating_prompt.
+	 *
+	 * This determines if there should be a prompt after speed score improvements. Initially the value is set to true by
+	 * default. Once the user clicks on the rating button, it is switched to false.
+	 *
+	 * @return bool
+	 */
+	public function get_show_rating_prompt() {
+		return \get_option( self::SHOW_RATING_PROMPT_OPTION, '1' ) === '1';
+	}
+
+	/**
+	 * Handle the ajax request to set show-rating-prompt status.
+	 */
+	public function handle_set_show_rating_prompt() {
+		if ( check_ajax_referer( self::SET_SHOW_RATING_PROMPT_NONCE, 'nonce' ) && $this->check_for_permissions() ) {
+			$response = array(
+				'status' => 'ok',
+			);
+
+			$is_enabled = isset( $_POST['value'] ) && 'true' === $_POST['value'] ? '1' : '0';
+			\update_option( self::SHOW_RATING_PROMPT_OPTION, $is_enabled );
+
+			wp_send_json( $response );
+		} else {
+			$error = new \WP_Error( 'authorization', __( 'You do not have permission to take this action.', 'jetpack-boost' ) );
+			wp_send_json_error( $error, 403 );
+		}
+	}
+
+	/**
+	 * Handle the ajax request to set show-rating-prompt status.
+	 */
+	public function handle_set_show_score_prompt() {
+		if ( check_ajax_referer( self::SET_SHOW_SCORE_PROMPT_NONCE, 'nonce' ) && $this->check_for_permissions() ) {
+			$response = array(
+				'status' => 'ok',
+			);
+
+			$is_enabled = isset( $_POST['value'] ) && 'true' === $_POST['value'] ? '1' : '0';
+			\update_option( self::SHOW_SCORE_PROMPT_OPTION, $is_enabled );
+
+			wp_send_json( $response );
+		} else {
+			$error = new \WP_Error( 'authorization', __( 'You do not have permission to take this action.', 'jetpack-boost' ) );
+			wp_send_json_error( $error, 403 );
+		}
+	}
+
+	/**
+	 * Check for permissions.
+	 *
+	 * @return bool
+	 */
+	public function check_for_permissions() {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Get the value of show_score_prompt.
+	 *
+	 * This determines if there should be a prompt after speed score worsens. Initially the value is set to true by
+	 * default. Once the user clicks on the support button, it is switched to false.
+	 *
+	 * @return bool
+	 */
+	public function get_show_score_prompt() {
+		return \get_option( self::SHOW_SCORE_PROMPT_OPTION, '1' ) === '1';
+	}
+
+	/**
+	 * Clear the status of show_rating_prompt
+	 */
+	public static function clear_show_rating_prompt() {
+		\delete_option( self::SHOW_RATING_PROMPT_OPTION );
+	}
+
+	/**
+	 * Clear the status of show_score_prompt
+	 */
+	public static function clear_show_score_prompt() {
+		\delete_option( self::SHOW_SCORE_PROMPT_OPTION );
+	}
+}

--- a/projects/plugins/boost/app/assets/src/js/Main.svelte
+++ b/projects/plugins/boost/app/assets/src/js/Main.svelte
@@ -20,7 +20,7 @@
 				<Header />
 			</div>
 
-			{#if $connection.connected || ! config.site.online}
+			{#if $connection.connected || ! $config.site.online}
 				<Settings />
 			{:else}
 				<Connection />

--- a/projects/plugins/boost/app/assets/src/js/pages/benefits/BenefitsInterstitial.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/benefits/BenefitsInterstitial.svelte
@@ -1,10 +1,12 @@
 <script>
 	import { PricingCard } from '@automattic/jetpack-components';
 	import React from 'react';
+	import { derived } from 'svelte/store';
 	import { createInterpolateElement } from '@wordpress/element';
 	import { __ } from '@wordpress/i18n';
 	import BackButton from '../../elements/BackButton.svelte';
 	import ReactComponent from '../../elements/ReactComponent.svelte';
+	import config from '../../stores/config';
 	import Logo from '../../svg/jetpack-green.svg';
 	import { jetpackURL } from '../../utils/jetpack-url';
 	import { getUpgradeURL } from '../../utils/upgrade';
@@ -35,9 +37,9 @@
 		}
 	);
 
-	const { pricing } = window.Jetpack_Boost;
+	const pricing = derived( config, $config => $config.pricing );
 
-	if ( ! ( 'yearly' in pricing ) ) {
+	if ( ! ( 'yearly' in $pricing ) ) {
 		goToCheckout();
 	}
 </script>
@@ -63,15 +65,15 @@
 			</div>
 
 			<div class="jb-card__cta px-2 my-4">
-				{#if 'yearly' in pricing}
+				{#if 'yearly' in $pricing}
 					<ReactComponent
 						this={PricingCard}
 						title={'Jetpack Boost'}
 						icon={`${ window.Jetpack_Boost.site.assetPath }../static/images/forward.svg`}
-						priceBefore={pricing.yearly.priceBefore / 12}
-						priceAfter={pricing.yearly.priceAfter / 12}
+						priceBefore={$pricing.yearly.priceBefore / 12}
+						priceAfter={$pricing.yearly.priceAfter / 12}
 						priceDetails={__( '/month, paid yearly', 'jetpack-boost' )}
-						currencyCode={pricing.yearly.currencyCode}
+						currencyCode={$pricing.yearly.currencyCode}
 						ctaText={__( 'Upgrade Jetpack Boost', 'jetpack-boost' )}
 						onCtaClick={goToCheckout}
 						{infoText}

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Support.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Support.svelte
@@ -3,7 +3,7 @@
 	import { hasPrioritySupport, openPaidSupport } from '../../../utils/paid-plan';
 </script>
 
-{#if hasPrioritySupport}
+{#if $hasPrioritySupport}
 	<div class="jb-section">
 		<div class="jb-container--narrow">
 			<div class="jb-support">

--- a/projects/plugins/boost/app/assets/src/js/stores/config.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/config.ts
@@ -1,4 +1,6 @@
+import { writable } from 'svelte/store';
+
 // eslint-disable-next-line camelcase
-const config = Jetpack_Boost;
+const config = writable( Jetpack_Boost );
 
 export default config;

--- a/projects/plugins/boost/app/assets/src/js/stores/config.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/config.ts
@@ -1,6 +1,18 @@
 import { writable } from 'svelte/store';
+import api from '../api/api';
 
 // eslint-disable-next-line camelcase
-const config = writable( Jetpack_Boost );
+const { subscribe, update } = writable( Jetpack_Boost );
 
-export default config;
+async function refresh(): Promise< void > {
+	const configuration = await api.get( '/configuration' );
+
+	update( store => {
+		return { ...store, ...configuration };
+	} );
+}
+
+export default {
+	subscribe,
+	refresh,
+};

--- a/projects/plugins/boost/app/assets/src/js/stores/modules.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/modules.ts
@@ -1,4 +1,4 @@
-import { writable } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import api from '../api/api';
 import { setModuleState } from '../api/modules';
 import config from './config';
@@ -15,7 +15,7 @@ export type ModulesState = {
 };
 
 const { subscribe, update, set } = writable< ModulesState >(
-	buildModuleState( config.optimizations )
+	buildModuleState( get( config ).optimizations )
 );
 
 // Keep a subscribed copy for quick reading.

--- a/projects/plugins/boost/app/assets/src/js/utils/connection.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/connection.ts
@@ -1,3 +1,4 @@
+import config from '../stores/config';
 import { isEnabled } from '../stores/modules';
 import { requestCloudCss } from './cloud-css';
 
@@ -9,4 +10,6 @@ export async function onConnectionComplete(): Promise< void > {
 	if ( isEnabled( 'cloud-css' ) ) {
 		await requestCloudCss();
 	}
+
+	await config.refresh();
 }

--- a/projects/plugins/boost/app/assets/src/js/utils/jetpack-url.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/jetpack-url.ts
@@ -1,8 +1,11 @@
+import { get } from 'svelte/store';
 import config from '../stores/config';
 
 export function jetpackURL( url ) {
-	if ( config.site.url ) {
-		url = url + '&site=' + encodeURIComponent( config.site.url );
+	const siteUrl = get( config ).site.url;
+
+	if ( siteUrl ) {
+		url = url + '&site=' + encodeURIComponent( siteUrl );
 	}
 	return url;
 }

--- a/projects/plugins/boost/app/assets/src/js/utils/paid-plan.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/paid-plan.ts
@@ -1,6 +1,7 @@
+import { derived } from 'svelte/store';
 import config from '../stores/config';
 
-export const hasPrioritySupport = config.preferences.prioritySupport;
+export const hasPrioritySupport = derived( config, $config => $config.preferences.prioritySupport );
 
 export const openPaidSupport = () => {
 	const supportUrl = 'https://jetpackme.wordpress.com/contact-support/';

--- a/projects/plugins/boost/app/assets/src/js/utils/upgrade.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/upgrade.ts
@@ -1,3 +1,4 @@
+import { get } from 'svelte/store';
 import config from '../stores/config';
 
 /**
@@ -8,7 +9,7 @@ import config from '../stores/config';
  * should be used instead. However, the redirect changes the redirect URL in a broken manner.
  */
 export function getUpgradeURL() {
-	const siteSuffix = config.site.domain;
+	const siteSuffix = get( config ).site.domain;
 	const product = 'jetpack_boost_yearly';
 
 	const redirectUrl = new URL( window.location.href );

--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -23,6 +23,7 @@ use Automattic\Jetpack_Boost\Lib\Connection;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Storage;
 use Automattic\Jetpack_Boost\Lib\Setup;
 use Automattic\Jetpack_Boost\Lib\Transient;
+use Automattic\Jetpack_Boost\REST_API\Endpoints\Config_State;
 use Automattic\Jetpack_Boost\REST_API\Endpoints\Optimization_Status;
 use Automattic\Jetpack_Boost\REST_API\Endpoints\Optimizations_Status;
 use Automattic\Jetpack_Boost\REST_API\REST_API;
@@ -129,6 +130,7 @@ class Jetpack_Boost {
 	public function init_admin( $modules ) {
 		REST_API::register( Optimization_Status::class );
 		REST_API::register( Optimizations_Status::class );
+		REST_API::register( Config_State::class );
 		$this->connection->ensure_connection();
 		new Admin( $modules );
 	}

--- a/projects/plugins/boost/app/rest-api/endpoints/Config_State.php
+++ b/projects/plugins/boost/app/rest-api/endpoints/Config_State.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\REST_API\Endpoints;
+
+use Automattic\Jetpack_Boost\Admin\Config;
+use Automattic\Jetpack_Boost\REST_API\Contracts\Endpoint;
+use Automattic\Jetpack_Boost\REST_API\Permissions\Current_User_Admin;
+
+class Config_State implements Endpoint {
+
+	public function request_methods() {
+		return \WP_REST_Server::READABLE;
+	}
+
+	// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public function response( $request ) {
+		$config = new Config();
+		return rest_ensure_response( $config->constants() );
+	}
+
+	public function permissions() {
+		return array(
+			new Current_User_Admin(),
+		);
+	}
+
+	public function name() {
+		return '/configuration';
+	}
+}

--- a/projects/plugins/boost/changelog/add-update-pricing-on-connection
+++ b/projects/plugins/boost/changelog/add-update-pricing-on-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Decouple config constants from enqueue scripts


### PR DESCRIPTION
Fixes 58-gh-Automattic/boost-cloud

#### Changes proposed in this Pull Request:
- [x] Decouple the config constants from `enqueue_scripts`
- [x] Add endpoint to serve the config
- [x] Reload the config on connection

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
p1655882229140969-slack-C016BBAFHHS

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* TBD