### PR TITLE
Jetpack: handle VPBlock caption attribute

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-vpblock-implement-caption
+++ b/projects/plugins/jetpack/changelog/update-jetpack-vpblock-implement-caption
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: handle VPBlock caption attribute

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/attributes.js
@@ -2,6 +2,11 @@ export default {
 	autoplay: {
 		type: 'boolean',
 	},
+	caption: {
+		type: 'string',
+		source: 'html',
+		selector: 'figcaption',
+	},
 	controls: {
 		type: 'boolean',
 		default: true,

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
@@ -14,12 +14,13 @@ export default function VideoPressPlayer( {
 	attributes,
 	setAttributes,
 	scripts = [],
+	className,
 } ) {
 	// @todo: implemen maxWidth
 	const { align, maxWidth, caption } = attributes;
 
 	const blockProps = useBlockProps( {
-		className: classNames( 'wp-block-jetpack-videopress', 'videopress-player', {
+		className: classNames( className, 'jetpack-videopress-player', {
 			[ `align${ align }` ]: align,
 			[ 'is-updating-preview' ]: isUpdatingPreview,
 		} ),

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
@@ -10,14 +10,13 @@ import classNames from 'classnames';
 export default function VideoPressPlayer( {
 	html,
 	isUpdatingPreview,
-	caption,
 	isSelected,
 	attributes,
 	setAttributes,
 	scripts = [],
 } ) {
 	// @todo: implemen maxWidth
-	const { align, maxWidth } = attributes;
+	const { align, maxWidth, caption } = attributes;
 
 	const blockProps = useBlockProps( {
 		className: classNames( 'wp-block-jetpack-videopress', 'videopress-player', {

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -357,6 +357,7 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 				attributes={ attributes }
 				setAttributes={ setAttributes }
 				isSelected={ isSelected }
+				className="wp-block-jetpack-videopress"
 			/>
 		</>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/save.js
@@ -27,9 +27,14 @@ export default function save( { attributes } ) {
 	} = attributes;
 
 	const blockProps = useBlockProps.save( {
-		className: classnames( 'jetpack-videopress', {
-			[ `align${ align }` ]: align,
-		} ),
+		className: classnames(
+			'wp-block-jetpack-videopress',
+			'jetpack-videopress-player',
+			'wp-block-embed',
+			{
+				[ `align${ align }` ]: align,
+			}
+		),
 	} );
 
 	const videoPressUrl = getVideoPressUrl( guid, {
@@ -53,8 +58,8 @@ export default function save( { attributes } ) {
 	}
 
 	return (
-		<figure { ...blockProps } style={ style }>
-			<div className="jetpack-videopress__wrapper">
+		<figure { ...blockProps }>
+			<div className="jetpack-videopress-player__wrapper">
 				{ `\n${ videoPressUrl }\n` /* URL needs to be on its own line. */ }
 			</div>
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/save.js
@@ -27,14 +27,9 @@ export default function save( { attributes } ) {
 	} = attributes;
 
 	const blockProps = useBlockProps.save( {
-		className: classnames(
-			'wp-block-jetpack-videopress',
-			'jetpack-videopress-player',
-			'wp-block-embed',
-			{
-				[ `align${ align }` ]: align,
-			}
-		),
+		className: classnames( 'wp-block-jetpack-videopress', 'jetpack-videopress-player', {
+			[ `align${ align }` ]: align,
+		} ),
 	} );
 
 	const videoPressUrl = getVideoPressUrl( guid, {

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/save.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useBlockProps } from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 import classnames from 'classnames';
 /**
  * Internal dependencies
@@ -12,6 +12,7 @@ export default function save( { attributes } ) {
 	const {
 		align,
 		autoplay,
+		caption,
 		loop,
 		muted,
 		controls,
@@ -56,6 +57,10 @@ export default function save( { attributes } ) {
 			<div className="jetpack-videopress__wrapper">
 				{ `\n${ videoPressUrl }\n` /* URL needs to be on its own line. */ }
 			</div>
+
+			{ ! RichText.isEmpty( caption ) && (
+				<RichText.Content tagName="figcaption" value={ caption } />
+			) }
 		</figure>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/style.scss
@@ -1,3 +1,3 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
-.jetpack-videopress {}
+.wp-block-jetpack-videopress {}

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/style.scss
@@ -1,3 +1,7 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
-.wp-block-jetpack-videopress {}
+.wp-block-jetpack-videopress {
+	figcaption {
+		@include caption-style-theme();
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR tackle the ability to set the video caption of the VPBlock.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack: handle VPBlock caption attribute

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to block editor
* Create a VPBlock
* Upload a video
* Confirm you see the caption text field just below of the video player
* Confirm you can edit applying styles
* Save the post
* Confirm the styles are applied in the front-end

block editor | front-end
------|------
<img width="619" alt="image" src="https://user-images.githubusercontent.com/77539/176546640-b161a174-52a5-439a-b15f-044fe2a12080.png"> | <img width="677" alt="image" src="https://user-images.githubusercontent.com/77539/176546701-6d2f0e40-42a9-42dd-8ba5-66078ae5e53a.png">



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202527904270996