### PR TITLE
Lazy Images: Do not allow processing attributes more than once

### DIFF
--- a/projects/packages/lazy-images/changelog/fix-lazy-images-srcset-broken
+++ b/projects/packages/lazy-images/changelog/fix-lazy-images-srcset-broken
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixes an issue where process image attributes more than once resulted in images not being shown

--- a/projects/packages/lazy-images/src/lazy-images.php
+++ b/projects/packages/lazy-images/src/lazy-images.php
@@ -285,7 +285,7 @@ class Jetpack_Lazy_Images {
 		unset( $old_attributes['loading'] );
 
 		// If we've already processed the image don't process it again.
-		if ( isset( $old_attributes['data-lazy-src'] ) ) {
+		if ( self::has_image_been_processed( $old_attributes ) ) {
 			return sprintf( '<img %1$s>', self::build_attributes_string( $old_attributes ) );
 		}
 
@@ -307,8 +307,7 @@ class Jetpack_Lazy_Images {
 	 * @return array The updated image attributes array with lazy load attributes.
 	 */
 	public static function process_image_attributes( $attributes ) {
-		// Do not process more than once. See https://github.com/Automattic/jetpack/issues/23553.
-		if ( ! empty( $attributes['data-lazy-src'] ) ) {
+		if ( self::has_image_been_processed( $attributes ) ) {
 			return $attributes;
 		}
 
@@ -547,5 +546,39 @@ class Jetpack_Lazy_Images {
 		}
 
 		return $value;
+	}
+
+	/**
+	 * Helper method for determining if image has been processed before or not.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $attributes The image attributes.
+	 *
+	 * @return boolean True if image has been processed before, false otherwise.
+	 */
+	public static function has_image_been_processed( $attributes ) {
+		$non_empty_attributes = array(
+			'data-lazy-src',
+			'data-lazy-srcset',
+			'data-lazy-sizes',
+		);
+
+		foreach ( $non_empty_attributes as $attribute ) {
+			if ( ! empty( $attributes[ $attribute ] ) ) {
+				return true;
+			}
+		}
+
+		if ( isset( $attributes['class'] ) && false !== strpos( $attributes['class'], 'jetpack-lazy-image' ) ) {
+			return true;
+		}
+
+		// If placeholder image is set, then we've already processed the image.
+		if ( isset( $attributes['srcset'] ) && self::get_placeholder_image() === $attributes['srcset'] ) {
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/projects/packages/lazy-images/src/lazy-images.php
+++ b/projects/packages/lazy-images/src/lazy-images.php
@@ -307,6 +307,11 @@ class Jetpack_Lazy_Images {
 	 * @return array The updated image attributes array with lazy load attributes.
 	 */
 	public static function process_image_attributes( $attributes ) {
+		// Do not process more than once. See https://github.com/Automattic/jetpack/issues/23553.
+		if ( ! empty( $attributes['data-lazy-src'] ) ) {
+			return $attributes;
+		}
+
 		if ( empty( $attributes['src'] ) ) {
 			return $attributes;
 		}

--- a/projects/packages/lazy-images/tests/php/test_class.lazy-images.php
+++ b/projects/packages/lazy-images/tests/php/test_class.lazy-images.php
@@ -513,6 +513,7 @@ class WP_Test_Lazy_Images extends BaseTestCase {
 
 		$processed_attrs_again = $instance->process_image_attributes( $processed_attrs );
 
+		// phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual, WordPress.PHP.StrictComparisons.LooseEqual.
 		$this->assertTrue( $processed_attrs == $processed_attrs_again, 'Attributes are not the same after processing twice.' );
 
 		$instance->remove_filters();

--- a/projects/packages/lazy-images/tests/php/test_class.lazy-images.php
+++ b/projects/packages/lazy-images/tests/php/test_class.lazy-images.php
@@ -504,6 +504,17 @@ class WP_Test_Lazy_Images extends BaseTestCase {
 
 		$this->assertSame( $processed, $processed_again );
 
+		$attributes = array(
+			'src'    => 'image.jpg',
+			'srcset' => 'medium.jpg 1000w, large.jpg 2000w',
+		);
+
+		$processed_attrs = $instance->process_image_attributes( $attributes );
+
+		$processed_attrs_again = $instance->process_image_attributes( $processed_attrs );
+
+		$this->assertTrue( $processed_attrs == $processed_attrs_again, 'Attributes are not the same after processing twice.' );
+
 		$instance->remove_filters();
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #23553

#### Changes proposed in this Pull Request:

This PR fixes an issue where processing attributes more than once could result in images not displaying properly.

The issue was that, after processing more than once, `data-lazy-srcset` gets set to the placeholder image. Then, after the JS does its magic, the `srcset` value is set to the placeholder. The placeholder is a blank gif, so no joy.

This PR simply adds a conditional to return early if we're trying to reprocess.

While I was not able to reproduce the issue on a live site, I was able to find a case where this issue could happen, write a test for the broken flow, and then make the unit test pass.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->


See linked issue.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Enable module on a Jetpack/Atomic site
- Create posts with several images that go below the fold on the frontend
- Load post, scroll down, ensure all images load
