### PR TITLE
Fix the url for antispam stats in admin dashboard

### DIFF
--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
@@ -340,7 +340,9 @@ class MyPlanBody extends React.Component {
 								this.props.isPluginActive( 'akismet/akismet.php' ) ? (
 									<Button
 										onClick={ this.handleButtonClickForTracking( 'view_spam_stats' ) }
-										href={ this.props.siteAdminUrl + 'admin.php?page=akismet-key-config' }
+										href={
+											this.props.siteAdminUrl + 'admin.php?page=akismet-key-config&view=stats'
+										}
 									>
 										{ __( 'View your spam stats', 'jetpack' ) }
 									</Button>

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
@@ -340,9 +340,7 @@ class MyPlanBody extends React.Component {
 								this.props.isPluginActive( 'akismet/akismet.php' ) ? (
 									<Button
 										onClick={ this.handleButtonClickForTracking( 'view_spam_stats' ) }
-										href={
-											this.props.siteAdminUrl + 'admin.php?page=akismet-key-config&view=stats'
-										}
+										href={ `${ this.props.siteAdminUrl }admin.php?page=akismet-key-config&view=stats` }
 									>
 										{ __( 'View your spam stats', 'jetpack' ) }
 									</Button>

--- a/projects/plugins/jetpack/changelog/fix-antispam-stats-redirect
+++ b/projects/plugins/jetpack/changelog/fix-antispam-stats-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed the url for antispam stats in admin dashboard

--- a/projects/plugins/jetpack/changelog/fix-antispam-stats-redirect
+++ b/projects/plugins/jetpack/changelog/fix-antispam-stats-redirect
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Fixed the url for antispam stats in admin dashboard
+Dashboard: fix the link to Anti-spam stats.


### PR DESCRIPTION
The current CTA for Antispam card in My Plan tab in admin dashboard redirects to Akismet Settings page despite the button saying "View your spam stats"

Fixes 1164141197617539-as-1202096940873861/f

#### Changes proposed in this Pull Request:
* Update URL for AntiSpam stats CTA in Admin dashboard  

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
Slack Discussion : p1656416271671969-slack-C029E4HPT

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
- Checkout the branch 
- Run `jetpack build`
- Open your JT site
- Purchase a plan that includes AntiSpam for example Jetpack Complete 
- Go to wp-admin -> Jetpack -> My Plan 
- Locate AntiSpam card 
- Click on "View your spam stats"
- Confirm that it redirects to stats page (`wp-admin/admin.php?page=akismet-key-config&view=stats`)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202096940873861