### PR TITLE
Publicize: Update package annotations

### DIFF
--- a/projects/packages/publicize/changelog/update-publicize-package-annotations
+++ b/projects/packages/publicize/changelog/update-publicize-package-annotations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+update annotations versions

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.7.0",
+	"version": "0.7.1-alpha",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/publicize/src/class-keyring-helper.php
+++ b/projects/packages/publicize/src/class-keyring-helper.php
@@ -110,7 +110,8 @@ class Keyring_Helper {
 		/**
 		 * Filters the API URL used to interact with WordPress.com.
 		 *
-		 * @since 2.0.0
+		 * @since 0.1.0
+		 * @since-jetpack 2.0.0
 		 *
 		 * @param string https://public-api.wordpress.com/connect/?jetpack=publicize Default Publicize API URL.
 		 */

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -147,9 +147,8 @@ abstract class Publicize_Base {
 				/**
 				 * Filter the default Publicize message.
 				 *
-				 * @module publicize
-				 *
-				 * @since 2.0.0
+				 * @since 0.1.0
+				 * @since-jetpack 2.0.0
 				 *
 				 * @param string $this->default_message Publicize's default message. Default is the post title.
 				 */
@@ -164,9 +163,8 @@ abstract class Publicize_Base {
 				/**
 				 * Filter the message prepended to the Publicize custom message.
 				 *
-				 * @module publicize
-				 *
-				 * @since 2.0.0
+				 * @since 0.1.0
+				 * @since-jetpack 2.0.0
 				 *
 				 * @param string $this->default_prefix String prepended to the Publicize custom message.
 				 */
@@ -180,9 +178,8 @@ abstract class Publicize_Base {
 				/**
 				 * Filter the message appended to the Publicize custom message.
 				 *
-				 * @module publicize
-				 *
-				 * @since 2.0.0
+				 * @since 0.1.0
+				 * @since-jetpack 2.0.0
 				 *
 				 * @param string $this->default_suffix String appended to the Publicize custom message.
 				 */
@@ -197,9 +194,8 @@ abstract class Publicize_Base {
 		 * All users with this cap can un-globalize all other global connections, and globalize any of their own
 		 * Globalized connections cannot be unselected by users without this capability when publishing.
 		 *
-		 * @module publicize
-		 *
-		 * @since 2.2.1
+		 * @since 0.1.0
+		 * @since-jetpack 2.2.1
 		 *
 		 * @param string $this->GLOBAL_CAP default capability in control of global Publicize connection options. Default to edit_others_posts.
 		 */
@@ -722,7 +718,8 @@ abstract class Publicize_Base {
 	 * data directly as array so it can be retrieved for static HTML generation
 	 * or JSON consumption.
 	 *
-	 * @since 6.7.0
+	 * @since 0.1.0
+	 * @since-jetpack 6.7.0
 	 *
 	 * @param integer $selected_post_id Optional. Post ID to query connection status for.
 	 *
@@ -776,9 +773,8 @@ abstract class Publicize_Base {
 				/**
 				 * Filter whether a post should be publicized to a given service.
 				 *
-				 * @module publicize
-				 *
-				 * @since 2.0.0
+				 * @since 0.1.0
+				 * @since-jetpack 2.0.0
 				 *
 				 * @param bool true Should the post be publicized to a given service? Default to true.
 				 * @param int $post_id Post ID.
@@ -821,9 +817,8 @@ abstract class Publicize_Base {
 				/**
 				 * Filter the checkbox state of each Publicize connection appearing in the post editor.
 				 *
-				 * @module publicize
-				 *
-				 * @since 2.0.1
+				 * @since 0.1.0
+				 * @since-jetpack 2.0.1
 				 *
 				 * @param bool $enabled Should the Publicize checkbox be enabled for a given service.
 				 * @param int $post_id Post ID.
@@ -842,9 +837,8 @@ abstract class Publicize_Base {
 					/**
 					 * Filters the checkboxes for global connections with non-prilvedged users.
 					 *
-					 * @module publicize
-					 *
-					 * @since 3.7.0
+					 * @since 0.1.0
+					 * @since-jetpack 3.7.0
 					 *
 					 * @param bool   $enabled Indicates if this connection should be enabled. Default true.
 					 * @param int    $post_id ID of the current post
@@ -880,7 +874,8 @@ abstract class Publicize_Base {
 	/**
 	 * Checks if post has already been shared by Publicize in the past.
 	 *
-	 * @since 6.7.0
+	 * @since 0.1.0
+	 * @since-jetpack 6.7.0
 	 *
 	 * @param integer $post_id Optional. Post ID to query connection status for: will use current post if missing.
 	 *
@@ -894,7 +889,8 @@ abstract class Publicize_Base {
 	 * Retrieves current available publicize service connections
 	 * with associated labels and URLs.
 	 *
-	 * @since 6.7.0
+	 * @since 0.1.0
+	 * @since-jetpack 6.7.0
 	 *
 	 * @return array {
 	 *     Array of UI service connection data for all services
@@ -977,9 +973,8 @@ abstract class Publicize_Base {
 		/**
 		 * Filter what user capability is required to use the publicize form on the edit post page. Useful if publish post capability has been removed from role.
 		 *
-		 * @module publicize
-		 *
-		 * @since 4.1.0
+		 * @since 0.1.0
+		 * @since-jetpack 4.1.0
 		 *
 		 * @param string $capability User capability needed to use publicize
 		 */
@@ -1218,7 +1213,8 @@ abstract class Publicize_Base {
 				 * Users may hook in here and do anything else they need to after meta is written,
 				 * and before the post is processed for Publicize.
 				 *
-				 * @since 2.1.2
+				 * @since 0.1.0
+				 * @since-jetpack 2.1.2
 				 *
 				 * @param bool $submit_post Should the post be publicized.
 				 * @param int $post->ID Post ID.

--- a/projects/packages/publicize/src/class-publicize-ui.php
+++ b/projects/packages/publicize/src/class-publicize-ui.php
@@ -571,9 +571,8 @@ jQuery( function($) {
 			/**
 			 * Filter the Publicize details form.
 			 *
-			 * @module publicize
-			 *
-			 * @since 2.0.0
+			 * @since 0.1.0
+			 * @since-jetpack 2.0.0
 			 *
 			 * @param string $publicize_form Publicize Details form appearing above Publish button in the editor.
 			 */
@@ -586,7 +585,8 @@ jQuery( function($) {
 	/**
 	 * Generates HTML content for connections form.
 	 *
-	 * @since 6.7
+	 * @since 0.1.0
+	 * @since-jetpack 6.7.0
 	 *
 	 * @global WP_Post $post The current post instance being published.
 	 *

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -490,8 +490,10 @@ class Publicize extends Publicize_Base {
 	/**
 	 * Get social networks, either all available or only those that the site is connected to.
 	 *
-	 * @since 2.0.0
-	 * @since 6.6.0 Removed Path. Service closed October 2018.
+	 * @since 0.1.0
+	 * @since-jetpack 2.0.0
+	 *
+	 * @since-jetpack 6.6.0 Removed Path. Service closed October 2018.
 	 *
 	 * @param string    $filter Select the list of services that will be returned. Defaults to 'all', accepts 'connected'.
 	 * @param false|int $_blog_id Get services for a specific blog by ID, or set to false for current blog. Default false.
@@ -553,10 +555,8 @@ class Publicize extends Publicize_Base {
 			 *
 			 * Side-note: Possibly our most alliterative filter name.
 			 *
-			 * @module publicize
-			 *
 			 * @since 0.1.0 No longer defaults to true. Adds checks to not publicize based on different contexts.
-			 * @since 4.1.0
+			 * @since-jetpack 4.1.0
 			 *
 			 * @param bool $should_publicize Should the post be publicized? Default to true.
 			 * @param WP_POST $post Current Post object.
@@ -613,7 +613,8 @@ class Publicize extends Publicize_Base {
 	 * 1. A POST_DONE . 'all' postmeta flag, or
 	 * 2. if the post has already been published.
 	 *
-	 * @since 6.7.0
+	 * @since 0.1.0
+	 * @since-jetpack 6.7.0
 	 *
 	 * @param integer $post_id Optional. Post ID to query connection status for: will use current post if missing.
 	 *


### PR DESCRIPTION
This PR updates the package annotation in Publicize package to match them with the package version instead of the Jetpack version.

When the annotation refers to a feature that existed before the package was created we are going to change it to the first released version of the package (0.1.0) and add a new annotation (eg. `@since-jetpack`) to register when this was first added to the Jetpack plugin

#### Changes proposed in this Pull Request:
- Updates the annotation versions to match the package version

#### Does this pull request change what data or activity we track or use?
- No

#### Testing instructions:
- Check if the versions changed match the conversion table in p9dueE-3cJ-p2