### PR TITLE
Jetpack: improve UI when refreshing the video preview of the VPBlock

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-videopress-improve-flickr-when-updating-video-preview
+++ b/projects/plugins/jetpack/changelog/update-jetpack-videopress-improve-flickr-when-updating-video-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: improve WPBlock video preview UX

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/attributes.js
@@ -44,4 +44,9 @@ export default {
 	src: {
 		type: 'string',
 	},
+
+	cacheHtml: {
+		type: 'string',
+		default: '',
+	},
 };

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
@@ -9,6 +9,7 @@ import classNames from 'classnames';
 
 export default function VideoPressPlayer( {
 	html,
+	isUpdatingPreview,
 	caption,
 	isSelected,
 	attributes,
@@ -21,6 +22,7 @@ export default function VideoPressPlayer( {
 	const blockProps = useBlockProps( {
 		className: classNames( 'wp-block-jetpack-videopress', {
 			[ `align${ align }` ]: align,
+			[ 'is-updating-preview' ]: isUpdatingPreview,
 		} ),
 	} );
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -105,6 +105,7 @@ export default function VideoPressEdit( { attributes, setAttributes } ) {
 			return;
 		}
 
+		// Update html cache when the preview changes.
 		setAttributes( { cacheHtml: previewHtml } );
 	}, [ previewHtml, cacheHtml, setAttributes ] );
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -291,6 +291,7 @@ export default function VideoPressEdit( { attributes, setAttributes } ) {
 			<VideoPressInspectorControls attributes={ attributes } setAttributes={ setAttributes } />
 			<VideoPressPlayer
 				html={ html }
+				isUpdatingPreview={ ! previewHtml }
 				scripts={ scripts }
 				attributes={ attributes }
 				setAttributes={ setAttributes }

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -35,6 +35,7 @@ export default function VideoPressEdit( { attributes, setAttributes } ) {
 		seekbarPlayedColor,
 		src,
 		guid,
+		cacheHtml,
 	} = attributes;
 
 	const videoPressUrl = getVideoPressUrl( guid, {
@@ -87,7 +88,25 @@ export default function VideoPressEdit( { attributes, setAttributes } ) {
 		},
 		[ videoPressUrl ]
 	);
-	const { html, scripts } = preview ? preview : { html: null, scripts: null };
+	const { html: previewHtml, scripts } = preview ? preview : { html: null, scripts: [] };
+
+	/*
+	 * Store the preview html into a block attribute,
+	 * to be used as a fallback while it pulls the new preview.
+	 * Once the html changes, the attr will be updated, too.
+	 */
+	const html = previewHtml || cacheHtml;
+	useEffect( () => {
+		if ( ! previewHtml ) {
+			return;
+		}
+
+		if ( previewHtml === cacheHtml ) {
+			return;
+		}
+
+		setAttributes( { cacheHtml: previewHtml } );
+	}, [ previewHtml, cacheHtml, setAttributes ] );
 
 	// Helper to invalidate the preview cache.
 	const invalidateResolution = useDispatch( coreStore ).invalidateResolution;

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -270,8 +270,8 @@ export default function VideoPressEdit( { attributes, setAttributes } ) {
 		);
 	}
 
-	// 4 - Generating video preview
-	if ( isRequestingEmbedPreview || !! isGeneratingPreview || ! preview ) {
+	// 4 - No html preview. Show generating message.
+	if ( ! html ) {
 		return (
 			<>
 				<div { ...blockProps }>

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/editor.scss
@@ -16,4 +16,8 @@
 		font-size: $default-font-size;
 		min-height: 200px;
 	}
+
+	&.is-updating-preview {
+		opacity: 0.5;
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

~# Branched off from https://github.com/Automattic/jetpack/pull/24883~

This PR tries to improve the UX when editing the video player attributes. Currently, when the app requests the new preview because of its attributes changes, it produces a flicker removing completely the video player representation until the new preview arrives.

The following video shows how the video player behaves when the user changes its attributes:

https://user-images.githubusercontent.com/77539/176463336-e03738a2-666d-41b6-a642-eceffae7dff9.mov

And the following one shows how the new VPBlock behaves:

https://user-images.githubusercontent.com/77539/176464242-0b732936-66cf-4067-8eef-3043d5550a31.mov

Under the hood, it stores the preview HTML in a new `cacheHtml` block attribute, which is used when the preview is not present. Once it gets the new HTML of the preview, it updates the attribute to make it available when the preview changes again. 

BTW, when the preview is refreshing it applies a simple opacity to the player, something that we can improve in follow-up PRs.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack: improve UI when refreshing the video preview of the VPBlock

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to block editor
* Add a new VPBlock
* Upload a video
* Change the player attributes
* Confirm it doesn't produce flicker or jumps in the UI when it refreshes the preview



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202514379845480