### PR TITLE
Jetpack: VPBlock - limit the attempts to get the video preview

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-vpblock-limit-the-attempts-to-get-the-video-preview
+++ b/projects/plugins/jetpack/changelog/update-jetpack-vpblock-limit-the-attempts-to-get-the-video-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: stop re-attempting to get the video preview when it achieves the limit

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -169,11 +169,7 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 		rePreviewAttemptTimer.current = setTimeout( () => {
 			// Abort whether the preview is already defined.
 			if ( preview ) {
-<<<<<<< HEAD
-				setIsGeneratingPreview( 0 ); // reset counter.
-=======
-				setGeneratingPreviewCounter( 0 );
->>>>>>> 1feb97fc8c ([not verified] rename local state to handle attempts to get the preview)
+				setGeneratingPreviewCounter( 0 ); // reset counter.
 				return;
 			}
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -206,18 +206,36 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 		);
 	}
 
-	// 2 - No html preview. Show generating message.
-	if ( ! html ) {
+	// 4 - Generating video preview
+	if (
+		isRequestingEmbedPreview ||
+		( isGeneratingPreview > 0 && isGeneratingPreview < 10 ) ||
+		! preview
+	) {
 		return (
 			<>
 				<div { ...blockProps }>
 					<Spinner />
-					<div>{ __( '(4) Generating preview…', 'jetpack' ) }</div>
+					<div>{ __( '(4) Generating preview…', 'jetpack' ) } </div>
 					<div>
 						Attempt: <strong>{ isGeneratingPreview }</strong>
 					</div>
 				</div>
 			</>
+		);
+	}
+
+	// 5 - Generating video preview
+	if ( isGeneratingPreview >= 10 && ! preview ) {
+		return (
+			<div { ...blockProps }>
+				<div>
+					{ __(
+						'(5) Impossible to get a video preview after ten attempts. Show error.',
+						'jetpack'
+					) }
+				</div>
+			</div>
 		);
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -138,7 +138,12 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 	}
 
 	useEffect( () => {
-		// VideoPress URL is not defined. Bail early and cleans the timer.
+		// Attempts limit achieved. Bail early.
+		if ( isGeneratingPreview >= 10 ) {
+			return cleanRegeneratingProcess();
+		}
+
+		// VideoPress URL is not defined. Bail early and cleans the time.
 		if ( ! videoPressUrl ) {
 			return cleanRegeneratingProcess();
 		}
@@ -172,6 +177,7 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 
 		return cleanRegeneratingProcess;
 	}, [
+		isGeneratingPreview,
 		rePreviewAttemptTimer,
 		invalidateCachedEmbedPreview,
 		preview,

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -19,6 +19,8 @@ import VideoPressUploader from './components/videopress-uploader';
 
 import './editor.scss';
 
+const VIDEO_PREVIEW_ATTEMPTS_LIMIT = 10;
+
 export default function VideoPressEdit( { attributes, setAttributes, isSelected } ) {
 	const {
 		autoplay,
@@ -139,7 +141,7 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 
 	useEffect( () => {
 		// Attempts limit achieved. Bail early.
-		if ( generatingPreviewCounter >= 10 ) {
+		if ( generatingPreviewCounter >= VIDEO_PREVIEW_ATTEMPTS_LIMIT ) {
 			return cleanRegeneratingProcess();
 		}
 
@@ -220,7 +222,7 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 	if (
 		( isRequestingEmbedPreview || ! preview ) &&
 		generatingPreviewCounter > 0 &&
-		generatingPreviewCounter < 10
+		generatingPreviewCounter < VIDEO_PREVIEW_ATTEMPTS_LIMIT
 	) {
 		return (
 			<>
@@ -236,7 +238,7 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 	}
 
 	// 5 - Generating video preview
-	if ( generatingPreviewCounter >= 10 && ! preview ) {
+	if ( generatingPreviewCounter >= VIDEO_PREVIEW_ATTEMPTS_LIMIT && ! preview ) {
 		return (
 			<div { ...blockProps }>
 				<div>

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -218,9 +218,9 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 
 	// 4 - Generating video preview
 	if (
-		isRequestingEmbedPreview ||
-		( generatingPreviewCounter > 0 && generatingPreviewCounter < 10 ) ||
-		! preview
+		( isRequestingEmbedPreview || ! preview ) &&
+		generatingPreviewCounter > 0 &&
+		generatingPreviewCounter < 10
 	) {
 		return (
 			<>

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -226,7 +226,7 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 			<>
 				<div { ...blockProps }>
 					<Spinner />
-					<div>{ __( '(4) Generating preview…', 'jetpack' ) } </div>
+					<div>{ __( '(4) Generating preview…', 'jetpack' ) }</div>
 					<div>
 						Attempt: <strong>{ generatingPreviewCounter }</strong>
 					</div>

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -126,7 +126,7 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 	 * the VideoPress URL is gotten.
 	 * It attempts every two seconds to get the so desired video preview.
 	 */
-	const [ isGeneratingPreview, setIsGeneratingPreview ] = useState( 0 );
+	const [ generatingPreviewCounter, setGeneratingPreviewCounter ] = useState( 0 );
 
 	const rePreviewAttemptTimer = useRef();
 	function cleanRegeneratingProcess() {
@@ -139,7 +139,7 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 
 	useEffect( () => {
 		// Attempts limit achieved. Bail early.
-		if ( isGeneratingPreview >= 10 ) {
+		if ( generatingPreviewCounter >= 10 ) {
 			return cleanRegeneratingProcess();
 		}
 
@@ -155,7 +155,7 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 
 		// Bail early (clean the timer) when preview is defined.
 		if ( preview ) {
-			setIsGeneratingPreview( 0 ); // reset counter.
+			setGeneratingPreviewCounter( 0 ); // reset counter.
 			return cleanRegeneratingProcess();
 		}
 
@@ -167,17 +167,21 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 		rePreviewAttemptTimer.current = setTimeout( () => {
 			// Abort whether the preview is already defined.
 			if ( preview ) {
+<<<<<<< HEAD
 				setIsGeneratingPreview( 0 ); // reset counter.
+=======
+				setGeneratingPreviewCounter( 0 );
+>>>>>>> 1feb97fc8c ([not verified] rename local state to handle attempts to get the preview)
 				return;
 			}
 
-			setIsGeneratingPreview( v => v + 1 );
+			setGeneratingPreviewCounter( v => v + 1 );
 			invalidateCachedEmbedPreview();
 		}, 2000 );
 
 		return cleanRegeneratingProcess;
 	}, [
-		isGeneratingPreview,
+		generatingPreviewCounter,
 		rePreviewAttemptTimer,
 		invalidateCachedEmbedPreview,
 		preview,
@@ -215,7 +219,7 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 	// 4 - Generating video preview
 	if (
 		isRequestingEmbedPreview ||
-		( isGeneratingPreview > 0 && isGeneratingPreview < 10 ) ||
+		( generatingPreviewCounter > 0 && generatingPreviewCounter < 10 ) ||
 		! preview
 	) {
 		return (
@@ -224,7 +228,7 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 					<Spinner />
 					<div>{ __( '(4) Generating preview…', 'jetpack' ) } </div>
 					<div>
-						Attempt: <strong>{ isGeneratingPreview }</strong>
+						Attempt: <strong>{ generatingPreviewCounter }</strong>
 					</div>
 				</div>
 			</>
@@ -232,7 +236,7 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 	}
 
 	// 5 - Generating video preview
-	if ( isGeneratingPreview >= 10 && ! preview ) {
+	if ( generatingPreviewCounter >= 10 && ! preview ) {
 		return (
 			<div { ...blockProps }>
 				<div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR handles the attempts to get the video preview. Although it shouldn't happen since getting the preview is always expected beyond it could take time and a few attempts, we need to ensure to do not request the preview forever.
This PR limits the attempts to 10. Statistically, the attempts are never more than 3 in my personal experience.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack: VPBlock - limit the attempts to get the video preview

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Add a new VideoPress block
* Set the video by using an invalid URL (BTW, this is a known issue that will be tackled in another PR). For instance:

```
https://video.wordpress.com/v/retrofox
```
* Confirm it isn't possible to get the preview
* Confirm it gets the attempts limit (10)
* Confirm you see a basic error message.

<img width="557" alt="Screen Shot 2022-07-06 at 1 23 14 PM" src="https://user-images.githubusercontent.com/77539/177598093-668472e9-77e0-4f4a-9690-8b65f4d68cb1.png">

<img width="557" alt="image" src="https://user-images.githubusercontent.com/77539/177598116-2b5ea165-203b-463e-b1e9-2d1ead937a4a.png">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202514379845507