### PR TITLE
VideoPress: Add attributes to player in editor

### DIFF
--- a/projects/plugins/jetpack/changelog/add-videopress-attributes-to-player
+++ b/projects/plugins/jetpack/changelog/add-videopress-attributes-to-player
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -22,10 +22,32 @@ import './editor.scss';
 const ALLOWED_MEDIA_TYPES = [ 'video' ];
 
 export default function VideoPressEdit( { attributes, setAttributes } ) {
-	const { controls, src, guid } = attributes;
+	const {
+		autoplay,
+		loop,
+		muted,
+		controls,
+		playsinline,
+		preload,
+		useAverageColor,
+		seekbarColor,
+		seekbarLoadingColor,
+		seekbarPlayedColor,
+		src,
+		guid,
+	} = attributes;
 
 	const videoPressUrl = getVideoPressUrl( guid, {
+		autoplay,
 		controls,
+		loop,
+		muted,
+		playsinline,
+		preload,
+		seekbarColor,
+		seekbarLoadingColor,
+		seekbarPlayedColor,
+		useAverageColor,
 	} );
 
 	/*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Propagate the attributes to the player in the editor

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
NA

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Verfy the code and add debuggers to confirm the attributes are available in the `VideoPressEdit` component



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202514379845487