### PR TITLE
Boost: Sync Critical CSS state

### DIFF
--- a/projects/plugins/boost/app/contracts/Has_Slug.php
+++ b/projects/plugins/boost/app/contracts/Has_Slug.php
@@ -2,5 +2,5 @@
 namespace Automattic\Jetpack_Boost\Contracts;
 
 interface Has_Slug {
-	public function get_slug();
+	public static function get_slug();
 }

--- a/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS.php
+++ b/projects/plugins/boost/app/features/optimizations/cloud-css/Cloud_CSS.php
@@ -49,7 +49,7 @@ class Cloud_CSS implements Feature, Has_Endpoints {
 		return true;
 	}
 
-	public function get_slug() {
+	public static function get_slug() {
 		return 'cloud-css';
 	}
 

--- a/projects/plugins/boost/app/features/optimizations/critical-css/Critical_CSS.php
+++ b/projects/plugins/boost/app/features/optimizations/critical-css/Critical_CSS.php
@@ -73,7 +73,7 @@ class Critical_CSS implements Feature, Has_Endpoints {
 		return true;
 	}
 
-	public function get_slug() {
+	public static function get_slug() {
 		return 'critical-css';
 	}
 

--- a/projects/plugins/boost/app/features/optimizations/lazy-images/class-lazy-images.php
+++ b/projects/plugins/boost/app/features/optimizations/lazy-images/class-lazy-images.php
@@ -11,7 +11,7 @@ class Lazy_Images implements Feature {
 		add_action( 'wp', array( Jetpack_Lazy_Images::class, 'instance' ) );
 	}
 
-	public function get_slug() {
+	public static function get_slug() {
 		return 'lazy-images';
 	}
 

--- a/projects/plugins/boost/app/features/optimizations/render-blocking-js/class-render-blocking-js.php
+++ b/projects/plugins/boost/app/features/optimizations/render-blocking-js/class-render-blocking-js.php
@@ -306,7 +306,7 @@ class Render_Blocking_JS implements Feature {
 		return $opening_tags_count > $closing_tags_count;
 	}
 
-	public function get_slug() {
+	public static function get_slug() {
 		return 'render-blocking-js';
 	}
 

--- a/projects/plugins/boost/app/lib/Status.php
+++ b/projects/plugins/boost/app/lib/Status.php
@@ -32,12 +32,12 @@ class Status {
 	}
 
 	public function is_enabled() {
-		return '1' === get_option( $this->get_status_slug( $this->slug ) );
+		return '1' === get_option( $this->get_option_name( $this->slug ) );
 	}
 
 	public function update( $new_status ) {
 
-		if ( update_option( $this->get_status_slug( $this->slug ), (bool) $new_status ) ) {
+		if ( update_option( $this->get_option_name( $this->slug ), (bool) $new_status ) ) {
 			$this->update_mapped_modules( $new_status );
 			// Only record analytics event if the config update succeeds.
 			$this->track_module_status( (bool) $new_status );
@@ -46,7 +46,7 @@ class Status {
 		return false;
 	}
 
-	protected function get_status_slug( $module_slug ) {
+	protected function get_option_name( $module_slug ) {
 		return 'jetpack_boost_status_' . $module_slug;
 	}
 
@@ -56,7 +56,7 @@ class Status {
 		}
 
 		foreach ( $this->status_sync_map[ $this->slug ] as $mapped_module ) {
-			update_option( $this->get_status_slug( $mapped_module ), (bool) $new_status );
+			update_option( $this->get_option_name( $mapped_module ), (bool) $new_status );
 		}
 	}
 

--- a/projects/plugins/boost/app/lib/Status.php
+++ b/projects/plugins/boost/app/lib/Status.php
@@ -50,6 +50,14 @@ class Status {
 		return 'jetpack_boost_status_' . $module_slug;
 	}
 
+	/**
+	 * Update modules which are to follow the status of the current module.
+	 *
+	 * For example: critical-css module status should be synced with cloud-css module.
+	 *
+	 * @param $new_status
+	 * @return void
+	 */
 	protected function update_mapped_modules( $new_status ) {
 		if ( ! isset( $this->status_sync_map[ $this->slug ] ) ) {
 			return;

--- a/projects/plugins/boost/app/lib/Status.php
+++ b/projects/plugins/boost/app/lib/Status.php
@@ -15,7 +15,7 @@ class Status {
 	protected $slug;
 
 	/**
-	 *
+	 * A map of modules whose status are synced.
 	 *
 	 * @var array[] $status_sync_map
 	 */

--- a/projects/plugins/boost/app/lib/Status.php
+++ b/projects/plugins/boost/app/lib/Status.php
@@ -2,26 +2,62 @@
 
 namespace Automattic\Jetpack_Boost\Lib;
 
+use Automattic\Jetpack_Boost\Features\Optimizations\Cloud_CSS\Cloud_CSS;
+use Automattic\Jetpack_Boost\Features\Optimizations\Critical_CSS\Critical_CSS;
+
 class Status {
 
+	/**
+	 * Slug of the optimization module which is currently being toggled
+	 *
+	 * @var string $slug
+	 */
 	protected $slug;
 
+	/**
+	 *
+	 *
+	 * @var array[] $status_sync_map
+	 */
+	protected $status_sync_map;
+
 	public function __construct( $slug ) {
-		$this->slug = 'jetpack_boost_status_' . $slug;
+		$this->slug = $slug;
+
+		$this->status_sync_map = array(
+			Cloud_CSS::get_slug() => array(
+				Critical_CSS::get_slug(),
+			),
+		);
 	}
 
 	public function is_enabled() {
-		return '1' === get_option( $this->slug );
+		return '1' === get_option( $this->get_status_slug( $this->slug ) );
 	}
 
 	public function update( $new_status ) {
 
-		if ( update_option( $this->slug, (bool) $new_status ) ) {
+		if ( update_option( $this->get_status_slug( $this->slug ), (bool) $new_status ) ) {
+			$this->update_mapped_modules( $new_status );
 			// Only record analytics event if the config update succeeds.
 			$this->track_module_status( (bool) $new_status );
 			return true;
 		}
 		return false;
+	}
+
+	protected function get_status_slug( $module_slug ) {
+		return 'jetpack_boost_status_' . $module_slug;
+	}
+
+	protected function update_mapped_modules( $new_status ) {
+		if ( ! isset( $this->status_sync_map[ $this->slug ] ) ) {
+			return;
+		}
+
+		foreach ( $this->status_sync_map[ $this->slug ] as $mapped_module ) {
+			update_option( $this->get_status_slug( $mapped_module ), (bool) $new_status );
+		}
 	}
 
 	protected function track_module_status( $status ) {

--- a/projects/plugins/boost/changelog/add-sync-ccss-state
+++ b/projects/plugins/boost/changelog/add-sync-ccss-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Keep Critical CSS status in sync with Cloud CSS for better experience in Cloud CSS subscription expiration


### PR DESCRIPTION
Fixes 62-gh-Automattic/boost-cloud

#### Changes proposed in this Pull Request:
Toggle local critical CSS status in sync with cloud CSS. This will make sure critical CSS has the probable intended status if boost subscription has expired.

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No
#### Testing instructions:
* Enable or disable cloud CSS.
* Use `add_filter( 'jetpack_boost_has_feature_cloud-critical-css', '__return_false' );` to switch to local CCSS.
* Do this multiple times and make sure the status of critical CSS remains in sync with cloud CSS.