### PR TITLE
Repo Gardening: introduce new task to triage to projects

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -3,7 +3,7 @@ on:
   pull_request_target: # When a PR is opened, edited, updated, closed, or a label is added.
     types: [opened, reopened, synchronize, edited, labeled, closed]
   issues: # For auto-triage of issues.
-    types: [opened, reopened]
+    types: [opened, reopened, labeled]
   push:
     branches:
       - trunk # Every time a PR is merged to trunk.
@@ -76,3 +76,5 @@ jobs:
           slack_team_channel: ${{ secrets.SLACK_TEAM_CHANNEL }}
           slack_design_channel: ${{ secrets.SLACK_DESIGN_CHANNEL }}
           slack_editorial_channel: ${{ secrets.SLACK_EDITORIAL_CHANNEL }}
+          project_automation_token: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}
+          project_automation_block_project: ${{ secrets.PROJECT_AUTOMATION_BLOCK_PROJECT }}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,16 +16,16 @@ importers:
 
   projects/github-actions/repo-gardening:
     specifiers:
-      '@actions/core': 1.6.0
-      '@actions/github': 5.0.1
+      '@actions/core': 1.9.0
+      '@actions/github': 5.0.3
       '@vercel/ncc': 0.28.5
       compare-versions: 3.6.0
       glob: 7.1.6
       moment: 2.29.2
       node-fetch: 2.6.7
     dependencies:
-      '@actions/core': 1.6.0
-      '@actions/github': 5.0.1
+      '@actions/core': 1.9.0
+      '@actions/github': 5.0.3
       compare-versions: 3.6.0
       glob: 7.1.6
       moment: 2.29.2
@@ -1905,10 +1905,27 @@ packages:
       '@actions/http-client': 1.0.11
     dev: false
 
+  /@actions/core/1.9.0:
+    resolution: {integrity: sha512-5pbM693Ih59ZdUhgk+fts+bUWTnIdHV3kwOSr+QIoFHMLg7Gzhwm0cifDY/AG68ekEJAkHnQVpcy4f6GjmzBCA==}
+    dependencies:
+      '@actions/http-client': 2.0.1
+    dev: false
+
   /@actions/github/5.0.1:
     resolution: {integrity: sha512-JZGyPM9ektb8NVTTI/2gfJ9DL7Rk98tQ7OVyTlgTuaQroariRBsOnzjy0I2EarX4xUZpK88YyO503fhmjFdyAg==}
     dependencies:
       '@actions/http-client': 1.0.11
+      '@octokit/core': 3.6.0
+      '@octokit/plugin-paginate-rest': 2.17.0_@octokit+core@3.6.0
+      '@octokit/plugin-rest-endpoint-methods': 5.13.0_@octokit+core@3.6.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /@actions/github/5.0.3:
+    resolution: {integrity: sha512-myjA/pdLQfhUGLtRZC/J4L1RXOG4o6aYdiEq+zr5wVVKljzbFld+xv10k1FX6IkIJtNxbAq44BdwSNpQ015P0A==}
+    dependencies:
+      '@actions/http-client': 2.0.1
       '@octokit/core': 3.6.0
       '@octokit/plugin-paginate-rest': 2.17.0_@octokit+core@3.6.0
       '@octokit/plugin-rest-endpoint-methods': 5.13.0_@octokit+core@3.6.0
@@ -1922,13 +1939,18 @@ packages:
       tunnel: 0.0.6
     dev: false
 
+  /@actions/http-client/2.0.1:
+    resolution: {integrity: sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==}
+    dependencies:
+      tunnel: 0.0.6
+    dev: false
+
   /@ampproject/remapping/2.2.0:
     resolution: {integrity: sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==}
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/gen-mapping': 0.1.1
       '@jridgewell/trace-mapping': 0.3.13
-    dev: true
 
   /@automattic/babel-plugin-preserve-i18n/1.0.0:
     resolution: {integrity: sha512-dRmLP0Ytf2oDNbUbO8MXLKYnPZfqhtFQ8v1hgDo2Fde1Y0bUz2Ll1UmUOHdyZudnrN/8Zt95cG/fIOJ0dxHi8Q==}
@@ -2089,7 +2111,6 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/eslint-parser/7.18.2_mw7va3pzj4xh5zikainml3ydb4:
     resolution: {integrity: sha512-oFQYkE8SuH14+uR51JVAmdqwKYXGRjEXx7s+WiagVjqQ+HPE+nnwyF2qlVG8evUsUHmPcA+6YXMEDbIhEyQc5A==}
@@ -2332,7 +2353,6 @@ packages:
       '@babel/types': 7.18.4
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/highlight/7.17.12:
     resolution: {integrity: sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==}
@@ -4025,7 +4045,6 @@ packages:
     dependencies:
       '@jridgewell/set-array': 1.1.1
       '@jridgewell/sourcemap-codec': 1.4.13
-    dev: true
 
   /@jridgewell/gen-mapping/0.3.1:
     resolution: {integrity: sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==}
@@ -12484,7 +12503,6 @@ packages:
   /gensync/1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /geojson-vt/3.2.1:
     resolution: {integrity: sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==}
@@ -16667,7 +16685,6 @@ packages:
 
   /preact/10.5.15:
     resolution: {integrity: sha512-5chK29n6QcJc3m1lVrKQSQ+V7K1Gb8HeQY6FViQ5AxCAEGu3DaHffWNDkC9+miZgsLvbvU9rxbV1qinGHMHzqA==}
-    dev: false
 
   /prelude-ls/1.1.2:
     resolution: {integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==}
@@ -18185,7 +18202,6 @@ packages:
     hasBin: true
     dependencies:
       chokidar: 3.5.3
-    dev: false
 
   /sass/1.43.3:
     resolution: {integrity: sha512-BJnLngqWpMeS65UvlYYEuCb3/fLxDxhHtOB/gWPxs6NKrslTxGt3ZxwIvOe/0Jm4tWwM/+tIpE3wj4dLEhPDeQ==}
@@ -19091,7 +19107,6 @@ packages:
   /svelte/3.42.4:
     resolution: {integrity: sha512-DqC0AmDdBrrbIA+Kzl3yhBb6qCn4vZOAfxye2pTnIpinLegyagC5sLI8Pe9GPlXu9VpHBXIwpDDedpMfu++epA==}
     engines: {node: '>= 8'}
-    dev: true
 
   /svelte2tsx/0.1.193_jnm2dayjvyndfzimboulpsettu:
     resolution: {integrity: sha512-vzy4YQNYDnoqp2iZPnJy7kpPAY6y121L0HKrSBjU/IWW7DQ6T7RMJed2VVHFmVYm0zAGYMDl9urPc6R4DDUyhg==}
@@ -19550,7 +19565,6 @@ packages:
     resolution: {integrity: sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==}
     engines: {node: '>=4.2.0'}
     hasBin: true
-    dev: true
 
   /uc.micro/1.0.6:
     resolution: {integrity: sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==}

--- a/projects/github-actions/repo-gardening/README.md
+++ b/projects/github-actions/repo-gardening/README.md
@@ -16,6 +16,7 @@ Here is the current list of tasks handled by this action:
 - Notify Editorial (`notifyEditorial`): Sends a Slack Notification to the Editorial team to request feedback, based on labels applied to a PR.
 - Flag OSS (`flagOss`): flags entries by external contributors, adds an "OSS Citizen" label to the PR, and sends a Slack message.
 - Triage New Issues (`triageNewIssues`): Adds labels to new issues based on issue content.
+- Add Issue to Board (`addIssueToBoard`): Adds an issue to a board based on the labels used on the issue.
 
 Some of the tasks are may not satisfy your needs. If that's the case, you can use the `tasks` option to limit the action to the list of tasks you need in your repo. See the example below to find out more.
 
@@ -75,6 +76,8 @@ The action relies on the following parameters.
 - (Optional) `slack_design_channel` is the Slack public channel ID where messages for the design team will be posted. Again, the value should be stored in a secret.
 - (Optional) `slack_editorial_channel` is the Slack public channel ID where messages for the Editorial team will be posted. Again, the value should be stored in a secret.
 - (Optional) `slack_team_channel` is the Slack public channel ID where general notifications about your repo should be posted. Again, the value should be stored in a secret.
+- (Optional) `project_automation_token` is a [personal access token](https://github.com/settings/tokens/new) with `repo` and `project` scopes. The token should be stored in a secret.
+- (Optional) `project_automation_block_project` is the node ID of the project that is used to triage block-related issues. The value should be stored in a secret.
 
 To create a bot and get your `SLACK_TOKEN`, follow [the general instructions here](https://slack.com/intl/en-hu/help/articles/115005265703-Create-a-bot-for-your-workspace):
 

--- a/projects/github-actions/repo-gardening/README.md
+++ b/projects/github-actions/repo-gardening/README.md
@@ -76,8 +76,8 @@ The action relies on the following parameters.
 - (Optional) `slack_design_channel` is the Slack public channel ID where messages for the design team will be posted. Again, the value should be stored in a secret.
 - (Optional) `slack_editorial_channel` is the Slack public channel ID where messages for the Editorial team will be posted. Again, the value should be stored in a secret.
 - (Optional) `slack_team_channel` is the Slack public channel ID where general notifications about your repo should be posted. Again, the value should be stored in a secret.
-- (Optional) `project_automation_token` is a [personal access token](https://github.com/settings/tokens/new) with `repo` and `project` scopes. The token should be stored in a secret.
-- (Optional) `project_automation_block_project` is the node ID of the project that is used to triage block-related issues. The value should be stored in a secret.
+- (Optional) `project_automation_token` is a [personal access token](https://github.com/settings/tokens/new) with `repo` and `project` scopes. The token should be stored in a secret. This is required if you want to use the `addIssueToBoard` task.
+- (Optional) `project_automation_block_project` is the ID of the project that is used to triage block-related issues. The value should be stored in a secret. This is required if you want to use the `addIssueToBoard` task.
 
 To create a bot and get your `SLACK_TOKEN`, follow [the general instructions here](https://slack.com/intl/en-hu/help/articles/115005265703-Create-a-bot-for-your-workspace):
 

--- a/projects/github-actions/repo-gardening/action.yml
+++ b/projects/github-actions/repo-gardening/action.yml
@@ -24,6 +24,14 @@ inputs:
     description: "Slack channel ID where general notifications should be sent"
     required: false
     default: ""
+  project_automation_token:
+    description: "Personal access token (with repo and project scopes) for the Project Automation task"
+    required: false
+    default: ""
+  project_automation_block_project:
+    description: "ID of the project that is used to triage block-related issues."
+    required: false
+    default: ""
   tasks:
     description: "Comma-separated selection of task names (function name, camelCase) this action should run. e.g. addLabels,cleanLabels"
     required: false

--- a/projects/github-actions/repo-gardening/changelog/add-project-triage-task
+++ b/projects/github-actions/repo-gardening/changelog/add-project-triage-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Introduce new task to triage specific issues into GitHub Project boards.

--- a/projects/github-actions/repo-gardening/package.json
+++ b/projects/github-actions/repo-gardening/package.json
@@ -13,8 +13,8 @@
 	],
 	"main": "src/index.js",
 	"dependencies": {
-		"@actions/core": "1.6.0",
-		"@actions/github": "5.0.1",
+		"@actions/core": "1.9.0",
+		"@actions/github": "5.0.3",
 		"compare-versions": "3.6.0",
 		"glob": "7.1.6",
 		"moment": "2.29.2",

--- a/projects/github-actions/repo-gardening/src/index.js
+++ b/projects/github-actions/repo-gardening/src/index.js
@@ -3,6 +3,7 @@ const { context, getOctokit } = require( '@actions/github' );
 const debug = require( './debug' );
 const ifNotClosed = require( './if-not-closed' );
 const ifNotFork = require( './if-not-fork' );
+const addIssueToBoard = require( './tasks/add-issue-to-board' );
 const addLabels = require( './tasks/add-labels' );
 const addMilestone = require( './tasks/add-milestone' );
 const assignIssues = require( './tasks/assign-issues' );
@@ -63,6 +64,11 @@ const automations = [
 		event: 'issues',
 		action: [ 'opened', 'reopened' ],
 		task: triageNewIssues,
+	},
+	{
+		event: 'issues',
+		action: [ 'labeled' ],
+		task: addIssueToBoard,
 	},
 ];
 

--- a/projects/github-actions/repo-gardening/src/tasks/add-issue-to-board/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-issue-to-board/index.js
@@ -82,11 +82,11 @@ async function addIssueToBoard( payload, octokit ) {
 				projectNumber: parseInt( blockProjectId, 10 ),
 			}
 		);
-		debug( `add-issue-to-board: ${ JSON.stringify( projectDetails ) }` );
+
+		// Get project board id.
 		const blockProjectNodeId = projectDetails.organization?.projectV2.id;
 
-		debug( `add-issue-to-board: block project node ID is ${ blockProjectNodeId }` );
-
+		// Add issue to project board.
 		await projectOctokit.graphql(
 			`mutation addIssueToProject($input: AddProjectV2ItemByIdInput!) {
 				addProjectV2ItemById(input: $input) {

--- a/projects/github-actions/repo-gardening/src/tasks/add-issue-to-board/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-issue-to-board/index.js
@@ -1,0 +1,108 @@
+const { getInput, setFailed } = require( '@actions/core' );
+const { getOctokit } = require( '@actions/github' );
+const debug = require( '../../debug' );
+const getLabels = require( '../../get-labels' );
+
+/* global GitHub, WebhookPayloadIssue */
+
+/**
+ * Check for block-related label on an issue.
+ *
+ * @param {GitHub} octokit - Initialized Octokit REST client.
+ * @param {string} owner   - Repository owner.
+ * @param {string} repo    - Repository name.
+ * @param {string} number  - Issue number.
+ * @returns {Promise<boolean>} Promise resolving to boolean.
+ */
+async function hasBlockLabel( octokit, owner, repo, number ) {
+	const labels = await getLabels( octokit, owner, repo, number );
+
+	// We're only interested in the labels related to blocks (or "extensions").
+	const blockLabelIndicators = [ '[Block]', '[Extension]', 'Gutenberg' ];
+
+	const hasLabel = labels.filter( label =>
+		blockLabelIndicators.some( indicator => label.includes( indicator ) )
+	);
+
+	if ( ! hasLabel.length ) {
+		debug( 'add-issue-to-board: This issue does not have block labels.' );
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Add an issue to a specific GitHub project board if necessary.
+ *
+ * @param {WebhookPayloadIssue} payload - Issue event payload.
+ * @param {GitHub}              octokit - Initialized Octokit REST client.
+ */
+async function addIssueToBoard( payload, octokit ) {
+	const { issue, repository } = payload;
+	const { number, node_id } = issue;
+	const { owner, name } = repository;
+	const ownerLogin = owner.login;
+
+	const projectToken = getInput( 'project_automation_token' );
+	if ( ! projectToken ) {
+		setFailed(
+			`add-issue-to-board: Input project_automation_token is required but missing. Aborting.`
+		);
+		return;
+	}
+
+	// Check if the issue has a block-related label.
+	const touchesBlocks = await hasBlockLabel( octokit, ownerLogin, name, number );
+
+	// ID of the board used to triage block-related issues.
+	const blockProjectId = getInput( 'project_automation_block_project' );
+
+	if ( true === touchesBlocks && blockProjectId ) {
+		debug(
+			`add-issue-to-board: Block-related issue. Adding #${ number } to project #${ blockProjectId }`
+		);
+
+		// For this task, we need octokit to have extra permissions not provided by the default GitHub token.
+		// Let's create a new octokit instance using our own custom token.
+		// eslint-disable-next-line new-cap
+		const projectOctokit = new getOctokit( projectToken );
+
+		// Use the GraphQL API to request the project's details.
+		const projectDetails = await projectOctokit.graphql(
+			`query getProject($ownerName: String!, $projectNumber: Int!) {
+				organization(login: $ownerName) {
+					projectV2(number: $projectNumber) {
+						id
+					}
+				}
+			}`,
+			{
+				ownerName: ownerLogin,
+				projectNumber: parseInt( blockProjectId, 10 ),
+			}
+		);
+		debug( `add-issue-to-board: ${ JSON.stringify( projectDetails ) }` );
+		const blockProjectNodeId = projectDetails.organization?.projectV2.id;
+
+		debug( `add-issue-to-board: block project node ID is ${ blockProjectNodeId }` );
+
+		await projectOctokit.graphql(
+			`mutation addIssueToProject($input: AddProjectV2ItemByIdInput!) {
+				addProjectV2ItemById(input: $input) {
+					item {
+						id
+					}
+				}
+			}`,
+			{
+				input: {
+					projectId: blockProjectNodeId,
+					contentId: node_id,
+				},
+			}
+		);
+	}
+}
+
+module.exports = addIssueToBoard;

--- a/projects/github-actions/repo-gardening/src/tasks/add-issue-to-board/readme.md
+++ b/projects/github-actions/repo-gardening/src/tasks/add-issue-to-board/readme.md
@@ -1,0 +1,7 @@
+# Add Issue to Board
+
+Add issues to a specific board based on the labels used on the issue.
+
+## Rationale
+
+Quickly triaging issues and directing them to the right team as quickly as possible is important. If we automatically add issues to the right board depending on the labels used on the issue, we should be able to speed up that process.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -167,6 +167,7 @@ async function getLabelsToAdd( octokit, owner, repo, number ) {
 		}
 
 		// Existing blocks and block plugins.
+		// If you update the label names here, make sure to update them in add-issue-to-board/index.js as well.
 		const blocks = file.match(
 			/^projects\/plugins\/jetpack\/extensions\/(?<type>blocks|plugins)\/(?<block>[^/]*)\//
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This should allow us to add issues to specific GitHub Project boards based on the labels used in the issue.

It relies on two new inputs to be added in each repo wanting to use the new task, `addIssueToBoard`:

- `project_automation_token` is a [personal access token](https://github.com/settings/tokens/new) with `repo` and `project` scopes. On our end, it can be handled via a token created via Matticbot. It is needed because traditional GitHub API requests made via the repo gardening action are done with a default set of permissions, which do not include permissions to manage projects, or projects in your organization.
-  `project_automation_block_project` is the ID of the project that is used to triage block-related issues. The value should be stored in a secret.

I've also taken the opportunity to update the GitHub dependencies used by the action, to benefit from the latest options.

> **Note**

This works in my tests, but with 2 important caveats.

It will only work with **the new GitHub projects**, currently in Beta. The "classic projects" seem to be on their way to being deprecated, and will be migrated to the new GitHub projects, either manually by their admins for now, or automatically in the future. I have not been able to find documentation on a timeline for that though. We only know that the API for the "classic projects" [will stop working on October 1, 2022](https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/).

Supporting both types of projects at the same time may not be useful, and will require a lot of logic to support both types since the graphQL queries are different for each project type.

**As is, this won't work for us since the board we would use is still a classic project, it would need to be migrated. I do not have the permission to do that as I am not a GitHub owner, and I would want to warn the folks using the project board first.**

Furthermore, this task can only be used in repos within an organization, since it looks for projects within an organization, not an individual user's account.

> **To do**

- [ ] Document the new inputs in the existing Jetpack Monorepo FG page.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

Internal references:

- pciE2j-18N-p2
- p3topS-193-p2

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* This will need to be tested in a separate test repo, since the code needs to be merged so one can add labels to an issue and see that the issue is properly added to a board.
* I've already added the necessary new inputs to this repository as well as Calypso.