### PR TITLE
Repo Gardening: extend auto-labelling to add priority labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -81,6 +81,13 @@ body:
         - Some (< 50%)
         - Most (> 50%)
         - All
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ## Additional context
+
+        Please provide whatever additional information you have available to you. If not, please scroll to the bottom and submit the issue.
   - type: dropdown
     id: os
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -54,6 +54,33 @@ body:
     attributes:
       label: Other information
       placeholder: Screenshots, additional logs, notes, etc.
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ## Issue severity
+
+        Please provide details around how often the issue is reproducible & how many users are affected.
+  - type: dropdown
+    id: reproducibility
+    attributes:
+      label: Reproducibility
+      options:
+        - Consistent
+        - Intermittent
+        - Once
+    validations:
+      required: true
+  - type: dropdown
+    id: users-affected
+    attributes:
+      label: Severity
+      description: How many users are impacted? A guess is fine.
+      options:
+        - One
+        - Some (< 50%)
+        - Most (> 50%)
+        - All
   - type: dropdown
     id: os
     attributes:

--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-severity
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-severity
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Automatically add a Priority label based off the contents of an issue

--- a/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/index.js
@@ -3,6 +3,55 @@ const debug = require( '../../debug' );
 /* global GitHub, WebhookPayloadIssue */
 
 /**
+ * Find specific plugin impacted by issue, based off issue contents.
+ *
+ * @param {string} body - The issue content.
+ * @returns {string} Plugin concerned by issue.
+ */
+function findPlugin( body ) {
+	const regex = /###\sImpacted\splugin\n\n(\w*)\n/gm;
+
+	let match;
+	while ( ( match = regex.exec( body ) ) ) {
+		const [ , plugin ] = match;
+		return plugin;
+	}
+
+	return null;
+}
+
+/**
+ * Find priority of issue, based off issue contents.
+ *
+ * @param {string} body - The issue content.
+ * @returns {string} Priority of issue.
+ */
+function findPriority( body ) {
+	const regex = /###\sSeverity\n\n(.*)\n/gm;
+
+	let match;
+	while ( ( match = regex.exec( body ) ) ) {
+		const [ , severity ] = match;
+
+		switch ( severity ) {
+			case 'All':
+				return 'High';
+			case 'Some (< 50%)':
+				return 'High';
+			case 'Most (> 50%)':
+				return 'Normal';
+			case 'One':
+				return 'Low';
+			default:
+				// This includes the "_No response_" case, where one does not fill in the severity field.
+				return null;
+		}
+	}
+
+	return null;
+}
+
+/**
  * Add labels to newly opened issues.
  *
  * @param {WebhookPayloadIssue} payload - Issue event payload.
@@ -13,18 +62,29 @@ async function triageNewIssues( payload, octokit ) {
 	const { number, body } = issue;
 	const { owner, name } = repository;
 
-	const regex = /###\sImpacted\splugin\n\n(\w*)\n/gm;
-
-	let match;
-	while ( ( match = regex.exec( body ) ) ) {
-		const [ , plugin ] = match;
-		debug( `triage-new-issues: Adding label to issue #${ number }` );
+	// Find impacted plugin.
+	const impactedPlugin = findPlugin( body );
+	if ( null !== impactedPlugin ) {
+		debug( `triage-new-issues: Adding plugin label to issue #${ number }` );
 
 		await octokit.rest.issues.addLabels( {
 			owner: owner.login,
 			repo: name,
 			issue_number: number,
-			labels: [ `[Plugin] ${ plugin }` ],
+			labels: [ `[Plugin] ${ impactedPlugin }` ],
+		} );
+	}
+
+	// Find Priority.
+	const priority = findPriority( body );
+	if ( null !== priority ) {
+		debug( `triage-new-issues: Adding priority label to issue #${ number }` );
+
+		await octokit.rest.issues.addLabels( {
+			owner: owner.login,
+			repo: name,
+			issue_number: number,
+			labels: [ `[Pri] ${ priority }` ],
 		} );
 	}
 }

--- a/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/readme.md
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/readme.md
@@ -9,4 +9,4 @@ This is best used in combination with GitHub [issue forms](https://docs.github.c
 
 ## Rationale
 
-Adding a label to new issues allows each team to get quick notices of issues that need their attention, without having to wait for a nanual triage. Priority also allows them to sort through the issues in the right order.
+Adding a label to new issues allows each team to get quick notices of issues that need their attention, without having to wait for manual triage. Priority also allows them to sort through the issues in the right order.

--- a/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/readme.md
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/readme.md
@@ -1,9 +1,12 @@
 # Triage New Issues
 
-Add labels to newly opened issues to indicate what plugin is impacted by the issue.
+Add labels to newly opened issues to help triage the issue:
+
+1. Add a `[Plugin]` label if a specific label is impacted by the issue.
+2. Add a `[Pri]` label if we can determine the severity of the issue from the issue contents.
 
 This is best used in combination with GitHub [issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms).
 
 ## Rationale
 
-Adding a label to new issues allows each plugin team to get quick notices of issues that need their attention, without having to wait for a nanual triage.
+Adding a label to new issues allows each team to get quick notices of issues that need their attention, without having to wait for a nanual triage. Priority also allows them to sort through the issues in the right order.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Let's automatically add a Priority label when information about the severity of the issue can be found in the contents of the issue.

This PR also updates the bug report issue template, to add a new "Severity" section that will be used to provide information about the severity of the issue. That section is exactly similar to the one used in the Calypso repo; that will allow us to use the Gardening action there as well.

**Screenshot of the new template section**
<img width="1032" alt="image" src="https://user-images.githubusercontent.com/426388/175900123-6b19aae5-b43a-4325-8eb1-06c0f806e93e.png">


#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

Internal reference: pciE2j-18N-p2

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

I'm afraid we'll need to merge this PR before we can really test this. You can see this in action in this test repo and issue:
- https://github.com/jeherve/jetpack/issues/27
