### PR TITLE
Boost: Hide heading focus on navigation

### DIFF
--- a/projects/plugins/boost/app/assets/src/css/main/wp-admin.scss
+++ b/projects/plugins/boost/app/assets/src/css/main/wp-admin.scss
@@ -31,6 +31,7 @@
 		color: $primary-black;
 		line-height: 1.3;
 		font-weight: 500;
+	  	outline-color: transparent;
 	}
 
 	h2 {

--- a/projects/plugins/boost/changelog/update-hide-heading-focus
+++ b/projects/plugins/boost/changelog/update-hide-heading-focus
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Remove focus outline on navigation for headers


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Removed the outline in the header added by svelte navigator.

Hiding the outline on the header should be fine as the headings are not focusable by user. The focus itself is for a11y. More explanation on: https://www.npmjs.com/package/svelte-navigator#user-content-what-are-the-weird-rectangles-around-the-headings-in-my-app

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Enable critical-css
* Click upgrade
* Make sure you do not see an outline on the first heading like the following screenshot
<img width="1064" alt="image" src="https://user-images.githubusercontent.com/3737780/175231561-3bfac094-132d-47aa-98e8-1cfa65f40936.png">
