### PR TITLE
Actions: Clarify that SVN is the expected ID

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/fix-clarify-expected-changeset-id
+++ b/projects/github-actions/repo-gardening/changelog/fix-clarify-expected-changeset-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+

--- a/projects/github-actions/repo-gardening/changelog/fix-clarify-expected-changeset-id
+++ b/projects/github-actions/repo-gardening/changelog/fix-clarify-expected-changeset-id
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-
+WordPress.com Commit reminder: clarify wording of the message to help contributors.

--- a/projects/github-actions/repo-gardening/src/tasks/wpcom-commit-reminder/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/wpcom-commit-reminder/index.js
@@ -101,7 +101,7 @@ async function wpcomCommitReminder( payload, octokit ) {
 	// Build our comment body.
 	const comment = `
 Great news! One last step: head over to your WordPress.com diff, ${ diffId[ 0 ] }, and deploy it.
-Once you've done so, come back to this PR and add a comment with your SVN changeset ID (e.g. `r12345-wpcom`).
+Once you've done so, come back to this PR and add a comment with your SVN changeset ID (e.g. \`r12345-wpcom\`).
 
 **Thank you!**
 	`;

--- a/projects/github-actions/repo-gardening/src/tasks/wpcom-commit-reminder/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/wpcom-commit-reminder/index.js
@@ -101,7 +101,7 @@ async function wpcomCommitReminder( payload, octokit ) {
 	// Build our comment body.
 	const comment = `
 Great news! One last step: head over to your WordPress.com diff, ${ diffId[ 0 ] }, and deploy it.
-Once you've done so, come back to this PR and add a comment with your changeset ID.
+Once you've done so, come back to this PR and add a comment with your SVN changeset ID (e.g. `r12345-wpcom`).
 
 **Thank you!**
 	`;


### PR DESCRIPTION
Clarifies that the SVN changeset ID (not Git hash) is the expected ID:

<img width="1003" alt="image" src="https://user-images.githubusercontent.com/36432/176214424-9b64aaf4-5a76-4755-a993-b93ea76461e3.png">

From conversation in p1656428550703389/1656427306.796319-slack-C0347E545HR

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

N/A

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

N/A