### PR TITLE
eslint-changed: Fix debug output

### DIFF
--- a/projects/js-packages/eslint-changed/changelog/fix-eslint-changed-debug-output
+++ b/projects/js-packages/eslint-changed/changelog/fix-eslint-changed-debug-output
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix debug output.

--- a/projects/js-packages/eslint-changed/src/cli.js
+++ b/projects/js-packages/eslint-changed/src/cli.js
@@ -102,7 +102,7 @@ async function main( process, argv, program ) {
 	} );
 
 	const writeOut = program.configureOutput().writeOut;
-	const debug = argv.debug ? ( ...m ) => writeOut( chalk.grey( ...m ) ) : () => {};
+	const debug = argv.debug ? ( ...m ) => writeOut( chalk.grey( ...m ) + '\n' ) : () => {};
 
 	/**
 	 * Get files from a diff.
@@ -141,7 +141,7 @@ async function main( process, argv, program ) {
 	}
 
 	const eslint = new ESLint();
-	debug( 'Using ESLint version', eslint.version );
+	debug( 'Using ESLint version', ESLint.version );
 	const formatter = await eslint.loadFormatter( argv.format );
 
 	let diff, diffBase, files, eslintOrig, eslintNew;
@@ -156,7 +156,7 @@ async function main( process, argv, program ) {
 				1
 			);
 		}
-		debug( 'Using git version', ret.stdout.trim() );
+		debug( 'Using git version', ret.stdout.trim().replace( /^git version /, '' ) );
 
 		args = [ 'rev-parse', '--show-toplevel' ];
 		debug( 'Getting git top level:', git, args.join( ' ' ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Print newlines after each line (broken in #24626)
* Fix fetching of eslint version (broken in #21606)
* Strip "git version" from `git version` output.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `pnpm eslint-changed --debug --git --git-base=origin/trunk`. The debug output should make sense.
