### PR TITLE
jetpack: Lint tests in `extensions/` and remove enzyme there

### DIFF
--- a/projects/plugins/jetpack/.eslintignore
+++ b/projects/plugins/jetpack/.eslintignore
@@ -7,6 +7,3 @@
 /modules/custom-css/custom-css/js/core-customizer-css-preview.js
 /modules/custom-css/custom-css/js/core-customizer-css.core-4.9.js
 /modules/custom-css/custom-css/js/core-customizer-css.js
-
-# Temporary ignore until Jest is set up
-/extensions/**/test/

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-product-card/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-product-card/test/component.js
@@ -5,7 +5,7 @@ import analytics from 'lib/analytics';
 import * as React from 'react';
 import { render, screen } from 'test/test-utils';
 import JetpackProductCard from '../index';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 
 describe( 'Jetpack Product Card', () => {
 	const mockAttributes = {

--- a/projects/plugins/jetpack/_inc/client/performance/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/performance/test/component.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { render, screen } from 'test/test-utils';
 import Search from '../search';
 import { buildInitialState } from './fixtures';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 
 describe( 'Performance tab', () => {
 	it( 'shows Jetpack Search Widget button if theme supports it', () => {

--- a/projects/plugins/jetpack/_inc/client/product-descriptions/product-description/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/product-descriptions/product-description/test/component.js
@@ -5,7 +5,7 @@ import { getProductsForPurchase } from 'state/initial-state';
 import { render, screen } from 'test/test-utils';
 import ProductDescription from '../index';
 import { buildInitialState } from './fixtures';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 
 describe( 'Product Description', () => {
 	const initialState = buildInitialState();

--- a/projects/plugins/jetpack/_inc/client/recommendations/product-purchased/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/product-purchased/test/component.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { render, screen } from 'test/test-utils';
 import { buildInitialState, sitePurchases } from '../../prompts/product-suggestions/test/fixtures';
 import { ProductPurchased } from '../index';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 
 describe( 'Recommendations – Product Purchased', () => {
 	const initialState = buildInitialState();

--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/feature-prompt/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/feature-prompt/test/component.js
@@ -6,7 +6,7 @@ import * as recommendationsActions from 'state/recommendations/actions';
 import { render, screen } from 'test/test-utils';
 import * as featureUtils from '../../../feature-utils';
 import { FeaturePrompt } from '../index';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 
 /**
  * Build initial state.

--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/product-suggestion/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/product-suggestion/test/component.js
@@ -6,7 +6,7 @@ import * as recommendationsActions from 'state/recommendations/actions';
 import { render, screen } from 'test/test-utils';
 import { buildInitialState } from '../../product-suggestions/test/fixtures';
 import { ProductSuggestion } from '../index';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 
 describe( 'Recommendations – Product Suggestion Item', () => {
 	const DUMMY_ACTION = { type: 'dummy' };

--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/product-suggestions/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/product-suggestions/test/component.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { render, screen } from 'test/test-utils';
 import { ProductSuggestions } from '../index';
 import { buildInitialState } from './fixtures';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 
 describe( 'Recommendations – Product Suggestions', () => {
 	it( 'shows the Product Suggestions component', () => {

--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/site-type/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/site-type/test/component.js
@@ -5,7 +5,7 @@ import * as React from 'react';
 import * as recommendationsActions from 'state/recommendations/actions';
 import { render, screen } from 'test/test-utils';
 import { SiteTypeQuestion } from '../index';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 
 /**
  * Build initial state.

--- a/projects/plugins/jetpack/_inc/client/recommendations/summary/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/summary/test/component.js
@@ -4,7 +4,7 @@ import * as recommendationsActions from 'state/recommendations/actions';
 import { render, screen, within } from 'test/test-utils';
 import { Summary as SummaryFeature } from '../index';
 import { buildInitialState } from './fixtures';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 
 describe( 'Recommendations – Summary', () => {
 	let updateRecommendationsStepStub;

--- a/projects/plugins/jetpack/changelog/add-jetpack-lint-extensions-tests
+++ b/projects/plugins/jetpack/changelog/add-jetpack-lint-extensions-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Lint extensions tests, and remove use of enzyme there. No change to the plugin itself.
+
+

--- a/projects/plugins/jetpack/extensions/blocks/business-hours/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/business-hours/test/edit.js
@@ -1,12 +1,7 @@
-/**
- * @jest-environment jsdom
- */
-
-import '@testing-library/jest-dom/extend-expect';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { render, screen, waitFor, getByLabelText } from '@testing-library/react';
-
 import BusinessHours, { defaultLocalization } from '../edit';
+import '@testing-library/jest-dom';
 
 const isWeekend = day => [ 'Sun', 'Sat' ].includes( day.substring( 0, 3 ) );
 
@@ -37,6 +32,7 @@ describe( 'Business Hours', () => {
 
 	beforeEach( () => {
 		setAttributes.mockClear();
+		// eslint-disable-next-line jest/prefer-spy-on -- Nothing to spy on.
 		window.fetch = jest.fn();
 		window.fetch.mockReturnValue(
 			Promise.resolve( { status: 200, json: () => Promise.resolve( defaultLocalization ) } )
@@ -51,7 +47,7 @@ describe( 'Business Hours', () => {
 		const propsNotSelected = { ...defaultProps, isSelected: false };
 		render( <BusinessHours { ...propsNotSelected } /> );
 
-		expect( window.fetch.mock.calls[ 0 ][ 0 ] ).toEqual(
+		expect( window.fetch.mock.calls[ 0 ][ 0 ] ).toBe(
 			'/wpcom/v2/business-hours/localized-week?_locale=user'
 		);
 
@@ -60,17 +56,15 @@ describe( 'Business Hours', () => {
 		expect( screen.queryByText( 'Saturday' ) ).not.toBeInTheDocument();
 
 		// Displays default days and business hours
-		await waitFor( () => expect( screen.getByText( 'Monday' ) ).toBeInTheDocument() );
-		await waitFor( () => expect( screen.getByText( 'Tuesday' ) ).toBeInTheDocument() );
-		await waitFor( () => expect( screen.getByText( 'Wednesday' ) ).toBeInTheDocument() );
-		await waitFor( () => expect( screen.getByText( 'Thursday' ) ).toBeInTheDocument() );
-		await waitFor( () => expect( screen.getByText( 'Friday' ) ).toBeInTheDocument() );
-		await waitFor( () => expect( screen.getByText( 'Saturday' ) ).toBeInTheDocument() );
-		await waitFor( () => expect( screen.getByText( 'Sunday' ) ).toBeInTheDocument() );
-		await waitFor( () =>
-			expect( screen.getAllByText( '9: 00 am - 5: 00 pm' ).length ).toEqual( 5 )
-		);
-		await waitFor( () => expect( screen.getAllByText( 'Closed' ).length ).toEqual( 2 ) );
+		await expect( screen.findByText( 'Monday' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'Tuesday' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Wednesday' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Thursday' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Friday' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Saturday' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Sunday' ) ).toBeInTheDocument();
+		expect( screen.getAllByText( '9: 00 am - 5: 00 pm' ) ).toHaveLength( 5 );
+		expect( screen.getAllByText( 'Closed' ) ).toHaveLength( 2 );
 	} );
 
 	test.each( dayStrings )(
@@ -89,21 +83,22 @@ describe( 'Business Hours', () => {
 
 			const openClosed = isWeekend( dayString ) ? 'Closed' : 'Open';
 
+			// eslint-disable-next-line testing-library/no-node-access
 			const dayRow = day.parentNode;
-			await user.click( getByLabelText( dayRow, openClosed ) );
+			await user.click( within( dayRow ).getByLabelText( openClosed ) );
 
+			let expectVal;
 			if ( 'Open' === openClosed ) {
-				expect(
-					setAttributes.mock.calls[ 0 ][ 0 ].days[ dayStrings.indexOf( dayString ) ]
-				).toEqual( { hours: [], name: dayString.substring( 0, 3 ) } );
+				expectVal = { hours: [], name: dayString.substring( 0, 3 ) };
 			} else {
-				expect(
-					setAttributes.mock.calls[ 0 ][ 0 ].days[ dayStrings.indexOf( dayString ) ]
-				).toEqual( {
+				expectVal = {
 					hours: [ { closing: '17:00', opening: '09:00' } ],
 					name: dayString.substring( 0, 3 ),
-				} );
+				};
 			}
+			expect( setAttributes.mock.calls[ 0 ][ 0 ].days[ dayStrings.indexOf( dayString ) ] ).toEqual(
+				expectVal
+			);
 		}
 	);
 
@@ -112,7 +107,7 @@ describe( 'Business Hours', () => {
 		const propsNotSelected = { ...defaultProps, isSelected: true };
 		render( <BusinessHours { ...propsNotSelected } /> );
 
-		await waitFor( () => expect( screen.getByText( 'Monday' ) ).toBeInTheDocument() );
+		await expect( screen.findByText( 'Monday' ) ).resolves.toBeInTheDocument();
 
 		// The behavior of <input type="time"> with user-event is kind of weird. Ctrl-A to select the contents before typing seems to work.
 		await user.type( screen.getAllByLabelText( 'Opening' )[ 0 ], '{Control>}a{/Control}6:00' );
@@ -128,7 +123,7 @@ describe( 'Business Hours', () => {
 		const propsSelected = { ...defaultProps, isSelected: true };
 		render( <BusinessHours { ...propsSelected } /> );
 
-		await waitFor( () => expect( screen.getByText( 'Monday' ) ).toBeInTheDocument() );
+		await expect( screen.findByText( 'Monday' ) ).resolves.toBeInTheDocument();
 
 		// The behavior of <input type="time"> with user-event is kind of weird. Ctrl-A to select the contents before typing seems to work.
 		await user.type( screen.getAllByLabelText( 'Closing' )[ 0 ], '{Control>}a{/Control}14:00' );
@@ -150,8 +145,8 @@ describe( 'Business Hours', () => {
 
 		const { rerender } = render( <BusinessHours { ...propsSelectedSingleDay } /> );
 
-		await waitFor( () => expect( screen.getAllByLabelText( 'Opening' ).length ).toEqual( 1 ) );
-		await waitFor( () => expect( screen.getAllByLabelText( 'Closing' ).length ).toEqual( 1 ) );
+		await expect( screen.findByLabelText( 'Opening' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByLabelText( 'Closing' ) ).toBeInTheDocument();
 
 		await user.click( screen.getByLabelText( 'Add Hours' ) );
 
@@ -168,8 +163,8 @@ describe( 'Business Hours', () => {
 
 		rerender( <BusinessHours { ...propsSelectedSingleDay } /> );
 
-		await waitFor( () => expect( screen.getAllByLabelText( 'Opening' ).length ).toEqual( 2 ) );
-		await waitFor( () => expect( screen.getAllByLabelText( 'Closing' ).length ).toEqual( 2 ) );
+		await waitFor( () => expect( screen.getAllByLabelText( 'Opening' ) ).toHaveLength( 2 ) );
+		expect( screen.getAllByLabelText( 'Closing' ) ).toHaveLength( 2 );
 	} );
 
 	test( 'should remove an additional set of opening/closing hours', async () => {
@@ -186,8 +181,8 @@ describe( 'Business Hours', () => {
 
 		const { rerender } = render( <BusinessHours { ...propsSelectedSingleDay } /> );
 
-		await waitFor( () => expect( screen.getAllByLabelText( 'Opening' ).length ).toEqual( 2 ) );
-		await waitFor( () => expect( screen.getAllByLabelText( 'Closing' ).length ).toEqual( 2 ) );
+		await waitFor( () => expect( screen.getAllByLabelText( 'Opening' ) ).toHaveLength( 2 ) );
+		expect( screen.getAllByLabelText( 'Closing' ) ).toHaveLength( 2 );
 
 		await user.click( screen.getAllByLabelText( 'Remove Hours' )[ 1 ] );
 
@@ -201,7 +196,7 @@ describe( 'Business Hours', () => {
 
 		rerender( <BusinessHours { ...propsSelectedSingleDay } /> );
 
-		await waitFor( () => expect( screen.getAllByLabelText( 'Opening' ).length ).toEqual( 1 ) );
-		await waitFor( () => expect( screen.getAllByLabelText( 'Closing' ).length ).toEqual( 1 ) );
+		await expect( screen.findByLabelText( 'Opening' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByLabelText( 'Closing' ) ).toBeInTheDocument();
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/button/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/button/test/controls.js
@@ -1,8 +1,7 @@
-import { render, screen, within, fireEvent } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import '@testing-library/jest-dom/extend-expect';
-
 import ButtonControls from '../controls';
+import '@testing-library/jest-dom';
 
 // Temporarily mock out the ButtonWidthControl, which is causing errors due to missing
 // dependencies in the jest test runner.
@@ -53,31 +52,38 @@ describe( 'Inspector settings', () => {
 		test( 'loads and displays Color Settings panel', () => {
 			render( <ButtonControls { ...defaultProps } /> );
 
-			expect( screen.getByText( 'Background & Text Color' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Text Color' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Background' ) ).toBeInTheDocument();
+			expect(
+				screen.getByRole( 'heading', { name: 'Background & Text Color' } )
+			).toBeInTheDocument();
+			expect( screen.getByRole( 'button', { name: 'Text Color' } ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'button', { name: 'Background' } ) ).toBeInTheDocument();
 		} );
 
 		test( 'loads and displays only default background color options', async () => {
 			const user = userEvent.setup();
 			render( <ButtonControls { ...defaultProps } /> );
 
-			await user.click( screen.getByText( 'Background', { ignore: '[aria-hidden=true]' } ) );
-			const backgroundColorPanel = screen
-				.getByText( 'Background' )
-				.closest( 'div.components-dropdown' );
-
-			expect( within( backgroundColorPanel ).queryByText( 'Solid' ) ).not.toBeInTheDocument();
-			expect( within( backgroundColorPanel ).queryByText( 'Gradient' ) ).not.toBeInTheDocument();
+			const backgroundButton = screen.getByRole( 'button', { name: 'Background' } );
+			await user.click( backgroundButton );
+			// eslint-disable-next-line testing-library/no-node-access
+			const backgroundSection = backgroundButton.closest( 'div.components-dropdown' );
+			expect(
+				within( backgroundSection ).queryByRole( 'radio', { name: 'Solid' } )
+			).not.toBeInTheDocument();
+			expect(
+				within( backgroundSection ).queryByRole( 'radio', { name: 'Gradient' } )
+			).not.toBeInTheDocument();
 		} );
 
 		test( 'sets text color attribute', async () => {
 			const user = userEvent.setup();
 			render( <ButtonControls { ...defaultProps } /> );
 
-			await user.click( screen.getByText( 'Text Color', { ignore: '[aria-hidden=true]' } ) );
-			const textColors = screen.getByText( 'Text Color' ).closest( 'div.components-dropdown' );
-			await user.click( within( textColors ).getAllByLabelText( 'Color: ', { exact: false } )[ 0 ] );
+			const textColorButton = screen.getByRole( 'button', { name: 'Text Color' } );
+			await user.click( textColorButton );
+			// eslint-disable-next-line testing-library/no-node-access
+			const textColors = textColorButton.closest( 'div.components-dropdown' );
+			await user.click( within( textColors ).getAllByRole( 'button', { name: /^Color: / } )[ 0 ] );
 
 			expect( setTextColor.mock.calls[ 0 ][ 0 ] ).toMatch( /#[a-z0-9]{6,6}/ );
 		} );
@@ -86,14 +92,13 @@ describe( 'Inspector settings', () => {
 			const user = userEvent.setup();
 			render( <ButtonControls { ...defaultProps } /> );
 
-			await user.click( screen.getByText( 'Background', { ignore: '[aria-hidden=true]' } ) );
-			const backgroundSection = screen
-				.getByText( 'Background' )
-				.closest( 'div.components-dropdown' );
-			const backgroundColorOption = within( backgroundSection ).getAllByLabelText( 'Color: ', {
-				exact: false,
-			} )[ 0 ];
-			await user.click( backgroundColorOption );
+			const backgroundButton = screen.getByRole( 'button', { name: 'Background' } );
+			await user.click( backgroundButton );
+			// eslint-disable-next-line testing-library/no-node-access
+			const backgroundSection = backgroundButton.closest( 'div.components-dropdown' );
+			await user.click(
+				within( backgroundSection ).getAllByRole( 'button', { name: /^Color: / } )[ 0 ]
+			);
 
 			expect( setBackgroundColor.mock.calls[ 0 ][ 0 ] ).toMatch( /#[a-z0-9]{6,6}/ );
 		} );
@@ -103,74 +108,72 @@ describe( 'Inspector settings', () => {
 		test( 'loads and displays Gradient Color Settings panel', () => {
 			render( <ButtonControls { ...defaultProps } isGradientAvailable={ true } /> );
 
-			expect( screen.getByText( 'Background & Text Color' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Text Color' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Background' ) ).toBeInTheDocument();
+			expect(
+				screen.getByRole( 'heading', { name: 'Background & Text Color' } )
+			).toBeInTheDocument();
+			expect( screen.getByRole( 'button', { name: 'Text Color' } ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'button', { name: 'Background' } ) ).toBeInTheDocument();
 		} );
 
-		test( 'loads and displays solid and gradient background color options', async () =>{
+		test( 'loads and displays solid and gradient background color options', async () => {
 			const user = userEvent.setup();
 			render( <ButtonControls { ...defaultProps } isGradientAvailable={ true } /> );
 
-			await user.click( screen.getByText( 'Background', { ignore: '[aria-hidden=true]' } ) );
-			const backgroundSection = screen
-				.getByText( 'Background' )
-				.closest( 'div.components-dropdown' );
-
+			const backgroundButton = screen.getByRole( 'button', { name: 'Background' } );
+			await user.click( backgroundButton );
+			// eslint-disable-next-line testing-library/no-node-access
+			const backgroundSection = backgroundButton.closest( 'div.components-dropdown' );
 			expect(
-				within( backgroundSection ).getByText( 'Solid', { ignore: '[aria-hidden=true]' } )
+				within( backgroundSection ).getByRole( 'radio', { name: 'Solid' } )
 			).toBeInTheDocument();
 			expect(
-				within( backgroundSection ).getByText( 'Gradient', { ignore: '[aria-hidden=true]' } )
+				within( backgroundSection ).getByRole( 'radio', { name: 'Gradient' } )
 			).toBeInTheDocument();
 		} );
 
-		test( 'sets text color attribute', async () =>{
+		test( 'sets text color attribute', async () => {
 			const user = userEvent.setup();
 			render( <ButtonControls { ...defaultProps } isGradientAvailable={ true } /> );
 
-			await user.click( screen.getByText( 'Text Color', { ignore: '[aria-hidden=true]' } ) );
-			const textColors = screen.getByText( 'Text Color' ).closest( 'div.components-dropdown' );
-			await user.click( within( textColors ).getAllByLabelText( 'Color: ', { exact: false } )[ 0 ] );
+			const textColorButton = screen.getByRole( 'button', { name: 'Text Color' } );
+			await user.click( textColorButton );
+			// eslint-disable-next-line testing-library/no-node-access
+			const textColors = textColorButton.closest( 'div.components-dropdown' );
+			await user.click( within( textColors ).getAllByRole( 'button', { name: /^Color: / } )[ 0 ] );
 
 			expect( setTextColor.mock.calls[ 0 ][ 0 ] ).toMatch( /#[a-z0-9]{6,6}/ );
 		} );
 
-		test( 'sets solid background color attribute', async () =>{
+		test( 'sets solid background color attribute', async () => {
 			const user = userEvent.setup();
 			render( <ButtonControls { ...defaultProps } isGradientAvailable={ true } /> );
 
-			await user.click( screen.getByText( 'Background', { ignore: '[aria-hidden=true]' } ) );
-			const backgroundSection = screen
-				.getByText( 'Background' )
-				.closest( 'div.components-dropdown' );
-
+			const backgroundButton = screen.getByRole( 'button', { name: 'Background' } );
+			await user.click( backgroundButton );
+			// eslint-disable-next-line testing-library/no-node-access
+			const backgroundSection = backgroundButton.closest( 'div.components-dropdown' );
+			await user.click( within( backgroundSection ).getByRole( 'radio', { name: 'Solid' } ) );
 			await user.click(
-				within( backgroundSection ).getByText( 'Solid', { ignore: '[aria-hidden=true]' } )
-			);
-			await user.click(
-				within( backgroundSection ).getAllByLabelText( 'Color: ', { exact: false } )[ 0 ]
+				within( backgroundSection ).getAllByRole( 'button', { name: /^Color: / } )[ 0 ]
 			);
 
 			expect( setBackgroundColor.mock.calls[ 0 ][ 0 ] ).toMatch( /#[a-z0-9]{6,6}/ );
 		} );
 
-		test( 'sets gradient background color attribute', async () =>{
+		test( 'sets gradient background color attribute', async () => {
 			const user = userEvent.setup();
 			render( <ButtonControls { ...defaultProps } isGradientAvailable={ true } /> );
 
-			await user.click( screen.getByText( 'Background', { ignore: '[aria-hidden=true]' } ) );
-			const backgroundSection = screen
-				.getByText( 'Background' )
-				.closest( 'div.components-dropdown' );
+			const backgroundButton = screen.getByRole( 'button', { name: 'Background' } );
+			await user.click( backgroundButton );
+			// eslint-disable-next-line testing-library/no-node-access
+			const backgroundSection = backgroundButton.closest( 'div.components-dropdown' );
+			await user.click( within( backgroundSection ).getByRole( 'radio', { name: 'Gradient' } ) );
 			await user.click(
-				within( backgroundSection ).getByText( 'Gradient', { ignore: '[aria-hidden=true]' } )
-			);
-			await user.click(
-				within( backgroundSection ).getAllByLabelText( 'Gradient: ', { exact: false } )[ 0 ]
+				within( backgroundSection ).getAllByRole( 'button', { name: /^Gradient: / } )[ 0 ]
 			);
 
-			expect( setGradient.mock.calls[ 0 ][ 0 ] ).toMatch( /linear\-gradient\((.+)\)/ );
+			expect( setGradient.mock.calls[ 0 ][ 0 ] ).toMatch( /linear-gradient\((.+)\)/ );
 		} );
 	} );
 
@@ -181,13 +184,12 @@ describe( 'Inspector settings', () => {
 			expect( screen.getByText( 'Border Settings' ) ).toBeInTheDocument();
 		} );
 
-		test( 'sets the border radius attribute', () => {
+		test( 'sets the border radius attribute', async () => {
+			const user = userEvent.setup();
 			render( <ButtonControls { ...defaultProps } /> );
 
-			const borderPanel = screen.getByText( 'Border Settings' ).closest( 'div' );
-			const input = borderPanel.querySelector( 'input[type="number"]' );
-			input.focus();
-			fireEvent.change( input, { target: { value: '6' } } );
+			const input = screen.getByRole( 'spinbutton', { name: 'Border radius' } );
+			await user.type( input, '6', { initialSelectionStart: 0, initialSelectionEnd: Infinity } );
 			expect( setAttributes ).toHaveBeenCalledWith( { borderRadius: 6 } );
 		} );
 	} );

--- a/projects/plugins/jetpack/extensions/blocks/button/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/button/test/edit.js
@@ -1,60 +1,54 @@
-/**
- * @jest-environment jsdom
- */
-
 import { render, screen, within } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
-
 // this is necessary because block editor store becomes unregistered during jest initialization
+import { store as blockEditorStore, __experimentalUseGradient } from '@wordpress/block-editor'; // eslint-disable-line wpcalypso/no-unsafe-wp-apis
 import { register } from '@wordpress/data';
-import { store as blockEditorStore } from '@wordpress/block-editor';
+import { ButtonEdit } from '../edit';
+import '@testing-library/jest-dom';
+
 register( blockEditorStore );
 
-import { ButtonEdit } from '../edit';
-import { __experimentalUseGradient } from '@wordpress/block-editor';
-
 const defaultAttributes = {
-    borderRadius: 15,
-    element: "button",
-    placeholder: "Placeholder text!!!",
-    text: "Contact Us",
+	borderRadius: 15,
+	element: 'button',
+	placeholder: 'Placeholder text!!!',
+	text: 'Contact Us',
 };
 
 const defaultProps = {
-    attributes: defaultAttributes,
-    backgroundColor: {
-        class: "has-black-background-color",
-        color: "#000000",
-    },
-    className: 'className',
-    fallbackBackgroundColor: 'rgba(0, 0, 0, 0)',
-    fallbackTextColor: 'rgba(0, 0, 0, 0)',
-    setAttributes: jest.fn(),
-    setBackgroundColor: jest.fn(),
-    setTextColor: jest.fn(),
-    textColor: {
-        class: "has-white-color",
-        color: "#FFFFFF",
-    },
+	attributes: defaultAttributes,
+	backgroundColor: {
+		class: 'has-black-background-color',
+		color: '#000000',
+	},
+	className: 'className',
+	fallbackBackgroundColor: 'rgba(0, 0, 0, 0)',
+	fallbackTextColor: 'rgba(0, 0, 0, 0)',
+	setAttributes: jest.fn(),
+	setBackgroundColor: jest.fn(),
+	setTextColor: jest.fn(),
+	textColor: {
+		class: 'has-white-color',
+		color: '#FFFFFF',
+	},
 };
 
 const gradientProps = {
-    gradientClass: 'has-green-to-yellow-gradient-background',
-    gradientValue: 'linear-gradient(160deg, rgb(209, 228, 221) 0%, rgb(238, 234, 221) 100%)',
-    setGradient: jest.fn(),
+	gradientClass: 'has-green-to-yellow-gradient-background',
+	gradientValue: 'linear-gradient(160deg, rgb(209, 228, 221) 0%, rgb(238, 234, 221) 100%)',
+	setGradient: jest.fn(),
 };
 
 jest.mock( '../constants', () => ( {
-    IS_GRADIENT_AVAILABLE: true
+	IS_GRADIENT_AVAILABLE: true,
 } ) );
 
 jest.mock( '@wordpress/block-editor', () => ( {
-    ...jest.requireActual( '@wordpress/block-editor' ),
-    __experimentalUseGradient: jest.fn().mockReturnValue( {
-        gradientClass: undefined,
-        gradientValue: undefined,
-        setGradient: jest.fn()
-    } ),
+	...jest.requireActual( '@wordpress/block-editor' ),
+	__experimentalUseGradient: jest.fn().mockReturnValue( {
+		gradientClass: undefined,
+		gradientValue: undefined,
+		setGradient: jest.fn(),
+	} ),
 } ) );
 
 // Temporarily mock out the ButtonWidthControl, which is causing errors due to missing
@@ -65,75 +59,89 @@ jest.mock( '../button-width-panel', () => ( {
 } ) );
 
 beforeEach( () => {
-    defaultProps.setAttributes.mockClear();
+	defaultProps.setAttributes.mockClear();
 } );
 
+/**
+ * Render the button.
+ *
+ * @param {object} props - Props.
+ * @returns {HTMLElement} Button.
+ */
 function renderButton( props ) {
-    const { container } = render( <ButtonEdit { ...props } /> );
-    return within( container ).getByRole( 'textbox' );
+	const { container } = render( <ButtonEdit { ...props } /> );
+	return within( container ).getByRole( 'textbox' );
 }
 
 describe( 'ButtonEdit', () => {
-    test( 'loads and displays button with buttonText attribute assigned to button', () => {
-        renderButton( defaultProps );
+	test( 'loads and displays button with buttonText attribute assigned to button', () => {
+		// eslint-disable-next-line testing-library/render-result-naming-convention -- False postive.
+		renderButton( defaultProps );
 
-        expect( screen.getByText( 'Contact Us' ) ).toBeInTheDocument();
-    } );
+		expect( screen.getByText( 'Contact Us' ) ).toBeInTheDocument();
+	} );
 
-    test( 'displays button as multiline textbox for updating the buttonText attribute', () => {
-        renderButton( defaultProps );
+	test( 'displays button as multiline textbox for updating the buttonText attribute', () => {
+		// eslint-disable-next-line testing-library/render-result-naming-convention -- False postive.
+		renderButton( defaultProps );
 
-        expect( screen.getByRole( 'textbox' ) ).toHaveAttribute( 'aria-multiline' );
-        expect( screen.getByRole( 'textbox' ) ).toHaveAttribute( 'contenteditable' );
-    } );
+		expect( screen.getByRole( 'textbox' ) ).toHaveAttribute( 'aria-multiline' );
+		expect( screen.getByRole( 'textbox' ) ).toHaveAttribute( 'contenteditable' );
+	} );
 
-    test( 'adds the placeholder when attribute is provided', () => {
-        const attributes = { ...defaultAttributes, text: undefined };
-        const button = renderButton( { ...defaultProps, attributes } );
-        expect( button.getAttribute( 'aria-label' ) ).toEqual( defaultAttributes.placeholder );
-    } );
+	test( 'adds the placeholder when attribute is provided', () => {
+		const attributes = { ...defaultAttributes, text: undefined };
+		// eslint-disable-next-line testing-library/render-result-naming-convention -- False postive.
+		const button = renderButton( { ...defaultProps, attributes } );
+		expect( button ).toHaveAttribute( 'aria-label', defaultAttributes.placeholder );
+	} );
 
-    test( 'assigns background color class and styles to the button', () => {
-        const button = renderButton( defaultProps );
+	test( 'assigns background color class and styles to the button', () => {
+		// eslint-disable-next-line testing-library/render-result-naming-convention -- False postive.
+		const button = renderButton( defaultProps );
 
-        expect( button ).toHaveClass( 'has-background' );
-        expect( button ).toHaveClass( 'has-black-background-color' );
-        expect( button ).toHaveStyle( { backgroundColor: '#000000' } );
-    } );
+		expect( button ).toHaveClass( 'has-background' );
+		expect( button ).toHaveClass( 'has-black-background-color' );
+		expect( button ).toHaveStyle( { backgroundColor: '#000000' } );
+	} );
 
-    test( 'applies text color class and style to the button', () => {
-        const button = renderButton( defaultProps );
+	test( 'applies text color class and style to the button', () => {
+		// eslint-disable-next-line testing-library/render-result-naming-convention -- False postive.
+		const button = renderButton( defaultProps );
 
-        expect( button ).toHaveClass( 'has-text-color' );
-        expect( button ).toHaveClass( 'has-white-color' );
-        expect( button ).toHaveStyle( { color: '#FFFFFF' } );
-    } );
+		expect( button ).toHaveClass( 'has-text-color' );
+		expect( button ).toHaveClass( 'has-white-color' );
+		expect( button ).toHaveStyle( { color: '#FFFFFF' } );
+	} );
 
-    test( 'applies border radius style to the button', () => {
-        const button = renderButton( defaultProps );
+	test( 'applies border radius style to the button', () => {
+		// eslint-disable-next-line testing-library/render-result-naming-convention -- False postive.
+		const button = renderButton( defaultProps );
 
-        expect( button ).toHaveStyle( { borderRadius: '15px' } );
-    } );
+		expect( button ).toHaveStyle( { borderRadius: '15px' } );
+	} );
 
-    test( 'applies class when 0 border radius selected', () => {
-        const attributes = {
-            ...defaultAttributes,
-            borderRadius: 0
-        };
-        const props = { ...defaultProps, attributes };
-        const button = renderButton( props );
+	test( 'applies class when 0 border radius selected', () => {
+		const attributes = {
+			...defaultAttributes,
+			borderRadius: 0,
+		};
+		const props = { ...defaultProps, attributes };
+		// eslint-disable-next-line testing-library/render-result-naming-convention -- False postive.
+		const button = renderButton( props );
 
-        expect( button ).toHaveClass( 'no-border-radius' );
-    } );
+		expect( button ).toHaveClass( 'no-border-radius' );
+	} );
 
-    test( 'applies gradient color class and style to the button', () => {
-        __experimentalUseGradient.mockImplementation( () => gradientProps );
+	test( 'applies gradient color class and style to the button', () => {
+		__experimentalUseGradient.mockImplementation( () => gradientProps );
 
-        const props = { ...defaultProps, backgroundColor: {} };
-        const button = renderButton( props );
+		const props = { ...defaultProps, backgroundColor: {} };
+		// eslint-disable-next-line testing-library/render-result-naming-convention -- False postive.
+		const button = renderButton( props );
 
-        expect( button ).toHaveClass( 'has-background' );
-        expect( button ).toHaveClass( gradientProps.gradientClass );
-        expect( button ).toHaveStyle( { background: gradientProps.gradientValue } );
-    } );
+		expect( button ).toHaveClass( 'has-background' );
+		expect( button ).toHaveClass( gradientProps.gradientClass );
+		expect( button ).toHaveStyle( { background: gradientProps.gradientValue } );
+	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/button/test/validate.js
+++ b/projects/plugins/jetpack/extensions/blocks/button/test/validate.js
@@ -6,10 +6,12 @@ import runBlockFixtureTests from '../../../shared/test/block-fixtures';
  * involved in this set of tests.
  *
  * Example containing multiple blocks:
+ * ```
  * const blocks = [
- *		{ name: 'jetpack/whatsapp-button', settings },
- *		{ name: 'jetpack/send-a-message', settings: parentSettings },
+ *     { name: 'jetpack/whatsapp-button', settings },
+ *     { name: 'jetpack/send-a-message', settings: parentSettings },
  * ];
+ * ```
  */
 const blocks = [ { name: `jetpack/${ name }`, settings } ];
 runBlockFixtureTests( `jetpack/${ name }`, blocks, __dirname );

--- a/projects/plugins/jetpack/extensions/blocks/calendly/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/test/controls.js
@@ -1,12 +1,7 @@
-/**
- * @jest-environment jsdom
- */
-
-import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { fireEvent, render, screen } from '@testing-library/react';
-
 import { CalendlyBlockControls, CalendlyInspectorControls } from '../controls';
+import '@testing-library/jest-dom';
 
 describe( 'CalendlyBlockControls', () => {
 	const onEditClick = jest.fn();
@@ -24,7 +19,7 @@ describe( 'CalendlyBlockControls', () => {
 		expect( wrapper ).toHaveAttribute( 'type', 'button' );
 	} );
 
-	test( 'triggers onEditClick when user clicks button', async () =>{
+	test( 'triggers onEditClick when user clicks button', async () => {
 		const user = userEvent.setup();
 		render( <CalendlyBlockControls { ...defaultProps } /> );
 
@@ -66,6 +61,7 @@ describe( 'CalendlyInspectorControls', () => {
 	test( 'displays calendar settings panel', () => {
 		render( <CalendlyInspectorControls { ...defaultProps } /> );
 		const panelHeaderButton = screen.getByText( 'Calendar settings' );
+		// eslint-disable-next-line testing-library/no-node-access
 		const panel = panelHeaderButton.closest( '.components-panel__body' );
 
 		expect( panelHeaderButton ).toBeInTheDocument();
@@ -104,7 +100,7 @@ describe( 'CalendlyInspectorControls', () => {
 		const user = userEvent.setup();
 
 		// Have parseEmbedCode call preventDefault() to avoid jsdom complaining that it doesn't know how to submit a form.
-		parseEmbedCode.mockImplementation((e) => e.preventDefault());
+		parseEmbedCode.mockImplementation( e => e.preventDefault() );
 
 		await renderExpandedSettings( user, defaultProps );
 
@@ -149,13 +145,15 @@ describe( 'CalendlyInspectorControls', () => {
 		const user = userEvent.setup();
 		await renderExpandedSettings( user, defaultProps );
 
-		const colorHelpUrl = 'https://help.calendly.com/hc/en-us/community/posts/360033166114-Embed-Widget-Color-Customization-Available-Now-';
+		const colorHelpUrl =
+			'https://help.calendly.com/hc/en-us/community/posts/360033166114-Embed-Widget-Color-Customization-Available-Now-';
 		const noticeClass = `${ defaultProps.defaultClassName }-color-notice`;
 		const linkText = 'Follow these instructions to change the colors in this block.';
 		const link = screen.getByText( linkText );
 
 		expect( link ).toBeInTheDocument();
 		expect( link ).toHaveAttribute( 'href', colorHelpUrl );
+		// eslint-disable-next-line testing-library/no-node-access
 		expect( link.closest( '.components-notice' ) ).toHaveClass( noticeClass );
 	} );
 
@@ -163,11 +161,14 @@ describe( 'CalendlyInspectorControls', () => {
 		const user = userEvent.setup();
 		const noticeClass = `.${ defaultProps.defaultClassName }-color-notice`;
 		const attributes = { ...defaultAttributes, url: undefined };
-		const { container } = render( <CalendlyInspectorControls { ...{ ...defaultProps, attributes } } /> );
+		const { container } = render(
+			<CalendlyInspectorControls { ...{ ...defaultProps, attributes } } />
+		);
 
 		await user.click( screen.getByText( 'Calendar settings' ) );
 
 		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 		expect( container.querySelector( noticeClass ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/calendly/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/test/edit.js
@@ -1,25 +1,18 @@
-/**
- * @jest-environment jsdom
- */
-
-import '@testing-library/jest-dom/extend-expect';
-import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor } from '@testing-library/react';
-
+import userEvent from '@testing-library/user-event';
 // this is necessary because block editor store becomes unregistered during jest initialization
-import { register } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { register } from '@wordpress/data';
+import testEmbedUrl from '../../../shared/test-embed-url';
+import { CalendlyEdit } from '../edit';
+import '@testing-library/jest-dom';
+
 register( blockEditorStore );
 
-// Need to mock InnerBlocks before import the CalendlyEdit component as it
-// requires the Gutenberg store setup to operate.
 jest.mock( '@wordpress/block-editor', () => ( {
 	...jest.requireActual( '@wordpress/block-editor' ),
 	InnerBlocks: () => <button>Mocked button</button>,
 } ) );
-
-import testEmbedUrl from '../../../shared/test-embed-url';
-import { CalendlyEdit } from '../edit';
 
 jest.mock( '../../../shared/test-embed-url', () => ( {
 	__esModule: true,
@@ -136,7 +129,7 @@ describe( 'CalendlyEdit', () => {
 		const attributes = { ...defaultAttributes, url: 'https://calendly.com/invalid-url' };
 		render( <CalendlyEdit { ...{ ...defaultProps, attributes } } /> );
 
-		await waitFor( () => expect( screen.getByText( 'Embedding…' ) ).toBeInTheDocument() );
+		await expect( screen.findByText( 'Embedding…' ) ).resolves.toBeInTheDocument();
 	} );
 
 	test( 'renders inline preview with iframe component', async () => {
@@ -146,7 +139,9 @@ describe( 'CalendlyEdit', () => {
 		await waitFor( () => ( iframe = screen.getByTitle( 'Calendly' ) ) );
 
 		expect( iframe ).toBeInTheDocument();
+		// eslint-disable-next-line testing-library/no-node-access
 		expect( iframe.parentElement ).toHaveClass( 'calendly-style-inline' );
+		// eslint-disable-next-line testing-library/no-node-access
 		expect( iframe.previousElementSibling ).toHaveClass( 'wp-block-jetpack-calendly-overlay' );
 	} );
 
@@ -172,6 +167,7 @@ describe( 'CalendlyEdit', () => {
 		const link = screen.getByText( 'Need help finding your embed code?' );
 
 		expect( link ).toBeInTheDocument();
+		// eslint-disable-next-line testing-library/no-node-access
 		expect( link.parentElement ).toHaveClass( 'wp-block-jetpack-calendly-learn-more' );
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/calendly/test/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/test/utils.js
@@ -1,4 +1,3 @@
-
 import { getAttributesFromEmbedCode } from '../utils';
 
 const inlineEmbedCode =

--- a/projects/plugins/jetpack/extensions/blocks/calendly/test/validate.js
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/test/validate.js
@@ -1,10 +1,8 @@
-import runBlockFixtureTests from '../../../shared/test/block-fixtures';
 import { name, settings } from '../';
+import runBlockFixtureTests from '../../../shared/test/block-fixtures';
 import { settings as buttonSettings } from '../../button';
 
 const primaryBlock = { name: `jetpack/${ name }`, settings };
-const innerBlocks = [
-	{ name: 'jetpack/button', settings: buttonSettings },
-];
+const innerBlocks = [ { name: 'jetpack/button', settings: buttonSettings } ];
 
 runBlockFixtureTests( `jetpack/${ name }`, [ primaryBlock, ...innerBlocks ], __dirname );

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/test/edit.js
@@ -1,15 +1,8 @@
-/**
- * @jest-environment jsdom
- */
-
-import '@testing-library/jest-dom/extend-expect';
 import { render, screen } from '@testing-library/react';
-
 import { JetpackContactFormEdit } from '../edit';
-import defaultVariations from '../variations';
+import '@testing-library/jest-dom';
 
-
-describe( '', () => {
+describe( 'Contact form', () => {
 	const defaultAttributes = {
 		subject: '',
 		to: '',
@@ -44,7 +37,7 @@ describe( '', () => {
 				icon: 'book',
 				attributes: {
 					className: 'wp-variation-susan',
-				}
+				},
 			},
 			{
 				name: 'barry',
@@ -52,8 +45,8 @@ describe( '', () => {
 				icon: 'edit',
 				attributes: {
 					className: 'wp-variation-barry',
-				}
-			}
+				},
+			},
 		],
 		defaultVariation: null,
 	};
@@ -62,9 +55,9 @@ describe( '', () => {
 		setAttributes.mockClear();
 	} );
 
-
 	test( 'renders a variation selector list', () => {
 		render( <JetpackContactFormEdit { ...defaultProps } /> );
+		// eslint-disable-next-line testing-library/no-node-access
 		expect( screen.getByRole( 'list' ).children ).toHaveLength( 2 );
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/test/validate.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/test/validate.js
@@ -6,10 +6,12 @@ import runBlockFixtureTests from '../../../shared/test/block-fixtures';
  * involved in this set of tests.
  *
  * Example containing multiple blocks:
+ * ```
  * const blocks = [
- *		{ name: 'jetpack/whatsapp-button', settings },
- *		{ name: 'jetpack/send-a-message', settings: parentSettings },
+ *     { name: 'jetpack/whatsapp-button', settings },
+ *     { name: 'jetpack/send-a-message', settings: parentSettings },
  * ];
+ * ```
  */
 const blocks = [ { name: `jetpack/${ name }`, settings } ];
 runBlockFixtureTests( `jetpack/${ name }`, blocks, __dirname );

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/address/test/edit.js
@@ -1,8 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import '@testing-library/jest-dom/extend-expect';
-
 import AddressEdit from '../edit';
+import '@testing-library/jest-dom';
 
 const defaultAttributes = {
 	address: '',
@@ -83,7 +82,7 @@ describe( 'Address', () => {
 		};
 		render( <AddressEdit { ...propsSelected } /> );
 
-		expect( screen.getByPlaceholderText( 'Street Address' ).value ).toEqual( '987 Photon Drive' );
+		expect( screen.getByPlaceholderText( 'Street Address' ).value ).toBe( '987 Photon Drive' );
 		expect( screen.getByPlaceholderText( 'Address Line 2' ) ).toBeInTheDocument();
 		expect( screen.getByPlaceholderText( 'Address Line 3' ) ).toBeInTheDocument();
 		expect( screen.getByPlaceholderText( 'City' ) ).toBeInTheDocument();

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/email/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/email/test/edit.js
@@ -1,8 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import '@testing-library/jest-dom/extend-expect';
-
 import EmailEdit from '../edit';
+import '@testing-library/jest-dom';
 
 const setAttributes = jest.fn();
 
@@ -48,9 +47,10 @@ describe( 'Email', () => {
 		};
 		render( <EmailEdit { ...propsNotSelected } /> );
 
-		expect(
-			screen.getByRole( 'link', { name: 'test@example.com' } ).getAttribute( 'href' )
-		).toEqual( 'mailto:test@example.com' );
+		expect( screen.getByRole( 'link', { name: 'test@example.com' } ) ).toHaveAttribute(
+			'href',
+			'mailto:test@example.com'
+		);
 		expect( screen.getByText( 'email me at:' ) ).toBeInTheDocument();
 	} );
 

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/phone/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/phone/test/edit.js
@@ -1,8 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import '@testing-library/jest-dom/extend-expect';
-
 import PhoneEdit from '../edit';
+import '@testing-library/jest-dom';
 
 const setAttributes = jest.fn();
 
@@ -48,9 +47,10 @@ describe( 'Phone', () => {
 		};
 		render( <PhoneEdit { ...propsNotSelected } /> );
 
-		expect(
-			screen.getByRole( 'link', { name: '+1-123-456-7890' } ).getAttribute( 'href' )
-		).toEqual( 'tel:+11234567890' );
+		expect( screen.getByRole( 'link', { name: '+1-123-456-7890' } ) ).toHaveAttribute(
+			'href',
+			'tel:+11234567890'
+		);
 		expect( screen.getByText( 'call me on:' ) ).toBeInTheDocument();
 	} );
 

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/test/controls.js
@@ -1,12 +1,7 @@
-/**
- * @jest-environment jsdom
- */
-
-import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { render, screen, waitFor } from '@testing-library/react';
-
 import { ToolbarControls } from '../controls';
+import '@testing-library/jest-dom';
 
 describe( 'Eventbrite block controls', () => {
 	const setEditingUrl = jest.fn();
@@ -17,7 +12,6 @@ describe( 'Eventbrite block controls', () => {
 	beforeEach( () => {
 		setEditingUrl.mockClear();
 	} );
-
 
 	test( 'renders okay', () => {
 		render( <ToolbarControls { ...defaultProps } /> );
@@ -31,6 +25,5 @@ describe( 'Eventbrite block controls', () => {
 		await user.click( screen.getByRole( 'button' ) );
 
 		expect( setEditingUrl ).toHaveBeenCalledWith( true );
-
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/test/edit.js
@@ -1,11 +1,6 @@
-/**
- * @jest-environment jsdom
- */
-
-import '@testing-library/jest-dom/extend-expect';
 import { render, screen } from '@testing-library/react';
-
 import { EventbriteEdit } from '../edit';
+import '@testing-library/jest-dom';
 
 describe( 'Eventbrite Edit', () => {
 	const defaultAttributes = {
@@ -31,6 +26,8 @@ describe( 'Eventbrite Edit', () => {
 	test( 'renders form by default', () => {
 		render( <EventbriteEdit { ...defaultProps } /> );
 
-		expect( screen.getByPlaceholderText( 'Enter an event URL to embed here…' ) ).toBeInTheDocument();
+		expect(
+			screen.getByPlaceholderText( 'Enter an event URL to embed here…' )
+		).toBeInTheDocument();
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/test/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/test/utils.js
@@ -1,21 +1,21 @@
-
 import { convertToLink, eventIdFromUrl, normalizeUrlInput } from '../utils';
 
-
 jest.mock( '@wordpress/blocks', () => ( {
-	createBlock: ( blockName, contentObj ) => ( { blockName, contentObj  } ),
+	createBlock: ( blockName, contentObj ) => ( { blockName, contentObj } ),
 } ) );
 
 describe( 'Eventbrite utils', () => {
 	describe( 'eventIdFromUrl', () => {
 		test( 'parses id from Eventbrite URL', () => {
-			const validIUrl = 'https://www.eventbrite.com.au/e/2021-nsw-open-championship-tickets-122642642445';
-			expect( eventIdFromUrl( validIUrl ) ).toEqual( 122642642445 );
+			const validIUrl =
+				'https://www.eventbrite.com.au/e/2021-nsw-open-championship-tickets-122642642445';
+			expect( eventIdFromUrl( validIUrl ) ).toBe( 122642642445 );
 		} );
 
 		test( 'checks end of URL string for id only', () => {
-			const validIUrl = 'https://www.eventbrite.com.au/e/1119993333-nsw-open-championship-tickets-122642642445';
-			expect( eventIdFromUrl( validIUrl ) ).toEqual( 122642642445 );
+			const validIUrl =
+				'https://www.eventbrite.com.au/e/1119993333-nsw-open-championship-tickets-122642642445';
+			expect( eventIdFromUrl( validIUrl ) ).toBe( 122642642445 );
 		} );
 
 		test( 'returns null when url is falsy', () => {
@@ -37,8 +37,8 @@ describe( 'Eventbrite utils', () => {
 			expect( onReplace ).toHaveBeenCalledWith( {
 				blockName: 'core/paragraph',
 				contentObj: {
-					content: '<a href=\"https://test.com\">https://test.com</a>',
-				}
+					content: '<a href="https://test.com">https://test.com</a>',
+				},
 			} );
 		} );
 	} );
@@ -50,12 +50,14 @@ describe( 'Eventbrite utils', () => {
 		} );
 
 		test( 'does not modify valid argument', () => {
-			const validUrl = 'https://www.eventbrite.com.au/e/2021-nsw-open-championship-tickets-122642642445';
+			const validUrl =
+				'https://www.eventbrite.com.au/e/2021-nsw-open-championship-tickets-122642642445';
 			expect( normalizeUrlInput( validUrl ) ).toEqual( validUrl );
 		} );
 
 		test( 'trims URL string', () => {
-			const paddedURl = '   https://www.eventbrite.com.au/e/2021-nsw-open-championship-tickets-122642642445   ';
+			const paddedURl =
+				'   https://www.eventbrite.com.au/e/2021-nsw-open-championship-tickets-122642642445   ';
 			expect( normalizeUrlInput( paddedURl ) ).toEqual( paddedURl.trim() );
 		} );
 	} );

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/test/validate.js
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/test/validate.js
@@ -1,13 +1,12 @@
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { register } from '@wordpress/data';
 import { name, settings } from '../';
 import runBlockFixtureTests from '../../../shared/test/block-fixtures';
-
-// this is necessary because block editor store becomes unregistered during jest initialization
-import { register } from '@wordpress/data';
-import { store as blockEditorStore } from '@wordpress/block-editor';
-register( blockEditorStore );
-
 // The Eventbrite block uses the Button block in Innerblocks so we have to import the button block type definitions.
 import { settings as buttonSettings } from '../../button';
+
+// this is necessary because block editor store becomes unregistered during jest initialization
+register( blockEditorStore );
 
 const blocks = [
 	{ name: `jetpack/${ name }`, settings },

--- a/projects/plugins/jetpack/extensions/blocks/gathering-tweetstorms/test/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/gathering-tweetstorms/test/editor.js
@@ -1,13 +1,19 @@
-import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import { useSelect } from '@wordpress/data';
-
 import addTweetstormToTweets from '../editor';
+import '@testing-library/jest-dom';
 
 jest.mock( '@wordpress/data/build/components/use-select', () => jest.fn() );
 
-useSelect.mockImplementation( ( cb ) => {
+// Fake <BlockControls> so we can easily test if it was inserted or not.
+jest.mock( '@wordpress/block-editor/build/components/block-controls', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="BlockControls">BlockControls</div>,
+} ) );
+
+useSelect.mockImplementation( cb => {
 	return cb( () => ( {
-		getEditedPostAttribute: () => ( { } ),
+		getEditedPostAttribute: () => ( {} ),
 		isFirstMultiSelectedBlock: jest.fn().mockReturnValueOnce( true ),
 		getMultiSelectedBlockClientIds: () => [],
 		getBlockName: () => 'DaName',
@@ -61,12 +67,11 @@ describe( 'addTweetstormToTweets', () => {
 		const wrappedBlock = addTweetstormToTweets( block );
 
 		expect( wrappedBlock ).not.toEqual( block );
-		expect( wrappedBlock.edit.name ).toEqual( 'Component' );
+		expect( wrappedBlock.edit.name ).toBe( 'Component' );
 
-		const wrapper = mount( <wrappedBlock.edit { ...block.props } /> );
-
-		expect( wrapper.exists( '#baseEdit' ) ).toEqual( true );
-		expect( wrapper.find( 'BlockControlsFill' ).length ).toBeGreaterThan( 0 );
+		render( <wrappedBlock.edit { ...block.props } /> );
+		expect( screen.getByText( 'Base Edit' ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'BlockControls' ) ).toBeInTheDocument();
 	} );
 
 	it( 'should not add block controls when passed a core/embed block definition with a different providerNameSlug', () => {
@@ -85,11 +90,10 @@ describe( 'addTweetstormToTweets', () => {
 		const wrappedBlock = addTweetstormToTweets( block );
 
 		expect( wrappedBlock ).not.toEqual( block );
-		expect( wrappedBlock.edit.name ).toEqual( 'Component' );
+		expect( wrappedBlock.edit.name ).toBe( 'Component' );
 
-		const wrapper = mount( <wrappedBlock.edit { ...block.props } /> );
-
-		expect( wrapper.exists( '#baseEdit' ) ).toEqual( true );
-		expect( wrapper.find( 'BlockControlsFill' ) ).toHaveLength( 0 );
+		render( <wrappedBlock.edit { ...block.props } /> );
+		expect( screen.getByText( 'Base Edit' ) ).toBeInTheDocument();
+		expect( screen.queryByTestId( 'BlockControls' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/gif/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/gif/test/edit.js
@@ -1,13 +1,8 @@
-/**
- * @jest-environment jsdom
- */
-
 import { render, fireEvent } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
-
 import GifEdit from '../edit';
-import { getUrl, getPaddingTop, getEmbedUrl } from '../utils';
 import useFetchGiphyData from '../hooks/use-fetch-giphy-data';
+import { getUrl, getPaddingTop, getEmbedUrl } from '../utils';
+import '@testing-library/jest-dom';
 
 const setAttributes = jest.fn();
 
@@ -38,7 +33,7 @@ const GIPHY_DATA = [
 				height: 10,
 				width: 10,
 			},
-		}
+		},
 	},
 	{
 		id: '99',
@@ -51,13 +46,13 @@ const GIPHY_DATA = [
 				height: 12,
 				width: 12,
 			},
-		}
-	}
+		},
+	},
 ];
 
 const fetchGiphyData = jest.fn();
 
-jest.mock('./../hooks/use-fetch-giphy-data' );
+jest.mock( './../hooks/use-fetch-giphy-data' );
 
 describe( 'GifEdit', () => {
 	beforeEach( () => {
@@ -66,7 +61,7 @@ describe( 'GifEdit', () => {
 				fetchGiphyData,
 				giphyData: [],
 				isFetching: false,
-			}
+			};
 		} );
 	} );
 
@@ -77,13 +72,20 @@ describe( 'GifEdit', () => {
 	} );
 
 	test( 'adds class names', () => {
-		const { container } = render( <GifEdit { ...defaultProps }  /> );
-		expect( container.querySelector( `.${ defaultProps.className }.align${ defaultProps.attributes.align }` ) ).toBeInTheDocument();
+		const { container } = render( <GifEdit { ...defaultProps } /> );
+		expect(
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			container.querySelector(
+				`.${ defaultProps.className }.align${ defaultProps.attributes.align }`
+			)
+		).toBeInTheDocument();
 	} );
 
 	test( 'loads default search form and not the gallery where there is no giphy URL', () => {
-		const { container } = render( <GifEdit { ...defaultProps }  /> );
+		const { container } = render( <GifEdit { ...defaultProps } /> );
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 		expect( container.querySelector( '.wp-block-jetpack-gif_placeholder' ) ).toBeInTheDocument();
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 		expect( container.querySelector( 'figure' ) ).not.toBeInTheDocument();
 	} );
 
@@ -93,7 +95,7 @@ describe( 'GifEdit', () => {
 				fetchGiphyData,
 				giphyData: GIPHY_DATA,
 				isFetching: false,
-			}
+			};
 		} );
 		const newProps = {
 			...defaultProps,
@@ -104,22 +106,31 @@ describe( 'GifEdit', () => {
 				searchText: 'a sausage roll',
 			},
 		};
-		const { container, screen } = render( <GifEdit { ...newProps } /> );
+		const { container } = render( <GifEdit { ...newProps } /> );
 
-		expect( container.querySelector( 'form input' ).value ).toEqual( newProps.attributes.searchText );
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+		expect( container.querySelector( 'form input' ).value ).toEqual(
+			newProps.attributes.searchText
+		);
 
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 		fireEvent.submit( container.querySelector( 'form' ) );
 
 		expect( fetchGiphyData ).toHaveBeenCalledWith( getUrl( newProps.attributes.searchText ) );
-		expect( setAttributes.mock.calls[0][0] ).toStrictEqual( {
-			giphyUrl: getEmbedUrl( GIPHY_DATA[0] ),
-			paddingTop: getPaddingTop( GIPHY_DATA[0] ),
+		expect( setAttributes.mock.calls[ 0 ][ 0 ] ).toStrictEqual( {
+			giphyUrl: getEmbedUrl( GIPHY_DATA[ 0 ] ),
+			paddingTop: getPaddingTop( GIPHY_DATA[ 0 ] ),
 		} );
 
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 		expect( container.querySelector( 'figure' ) ).toBeInTheDocument();
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 		expect( container.querySelector( 'figcaption' ) ).toBeInTheDocument();
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 		expect( container.querySelector( '.wp-block-jetpack-gif-wrapper iframe' ) ).toBeInTheDocument();
-		expect( container.querySelectorAll( '.wp-block-jetpack-gif_thumbnail-container' ) ).toHaveLength( 2 );
-
+		expect(
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			container.querySelectorAll( '.wp-block-jetpack-gif_thumbnail-container' )
+		).toHaveLength( 2 );
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/gif/test/search-form.js
+++ b/projects/plugins/jetpack/extensions/blocks/gif/test/search-form.js
@@ -1,20 +1,15 @@
-/**
- * @jest-environment jsdom
- */
-
 import { render, screen, fireEvent } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
-import userEvent from '@testing-library/user-event'
-
+import userEvent from '@testing-library/user-event';
 import SearchForm from '../components/search-form';
+import '@testing-library/jest-dom';
 
 describe( 'SearchForm', () => {
 	const onChange = jest.fn();
 	const onSubmit = jest.fn();
 	const ref = {
 		current: {
-			focus: jest.fn()
-		}
+			focus: jest.fn(),
+		},
 	};
 	const defaultProps = {
 		onChange,
@@ -25,18 +20,21 @@ describe( 'SearchForm', () => {
 
 	test( 'loads and applies value to input field', () => {
 		render( <SearchForm { ...defaultProps } /> );
-		expect( screen.getByPlaceholderText( 'Enter search terms, e.g. cat…' ).value ).toBe( 'Woolloomooloo' );
+		expect( screen.getByPlaceholderText( 'Enter search terms, e.g. cat…' ).value ).toBe(
+			'Woolloomooloo'
+		);
 	} );
 
 	test( 'loads and applies passed props to children', async () => {
 		const user = userEvent.setup();
-		render( <SearchForm { ...defaultProps } value={ '' }/> );
+		render( <SearchForm { ...defaultProps } value={ '' } /> );
 		await user.type( screen.getByPlaceholderText( 'Enter search terms, e.g. cat…' ), 'Hi' );
 		expect( onChange ).toHaveBeenCalledTimes( 2 );
 	} );
 
-	test( 'loads and applies passed props to children', () => {
+	test( 'calls onSubmit on submit', () => {
 		const { container } = render( <SearchForm { ...defaultProps } /> );
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 		fireEvent.submit( container.querySelector( 'form' ) );
 		expect( onSubmit ).toHaveBeenCalled();
 	} );

--- a/projects/plugins/jetpack/extensions/blocks/gif/test/use-fetch-giphy-data.js
+++ b/projects/plugins/jetpack/extensions/blocks/gif/test/use-fetch-giphy-data.js
@@ -1,5 +1,4 @@
 import { renderHook, act } from '@testing-library/react-hooks';
-
 import useFetchGiphyData from '../hooks/use-fetch-giphy-data';
 
 const originalFetch = window.fetch;
@@ -16,11 +15,11 @@ const GIPHY_SINGLE_RESPONSE = {
 				height: 10,
 				width: 10,
 			},
-		}
+		},
 	},
 };
 
-export const GIPHY_MULTIPLE_RESPONSE = {
+const GIPHY_MULTIPLE_RESPONSE = {
 	data: [
 		{
 			id: '9',
@@ -33,7 +32,7 @@ export const GIPHY_MULTIPLE_RESPONSE = {
 					height: 10,
 					width: 10,
 				},
-			}
+			},
 		},
 		{
 			id: '99',
@@ -46,15 +45,16 @@ export const GIPHY_MULTIPLE_RESPONSE = {
 					height: 12,
 					width: 12,
 				},
-			}
-		}
-	]
+			},
+		},
+	],
 };
 
 /**
  * Mock return value for a successful fetch JSON return value.
  *
- * @return {Promise} Mock return value.
+ * @param {*} resolvedFetchPromiseResponse - JSON return value.
+ * @returns {Promise} Mock return value.
  */
 function getFetchMockReturnValue( resolvedFetchPromiseResponse ) {
 	const resolvedFetchPromise = Promise.resolve( resolvedFetchPromiseResponse );
@@ -66,6 +66,7 @@ function getFetchMockReturnValue( resolvedFetchPromiseResponse ) {
 
 describe( 'useFetchGiphyData', () => {
 	beforeEach( () => {
+		// eslint-disable-next-line jest/prefer-spy-on -- Nothing to spy on.
 		window.fetch = jest.fn();
 		window.fetch.mockReturnValue( getFetchMockReturnValue( GIPHY_SINGLE_RESPONSE ) );
 	} );
@@ -75,9 +76,7 @@ describe( 'useFetchGiphyData', () => {
 	} );
 
 	test( 'should return object response data after fetch', async () => {
-		const { result } = renderHook(() =>
-			useFetchGiphyData()
-		);
+		const { result } = renderHook( () => useFetchGiphyData() );
 
 		await act( async () => {
 			result.current.fetchGiphyData( 'https://icantbelieve.its/not/butter' );
@@ -89,11 +88,9 @@ describe( 'useFetchGiphyData', () => {
 	} );
 
 	test( 'should return array data after fetch', async () => {
-		window.fetch.mockReturnValueOnce( getFetchMockReturnValue( GIPHY_MULTIPLE_RESPONSE ) )
+		window.fetch.mockReturnValueOnce( getFetchMockReturnValue( GIPHY_MULTIPLE_RESPONSE ) );
 
-		const { result } = renderHook(() =>
-			useFetchGiphyData()
-		);
+		const { result } = renderHook( () => useFetchGiphyData() );
 
 		await act( async () => {
 			result.current.fetchGiphyData( 'https://icantbelieve.its/not/butter' );
@@ -105,9 +102,7 @@ describe( 'useFetchGiphyData', () => {
 	} );
 
 	test( 'should not fetch if url is falsy', async () => {
-		const { result } = renderHook(() =>
-			useFetchGiphyData()
-		);
+		const { result } = renderHook( () => useFetchGiphyData() );
 
 		await act( async () => {
 			result.current.fetchGiphyData( null );
@@ -117,5 +112,4 @@ describe( 'useFetchGiphyData', () => {
 
 		expect( result.current.isFetching ).toBe( false );
 	} );
-
 } );

--- a/projects/plugins/jetpack/extensions/blocks/gif/test/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/gif/test/utils.js
@@ -1,5 +1,4 @@
-import '@testing-library/jest-dom/extend-expect';
-
+import { GIPHY_API_KEY } from '../constants';
 import {
 	getUrl,
 	getPaddingTop,
@@ -7,10 +6,9 @@ import {
 	getSearchUrl,
 	getUrlWithId,
 	splitStringAndReturnLastItem,
-	getSelectedGiphyAttributes
+	getSelectedGiphyAttributes,
 } from '../utils';
-import { GIPHY_API_KEY } from '../constants';
-
+import '@testing-library/jest-dom';
 
 describe( 'Gif Block utils', () => {
 	const GIPHY_ITEM = {
@@ -25,35 +23,57 @@ describe( 'Gif Block utils', () => {
 
 	describe( 'getUrl', () => {
 		test( 'returns getSearchUrl where there is no id', () => {
-			expect( getUrl( 'bubble tea' ) ).toEqual( `https://api.giphy.com/v1/gifs/search?q=bubble%20tea&api_key=${ GIPHY_API_KEY }&limit=10` );
+			expect( getUrl( 'bubble tea' ) ).toBe(
+				`https://api.giphy.com/v1/gifs/search?q=bubble%20tea&api_key=${ GIPHY_API_KEY }&limit=10`
+			);
 		} );
 
 		test( 'returns trimmed getSearchUrl where there is no id', () => {
-			expect( getUrl( ' bubble bath  ' ) ).toEqual( `https://api.giphy.com/v1/gifs/search?q=bubble%20bath&api_key=${ GIPHY_API_KEY }&limit=10` );
+			expect( getUrl( ' bubble bath  ' ) ).toBe(
+				`https://api.giphy.com/v1/gifs/search?q=bubble%20bath&api_key=${ GIPHY_API_KEY }&limit=10`
+			);
 		} );
 
 		test( 'returns getUrlWithId where there is an expected http URL with an id', () => {
-			expect( getUrl( 'http://giphy.com/embed/tomatenAugen7777aSSSS' ) ).toEqual( `https://api.giphy.com/v1/gifs/tomatenAugen7777aSSSS?api_key=${ GIPHY_API_KEY }` );
-			expect( getUrl( 'http://giphy.com/gifs/pineapple-kopf-ddddd123' ) ).toEqual( `https://api.giphy.com/v1/gifs/ddddd123?api_key=${ GIPHY_API_KEY }` );
-			expect( getUrl( 'http://i.giphy.com/bananaGesicht999999999.gif' ) ).toEqual( `https://api.giphy.com/v1/gifs/bananaGesicht999999999?api_key=${ GIPHY_API_KEY }` );
-			expect( getUrl( 'http://media.giphy.com/media/blaubeerenAugen000/giphy.gif' ) ).toEqual( `https://api.giphy.com/v1/gifs/blaubeerenAugen000?api_key=${ GIPHY_API_KEY }` );
+			expect( getUrl( 'http://giphy.com/embed/tomatenAugen7777aSSSS' ) ).toBe(
+				`https://api.giphy.com/v1/gifs/tomatenAugen7777aSSSS?api_key=${ GIPHY_API_KEY }`
+			);
+			expect( getUrl( 'http://giphy.com/gifs/pineapple-kopf-ddddd123' ) ).toBe(
+				`https://api.giphy.com/v1/gifs/ddddd123?api_key=${ GIPHY_API_KEY }`
+			);
+			expect( getUrl( 'http://i.giphy.com/bananaGesicht999999999.gif' ) ).toBe(
+				`https://api.giphy.com/v1/gifs/bananaGesicht999999999?api_key=${ GIPHY_API_KEY }`
+			);
+			expect( getUrl( 'http://media.giphy.com/media/blaubeerenAugen000/giphy.gif' ) ).toBe(
+				`https://api.giphy.com/v1/gifs/blaubeerenAugen000?api_key=${ GIPHY_API_KEY }`
+			);
 		} );
 
 		test( 'returns getUrlWithId where there is an expected https URL with an id', () => {
-			expect( getUrl( 'https://giphy.com/embed/tomatenAugen7777aSSSS' ) ).toEqual( `https://api.giphy.com/v1/gifs/tomatenAugen7777aSSSS?api_key=${ GIPHY_API_KEY }` );
-			expect( getUrl( 'https://giphy.com/gifs/pineapple-kopf-ddddd123' ) ).toEqual( `https://api.giphy.com/v1/gifs/ddddd123?api_key=${ GIPHY_API_KEY }` );
-			expect( getUrl( 'https://i.giphy.com/bananaGesicht999999999.gif' ) ).toEqual( `https://api.giphy.com/v1/gifs/bananaGesicht999999999?api_key=${ GIPHY_API_KEY }` );
-			expect( getUrl( 'https://media.giphy.com/media/blaubeerenAugen000/giphy.gif' ) ).toEqual( `https://api.giphy.com/v1/gifs/blaubeerenAugen000?api_key=${ GIPHY_API_KEY }` );
+			expect( getUrl( 'https://giphy.com/embed/tomatenAugen7777aSSSS' ) ).toBe(
+				`https://api.giphy.com/v1/gifs/tomatenAugen7777aSSSS?api_key=${ GIPHY_API_KEY }`
+			);
+			expect( getUrl( 'https://giphy.com/gifs/pineapple-kopf-ddddd123' ) ).toBe(
+				`https://api.giphy.com/v1/gifs/ddddd123?api_key=${ GIPHY_API_KEY }`
+			);
+			expect( getUrl( 'https://i.giphy.com/bananaGesicht999999999.gif' ) ).toBe(
+				`https://api.giphy.com/v1/gifs/bananaGesicht999999999?api_key=${ GIPHY_API_KEY }`
+			);
+			expect( getUrl( 'https://media.giphy.com/media/blaubeerenAugen000/giphy.gif' ) ).toBe(
+				`https://api.giphy.com/v1/gifs/blaubeerenAugen000?api_key=${ GIPHY_API_KEY }`
+			);
 		} );
 
 		test( 'treats searchText as a query string for other URL-like non-matches', () => {
-			expect( getUrl( 'https://this.does.not/work' ) ).toEqual( `https://api.giphy.com/v1/gifs/search?q=https%3A%2F%2Fthis.does.not%2Fwork&api_key=${ GIPHY_API_KEY }&limit=10` );
+			expect( getUrl( 'https://this.does.not/work' ) ).toBe(
+				`https://api.giphy.com/v1/gifs/search?q=https%3A%2F%2Fthis.does.not%2Fwork&api_key=${ GIPHY_API_KEY }&limit=10`
+			);
 		} );
 	} );
 
 	describe( 'getPaddingTop', () => {
 		test( 'returns padding as a percentage', () => {
-			expect( getPaddingTop( GIPHY_ITEM ) ).toEqual( '100%' );
+			expect( getPaddingTop( GIPHY_ITEM ) ).toBe( '100%' );
 		} );
 	} );
 
@@ -70,37 +90,48 @@ describe( 'Gif Block utils', () => {
 
 	describe( 'getSearchUrl', () => {
 		test( 'returns giphy url with query parameters', () => {
-			expect( getSearchUrl( 'grumpy cat' ) ).toEqual( `https://api.giphy.com/v1/gifs/search?q=grumpy%20cat&api_key=${ GIPHY_API_KEY }&limit=10` );
+			expect( getSearchUrl( 'grumpy cat' ) ).toBe(
+				`https://api.giphy.com/v1/gifs/search?q=grumpy%20cat&api_key=${ GIPHY_API_KEY }&limit=10`
+			);
 		} );
 	} );
 
 	describe( 'getUrlWithId', () => {
 		test( 'returns giphy url with query parameters', () => {
-			expect( getUrlWithId( 'grumpy_cat' ) ).toEqual( `https://api.giphy.com/v1/gifs/grumpy_cat?api_key=${ GIPHY_API_KEY }` );
+			expect( getUrlWithId( 'grumpy_cat' ) ).toBe(
+				`https://api.giphy.com/v1/gifs/grumpy_cat?api_key=${ GIPHY_API_KEY }`
+			);
 		} );
 	} );
 
 	describe( 'splitStringAndReturnLastItem', () => {
 		test( 'returns the last item from a split string', () => {
-			expect( splitStringAndReturnLastItem( 'the-night-was-dark-and-stormy', '-' ) ).toEqual( 'stormy' );
-			expect( splitStringAndReturnLastItem( 'https://thenight.was/dark/and/stormy', '/' ) ).toEqual( 'stormy' );
+			expect( splitStringAndReturnLastItem( 'the-night-was-dark-and-stormy', '-' ) ).toBe(
+				'stormy'
+			);
+			expect( splitStringAndReturnLastItem( 'https://thenight.was/dark/and/stormy', '/' ) ).toBe(
+				'stormy'
+			);
 		} );
 
 		test( 'returns the entire string when no delimiter provided (default String.prototype.split() behaviour)', () => {
-			expect( splitStringAndReturnLastItem( 'the-night-was-dark-and-stormy' ) ).toEqual( 'the-night-was-dark-and-stormy' );
-			expect( splitStringAndReturnLastItem( 'ID1WITHOUT9STUFF' ) ).toEqual( 'ID1WITHOUT9STUFF' );
+			expect( splitStringAndReturnLastItem( 'the-night-was-dark-and-stormy' ) ).toBe(
+				'the-night-was-dark-and-stormy'
+			);
+			expect( splitStringAndReturnLastItem( 'ID1WITHOUT9STUFF' ) ).toBe( 'ID1WITHOUT9STUFF' );
 		} );
 
 		test( 'returns empty string where there are no arguments', () => {
-			expect( splitStringAndReturnLastItem() ).toEqual( '' );
+			expect( splitStringAndReturnLastItem() ).toBe( '' );
 		} );
 	} );
 
 	describe( 'getSelectedGiphyAttributes', () => {
 		test( 'returns expected object', () => {
-			expect( getSelectedGiphyAttributes( GIPHY_ITEM ) ).toStrictEqual(
-				{ giphyUrl: getEmbedUrl( GIPHY_ITEM ), paddingTop: getPaddingTop( GIPHY_ITEM ) }
-			);
+			expect( getSelectedGiphyAttributes( GIPHY_ITEM ) ).toStrictEqual( {
+				giphyUrl: getEmbedUrl( GIPHY_ITEM ),
+				paddingTop: getPaddingTop( GIPHY_ITEM ),
+			} );
 		} );
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/google-calendar/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/google-calendar/test/controls.js
@@ -1,12 +1,7 @@
-/**
- * @jest-environment jsdom
- */
-
-import '@testing-library/jest-dom/extend-expect';
-import userEvent from '@testing-library/user-event';
 import { fireEvent, render, screen } from '@testing-library/react';
-
+import userEvent from '@testing-library/user-event';
 import GoogleCalendarInspectorControls from '../controls';
+import '@testing-library/jest-dom';
 
 describe( 'GoogleCalendarInspectorControls', () => {
 	const onChange = jest.fn();
@@ -14,7 +9,8 @@ describe( 'GoogleCalendarInspectorControls', () => {
 
 	const defaultProps = {
 		className: 'calendar-embed-form',
-		embedValue: 'https://calendar.google.com/calendar/embed?src=c_rr8cguo95gga9im2vs4tqi939g%40group.calendar.google.com&ctz=Australia%2FBrisbane',
+		embedValue:
+			'https://calendar.google.com/calendar/embed?src=c_rr8cguo95gga9im2vs4tqi939g%40group.calendar.google.com&ctz=Australia%2FBrisbane',
 		onChange,
 		onSubmit,
 	};
@@ -40,9 +36,12 @@ describe( 'GoogleCalendarInspectorControls', () => {
 		const button = await screen.findByText( 'Embed' );
 
 		expect( button ).toBeInTheDocument();
+		// eslint-disable-next-line testing-library/no-node-access
 		expect( button.closest( 'form' ) ).toHaveClass( defaultProps.className );
 		expect( screen.getByLabelText( 'Google Calendar URL or iframe' ) ).toBeInTheDocument();
-		expect( screen.getByPlaceholderText( 'Enter URL or iframe to embed here…' ) ).toBeInTheDocument();
+		expect(
+			screen.getByPlaceholderText( 'Enter URL or iframe to embed here…' )
+		).toBeInTheDocument();
 		expect( screen.getByText( defaultProps.embedValue ) ).toBeInTheDocument();
 	} );
 

--- a/projects/plugins/jetpack/extensions/blocks/google-calendar/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/google-calendar/test/edit.js
@@ -1,21 +1,13 @@
-/**
- * @jest-environment jsdom
- */
-
-import '@testing-library/jest-dom/extend-expect';
-import userEvent from '@testing-library/user-event';
-import { render, screen } from '@testing-library/react';
 import { isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GoogleCalendarEdit } from '../edit';
+import '@testing-library/jest-dom';
 
-import { SandBox } from '@wordpress/components';
-
-// SandBox is mocked to avoid the runtime JS scripts in includes.
 jest.mock( '@wordpress/components/build/sandbox', () => ( {
 	__esModule: true,
-	default: props => <iframe { ...props } />,
+	default: props => <iframe title="Some title" { ...props } />,
 } ) );
-
-import { GoogleCalendarEdit } from '../edit';
 
 // isSimpleSite is mocked simply to check appropriate support link is displayed.
 jest.mock( '@automattic/jetpack-shared-extension-utils', () => ( {
@@ -67,14 +59,18 @@ describe( 'GoogleCalendarEdit', () => {
 		const { container } = render( <GoogleCalendarEdit { ...emptyProps } /> );
 
 		// Check block specific CSS classes are applied.
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 		expect( container.firstChild ).toHaveClass( defaultProps.className );
 		expect(
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 			container.querySelector( `.${ defaultClassName }-placeholder-instructions` )
 		).toBeInTheDocument();
 		expect(
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 			container.querySelector( `.${ defaultClassName }-embed-form-editor` )
 		).toBeInTheDocument();
 		expect(
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 			container.querySelector( `.${ defaultClassName }-placeholder-links` )
 		).toBeInTheDocument();
 
@@ -82,6 +78,7 @@ describe( 'GoogleCalendarEdit', () => {
 		const label = screen.getByText( 'Google Calendar' );
 
 		expect( label ).toBeInTheDocument();
+		// eslint-disable-next-line testing-library/no-node-access
 		expect( label.querySelector( 'svg' ) ).toBeInTheDocument();
 		expect(
 			screen.getByText( 'Enable Permissions for the calendar you want to share' )
@@ -120,7 +117,7 @@ describe( 'GoogleCalendarEdit', () => {
 	test( 'handles submitted embed codes', async () => {
 		const user = userEvent.setup();
 		const emptyProps = { ...defaultProps, attributes: emptyAttributes };
-		const { container } = render( <GoogleCalendarEdit { ...emptyProps } /> );
+		render( <GoogleCalendarEdit { ...emptyProps } /> );
 
 		const input = screen.getByPlaceholderText( 'Enter URL or iframe to embed here…' );
 		const button = screen.getByRole( 'button', { name: 'Embed' } );
@@ -148,11 +145,13 @@ describe( 'GoogleCalendarEdit', () => {
 	test( 'displays embedded calendar', () => {
 		const { container } = render( <GoogleCalendarEdit { ...defaultProps } /> );
 		const html = `<iframe src="${ defaultAttributes.url }" style="border:0" scrolling="no" frameborder="0" height="${ defaultAttributes.height }"></iframe>`;
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 		const iframe = container.querySelector( 'iframe' );
 
 		expect( iframe ).toBeInTheDocument();
 		expect( iframe ).toHaveAttribute( 'html', html );
 		expect(
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 			container.querySelector( '.block-library-embed__interactive-overlay' )
 		).toBeInTheDocument();
 	} );
@@ -161,6 +160,7 @@ describe( 'GoogleCalendarEdit', () => {
 		const user = userEvent.setup();
 		const deselectedProps = { ...defaultProps, isSelected: false };
 		const { container } = render( <GoogleCalendarEdit { ...deselectedProps } /> );
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 		const overlay = container.querySelector( '.block-library-embed__interactive-overlay' );
 
 		expect( overlay ).toBeInTheDocument();

--- a/projects/plugins/jetpack/extensions/blocks/google-calendar/test/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/google-calendar/test/utils.js
@@ -3,9 +3,10 @@ import { convertShareableUrl, extractAttributesFromIframe, parseEmbed } from '..
 const shareableUrl = 'https://calendar.google.com/calendar?cid=Z2xlbi5kYXZpZXNAYThjLmNvbQ';
 const shareableData = {
 	url: 'https://calendar.google.com/calendar/embed?src=glen.davies%40a8c.com',
-}
+};
 
-const iframeEmbed = '<iframe src="https://calendar.google.com/calendar/embed?src=test.user%40a8c.com&ctz=Pacific%2FAuckland" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>';
+const iframeEmbed =
+	'<iframe src="https://calendar.google.com/calendar/embed?src=test.user%40a8c.com&ctz=Pacific%2FAuckland" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>';
 const iframeData = {
 	url: 'https://calendar.google.com/calendar/embed?src=test.user%40a8c.com&ctz=Pacific%2FAuckland',
 	height: '600',

--- a/projects/plugins/jetpack/extensions/blocks/image-compare/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/image-compare/test/controls.js
@@ -1,12 +1,7 @@
-/**
- * @jest-environment jsdom
- */
-
-import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { render, screen, waitFor } from '@testing-library/react';
-
 import ImageCompareControls from '../controls';
+import '@testing-library/jest-dom';
 
 describe( 'ImageCompareControls', () => {
 	const setAttributes = jest.fn();
@@ -30,19 +25,19 @@ describe( 'ImageCompareControls', () => {
 	test( 'defaults orientation selection to horizontal', () => {
 		render( <ImageCompareControls { ...defaultProps } /> );
 
-		expect( screen.getByLabelText( 'Side by side' ) ).toHaveAttribute( 'checked' );
+		expect( screen.getByLabelText( 'Side by side' ) ).toBeChecked();
 	} );
 
 	test( 'selects option according to orientation attribute', () => {
 		const attributes = { orientation: 'vertical' };
 		render( <ImageCompareControls { ...{ ...defaultProps, attributes } } /> );
 
-		expect( screen.getByLabelText( 'Above and below' ) ).toHaveAttribute( 'checked' );
+		expect( screen.getByLabelText( 'Above and below' ) ).toBeChecked();
 	} );
 
-	test( 'sets the orientation attribute ', async () => {
+	test( 'sets the orientation attribute', async () => {
 		const user = userEvent.setup();
-		render( <ImageCompareControls { ...defaultProps } /> )
+		render( <ImageCompareControls { ...defaultProps } /> );
 		await user.click( screen.getByLabelText( 'Above and below' ) );
 
 		expect( setAttributes ).toHaveBeenCalledWith( { orientation: 'vertical' } );

--- a/projects/plugins/jetpack/extensions/blocks/image-compare/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/image-compare/test/edit.js
@@ -1,14 +1,16 @@
-/**
- * @jest-environment jsdom
- */
-
-import '@testing-library/jest-dom/extend-expect';
-import { render, screen, waitFor } from '@testing-library/react';
-
+import { render, screen } from '@testing-library/react';
 import ImageCompareEdit from '../edit';
+import '@testing-library/jest-dom';
 
+/**
+ * Render image compare.
+ *
+ * @param {object} props - Props.
+ * @returns {HTMLElement} Element.
+ */
 function renderImageCompare( props ) {
 	const { container } = render( <ImageCompareEdit { ...props } /> );
+	// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 	return container.querySelector( `.${ props.className } > div:not([aria-hidden="true"])` );
 }
 
@@ -42,9 +44,10 @@ describe( 'ImageCompareEdit', () => {
 
 		expect( wrapper ).toHaveClass( defaultProps.className );
 		expect( wrapper ).toHaveAttribute( 'id', defaultProps.clientId );
-	} )
+	} );
 
 	test( 'applies juxtapose classes when images present', () => {
+		// eslint-disable-next-line testing-library/render-result-naming-convention -- False positive.
 		const element = renderImageCompare( defaultProps );
 
 		expect( element ).toHaveClass( 'image-compare__comparison' );
@@ -54,6 +57,7 @@ describe( 'ImageCompareEdit', () => {
 
 	test( 'applies placeholder classes when without images', () => {
 		const attributes = { ...defaultAttributes, ...emptyImages };
+		// eslint-disable-next-line testing-library/render-result-naming-convention -- False positive.
 		const element = renderImageCompare( { ...defaultProps, attributes } );
 
 		expect( element ).not.toHaveClass( 'image-compare__comparison' );
@@ -62,6 +66,7 @@ describe( 'ImageCompareEdit', () => {
 	} );
 
 	test( 'applies fallback horizontal orientation in data-mode attribute', () => {
+		// eslint-disable-next-line testing-library/render-result-naming-convention -- False positive.
 		const element = renderImageCompare( defaultProps );
 
 		expect( element ).toHaveAttribute( 'data-mode', 'horizontal' );
@@ -69,6 +74,7 @@ describe( 'ImageCompareEdit', () => {
 
 	test( 'applies selected orientation in data-mode attribute', () => {
 		const attributes = { ...defaultAttributes, orientation: 'vertical' };
+		// eslint-disable-next-line testing-library/render-result-naming-convention -- False positive.
 		const element = renderImageCompare( { ...defaultProps, attributes } );
 
 		expect( element ).toHaveAttribute( 'data-mode', 'vertical' );

--- a/projects/plugins/jetpack/extensions/blocks/image-compare/test/img-upload.js
+++ b/projects/plugins/jetpack/extensions/blocks/image-compare/test/img-upload.js
@@ -1,11 +1,6 @@
-/**
- * @jest-environment jsdom
- */
-
-import '@testing-library/jest-dom/extend-expect';
-import { render, screen, waitFor } from '@testing-library/react';
-
+import { render, screen } from '@testing-library/react';
 import ImgUpload from '../img-upload';
+import '@testing-library/jest-dom';
 
 describe( 'ImgUpload', () => {
 	const onChange = jest.fn();
@@ -25,7 +20,7 @@ describe( 'ImgUpload', () => {
 
 		expect( screen.getByText( defaultProps.placeHolderLabel ) ).toBeInTheDocument();
 		expect( screen.queryByRole( 'img' ) ).not.toBeInTheDocument();
-	} )
+	} );
 
 	test( 'displays image when available', () => {
 		render( <ImgUpload { ...defaultProps } /> );

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/test/controls.js
@@ -1,12 +1,7 @@
-/**
- * @jest-environment jsdom
- */
-
-import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { render, screen, fireEvent } from '@testing-library/react';
-
 import InstagramGalleryInspectorControls from '../controls';
+import '@testing-library/jest-dom';
 
 describe( 'InstagramGalleryInspectorControls', () => {
 	const defaultAttributes = {
@@ -48,24 +43,42 @@ describe( 'InstagramGalleryInspectorControls', () => {
 	} );
 
 	test( 'renders notice that there are no images available', () => {
-		const propsNoImages = { ...defaultProps, accountImageTotal: 0, shouldRenderSidebarNotice: true };
+		const propsNoImages = {
+			...defaultProps,
+			accountImageTotal: 0,
+			shouldRenderSidebarNotice: true,
+		};
 		render( <InstagramGalleryInspectorControls { ...propsNoImages } /> );
 
-		expect( screen.getAllByText( 'There are currently no posts in your Instagram account.' )[0] ).toBeInTheDocument();
+		expect(
+			screen.getAllByText( 'There are currently no posts in your Instagram account.' )[ 0 ]
+		).toBeInTheDocument();
 	} );
 
 	test( 'renders notice that there is only one image available', () => {
-		const propsOneImage = { ...defaultProps, accountImageTotal: 1, shouldRenderSidebarNotice: true };
+		const propsOneImage = {
+			...defaultProps,
+			accountImageTotal: 1,
+			shouldRenderSidebarNotice: true,
+		};
 		render( <InstagramGalleryInspectorControls { ...propsOneImage } /> );
 
-		expect( screen.getAllByText( 'There is currently only 1 post in your Instagram account.' )[0] ).toBeInTheDocument();
+		expect(
+			screen.getAllByText( 'There is currently only 1 post in your Instagram account.' )[ 0 ]
+		).toBeInTheDocument();
 	} );
 
 	test( 'renders notice that there is only a small number of images available', () => {
-		const propsSmallNumberOfImages = { ...defaultProps, accountImageTotal: 3, shouldRenderSidebarNotice: true };
+		const propsSmallNumberOfImages = {
+			...defaultProps,
+			accountImageTotal: 3,
+			shouldRenderSidebarNotice: true,
+		};
 		render( <InstagramGalleryInspectorControls { ...propsSmallNumberOfImages } /> );
 
-		expect( screen.getAllByText( 'There are currently only 3 posts in your Instagram account.' )[0] ).toBeInTheDocument();
+		expect(
+			screen.getAllByText( 'There are currently only 3 posts in your Instagram account.' )[ 0 ]
+		).toBeInTheDocument();
 	} );
 
 	test( 'updates count when changing number of posts', async () => {
@@ -73,19 +86,20 @@ describe( 'InstagramGalleryInspectorControls', () => {
 		const propsSmallCount = { ...defaultProps, attributes: { ...defaultAttributes, count: 1 } };
 		render( <InstagramGalleryInspectorControls { ...propsSmallCount } /> );
 
-		await user.click( screen.getAllByLabelText( 'Number of Posts' )[1] );
+		await user.click( screen.getAllByLabelText( 'Number of Posts' )[ 1 ] );
 		await user.paste( '5' );
 
 		expect( setAttributes ).toHaveBeenCalledWith( { count: 15 } );
 	} );
 
-	test( 'updates columns when changing number of columns', () => {
+	test( 'updates columns when changing number of columns', async () => {
+		const user = userEvent.setup();
 		const propsSmallCount = { ...defaultProps, attributes: { ...defaultAttributes, columns: 0 } };
 		render( <InstagramGalleryInspectorControls { ...propsSmallCount } /> );
 
 		const input = screen.getAllByLabelText( 'Number of Columns' )[ 1 ];
-		input.focus();
-		fireEvent.change( input, { target: { value: '3' } } );
+		await user.clear( input );
+		await user.type( input, '3' );
 
 		expect( setAttributes ).toHaveBeenCalledWith( { columns: 3 } );
 	} );
@@ -95,7 +109,7 @@ describe( 'InstagramGalleryInspectorControls', () => {
 		const propsSmallCount = { ...defaultProps, attributes: { ...defaultAttributes, spacing: 0 } };
 		render( <InstagramGalleryInspectorControls { ...propsSmallCount } /> );
 
-		await user.click( screen.getAllByLabelText( 'Image Spacing (px)' )[1] );
+		await user.click( screen.getAllByLabelText( 'Image Spacing (px)' )[ 1 ] );
 		await user.paste( '5' );
 
 		expect( setAttributes ).toHaveBeenCalledWith( { spacing: 5 } );
@@ -103,7 +117,10 @@ describe( 'InstagramGalleryInspectorControls', () => {
 
 	test( 'updates isStackedOnMobile when toggling stack on mobile', async () => {
 		const user = userEvent.setup();
-		const propsSmallCount = { ...defaultProps, attributes: { ...defaultAttributes, isStackedOnMobile: true } };
+		const propsSmallCount = {
+			...defaultProps,
+			attributes: { ...defaultAttributes, isStackedOnMobile: true },
+		};
 		render( <InstagramGalleryInspectorControls { ...propsSmallCount } /> );
 
 		await user.click( screen.getByLabelText( 'Stack on mobile' ) );

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/test/edit.js
@@ -1,13 +1,8 @@
-/**
- * @jest-environment jsdom
- */
-
-import '@testing-library/jest-dom/extend-expect';
-import userEvent from '@testing-library/user-event';
-import { render, screen, waitFor } from '@testing-library/react';
 import { JETPACK_DATA_PATH } from '@automattic/jetpack-shared-extension-utils';
-
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import InstagramGalleryEdit from '../edit';
+import '@testing-library/jest-dom';
 
 const originalFetch = window.fetch;
 
@@ -43,6 +38,7 @@ describe( 'InstagramGalleryEdit', () => {
 
 	beforeEach( () => {
 		setAttributes.mockClear();
+		// eslint-disable-next-line jest/prefer-spy-on -- Nothing to spy on.
 		window.fetch = jest.fn();
 		window[ JETPACK_DATA_PATH ] = {
 			jetpack: {
@@ -64,18 +60,15 @@ describe( 'InstagramGalleryEdit', () => {
 		render( <InstagramGalleryEdit { ...defaultProps } /> );
 
 		await waitFor( () =>
-			expect( window.fetch.mock.calls[ 0 ][ 0 ] ).toEqual(
+			expect( window.fetch.mock.calls[ 0 ][ 0 ] ).toBe(
 				'/wpcom/v2/instagram-gallery/connections?_locale=user'
 			)
 		);
 
-		await waitFor( () =>
-			expect(
-				screen.getByText( 'Connect to Instagram to start sharing your images.' )
-			).toBeInTheDocument()
-		);
-
-		await waitFor( () => expect( screen.getByText( 'Connect to Instagram' ) ).toBeInTheDocument() );
+		expect(
+			screen.getByText( 'Connect to Instagram to start sharing your images.' )
+		).toBeInTheDocument();
+		expect( screen.getByText( 'Connect to Instagram' ) ).toBeInTheDocument();
 	} );
 
 	test( 'updates instagram user and access token when selecting existing connection', async () => {
@@ -91,17 +84,15 @@ describe( 'InstagramGalleryEdit', () => {
 		render( <InstagramGalleryEdit { ...defaultProps } /> );
 
 		await waitFor( () =>
-			expect( window.fetch.mock.calls[ 0 ][ 0 ] ).toEqual(
+			expect( window.fetch.mock.calls[ 0 ][ 0 ] ).toBe(
 				'/wpcom/v2/instagram-gallery/connections?_locale=user'
 			)
 		);
 
-		await waitFor( () =>
-			expect( screen.getByText( 'Select your Instagram account:' ) ).toBeInTheDocument()
-		);
+		expect( screen.getByText( 'Select your Instagram account:' ) ).toBeInTheDocument();
 
-		await waitFor( async () => await user.click( screen.getByLabelText( '@testjetpackuser' ) ) );
-		await waitFor( async () => await user.click( screen.getByText( 'Connect to Instagram' ) ) );
+		await user.click( screen.getByLabelText( '@testjetpackuser' ) );
+		await user.click( screen.getByText( 'Connect to Instagram' ) );
 
 		expect( setAttributes ).toHaveBeenLastCalledWith( {
 			accessToken: '123456',
@@ -122,25 +113,20 @@ describe( 'InstagramGalleryEdit', () => {
 		render( <InstagramGalleryEdit { ...defaultProps } /> );
 
 		await waitFor( () =>
-			expect( window.fetch.mock.calls[ 0 ][ 0 ] ).toEqual(
+			expect( window.fetch.mock.calls[ 0 ][ 0 ] ).toBe(
 				'/wpcom/v2/instagram-gallery/connections?_locale=user'
 			)
 		);
 
-		await waitFor( () =>
-			expect( screen.getByText( 'Select your Instagram account:' ) ).toBeInTheDocument()
-		);
+		expect( screen.getByText( 'Select your Instagram account:' ) ).toBeInTheDocument();
 
-		await waitFor( async () => await user.click( screen.getByLabelText( 'Add a new account' ) ) );
-		await waitFor( () =>
-			expect(
-				screen.getByText(
-					'If you are currently logged in to Instagram on this device, you might need to log out of it first.'
-				)
-			).toBeInTheDocument()
-		);
-
-		await waitFor( () => expect( screen.getByText( 'Connect to Instagram' ) ).toBeInTheDocument() );
+		await user.click( screen.getByLabelText( 'Add a new account' ) );
+		expect(
+			screen.getByText(
+				'If you are currently logged in to Instagram on this device, you might need to log out of it first.'
+			)
+		).toBeInTheDocument();
+		expect( screen.getByText( 'Connect to Instagram' ) ).toBeInTheDocument();
 	} );
 
 	test( 'renders a gallery when an existing connection is active', async () => {
@@ -173,15 +159,13 @@ describe( 'InstagramGalleryEdit', () => {
 		render( <InstagramGalleryEdit { ...propsWithConnectedAccount } /> );
 
 		await waitFor( () =>
-			expect( window.fetch.mock.calls[ 0 ][ 0 ] ).toEqual(
+			expect( window.fetch.mock.calls[ 0 ][ 0 ] ).toBe(
 				'/wpcom/v2/instagram-gallery/gallery?access_token=123456&count=30&_locale=user'
 			)
 		);
 
-		await waitFor( () => expect( screen.getByAltText( 'test image 1' ) ).toBeInTheDocument() );
-		await waitFor( () => expect( screen.getByAltText( 'test image 2' ) ).toBeInTheDocument() );
-		await waitFor( () =>
-			expect( screen.queryByText( 'Connect to Instagram' ) ).not.toBeInTheDocument()
-		);
+		expect( screen.getByAltText( 'test image 1' ) ).toBeInTheDocument();
+		expect( screen.getByAltText( 'test image 2' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Connect to Instagram' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/test/controls.js
@@ -1,15 +1,14 @@
-import '@testing-library/jest-dom/extend-expect';
+import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { render, screen, act, waitFor } from '@testing-library/react';
-
 import { MailChimpBlockControls } from '../controls';
+import '@testing-library/jest-dom';
 
 const originalFetch = window.fetch;
 
 /**
  * Mock return value for a successful fetch JSON return value.
  *
- * @return {Promise} Mock return value.
+ * @returns {Promise} Mock return value.
  */
 const RESOLVED_FETCH_PROMISE = Promise.resolve( {
 	interest_categories: [
@@ -28,6 +27,7 @@ const DEFAULT_FETCH_MOCK_RETURN = Promise.resolve( {
 
 describe( 'Mailchimp block controls component', () => {
 	beforeEach( () => {
+		// eslint-disable-next-line jest/prefer-spy-on -- Nothing to spy on.
 		window.fetch = jest.fn();
 		window.fetch.mockReturnValue( DEFAULT_FETCH_MOCK_RETURN );
 	} );
@@ -132,8 +132,7 @@ describe( 'Mailchimp block controls component', () => {
 	test( 'updates selected groups', async () => {
 		const user = userEvent.setup();
 		render( <MailChimpBlockControls { ...defaultProps } /> );
-		await waitFor( () => screen.getByLabelText( 'golf' ) );
-		await user.click( screen.getByLabelText( 'golf' ) );
+		await user.click( await screen.findByLabelText( 'golf' ) );
 		expect( setAttributes ).toHaveBeenCalledWith( {
 			interests: [ 1 ],
 		} );

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/test/edit.js
@@ -1,17 +1,14 @@
-import '@testing-library/jest-dom/extend-expect';
-import { render, screen, act, waitFor } from '@testing-library/react';
 import { JETPACK_DATA_PATH } from '@automattic/jetpack-shared-extension-utils';
+import { render, screen, act } from '@testing-library/react';
+import { registerBlocks } from '../../../shared/test/block-fixtures';
+import { settings } from '../../button';
+import MailchimpSubscribeEdit from '../edit';
+import '@testing-library/jest-dom';
 
-// We need to mock InnerBlocks before importing our edit component as it requires the Gutenberg store setup
-// to operate
 jest.mock( '@wordpress/block-editor', () => ( {
 	...jest.requireActual( '@wordpress/block-editor' ),
 	InnerBlocks: () => <button>Mocked button</button>,
 } ) );
-
-import MailchimpSubscribeEdit from '../edit';
-import { settings } from '../../button';
-import { registerBlocks } from '../../../shared/test/block-fixtures';
 
 registerBlocks( [ { name: 'jetpack/button', settings } ] );
 
@@ -20,7 +17,7 @@ const originalFetch = window.fetch;
 /**
  * Mock return value for a successful fetch JSON return value.
  *
- * @return {Promise} Mock return value.
+ * @returns {Promise} Mock return value.
  */
 const NOT_CONNECTED_RESOLVED_FETCH_PROMISE = Promise.resolve( {
 	connected: undefined,
@@ -43,6 +40,7 @@ const CONNECTED_FETCH_MOCK_RETURN = Promise.resolve( {
 
 describe( 'Mailchimp block edit component', () => {
 	beforeEach( () => {
+		// eslint-disable-next-line jest/prefer-spy-on -- Nothing to spy on.
 		window.fetch = jest.fn();
 		window.fetch.mockReturnValue( DEFAULT_FETCH_MOCK_RETURN );
 	} );
@@ -102,8 +100,7 @@ describe( 'Mailchimp block edit component', () => {
 
 	test( 'shows set up mailchimp button and recheck connection if not connected', async () => {
 		render( <MailchimpSubscribeEdit { ...defaultProps } /> );
-		await waitFor( () => screen.getByText( 'Set up Mailchimp form' ) );
-		expect( screen.getByText( 'Set up Mailchimp form' ) ).toBeInTheDocument();
+		await expect( screen.findByText( 'Set up Mailchimp form' ) ).resolves.toBeInTheDocument();
 		expect( screen.getByText( 'Re-check Connection' ) ).toBeInTheDocument();
 	} );
 
@@ -111,7 +108,6 @@ describe( 'Mailchimp block edit component', () => {
 		window.fetch.mockReturnValue( CONNECTED_FETCH_MOCK_RETURN );
 		const connectedProps = { ...defaultProps, attributes: { ...attributes, preview: true } };
 		render( <MailchimpSubscribeEdit { ...connectedProps } /> );
-		await waitFor( () => screen.getByLabelText( 'Enter your email' ) );
-		expect( screen.getByLabelText( 'Enter your email' ) ).toBeInTheDocument();
+		await expect( screen.findByLabelText( 'Enter your email' ) ).resolves.toBeInTheDocument();
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/test/validate.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/test/validate.js
@@ -7,10 +7,12 @@ import { settings as buttonSettings } from '../../button';
  * involved in this set of tests.
  *
  * Example containing multiple blocks:
+ * ```
  * const blocks = [
- *		{ name: 'jetpack/whatsapp-button', settings },
- *		{ name: 'jetpack/send-a-message', settings: parentSettings },
+ *    { name: 'jetpack/whatsapp-button', settings },
+ *    { name: 'jetpack/send-a-message', settings: parentSettings },
  * ];
+ * ```
  */
 const blocks = [
 	{ name: `jetpack/${ name }`, settings },

--- a/projects/plugins/jetpack/extensions/blocks/map/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/test/controls.js
@@ -1,11 +1,6 @@
-/**
- * @jest-environment jsdom
- */
-
-import '@testing-library/jest-dom/extend-expect';
 import { render, screen } from '@testing-library/react';
-
 import MapControls from '../controls';
+import '@testing-library/jest-dom';
 
 const API_STATE_SUCCESS = 2;
 const setAttributes = jest.fn();

--- a/projects/plugins/jetpack/extensions/blocks/markdown/test/__snapshots__/markdown-renderer.js.snap
+++ b/projects/plugins/jetpack/extensions/blocks/markdown/test/__snapshots__/markdown-renderer.js.snap
@@ -1,64 +1,253 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MarkdownRenderer renders markdown to HTML as expected 1`] = `
-<RawHTML
-  className="markdown"
-  onClick={[Function]}
-  style={Object {}}
->
-  &lt;h1&gt;Heading&lt;/h1&gt;
-&lt;h2&gt;2nd Heading&lt;/h2&gt;
-&lt;ul&gt;
-&lt;li&gt;List 1&lt;/li&gt;
-&lt;li&gt;List 1&lt;/li&gt;
-&lt;/ul&gt;
-&lt;ul&gt;
-&lt;li&gt;List 2&lt;/li&gt;
-&lt;li&gt;List 2&lt;/li&gt;
-&lt;/ul&gt;
-&lt;ul&gt;
-&lt;li&gt;List 3&lt;/li&gt;
-&lt;li&gt;List 3&lt;/li&gt;
-&lt;/ul&gt;
-&lt;ol&gt;
-&lt;li&gt;Red&lt;/li&gt;
-&lt;li&gt;Green&lt;/li&gt;
-&lt;li&gt;Blue&lt;/li&gt;
-&lt;/ol&gt;
-&lt;ul&gt;
-&lt;li&gt;
-&lt;p&gt;A list item.&lt;/p&gt;
-&lt;p&gt;With multiple paragraphs.&lt;/p&gt;
-&lt;/li&gt;
-&lt;li&gt;
-&lt;p&gt;Another item in the list.&lt;/p&gt;
-&lt;/li&gt;
-&lt;/ul&gt;
-&lt;p&gt;&lt;em&gt;em&lt;/em&gt;
-&lt;em&gt;em&lt;/em&gt;
-&lt;strong&gt;strong&lt;/strong&gt;
-&lt;strong&gt;strong&lt;/strong&gt;
-&lt;em&gt;&lt;strong&gt;em strong&lt;/strong&gt;&lt;/em&gt;&lt;/p&gt;
-&lt;p&gt;*Literal asterisks*&lt;/p&gt;
-&lt;p&gt;Link to &lt;a href="https://wordpress.com"&gt;WordPress&lt;/a&gt; and &lt;a href="https://jetpack.com/"&gt;https://jetpack.com/&lt;/a&gt;&lt;/p&gt;
-&lt;p&gt;email me: &lt;a href="mailto:address@example.com"&gt;address@example.com&lt;/a&gt;&lt;/p&gt;
-&lt;p&gt;Inline &lt;code&gt;code&lt;/code&gt; here.&lt;/p&gt;
-&lt;pre&gt;&lt;code&gt;Block of code with backticks.
-&lt;/code&gt;&lt;/pre&gt;
-&lt;pre&gt;&lt;code&gt;Block of code prefixed by four spaces
-&lt;/code&gt;&lt;/pre&gt;
-&lt;blockquote&gt;
-&lt;p&gt;a blockquote.&lt;/p&gt;
-&lt;p&gt;2nd paragraph in the blockquote.&lt;/p&gt;
-&lt;h2&gt;H2 in a blockquote&lt;/h2&gt;
-&lt;/blockquote&gt;
-&lt;p&gt;A bunch of horizontal rules:&lt;/p&gt;
-&lt;hr&gt;
-&lt;hr&gt;
-&lt;hr&gt;
-&lt;hr&gt;
-&lt;hr&gt;
-&lt;p&gt;👋&lt;/p&gt;
+exports[`MarkdownRenderer renders markdown to HTML as expected: source 1`] = `
+<div>
+  <div
+    class="markdown"
+  >
+    <h1>
+      Heading
+    </h1>
+    
 
-</RawHTML>
+    <h2>
+      2nd Heading
+    </h2>
+    
+
+    <ul>
+      
+
+      <li>
+        List 1
+      </li>
+      
+
+      <li>
+        List 1
+      </li>
+      
+
+    </ul>
+    
+
+    <ul>
+      
+
+      <li>
+        List 2
+      </li>
+      
+
+      <li>
+        List 2
+      </li>
+      
+
+    </ul>
+    
+
+    <ul>
+      
+
+      <li>
+        List 3
+      </li>
+      
+
+      <li>
+        List 3
+      </li>
+      
+
+    </ul>
+    
+
+    <ol>
+      
+
+      <li>
+        Red
+      </li>
+      
+
+      <li>
+        Green
+      </li>
+      
+
+      <li>
+        Blue
+      </li>
+      
+
+    </ol>
+    
+
+    <ul>
+      
+
+      <li>
+        
+
+        <p>
+          A list item.
+        </p>
+        
+
+        <p>
+          With multiple paragraphs.
+        </p>
+        
+
+      </li>
+      
+
+      <li>
+        
+
+        <p>
+          Another item in the list.
+        </p>
+        
+
+      </li>
+      
+
+    </ul>
+    
+
+    <p>
+      <em>
+        em
+      </em>
+      
+
+      <em>
+        em
+      </em>
+      
+
+      <strong>
+        strong
+      </strong>
+      
+
+      <strong>
+        strong
+      </strong>
+      
+
+      <em>
+        <strong>
+          em strong
+        </strong>
+      </em>
+    </p>
+    
+
+    <p>
+      *Literal asterisks*
+    </p>
+    
+
+    <p>
+      Link to 
+      <a
+        href="https://wordpress.com"
+      >
+        WordPress
+      </a>
+       and 
+      <a
+        href="https://jetpack.com/"
+      >
+        https://jetpack.com/
+      </a>
+    </p>
+    
+
+    <p>
+      email me: 
+      <a
+        href="mailto:address@example.com"
+      >
+        address@example.com
+      </a>
+    </p>
+    
+
+    <p>
+      Inline 
+      <code>
+        code
+      </code>
+       here.
+    </p>
+    
+
+    <pre>
+      <code>
+        Block of code with backticks.
+
+      </code>
+    </pre>
+    
+
+    <pre>
+      <code>
+        Block of code prefixed by four spaces
+
+      </code>
+    </pre>
+    
+
+    <blockquote>
+      
+
+      <p>
+        a blockquote.
+      </p>
+      
+
+      <p>
+        2nd paragraph in the blockquote.
+      </p>
+      
+
+      <h2>
+        H2 in a blockquote
+      </h2>
+      
+
+    </blockquote>
+    
+
+    <p>
+      A bunch of horizontal rules:
+    </p>
+    
+
+    <hr />
+    
+
+    <hr />
+    
+
+    <hr />
+    
+
+    <hr />
+    
+
+    <hr />
+    
+
+    <p>
+      👋
+    </p>
+    
+
+  </div>
+</div>
 `;

--- a/projects/plugins/jetpack/extensions/blocks/markdown/test/markdown-renderer.js
+++ b/projects/plugins/jetpack/extensions/blocks/markdown/test/markdown-renderer.js
@@ -1,13 +1,11 @@
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 import React from 'react';
-
-import { source } from './fixtures/source';
 import MarkdownRenderer from '../renderer';
+import { source } from './fixtures/source';
 
 describe( 'MarkdownRenderer', () => {
 	test( 'renders markdown to HTML as expected', () => {
-		expect(
-			shallow( <MarkdownRenderer className="markdown" source={ source } /> )
-		).toMatchSnapshot();
+		const { container } = render( <MarkdownRenderer className="markdown" source={ source } /> );
+		expect( container ).toMatchSnapshot( 'source' );
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/opentable/test/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/opentable/test/utils.js
@@ -1,4 +1,3 @@
-
 import { getAttributesFromEmbedCode } from '../utils';
 
 const widgetEmbedCode =

--- a/projects/plugins/jetpack/extensions/blocks/pinterest/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/pinterest/test/controls.js
@@ -1,12 +1,7 @@
-/**
- * @jest-environment jsdom
- */
-
-import '@testing-library/jest-dom/extend-expect';
-import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
-
+import userEvent from '@testing-library/user-event';
 import { PinterestBlockControls } from '../controls';
+import '@testing-library/jest-dom';
 
 describe( 'PinterestBlockControls', () => {
 	const setEditingState = jest.fn();

--- a/projects/plugins/jetpack/extensions/blocks/pinterest/test/edit-url-form.js
+++ b/projects/plugins/jetpack/extensions/blocks/pinterest/test/edit-url-form.js
@@ -1,12 +1,7 @@
-/**
- * @jest-environment jsdom
- */
-
-import '@testing-library/jest-dom/extend-expect';
-import userEvent from '@testing-library/user-event';
 import { fireEvent, render, screen } from '@testing-library/react';
-
+import userEvent from '@testing-library/user-event';
 import EditUrlForm from '../components/edit-url-form';
+import '@testing-library/jest-dom';
 
 describe( 'EditUrlForm', () => {
 	const onSubmit = jest.fn();
@@ -27,6 +22,7 @@ describe( 'EditUrlForm', () => {
 	test( 'should render', () => {
 		render( <EditUrlForm { ...defaultProps } /> );
 		const { container } = render( <EditUrlForm { ...defaultProps } /> );
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 		expect( container.querySelector( 'div' ).className ).toContain( defaultProps.className );
 	} );
 
@@ -38,6 +34,7 @@ describe( 'EditUrlForm', () => {
 
 	test( 'calls onSubmit when submitting form', () => {
 		const { container } = render( <EditUrlForm { ...defaultProps } /> );
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 		const form = container.querySelector( 'form' );
 		fireEvent.submit( form );
 
@@ -51,6 +48,4 @@ describe( 'EditUrlForm', () => {
 
 		expect( setUrl ).toHaveBeenCalledTimes( 4 );
 	} );
-
 } );
-

--- a/projects/plugins/jetpack/extensions/blocks/pinterest/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/pinterest/test/edit.js
@@ -1,22 +1,16 @@
-/**
- * @jest-environment jsdom
- */
-
-import '@testing-library/jest-dom/extend-expect';
-import userEvent from '@testing-library/user-event'
 import { fireEvent, render, screen } from '@testing-library/react';
-import { SandBox } from '@wordpress/components';
-
+import userEvent from '@testing-library/user-event';
 import { PinterestEdit } from '../edit';
 import useTestPinterestEmbedUrl from '../hooks/use-test-pinterest-embed-url';
+import '@testing-library/jest-dom';
 
-jest.mock('../hooks/use-test-pinterest-embed-url' );
+jest.mock( '../hooks/use-test-pinterest-embed-url' );
 jest.mock( '@wordpress/components/build/sandbox', () => ( {
 	__esModule: true,
-	default: ( props ) => <iframe { ...props } />,
+	default: props => <iframe title="Some name" { ...props } />,
 } ) );
 
-describe( '', () => {
+describe( 'Pinterest block', () => {
 	const defaultAttributes = {
 		url: '',
 	};
@@ -33,7 +27,7 @@ describe( '', () => {
 			removeAllNotices,
 			createErrorNotice,
 		},
-		noticeUI: [ <p key="ahoy">ahoy!</p>],
+		noticeUI: [ <p key="ahoy">ahoy!</p> ],
 		setAttributes,
 		onReplace,
 	};
@@ -68,7 +62,7 @@ describe( '', () => {
 				pinterestUrl: '',
 				testUrl,
 				hasTestUrlError: false,
-			}
+			};
 		} );
 		render( <PinterestEdit { ...defaultProps } /> );
 		expect( screen.getByText( 'Embedding…' ) ).toBeInTheDocument();
@@ -77,8 +71,12 @@ describe( '', () => {
 	test( 'fires off a call to test the url', async () => {
 		const user = userEvent.setup();
 		const { container } = render( <PinterestEdit { ...defaultProps } /> );
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 		const form = container.querySelector( 'form' );
-		await user.type( screen.getByLabelText( 'Pinterest URL' ), 'https://www.pinterest.com.au/jeanette1952/decor-enamelwarecloisonn%C3%A9glassware/' );
+		await user.type(
+			screen.getByLabelText( 'Pinterest URL' ),
+			'https://www.pinterest.com.au/jeanette1952/decor-enamelwarecloisonn%C3%A9glassware/'
+		);
 		fireEvent.submit( form );
 		expect( testUrl ).toHaveBeenCalled();
 	} );
@@ -91,8 +89,8 @@ describe( '', () => {
 			},
 		};
 		const { container } = render( <PinterestEdit { ...newProps } /> );
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 		const wrapperElement = container.querySelector( `.${ defaultProps.className }` );
 		expect( wrapperElement ).toBeInTheDocument();
 	} );
 } );
-

--- a/projects/plugins/jetpack/extensions/blocks/pinterest/test/error-notice.js
+++ b/projects/plugins/jetpack/extensions/blocks/pinterest/test/error-notice.js
@@ -1,15 +1,10 @@
-/**
- * @jest-environment jsdom
- */
-
-import '@testing-library/jest-dom/extend-expect';
-import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
-
+import userEvent from '@testing-library/user-event';
 import ErrorNotice from '../components/error-notice';
+import '@testing-library/jest-dom';
 
 jest.mock( '@wordpress/blocks', () => ( {
-	createBlock: ( blockName, contentObj ) => ( { blockName, contentObj  } ),
+	createBlock: ( blockName, contentObj ) => ( { blockName, contentObj } ),
 } ) );
 
 describe( 'ErrorNotice', () => {
@@ -17,7 +12,7 @@ describe( 'ErrorNotice', () => {
 
 	const defaultProps = {
 		onClick,
-		fallbackUrl: 'https://rain.drops/keep/falling'
+		fallbackUrl: 'https://rain.drops/keep/falling',
 	};
 
 	beforeEach( () => {
@@ -31,7 +26,7 @@ describe( 'ErrorNotice', () => {
 		expect( onClick ).toHaveBeenCalledWith( {
 			blockName: 'core/paragraph',
 			contentObj: {
-				content: `<a href="${ defaultProps.fallbackUrl }">${ defaultProps.fallbackUrl }</a>`
+				content: `<a href="${ defaultProps.fallbackUrl }">${ defaultProps.fallbackUrl }</a>`,
 			},
 		} );
 	} );

--- a/projects/plugins/jetpack/extensions/blocks/pinterest/test/use-test-pinterest-embed-url.js
+++ b/projects/plugins/jetpack/extensions/blocks/pinterest/test/use-test-pinterest-embed-url.js
@@ -1,12 +1,11 @@
 import { renderHook, act } from '@testing-library/react-hooks';
-
-import useTestPinterestEmbedUrl from '../hooks/use-test-pinterest-embed-url';
-import testEmbedUrl from '../../../shared/test-embed-url';
 import { PINTEREST_EXAMPLE_URL } from '../';
+import testEmbedUrl from '../../../shared/test-embed-url';
+import useTestPinterestEmbedUrl from '../hooks/use-test-pinterest-embed-url';
 
 jest.mock( '../../../shared/test-embed-url', () => ( {
 	__esModule: true,
-	default: jest.fn().mockImplementation( ( url, setIsResolvingUrl = () => {} ) => {
+	default: jest.fn( url => {
 		return new Promise( ( resolve, reject ) => {
 			url === 'https://www.hello.com/is/it/me' ? reject() : resolve( url );
 		} );
@@ -19,9 +18,7 @@ describe( 'useTestPinterestEmbedUrl', () => {
 	} );
 	test( 'should return resolved url for valid urls', async () => {
 		const validUrl = 'https://www.pinterest.com.au/thebestpinterestuser';
-		const { result } = renderHook(() =>
-			useTestPinterestEmbedUrl()
-		);
+		const { result } = renderHook( () => useTestPinterestEmbedUrl() );
 
 		await act( async () => {
 			result.current.testUrl( validUrl );
@@ -35,9 +32,7 @@ describe( 'useTestPinterestEmbedUrl', () => {
 
 	test( 'should return provided url for invalid urls', async () => {
 		const invalidUrl = 'https://www.hello.com/is/it/me';
-		const { result } = renderHook(() =>
-			useTestPinterestEmbedUrl()
-		);
+		const { result } = renderHook( () => useTestPinterestEmbedUrl() );
 
 		await act( async () => {
 			result.current.testUrl( invalidUrl );
@@ -51,9 +46,7 @@ describe( 'useTestPinterestEmbedUrl', () => {
 
 	test( 'should not call testEmbed url if the url is falsy', async () => {
 		const invalidUrl = '';
-		const { result } = renderHook(() =>
-			useTestPinterestEmbedUrl()
-		);
+		const { result } = renderHook( () => useTestPinterestEmbedUrl() );
 
 		await act( async () => {
 			result.current.testUrl( invalidUrl );
@@ -63,10 +56,7 @@ describe( 'useTestPinterestEmbedUrl', () => {
 	} );
 
 	test( 'should not call testEmbed url if the url is the example url', async () => {
-		const invalidUrl = '';
-		const { result } = renderHook(() =>
-			useTestPinterestEmbedUrl()
-		);
+		const { result } = renderHook( () => useTestPinterestEmbedUrl() );
 
 		await act( async () => {
 			result.current.testUrl( PINTEREST_EXAMPLE_URL );

--- a/projects/plugins/jetpack/extensions/blocks/pinterest/test/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/pinterest/test/utils.js
@@ -3,33 +3,37 @@ import { pinType } from '../utils';
 describe( 'utils', () => {
 	describe( 'pinType', () => {
 		test( 'should return empty string for invalid urls', () => {
-			expect( pinType() ).toEqual( '' );
-			expect( pinType( '' ) ).toEqual( '' );
-			expect( pinType( 'https://jetpack.com' ) ).toEqual( '' );
-			expect( pinType( 'https://pinterest.com' ) ).toEqual( '' );
-			expect( pinType( 'https://bananas.rule.net/pin/4524524543' ) ).toEqual( '' );
+			expect( pinType() ).toBe( '' );
+			expect( pinType( '' ) ).toBe( '' );
+			expect( pinType( 'https://jetpack.com' ) ).toBe( '' );
+			expect( pinType( 'https://pinterest.com' ) ).toBe( '' );
+			expect( pinType( 'https://bananas.rule.net/pin/4524524543' ) ).toBe( '' );
 		} );
 
 		test( 'should return `embedPin` for pin urls', () => {
-			expect( pinType() ).toEqual( '' );
-			expect( pinType( 'https://www.pinterest.com.au/pin/766667536554271154/' ) ).toEqual( 'embedPin' );
-			expect( pinType( 'https://pinterest.com/pin/766667536554271154' ) ).toEqual( 'embedPin' );
-			expect( pinType( 'https://pinterest.de/pin/766667536554271154/' ) ).toEqual( 'embedPin' );
-			expect( pinType( 'http://pinterest.com/pin/766667536554271154/' ) ).toEqual( 'embedPin' );
+			expect( pinType() ).toBe( '' );
+			expect( pinType( 'https://www.pinterest.com.au/pin/766667536554271154/' ) ).toBe(
+				'embedPin'
+			);
+			expect( pinType( 'https://pinterest.com/pin/766667536554271154' ) ).toBe( 'embedPin' );
+			expect( pinType( 'https://pinterest.de/pin/766667536554271154/' ) ).toBe( 'embedPin' );
+			expect( pinType( 'http://pinterest.com/pin/766667536554271154/' ) ).toBe( 'embedPin' );
 		} );
 
 		test( 'should return `embedUser` for user urls', () => {
-			expect( pinType() ).toEqual( '' );
-			expect( pinType( 'https://www.pinterest.com.au/jeanette1952/' ) ).toEqual( 'embedUser' );
-			expect( pinType( 'https://pinterest.com/jeanette1952' ) ).toEqual( 'embedUser' );
-			expect( pinType( 'https://pinterest.fr/jeanette1952' ) ).toEqual( 'embedUser' );
+			expect( pinType() ).toBe( '' );
+			expect( pinType( 'https://www.pinterest.com.au/jeanette1952/' ) ).toBe( 'embedUser' );
+			expect( pinType( 'https://pinterest.com/jeanette1952' ) ).toBe( 'embedUser' );
+			expect( pinType( 'https://pinterest.fr/jeanette1952' ) ).toBe( 'embedUser' );
 		} );
 
 		test( 'should return `embedBoard` for board urls', () => {
-			expect( pinType() ).toEqual( '' );
-			expect( pinType( 'https://www.pinterest.com.au/pinchofyum/pasta-recipes/' ) ).toEqual( 'embedBoard' );
-			expect( pinType( 'https://pinterest.com/pinchofyum/pasta-recipes/' ) ).toEqual( 'embedBoard' );
-			expect( pinType( 'https://pinterest.fr/pinchofyum/pasta-recipes/' ) ).toEqual( 'embedBoard' );
+			expect( pinType() ).toBe( '' );
+			expect( pinType( 'https://www.pinterest.com.au/pinchofyum/pasta-recipes/' ) ).toBe(
+				'embedBoard'
+			);
+			expect( pinType( 'https://pinterest.com/pinchofyum/pasta-recipes/' ) ).toBe( 'embedBoard' );
+			expect( pinType( 'https://pinterest.fr/pinchofyum/pasta-recipes/' ) ).toBe( 'embedBoard' );
 		} );
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/rating-star/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/rating-star/test/edit.js
@@ -1,19 +1,14 @@
-/**
- * @jest-environment jsdom
- */
-
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event'
-import '@testing-library/jest-dom/extend-expect';
-
+import userEvent from '@testing-library/user-event';
 import { Rating } from '../edit';
+import '@testing-library/jest-dom';
 
 describe( 'Rating', () => {
 	const setRatingMock = jest.fn();
 	const defaultProps = {
 		id: 1,
 		setRating: setRatingMock,
-		children: [ <p key="yo">Things are just fine!</p> ]
+		children: [ <p key="yo">Things are just fine!</p> ],
 	};
 
 	beforeEach( () => {
@@ -29,8 +24,8 @@ describe( 'Rating', () => {
 		const user = userEvent.setup();
 		render( <Rating { ...defaultProps } /> );
 		await user.click( screen.getByRole( 'button' ) );
-		expect( setRatingMock ).toBeCalledTimes( 1 );
-		expect( setRatingMock ).toBeCalledWith( defaultProps.id );
+		expect( setRatingMock ).toHaveBeenCalledTimes( 1 );
+		expect( setRatingMock ).toHaveBeenCalledWith( defaultProps.id );
 	} );
 
 	test( 'fires keydown event handler callbacks', async () => {
@@ -38,8 +33,8 @@ describe( 'Rating', () => {
 		render( <Rating { ...defaultProps } /> );
 		await user.type( screen.getByRole( 'button' ), '{enter}' );
 		// A focused keypress event fires both keydown and click so we expect two executions
-		expect( setRatingMock ).toBeCalledTimes( 2 );
-		expect( setRatingMock.mock.calls[0][0] ).toBe( defaultProps.id );
-		expect( setRatingMock.mock.calls[1][0] ).toBe( defaultProps.id );
+		expect( setRatingMock ).toHaveBeenCalledTimes( 2 );
+		expect( setRatingMock.mock.calls[ 0 ][ 0 ] ).toBe( defaultProps.id );
+		expect( setRatingMock.mock.calls[ 1 ][ 0 ] ).toBe( defaultProps.id );
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/rating-star/test/icon.js
+++ b/projects/plugins/jetpack/extensions/blocks/rating-star/test/icon.js
@@ -1,11 +1,6 @@
-/**
- * @jest-environment jsdom
- */
-
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
-
 import { StarIcon } from '../icon';
+import '@testing-library/jest-dom';
 
 describe( 'StarIcon', () => {
 	const defaultProps = {
@@ -15,13 +10,17 @@ describe( 'StarIcon', () => {
 
 	test( 'loads and applies default props to children', () => {
 		const { container } = render( <StarIcon /> );
-		expect( container.firstChild.getAttribute( 'color' ) ).toEqual( 'currentColor' );
-		expect( container.firstChild.firstChild.getAttribute( 'class' ) ).toEqual( '' )
+		// eslint-disable-next-line testing-library/no-node-access
+		expect( container.firstChild ).toHaveAttribute( 'color', 'currentColor' );
+		// eslint-disable-next-line testing-library/no-node-access
+		expect( container.firstChild.firstChild ).toHaveAttribute( 'class', '' );
 	} );
 
 	test( 'loads and applies passed props to children', () => {
 		const { container } = render( <StarIcon { ...defaultProps } /> );
-		expect( container.firstChild.getAttribute( 'color' ) ).toEqual( 'orange' );
+		// eslint-disable-next-line testing-library/no-node-access
+		expect( container.firstChild ).toHaveAttribute( 'color', 'orange' );
+		// eslint-disable-next-line testing-library/no-node-access
 		expect( container.firstChild.firstChild ).toHaveClass( 'juice' );
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/test/edit.js
@@ -1,13 +1,10 @@
-/**
- * @jest-environment jsdom
- */
-
-import '@testing-library/jest-dom/extend-expect';
-import { render, screen, waitFor } from '@testing-library/react';
 import { JETPACK_DATA_PATH } from '@automattic/jetpack-shared-extension-utils';
+import { render, screen, waitFor } from '@testing-library/react';
+import { registerBlocks } from '../../../shared/test/block-fixtures';
+import { settings } from '../../button';
+import Edit from '../edit';
+import '@testing-library/jest-dom';
 
-// We need to mock InnerBlocks before importing our edit component as it requires the Gutenberg store setup
-// to operate
 jest.mock( '@wordpress/block-editor', () => ( {
 	...jest.requireActual( '@wordpress/block-editor' ),
 	InnerBlocks: () => <button>Mocked button</button>,
@@ -15,11 +12,6 @@ jest.mock( '@wordpress/block-editor', () => ( {
 
 // Mock the @wordpress/edit-post, used internally to resolve the fallback URL.
 jest.mock( '@wordpress/edit-post', () => jest.fn() );
-
-import Edit from '../edit';
-
-import { settings } from '../../button';
-import { registerBlocks } from '../../../shared/test/block-fixtures';
 
 registerBlocks( [ { name: 'jetpack/button', settings } ] );
 
@@ -48,23 +40,6 @@ describe( 'MembershipsButtonEdit', () => {
 		isSelected: true,
 		context: {},
 	};
-
-	const defaultProducts = [
-		{
-			id: 1,
-			currency: 'USD',
-			price: '10.00',
-			interval: '1 month',
-			title: 'ten a month',
-		},
-		{
-			id: 2,
-			currency: 'DKK',
-			price: '5.00',
-			interval: '1 year',
-			title: 'five a year',
-		},
-	];
 
 	const defaultFetchData = {
 		connect_url: '',
@@ -95,6 +70,7 @@ describe( 'MembershipsButtonEdit', () => {
 		onReplace.mockClear();
 		autosaveAndRedirect.mockClear();
 
+		// eslint-disable-next-line jest/prefer-spy-on -- Nothing to spy on.
 		window.fetch = jest.fn();
 		window.fetch.mockReturnValue( defaultApiResponse );
 		window[ JETPACK_DATA_PATH ] = {
@@ -107,6 +83,12 @@ describe( 'MembershipsButtonEdit', () => {
 		window[ JETPACK_DATA_PATH ] = originalJetpackData;
 	} );
 
+	/**
+	 * Get API response.
+	 *
+	 * @param {object} overrides - Data overrides.
+	 * @returns {Promise} Promise resolving to an API response.
+	 */
 	function getApiResponse( overrides ) {
 		const data = {
 			...defaultFetchData,
@@ -137,8 +119,7 @@ describe( 'MembershipsButtonEdit', () => {
 	} );
 
 	describe( 'when the site requires an upgrade', () => {
-		/* This will be re-enabled in a follow-up PR.
-		test( 'the upgrade nudge does not display if the block is part of a Premium Content block', async () => {
+		test.skip( 'the upgrade nudge does not display if the block is part of a Premium Content block', async () => {
 			window.fetch.mockReturnValue(
 				getApiResponse( { should_upgrade_to_access_memberships: true } )
 			);
@@ -149,6 +130,5 @@ describe( 'MembershipsButtonEdit', () => {
 				expect( screen.queryByText( 'Upgrade your plan' ) ).not.toBeInTheDocument()
 			);
 		} );
-		*/
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/test/validate.js
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/test/validate.js
@@ -1,10 +1,10 @@
 import { name, settings } from '../';
-import { settings as buttonSettings } from '../../button';
 import runBlockFixtureTests from '../../../shared/test/block-fixtures';
+import { settings as buttonSettings } from '../../button';
 
 const blocks = [
-    { name: `jetpack/${ name }`, settings },
-    { name: `jetpack/button`, settings: buttonSettings },
+	{ name: `jetpack/${ name }`, settings },
+	{ name: `jetpack/button`, settings: buttonSettings },
 ];
 
 runBlockFixtureTests( `jetpack/${ name }`, blocks, __dirname );

--- a/projects/plugins/jetpack/extensions/blocks/related-posts/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/related-posts/test/controls.js
@@ -1,14 +1,7 @@
-/**
- * @jest-environment jsdom
- */
-
-import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { render, screen, fireEvent } from '@testing-library/react';
-
-import {
-	RelatedPostsInspectorControls, RelatedPostsBlockControls
-} from '../controls';
+import { RelatedPostsInspectorControls, RelatedPostsBlockControls } from '../controls';
+import '@testing-library/jest-dom';
 
 describe( 'RelatedPostsControls', () => {
 	const defaultAttributes = {
@@ -78,11 +71,11 @@ describe( 'RelatedPostsControls', () => {
 			expect( screen.getByText( 'Number of posts' ) ).toBeInTheDocument();
 		} );
 
-		test( 'sets postsToShow attribute', () => {
+		test( 'sets postsToShow attribute', async () => {
+			const user = userEvent.setup();
 			render( <RelatedPostsInspectorControls { ...defaultProps } /> );
 			const input = screen.getAllByLabelText( 'Number of posts' )[ 1 ];
-			input.focus();
-			fireEvent.change( input, { target: { value: '3' } } );
+			await user.type( input, '3' );
 
 			expect( setAttributes ).toHaveBeenCalledWith( { postsToShow: 3 } );
 		} );

--- a/projects/plugins/jetpack/extensions/blocks/related-posts/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/related-posts/test/edit.js
@@ -1,54 +1,49 @@
-/**
- * @jest-environment jsdom
- */
-
-import '@testing-library/jest-dom/extend-expect';
 import { render, screen } from '@testing-library/react';
-
 import { RelatedPostsEdit } from '../edit';
+import '@testing-library/jest-dom';
 
 const posts = [
 	{
 		classes: [],
 		context: "In 'test one'",
-		date: "February 15, 2020",
-		excerpt: "This is the first post!",
+		date: 'February 15, 2020',
+		excerpt: 'This is the first post!',
 		format: false,
 		id: 10,
 		img: {
-			alt_text: "",
+			alt_text: '',
 			height: 200,
 			width: 350,
-			src: "https://i0.wp.com/test/wp-content/uploads/2021/03/IMG_001.jpg?resize=350%2C200"
+			src: 'https://i0.wp.com/test/wp-content/uploads/2021/03/IMG_001.jpg?resize=350%2C200',
 		},
-		rel: "",
-		title: "Test Post One",
-		url: "http://test.com/?p=10",
+		rel: '',
+		title: 'Test Post One',
+		url: 'http://test.com/?p=10',
 		url_meta: {
 			origin: 153,
-			positon: 0
-		}
+			positon: 0,
+		},
 	},
 	{
 		classes: [],
 		context: "In 'test two'",
-		date: "February 14, 2020",
-		excerpt: "This is the second post!",
+		date: 'February 14, 2020',
+		excerpt: 'This is the second post!',
 		format: false,
 		id: 9,
 		img: {
-			alt_text: "",
+			alt_text: '',
 			height: 200,
 			width: 350,
-			src: "https://i0.wp.com/test/wp-content/uploads/2021/03/IMG_002.jpg?resize=350%2C200"
+			src: 'https://i0.wp.com/test/wp-content/uploads/2021/03/IMG_002.jpg?resize=350%2C200',
 		},
-		rel: "",
-		title: "Test Post Two",
-		url: "http://test.com/?p=9",
+		rel: '',
+		title: 'Test Post Two',
+		url: 'http://test.com/?p=9',
 		url_meta: {
 			origin: 153,
-			positon: 0
-		}
+			positon: 0,
+		},
 	},
 ];
 
@@ -68,17 +63,21 @@ describe( 'RelatedPostsEdit', () => {
 		clientId: 1,
 		posts: posts,
 		className: 'className',
-		instanceId: 2
+		instanceId: 2,
 	};
 
 	beforeEach( () => {
 		setAttributes.mockClear();
 	} );
 
+	/**
+	 * Render related posts.
+	 *
+	 * @param {object} attributeOverrides - Attribute overrides.
+	 */
 	function renderRelatedPosts( attributeOverrides = {} ) {
 		const attributes = { ...defaultAttributes, ...attributeOverrides };
-		const { relatedPosts } = render( <RelatedPostsEdit { ...{ ...defaultProps, attributes } } /> );
-		return relatedPosts;
+		render( <RelatedPostsEdit { ...{ ...defaultProps, attributes } } /> );
 	}
 
 	describe( 'layout', () => {
@@ -108,7 +107,11 @@ describe( 'RelatedPostsEdit', () => {
 
 			expect( screen.getByText( 'Test Post One' ) ).toBeInTheDocument();
 			expect( screen.getByText( 'Test Post Two' ) ).toBeInTheDocument();
-			expect( screen.getByText( "Preview unavailable: you haven't published enough posts with similar content." ) ).toBeInTheDocument();
+			expect(
+				screen.getByText(
+					"Preview unavailable: you haven't published enough posts with similar content."
+				)
+			).toBeInTheDocument();
 		} );
 	} );
 
@@ -153,13 +156,17 @@ describe( 'RelatedPostsEdit', () => {
 		test( 'post title links to the post', () => {
 			renderRelatedPosts();
 
-			expect( screen.getByText( 'Test Post One' ) ).toHaveAttribute( 'href', 'http://test.com/?p=10' );
+			expect( screen.getByText( 'Test Post One' ) ).toHaveAttribute(
+				'href',
+				'http://test.com/?p=10'
+			);
 		} );
 
 		test( 'post thumbnail links to the post', () => {
 			renderRelatedPosts( { displayThumbnails: true } );
 			const thumbnail = screen.getByAltText( 'Test Post One' );
 
+			// eslint-disable-next-line testing-library/no-node-access
 			expect( thumbnail.closest( 'a' ) ).toHaveAttribute( 'href', 'http://test.com/?p=10' );
 		} );
 	} );

--- a/projects/plugins/jetpack/extensions/blocks/related-posts/test/validate.js
+++ b/projects/plugins/jetpack/extensions/blocks/related-posts/test/validate.js
@@ -6,10 +6,12 @@ import runBlockFixtureTests from '../../../shared/test/block-fixtures';
  * involved in this set of tests.
  *
  * Example containing multiple blocks:
+ * ```
  * const blocks = [
- *		{ name: 'jetpack/whatsapp-button', settings },
- *		{ name: 'jetpack/send-a-message', settings: parentSettings },
+ *    { name: 'jetpack/whatsapp-button', settings },
+ *    { name: 'jetpack/send-a-message', settings: parentSettings },
  * ];
+ * ```
  */
 const blocks = [ { name: `jetpack/${ name }`, settings } ];
 runBlockFixtureTests( `jetpack/${ name }`, blocks, __dirname );

--- a/projects/plugins/jetpack/extensions/blocks/repeat-visitor/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/repeat-visitor/test/edit.js
@@ -1,22 +1,15 @@
-/**
- * @jest-environment jsdom
- */
-
-import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import userEvent from '@testing-library/user-event';
+import { RepeatVisitorEdit } from '../components/edit';
+import { CRITERIA_BEFORE, CRITERIA_AFTER, DEFAULT_THRESHOLD } from '../constants';
+import '@testing-library/jest-dom';
 
-// Need to mock InnerBlocks before importing the RepeatVisitorEdit component as it
-// requires the Gutenberg store setup to operate.
 jest.mock( '@wordpress/block-editor', () => ( {
 	...jest.requireActual( '@wordpress/block-editor' ),
 	InnerBlocks: () => <p>Mocked inner block</p>,
 } ) );
 
-import { RepeatVisitorEdit } from '../components/edit';
-import { CRITERIA_BEFORE, CRITERIA_AFTER, DEFAULT_THRESHOLD } from '../constants';
-
-describe( '', () => {
+describe( 'Repeat-visitor', () => {
 	const defaultAttributes = {
 		// 👀 Setup default block attributes.
 		criteria: CRITERIA_AFTER,
@@ -38,6 +31,7 @@ describe( '', () => {
 		const propsSelected = { ...defaultProps, isSelected: true };
 		const { container } = render( <RepeatVisitorEdit { ...propsSelected } /> );
 
+		// eslint-disable-next-line testing-library/no-node-access
 		expect( container.firstChild ).not.toHaveClass(
 			'wp-block-jetpack-repeat-visitor--is-unselected'
 		);
@@ -138,6 +132,7 @@ describe( '', () => {
 		const propsNotSelected = { ...defaultProps, isSelected: false };
 		const { container } = render( <RepeatVisitorEdit { ...propsNotSelected } /> );
 
+		// eslint-disable-next-line testing-library/no-node-access
 		expect( container.firstChild ).toHaveClass( 'wp-block-jetpack-repeat-visitor--is-unselected' );
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/repeat-visitor/test/validate.js
+++ b/projects/plugins/jetpack/extensions/blocks/repeat-visitor/test/validate.js
@@ -1,5 +1,4 @@
 import { RichText } from '@wordpress/block-editor';
-
 import { name, settings } from '../';
 import runBlockFixtureTests from '../../../shared/test/block-fixtures';
 

--- a/projects/plugins/jetpack/extensions/blocks/send-a-message/whatsapp-button/test/configuration.js
+++ b/projects/plugins/jetpack/extensions/blocks/send-a-message/whatsapp-button/test/configuration.js
@@ -1,8 +1,7 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import '@testing-library/jest-dom/extend-expect';
-
 import WhatsAppButtonConfiguration from '../configuration';
+import '@testing-library/jest-dom';
 
 const defaultAttributes = {
 	countryCode: 'us',
@@ -100,8 +99,6 @@ describe( 'Toolbar settings', () => {
 		const user = userEvent.setup();
 		render( <WhatsAppButtonConfiguration { ...props } /> );
 		await user.click( screen.getByLabelText( 'WhatsApp Button Settings' ) );
-		await waitFor( () => screen.getByLabelText( 'Country code' ) );
-
-		expect( screen.getByLabelText( 'Country code' ) ).toBeInTheDocument();
+		await expect( screen.findByLabelText( 'Country code' ) ).resolves.toBeInTheDocument();
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/send-a-message/whatsapp-button/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/send-a-message/whatsapp-button/test/edit.js
@@ -1,16 +1,11 @@
-/**
- * @jest-environment jsdom
- */
-
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
-
 // this is necessary because block editor store becomes unregistered during jest initialization
-import { register } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-register( blockEditorStore );
-
+import { register } from '@wordpress/data';
 import WhatsAppButtonEdit from '../edit';
+import '@testing-library/jest-dom';
+
+register( blockEditorStore );
 
 const defaultAttributes = {
 	countryCode: 'us',
@@ -45,5 +40,6 @@ test( 'displays button as multiline textbox for updating the buttonText attribut
 test( 'assigns colorClass attribute to the block wrapper', () => {
 	const { container } = render( <WhatsAppButtonEdit { ...defaultProps } /> );
 
+	// eslint-disable-next-line testing-library/no-node-access
 	expect( container.firstChild ).toHaveClass( 'is-color-blue' );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/simple-payments/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/simple-payments/test/controls.js
@@ -1,8 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import '@testing-library/jest-dom/extend-expect';
-
 import { PanelControls } from '../controls';
+import '@testing-library/jest-dom';
 
 const setAttributes = jest.fn();
 

--- a/projects/plugins/jetpack/extensions/blocks/simple-payments/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/simple-payments/test/edit.js
@@ -1,18 +1,18 @@
 import { render, screen } from '@testing-library/react';
 import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event';
-import '@testing-library/jest-dom/extend-expect';
-
 // this is necessary because block editor store becomes unregistered during jest initialization
-import { register } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-register( blockEditorStore );
-
+import { register } from '@wordpress/data';
 import { SimplePaymentsEdit } from '../edit';
+import '@testing-library/jest-dom';
+
+register( blockEditorStore );
 
 const setAttributes = jest.fn();
 beforeEach( () => {
-	Intl.NumberFormat = jest
-		.fn()
+	jest
+		.spyOn( Intl, 'NumberFormat' )
+		.mockImplementation()
 		.mockImplementation( () => ( { format: value => `A$${ value.toString() }.00` } ) );
 } );
 afterEach( () => {
@@ -149,7 +149,6 @@ describe( 'Edit component', () => {
 	} );
 
 	test( 'displays title and price fields when not selected', () => {
-
 		const notSelectedProps = {
 			...props,
 			isSelected: false,

--- a/projects/plugins/jetpack/extensions/blocks/simple-payments/test/validate.js
+++ b/projects/plugins/jetpack/extensions/blocks/simple-payments/test/validate.js
@@ -1,14 +1,15 @@
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { register } from '@wordpress/data';
 import { settings } from '../';
 import runBlockFixtureTests from '../../../shared/test/block-fixtures';
 
 // this is necessary because block editor store becomes unregistered during jest initialization
-import { register } from '@wordpress/data';
-import { store as blockEditorStore } from '@wordpress/block-editor';
 register( blockEditorStore );
 
 beforeEach( () => {
-	Intl.NumberFormat = jest
-		.fn()
+	jest
+		.spyOn( Intl, 'NumberFormat' )
+		.mockImplementation()
 		.mockImplementation( () => ( { format: value => `A$${ value.toString() }.00` } ) );
 } );
 

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/test/controls.js
@@ -1,8 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import '@testing-library/jest-dom/extend-expect';
-
 import { PanelControls } from '../controls';
+import '@testing-library/jest-dom';
 
 const images = [
 	{
@@ -21,19 +20,12 @@ const images = [
 
 const setAttributes = jest.fn();
 const onChangeImageSize = jest.fn();
-const onSelectImages = jest.fn();
 
 const panelProps = {
 	attributes: { autoplay: false, delay: 1, effect: 'slide', images, sizeSlug: 'large' },
 	imageSizeOptions: [ { label: 'Thumbnail', value: 'thumbnail' } ],
 	onChangeImageSize,
 	setAttributes,
-};
-
-const toolbarProps = {
-	allowedMediaTypes: [ 'image' ],
-	attributes: { autoplay: false, delay: 1, effect: 'slide', images, sizeSlug: 'large' },
-	onSelectImages,
 };
 
 beforeEach( () => {

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/test/edit.js
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
-
 import { SlideshowEdit } from '../edit';
+import '@testing-library/jest-dom';
 
 const defaultAttributes = {
 	ids: [ 1, 2 ],

--- a/projects/plugins/jetpack/extensions/blocks/story/player/store/test/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/story/player/store/test/index.js
@@ -1,18 +1,17 @@
 import { registerStore } from '@wordpress/data';
-
-import { defaultPlayerState, defaultPlayerSettings, defaultCurrentSlideState } from '../constants';
 import * as actions from '../actions';
-import * as selectors from '../selectors';
+import { defaultPlayerState, defaultPlayerSettings, defaultCurrentSlideState } from '../constants';
 import reducer from '../reducer';
-import {setCurrentSlideEnded} from "../actions";
+import * as selectors from '../selectors';
 
 const STORE_ID = 'jetpack/story/player';
 
-const setup = () => registerStore( STORE_ID, {
-	actions,
-	reducer,
-	selectors,
-} );
+const setup = () =>
+	registerStore( STORE_ID, {
+		actions,
+		reducer,
+		selectors,
+	} );
 
 describe( 'player', () => {
 	test( 'Initial State', () => {
@@ -58,7 +57,7 @@ describe( 'player', () => {
 				},
 				previousSlide: {
 					...defaultCurrentSlideState,
-				}
+				},
 			},
 		};
 		expect( got2 ).toEqual( want2 );
@@ -80,7 +79,6 @@ describe( 'player', () => {
 		expect( got3 ).toEqual( want3 );
 		store.dispatch( actions.setCurrentSlideEnded( playerId ) );
 		store.dispatch( actions.showSlide( playerId, 1 ) );
-		const got4 = store.getState();
 		const want4 = {
 			[ playerId ]: {
 				...want3[ playerId ],
@@ -89,7 +87,7 @@ describe( 'player', () => {
 				},
 				previousSlide: {
 					...want3[ playerId ].currentSlide,
-				}
+				},
 			},
 		};
 		store.dispatch( actions.slideReady( playerId, mediaElement, 5 ) );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/test/controls.js
@@ -1,9 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import '@testing-library/jest-dom/extend-expect';
-
-import SubscriptionsInspectorControls from '../controls';
 import { DEFAULT_FONTSIZE_VALUE } from '../constants';
+import SubscriptionsInspectorControls from '../controls';
+import '@testing-library/jest-dom';
 
 // Temporarily mock out the ButtonWidthControl, which is causing errors due to missing
 // dependencies in the jest test runner.
@@ -64,7 +63,7 @@ describe( 'Inspector controls', () => {
 			await user.click( screen.getByText( 'Button Background', { ignore: '[aria-hidden=true]' } ) );
 			await user.click( screen.getByText( 'Solid', { ignore: '[aria-hidden=true]' } ) );
 			await user.click(
-				screen.queryAllByLabelText( /Color\: (?!Black)/i, { selector: 'button' } )[ 0 ]
+				screen.queryAllByLabelText( /Color: (?!Black)/i, { selector: 'button' } )[ 0 ]
 			);
 
 			expect( setButtonBackgroundColor.mock.calls[ 0 ][ 0 ] ).toMatch( /#[a-z0-9]{6,6}/ );
@@ -86,9 +85,9 @@ describe( 'Inspector controls', () => {
 			render( <SubscriptionsInspectorControls { ...defaultProps } /> );
 			await user.click( screen.getByText( 'Button Background', { ignore: '[aria-hidden=true]' } ) );
 			await user.click( screen.getByText( 'Gradient', { ignore: '[aria-hidden=true]' } ) );
-			await user.click( screen.queryAllByLabelText( /Gradient\:/i, { selector: 'button' } )[ 0 ] );
+			await user.click( screen.queryAllByLabelText( /Gradient:/i, { selector: 'button' } )[ 0 ] );
 
-			expect( setGradient.mock.calls[ 0 ][ 0 ] ).toMatch( /linear\-gradient\((.+)\)/ );
+			expect( setGradient.mock.calls[ 0 ][ 0 ] ).toMatch( /linear-gradient\((.+)\)/ );
 		} );
 	} );
 
@@ -99,7 +98,7 @@ describe( 'Inspector controls', () => {
 			expect( screen.getByText( 'Typography' ) ).toBeInTheDocument();
 		} );
 
-		test( 'set custom text ', async () => {
+		test( 'set custom text', async () => {
 			const user = userEvent.setup();
 			render( <SubscriptionsInspectorControls { ...defaultProps } /> );
 			await user.click( screen.getByText( 'Typography' ), { selector: 'button' } );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/test/edit.js
@@ -1,8 +1,7 @@
-import { render, screen, act } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import '@testing-library/jest-dom/extend-expect';
-
 import { SubscriptionEdit } from '../edit';
+import '@testing-library/jest-dom';
 
 const setAttributes = jest.fn();
 
@@ -32,21 +31,15 @@ const defaultProps = {
 	fontSize: 12,
 };
 
-const originalFetch = window.fetch;
-
-/**
- * Mock return value for a successful fetch JSON return value.
- *
- * @return {Promise} Mock return value.
- */
-const RESOLVED_FETCH_PROMISE = Promise.resolve( { count: 100 } );
-const DEFAULT_FETCH_MOCK_RETURN = Promise.resolve( {
-	status: 200,
-	json: () => RESOLVED_FETCH_PROMISE,
-} );
+jest.mock( '../api', () => ( {
+	__esModule: true,
+	getSubscriberCount: jest.fn( successCallback => {
+		successCallback( 100 );
+	} ),
+} ) );
 
 jest.mock( '../constants', () => ( {
-	IS_GRADIENT_AVAILABLE: true
+	IS_GRADIENT_AVAILABLE: true,
 } ) );
 
 jest.mock( '@wordpress/block-editor', () => ( {
@@ -54,44 +47,25 @@ jest.mock( '@wordpress/block-editor', () => ( {
 	__experimentalUseGradient: jest.fn().mockReturnValue( {
 		gradientClass: undefined,
 		gradientValue: undefined,
-		setGradient: jest.fn()
+		setGradient: jest.fn(),
 	} ),
 } ) );
 
 describe( 'SubscriptionEdit', () => {
-	beforeEach( () => {
-		window.fetch = jest.fn();
-		window.fetch.mockReturnValue( DEFAULT_FETCH_MOCK_RETURN );
-	} );
-
-	afterEach( () => {
-		window.fetch = originalFetch;
-	} );
-
-	/**
-	 * Use the asynchronous version of act to apply resolved promises.
-	 *
-	 * @param {SubscriptionEdit} ui - Object to render.
-	 * @return {RenderResult}
-	 */
-	async function renderAsync( ui ) {
-		let ret;
-		await act( async () => {
-			ret = render( ui );
-		} );
-		return ret;
-	}
-
 	test( 'adds correct classes to container', async () => {
-		const { container, rerender } = await renderAsync( <SubscriptionEdit { ...defaultProps }  /> );
+		const { container } = render( <SubscriptionEdit { ...defaultProps } /> );
 
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 		expect( container.querySelector( `.${ defaultProps.className }` ) ).toBeInTheDocument();
 	} );
 
 	test( 'adds correct classes when button on new line', async () => {
-		const { container, rerender } = await renderAsync( <SubscriptionEdit { ...defaultProps }  /> );
+		const { container, rerender } = render( <SubscriptionEdit { ...defaultProps } /> );
 
-		expect( container.querySelector( '.wp-block-jetpack-subscriptions__use-newline' ) ).not.toBeInTheDocument();
+		expect(
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			container.querySelector( '.wp-block-jetpack-subscriptions__use-newline' )
+		).not.toBeInTheDocument();
 
 		const updatedProps = {
 			...defaultProps,
@@ -100,43 +74,52 @@ describe( 'SubscriptionEdit', () => {
 				buttonOnNewLine: true,
 			},
 		};
-		rerender( <SubscriptionEdit { ...updatedProps }  /> );
+		rerender( <SubscriptionEdit { ...updatedProps } /> );
 
-		expect( container.querySelector( '.wp-block-jetpack-subscriptions__use-newline' ) ).toBeInTheDocument();
+		expect(
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			container.querySelector( '.wp-block-jetpack-subscriptions__use-newline' )
+		).toBeInTheDocument();
 	} );
 
 	test( 'renders text field with placeholder text', async () => {
-		await renderAsync( <SubscriptionEdit { ...defaultProps }  /> );
+		render( <SubscriptionEdit { ...defaultProps } /> );
 
-		expect( screen.getByPlaceholderText( defaultAttributes.subscribePlaceholder ) ).toBeInTheDocument();
+		expect(
+			screen.getByPlaceholderText( defaultAttributes.subscribePlaceholder )
+		).toBeInTheDocument();
 	} );
 
 	test( 'renders button with default text', async () => {
-		await renderAsync( <SubscriptionEdit { ...defaultProps }  /> );
+		render( <SubscriptionEdit { ...defaultProps } /> );
 
 		expect( screen.getByText( defaultAttributes.submitButtonText ) ).toBeInTheDocument();
 	} );
 
 	test( 'calls setAttributes handler on button when value changes', async () => {
-		await renderAsync( <SubscriptionEdit { ...defaultProps }  /> );
+		render( <SubscriptionEdit { ...defaultProps } /> );
 
 		expect( screen.getByText( defaultAttributes.submitButtonText ) ).toBeInTheDocument();
 	} );
 
 	test( 'displays subscriber total', async () => {
 		const user = userEvent.setup();
-		await renderAsync( <SubscriptionEdit { ...defaultProps }  /> );
+		render( <SubscriptionEdit { ...defaultProps } /> );
 		await user.type( screen.getByText( defaultAttributes.submitButtonText ), '-right-now!' );
 
 		expect( setAttributes ).toHaveBeenCalledWith( {
-			submitButtonText: `${ defaultAttributes.submitButtonText}-right-now!`,
+			submitButtonText: `${ defaultAttributes.submitButtonText }-right-now!`,
 		} );
 	} );
 
-	test( 'displays subscriber total', async () => {
-		const { container, rerender } = await renderAsync( <SubscriptionEdit { ...defaultProps }  /> );
+	test( 'displays subscriber total after update', async () => {
+		const { container, rerender } = render( <SubscriptionEdit { ...defaultProps } /> );
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 		expect( container.querySelector( 'p' ) ).not.toBeInTheDocument();
-		expect( container.querySelector( '.wp-block-jetpack-subscriptions__show-subs' ) ).not.toBeInTheDocument();
+		expect(
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			container.querySelector( '.wp-block-jetpack-subscriptions__show-subs' )
+		).not.toBeInTheDocument();
 
 		const updatedProps = {
 			...defaultProps,
@@ -145,9 +128,13 @@ describe( 'SubscriptionEdit', () => {
 				showSubscribersTotal: true,
 			},
 		};
-		rerender( <SubscriptionEdit { ...updatedProps }  /> );
+		rerender( <SubscriptionEdit { ...updatedProps } /> );
 
-		expect( container.querySelector( '.wp-block-jetpack-subscriptions__show-subs' ) ).toBeInTheDocument();
+		expect(
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			container.querySelector( '.wp-block-jetpack-subscriptions__show-subs' )
+		).toBeInTheDocument();
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 		expect( container.querySelector( 'p' ) ).toBeInTheDocument();
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/__snapshots__/index.js.snap
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/__snapshots__/index.js.snap
@@ -1,98 +1,96 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders as expected 1`] = `
-<Gallery
-  galleryRef={
-    Object {
-      "current": null,
-    }
-  }
->
-  <Row
-    key="0"
+exports[`renders as expected (set imageSet1): images 1`] = `
+<div>
+  <div
+    class="tiled-gallery__gallery"
   >
-    <Column
-      key="0"
+    <div
+      class="tiled-gallery__row"
     >
-      0
-    </Column>
-  </Row>
-  <Row
-    key="1"
-  >
-    <Column
-      key="0"
+      <div
+        class="tiled-gallery__col"
+      >
+        0
+      </div>
+    </div>
+    <div
+      class="tiled-gallery__row"
     >
-      1
-    </Column>
-  </Row>
-  <Row
-    key="2"
-  >
-    <Column
-      key="0"
+      <div
+        class="tiled-gallery__col"
+      >
+        1
+      </div>
+    </div>
+    <div
+      class="tiled-gallery__row"
     >
-      2
-    </Column>
-    <Column
-      key="1"
+      <div
+        class="tiled-gallery__col"
+      >
+        2
+      </div>
+      <div
+        class="tiled-gallery__col"
+      >
+        3
+      </div>
+      <div
+        class="tiled-gallery__col"
+      >
+        4
+      </div>
+      <div
+        class="tiled-gallery__col"
+      >
+        5
+      </div>
+    </div>
+    <div
+      class="tiled-gallery__row"
     >
-      3
-    </Column>
-    <Column
-      key="2"
+      <div
+        class="tiled-gallery__col"
+      >
+        6
+      </div>
+      <div
+        class="tiled-gallery__col"
+      >
+        7
+      </div>
+    </div>
+    <div
+      class="tiled-gallery__row"
     >
-      4
-    </Column>
-    <Column
-      key="3"
+      <div
+        class="tiled-gallery__col"
+      >
+        8
+      </div>
+      <div
+        class="tiled-gallery__col"
+      >
+        9
+        10
+      </div>
+    </div>
+    <div
+      class="tiled-gallery__row"
     >
-      5
-    </Column>
-  </Row>
-  <Row
-    key="3"
-  >
-    <Column
-      key="0"
-    >
-      6
-    </Column>
-    <Column
-      key="1"
-    >
-      7
-    </Column>
-  </Row>
-  <Row
-    key="4"
-  >
-    <Column
-      key="0"
-    >
-      8
-    </Column>
-    <Column
-      key="1"
-    >
-      9
-      10
-    </Column>
-  </Row>
-  <Row
-    key="5"
-  >
-    <Column
-      key="0"
-    >
-      11
-      12
-    </Column>
-    <Column
-      key="1"
-    >
-      13
-    </Column>
-  </Row>
-</Gallery>
+      <div
+        class="tiled-gallery__col"
+      >
+        11
+        12
+      </div>
+      <div
+        class="tiled-gallery__col"
+      >
+        13
+      </div>
+    </div>
+  </div>
+</div>
 `;

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/__snapshots__/ratios.js.snap
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/__snapshots__/ratios.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ratiosToMosaicRows transforms as expected 1`] = `
+exports[`ratiosToMosaicRows transforms as expected: ratios 1`] = `
 Array [
   Array [
     1,

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/index.js
@@ -1,15 +1,12 @@
-import React from 'react';
+import { render } from '@testing-library/react';
 import { range } from 'lodash';
-import { shallow } from 'enzyme';
-
+import React from 'react';
 import Mosaic from '..';
 import * as imageSets from '../../test/fixtures/image-sets';
 
-test( 'renders as expected', () => {
-	Object.keys( imageSets ).forEach( k => {
-		const images = imageSets[ k ];
-		expect(
-			shallow( <Mosaic images={ images } renderedImages={ range( images.length ) } /> )
-		).toMatchSnapshot();
-	} );
+test.each( Object.entries( imageSets ) )( 'renders as expected (set %s)', ( k, images ) => {
+	const { container } = render(
+		<Mosaic images={ images } renderedImages={ range( images.length ) } />
+	);
+	expect( container ).toMatchSnapshot( 'images' );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/ratios.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/ratios.js
@@ -3,6 +3,6 @@ import { ratios } from './fixtures/ratios';
 
 describe( 'ratiosToMosaicRows', () => {
 	test( 'transforms as expected', () => {
-		expect( ratiosToMosaicRows( ratios ) ).toMatchSnapshot();
+		expect( ratiosToMosaicRows( ratios ) ).toMatchSnapshot( 'ratios' );
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/wordads/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/wordads/test/controls.js
@@ -1,14 +1,9 @@
-/**
- * @jest-environment jsdom
- */
-
-import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { render, screen, waitFor } from '@testing-library/react';
-
-import FormatPicker from '../format-picker';
 import { AD_FORMATS, DEFAULT_FORMAT } from '../constants';
 import { AdVisibilityToggle } from '../controls';
+import FormatPicker from '../format-picker';
+import '@testing-library/jest-dom';
 
 const getFormat = format => AD_FORMATS.find( ( { tag } ) => tag === format );
 
@@ -29,6 +24,7 @@ describe( 'AdVisibilityToggle', () => {
 
 	test( 'applies correct class to toggle control', () => {
 		const { container } = render( <AdVisibilityToggle { ...defaultProps } /> );
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 		const toggle = container.querySelector( '.components-toggle-control' );
 
 		expect( toggle ).toHaveClass( 'jetpack-wordads__mobile-visibility' );
@@ -101,7 +97,8 @@ describe( 'FormatPicker', () => {
 		render( <FormatPicker { ...defaultProps } /> );
 
 		await user.click( screen.getByLabelText( 'Pick an ad format' ) );
-		await waitFor( () => screen.getByText( defaultFormat.name ) );
+		// eslint-disable-next-line testing-library/prefer-explicit-assert
+		await screen.findByText( defaultFormat.name );
 
 		AD_FORMATS.forEach( format => {
 			expect( screen.getByText( format.name ) ).toBeInTheDocument();
@@ -113,7 +110,8 @@ describe( 'FormatPicker', () => {
 		render( <FormatPicker { ...defaultProps } /> );
 
 		await user.click( screen.getByLabelText( 'Pick an ad format' ) );
-		await waitFor( () => screen.getByText( defaultFormat.name ) );
+		// eslint-disable-next-line testing-library/prefer-explicit-assert
+		await screen.findByText( defaultFormat.name );
 
 		expect( screen.getByText( defaultFormat.name ).innerHTML ).toMatch( /[A-Za-z0-9 ]+/ );
 	} );
@@ -121,7 +119,9 @@ describe( 'FormatPicker', () => {
 	test( 'applies correct class to toolbar button', () => {
 		render( <FormatPicker { ...defaultProps } /> );
 
-		expect( screen.getByLabelText( 'Pick an ad format' ) ).toHaveClass( 'wp-block-jetpack-wordads__format-picker-icon' );
+		expect( screen.getByLabelText( 'Pick an ad format' ) ).toHaveClass(
+			'wp-block-jetpack-wordads__format-picker-icon'
+		);
 	} );
 
 	test( 'applies format picker class to menu', async () => {
@@ -129,7 +129,8 @@ describe( 'FormatPicker', () => {
 		render( <FormatPicker { ...defaultProps } /> );
 
 		await user.click( screen.getByLabelText( 'Pick an ad format' ) );
-		await waitFor( () => screen.getByText( defaultFormat.name ) );
+		// eslint-disable-next-line testing-library/prefer-explicit-assert
+		await screen.findByText( defaultFormat.name );
 		const menu = screen.getByRole( 'menu' );
 
 		expect( menu ).toBeInTheDocument();
@@ -142,7 +143,8 @@ describe( 'FormatPicker', () => {
 		const leaderboard = getFormat( 'leaderboard' );
 
 		await user.click( screen.getByLabelText( 'Pick an ad format' ) );
-		await waitFor( () => screen.getByText( leaderboard.name ) );
+		// eslint-disable-next-line testing-library/prefer-explicit-assert
+		await screen.findByText( leaderboard.name );
 		await user.click( screen.getByText( leaderboard.name ) );
 
 		expect( onChange ).toHaveBeenCalledWith( leaderboard.tag );

--- a/projects/plugins/jetpack/extensions/blocks/wordads/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/wordads/test/edit.js
@@ -1,17 +1,11 @@
-/**
- * @jest-environment jsdom
- */
-
-import '@testing-library/jest-dom/extend-expect';
 import { render } from '@testing-library/react';
-
-import WordAdsEdit from '../edit';
 import { AD_FORMATS, DEFAULT_FORMAT } from '../constants';
-
-import rectangleExample from '../example_300x250.png';
-import leaderboardExample from '../example_728x90.png';
-import mobileLeaderboardExample from '../example_320x50.png';
+import WordAdsEdit from '../edit';
 import wideSkyscraperExample from '../example_160x600.png';
+import rectangleExample from '../example_300x250.png';
+import mobileLeaderboardExample from '../example_320x50.png';
+import leaderboardExample from '../example_728x90.png';
+import '@testing-library/jest-dom';
 
 describe( 'WordAdsEdit', () => {
 	const defaultAttributes = { format: DEFAULT_FORMAT };
@@ -19,18 +13,20 @@ describe( 'WordAdsEdit', () => {
 
 	const getFormat = format => AD_FORMATS.find( ( { tag } ) => tag === format );
 
-	const renderWordAdsEdit = ( props ) => {
+	const renderWordAdsEdit = props => {
 		const { container } = render( <WordAdsEdit { ...props } /> );
 
+		// eslint-disable-next-line testing-library/no-node-access
 		return container.firstChild.firstChild;
 	};
 
 	// Renders the component, extracting the inner placeholder element and finding
 	// selected format object styles are created from.
-	const renderFormatted = ( format ) => {
+	const renderFormatted = format => {
+		// eslint-disable-next-line testing-library/render-result-naming-convention -- False positive.
 		const placeholder = renderWordAdsEdit( {
 			...defaultProps,
-			attributes: { format }
+			attributes: { format },
 		} );
 		const selectedFormat = getFormat( format );
 
@@ -40,11 +36,14 @@ describe( 'WordAdsEdit', () => {
 	test( 'renders wrapper with correct css class', () => {
 		const { container } = render( <WordAdsEdit { ...defaultProps } /> );
 
+		// eslint-disable-next-line testing-library/no-node-access
 		expect( container.firstChild ).toHaveClass( 'wp-block-jetpack-wordads' );
+		// eslint-disable-next-line testing-library/no-node-access
 		expect( container.firstChild ).toHaveClass( `jetpack-wordads-${ defaultAttributes.format }` );
 	} );
 
 	test( 'renders ad placeholder with correct css class and styles', () => {
+		// eslint-disable-next-line testing-library/render-result-naming-convention -- False positive.
 		const placeholder = renderWordAdsEdit( defaultProps );
 		const selectedFormat = getFormat( defaultAttributes.format );
 

--- a/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/test/render-paid-icon.js
+++ b/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/test/render-paid-icon.js
@@ -1,11 +1,6 @@
-/**
- * @jest-environment jsdom
- */
-
 import { SVG, G } from '@wordpress/components';
-
-import renderPaidIcon from '../render-paid-icon';
 import PaidSymbol from '../paid-symbol';
+import renderPaidIcon from '../render-paid-icon';
 
 const iconWithSrc = {
 	src: (

--- a/projects/plugins/jetpack/extensions/shared/test/block-fixtures.js
+++ b/projects/plugins/jetpack/extensions/shared/test/block-fixtures.js
@@ -1,15 +1,22 @@
-import { omit, uniq, pick } from 'lodash';
-import { format } from 'util';
 import fs from 'fs';
 import path from 'path';
-import { __, sprintf } from '@wordpress/i18n';
-
-import { parse, serialize, registerBlockType, setCategories } from '@wordpress/blocks';
+import { format } from 'util';
 import { parse as grammarParse } from '@wordpress/block-serialization-default-parser';
+import { parse, serialize, registerBlockType, setCategories } from '@wordpress/blocks';
+import { __, sprintf } from '@wordpress/i18n';
+import { omit, uniq } from 'lodash';
 
 let FIXTURES_DIR;
 
 /* eslint-disable jest/no-export */
+
+/**
+ * Run block fixture tests.
+ *
+ * @param {string} blockName - Block name.
+ * @param {Array} blocks - Blocks.
+ * @param {string} fixturesPath - Fixtures path.
+ */
 export default function runBlockFixtureTests( blockName, blocks, fixturesPath ) {
 	registerBlocks( blocks );
 	setFixturesDir( fixturesPath );
@@ -75,10 +82,13 @@ export default function runBlockFixtureTests( blockName, blocks, fixturesPath ) 
 
 				const blocksActual = parse( htmlFixtureContent );
 
+				// eslint-disable-next-line no-console
 				console.groupCollapsed.mockRestore();
+				// eslint-disable-next-line no-console
 				console.groupEnd.mockRestore();
 
 				// @wordpress/blocks needlessly calls console.info. Ignore that.
+				// eslint-disable-next-line no-console
 				console.info.mockClear();
 
 				// Block validation may log errors during deprecation migration,
@@ -86,7 +96,9 @@ export default function runBlockFixtureTests( blockName, blocks, fixturesPath ) 
 				// Match on basename for deprecated blocks fixtures to allow.
 				const isDeprecated = /__deprecated([-_]|$)/.test( basename );
 				if ( isDeprecated ) {
+					// eslint-disable-next-line no-console
 					console.warn.mockClear();
+					// eslint-disable-next-line no-console
 					console.error.mockClear();
 				}
 
@@ -113,7 +125,7 @@ export default function runBlockFixtureTests( blockName, blocks, fixturesPath ) 
 				if ( blocksExpected?.length ) {
 					blocksExpected.forEach( ( block, index ) => {
 						// we need to look up validation messages here as they may be useful
-						return checkParseValid( block, basename, validationIssues[index] );
+						return checkParseValid( block, basename, validationIssues[ index ] );
 					} );
 				}
 
@@ -176,7 +188,7 @@ export default function runBlockFixtureTests( blockName, blocks, fixturesPath ) 
 					}
 				} );
 				try {
-					expect( errors.length ).toEqual( 0 );
+					expect( errors ).toHaveLength( 0 );
 				} catch ( error ) {
 					throw new Error( 'Problem(s) with fixture files:\n\n' + errors.join( '\n' ) );
 				}
@@ -187,31 +199,60 @@ export default function runBlockFixtureTests( blockName, blocks, fixturesPath ) 
 
 /**
  * Convert a nested object representing blocks into just the validation messages.
+ *
+ * @param {Array} blocks - Blocks.
+ * @returns {Array} Validation issues object.
  */
 function gatherValidationIssues( blocks ) {
 	return blocks.map( block => {
 		const innerBlocks = block.innerBlocks ? gatherValidationIssues( block.innerBlocks ) : [];
-		const validationIssues = block.validationIssues ? block.validationIssues.map( issue => sprintf( __( issue.args[0] ), ...issue.args.slice(1) ) ) : [];
+		const validationIssues = block.validationIssues
+			? block.validationIssues.map( issue =>
+					sprintf(
+						// eslint-disable-next-line @wordpress/i18n-no-variables
+						__( issue.args[ 0 ], 'jetpack' ),
+						...issue.args.slice( 1 )
+					)
+			  )
+			: [];
 		return {
 			name: block.name || 'unknown',
 			validationIssues,
-			innerBlocks
-		}
+			innerBlocks,
+		};
 	} );
 }
 
-/* eslint-disable jest/no-export */
-
+/**
+ * Check for valid parse.
+ *
+ * @param {object} block - Block.
+ * @param {string} fixtureName - Fixture name.
+ * @param {object|null} validationIssues - Issues object.
+ * @throws {Error} If the parse was invalid.
+ */
 function checkParseValid( block, fixtureName, validationIssues = null ) {
 	if ( ! block.isValid ) {
+		// eslint-disable-next-line testing-library/render-result-naming-convention -- False positive.
 		const validationIssuesString = renderValidationIssuesString( validationIssues );
-		throw new Error( `Fixture ${ fixtureName } is invalid` + ( validationIssuesString ? `: ${validationIssuesString}` : '' ) );
+		throw new Error(
+			`Fixture ${ fixtureName } is invalid` +
+				( validationIssuesString ? `: ${ validationIssuesString }` : '' )
+		);
 	}
 	if ( block.innerBlocks.length > 0 ) {
-		block.innerBlocks.forEach( ( block, index ) => checkParseValid( block, fixtureName, validationIssues.innerBlocks[index] ) );
+		block.innerBlocks.forEach( ( innerBlock, index ) =>
+			checkParseValid( innerBlock, fixtureName, validationIssues.innerBlocks[ index ] )
+		);
 	}
 }
 
+/**
+ * Render validation issues string.
+ *
+ * @param {object} issues - Issues object.
+ * @returns {string} Rendered string.
+ */
 function renderValidationIssuesString( issues ) {
 	if ( ! issues ) {
 		return null;
@@ -219,16 +260,21 @@ function renderValidationIssuesString( issues ) {
 
 	let validationIssuesString = '';
 	if ( issues.validationIssues.length > 0 ) {
-		validationIssuesString += issues.name + "\n    " + issues.validationIssues.join("\n\n    ");
+		validationIssuesString += issues.name + '\n    ' + issues.validationIssues.join( '\n\n    ' );
 	}
 
 	if ( issues.innerBlocks.length > 0 ) {
-		validationIssuesString += issues.innerBlocks.map( renderValidationIssuesString ).join("\n\n");
+		validationIssuesString += issues.innerBlocks.map( renderValidationIssuesString ).join( '\n\n' );
 	}
 
 	return validationIssuesString;
 }
 
+/**
+ * Register blocks.
+ *
+ * @param {Array} blocks - Blocks.
+ */
 export function registerBlocks( blocks ) {
 	// Need to add a valid category or block registration fails
 	setCategories( [
@@ -242,6 +288,12 @@ export function registerBlocks( blocks ) {
 	} );
 }
 
+/**
+ * Normalize parsed blocks.
+ *
+ * @param {Array} blocks - Blocks.
+ * @returns {Array} Normalized blocks.
+ */
 function normalizeParsedBlocks( blocks ) {
 	return blocks.map( ( block, index ) => {
 		// Clone and remove React-instance-specific stuff; also, attribute
@@ -259,6 +311,13 @@ function normalizeParsedBlocks( blocks ) {
 	} );
 }
 
+/**
+ * Read fixture file.
+ *
+ * @param {string} fixturesDir - Fixtures directory.
+ * @param {string} filename - Filename.
+ * @returns {string|null} Content.
+ */
 function readFixtureFile( fixturesDir, filename ) {
 	try {
 		return fs.readFileSync( path.join( fixturesDir, filename ), 'utf8' );
@@ -267,17 +326,40 @@ function readFixtureFile( fixturesDir, filename ) {
 	}
 }
 
+/**
+ * Write fixture file.
+ *
+ * @param {string} fixturesDir - Fixtures directory.
+ * @param {string} filename - Filename.
+ * @param {string} content - Content.
+ */
 function writeFixtureFile( fixturesDir, filename, content ) {
 	fs.writeFileSync( path.join( fixturesDir, filename ), content );
 }
 
+/**
+ * Set fixtures dir.
+ *
+ * @param {string} fixturePath - Path.
+ */
 function setFixturesDir( fixturePath ) {
 	FIXTURES_DIR = path.join( fixturePath, 'fixtures' );
 }
+/**
+ * Block name to fixture basename.
+ *
+ * @param {string} blockName - Block name.
+ * @returns {string} Fixture base name.
+ */
 function blockNameToFixtureBasename( blockName ) {
 	return blockName.replace( /\//g, '__' );
 }
 
+/**
+ * Get available block fixtures basenames.
+ *
+ * @returns {string[]} Names.
+ */
 function getAvailableBlockFixturesBasenames() {
 	// We expect 4 different types of files for each fixture:
 	//  - fixture.html            : original content
@@ -293,6 +375,12 @@ function getAvailableBlockFixturesBasenames() {
 	);
 }
 
+/**
+ * Get block fixture HTML
+ *
+ * @param {string} basename - Filename base.
+ * @returns {object} Fixture data.
+ */
 function getBlockFixtureHTML( basename ) {
 	const filename = `${ basename }.html`;
 	const fileContents = readFixtureFile( FIXTURES_DIR, filename );
@@ -302,6 +390,12 @@ function getBlockFixtureHTML( basename ) {
 	};
 }
 
+/**
+ * Get block fixture JSON.
+ *
+ * @param {string} basename - Filename base.
+ * @returns {object} Fixture data.
+ */
 function getBlockFixtureJSON( basename ) {
 	const filename = `${ basename }.json`;
 	return {
@@ -310,6 +404,12 @@ function getBlockFixtureJSON( basename ) {
 	};
 }
 
+/**
+ * Get block fixture parsed JSON
+ *
+ * @param {string} basename - Filename base.
+ * @returns {object} Fixture data.
+ */
 function getBlockFixtureParsedJSON( basename ) {
 	const filename = `${ basename }.parsed.json`;
 	return {
@@ -318,6 +418,12 @@ function getBlockFixtureParsedJSON( basename ) {
 	};
 }
 
+/**
+ * Get block fixture serialized HTML
+ *
+ * @param {string} basename - Filename base.
+ * @returns {object} Fixture data.
+ */
 function getBlockFixtureSerializedHTML( basename ) {
 	const filename = `${ basename }.serialized.html`;
 	return {
@@ -326,14 +432,32 @@ function getBlockFixtureSerializedHTML( basename ) {
 	};
 }
 
+/**
+ * Write block fixture JSON
+ *
+ * @param {string} basename - Filename base.
+ * @param {string} fixture - Data to write.
+ */
 function writeBlockFixtureJSON( basename, fixture ) {
 	writeFixtureFile( FIXTURES_DIR, `${ basename }.json`, fixture );
 }
 
+/**
+ * Write block fixture parsed JSON
+ *
+ * @param {string} basename - Filename base.
+ * @param {string} fixture - Data to write.
+ */
 function writeBlockFixtureParsedJSON( basename, fixture ) {
 	writeFixtureFile( FIXTURES_DIR, `${ basename }.parsed.json`, fixture );
 }
 
+/**
+ * Write block fixture serialized HTML
+ *
+ * @param {string} basename - Filename base.
+ * @param {string} fixture - Data to write.
+ */
 function writeBlockFixtureSerializedHTML( basename, fixture ) {
 	writeFixtureFile( FIXTURES_DIR, `${ basename }.serialized.html`, fixture );
 }

--- a/projects/plugins/jetpack/extensions/shared/test/execution-lock-test.js
+++ b/projects/plugins/jetpack/extensions/shared/test/execution-lock-test.js
@@ -1,163 +1,163 @@
-import executionLock from "../execution-lock";
+import executionLock from '../execution-lock';
 
 describe( 'Execution lock', () => {
-    const ANY_LOCK_KEY = 'anyLockName';
-    const ANY_OTHER_LOCK_KEY = 'anyOtherLockName';
-    const ANY_RANDOM_NUMBER = 123;
+	const ANY_LOCK_KEY = 'anyLockName';
+	const ANY_OTHER_LOCK_KEY = 'anyOtherLockName';
+	const ANY_RANDOM_NUMBER = 123;
 
-    afterEach( () => {
-        jest.restoreAllMocks();
-        executionLock.clearAll();
-    } );
+	afterEach( () => {
+		jest.restoreAllMocks();
+		executionLock.clearAll();
+	} );
 
-    describe( 'Acquire lock tests', () => {
-        test( 'Acquire lock happy case', () => {
-            // Given
-            jest.spyOn( Math, 'random' ).mockImplementation(() => ANY_RANDOM_NUMBER );
-            const expectedLock = [ ANY_LOCK_KEY, ANY_RANDOM_NUMBER ];
+	describe( 'Acquire lock tests', () => {
+		test( 'Acquire lock happy case', () => {
+			// Given
+			jest.spyOn( Math, 'random' ).mockImplementation( () => ANY_RANDOM_NUMBER );
+			const expectedLock = [ ANY_LOCK_KEY, ANY_RANDOM_NUMBER ];
 
-            // When
-            const acquireResult = executionLock.acquire( ANY_LOCK_KEY );
+			// When
+			const acquireResult = executionLock.acquire( ANY_LOCK_KEY );
 
-            // Then
-            expect( acquireResult ).toEqual( expectedLock );
-        } );
+			// Then
+			expect( acquireResult ).toEqual( expectedLock );
+		} );
 
-        test( "When a lock for the given key is already acquired we can't get a new lock for the given key", () => {
-            // Given
-            jest.spyOn( Math, 'random' ).mockImplementation(() => ANY_RANDOM_NUMBER );
-            const expectedFirst = [ ANY_LOCK_KEY, ANY_RANDOM_NUMBER ];
-            const expectedSecond = null;
+		test( "When a lock for the given key is already acquired we can't get a new lock for the given key", () => {
+			// Given
+			jest.spyOn( Math, 'random' ).mockImplementation( () => ANY_RANDOM_NUMBER );
+			const expectedFirst = [ ANY_LOCK_KEY, ANY_RANDOM_NUMBER ];
+			const expectedSecond = null;
 
-            // When
-            const firstResult = executionLock.acquire( ANY_LOCK_KEY );
-            const secondResult = executionLock.acquire( ANY_LOCK_KEY );
+			// When
+			const firstResult = executionLock.acquire( ANY_LOCK_KEY );
+			const secondResult = executionLock.acquire( ANY_LOCK_KEY );
 
-            // Then
-            expect( firstResult ).toEqual( expectedFirst );
-            expect( secondResult ).toEqual( expectedSecond );
-        } );
+			// Then
+			expect( firstResult ).toEqual( expectedFirst );
+			expect( secondResult ).toEqual( expectedSecond );
+		} );
 
-        test( 'We can acquire valid locks for different keys', () => {
-            // Given
-            jest.spyOn( Math, 'random' ).mockImplementation(() => ANY_RANDOM_NUMBER );
-            const firstExpectedLock = [ ANY_LOCK_KEY, ANY_RANDOM_NUMBER ];
-            const secondExpectedLock = [ ANY_OTHER_LOCK_KEY, ANY_RANDOM_NUMBER ];
+		test( 'We can acquire valid locks for different keys', () => {
+			// Given
+			jest.spyOn( Math, 'random' ).mockImplementation( () => ANY_RANDOM_NUMBER );
+			const firstExpectedLock = [ ANY_LOCK_KEY, ANY_RANDOM_NUMBER ];
+			const secondExpectedLock = [ ANY_OTHER_LOCK_KEY, ANY_RANDOM_NUMBER ];
 
-            // When
-            const firstLockResult = executionLock.acquire( ANY_LOCK_KEY );
-            const secondLockResult = executionLock.acquire( ANY_OTHER_LOCK_KEY );
+			// When
+			const firstLockResult = executionLock.acquire( ANY_LOCK_KEY );
+			const secondLockResult = executionLock.acquire( ANY_OTHER_LOCK_KEY );
 
-            // Then
-            expect( firstLockResult ).toEqual( firstExpectedLock );
-            expect( secondLockResult ).toEqual( secondExpectedLock );
-        } )
-    } );
+			// Then
+			expect( firstLockResult ).toEqual( firstExpectedLock );
+			expect( secondLockResult ).toEqual( secondExpectedLock );
+		} );
+	} );
 
-    describe('Block execution tests', () => {
-        test( "When the supplied key isn't locked we can continue with the execution flow", async () => {
-            // Given
-            // No initial conditions.
+	describe( 'Block execution tests', () => {
+		test( "When the supplied key isn't locked we can continue with the execution flow", async () => {
+			// Given
+			// No initial conditions.
 
-            // When
-            await executionLock.blockExecution( ANY_LOCK_KEY );
+			// When
+			await executionLock.blockExecution( ANY_LOCK_KEY );
 
-            // Then
-            // If the lock doesn't resolve the test will time out fail.
-            expect( true ).toBeTruthy();
-        } );
+			// Then
+			// If the lock doesn't resolve the test will time out fail.
+			expect( true ).toBeTruthy();
+		} );
 
-        test( 'When the supplied key is locked execution is halted until the lock is released', async () => {
-            // Given
-            const lock = executionLock.acquire( ANY_LOCK_KEY );
-            const RELEASE_LOCK_AFTER_ANY_MS = 400;
-            setTimeout(() => executionLock.release( lock ), RELEASE_LOCK_AFTER_ANY_MS );
+		test( 'When the supplied key is locked execution is halted until the lock is released', async () => {
+			// Given
+			const lock = executionLock.acquire( ANY_LOCK_KEY );
+			const RELEASE_LOCK_AFTER_ANY_MS = 400;
+			setTimeout( () => executionLock.release( lock ), RELEASE_LOCK_AFTER_ANY_MS );
 
-            // When
-            await executionLock.blockExecution( ANY_LOCK_KEY );
+			// When
+			await executionLock.blockExecution( ANY_LOCK_KEY );
 
-            // Then
-            // If the lock doesn't resolve the test will time out and fail.
-            expect( true ).toBeTruthy();
-        } );
+			// Then
+			// If the lock doesn't resolve the test will time out and fail.
+			expect( true ).toBeTruthy();
+		} );
 
-        test( 'Blocking the execution until the lock is released does not block the current thread', () => {
-            // Given
-            executionLock.acquire( ANY_LOCK_KEY );
+		test( 'Blocking the execution until the lock is released does not block the current thread', () => {
+			// Given
+			executionLock.acquire( ANY_LOCK_KEY );
 
-            // When
-            (async () => await executionLock.blockExecution( ANY_LOCK_KEY ))();
+			// When
+			( async () => await executionLock.blockExecution( ANY_LOCK_KEY ) )();
 
-            // Then
-            // The lock will not be resolved before the test timeout, and we should reach this point.
-            expect( true ).toBeTruthy();
-        } );
+			// Then
+			// The lock will not be resolved before the test timeout, and we should reach this point.
+			expect( true ).toBeTruthy();
+		} );
 
-        test( 'The time elapsed between lock checks when the execution is halted is greater than the time offSet value', async () => {
-            // Given
-            const lock = executionLock.acquire( ANY_LOCK_KEY );
-            const RELEASE_LOCK_AFTER_90_MS = 90;
-            const OFFSET_FOR_100_MS = 100;
-            setTimeout(() => executionLock.release( lock ), RELEASE_LOCK_AFTER_90_MS );
-            const initialTimeMillis = Date.now();
+		test( 'The time elapsed between lock checks when the execution is halted is greater than the time offSet value', async () => {
+			// Given
+			const lock = executionLock.acquire( ANY_LOCK_KEY );
+			const RELEASE_LOCK_AFTER_90_MS = 90;
+			const OFFSET_FOR_100_MS = 100;
+			setTimeout( () => executionLock.release( lock ), RELEASE_LOCK_AFTER_90_MS );
+			const initialTimeMillis = Date.now();
 
-            // When
-            await executionLock.blockExecution( ANY_LOCK_KEY, OFFSET_FOR_100_MS );
+			// When
+			await executionLock.blockExecution( ANY_LOCK_KEY, OFFSET_FOR_100_MS );
 
-            // Then
-            const timeElapsedInMillis = Date.now() - initialTimeMillis;
-            // The time measurement can sometimes lose 1ms.
-            expect( timeElapsedInMillis ).toBeGreaterThanOrEqual( OFFSET_FOR_100_MS - 1 );
-            // While the delay beyond the specified time may be arbitrarily long, within the test infrastructure it shouldn't be that far off.
-            expect( timeElapsedInMillis ).toBeLessThanOrEqual( OFFSET_FOR_100_MS + 20 );
-        } );
-    } );
+			// Then
+			const timeElapsedInMillis = Date.now() - initialTimeMillis;
+			// The time measurement can sometimes lose 1ms.
+			expect( timeElapsedInMillis ).toBeGreaterThanOrEqual( OFFSET_FOR_100_MS - 1 );
+			// While the delay beyond the specified time may be arbitrarily long, within the test infrastructure it shouldn't be that far off.
+			expect( timeElapsedInMillis ).toBeLessThanOrEqual( OFFSET_FOR_100_MS + 20 );
+		} );
+	} );
 
-    describe( 'Check lock tests', () => {
-        test( 'Unlocked key returns the correct status', () => {
-            // Given
-            // No initial conditions.
+	describe( 'Check lock tests', () => {
+		test( 'Unlocked key returns the correct status', () => {
+			// Given
+			// No initial conditions.
 
-            // When
-            const isLocked = executionLock.isLocked( ANY_LOCK_KEY );
+			// When
+			const isLocked = executionLock.isLocked( ANY_LOCK_KEY );
 
-            // Then
-            expect( isLocked ).toBeFalsy();
-        } );
+			// Then
+			expect( isLocked ).toBeFalsy();
+		} );
 
-        test( 'Locked key returns the correct status', () => {
-            // Given
-            executionLock.acquire( ANY_LOCK_KEY );
+		test( 'Locked key returns the correct status', () => {
+			// Given
+			executionLock.acquire( ANY_LOCK_KEY );
 
-            // When
-            const isLocked = executionLock.isLocked( ANY_LOCK_KEY );
+			// When
+			const isLocked = executionLock.isLocked( ANY_LOCK_KEY );
 
-            // Then
-            expect( isLocked ).toBeTruthy();
-        } );
-    } );
+			// Then
+			expect( isLocked ).toBeTruthy();
+		} );
+	} );
 
-    describe( 'Release lock tests', () => {
-        test( 'Lock is correctly released when there is a lock in place', () => {
-            // Given
-            const lock = executionLock.acquire( ANY_LOCK_KEY );
+	describe( 'Release lock tests', () => {
+		test( 'Lock is correctly released when there is a lock in place', () => {
+			// Given
+			const lock = executionLock.acquire( ANY_LOCK_KEY );
 
-            // When
-            const releaseResult = executionLock.release( lock );
+			// When
+			const releaseResult = executionLock.release( lock );
 
-            // Then
-            expect( releaseResult ).toBeTruthy();
-        } );
+			// Then
+			expect( releaseResult ).toBeTruthy();
+		} );
 
-        test( "No lock is released when there isn't a lock in place", () => {
-            // Given
-            const lock = [ ANY_LOCK_KEY, ANY_RANDOM_NUMBER ];
+		test( "No lock is released when there isn't a lock in place", () => {
+			// Given
+			const lock = [ ANY_LOCK_KEY, ANY_RANDOM_NUMBER ];
 
-            // When
-            const releaseResult = executionLock.release( lock );
+			// When
+			const releaseResult = executionLock.release( lock );
 
-            // Then
-            expect( releaseResult ).toBeFalsy();
-        } );
-    } );
+			// Then
+			expect( releaseResult ).toBeFalsy();
+		} );
+	} );
 } );

--- a/projects/plugins/jetpack/extensions/shared/test/get-editor-type-test.js
+++ b/projects/plugins/jetpack/extensions/shared/test/get-editor-type-test.js
@@ -1,65 +1,65 @@
 import * as data from '@wordpress/data';
-
 import {
-    getEditorType, CUSTOMIZER_EDITOR,
-    NAVIGATION_EDITOR, POST_EDITOR,
-    SITE_EDITOR, UNKNOWN_EDITOR,
-    WIDGET_EDITOR
-} from "../get-editor-type";
+	getEditorType,
+	CUSTOMIZER_EDITOR,
+	NAVIGATION_EDITOR,
+	POST_EDITOR,
+	SITE_EDITOR,
+	UNKNOWN_EDITOR,
+	WIDGET_EDITOR,
+} from '../get-editor-type';
 
 const testCaseMap = [
-    {
-        name: 'When in site editor context we get the corresponding value',
-        store: 'core/edit-site',
-        context: SITE_EDITOR,
-    },
-    {
-        name: 'When we are in widget editor we get the corresponding context value',
-        store: 'core/edit-widgets',
-        context: WIDGET_EDITOR,
-    },
-    {
-        name: 'When we are in customizer editor we get the corresponding context value',
-        store: 'core/customize-widgets',
-        context: CUSTOMIZER_EDITOR,
-    },
-    {
-        name: 'When we are in navigation editor we get the corresponding context value',
-        store: 'core/edit-navigation',
-        context: NAVIGATION_EDITOR,
-    },
-    {
-        name: 'When we are not in any of the other editors and the core/editor store is available we return post editor context',
-        store: 'core/edit-post',
-        context: POST_EDITOR,
-    },
-    {
-        name: 'When we are in an unknown editor we get post editor context value',
-        store: 'any-store',
-        context: UNKNOWN_EDITOR,
-    },
+	{
+		name: 'When in site editor context we get the corresponding value',
+		store: 'core/edit-site',
+		context: SITE_EDITOR,
+	},
+	{
+		name: 'When we are in widget editor we get the corresponding context value',
+		store: 'core/edit-widgets',
+		context: WIDGET_EDITOR,
+	},
+	{
+		name: 'When we are in customizer editor we get the corresponding context value',
+		store: 'core/customize-widgets',
+		context: CUSTOMIZER_EDITOR,
+	},
+	{
+		name: 'When we are in navigation editor we get the corresponding context value',
+		store: 'core/edit-navigation',
+		context: NAVIGATION_EDITOR,
+	},
+	{
+		name:
+			'When we are not in any of the other editors and the core/editor store is available we return post editor context',
+		store: 'core/edit-post',
+		context: POST_EDITOR,
+	},
+	{
+		name: 'When we are in an unknown editor we get post editor context value',
+		store: 'any-store',
+		context: UNKNOWN_EDITOR,
+	},
 ];
 
 describe( 'Gutenberg context resolution', () => {
+	const getMockImplementationForStore = store => storeArgument => {
+		return store === storeArgument;
+	};
 
-    const getMockImplementationForStore = ( store ) => ( storeArgument ) => {
-        return store === storeArgument;
-    }
+	test.each( testCaseMap )( '$name', testCase => {
+		// Given
+		const context = testCase.context;
+		const mock = jest
+			.spyOn( data, 'select' )
+			.mockImplementation( getMockImplementationForStore( testCase.store ) );
 
-    testCaseMap.forEach( ( testCase ) => {
-        test( testCase.name, () => {
-            // Given
-            const context = testCase.context;
-            const mock = jest.spyOn( data, 'select' )
-                .mockImplementation( getMockImplementationForStore( testCase.store ) );
+		// When
+		const editorType = getEditorType();
 
-            // When
-            const editorType = getEditorType();
-
-            // Then
-            expect( editorType ).toEqual( context );
-            mock.mockReset();
-        });
-    } );
+		// Then
+		expect( editorType ).toEqual( context );
+		mock.mockReset();
+	} );
 } );
-

--- a/projects/plugins/jetpack/extensions/shared/test/i18n-to-php.js
+++ b/projects/plugins/jetpack/extensions/shared/test/i18n-to-php.js
@@ -1,15 +1,14 @@
 import { renderToStaticMarkup } from 'react-dom/server';
-
 import { __, _n, _x, _nx } from '../i18n-to-php';
 
 describe( 'i18n-to-php', () => {
 	test( 'renders __() to its PHP counterpart as expected', () => {
 		expect(
 			renderToStaticMarkup(
-				__( 'Upgrade to a paid plan to use this block on your site.', 'text-domain' )
+				__( 'Upgrade to a paid plan to use this block on your site.', 'jetpack' )
 			)
 		).toBe(
-			"<span><?php esc_html_e( 'Upgrade to a paid plan to use this block on your site.', 'text-domain' ) ?></span>"
+			"<span><?php esc_html_e( 'Upgrade to a paid plan to use this block on your site.', 'jetpack' ) ?></span>"
 		);
 	} );
 
@@ -17,18 +16,19 @@ describe( 'i18n-to-php', () => {
 		expect(
 			renderToStaticMarkup(
 				/* Translators: placeholder is a number of people. */
-				_n( '%d person', '%d people', 1 + 2, 'text-domain' )
+				_n( '%d person', '%d people', 1 + 2, 'jetpack' )
 			)
 		).toBe(
-			"<span><?php echo esc_html( _n( '%d person', '%d people', 3, 'text-domain' ) ) ?></span>"
+			// prettier-ignore
+			"<span><?php echo esc_html( _n( '%d person', '%d people', 3, 'jetpack' ) ) ?></span>"
 		);
 	} );
 
 	test( 'renders _x() to its PHP counterpart as expected', () => {
 		expect(
-			renderToStaticMarkup( _x( 'Read', 'past participle: books I have read', 'text-domain' ) )
+			renderToStaticMarkup( _x( 'Read', 'past participle: books I have read', 'jetpack' ) )
 		).toBe(
-			"<span><?php echo esc_html( _x( 'Read', 'past participle: books I have read', 'text-domain' ) ) ?></span>"
+			"<span><?php echo esc_html( _x( 'Read', 'past participle: books I have read', 'jetpack' ) ) ?></span>"
 		);
 	} );
 
@@ -36,10 +36,10 @@ describe( 'i18n-to-php', () => {
 		expect(
 			renderToStaticMarkup(
 				/* Translators: placeholder is a number (group of people). */
-				_nx( '%d group', '%d groups', 2 + 3, 'group of people', 'text-domain' )
+				_nx( '%d group', '%d groups', 2 + 3, 'group of people', 'jetpack' )
 			)
 		).toBe(
-			"<span><?php echo esc_html( _nx( '%d group', '%d groups', 5, 'group of people', 'text-domain' ) ) ?></span>"
+			"<span><?php echo esc_html( _nx( '%d group', '%d groups', 5, 'group of people', 'jetpack' ) ) ?></span>"
 		);
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/shared/test/stripe-nudge-test.js
+++ b/projects/plugins/jetpack/extensions/shared/test/stripe-nudge-test.js
@@ -1,63 +1,62 @@
+import { render, screen, waitFor } from '@testing-library/react';
 import * as data from '@wordpress/data';
-
-import { StripeNudge } from "../components/stripe-nudge";
-
-import '@testing-library/jest-dom/extend-expect';
-import { render, screen, waitFor } from "@testing-library/react";
+import { StripeNudge } from '../components/stripe-nudge';
+import '@testing-library/jest-dom';
 
 describe( 'Stripe nudge component', () => {
+	describe( 'Membership store aware stripe nudge tests', () => {
+		const selectSpy = jest.spyOn( data, 'select' );
+		const ANY_VALID_CONNECT_URL = 'anyValidConnectUrl';
+		const ANY_INVALID_CONNECT_URL = null;
+		const USER_SHOULD_NOT_UPGRADE_PLAN = false;
+		const USER_MUST_UPGRADE_PLAN = true;
+		const ANY_BLOCK_NAME = 'anyBlockName';
+		const NUDGE_RENDERED_TEXT = 'Connect to Stripe to use this block on your site';
 
-    describe( 'Membership store aware stripe nudge tests', () => {
+		test( 'Given that we have a paid plan and a Stripe connect URL, we display the Stripe connect nudge.', async () => {
+			// Given
+			selectSpy.mockImplementation( () => ( {
+				getShouldUpgrade: () => USER_SHOULD_NOT_UPGRADE_PLAN,
+				getConnectUrl: () => ANY_VALID_CONNECT_URL,
+			} ) );
 
-        const selectSpy = jest.spyOn( data, 'select' );
-        const ANY_VALID_CONNECT_URL = 'anyValidConnectUrl';
-        const ANY_INVALID_CONNECT_URL = null;
-        const USER_SHOULD_NOT_UPGRADE_PLAN = false;
-        const USER_MUST_UPGRADE_PLAN = true;
-        const ANY_BLOCK_NAME = 'anyBlockName';
-        const NUDGE_RENDERED_TEXT = 'Connect to Stripe to use this block on your site';
+			// When
+			render( <StripeNudge blockName={ ANY_BLOCK_NAME } /> );
 
-        test( 'Given that we have a paid plan and a Stripe connect URL, we display the Stripe connect nudge.', async () => {
-            // Given
-            selectSpy.mockImplementation(() => ( {
-                getShouldUpgrade: () => USER_SHOULD_NOT_UPGRADE_PLAN,
-                getConnectUrl: () => ANY_VALID_CONNECT_URL
-            } ) );
+			// Then
+			await expect( screen.findByText( NUDGE_RENDERED_TEXT ) ).resolves.toBeInTheDocument();
+		} );
 
-            // When
-            render( <StripeNudge blockName={ ANY_BLOCK_NAME } /> );
+		test( 'When the user needs to upgrade his plan we will not show the Stripe nudge.', async () => {
+			// Given
+			selectSpy.mockImplementation( () => ( {
+				getShouldUpgrade: () => USER_MUST_UPGRADE_PLAN,
+				getConnectUrl: () => ANY_VALID_CONNECT_URL,
+			} ) );
 
-            // Then
-            await waitFor( () => expect( screen.getByText( NUDGE_RENDERED_TEXT ) ).toBeInTheDocument() );
-        } );
+			// When
+			render( <StripeNudge blockName={ ANY_BLOCK_NAME } /> );
 
-        test( 'When the user needs to upgrade his plan we will not show the Stripe nudge.', async () => {
-            // Given
-            selectSpy.mockImplementation(() => ( {
-                getShouldUpgrade: () => USER_MUST_UPGRADE_PLAN,
-                getConnectUrl: () => ANY_VALID_CONNECT_URL
-            } ) );
+			// Then
+			await waitFor( () =>
+				expect( screen.queryByText( NUDGE_RENDERED_TEXT ) ).not.toBeInTheDocument()
+			);
+		} );
 
-            // When
-            render( <StripeNudge blockName={ ANY_BLOCK_NAME } /> );
+		test( 'When we do not have a connect URL to connect to we will not show the Stripe connect nudge', async () => {
+			// Given
+			selectSpy.mockImplementation( () => ( {
+				getShouldUpgrade: () => USER_SHOULD_NOT_UPGRADE_PLAN,
+				getConnectUrl: () => ANY_INVALID_CONNECT_URL,
+			} ) );
 
-            // Then
-            await waitFor( () => expect( screen.queryByText( NUDGE_RENDERED_TEXT ) ).not.toBeInTheDocument() );
-        } );
+			// When
+			render( <StripeNudge blockName={ ANY_BLOCK_NAME } /> );
 
-        test( 'When we do not have a connect URL to connect to we will not show the Stripe connect nudge', async () => {
-            // Given
-            selectSpy.mockImplementation(() => ( {
-                getShouldUpgrade: () => USER_SHOULD_NOT_UPGRADE_PLAN,
-                getConnectUrl: () => ANY_INVALID_CONNECT_URL
-            } ) );
-
-            // When
-            render( <StripeNudge blockName={ ANY_BLOCK_NAME } /> );
-
-            // Then
-            await waitFor( () => expect( screen.queryByText( NUDGE_RENDERED_TEXT ) ).not.toBeInTheDocument() );
-        } );
-    } )
+			// Then
+			await waitFor( () =>
+				expect( screen.queryByText( NUDGE_RENDERED_TEXT ) ).not.toBeInTheDocument()
+			);
+		} );
+	} );
 } );
-

--- a/projects/plugins/jetpack/extensions/store/media-source/test/index.js
+++ b/projects/plugins/jetpack/extensions/store/media-source/test/index.js
@@ -1,6 +1,6 @@
 import { registerStore } from '@wordpress/data';
-import storeDefinition from '../store-definition';
 import { STATE_PLAYING, STATE_PAUSED, STATE_ERROR } from '../constants';
+import storeDefinition from '../store-definition';
 
 const { actions } = storeDefinition;
 const STORE_ID = 'jetpack/media-source';
@@ -107,8 +107,6 @@ describe( 'save', () => {
 
 		// Create sources
 		store.dispatch( actions.registerMediaSource( 100, {} ) );
-		const stateAfterOneAction = store.getState();
-		const frozenStateAfterOneAction = JSON.parse( JSON.stringify( stateAfterOneAction ) );
 
 		let got = store.getState();
 		let want = {

--- a/projects/plugins/jetpack/extensions/store/membership-products/test/actions-test.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/test/actions-test.js
@@ -1,3 +1,7 @@
+import apiFetch from '@wordpress/api-fetch';
+import { PRODUCT_TYPE_PAYMENT_PLAN } from '../../../shared/components/product-management-controls/constants';
+import * as message from '../../../shared/components/product-management-controls/utils';
+import * as currencies from '../../../shared/currencies';
 import {
 	saveProduct,
 	setApiState,
@@ -8,11 +12,6 @@ import {
 	setUpgradeUrl,
 } from '../actions';
 import * as utils from '../utils';
-import * as message from '../../../shared/components/product-management-controls/utils';
-import * as currencies from '../../../shared/currencies';
-import apiFetch from '@wordpress/api-fetch';
-import { PRODUCT_TYPE_PAYMENT_PLAN } from '../../../shared/components/product-management-controls/constants';
-import { minimumTransactionAmountForCurrency } from '../../../shared/currencies';
 
 const ANY_VALID_DATA = {
 	anyProductProperty: 'anyValue',
@@ -126,27 +125,28 @@ describe( 'Membership Products Actions', () => {
 		},
 	];
 
-	productsForTitleTesting.forEach( testCase => {
-		test( testCase.name, async () => {
-			// Given
-			const selectedProductIdCallback = anyFunction;
-			const paymentPlanProductType = PRODUCT_TYPE_PAYMENT_PLAN;
-			const noticeMock = jest.spyOn( utils, 'onError' ).mockImplementation( anyFunction );
-			const getMessageMock = jest
-				.spyOn( message, 'getMessageByProductType' )
-				.mockImplementation( anyFunction );
+	test.each( productsForTitleTesting )( '$name', async testCase => {
+		// Given
+		const selectedProductIdCallback = anyFunction;
+		const paymentPlanProductType = PRODUCT_TYPE_PAYMENT_PLAN;
+		const noticeMock = jest.spyOn( utils, 'onError' ).mockImplementation( anyFunction );
+		const getMessageMock = jest
+			.spyOn( message, 'getMessageByProductType' )
+			.mockImplementation( anyFunction );
 
-			// When
-			await saveProduct(
-				testCase.product,
-				paymentPlanProductType,
-				selectedProductIdCallback
-			)( anyFunction, anyFunction );
+		// When
+		await saveProduct(
+			testCase.product,
+			paymentPlanProductType,
+			selectedProductIdCallback
+		)( anyFunction, anyFunction );
 
-			// Then
-			expect( noticeMock ).toBeCalled();
-			expect( getMessageMock ).toBeCalledWith( 'product requires a name', paymentPlanProductType );
-		} );
+		// Then
+		expect( noticeMock ).toHaveBeenCalled();
+		expect( getMessageMock ).toHaveBeenCalledWith(
+			'product requires a name',
+			paymentPlanProductType
+		);
 	} );
 
 	test( 'having a price below the minimum price triggers an error notice.', async () => {
@@ -168,7 +168,7 @@ describe( 'Membership Products Actions', () => {
 		)( anyFunction, anyFunction );
 
 		// Then
-		expect( noticeMock ).toBeCalled();
+		expect( noticeMock ).toHaveBeenCalled();
 	} );
 
 	test( 'an invalid product price triggers an error notice.', async () => {
@@ -189,8 +189,8 @@ describe( 'Membership Products Actions', () => {
 		)( anyFunction, anyFunction );
 
 		// Then
-		expect( noticeMock ).toBeCalled();
-		expect( getMessageMock ).toBeCalledWith(
+		expect( noticeMock ).toHaveBeenCalled();
+		expect( getMessageMock ).toHaveBeenCalledWith(
 			'product requires a valid price',
 			paymentPlanProductType
 		);
@@ -227,18 +227,18 @@ describe( 'Membership Products Actions', () => {
 		)( { dispatch, registry } );
 
 		// Then
-		expect( apiFetch ).toBeCalledWith( {
+		expect( apiFetch ).toHaveBeenCalledWith( {
 			path: '/wpcom/v2/memberships/product',
 			method: 'POST',
 			data: anyValidProduct,
 		} );
-		expect( dispatch ).toBeCalledWith( {
+		expect( dispatch ).toHaveBeenCalledWith( {
 			products: registryProductList.concat( [ apiResponseProduct ] ),
 			type: 'SET_PRODUCTS',
 		} );
-		expect( selectedProductCallback ).toBeCalledWith( apiResponseProduct.id );
-		expect( noticeMock ).toBeCalled();
-		expect( getMessageMock ).toBeCalledWith(
+		expect( selectedProductCallback ).toHaveBeenCalledWith( apiResponseProduct.id );
+		expect( noticeMock ).toHaveBeenCalled();
+		expect( getMessageMock ).toHaveBeenCalledWith(
 			'successfully created product',
 			PRODUCT_TYPE_PAYMENT_PLAN
 		);
@@ -262,8 +262,8 @@ describe( 'Membership Products Actions', () => {
 		)( anyFunction, anyFunction );
 
 		// Then
-		expect( noticeMock ).toBeCalled();
-		expect( getMessageMock ).toBeCalledWith(
+		expect( noticeMock ).toHaveBeenCalled();
+		expect( getMessageMock ).toHaveBeenCalledWith(
 			'there was an error when adding the product',
 			PRODUCT_TYPE_PAYMENT_PLAN
 		);

--- a/projects/plugins/jetpack/tests/jest.config.extensions.js
+++ b/projects/plugins/jetpack/tests/jest.config.extensions.js
@@ -1,4 +1,3 @@
-const path = require( 'path' );
 const baseConfig = require( './jest.config.base.js' );
 
 module.exports = {
@@ -6,12 +5,6 @@ module.exports = {
 	roots: [ '<rootDir>/extensions/' ],
 	coverageDirectory: 'coverage/extensions',
 	setupFiles: [ ...baseConfig.setupFiles, '<rootDir>/tests/jest-globals.extensions.js' ],
-	setupFilesAfterEnv: [
-		...baseConfig.setupFilesAfterEnv,
-		path.join( __dirname, 'jest-enzyme-init.js' ),
-		require.resolve( 'jest-enzyme' ),
-	],
-	snapshotSerializers: [ 'enzyme-to-json/serializer' ],
 	testPathIgnorePatterns: [
 		...baseConfig.testPathIgnorePatterns,
 		'extensions/shared/test/block-fixtures.js',

--- a/tools/js-tools/eslintrc/jest.js
+++ b/tools/js-tools/eslintrc/jest.js
@@ -3,7 +3,7 @@
  */
 module.exports = {
 	extends: [
-		'./base',
+		'./preload',
 		'plugin:jest/recommended',
 		'plugin:jest/style',
 		'plugin:jest-dom/recommended',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This enables linting for `extensions/**/test/`, and removes the use of
`enzyme` from the handful of tests there that were using it.

Other notes:

* Fixed our `jest` eslint preset to not reapply `base`, mainly so it
  doesn't overwrite the i18n textdomain setting.
* Regularize where and when `import '@testing-library/jest-dom'`
  happens.
* Remove unnecessary `@jest-environment jsdom` comments.
* Reduce the amount of waiting in `business-hours/test/edit.js` and
  `instagram-gallery/test/edit.js`, once the first item shows up the
  rest should be there too.
* Make better use of roles in `button/test/controls.js`.
* Mock the whole "api" wrapper in `subscriptions/test/edit.js` to avoid
  React whining about needing `act()` because it changes stuff in
  reaction to the fetch "completing".
* A bunch of places that put a mock in the middle of the imports,
  claiming it was needed to avoid some problem, don't actually need to
  do so. Jest hoists its mocks above the requires/imports, and otherwise
  imports are supposed to happen before any other code is run anyway.

There are a lot of places where I had to add an ignore for
`testing-library/no-container` or `testing-library/no-node-access` as
refactoring the tests didn't look straightforward. Ideally someone who
knows the blocks better should look at cleaning those up.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Fixes #24452
p9dueE-5j2-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy? This is all changes to tests.