### PR TITLE
Minor: Add action before switch theme

### DIFF
--- a/projects/plugins/jetpack/changelog/add-action-before-switch-theme
+++ b/projects/plugins/jetpack/changelog/add-action-before-switch-theme
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: other
 
-Adds an action before calling switch_theme from /wp-content/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-active-endpoint.php
+WordPress.com REST API: add new action allowing you to trigger an action right before we switch themes via the API.

--- a/projects/plugins/jetpack/changelog/add-action-before-switch-theme
+++ b/projects/plugins/jetpack/changelog/add-action-before-switch-theme
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Adds an action before calling switch_theme from /wp-content/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-active-endpoint.php

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-active-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-active-endpoint.php
@@ -47,8 +47,15 @@ class Jetpack_JSON_API_Themes_Active_Endpoint extends Jetpack_JSON_API_Themes_En
 		}
 
 		/**
-		* Trigger action before the switch theme happens.
-		*/
+		 * Trigger action before the switch theme happens.
+		 *
+		 * @module json-api
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param string $theme_slug Directory name for the theme.
+		 * @param mixed  $args       POST body data, including info about the theme we must switch to.
+		 */
 		do_action( 'jetpack_pre_switch_theme', $theme_slug, $args );
 
 		$theme = wp_get_theme( $theme_slug );

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-active-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-active-endpoint.php
@@ -46,6 +46,11 @@ class Jetpack_JSON_API_Themes_Active_Endpoint extends Jetpack_JSON_API_Themes_En
 			return new WP_Error( 'theme_not_found', __( 'Theme is empty.', 'jetpack' ), 404 );
 		}
 
+		/**
+		* Trigger action before the switch theme happens.
+		*/
+		do_action( 'jetpack_pre_switch_theme', $theme_slug, $args );
+
 		$theme = wp_get_theme( $theme_slug );
 
 		if ( ! $theme->exists() ) {


### PR DESCRIPTION
This PR adds an action called `jetpack_pre_switch_theme`. The idea is to be able to do some previous setup before `switch_theme` happens. 

For more context see: paYKcK-1Mb-p2#comment-1395.

#### Testing instructions:
1. Set up a Jurassic Ninja site.
2. Connect it to WP.com.
3. Connect to your JN site through ssh.
4. Add this snippet to the bottom of `/srv/users/[USER]/apps/[USER]/public/wp-load.php`.
```
add_action('jetpack_pre_switch_theme', function($arg1, $args ) {
        error_log( var_export( $arg1, true ) );
        error_log( var_export( $args, true ) );
}, 10, 2);
```
5. Run `tail -F /srv/users/[USER]/apps/[USER]/public/debug.log`.
6. Go to WPCOM and select the JN created in 1.
7. Change a theme using the **Activate** option in the menu. 
<img width="586" alt="image" src="https://user-images.githubusercontent.com/375980/175120620-afd346a3-4010-442d-8095-a99166d7b077.png">
8. Verify you see the log in the tail added in 5.

#### Does this pull request change what data or activity we track or use?
No.

Related to: https://github.com/Automattic/wp-calypso/issues/56869