### PR TITLE
live-branches: Allow for not installing Jetpack

### DIFF
--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jetpack Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.21
+// @version      1.22
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @grant        GM_xmlhttpRequest
 // @connect      jurassic.ninja
@@ -136,6 +136,12 @@
 						<h4>Plugins</h4>
 						${ getOptionsList(
 							[
+								{
+									label: 'Jetpack',
+									name: 'nojetpack',
+									checked: true,
+									invert: true,
+								},
 								{
 									label: 'WordPress Beta Tester',
 									name: 'wordpress-beta-tester',
@@ -277,7 +283,9 @@
 		 */
 		function getLink() {
 			const query = [ 'jetpack-beta' ];
-			$( '#jetpack-live-branches input[type=checkbox]:checked' ).each( ( i, input ) => {
+			$(
+				'#jetpack-live-branches input[type=checkbox]:checked:not([data-invert]), #jetpack-live-branches input[type=checkbox][data-invert]:not(:checked)'
+			).each( ( i, input ) => {
 				if ( input.value ) {
 					query.push( encodeURIComponent( input.name ) + '=' + encodeURIComponent( input.value ) );
 				} else {
@@ -297,18 +305,19 @@
 		 * @param {string} [opts.value] - Checkbox value, if any.
 		 * @param {boolean} [opts.checked] - Whether the checkbox is default checked.
 		 * @param {boolean} [opts.disabled] - Whether the checkbox is disabled.
+		 * @param {boolean} [opts.invert] - Whether the sense of the checkbox is inverted.
 		 * @param {number} columnWidth - Column width.
 		 * @returns {string} HTML.
 		 */
 		function getOption(
-			{ disabled = false, checked = false, value = '', label, name },
+			{ disabled = false, checked = false, invert = false, value = '', label, name },
 			columnWidth
 		) {
 			// prettier-ignore
 			return `
 			<li style="min-width: ${ columnWidth }%">
 				<label style="font-weight: inherit; ">
-					<input type="checkbox" name="${ encodeHtmlEntities( name ) }" value="${ encodeHtmlEntities( value ) }"${ checked ? ' checked' : '' }${ disabled ? ' disabled' : '' }>
+					<input type="checkbox" name="${ encodeHtmlEntities( name ) }" value="${ encodeHtmlEntities( value ) }"${ checked ? ' checked' : '' }${ disabled ? ' disabled' : '' }${ invert ? ' data-invert' : '' }>
 					${ label }
 				</label>
 			</li>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Jurassic Ninja installs the release version of the Jetpack plugin by
default, unless a `nojetpack` option is supplied. Let's add a UI for
that to simplify testing of the standalone plugins without Jetpack
itself installed.

To keep the UI simple, we add "Jetpack" in the existing "Plugins" list,
pre-checked to preserve the current behavior as the default. In the JS
we invert the sense of this checkbox so `nojetpack` is added to the URL
when the checkbox is unchecked.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. But see pdV5qK-2I-p2#comment-81

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install the new version of the script from https://github.com/Automattic/jetpack/raw/add/live-branches-allow-no-jetpack/tools/jetpack-live-branches/jetpack-live-branches.user.js
* Load a PR. See the new "Jetpack" option under "Plugins". Verify that unchecking and checking it updates the URL as expected. Also verify that other existing checkboxes continue to update the URL as they did before.