### PR TITLE
Jetpack: add an overlay to VPBlock to improve when selecting the video player

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-vpblock-improve-selecting-block
+++ b/projects/plugins/jetpack/changelog/update-jetpack-vpblock-improve-selecting-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: add an overlay to VPBlock to improve when selecting the video player

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
@@ -68,6 +68,7 @@ export default function VideoPressPlayer( {
 				style={ { margin: 'auto' } }
 				onResizeStop={ onBlockResize }
 			>
+				{ ! isSelected && <div className="wp-block-jetpack-videopress__overlay" /> }
 				<SandBox html={ html } scripts={ scripts } />
 			</ResizableBox>
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -21,7 +21,7 @@ import './editor.scss';
 
 const ALLOWED_MEDIA_TYPES = [ 'video' ];
 
-export default function VideoPressEdit( { attributes, setAttributes } ) {
+export default function VideoPressEdit( { attributes, setAttributes, isSelected } ) {
 	const {
 		autoplay,
 		loop,
@@ -329,6 +329,7 @@ export default function VideoPressEdit( { attributes, setAttributes } ) {
 				scripts={ scripts }
 				attributes={ attributes }
 				setAttributes={ setAttributes }
+				isSelected={ isSelected }
 			/>
 		</>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/editor.scss
@@ -1,6 +1,8 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
 .wp-block-jetpack-videopress {
+	position: relative;
+
 	&.is-placeholder-container {
 		background: $white;
 		color: $gray-900;
@@ -17,8 +19,19 @@
 		min-height: 200px;
 	}
 
+
 	&.is-updating-preview {
 		opacity: 0.5;
+	}
+
+	.wp-block-jetpack-videopress__overlay {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		background-color: transparent;
+		z-index: 1;
 	}
 }
 
@@ -26,4 +39,3 @@
 	color: $alert-red;
 	width: 100%;
 }
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR improves the UX when selecting the VPBlock when the video player is rendered.
Currently, when the user selects the block, the player starts to play right after the click happens, which is not ok since the idea is just to select the block in the initial click.

With these changes, the block adds initially an overlay element that covers the player when the block is not selected (fundamental condition).
When the user selects the block by clicking on its representation, it happens over the overlay element, which, in some way, disables the player, but just once. Because, and since the block is now selected, the overlay disappears releasing the player to be ready to use.

We can't use `<Disable />` component because it re-renders the component producing a not very well experience.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack: add an overlay to VPBlock to improve when selecting the video player

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Add a VideoPress block
* Upload a video
* Confirm that, when the block is not selected, when you select the block it doesn't trigger any action with the player: play, stop, etc doesn't work.
* Once the block is selected, the player is ready to be used. Confirm you can play, stop, etc the player.


https://user-images.githubusercontent.com/77539/176540316-69fbde0e-1eb1-4243-8453-d25e157062a5.mov

Pay attention to the sequences of clicks when selecting the block


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202509770630164