### PR TITLE
Fix feature caching

### DIFF
--- a/projects/plugins/boost/app/lib/Premium_Features.php
+++ b/projects/plugins/boost/app/lib/Premium_Features.php
@@ -17,9 +17,9 @@ class Premium_Features {
 	}
 
 	public static function get_features() {
-		$features = Transient::get( self::TRANSIENT_KEY, array() );
+		$features = Transient::get( self::TRANSIENT_KEY, false );
 
-		if ( empty( $features ) ) {
+		if ( ! is_array( $features ) ) {
 			$features = Boost_API::get( 'features' );
 			if ( ! is_array( $features ) ) {
 				$features = array();

--- a/projects/plugins/boost/changelog/fix-feature-caching
+++ b/projects/plugins/boost/changelog/fix-feature-caching
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix caching of purchased plan features to reduce calls to wpcom api


### PR DESCRIPTION
Fix caching of Premium features when none purchased, to prevent unnecessary calls to the WPCOM API.

#### Changes proposed in this Pull Request:
* Don't treat an empty array (i.e.: no purchased features) as a cache miss.

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Make sure that Jetpack Boost doesn't hit the feature API more often than it needs to
* Make sure that upgrading Boost still works.

