### PR TITLE
Fix sharing buttons in blog posts block

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sharing-buttons-in-blog-posts-block
+++ b/projects/plugins/jetpack/changelog/fix-sharing-buttons-in-blog-posts-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Ensure that sharing buttons are not displayed for excerpts

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -425,9 +425,16 @@ class Jetpack_Likes {
 	 * @param string $content - content of the page.
 	 */
 	public function post_likes( $content ) {
+		global $wp_current_filter;
 		$post_id = get_the_ID();
 
 		if ( ! is_numeric( $post_id ) || ! $this->settings->is_likes_visible() ) {
+			return $content;
+		}
+
+		// Ensure we don't display like button on excerpts unless we are on search, archive or home page.
+		if ( ! is_search() && ! is_home() && ! is_archive() &&
+			in_array( 'the_excerpt', (array) $wp_current_filter, true ) ) {
 			return $content;
 		}
 

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -432,9 +432,9 @@ class Jetpack_Likes {
 			return $content;
 		}
 
-		// Ensure we don't display like button on excerpts unless we are on search, archive or home page.
-		if ( ! is_search() && ! is_home() && ! is_archive() &&
-			in_array( 'the_excerpt', (array) $wp_current_filter, true ) ) {
+		// Ensure we don't display like button on post excerpts that are hooked inside the post content
+		if ( in_array( 'the_excerpt', (array) $wp_current_filter, true ) &&
+			in_array( 'the_content', (array) $wp_current_filter, true ) ) {
 			return $content;
 		}
 

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
@@ -943,7 +943,7 @@ function sharing_display( $text = '', $echo = false ) {
 	}
 
 	// Don't output flair on excerpts.
-	if ( in_array( 'get_the_excerpt', (array) $wp_current_filter, true ) ) {
+	if ( in_array( 'the_excerpt', (array) $wp_current_filter, true ) ) {
 		return $text;
 	}
 

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
@@ -943,7 +943,13 @@ function sharing_display( $text = '', $echo = false ) {
 	}
 
 	// Don't output flair on excerpts.
-	if ( in_array( 'the_excerpt', (array) $wp_current_filter, true ) ) {
+	if ( in_array( 'get_the_excerpt', (array) $wp_current_filter, true ) ) {
+		return $text;
+	}
+
+	// Ensure we don't display sharing buttons on excerpts unless we are on search, archive or home page.
+	if ( ! is_search() && ! is_home() && ! is_archive() &&
+		in_array( 'the_excerpt', (array) $wp_current_filter, true ) ) {
 		return $text;
 	}
 

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
@@ -947,9 +947,9 @@ function sharing_display( $text = '', $echo = false ) {
 		return $text;
 	}
 
-	// Ensure we don't display sharing buttons on excerpts unless we are on search, archive or home page.
-	if ( ! is_search() && ! is_home() && ! is_archive() &&
-		in_array( 'the_excerpt', (array) $wp_current_filter, true ) ) {
+	// Ensure we don't display sharing buttons on post excerpts that are hooked inside the post content
+	if ( in_array( 'the_excerpt', (array) $wp_current_filter, true ) &&
+		in_array( 'the_content', (array) $wp_current_filter, true ) ) {
 		return $text;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/46634 and https://github.com/Automattic/wp-calypso/issues/52347

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

##### Reasoning 
The docs say this about [sharing buttons](https://wordpress.com/support/sharing/):

> Posts – all individual blog posts will display the likes and sharing buttons
> Pages – all static pages (like an about or contact us page) will display the likes and sharing buttons

I understand that we should show sharing buttons for a single post and a single page, but not for items that are displayed on the list like in the Blog Posts block.

Thus I would remove sharing buttons for listed items altogether.

##### Technical details
There is a check for the `get_the_excerpt()` filter, which doesn’t show sharing buttons if the `sharing_display()` function is called via this filter. However, the function is added as a filter for `the_content()` and `the_excerpt()`. This condition wouldn’t be caught at all.

I modified this condition to check for `the_excerpt()` instead of `get_the_excerpt()`. It fixes the issue, however, I’m not sure about the following:

**why we add `sharing_display()` for `the_excerpt()` in the `init()` method? Is there any use case in which we want sharing buttons content displayed for the excerpt? Or could we delete it?**

This blame shows that we added this code 10-12 years ago:
https://github.com/Automattic/jetpack/blame/a7208f678a4239211bdc4f34d75d196b780c7a25/modules/sharedaddy/sharing-service.php

If the fix is valid and no code should add sharing buttons for `the_excerpt()`, we could modify the fix and remove all other calls related to `the_excerpt()` in the class.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

##### Main test case 
1. Start a Jetpack environment
2. Go to WP Admin
3. Install a WordPress.com Editing Toolkit plugin
4. Enable Sharing buttons in Jetpack -> Settings -> Sharing (works in Jetpack's offline mode)
5. Add a new page with a **Blog Posts** block (and not Posts Lists)
6. Confirm sharing buttons are not displayed under each post in the list of posts on the created page

##### Regression test

Let's test if we can still enable/disable sharing buttons for individual post and page:

1. Go to Jetpack -> Settings -> Sharing 
2. Click on “Configure your sharing buttons”
3. Disable Show buttons on Pages, Save changes

Then ensure that the page doesn't display sharing buttons. Check the same for posts.