### PR TITLE
Protect: Fix recommendation when plugin doesn't have a fix yet

### DIFF
--- a/projects/plugins/protect/changelog/fix-protect-recomendation-fixed-in-null
+++ b/projects/plugins/protect/changelog/fix-protect-recomendation-fixed-in-null
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed recommendation for plugins that don't have a fix yet

--- a/projects/plugins/protect/src/js/components/vulnerabilities-list/list.jsx
+++ b/projects/plugins/protect/src/js/components/vulnerabilities-list/list.jsx
@@ -21,19 +21,18 @@ const VulAccordionItem = ( { id, name, version, title, icon, fixedIn, type } ) =
 			}, [ recordEvent, type ] ) }
 		>
 			{ fixedIn && (
-				<Text variant="title-small" mb={ 2 }>
-					{ __( 'How to fix it?', 'jetpack-protect' ) }
-				</Text>
+				<>
+					<Text variant="title-small" mb={ 2 }>
+						{ __( 'How to fix it?', 'jetpack-protect' ) }
+					</Text>
+					<Text mb={ 2 }>
+						{
+							/* translators: Translates to Update to. %1$s: Name. %2$s: Fixed version */
+							sprintf( __( 'Update to %1$s %2$s', 'jetpack-protect' ), name, fixedIn )
+						}
+					</Text>
+				</>
 			) }
-			{ fixedIn && (
-				<Text mb={ 2 }>
-					{
-						/* translators: Translates to Update to. %1$s: Name. %2$s: Fixed version */
-						sprintf( __( 'Update to %1$s %2$s', 'jetpack-protect' ), name, fixedIn )
-					}
-				</Text>
-			) }
-
 			<Button
 				variant="link"
 				isExternalLink={ true }

--- a/projects/plugins/protect/src/js/components/vulnerabilities-list/list.jsx
+++ b/projects/plugins/protect/src/js/components/vulnerabilities-list/list.jsx
@@ -20,15 +20,20 @@ const VulAccordionItem = ( { id, name, version, title, icon, fixedIn, type } ) =
 				recordEvent( `jetpack_protect_${ type }_vulnerability_open` );
 			}, [ recordEvent, type ] ) }
 		>
-			<Text variant="title-small" mb={ 2 }>
-				{ __( 'How to fix it?', 'jetpack-protect' ) }
-			</Text>
-			<Text mb={ 2 }>
-				{
-					/* translators: Translates to Update to. %1$s: Name. %2$s: Fixed version */
-					sprintf( __( 'Update to %1$s %2$s', 'jetpack-protect' ), name, fixedIn )
-				}
-			</Text>
+			{ fixedIn && (
+				<Text variant="title-small" mb={ 2 }>
+					{ __( 'How to fix it?', 'jetpack-protect' ) }
+				</Text>
+			) }
+			{ fixedIn && (
+				<Text mb={ 2 }>
+					{
+						/* translators: Translates to Update to. %1$s: Name. %2$s: Fixed version */
+						sprintf( __( 'Update to %1$s %2$s', 'jetpack-protect' ), name, fixedIn )
+					}
+				</Text>
+			) }
+
 			<Button
 				variant="link"
 				isExternalLink={ true }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This hides the how to fix? text in cases where the plugin fixedIn is null.

#### Other information:
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install this branch on your site.
* Install a plugin with a vulnerability that doesn't have a fix yet. (You can use this [vulnerability](https://wpscan.com/plugin/dx-share-selection) and rename one of your plugins to it as this particular plugin is closed)
* Verify that the How to fix? recommendation to update to null is not there anymore.

