### PR TITLE
Triage: update logic to follow issue priority matrix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -81,6 +81,23 @@ body:
         - Some (< 50%)
         - Most (> 50%)
         - All
+  - type: dropdown
+    id: workarounds
+    attributes:
+      label: Available workarounds?
+      options:
+        - No and the platform is unusable
+        - No but the platform is still usable
+        - Yes, difficult to implement
+        - Yes, easy to implement
+        - There is no user impact
+  - type: textarea
+    id: workarounds-detail
+    attributes:
+      label: Workaround details
+      description: If you are aware of a workaround, please describe it below.
+      placeholder: |
+        e.g. There is an alternative way to access this setting in the sidebar, but it's not readily apparent.
   - type: markdown
     attributes:
       value: |

--- a/projects/github-actions/repo-gardening/changelog/update-triage-priority-matrix
+++ b/projects/github-actions/repo-gardening/changelog/update-triage-priority-matrix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Triage: update priority logic to follow issue priority matrix.

--- a/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/index.js
@@ -44,7 +44,7 @@ function findPriority( body ) {
 			return 'High';
 		} else if ( blocking === 'Yes, difficult to implement' ) {
 			return severity === 'All' ? 'High' : 'Normal';
-		} else if ( blocking !== '' ) {
+		} else if ( blocking !== '' && blocking !== '_No response_' ) {
 			return severity === 'All' || severity === 'Most (> 50%)' ? 'Normal' : 'Low';
 		}
 		return null;

--- a/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/index.js
@@ -30,9 +30,9 @@ function findPlugin( body ) {
 function findPriority( body ) {
 	// Look for priority indicators in body.
 	const priorityRegex = /###\sSeverity\n\n(?<severity>.*)\n\n###\sAvailable\sworkarounds\?\n\n(?<blocking>.*)\n/gm;
-	const priority = body.match( priorityRegex );
-	if ( priority ) {
-		const [ , severity = '', blocking = '' ] = priority.groups;
+	let match;
+	while ( ( match = priorityRegex.exec( body ) ) ) {
+		const [ , severity = '', blocking = '' ] = match;
 
 		debug(
 			`triage-new-issues: Reported priority indicators for issue: "${ severity }" / "${ blocking }"`

--- a/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/index.js
@@ -32,7 +32,11 @@ function findPriority( body ) {
 	const priorityRegex = /###\sSeverity\n\n(?<severity>.*)\n\n###\sAvailable\sworkarounds\?\n\n(?<blocking>.*)\n/gm;
 	const priority = body.match( priorityRegex );
 	if ( priority ) {
-		const [ , severity = '', blocking = '' ] = priority;
+		const [ , severity = '', blocking = '' ] = priority.groups;
+
+		debug(
+			`triage-new-issues: Reported priority indicators for issue: "${ severity }" / "${ blocking }"`
+		);
 
 		if ( blocking === 'No and the platform is unusable' ) {
 			return severity === 'One' ? 'High' : 'BLOCKER';
@@ -46,6 +50,7 @@ function findPriority( body ) {
 		return null;
 	}
 
+	debug( `triage-new-issues: No priority indicators found.` );
 	return null;
 }
 
@@ -74,6 +79,7 @@ async function triageNewIssues( payload, octokit ) {
 	}
 
 	// Find Priority.
+	debug( `triage-new-issues: Finding priority for issue #${ number }` );
 	const priority = findPriority( body );
 	if ( null !== priority ) {
 		debug( `triage-new-issues: Adding priority label to issue #${ number }` );

--- a/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/index.js
@@ -21,31 +21,29 @@ function findPlugin( body ) {
 }
 
 /**
- * Find priority of issue, based off issue contents.
+ * Figure out the priority of the issue, based off issue contents.
+ * Logic follows this priority matrix: pciE2j-oG-p2
  *
  * @param {string} body - The issue content.
  * @returns {string} Priority of issue.
  */
 function findPriority( body ) {
-	const regex = /###\sSeverity\n\n(.*)\n/gm;
+	// Look for priority indicators in body.
+	const priorityRegex = /###\sSeverity\n\n(?<severity>.*)\n\n###\sAvailable\sworkarounds\?\n\n(?<blocking>.*)\n/gm;
+	const priority = body.match( priorityRegex );
+	if ( priority ) {
+		const [ , severity = '', blocking = '' ] = priority;
 
-	let match;
-	while ( ( match = regex.exec( body ) ) ) {
-		const [ , severity ] = match;
-
-		switch ( severity ) {
-			case 'All':
-				return 'High';
-			case 'Some (< 50%)':
-				return 'High';
-			case 'Most (> 50%)':
-				return 'Normal';
-			case 'One':
-				return 'Low';
-			default:
-				// This includes the "_No response_" case, where one does not fill in the severity field.
-				return null;
+		if ( blocking === 'No and the platform is unusable' ) {
+			return severity === 'One' ? 'High' : 'BLOCKER';
+		} else if ( blocking === 'No but the platform is still usable' ) {
+			return 'High';
+		} else if ( blocking === 'Yes, difficult to implement' ) {
+			return severity === 'All' ? 'High' : 'Normal';
+		} else if ( blocking !== '' ) {
+			return severity === 'All' || severity === 'Most (> 50%)' ? 'Normal' : 'Low';
 		}
+		return null;
 	}
 
 	return null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Follow-up from #24841.

Instead of only relying on the severity declared in the issue body, let's add a new field (also used in Calypso) about the extent of the problem, and factor that when calculating the priority of an issue.

This follows an issue matrix described here: pciE2j-oG-p2

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

Internal reference: pciE2j-18N-p2#comment-1024

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Hard to test in this repo, but you can check the new outcome in the issues below:

- https://github.com/jeherve/jetpack/issues/46
- https://github.com/jeherve/jetpack/issues/41
- https://github.com/jeherve/jetpack/issues/42
- https://github.com/jeherve/jetpack/issues/43
- https://github.com/jeherve/jetpack/issues/44