### PR TITLE
Jetpack: introduce the new VideoPressPlayer component (VPBlock)

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-vpblock-add-videopress-sandbox-component
+++ b/projects/plugins/jetpack/changelog/update-jetpack-vpblock-add-videopress-sandbox-component
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: introduce VideoPressSandbox component (VPBlock)

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
@@ -7,7 +7,7 @@ import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 
-export default function VideoPressSandbox( {
+export default function VideoPressPlayer( {
 	html,
 	caption,
 	isSelected,

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-sandbox/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-sandbox/index.js
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import { RichText, useBlockProps } from '@wordpress/block-editor';
+import { ResizableBox, SandBox } from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import classNames from 'classnames';
+
+export default function VideoPressSandbox( {
+	html,
+	caption,
+	isSelected,
+	attributes,
+	setAttributes,
+	scripts = [],
+} ) {
+	// @todo: implemen maxWidth
+	const { align, maxWidth } = attributes;
+
+	const blockProps = useBlockProps( {
+		className: classNames( 'wp-block-jetpack-videopress', {
+			[ `align${ align }` ]: align,
+		} ),
+	} );
+
+	const onBlockResize = useCallback(
+		( event, direction, domElement ) => {
+			let newMaxWidth = getComputedStyle( domElement ).width;
+			const parentElement = domElement.parentElement;
+			if ( null !== parentElement ) {
+				const parentWidth = getComputedStyle( domElement.parentElement ).width;
+				if ( newMaxWidth === parentWidth ) {
+					newMaxWidth = '100%';
+				}
+			}
+
+			setAttributes( { maxWidth: newMaxWidth } );
+		},
+		[ setAttributes ]
+	);
+
+	// Populate scripts array with videopresAjaxURLBlob blobal var.
+	if ( window.videopressAjax ) {
+		const videopresAjaxURLBlob = new Blob(
+			[ `var videopressAjax = ${ JSON.stringify( window.videopressAjax ) };` ],
+			{
+				type: 'text/javascript',
+			}
+		);
+
+		scripts.push( URL.createObjectURL( videopresAjaxURLBlob ), window.videopressAjax.bridgeUrl );
+	}
+
+	return (
+		<figure { ...blockProps }>
+			<ResizableBox
+				enable={ {
+					top: false,
+					bottom: false,
+					left: true,
+					right: true,
+				} }
+				maxWidth="100%"
+				size={ { width: maxWidth } }
+				style={ { margin: 'auto' } }
+				onResizeStop={ onBlockResize }
+			>
+				<SandBox html={ html } scripts={ scripts } />
+			</ResizableBox>
+
+			{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
+				<RichText
+					tagName="figcaption"
+					placeholder={ __( 'Write caption…', 'jetpack' ) }
+					value={ caption }
+					onChange={ value => setAttributes( { caption: value } ) }
+					inlineToolbar
+				/>
+			) }
+		</figure>
+	);
+}

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -15,7 +15,7 @@ import { VideoPressIcon as icon } from '../../../shared/icons';
 import Loading from '../loading';
 import { getVideoPressUrl } from '../url';
 import VideoPressInspectorControls from './components/inspector-controls';
-import VideoPressSandbox from './components/videopress-sandbox';
+import VideoPressPlayer from './components/videopress-player';
 import { useResumableUploader } from './hooks/use-uploader.js';
 import './editor.scss';
 
@@ -269,7 +269,7 @@ export default function VideoPressEdit( { attributes, setAttributes } ) {
 	return (
 		<>
 			<VideoPressInspectorControls attributes={ attributes } setAttributes={ setAttributes } />
-			<VideoPressSandbox
+			<VideoPressPlayer
 				html={ html }
 				scripts={ scripts }
 				attributes={ attributes }

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -12,10 +12,10 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { VideoPressIcon as icon } from '../../../shared/icons';
-import { VpBlock } from '../edit';
 import Loading from '../loading';
 import { getVideoPressUrl } from '../url';
 import VideoPressInspectorControls from './components/inspector-controls';
+import VideoPressSandbox from './components/videopress-sandbox';
 import { useResumableUploader } from './hooks/use-uploader.js';
 import './editor.scss';
 
@@ -247,11 +247,9 @@ export default function VideoPressEdit( { attributes, setAttributes } ) {
 	return (
 		<>
 			<VideoPressInspectorControls attributes={ attributes } setAttributes={ setAttributes } />
-			<VpBlock
+			<VideoPressSandbox
 				html={ html }
 				scripts={ scripts }
-				interactive={ true }
-				hideOverlay={ false }
 				attributes={ attributes }
 				setAttributes={ setAttributes }
 			/>

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/editor.scss
@@ -1,8 +1,6 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
 .wp-block-jetpack-videopress {
-	background: var( --wp-admin-theme-color );
-
 	&.is-placeholder-container {
 		background: $white;
 		color: $gray-900;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds a new `<VideoPressPlayer />` component, based on the current `<VpBlock />` component.
This new component handles the primary features needed to render the player visualization of the VPBlock in the editor context.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack: introduce the new VideoPressPlayer component (VPBlock)

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to block editor
* Add a new VPBlock
* Upload a video
* Confirm it renders the player
* Confirm it works as expected
* You may like to take a look at the components tool of your dev client, filtering by `VideoPressSandbox`
* Confirm you see the new component there
<img width="1790" alt="image" src="https://user-images.githubusercontent.com/77539/176428369-88cc0108-8fe2-4a3d-b163-9b18d87f7b70.png">



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202514379845497