### PR TITLE
Jetpack: save custom size of the VideoPress block

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-wp-block-store-block-sizes
+++ b/projects/plugins/jetpack/changelog/update-jetpack-wp-block-store-block-sizes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: store and apply VPBlock size

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/attributes.js
@@ -9,6 +9,10 @@ export default {
 	loop: {
 		type: 'boolean',
 	},
+	maxWidth: {
+		type: 'string',
+		default: '100%',
+	},
 	muted: {
 		type: 'boolean',
 	},

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
@@ -20,7 +20,7 @@ export default function VideoPressPlayer( {
 	const { align, maxWidth } = attributes;
 
 	const blockProps = useBlockProps( {
-		className: classNames( 'wp-block-jetpack-videopress', {
+		className: classNames( 'wp-block-jetpack-videopress', 'videopress-player', {
 			[ `align${ align }` ]: align,
 			[ 'is-updating-preview' ]: isUpdatingPreview,
 		} ),

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/editor.scss
@@ -33,6 +33,10 @@
 		background-color: transparent;
 		z-index: 1;
 	}
+
+	&.videopress-player {
+		margin: 0;
+	}
 }
 
 .jetpack-videopress-upload-error-message {

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/save.js
@@ -22,6 +22,7 @@ export default function save( { attributes } ) {
 		seekbarLoadingColor,
 		seekbarPlayedColor,
 		guid,
+		maxWidth,
 	} = attributes;
 
 	const blockProps = useBlockProps.save( {
@@ -43,8 +44,15 @@ export default function save( { attributes } ) {
 		useAverageColor,
 	} );
 
+	// Adjust block with based on custom maxWidth.
+	const style = {};
+	if ( maxWidth && maxWidth.length > 0 && '100%' !== maxWidth ) {
+		style.maxWidth = maxWidth;
+		style.margin = 'auto';
+	}
+
 	return (
-		<figure { ...blockProps }>
+		<figure { ...blockProps } style={ style }>
 			<div className="jetpack-videopress__wrapper">
 				{ `\n${ videoPressUrl }\n` /* URL needs to be on its own line. */ }
 			</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

~# branched off from  https://github.com/Automattic/jetpack/pull/24883~

This PR registers the maxWidth attribute and handles saving the custom size to finally render the proper size in the front-end.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack: save custom size of the VideoPress block

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to 'block editor
* Create a new VPBlock
* Upload a video
* Play with the block size by resizing it
* Save the post
* Confirm the size is applied properly in the front-ent
* You may like to take a look a the element styles

<img width="1340" alt="Screen Shot 2022-06-29 at 2 00 48 PM" src="https://user-images.githubusercontent.com/77539/176494135-e2d22f24-8a91-4bc7-ab27-06d1fa532803.png">




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202514379845492