### PR TITLE
Jetpack: implement save process of the VideoPress block

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-videopress-save-block
+++ b/projects/plugins/jetpack/changelog/update-jetpack-videopress-save-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack: handle VideoPress block saving process

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/index.js
@@ -24,4 +24,7 @@ export const settings = {
 	edit,
 	save,
 	attributes,
+	supports: {
+		align: true,
+	},
 };

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/save.js
@@ -1,13 +1,32 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import { useBlockProps } from '@wordpress/block-editor';
-import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
+/**
+ * Internal dependencies
+ */
+import { getVideoPressUrl } from '../url';
 
-export default function save() {
+export default function save( { attributes } ) {
+	const { align, autoplay, guid } = attributes;
+
 	const blockProps = useBlockProps.save( {
-		className: 'jetpack-videopress',
+		className: classnames( 'jetpack-videopress', {
+			[ `align${ align }` ]: align,
+		} ),
 	} );
 
-	return <div { ...blockProps }>{ __( 'VideoPress', 'jetpack' ) }</div>;
+	const url = getVideoPressUrl( guid, {
+		autoplay,
+		controls: true, // @todo: implement.
+	} );
+
+	return (
+		<figure { ...blockProps }>
+			<div className="jetpack-videopress__wrapper">
+				{ `\n${ url }\n` /* URL needs to be on its own line. */ }
+			</div>
+		</figure>
+	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/save.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 import { getVideoPressUrl } from '../url';
 
 export default function save( { attributes } ) {
-	const { align, autoplay, guid } = attributes;
+	const { align, autoplay, guid, controls } = attributes;
 
 	const blockProps = useBlockProps.save( {
 		className: classnames( 'jetpack-videopress', {
@@ -19,7 +19,7 @@ export default function save( { attributes } ) {
 
 	const url = getVideoPressUrl( guid, {
 		autoplay,
-		controls: true, // @todo: implement.
+		controls,
 	} );
 
 	return (

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/style.scss
@@ -1,5 +1,3 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
-.jetpack-videopress {
-	background: var( --wp-admin-theme-color );
-}
+.jetpack-videopress {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

~# Branched off from https://github.com/Automattic/jetpack/pull/24844~

This PR implements the first approach to handling the saving process of the VideoPress block. Starting with the simplest approach, it simply renders the player in the front-end.
Also, it adds block alignment support.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack: implement save process of the VideoPress block

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create/edit a new post
* Add a VideoPress block
* Confirm the block supports alignment 

<img width="718" alt="image" src="https://user-images.githubusercontent.com/77539/176028010-fc41dfb3-bcbc-4509-af77-66a5bbe8ce6e.png">

* Save the post
* Confirm the player is properly rendered in the front-end
<img width="1054" alt="image" src="https://user-images.githubusercontent.com/77539/176028048-5098cc12-05aa-4c56-a3e2-b0b524cdc884.png">





---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202509770630161