### PR TITLE
Lazy Images: release v2.1.19

### DIFF
--- a/projects/packages/lazy-images/CHANGELOG.md
+++ b/projects/packages/lazy-images/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.19] - 2022-06-28
+### Fixed
+- Fix an issue where processing image attributes more than once resulted in images not being displayed.
+
 ## [2.1.18] - 2022-06-21
 ### Changed
 - Disable core lazy loading implementation for images that get lazy loaded by Jetpack
@@ -237,6 +241,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Lazy Images: Move into a package
 
+[2.1.19]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.1.18...v2.1.19
 [2.1.18]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.1.17...v2.1.18
 [2.1.17]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.1.16...v2.1.17
 [2.1.16]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.1.15...v2.1.16

--- a/projects/packages/lazy-images/changelog/fix-lazy-images-srcset-broken
+++ b/projects/packages/lazy-images/changelog/fix-lazy-images-srcset-broken
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixes an issue where process image attributes more than once resulted in images not being shown

--- a/projects/packages/lazy-images/src/lazy-images.php
+++ b/projects/packages/lazy-images/src/lazy-images.php
@@ -551,7 +551,7 @@ class Jetpack_Lazy_Images {
 	/**
 	 * Helper method for determining if image has been processed before or not.
 	 *
-	 * @since $$next-version$$
+	 * @since 2.1.19
 	 *
 	 * @param array $attributes The image attributes.
 	 *

--- a/projects/plugins/jetpack/changelog/jetpack-branch-11.1
+++ b/projects/plugins/jetpack/changelog/jetpack-branch-11.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Release v2.1.19 of the lazy images package.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

n/a

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

Proofread.
