### PR TITLE
Jetpack: implement uploading video for VideoPress block

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-videopress-allow-add-video-source
+++ b/projects/plugins/jetpack/changelog/update-jetpack-videopress-allow-add-video-source
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack: implement uploading video to VPBlock

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
@@ -788,7 +788,7 @@ const VideoPressEdit = CoreVideoEdit =>
 
 // The actual, final rendered video player markup
 // In a separate function component so that `useBlockProps` could be called.
-const VpBlock = props => {
+export const VpBlock = props => {
 	let { scripts } = props;
 	const { html, interactive, caption, isSelected, hideOverlay, attributes, setAttributes } = props;
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/attributes.js
@@ -1,4 +1,7 @@
 export default {
+	src: {
+		type: 'string',
+	},
 	autoplay: {
 		type: 'boolean',
 	},

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/attributes.js
@@ -1,4 +1,11 @@
 export default {
+	autoplay: {
+		type: 'boolean',
+	},
+	controls: {
+		type: 'boolean',
+		default: true,
+	},
 	id: {
 		type: 'number',
 	},
@@ -7,12 +14,5 @@ export default {
 	},
 	src: {
 		type: 'string',
-	},
-	autoplay: {
-		type: 'boolean',
-	},
-	controls: {
-		type: 'boolean',
-		default: true,
 	},
 };

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/attributes.js
@@ -1,4 +1,10 @@
 export default {
+	id: {
+		type: 'number',
+	},
+	guid: {
+		type: 'string',
+	},
 	src: {
 		type: 'string',
 	},

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -1,20 +1,27 @@
 /**
  * WordPress dependencies
  */
-import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	useBlockProps,
+	BlockIcon,
+	MediaPlaceholder,
+} from '@wordpress/block-editor';
 import { PanelBody, ToggleControl, Tooltip } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-
 /**
  * Internal dependencies
  */
-import './editor.scss';
+import { VideoPressIcon as icon } from '../../../shared/icons';
+
+const ALLOWED_MEDIA_TYPES = [ 'video' ];
+
+// @Todo: replace with uploading implementation.
+const noop = () => {};
 
 export default function VideoPressEdit( props ) {
 	const { attributes, setAttributes } = props;
-
-	const { controls } = attributes;
-
+	const { controls, src } = attributes;
 	const blockProps = useBlockProps( {
 		className: 'wp-block-jetpack-videopress',
 	} );
@@ -51,10 +58,27 @@ export default function VideoPressEdit( props ) {
 		</>
 	);
 
-	return (
-		<>
-			{ blockSettings }
-			<div { ...blockProps }>{ __( 'VideoPress', 'jetpack' ) }</div>
-		</>
-	);
+	if ( ! src ) {
+		return (
+			<>
+				{ blockSettings }
+				<div { ...blockProps }>
+					<MediaPlaceholder
+						icon={ <BlockIcon icon={ icon } /> }
+						labels={ {
+							title: __( 'VideoPress', 'jetpack' ),
+						} }
+						onSelect={ noop }
+						onSelectURL={ noop }
+						accept="video/*"
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						value={ attributes }
+						onError={ noop }
+					/>
+				</div>
+			</>
+		);
+	}
+
+	return <div { ...blockProps }>{ __( 'VideoPress', 'jetpack' ) }</div>;
 }

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -10,6 +10,7 @@ import {
 	MediaPlaceholder,
 } from '@wordpress/block-editor';
 import { SandBox, PanelBody, ToggleControl, Tooltip } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -43,8 +44,8 @@ export default function VideoPressEdit( { attributes, setAttributes } ) {
 	// Check whether it's working on the video preview
 	const { preview, isRequestingEmbedPreview } = useSelect(
 		select => ( {
-			preview: select( 'core' ).getEmbedPreview( videoPressUrl ),
-			isRequestingEmbedPreview: select( 'core' ).isRequestingEmbedPreview( videoPressUrl ),
+			preview: select( coreStore ).getEmbedPreview( videoPressUrl ),
+			isRequestingEmbedPreview: select( coreStore ).isRequestingEmbedPreview( videoPressUrl ),
 		} ),
 		[ videoPressUrl ]
 	);

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -25,6 +25,7 @@ import Loading from '../loading';
 // import { getJWT, useResumableUploader } from '../resumable-upload/use-uploader';
 import { getVideoPressUrl } from '../url';
 import { useResumableUploader } from './hooks/use-uploader.js';
+import './editor.scss';
 
 const ALLOWED_MEDIA_TYPES = [ 'video' ];
 
@@ -88,7 +89,7 @@ export default function VideoPressEdit( { attributes, setAttributes } ) {
 	}, [ src, prevMediaSrc, invalidateCachedEmbedPreview ] );
 
 	const blockProps = useBlockProps( {
-		className: 'wp-block-jetpack-videopress',
+		className: 'wp-block-jetpack-videopress is-placeholder-container',
 	} );
 
 	const renderControlLabelWithTooltip = ( label, tooltipText ) => {
@@ -171,20 +172,18 @@ export default function VideoPressEdit( { attributes, setAttributes } ) {
 	 */
 	if ( ! src && ! isUploadingFile && ! fileHasBeenUploaded ) {
 		return (
-			<div { ...blockProps }>
-				<MediaPlaceholder
-					icon={ <BlockIcon icon={ icon } /> }
-					labels={ {
-						title: __( 'VideoPress', 'jetpack' ),
-					} }
-					onSelect={ onSelectVideo }
-					onSelectURL={ onSelectURL }
-					accept="video/*"
-					allowedTypes={ ALLOWED_MEDIA_TYPES }
-					value={ attributes }
-					onError={ noop }
-				/>
-			</div>
+			<MediaPlaceholder
+				icon={ <BlockIcon icon={ icon } /> }
+				labels={ {
+					title: __( 'VideoPress', 'jetpack' ),
+				} }
+				onSelect={ onSelectVideo }
+				onSelectURL={ onSelectURL }
+				accept="video/*"
+				allowedTypes={ ALLOWED_MEDIA_TYPES }
+				value={ attributes }
+				onError={ noop }
+			/>
 		);
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -35,14 +35,8 @@ export default function VideoPressEdit( { attributes, setAttributes } ) {
 	const { controls, src, guid } = attributes;
 	const prevMediaSrc = usePrevious( src );
 
-	/*
-	 * Store here the file uploaded by the user to the client
-	 * This file is going to be uploaded to the VideoPress infrastructure
-	 */
-	const [ fileForUpload, setFileForUpload ] = useState( null );
-
 	const videoPressUrl = getVideoPressUrl( guid, {
-		controls: true, // @todo: behave all video options here.
+		controls,
 	} );
 
 	// Uploading file to backend states.

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -7,7 +7,7 @@ import {
 	BlockIcon,
 	MediaPlaceholder,
 } from '@wordpress/block-editor';
-import { PanelBody, ToggleControl, Tooltip } from '@wordpress/components';
+import { ExternalLink, PanelBody, ToggleControl, Tooltip } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -19,9 +19,9 @@ const ALLOWED_MEDIA_TYPES = [ 'video' ];
 // @Todo: replace with uploading implementation.
 const noop = () => {};
 
-export default function VideoPressEdit( props ) {
-	const { attributes, setAttributes } = props;
+export default function VideoPressEdit( { attributes, setAttributes } ) {
 	const { controls, src } = attributes;
+
 	const blockProps = useBlockProps( {
 		className: 'wp-block-jetpack-videopress',
 	} );
@@ -58,6 +58,10 @@ export default function VideoPressEdit( props ) {
 		</>
 	);
 
+	function onSelectURL( newSrc ) {
+		setAttributes( { src: newSrc } );
+	}
+
 	if ( ! src ) {
 		return (
 			<>
@@ -69,7 +73,7 @@ export default function VideoPressEdit( props ) {
 							title: __( 'VideoPress', 'jetpack' ),
 						} }
 						onSelect={ noop }
-						onSelectURL={ noop }
+						onSelectURL={ onSelectURL }
 						accept="video/*"
 						allowedTypes={ ALLOWED_MEDIA_TYPES }
 						value={ attributes }
@@ -80,5 +84,12 @@ export default function VideoPressEdit( props ) {
 		);
 	}
 
-	return <div { ...blockProps }>{ __( 'VideoPress', 'jetpack' ) }</div>;
+	return (
+		<div { ...blockProps }>
+			{ __( 'VideoPress', 'jetpack' ) }
+			<div>
+				<ExternalLink href={ src }>source</ExternalLink>
+			</div>
+		</div>
+	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -13,9 +13,8 @@ import { Button, PanelBody, ToggleControl, Tooltip } from '@wordpress/components
 import { usePrevious } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useState, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useCallback } from 'react';
 /**
  * Internal dependencies
  */

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/editor.scss
@@ -2,4 +2,20 @@
 
 .wp-block-jetpack-videopress {
 	background: var( --wp-admin-theme-color );
+
+	&.is-placeholder-container {
+		background: $white;
+		color: $gray-900;
+		font-family: $default-font;
+		box-sizing: border-box;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: flex-start;
+		padding: 20px;
+		border: 1px solid $gray-900;
+		border-radius: 2px;
+		font-size: $default-font-size;
+		min-height: 200px;
+	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/hooks/use-uploader.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/hooks/use-uploader.js
@@ -1,0 +1,131 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+import * as tus from 'tus-js-client';
+import { getJWT } from '../../resumable-upload/use-uploader';
+
+const jwtsForKeys = {};
+
+export const useResumableUploader = ( { onError, onProgress, onSuccess, key } ) => {
+	const [ data, setData ] = useState( {} );
+	const [ error, setError ] = useState( null );
+
+	// collect the jwt for the key
+	useEffect( () => {
+		getJWT( key ).then( setData ).catch( setError );
+	}, [ key, data ] );
+
+	const uploaded = file => {
+		const upload = new tus.Upload( file, {
+			onError: onError,
+			onProgress: onProgress,
+			endpoint: data.url,
+			removeFingerprintOnSuccess: true,
+			withCredentials: false,
+			autoRetry: true,
+			overridePatchMethod: false,
+			chunkSize: 10000000, // 10 Mb.
+			allowedFileTypes: [ 'video/*' ],
+			metadata: {
+				filename: file.name,
+				filetype: file.type,
+			},
+			retryDelays: [ 0, 1000, 3000, 5000, 10000 ],
+			onAfterResponse: function ( req, res ) {
+				// Why is this not showing the x-headers?
+				if ( res.getStatus() >= 400 ) {
+					return;
+				}
+
+				const GUID_HEADER = 'x-videopress-upload-guid';
+				const MEDIA_ID_HEADER = 'x-videopress-upload-media-id';
+				const SRC_URL_HEADER = 'x-videopress-upload-src-url';
+				const guid = res.getHeader( GUID_HEADER );
+				const mediaId = res.getHeader( MEDIA_ID_HEADER );
+				const src = res.getHeader( SRC_URL_HEADER );
+				if ( guid && mediaId && src ) {
+					onSuccess && onSuccess( { mediaId: Number( mediaId ), guid, src } );
+					return;
+				}
+
+				const headerMap = {
+					'x-videopress-upload-key-token': 'token',
+					'x-videopress-upload-key': 'key',
+				};
+
+				const tokenData = {};
+				Object.keys( headerMap ).forEach( function ( header ) {
+					const value = res.getHeader( header );
+					if ( ! value ) {
+						return;
+					}
+
+					tokenData[ headerMap[ header ] ] = value;
+				} );
+
+				if ( tokenData.key && tokenData.token ) {
+					jwtsForKeys[ tokenData.key ] = tokenData.token;
+				}
+			},
+			onBeforeRequest: function ( req ) {
+				// make ALL requests be either POST or GET to honor the public-api.wordpress.com "contract".
+				const method = req._method;
+				if ( [ 'HEAD', 'OPTIONS' ].indexOf( method ) >= 0 ) {
+					req._method = 'GET';
+					req.setHeader( 'X-HTTP-Method-Override', method );
+				}
+
+				if ( [ 'DELETE', 'PUT', 'PATCH' ].indexOf( method ) >= 0 ) {
+					req._method = 'POST';
+					req.setHeader( 'X-HTTP-Method-Override', method );
+				}
+
+				req._xhr.open( req._method, req._url, true );
+				// Set the headers again, reopening the xhr resets them.
+				Object.keys( req._headers ).map( function ( headerName ) {
+					req.setHeader( headerName, req._headers[ headerName ] );
+				} );
+
+				if ( 'POST' === method ) {
+					const hasJWT = !! data.token;
+					if ( hasJWT ) {
+						req.setHeader( 'x-videopress-upload-token', data.token );
+					} else {
+						throw 'should never happen';
+					}
+				}
+
+				if ( [ 'OPTIONS', 'GET', 'HEAD', 'DELETE', 'PUT', 'PATCH' ].indexOf( method ) >= 0 ) {
+					const url = new URL( req._url );
+					const path = url.pathname;
+					const parts = path.split( '/' );
+					const maybeUploadkey = parts[ parts.length - 1 ];
+					if ( jwtsForKeys[ maybeUploadkey ] ) {
+						req.setHeader( 'x-videopress-upload-token', jwtsForKeys[ maybeUploadkey ] );
+					} else if ( 'HEAD' === method ) {
+						return getJWT( maybeUploadkey ).then( responseData => {
+							jwtsForKeys[ maybeUploadkey ] = responseData.token;
+							req.setHeader( 'x-videopress-upload-token', responseData.token );
+							return req;
+						} );
+					}
+				}
+
+				return Promise.resolve( req );
+			},
+		} );
+
+		upload.findPreviousUploads().then( function ( previousUploads ) {
+			if ( previousUploads.length ) {
+				upload.resumeFromPreviousUpload( previousUploads[ 0 ] );
+			}
+
+			upload.start();
+		} );
+
+		return upload;
+	};
+
+	return [ uploaded, data, error ];
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds the basic logic to upload a video file to the VPBlock. The code is based, and partially it's a copy, of the current implementation of the VideoPress.

Most relevant changes:

* It registers three new block attributes: `src`, `guid` and `id`
* Adds a new `useResumableUploader()` hook
* Implement the basic logic to upload a video file

# Discalimer
It doesn't handle properly a cache issue. For now, when it happens, it renders a button to invalidate the cache in order to get the block preview properly. This is going to be handled in a follow-up PR.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack: implement uploading video for the VideoPress block:
  * Registers three new block attributes: `id`, `src` and `guid
  * Adds the new `useResumableUploader()` hook

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to block editor
* Add a VideoPress block instance
* Upload a video
* Confirm you see the changes in the UI showing the different states of the file
* Probably you'll get the message about there being a cache issue. Try to fix it by clicking on the "Clear cache" button.
* Save the post
* Confirm the block renders properly after a hard-refresh


https://user-images.githubusercontent.com/77539/175998439-b87c18b8-09bc-4055-b45a-6a3994e53d48.mov


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202490094773357