### PR TITLE
js/shared-extension-utils: Remove unused testing infrastructure

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -521,9 +521,7 @@ importers:
       '@wordpress/i18n': 4.10.0
       '@wordpress/plugins': 4.8.0
       '@wordpress/url': 3.11.0
-      jetpack-js-test-runner: workspace:*
       lodash: 4.17.21
-      nyc: 15.1.0
       react: 17.0.2
     dependencies:
       '@wordpress/compose': 5.8.0_react@17.0.2
@@ -534,8 +532,6 @@ importers:
     devDependencies:
       '@babel/core': 7.18.5
       '@babel/preset-react': 7.17.12_@babel+core@7.18.5
-      jetpack-js-test-runner: link:../../../tools/js-test-runner
-      nyc: 15.1.0
       react: 17.0.2
 
   projects/js-packages/storybook:

--- a/projects/js-packages/shared-extension-utils/.eslintrc.cjs
+++ b/projects/js-packages/shared-extension-utils/.eslintrc.cjs
@@ -16,4 +16,10 @@ module.exports = {
 			},
 		],
 	},
+	overrides: [
+		{
+			files: [ '**/test/*.[jt]s?(x)', '**/*.test.[jt]s?(x)' ],
+			extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
+		},
+	],
 };

--- a/projects/js-packages/shared-extension-utils/.nycrc
+++ b/projects/js-packages/shared-extension-utils/.nycrc
@@ -1,5 +1,0 @@
-{
-	"extensions": [".js", ".jsx"],
-	"exclude": "**/test/*.jsx",
-	"reporter": "clover"
-}

--- a/projects/js-packages/shared-extension-utils/changelog/update-js-shared-extension-utils-rm-unused-test-infrastructure
+++ b/projects/js-packages/shared-extension-utils/changelog/update-js-shared-extension-utils-rm-unused-test-infrastructure
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove unused testing infrastructure. If someone adds tests in the future, they can copy-paste from one of the other packages then.
+
+

--- a/projects/js-packages/shared-extension-utils/composer.json
+++ b/projects/js-packages/shared-extension-utils/composer.json
@@ -8,14 +8,7 @@
 		"yoast/phpunit-polyfills": "1.0.3",
 		"automattic/jetpack-changelogger": "^3.1"
 	},
-	"scripts": {
-		"test-js": [
-			"pnpm run test"
-		],
-		"test-coverage": [
-			"pnpm nyc --report-dir=\"$COVERAGE_DIR\" pnpm run test"
-		]
-	},
+	"scripts": {},
 	"repositories": [
 		{
 			"type": "path",

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.4.10",
+	"version": "0.4.11-alpha",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {
@@ -13,9 +13,7 @@
 	},
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic",
-	"scripts": {
-		"test": "NODE_ENV=test NODE_PATH=tests:. js-test-runner --jsdom --initfile=test-main.jsx 'glob:./!(node_modules)/**/test/*.@(jsx|js)'"
-	},
+	"scripts": {},
 	"dependencies": {
 		"@wordpress/compose": "5.8.0",
 		"@wordpress/i18n": "4.10.0",
@@ -26,8 +24,6 @@
 	"devDependencies": {
 		"@babel/core": "7.18.5",
 		"@babel/preset-react": "7.17.12",
-		"jetpack-js-test-runner": "workspace:*",
-		"nyc": "15.1.0",
 		"react": "17.0.2"
 	},
 	"engines": {

--- a/projects/js-packages/shared-extension-utils/test-main.jsx
+++ b/projects/js-packages/shared-extension-utils/test-main.jsx
@@ -1,4 +1,0 @@
-import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
-import Enzyme from 'enzyme';
-
-Enzyme.configure( { adapter: new Adapter() } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
When I went to convert this package to use jest instead of
js-test-runner, I found no tests to convert. So I left it at setting up
test linting and removed the rest.

If someone wants to add tests to the package in the future, they can
copy-paste from one of the other packages at that time, when they'll
have actual tests to know what specifically needs to be set up.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-5j2-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?