### PR TITLE
Move Comments in API Files for Sniff

### DIFF
--- a/projects/plugins/jetpack/changelog/update-comments-json-endpoints
+++ b/projects/plugins/jetpack/changelog/update-comments-json-endpoints
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+moving a comment

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-post-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-post-endpoint.php
@@ -248,7 +248,8 @@ abstract class WPCOM_JSON_API_Post_Endpoint extends WPCOM_JSON_API_Endpoint {
 						$response[ $key ] = htmlspecialchars_decode( (string) $response[ $key ], ENT_QUOTES );
 					}
 					break;
-				case 'parent': /** (object|false) */
+				/** (object|false) */
+				case 'parent':
 					if ( $post->post_parent ) {
 						$parent = get_post( $post->post_parent );
 						if ( 'display' === $context ) {
@@ -345,7 +346,8 @@ abstract class WPCOM_JSON_API_Post_Endpoint extends WPCOM_JSON_API_Endpoint {
 						$response[ $key ] = 'standard';
 					}
 					break;
-				case 'geo': /** (object|false) */
+				/** (object|false) */
+				case 'geo':
 					if ( ! $geo ) {
 						$response[ $key ] = false;
 					} else {
@@ -439,7 +441,8 @@ abstract class WPCOM_JSON_API_Post_Endpoint extends WPCOM_JSON_API_Endpoint {
 					}
 					$response[ $key ] = (object) $response[ $key ];
 					break;
-				case 'metadata': /** (array|false) */
+				/** (array|false) */
+				case 'metadata':
 					$metadata = array();
 					foreach ( (array) has_meta( $post_id ) as $meta ) {
 						// Don't expose protected fields.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php
@@ -220,7 +220,8 @@ abstract class WPCOM_JSON_API_Post_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint
 				case 'password':
 					$response[ $key ] = $post->get_password();
 					break;
-				case 'parent': /** (object|false) */
+				/** (object|false) */
+				case 'parent':
 					$response[ $key ] = $post->get_parent();
 					break;
 				case 'type':
@@ -259,7 +260,8 @@ abstract class WPCOM_JSON_API_Post_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint
 				case 'format':
 					$response[ $key ] = $post->get_format();
 					break;
-				case 'geo': /** (object|false) */
+				/** (object|false) */
+				case 'geo':
 					$response[ $key ] = $post->get_geo();
 					break;
 				case 'menu_order':
@@ -285,7 +287,8 @@ abstract class WPCOM_JSON_API_Post_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint
 					$response[ $key ]                       = $attachments;
 					$response['attachment_count']           = $attachment_count;
 					break;
-				case 'metadata': /** (array|false) */
+				/** (array|false) */
+				case 'metadata':
 					$response[ $key ] = $post->get_metadata();
 					break;
 				case 'meta':


### PR DESCRIPTION
This just moves some comments above the switch statement to make a bugged wpcom sniff check happy.*

#### Other information:

- [X] Have you written new tests for your changes, if applicable?
- [X] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* No testing required.'
*
