### PR TITLE
Fix/remote provision xmlrpc in standalone plugins

### DIFF
--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.41.3] - 2022-06-28
+### Fixed
+- Connection: fix fatal error due to undefined constant in remote_provision()
+
 ## [1.41.2] - 2022-06-28
 ### Removed
 - Removed use of autounit tag [#24845]
@@ -629,6 +633,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[1.41.3]: https://github.com/Automattic/jetpack-connection/compare/v1.41.2...v1.41.3
 [1.41.2]: https://github.com/Automattic/jetpack-connection/compare/v1.41.1...v1.41.2
 [1.41.1]: https://github.com/Automattic/jetpack-connection/compare/v1.41.0...v1.41.1
 [1.41.0]: https://github.com/Automattic/jetpack-connection/compare/v1.40.5...v1.41.0

--- a/projects/packages/connection/changelog/fix-remote-provision-xmlrpc-in-standalone-plugins
+++ b/projects/packages/connection/changelog/fix-remote-provision-xmlrpc-in-standalone-plugins
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Bump package version to 1.41.3
+
+

--- a/projects/packages/connection/changelog/fix-remote-provision-xmlrpc-in-standalone-plugins
+++ b/projects/packages/connection/changelog/fix-remote-provision-xmlrpc-in-standalone-plugins
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Connection: fix fatal error due to undefined constant in remote_provision()

--- a/projects/packages/connection/changelog/fix-remote-provision-xmlrpc-in-standalone-plugins
+++ b/projects/packages/connection/changelog/fix-remote-provision-xmlrpc-in-standalone-plugins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Connection: fix fatal error due to undefined constant in remote_provision()

--- a/projects/packages/connection/legacy/class-jetpack-xmlrpc-server.php
+++ b/projects/packages/connection/legacy/class-jetpack-xmlrpc-server.php
@@ -10,6 +10,7 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Secrets;
 use Automattic\Jetpack\Connection\Tokens;
 use Automattic\Jetpack\Connection\Urls;
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Roles;
 
 /**
@@ -407,7 +408,7 @@ class Jetpack_XMLRPC_Server {
 		$secrets = ( new Secrets() )->generate( 'authorize', $user->ID );
 
 		$response = array(
-			'jp_version'   => JETPACK__VERSION,
+			'jp_version'   => Constants::get_constant( 'JETPACK__VERSION' ),
 			'redirect_uri' => $redirect_uri,
 			'user_id'      => $user->ID,
 			'user_email'   => $user->user_email,

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.41.2';
+	const PACKAGE_VERSION = '1.41.3';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.41.3';
+	const PACKAGE_VERSION = '1.41.4-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Fix fatal error in remote_provision XMLRPC handling due to JETPACK__VERSION being undefined in standalone plugins.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

pdpAdu-ti-p2

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* A partner account is required in order to test - please reach out to team Avalon if you do not have one.
* Do not check out this PR yet.
* Run docker and JT.
* Build and activate a standalone plugin such as Jetpack Backup.
* Change your administrator email address to one not registered on WPCOM but you still control (you can use the Gmail `foo+bar@` trick for unlimited emails).
* Run `jetpack docker tail` and monitor for fatal errors.
* Provision any Jetpack product via Jetpack Start to your local docker site.
* Check your error logs - you should see a fatal about `JETPACK__VERSION` not being defined.
* Check out this PR's branch locally.
* Provision any Jetpack product via Jetpack Start to your local docker site.
* Provisioning should succeed with no errors, the product should become available and you should have a user connection established with an automatically generated WPCOM account for your email address.