### PR TITLE
Contact Form Block: Prevent error notice when processing form submission from 404 page

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-contact-form-block-404-error-notice
+++ b/projects/plugins/jetpack/changelog/fix-contact-form-block-404-error-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Contact Form Block: Prevent error notice when processing submission from 404 page

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -3507,7 +3507,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 				'post_date'    => addslashes( $feedback_time ),
 				'post_type'    => 'feedback',
 				'post_status'  => addslashes( $feedback_status ),
-				'post_parent'  => (int) $post->ID,
+				'post_parent'  => $post ? (int) $post->ID : 0,
 				'post_title'   => addslashes( wp_kses( $feedback_title, array() ) ),
 				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.InterpolatedVariableNotSnakeCase, WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DevelopmentFunctions.error_log_print_r
 				'post_content' => addslashes( wp_kses( "$comment_content\n<!--more-->\nAUTHOR: {$comment_author}\nAUTHOR EMAIL: {$comment_author_email}\nAUTHOR URL: {$comment_author_url}\nSUBJECT: {$subject}\nIP: {$comment_author_IP}\n" . @print_r( $all_values, true ), array() ) ), // so that search will pick up this data


### PR DESCRIPTION
While it's nice to have `post_parent` set to the originating `$post`, no such global `$post` exists on the 404 page.

Fixes https://github.com/Automattic/jetpack/issues/22749#issuecomment-1168777357

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

N/A

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

1. Activate the Twenty Twenty-Two theme.
2. Add a Contact Form Block to the 404 FSE Template.
3. Navigate to a 404 page.
4. Submit the Contact Form Block.
5. Observe the form submit successfully without PHP error notices.