### PR TITLE
Contact Form Block: Ensure styles are enqueued in Block Widget, FSE Template, and FSE Template Part

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-render-contact-form-block-styles
+++ b/projects/plugins/jetpack/changelog/fix-render-contact-form-block-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+

--- a/projects/plugins/jetpack/changelog/fix-render-contact-form-block-styles
+++ b/projects/plugins/jetpack/changelog/fix-render-contact-form-block-styles
@@ -1,4 +1,4 @@
 Significance: patch
-Type: compat
+Type: bugfix
 
-
+Contact Form: ensure the forms are always properly displayed, regardless of how you add them to your site.

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -41,6 +41,7 @@ function grunion_contact_form_require_endpoint() {
 function grunion_contact_form_set_block_template_attribute( $template ) {
 	global $_wp_current_template_content;
 	if ( ABSPATH . WPINC . '/template-canvas.php' === $template ) {
+		Grunion_Contact_Form::style_on();
 		$_wp_current_template_content = grunion_contact_form_apply_block_attribute(
 			$_wp_current_template_content,
 			array(
@@ -95,6 +96,7 @@ add_filter( 'render_block', 'grunion_contact_form_unset_block_template_part_id_g
  * @return string
  */
 function grunion_contact_form_filter_widget_block_content( $content, $instance, $widget ) {
+	Grunion_Contact_Form::style_on();
 	// Inject 'block_template' => <widget-id> into all instances of the contact form block.
 	return grunion_contact_form_apply_block_attribute(
 		$content,
@@ -2564,6 +2566,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			return '';
 		}
 		if ( isset( $GLOBALS['grunion_block_template_part_id'] ) ) {
+			self::style_on();
 			$attributes['block_template_part'] = $GLOBALS['grunion_block_template_part_id'];
 		}
 		// Create a new Grunion_Contact_Form object (this class)


### PR DESCRIPTION
Ensures the `grunion.css` stylesheet is enqueued when the Contact Form Block renders inside of a Block Widget, FSE Template, or FSE Template Part.

Notably, the problem primarily manifests itself on 404 pages, because `Grunion_Contact_Form::style_on()` is called on `loop_start` for any page with a valid loop: https://github.com/Automattic/jetpack/blob/421a8745cd3216652aa99a3c2b35b6a826280765/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php#L291

Discovered while debugging https://github.com/Automattic/jetpack/issues/22749

### Block Widget screenshots

**Block Widget before**

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/36432/176174626-872c2df5-ec4c-4d36-aa62-2f6f0bee0984.png">

**Block Widget after**

<img width="1374" alt="image" src="https://user-images.githubusercontent.com/36432/176174667-877cad85-dd91-44ad-b515-f83867f052f6.png">

### FSE Template screenshots

**FSE Template before:**

<img width="1719" alt="image" src="https://user-images.githubusercontent.com/36432/176175581-dae4777c-b94a-4561-993e-9cbe6afd43d4.png">

**FSE Template after:**

<img width="1700" alt="image" src="https://user-images.githubusercontent.com/36432/176175538-68970ab9-9b33-4672-8c4d-f255951ab54b.png">

### FSE Template Part screenshots

**FSE Template Part before:**

<img width="1250" alt="image" src="https://user-images.githubusercontent.com/36432/176176210-bae2b6dc-3504-4721-87e5-c1575e0778fb.png">

**FSE Template Part after:**

<img width="1262" alt="image" src="https://user-images.githubusercontent.com/36432/176176245-c7774471-6238-4e91-beb9-deae3783d3b5.png">


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

### Jetpack product discussion

N/A

### Does this pull request change what data or activity we track or use?

No.

### Testing instructions:

#### Block Widget:
1. Activate the Twenty Nineteen theme.
2. Add a Contact Form Block to Widgets:

<img width="1732" alt="image" src="https://user-images.githubusercontent.com/36432/176174971-7cdd3fd4-2b65-4f54-92d7-a5b753394abc.png">

3. Observe the Contact Form Block to be styled when viewed within the sidebar:

<img width="1398" alt="image" src="https://user-images.githubusercontent.com/36432/176175214-393f3036-0dec-480d-a100-dfef5bf92f68.png">

#### FSE Template:
1. Activate the Twenty Twenty-Two theme.
2. Add a Contact Form Block to the 404 Template:

<img width="1352" alt="image" src="https://user-images.githubusercontent.com/36432/176175396-eab43426-1981-436a-90fe-8a376cb26802.png">

3. Observe the Contact Form Block to be styled when viewed on a 404 page:

<img width="1700" alt="image" src="https://user-images.githubusercontent.com/36432/176175538-68970ab9-9b33-4672-8c4d-f255951ab54b.png">

#### FSE Template Part:
1. Activate the Twenty Twenty-Two theme.
2. Add a Contact Form Block to the Footer Template Part:

<img width="1195" alt="image" src="https://user-images.githubusercontent.com/36432/176175996-5c44d6fd-faae-49db-aa75-f3c623e69206.png">

3. Observe the Contact Form Block to be styled when viewed in the footer:

<img width="1269" alt="image" src="https://user-images.githubusercontent.com/36432/176176512-0c45dc20-b9cd-4423-863f-b87d7dff8700.png">
