### PR TITLE
Record meter: format the numbers used in notice.

### DIFF
--- a/projects/packages/search/changelog/update-recordmeter-format
+++ b/projects/packages/search/changelog/update-recordmeter-format
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Record meter: format the numbers used in notice.

--- a/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
@@ -10,6 +10,11 @@ const CLOSE_TO_LIMIT_PERCENT = 0.8;
 const DISMISSED_NOTICES = 'jetpack-search-dismissed-notices';
 
 const getNotices = ( tierMaximumRecords = null ) => {
+	const recordLimit =
+		typeof tierMaximumRecords === 'number'
+			? tierMaximumRecords?.toLocaleString()
+			: tierMaximumRecords;
+
 	return {
 		1: {
 			id: 1,
@@ -42,7 +47,7 @@ const getNotices = ( tierMaximumRecords = null ) => {
 						"You won't be charged for the new tier until your next billing date.",
 					'jetpack-search-pkg'
 				),
-				tierMaximumRecords
+				recordLimit
 			),
 			link: {
 				text: __( 'Learn more', 'jetpack-search-pkg' ),

--- a/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
@@ -12,7 +12,7 @@ const DISMISSED_NOTICES = 'jetpack-search-dismissed-notices';
 const getNotices = ( tierMaximumRecords = null ) => {
 	const recordLimit =
 		typeof tierMaximumRecords === 'number'
-			? tierMaximumRecords?.toLocaleString()
+			? tierMaximumRecords.toLocaleString()
 			: tierMaximumRecords;
 
 	return {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Let's use formatted numbers whenever possible, it looks better with bigger numbers.

**Before**

<img width="780" alt="image" src="https://user-images.githubusercontent.com/426388/175036388-295b8a43-9c2c-4775-a7ef-8bcd8e01a7f2.png">

**After**

<img width="785" alt="Screen Shot 2022-06-22 at 14 51 14" src="https://user-images.githubusercontent.com/426388/175035667-cb97402b-474e-4ac1-a226-bc7186c2b7b3.png">

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start with a site with a Jetpack Search plan
* Go to `yoursite.com/wp-admin/admin.php?page=jetpack-search&features=record-meter`
* Update `postCount` and `tierMaximumRecords` to something like `1218` and `1300`.
* Re-build the Search package with `jetpack build packages/search`
* Refresh the page, and notice the notice with the updated formatted number.

