### PR TITLE
Search: Record meter display post type label instead of slug

### DIFF
--- a/projects/packages/search/changelog/add-search-record-meter-get-post-type-labels
+++ b/projects/packages/search/changelog/add-search-record-meter-get-post-type-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Record Meter: adds labels to custom post type breakdown

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -72,6 +72,7 @@ class Initial_State {
 				'blogId'            => Jetpack_Options::get_option( 'id', 0 ),
 				'version'           => Package::VERSION,
 				'calypsoSlug'       => ( new Status() )->get_site_suffix(),
+				'postTypeLabels'    => $this->get_post_type_labels(),
 			),
 			'userData'        => array(
 				'currentUser' => $this->current_user_data(),
@@ -85,7 +86,6 @@ class Initial_State {
 				// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 				isset( $_GET['features'] ) ? explode( ',', wp_unslash( $_GET['features'] ) ) : array()
 			),
-			'postTypeLabels'  => $this->get_post_type_labels(),
 		);
 	}
 

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -15,6 +15,7 @@ use Jetpack_Options;
  * The React initial state.
  */
 class Initial_State {
+
 	/**
 	 * Connection Manager
 	 *
@@ -60,6 +61,7 @@ class Initial_State {
 				'WP_API_root'       => esc_url_raw( rest_url() ),
 				'WP_API_nonce'      => wp_create_nonce( 'wp_rest' ),
 				'registrationNonce' => wp_create_nonce( 'jetpack-registration-nonce' ),
+				'postTypeLabels'    => $this->get_post_type_labels(),
 				'purchaseToken'     => $this->get_purchase_token(),
 				/**
 				 * Whether promotions are visible or not.
@@ -110,6 +112,27 @@ class Initial_State {
 		);
 
 		return $current_user_data;
+	}
+
+	/**
+	 * Gets the post type labels for all of the site's post types (including custom post types)
+	 *
+	 * @return array
+	 */
+	protected function get_post_type_labels() {
+		global $wp_post_types;
+		$post_type_labels = array();
+
+		// We don't need all the additional post_type data, just the slug & label
+		foreach ( $wp_post_types as $post_type_object ) {
+			$post_type_data = array(
+				'slug'  => $post_type_object->name,
+				'label' => $post_type_object->label,
+			);
+
+			$post_type_labels[] = $post_type_data;
+		}
+		return $post_type_labels;
 	}
 
 	/**

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -124,13 +124,13 @@ class Initial_State {
 		$post_type_labels = array();
 
 		// We don't need all the additional post_type data, just the slug & label
-		foreach ( $wp_post_types as $post_type_object ) {
-			$post_type_data = array(
-				'slug'  => $post_type_object->name,
-				'label' => $post_type_object->label,
+		foreach ( $wp_post_types as $wp_post_type ) {
+			$post_type = array(
+				'slug'  => $wp_post_type->name,
+				'label' => $wp_post_type->label,
 			);
 
-			$post_type_labels[] = $post_type_data;
+			$post_type_labels[] = $post_type;
 		}
 		return $post_type_labels;
 	}

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -61,7 +61,6 @@ class Initial_State {
 				'WP_API_root'       => esc_url_raw( rest_url() ),
 				'WP_API_nonce'      => wp_create_nonce( 'wp_rest' ),
 				'registrationNonce' => wp_create_nonce( 'jetpack-registration-nonce' ),
-				'postTypeLabels'    => $this->get_post_type_labels(),
 				'purchaseToken'     => $this->get_purchase_token(),
 				/**
 				 * Whether promotions are visible or not.
@@ -86,6 +85,7 @@ class Initial_State {
 				// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 				isset( $_GET['features'] ) ? explode( ',', wp_unslash( $_GET['features'] ) ) : array()
 			),
+			'postTypeLabels'  => $this->get_post_type_labels(),
 		);
 	}
 

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -72,7 +72,7 @@ class Initial_State {
 				'blogId'            => Jetpack_Options::get_option( 'id', 0 ),
 				'version'           => Package::VERSION,
 				'calypsoSlug'       => ( new Status() )->get_site_suffix(),
-				'postTypeLabels'    => $this->get_post_type_labels(),
+				'postTypes'         => $this->get_post_types_with_labels(),
 			),
 			'userData'        => array(
 				'currentUser' => $this->current_user_data(),
@@ -119,25 +119,26 @@ class Initial_State {
 	 *
 	 * @return array
 	 */
-	protected function get_post_type_labels() {
+	protected function get_post_types_with_labels() {
 
 		$args = array(
 			'public' => true,
 		);
 
-		$post_type_labels = array();
-		$post_types       = get_post_types( $args, 'objects' );
+		$post_types_with_labels = array();
+
+		$post_types = get_post_types( $args, 'objects' );
 
 		// We don't need all the additional post_type data, just the slug & label
-		foreach ( $post_types as $wp_post_type ) {
-			$post_type = array(
-				'slug'  => $wp_post_type->name,
-				'label' => $wp_post_type->label,
+		foreach ( $post_types as $post_type ) {
+			$post_type_with_label = array(
+				'slug'  => $post_type->name,
+				'label' => $post_type->label,
 			);
 
-			$post_type_labels[] = $post_type;
+			$post_types_with_labels[] = $post_type_with_label;
 		}
-		return $post_type_labels;
+		return $post_types_with_labels;
 	}
 
 	/**

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -120,11 +120,16 @@ class Initial_State {
 	 * @return array
 	 */
 	protected function get_post_type_labels() {
-		global $wp_post_types;
+
+		$args = array(
+			'public' => true,
+		);
+
 		$post_type_labels = array();
+		$post_types       = get_post_types( $args, 'objects' );
 
 		// We don't need all the additional post_type data, just the slug & label
-		foreach ( $wp_post_types as $wp_post_type ) {
+		foreach ( $post_types as $wp_post_type ) {
 			$post_type = array(
 				'slug'  => $wp_post_type->name,
 				'label' => $wp_post_type->label,

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -136,7 +136,7 @@ class Initial_State {
 				'label' => $post_type->label,
 			);
 
-			$post_types_with_labels[] = $post_type_with_label;
+			$post_types_with_labels[ $post_type->name ] = $post_type_with_label;
 		}
 		return $post_types_with_labels;
 	}

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -65,7 +65,7 @@ export default function DashboardPage( { isLoading = false } ) {
 	const postCount = useSelect( select => select( STORE_ID ).getPostCount() );
 	const postTypeBreakdown = useSelect( select => select( STORE_ID ).getPostTypeBreakdown() );
 	const lastIndexedDate = useSelect( select => select( STORE_ID ).getLastIndexedDate() );
-
+	const postTypeLabels = useSelect( select => select( STORE_ID ).getPostTypeLabels() );
 	const handleLocalNoticeDismissClick = useDispatch( STORE_ID ).removeNotice;
 	const notices = useSelect( select => select( STORE_ID ).getNotices(), [] );
 
@@ -164,6 +164,7 @@ export default function DashboardPage( { isLoading = false } ) {
 							postTypeBreakdown={ postTypeBreakdown }
 							tierMaximumRecords={ tierMaximumRecords }
 							lastIndexedDate={ lastIndexedDate }
+							postTypeLabels={ postTypeLabels }
 						/>
 					) }
 					{ renderModuleControl() }

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -65,7 +65,7 @@ export default function DashboardPage( { isLoading = false } ) {
 	const postCount = useSelect( select => select( STORE_ID ).getPostCount() );
 	const postTypeBreakdown = useSelect( select => select( STORE_ID ).getPostTypeBreakdown() );
 	const lastIndexedDate = useSelect( select => select( STORE_ID ).getLastIndexedDate() );
-	const postTypeLabels = useSelect( select => select( STORE_ID ).getPostTypeLabels() );
+	const postTypes = useSelect( select => select( STORE_ID ).getPostTypes() );
 	const handleLocalNoticeDismissClick = useDispatch( STORE_ID ).removeNotice;
 	const notices = useSelect( select => select( STORE_ID ).getNotices(), [] );
 
@@ -164,7 +164,7 @@ export default function DashboardPage( { isLoading = false } ) {
 							postTypeBreakdown={ postTypeBreakdown }
 							tierMaximumRecords={ tierMaximumRecords }
 							lastIndexedDate={ lastIndexedDate }
-							postTypeLabels={ postTypeLabels }
+							postTypes={ postTypes }
 						/>
 					) }
 					{ renderModuleControl() }

--- a/projects/packages/search/src/dashboard/components/record-meter/index.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/index.jsx
@@ -13,7 +13,7 @@ import './style.scss';
  * @param {object} props - Props
  * @param {number} props.postCount - Post count number of posts in total
  * @param {object} props.postTypeBreakdown - Post type breakdown (post type => number of posts)
- * @param {object} props.postTypeLabels - Post type labels (post type label => post type slug)
+ * @param {object} props.postTypes - Post types  (post type label => post type slug)
  * @param {number} props.tierMaximumRecords - Max number of records allowed in user's current tier
  * @param {string} props.lastIndexedDate - The date on which the site was last indexed in ISO 8601 format
  * @returns {React.Component} RecordMeter React component
@@ -23,9 +23,9 @@ export default function RecordMeter( {
 	postTypeBreakdown,
 	tierMaximumRecords,
 	lastIndexedDate,
-	postTypeLabels,
+	postTypes,
 } ) {
-	const recordInfo = getRecordInfo( postCount, postTypeBreakdown, lastIndexedDate, postTypeLabels );
+	const recordInfo = getRecordInfo( postCount, postTypeBreakdown, lastIndexedDate, postTypes );
 
 	return (
 		<div className="jp-search-record-meter jp-search-dashboard-wrap" data-testid="record-meter">

--- a/projects/packages/search/src/dashboard/components/record-meter/index.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/index.jsx
@@ -13,6 +13,7 @@ import './style.scss';
  * @param {object} props - Props
  * @param {number} props.postCount - Post count number of posts in total
  * @param {object} props.postTypeBreakdown - Post type breakdown (post type => number of posts)
+ * @param {object} props.postTypeLabels - Post type labels (post type label => post type slug)
  * @param {number} props.tierMaximumRecords - Max number of records allowed in user's current tier
  * @param {string} props.lastIndexedDate - The date on which the site was last indexed in ISO 8601 format
  * @returns {React.Component} RecordMeter React component
@@ -22,8 +23,9 @@ export default function RecordMeter( {
 	postTypeBreakdown,
 	tierMaximumRecords,
 	lastIndexedDate,
+	postTypeLabels,
 } ) {
-	const recordInfo = getRecordInfo( postCount, postTypeBreakdown, lastIndexedDate );
+	const recordInfo = getRecordInfo( postCount, postTypeBreakdown, lastIndexedDate, postTypeLabels );
 
 	return (
 		<div className="jp-search-record-meter jp-search-dashboard-wrap" data-testid="record-meter">

--- a/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
+++ b/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
@@ -113,7 +113,7 @@ export default function getRecordInfo( postCount, postTypeBreakdown, lastIndexed
  */
 export function addLabelsToPostTypeBreakdown( postTypeBreakdown, postTypes ) {
 	const postTypeBreakdownWithLabels = postTypeBreakdown.map( postType => {
-		const postTypeLabelItem = postType[ postType.slug ];
+		const postTypeLabelItem = postTypes[ postType.slug ];
 		postType.label = postTypeLabelItem ? postTypeLabelItem.label : null;
 		return postType;
 	} );

--- a/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
+++ b/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
@@ -113,7 +113,7 @@ export default function getRecordInfo( postCount, postTypeBreakdown, lastIndexed
  */
 export function addLabelsToPostTypeBreakdown( postTypeBreakdown, postTypes ) {
 	const postTypeBreakdownWithLabels = postTypeBreakdown.map( postType => {
-		const postTypeLabelItem = postTypes.find( label => label.slug === postType.slug );
+		const postTypeLabelItem = postType[ postType.slug ];
 		postType.label = postTypeLabelItem ? postTypeLabelItem.label : null;
 		return postType;
 	} );

--- a/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
+++ b/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
@@ -117,18 +117,12 @@ export default function getRecordInfo(
  * @returns {object} updated postTypeBreakdown containing the post type slug, label, and count
  */
 export function addLabelsToPostTypeBreakdown( postTypeBreakdown, postTypeLabels ) {
-	const postTypeBreakdownWithLabels = [];
-	for ( const postType of postTypeBreakdown ) {
-		for ( const label of postTypeLabels ) {
-			if ( postType.slug === label.slug ) {
-				postTypeBreakdownWithLabels.push( {
-					count: postType.count,
-					slug: label.slug,
-					label: label.label,
-				} );
-			}
-		}
-	}
+	const postTypeBreakdownWithLabels = postTypeBreakdown.map( postType => {
+		const postTypeLabelItem = postTypeLabels.find( label => label.slug === postType.slug );
+		postType.label = postTypeLabelItem ? postTypeLabelItem.label : null;
+		return postType;
+	} );
+
 	return postTypeBreakdownWithLabels;
 }
 

--- a/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
+++ b/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
@@ -50,13 +50,12 @@ export default function getRecordInfo(
 		PALETTE.colors[ 'Yellow 30' ],
 	];
 
-	// add labels to post type breakdown
-	const postTypeBreakdownWithLabels = addLabelsToPostTypeBreakdown(
-		postTypeBreakdown,
-		postTypeLabels
-	);
-
 	if ( numItems > 0 && hasValidData && hasBeenIndexed ) {
+		// add labels to post type breakdown
+		const postTypeBreakdownWithLabels = addLabelsToPostTypeBreakdown(
+			postTypeBreakdown,
+			postTypeLabels
+		);
 		for ( let i = 0; i < numItems; i++ ) {
 			const postTypeDetails = Object.values( postTypeBreakdownWithLabels )[ i ];
 			const { count, slug: slug, label: name } = postTypeDetails;

--- a/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
+++ b/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
@@ -7,9 +7,15 @@ const PALETTE = require( '@automattic/color-studio' );
  * @param {number} postCount - The total count of indexed post records
  * @param {object} postTypeBreakdown - Post type breakdown (post type => number of posts)
  * @param {string} lastIndexedDate - The date on which the site was last indexed as a string
+ * @param {object} postTypeLabels - Post type labels (post type label => post type slug)
  * @returns {object} data in correct form to use in chart and notice-box
  */
-export default function getRecordInfo( postCount, postTypeBreakdown, lastIndexedDate ) {
+export default function getRecordInfo(
+	postCount,
+	postTypeBreakdown,
+	lastIndexedDate,
+	postTypeLabels
+) {
 	const maxPostTypeCount = 5; // this value determines when to cut off displaying post times & compound into an 'other'
 	const recordInfo = [];
 	const chartPostTypeBreakdown = [];
@@ -44,13 +50,18 @@ export default function getRecordInfo( postCount, postTypeBreakdown, lastIndexed
 		PALETTE.colors[ 'Yellow 30' ],
 	];
 
+	// add labels to post type breakdown
+	const postTypeBreakdownWithLabels = addLabelsToPostTypeBreakdown(
+		postTypeBreakdown,
+		postTypeLabels
+	);
+
 	if ( numItems > 0 && hasValidData && hasBeenIndexed ) {
 		for ( let i = 0; i < numItems; i++ ) {
-			const postTypeDetails = Object.values( postTypeBreakdown )[ i ];
-			const { count, slug: name } = postTypeDetails;
-
+			const postTypeDetails = Object.values( postTypeBreakdownWithLabels )[ i ];
+			const { count, slug: slug, label: name } = postTypeDetails;
 			chartPostTypeBreakdown.push( {
-				data: createData( count, colors[ i ], name ),
+				data: createData( count, colors[ i ], name, slug ),
 			} );
 			currentCount = currentCount + count;
 		}
@@ -96,6 +107,29 @@ export default function getRecordInfo( postCount, postTypeBreakdown, lastIndexed
 		hasItems,
 		isValid,
 	};
+}
+
+/**
+ * adds the appropriate labels the post type breakdown
+ *
+ * @param {Array} postTypeBreakdown - an array of the different post types with their counts
+ * @param {Array} postTypeLabels - an array of the different post types labels matched with their slugs
+ * @returns {object} updated postTypeBreakdown containing the post type slug, label, and count
+ */
+export function addLabelsToPostTypeBreakdown( postTypeBreakdown, postTypeLabels ) {
+	const postTypeBreakdownWithLabels = [];
+	for ( const postType of postTypeBreakdown ) {
+		for ( const label of postTypeLabels ) {
+			if ( postType.slug === label.slug ) {
+				postTypeBreakdownWithLabels.push( {
+					label: label.label,
+					slug: label.slug,
+					count: postType.count,
+				} );
+			}
+		}
+	}
+	return postTypeBreakdownWithLabels;
 }
 
 /**

--- a/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
+++ b/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
@@ -7,15 +7,10 @@ const PALETTE = require( '@automattic/color-studio' );
  * @param {number} postCount - The total count of indexed post records
  * @param {object} postTypeBreakdown - Post type breakdown (post type => number of posts)
  * @param {string} lastIndexedDate - The date on which the site was last indexed as a string
- * @param {object} postTypeLabels - Post type labels (post type label => post type slug)
+ * @param {object} postTypes - Post types (post type label => post type slug)
  * @returns {object} data in correct form to use in chart and notice-box
  */
-export default function getRecordInfo(
-	postCount,
-	postTypeBreakdown,
-	lastIndexedDate,
-	postTypeLabels
-) {
+export default function getRecordInfo( postCount, postTypeBreakdown, lastIndexedDate, postTypes ) {
 	const maxPostTypeCount = 5; // this value determines when to cut off displaying post times & compound into an 'other'
 	const recordInfo = [];
 	const chartPostTypeBreakdown = [];
@@ -54,7 +49,7 @@ export default function getRecordInfo(
 		// add labels to post type breakdown
 		const postTypeBreakdownWithLabels = addLabelsToPostTypeBreakdown(
 			postTypeBreakdown,
-			postTypeLabels
+			postTypes
 		);
 
 		for ( let i = 0; i < numItems - 1; i++ ) {
@@ -113,12 +108,12 @@ export default function getRecordInfo(
  * adds the appropriate labels the post type breakdown
  *
  * @param {Array} postTypeBreakdown - an array of the different post types with their counts
- * @param {Array} postTypeLabels - an array of the different post types labels matched with their slugs
+ * @param {Array} postTypes - an array of the different post types labels matched with their slugs
  * @returns {object} updated postTypeBreakdown containing the post type slug, label, and count
  */
-export function addLabelsToPostTypeBreakdown( postTypeBreakdown, postTypeLabels ) {
+export function addLabelsToPostTypeBreakdown( postTypeBreakdown, postTypes ) {
 	const postTypeBreakdownWithLabels = postTypeBreakdown.map( postType => {
-		const postTypeLabelItem = postTypeLabels.find( label => label.slug === postType.slug );
+		const postTypeLabelItem = postTypes.find( label => label.slug === postType.slug );
 		postType.label = postTypeLabelItem ? postTypeLabelItem.label : null;
 		return postType;
 	} );

--- a/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
+++ b/projects/packages/search/src/dashboard/components/record-meter/lib/record-info.js
@@ -56,11 +56,12 @@ export default function getRecordInfo(
 			postTypeBreakdown,
 			postTypeLabels
 		);
-		for ( let i = 0; i < numItems; i++ ) {
+
+		for ( let i = 0; i < numItems - 1; i++ ) {
 			const postTypeDetails = Object.values( postTypeBreakdownWithLabels )[ i ];
-			const { count, slug: slug, label: name } = postTypeDetails;
+			const { count, label } = postTypeDetails;
 			chartPostTypeBreakdown.push( {
-				data: createData( count, colors[ i ], name, slug ),
+				data: createData( count, colors[ i ], label ),
 			} );
 			currentCount = currentCount + count;
 		}
@@ -121,9 +122,9 @@ export function addLabelsToPostTypeBreakdown( postTypeBreakdown, postTypeLabels 
 		for ( const label of postTypeLabels ) {
 			if ( postType.slug === label.slug ) {
 				postTypeBreakdownWithLabels.push( {
-					label: label.label,
-					slug: label.slug,
 					count: postType.count,
+					slug: label.slug,
+					label: label.label,
 				} );
 			}
 		}

--- a/projects/packages/search/src/dashboard/store/selectors/site-data.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-data.js
@@ -7,7 +7,7 @@ const siteDataSelectors = {
 	getBlogId: state => state.siteData?.blogId ?? 0,
 	getVersion: state => state.siteData?.version ?? 'development',
 	getCalypsoSlug: state => state.siteData?.calypsoSlug,
-	getPostTypeLabels: state => state.siteData?.postTypeLabels,
+	getPostTypes: state => state.siteData?.postTypes,
 };
 
 export default siteDataSelectors;

--- a/projects/packages/search/src/dashboard/store/selectors/site-data.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-data.js
@@ -7,6 +7,7 @@ const siteDataSelectors = {
 	getBlogId: state => state.siteData?.blogId ?? 0,
 	getVersion: state => state.siteData?.version ?? 'development',
 	getCalypsoSlug: state => state.siteData?.calypsoSlug,
+	getPostTypeLabels: state => state.siteData?.postTypeLabels,
 };
 
 export default siteDataSelectors;


### PR DESCRIPTION
This PR updates the Record Meter chart legend to display the post type label, instead of the slug. This should resolve issues with pluralization, localization, and hyphenation problems with the existing post type name display. 

![image](https://user-images.githubusercontent.com/30754158/176354592-feee811a-51b0-4925-ba55-262f4b74ccda.png)

#### Changes proposed in this Pull Request:

* retrieves the post type labels and uses them in the Record Meter chart legend instead of slugs

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* Go to /wp-admin/admin.php?page=jetpack-search&features=record-meter on your test site with Search enabled.
* Check that the post type legend items are correct, that they do not show hyphens/slugs, that they are plurals, and capitalised, and translatable in the case of known post types (eg posts) 
