### PR TITLE
My Jetpack: Disambigue redirect urls

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connections-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connections-section/index.jsx
@@ -11,7 +11,7 @@ import { STORE_ID } from '../../state/store';
  * @returns {object} ConnectionsSection React component.
  */
 export default function ConnectionsSection() {
-	const { apiRoot, apiNonce, redirectUrl, connectedPlugins } = useMyJetpackConnection();
+	const { apiRoot, apiNonce, topJetpackMenuItemUrl, connectedPlugins } = useMyJetpackConnection();
 	const navigate = useMyJetpackNavigate( '/connection' );
 	const productsThatRequiresUserConnection = useSelect( select =>
 		select( STORE_ID ).getProductsThatRequiresUserConnection()
@@ -21,7 +21,7 @@ export default function ConnectionsSection() {
 		<ConnectionStatusCard
 			apiRoot={ apiRoot }
 			apiNonce={ apiNonce }
-			redirectUri={ redirectUrl }
+			redirectUri={ topJetpackMenuItemUrl }
 			onConnectUser={ navigate }
 			connectedPlugins={ connectedPlugins }
 			requiresUserConnection={ productsThatRequiresUserConnection.length > 0 }

--- a/projects/packages/my-jetpack/_inc/components/plans-section/stories/mock-data.js
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/stories/mock-data.js
@@ -1,6 +1,6 @@
 window.myJetpackInitialState = {
 	siteSuffix: 'my-jetpack-mock-site.com',
-	redirectUrl: 'https://my-jetpack-mock-site.com/wp-admin/?page=my-jetpack',
+	myJetpackUrl: 'https://my-jetpack-mock-site.com/wp-admin/?page=my-jetpack',
 };
 
 export const siteWithSecurityPlanResponseBody = {

--- a/projects/packages/my-jetpack/_inc/hooks/use-connection-watcher/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-connection-watcher/index.js
@@ -16,7 +16,7 @@ export default function useConnectionWatcher() {
 	const productsThatRequiresUserConnection = useSelect( select =>
 		select( STORE_ID ).getProductsThatRequiresUserConnection()
 	);
-	const { isSiteConnected, redirectUrl, hasConnectedOwner } = useMyJetpackConnection();
+	const { isSiteConnected, topJetpackMenuItemUrl, hasConnectedOwner } = useMyJetpackConnection();
 
 	const requiresUserConnection =
 		! hasConnectedOwner && productsThatRequiresUserConnection.length > 0;
@@ -42,10 +42,10 @@ export default function useConnectionWatcher() {
 	 * When the site is not connect, redirect to the Jetpack dashboard.
 	 */
 	useEffect( () => {
-		if ( ! isSiteConnected && redirectUrl ) {
-			window.location = redirectUrl;
+		if ( ! isSiteConnected && topJetpackMenuItemUrl ) {
+			window.location = topJetpackMenuItemUrl;
 		}
-	}, [ isSiteConnected, redirectUrl ] );
+	}, [ isSiteConnected, topJetpackMenuItemUrl ] );
 
 	useEffect( () => {
 		if ( requiresUserConnection ) {

--- a/projects/packages/my-jetpack/_inc/hooks/use-my-jetpack-connection/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-my-jetpack-connection/index.js
@@ -20,6 +20,6 @@ export default function useMyJetpackConnection() {
 		apiRoot,
 		...connectionData,
 		isSiteConnected,
-		redirectUrl: topJetpackMenuItemUrl,
+		topJetpackMenuItemUrl,
 	};
 }

--- a/projects/packages/my-jetpack/_inc/utils/get-product-checkout-url.js
+++ b/projects/packages/my-jetpack/_inc/utils/get-product-checkout-url.js
@@ -12,15 +12,15 @@
  * @returns {string} the redirect URL
  */
 export default function getProductCheckoutUrl( product, isUserConnected ) {
-	const { siteSuffix, redirectUrl } = window?.myJetpackInitialState || {};
+	const { siteSuffix, myJetpackUrl } = window?.myJetpackInitialState || {};
 
 	const checkoutUrl = new URL( 'https://wordpress.com/checkout/' );
 	const checkoutProductUrl = new URL( `${ checkoutUrl }${ siteSuffix }/${ product }` );
 
 	// Add redirect_to parameter
-	checkoutProductUrl.searchParams.set( 'redirect_to', redirectUrl );
+	checkoutProductUrl.searchParams.set( 'redirect_to', myJetpackUrl );
 
-	// Add unlimited when user is not connected to Jetpack.
+	// Add unlinked when user is not connected to Jetpack.
 	if ( ! isUserConnected ) {
 		checkoutProductUrl.searchParams.set( 'unlinked', 1 );
 	}

--- a/projects/packages/my-jetpack/changelog/update-disambigue_redirect_urls
+++ b/projects/packages/my-jetpack/changelog/update-disambigue_redirect_urls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+disambigue redirectUrls vars

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -144,7 +144,7 @@ class Initializer {
 				'purchases'             => array(
 					'items' => array(),
 				),
-				'redirectUrl'           => admin_url( 'admin.php?page=my-jetpack' ),
+				'myJetpackUrl'          => admin_url( 'admin.php?page=my-jetpack' ),
 				'topJetpackMenuItemUrl' => Admin_Menu::get_top_level_menu_item_url(),
 				'siteSuffix'            => ( new Status() )->get_site_suffix(),
 				'myJetpackVersion'      => self::PACKAGE_VERSION,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In My Jetpack code there are many `redirectUrl` vars meaning different things. This makes the code harder to understand and confusing.

This is a small refactor to rename some of the vars we use.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Disambigue redirect urls

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1202184803119163-as-1202324040023246

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Nothing should change, let's test for regressions:

* Try to buy one of our products from My Jetpack. Make sure the `redirect_uri` param in the Checkout URL (in the checkout page on wpcom) points back to the My Jetpack page on the site
* Go to My Jetpack and disconnect - Make sure you are redirected to the first menu item under the Jetpack top level menu

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202324040023246