### PR TITLE
VideoPress: Add Playback Control toggle

### DIFF
--- a/projects/plugins/jetpack/changelog/videopress-add-playback-controls-toggle
+++ b/projects/plugins/jetpack/changelog/videopress-add-playback-controls-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/attributes.js
@@ -2,4 +2,8 @@ export default {
 	autoplay: {
 		type: 'boolean',
 	},
+	controls: {
+		type: 'boolean',
+		default: true,
+	},
 };

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -1,7 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { useBlockProps } from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl, Tooltip } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -9,10 +10,51 @@ import { __ } from '@wordpress/i18n';
  */
 import './editor.scss';
 
-export default function VideoPressEdit() {
+export default function VideoPressEdit( props ) {
+	const { attributes, setAttributes } = props;
+
+	const { controls } = attributes;
+
 	const blockProps = useBlockProps( {
 		className: 'wp-block-jetpack-videopress',
 	} );
 
-	return <div { ...blockProps }>{ __( 'VideoPress', 'jetpack' ) }</div>;
+	const renderControlLabelWithTooltip = ( label, tooltipText ) => {
+		return (
+			<Tooltip text={ tooltipText } position="top">
+				<span>{ label }</span>
+			</Tooltip>
+		);
+	};
+
+	const toggleAttribute = attribute => {
+		return newValue => {
+			setAttributes( { [ attribute ]: newValue } );
+		};
+	};
+
+	const blockSettings = (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Video Settings', 'jetpack' ) }>
+					<ToggleControl
+						label={ renderControlLabelWithTooltip(
+							__( 'Playback Controls', 'jetpack' ),
+							/* translators: Tooltip describing the "controls" option for the VideoPress player */
+							__( 'Display the video playback controls', 'jetpack' )
+						) }
+						onChange={ toggleAttribute( 'controls' ) }
+						checked={ controls }
+					/>
+				</PanelBody>
+			</InspectorControls>
+		</>
+	);
+
+	return (
+		<>
+			{ blockSettings }
+			<div { ...blockProps }>{ __( 'VideoPress', 'jetpack' ) }</div>
+		</>
+	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -27,9 +27,9 @@ export default function VideoPressEdit( props ) {
 		);
 	};
 
-	const toggleAttribute = attribute => {
+	const handleAttributeChange = attributeName => {
 		return newValue => {
-			setAttributes( { [ attribute ]: newValue } );
+			setAttributes( { [ attributeName ]: newValue } );
 		};
 	};
 
@@ -43,7 +43,7 @@ export default function VideoPressEdit( props ) {
 							/* translators: Tooltip describing the "controls" option for the VideoPress player */
 							__( 'Display the video playback controls', 'jetpack' )
 						) }
-						onChange={ toggleAttribute( 'controls' ) }
+						onChange={ handleAttributeChange( 'controls' ) }
 						checked={ controls }
 					/>
 				</PanelBody>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds the "Playback Controls" toggle to the new VideoPress block

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
NA

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable beta blocks
* Add a couple of the new VideoPress block to a post
* Confirm you see the Video Settings panel on the sidebar:

![Captura de tela de 2022-06-27 17-20-48](https://user-images.githubusercontent.com/971483/176029496-8dc9ba21-157d-47f7-a50e-79ace58681df.png)

* Hover over the "Playback controls" label and confirm you see a tooltip
* Change the value of this option in some blocks
* Save the post and confirm the values are saved
* Check the source code and confirm you see `{"controls":false}` in those blocks where the option is set to false



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202509770630156