### PR TITLE
My Jetpack: Update filesystem check

### DIFF
--- a/projects/js-packages/components/changelog/update-my-jetpack-cant-install-plugin
+++ b/projects/js-packages/components/changelog/update-my-jetpack-cant-install-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Export Alert component

--- a/projects/js-packages/components/index.ts
+++ b/projects/js-packages/components/index.ts
@@ -42,4 +42,5 @@ export { default as ProductOffer, IconsCard } from './components/product-offer';
 export { default as Dialog } from './components/dialog';
 export { default as RecordMeterBar } from './components/record-meter-bar';
 export { default as ContextualUpgradeTrigger } from './components/contextual-upgrade-trigger';
+export { default as Alert } from './components/alert';
 export { getUserLocale, cleanLocale } from './lib/locale';

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.16.4",
+	"version": "0.16.5-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/packages/my-jetpack/_inc/components/product-detail-button/index.js
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-button/index.js
@@ -2,14 +2,22 @@ import { Button, Spinner } from '@wordpress/components';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const ProductDetailButton = ( { children, className, href, isLoading, onClick, isPrimary } ) => {
+const ProductDetailButton = ( {
+	children,
+	className,
+	href,
+	isLoading,
+	onClick,
+	isPrimary,
+	disabled,
+} ) => {
 	return (
 		<Button
 			onClick={ onClick }
 			className={ className }
 			href={ href }
 			variant={ isPrimary ? 'primary' : 'secondary' }
-			disabled={ isLoading }
+			disabled={ isLoading || disabled }
 		>
 			{ isLoading ? <Spinner /> : children }
 		</Button>
@@ -20,11 +28,13 @@ ProductDetailButton.propTypes = {
 	className: PropTypes.string,
 	isLoading: PropTypes.bool,
 	isPrimary: PropTypes.bool,
+	disabled: PropTypes.bool,
 };
 
 ProductDetailButton.defaultProps = {
 	isLoading: false,
 	isPrimary: true,
+	disabled: false,
 };
 
 export default ProductDetailButton;

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -1,5 +1,16 @@
+// eslint-disable-next-line no-unused-vars
+/* global myJetpackInitialState */
+
 import { getCurrencyObject } from '@automattic/format-currency';
-import { CheckmarkIcon, getIconBySlug, StarIcon, Text, H3 } from '@automattic/jetpack-components';
+import {
+	CheckmarkIcon,
+	getIconBySlug,
+	StarIcon,
+	Text,
+	H3,
+	Alert,
+} from '@automattic/jetpack-components';
+import { ExternalLink } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, check, plus } from '@wordpress/icons';
 import classnames from 'classnames';
@@ -55,6 +66,7 @@ function Price( { value, currency, isOld } ) {
  * @returns {object}                               ProductDetailCard react component.
  */
 const ProductDetailCard = ( { slug, onClick, trackButtonClick, className, supportingInfo } ) => {
+	const fileSystemWriteAccess = window?.myJetpackInitialState?.fileSystemWriteAccess;
 	const { detail, isFetching } = useProduct( slug );
 	const {
 		title,
@@ -64,7 +76,11 @@ const ProductDetailCard = ( { slug, onClick, trackButtonClick, className, suppor
 		isBundle,
 		supportedProducts,
 		hasRequiredPlan,
+		status,
+		pluginSlug,
 	} = detail;
+
+	const cantInstallPlugin = status === 'plugin_absent' && 'no' === fileSystemWriteAccess;
 
 	const {
 		isFree,
@@ -181,11 +197,31 @@ const ProductDetailCard = ( { slug, onClick, trackButtonClick, className, suppor
 
 				{ isFree && <H3>{ __( 'Free', 'jetpack-my-jetpack' ) }</H3> }
 
+				{ cantInstallPlugin && (
+					<Alert>
+						<Text>
+							{ sprintf(
+								// translators: %s is the plugin name.
+								__(
+									"Due to your server settings, we can't automatically install the plugin for you. Please manually install the %s plugin.",
+									'jetpack-my-jetpack'
+								),
+								title
+							) }
+							&nbsp;
+							<ExternalLink href={ `https://wordpress.org/plugins/${ pluginSlug }` }>
+								{ __( 'Get plugin', 'jetpack-my-jetpack' ) }
+							</ExternalLink>
+						</Text>
+					</Alert>
+				) }
+
 				{ ( ! isBundle || ( isBundle && ! hasRequiredPlan ) ) && (
 					<Text
 						component={ ProductDetailButton }
 						onClick={ clickHandler }
 						isLoading={ isFetching }
+						disabled={ cantInstallPlugin }
 						isPrimary={ ! isBundle }
 						href={ onClick ? undefined : addProductUrl }
 						className={ styles[ 'checkout-button' ] }

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-cant-install-plugin
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-cant-install-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Display alert when we cant automatically install the plugin

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "1.7.2",
+	"version": "1.7.3-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -28,7 +28,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '1.7.2';
+	const PACKAGE_VERSION = '1.7.3-alpha';
 
 	/**
 	 * Initialize My Jetapack

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -112,6 +112,7 @@ abstract class Product {
 		}
 		return array(
 			'slug'                     => static::$slug,
+			'plugin_slug'              => static::$plugin_slug,
 			'name'                     => static::get_name(),
 			'title'                    => static::get_title(),
 			'description'              => static::get_description(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Reconstructed after #24780

Fixes #22982

This PR explores how to handle the situations in which we are not able to automatically install a plugin for the user.

The proposal is to:
* Disable the button
* Add a notice above the button with a link to the plugin on the .org repository


![Captura de tela de 2022-06-24 10-27-32](https://user-images.githubusercontent.com/971483/175546384-69fa41b8-56d3-48da-a686-de661f50a709.png)



Another option I considered was to use the `Notice` core component, but it didn't fit in very well on a first try:

![Captura de tela de 2022-06-17 18-35-15](https://user-images.githubusercontent.com/971483/174404053-c3c9b19d-d5ca-4c18-9270-a64e2e4bd7ea.png)

What do you think?

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Display an alert when we can't install the plugin for the user

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1202184803119163-as-1202324040023250

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Easiest way to test this PR is by modifying the `class-initializer.php` file inside the my-jetpack package folder, on line 151 and make it read like:

```PHP
'fileSystemWriteAccess' => 'no',
```

* Go to My Jetpack
* Click on "Add CRM" (or any other card for which you don't have the plugin installed

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202324040023250