### PR TITLE
Jetpack: avoid re-render ensuring pass an unique setUploadingProgress() instance.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-wpblock-performance-issue
+++ b/projects/plugins/jetpack/changelog/update-jetpack-wpblock-performance-issue
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack: memoize uploading progress handler function

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -47,10 +47,7 @@ export default function VideoPressEdit( { attributes, setAttributes } ) {
 	 */
 	const [ uploadingProgress, setUploadingProgressState ] = useState( [] );
 
-	/*
-	 * Uploading progress handler, wrapper by the useCallback() hook
-	 * to avoid re-rendering the component when the progress is updated.
-	 */
+	// Define a memoized function to register the upload progress.
 	const setUploadingProgress = useCallback( function ( ...args ) {
 		setUploadingProgressState( args );
 	}, [] );

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -39,16 +39,36 @@ export default function VideoPressEdit( { attributes, setAttributes } ) {
 		controls,
 	} );
 
-	// Uploading file to backend states.
-	const [ uploadingProgress, setUploadingProgress ] = useState( [] );
+	/*
+	 * Tracking state when uploading the video file.
+	 * uploadingProgress is an array with two items:
+	 *  - the first item is the upload progress
+	 *  - the second item is total
+	 */
+	const [ uploadingProgress, setUploadingProgressState ] = useState( [] );
+
+	/*
+	 * Uploading progress handler, wrapper by the useCallback() hook
+	 * to avoid re-rendering the component when the progress is updated.
+	 */
+	const setUploadingProgress = useCallback( function ( ...args ) {
+		setUploadingProgressState( args );
+	}, [] );
+
+	/*
+	 * It's considered the file is uploading
+	 * when the progress value is lower than the total.
+	 */
 	const isUploadingFile = !! (
-		uploadingProgress?.length && uploadingProgress[ 0 ] !== uploadingProgress[ 1 ]
+		uploadingProgress?.length && uploadingProgress[ 0 ] < uploadingProgress[ 1 ]
 	);
+
+	// File has been upload when the progress value is equal to the total.
 	const fileHasBeenUploaded = !! (
 		uploadingProgress?.length && uploadingProgress[ 0 ] === uploadingProgress[ 1 ]
 	);
 
-	// Get video preview status
+	// Get video preview status.
 	const { preview, isRequestingEmbedPreview } = useSelect(
 		select => {
 			return {
@@ -101,7 +121,7 @@ export default function VideoPressEdit( { attributes, setAttributes } ) {
 
 	// Helper instance to upload the video to the VideoPress infrastructure.
 	const [ videoPressUploader ] = useResumableUploader( {
-		onProgress: ( progress, total ) => setUploadingProgress( [ progress, total ] ),
+		onProgress: setUploadingProgress,
 		onSuccess: setAttributes,
 	} );
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/hooks/use-uploader.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/hooks/use-uploader.js
@@ -14,7 +14,7 @@ export const useResumableUploader = ( { onError, onProgress, onSuccess, key } ) 
 	// collect the jwt for the key
 	useEffect( () => {
 		getJWT( key ).then( setData ).catch( setError );
-	}, [ key, data ] );
+	}, [ key ] );
 
 	const uploaded = file => {
 		const upload = new tus.Upload( file, {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR ensures to pass a unique instance of `setUploadingProgress()` function by wrapping it with the `useCallback()` hook, avoiding re-render the edit component needlessly.
Also, it improves the jsdoc a little bit.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack: avoid re-render ensuring pass an unique setUploadingProgress() instance.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* It isn't easy to see how these changes affect the functionality of the component. So, the testing instructions reduces to check everything is working as expected
* In case you want to check it, add a console.log() into the `useResumableUploader()` hook:

```es6
export const useResumableUploader = ( { onError, onProgress, onSuccess, key } ) => {
	console.count( ' useResumableUploader' );
	const [ data, setData ] = useState( {} );
	// ...
```





---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202514379845465