### PR TITLE
Eslint all JS tests with the jest preset

### DIFF
--- a/projects/js-packages/analytics/changelog/add-eslint-add-tests-as-jest
+++ b/projects/js-packages/analytics/changelog/add-eslint-add-tests-as-jest
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Lint all JS tests. No change to the project itself.
+
+

--- a/projects/js-packages/analytics/package.json
+++ b/projects/js-packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-analytics",
-	"version": "0.1.15",
+	"version": "0.1.16-alpha",
 	"description": "Jetpack Analytics Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/analytics/test/.eslintrc.cjs
+++ b/projects/js-packages/analytics/test/.eslintrc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-};

--- a/projects/js-packages/api/changelog/add-eslint-add-tests-as-jest
+++ b/projects/js-packages/api/changelog/add-eslint-add-tests-as-jest
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Lint all JS tests. No change to the project itself.
+
+

--- a/projects/js-packages/api/package.json
+++ b/projects/js-packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-api",
-	"version": "0.13.6",
+	"version": "0.13.7-alpha",
 	"description": "Jetpack Api Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/api/test/.eslintrc.cjs
+++ b/projects/js-packages/api/test/.eslintrc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-};

--- a/projects/js-packages/babel-plugin-replace-textdomain/changelog/add-eslint-add-tests-as-jest
+++ b/projects/js-packages/babel-plugin-replace-textdomain/changelog/add-eslint-add-tests-as-jest
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Lint all JS tests. No change to the project itself.
+
+

--- a/projects/js-packages/babel-plugin-replace-textdomain/package.json
+++ b/projects/js-packages/babel-plugin-replace-textdomain/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/babel-plugin-replace-textdomain",
-	"version": "1.0.9",
+	"version": "1.0.10-alpha",
 	"description": "A Babel plugin to replace the textdomain in gettext-style function calls.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/babel-plugin-replace-textdomain/#readme",
 	"bugs": {

--- a/projects/js-packages/babel-plugin-replace-textdomain/tests/plugin.test.js
+++ b/projects/js-packages/babel-plugin-replace-textdomain/tests/plugin.test.js
@@ -221,6 +221,6 @@ test( 'Default functions exported', () => {
 	// Test that it's immutable.
 	plugin.defaultFunctions.__ = 10;
 	plugin.defaultFunctions.foo = 11;
-	expect( plugin.defaultFunctions.__ ).toEqual( 1 );
+	expect( plugin.defaultFunctions.__ ).toBe( 1 );
 	expect( plugin.defaultFunctions.foo ).toBeUndefined();
 } );

--- a/projects/js-packages/components/.eslintrc.cjs
+++ b/projects/js-packages/components/.eslintrc.cjs
@@ -16,10 +16,4 @@ module.exports = {
 			},
 		],
 	},
-	overrides: [
-		{
-			files: [ '**/test/*.[jt]s?(x)' ],
-			extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-		},
-	],
 };

--- a/projects/js-packages/components/changelog/add-eslint-add-tests-as-jest
+++ b/projects/js-packages/components/changelog/add-eslint-add-tests-as-jest
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Lint all JS tests. No change to the project itself.
+
+

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.16.4",
+	"version": "0.16.5-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/config/.eslintrc.js
+++ b/projects/js-packages/config/.eslintrc.js
@@ -1,8 +1,0 @@
-module.exports = {
-	overrides: [
-		{
-			files: [ '**/test/*.[jt]s' ],
-			extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-		},
-	],
-};

--- a/projects/js-packages/config/changelog/add-eslint-add-tests-as-jest
+++ b/projects/js-packages/config/changelog/add-eslint-add-tests-as-jest
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Lint all JS tests. No change to the project itself.
+
+

--- a/projects/js-packages/config/package.json
+++ b/projects/js-packages/config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-config",
-	"version": "0.1.10",
+	"version": "0.1.11-alpha",
 	"description": "Handles Jetpack global configuration shared across all packages",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/config/#readme",
 	"bugs": {

--- a/projects/js-packages/connection/.eslintrc.cjs
+++ b/projects/js-packages/connection/.eslintrc.cjs
@@ -16,10 +16,4 @@ module.exports = {
 			},
 		],
 	},
-	overrides: [
-		{
-			files: [ '**/test/*.[jt]s?(x)' ],
-			extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-		},
-	],
 };

--- a/projects/js-packages/connection/changelog/add-eslint-add-tests-as-jest
+++ b/projects/js-packages/connection/changelog/add-eslint-add-tests-as-jest
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Lint all JS tests. No change to the project itself.
+
+

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.18.7",
+	"version": "0.18.8-alpha",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/eslint-changed/changelog/add-eslint-add-tests-as-jest
+++ b/projects/js-packages/eslint-changed/changelog/add-eslint-add-tests-as-jest
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Lint all JS tests. No change to the project itself.
+
+

--- a/projects/js-packages/eslint-changed/tests/.eslintrc.cjs
+++ b/projects/js-packages/eslint-changed/tests/.eslintrc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-};

--- a/projects/js-packages/eslint-config-target-es/changelog/add-eslint-add-tests-as-jest
+++ b/projects/js-packages/eslint-config-target-es/changelog/add-eslint-add-tests-as-jest
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Lint all JS tests. No change to the project itself.
+
+

--- a/projects/js-packages/eslint-config-target-es/tests/rulesMap.test.js
+++ b/projects/js-packages/eslint-config-target-es/tests/rulesMap.test.js
@@ -2,26 +2,87 @@ const mdn = require( '@mdn/browser-compat-data' );
 const { rules: esRules } = require( 'eslint-plugin-es' );
 const rulesMap = require( '../src/rulesMap.js' );
 
+expect.extend( {
+	toBeValidMapping( received ) {
+		const options = {
+			isNot: this.isNot,
+			promise: this.promise,
+		};
+
+		let ok = false;
+		if ( received === true || received === false ) {
+			ok = true;
+		} else if ( typeof received === 'string' ) {
+			ok = true;
+		} else if ( Array.isArray( received ) ) {
+			ok = received.length > 0 && received.every( p => typeof p === 'string' );
+		}
+		if ( ok ) {
+			return {
+				message: () =>
+					this.utils.matcherHint( 'toBeValidMapping', undefined, '', options ) +
+					`\n\nReceived: ${ this.utils.printReceived( received ) }`,
+				pass: true,
+			};
+		}
+		return {
+			message: () =>
+				this.utils.matcherHint( 'toBeValidMapping', undefined, '', options ) +
+				// prettier-ignore
+				`\n\nExpected: a boolean, string, or array of strings.\nReceived: ${ this.utils.printReceived( received ) }`,
+			pass: false,
+		};
+	},
+	toBeValidMDNPath( received ) {
+		const options = {
+			isNot: this.isNot,
+			promise: this.promise,
+		};
+
+		let data = mdn;
+		const p = [];
+		for ( const k of received.split( '.' ) ) {
+			p.push( k );
+			data = data[ k ];
+			if ( ! data ) {
+				return {
+					message: () =>
+						this.utils.matcherHint( 'toBeValidMDNPath', received, '', options ) +
+						`\n\nPath ${ p.join( '.' ) } does not exist.`,
+					pass: false,
+				};
+			} else if ( typeof data !== 'object' ) {
+				return {
+					message: () =>
+						this.utils.matcherHint( 'toBeValidMDNPath', received, '', options ) +
+						`\n\nPath ${ p.join( '.' ) } is not an object.`,
+					pass: false,
+				};
+			}
+		}
+		if ( ! data.__compat || ! data.__compat.support ) {
+			return {
+				message: () =>
+					this.utils.matcherHint( 'toBeValidMDNPath', received, '', options ) +
+					`\n\nPath has no compat data.`,
+				pass: false,
+			};
+		}
+		return {
+			message: () =>
+				this.utils.matcherHint( 'toBeValidMDNPath', received, '', options ) + `\n\nPath is valid.`,
+			pass: true,
+		};
+	},
+} );
+
 test( 'All rules are mapped', () => {
 	expect( Object.keys( rulesMap ).sort() ).toEqual( Object.keys( esRules ).sort() );
 } );
 
 describe( 'All mappings are valid', () => {
 	test.each( Object.entries( rulesMap ) )( 'Mapping for %s is valid', ( rule, paths ) => {
-		if ( paths === true || paths === false ) {
-			return;
-		} else if ( typeof paths === 'string' ) {
-			paths = [ paths ];
-		} else if ( Array.isArray( paths ) ) {
-			expect( paths ).not.toEqual( [] );
-			for ( const path of paths ) {
-				expect( path ).toEqual( expect.any( String ) );
-			}
-		} else {
-			throw new Error(
-				`Mapping should be a boolean, string, or array of strings. Got ${ typeof paths }.`
-			);
-		}
+		expect( paths ).toBeValidMapping();
 	} );
 
 	const allpaths = new Set(
@@ -36,19 +97,6 @@ describe( 'All mappings are valid', () => {
 		} )
 	);
 	test.each( [ ...allpaths ].sort().map( v => [ v ] ) )( 'MDN path %s exists', path => {
-		let data = mdn;
-		const p = [];
-		for ( const k of path.split( '.' ) ) {
-			p.push( k );
-			data = data[ k ];
-			if ( ! data ) {
-				throw new Error( `Path ${ p.join( '.' ) } does not exist` );
-			} else if ( typeof data !== 'object' ) {
-				throw new Error( `Path ${ p.join( '.' ) } is not an object` );
-			}
-		}
-		if ( ! data.__compat || ! data.__compat.support ) {
-			throw new Error( 'Path has no compat data' );
-		}
+		expect( path ).toBeValidMDNPath();
 	} );
 } );

--- a/projects/js-packages/i18n-check-webpack-plugin/changelog/add-eslint-add-tests-as-jest
+++ b/projects/js-packages/i18n-check-webpack-plugin/changelog/add-eslint-add-tests-as-jest
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Lint all JS tests. No change to the project itself.
+
+

--- a/projects/js-packages/i18n-check-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-check-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-check-webpack-plugin",
-	"version": "1.0.14",
+	"version": "1.0.15-alpha",
 	"description": "A Webpack plugin to check that WordPress i18n hasn't been mangled by Webpack optimizations.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/i18n-check-webpack-plugin/#readme",
 	"bugs": {

--- a/projects/js-packages/i18n-check-webpack-plugin/tests/build.test.js
+++ b/projects/js-packages/i18n-check-webpack-plugin/tests/build.test.js
@@ -76,7 +76,9 @@ test.each( configFixtures )(
 
 		if ( fixture === 'dropped-is-ok' ) {
 			const contents = fs.readFileSync( path.join( builddir, 'main.js' ), { encoding: 'utf8' } );
+			// eslint-disable-next-line jest/no-conditional-expect
 			expect( contents ).toEqual( expect.stringContaining( 'This is production' ) );
+			// eslint-disable-next-line jest/no-conditional-expect
 			expect( contents ).toEqual( expect.not.stringContaining( 'This is not production' ) );
 		}
 	},

--- a/projects/js-packages/idc/.eslintrc.cjs
+++ b/projects/js-packages/idc/.eslintrc.cjs
@@ -16,10 +16,4 @@ module.exports = {
 			},
 		],
 	},
-	overrides: [
-		{
-			files: [ '**/test/*.[jt]s?(x)', '**/*.test.[jt]s?(x)' ],
-			extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-		},
-	],
 };

--- a/projects/js-packages/idc/changelog/add-eslint-add-tests-as-jest
+++ b/projects/js-packages/idc/changelog/add-eslint-add-tests-as-jest
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Lint all JS tests. No change to the project itself.
+
+

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-idc",
-	"version": "0.10.15",
+	"version": "0.10.16-alpha",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/licensing/.eslintrc.cjs
+++ b/projects/js-packages/licensing/.eslintrc.cjs
@@ -16,10 +16,4 @@ module.exports = {
 			},
 		],
 	},
-	overrides: [
-		{
-			files: [ '**/test/*.[jt]s?(x)', '**/*.test.[jt]s?(x)' ],
-			extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-		},
-	],
 };

--- a/projects/js-packages/licensing/changelog/add-eslint-add-tests-as-jest
+++ b/projects/js-packages/licensing/changelog/add-eslint-add-tests-as-jest
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Lint all JS tests. No change to the project itself.
+
+

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.5.5",
+	"version": "0.5.6-alpha",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {

--- a/projects/js-packages/partner-coupon/.eslintrc.cjs
+++ b/projects/js-packages/partner-coupon/.eslintrc.cjs
@@ -16,10 +16,4 @@ module.exports = {
 			},
 		],
 	},
-	overrides: [
-		{
-			files: [ '**/test/*.[jt]s?(x)', '**/*.test.[jt]s?(x)' ],
-			extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-		},
-	],
 };

--- a/projects/js-packages/partner-coupon/changelog/add-eslint-add-tests-as-jest
+++ b/projects/js-packages/partner-coupon/changelog/add-eslint-add-tests-as-jest
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Lint all JS tests. No change to the project itself.
+
+

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.18",
+	"version": "0.2.19-alpha",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/.eslintrc.js
+++ b/projects/js-packages/publicize-components/.eslintrc.js
@@ -16,10 +16,4 @@ module.exports = {
 			},
 		],
 	},
-	overrides: [
-		{
-			files: [ '**/test/*.[jt]s?(x)', '**/*.test.[jt]s?(x)' ],
-			extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-		},
-	],
 };

--- a/projects/js-packages/publicize-components/changelog/add-eslint-add-tests-as-jest
+++ b/projects/js-packages/publicize-components/changelog/add-eslint-add-tests-as-jest
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Lint all JS tests. No change to the project itself.
+
+

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.3.1",
+	"version": "0.3.2-alpha",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/src/components/twitter/test/.eslintrc.js
+++ b/projects/js-packages/publicize-components/src/components/twitter/test/.eslintrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-};

--- a/projects/js-packages/publicize-components/src/store/test/.eslintrc.js
+++ b/projects/js-packages/publicize-components/src/store/test/.eslintrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-};

--- a/projects/js-packages/shared-extension-utils/.eslintrc.cjs
+++ b/projects/js-packages/shared-extension-utils/.eslintrc.cjs
@@ -16,10 +16,4 @@ module.exports = {
 			},
 		],
 	},
-	overrides: [
-		{
-			files: [ '**/test/*.[jt]s?(x)', '**/*.test.[jt]s?(x)' ],
-			extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-		},
-	],
 };

--- a/projects/js-packages/shared-extension-utils/changelog/add-eslint-add-tests-as-jest
+++ b/projects/js-packages/shared-extension-utils/changelog/add-eslint-add-tests-as-jest
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Lint all JS tests. No change to the project itself.
+
+

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.4.11",
+	"version": "0.4.12-alpha",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/packages/assets/changelog/add-eslint-add-tests-as-jest
+++ b/projects/packages/assets/changelog/add-eslint-add-tests-as-jest
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Lint all JS tests. No change to the project itself.
+
+

--- a/projects/packages/assets/tests/js/i18n-loader.test.js
+++ b/projects/packages/assets/tests/js/i18n-loader.test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line jest/prefer-spy-on -- Nothing to spy on.
 global.fetch = jest.fn();
 fetch.mockFetchResponse = function ( body, init = {} ) {
 	const status = parseInt( init.status || 200 );

--- a/projects/packages/connection-ui/_inc/components/header/test/header.test.jsx
+++ b/projects/packages/connection-ui/_inc/components/header/test/header.test.jsx
@@ -5,5 +5,5 @@ import Header from '../index';
 
 test( 'Displays the header', () => {
 	const tree = renderer.create( <Header /> ).toJSON();
-	expect( tree ).toMatchSnapshot();
+	expect( tree ).toMatchSnapshot( 'header' );
 } );

--- a/projects/packages/connection-ui/changelog/add-eslint-add-tests-as-jest
+++ b/projects/packages/connection-ui/changelog/add-eslint-add-tests-as-jest
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Lint all JS tests. No change to the project itself.
+
+

--- a/projects/packages/connection-ui/package.json
+++ b/projects/packages/connection-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-connection-manager-ui",
-	"version": "2.4.9",
+	"version": "2.4.10-alpha",
 	"description": "Jetpack Connection Manager UI",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/my-jetpack/.eslintrc.js
+++ b/projects/packages/my-jetpack/.eslintrc.js
@@ -14,10 +14,4 @@ module.exports = {
 			},
 		],
 	},
-	overrides: [
-		{
-			files: [ '**/test/*.[jt]s?(x)', '**/*.test.[jt]s?(x)' ],
-			extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-		},
-	],
 };

--- a/projects/packages/my-jetpack/changelog/add-eslint-add-tests-as-jest
+++ b/projects/packages/my-jetpack/changelog/add-eslint-add-tests-as-jest
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Lint all JS tests. No change to the project itself.
+
+

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "1.7.2",
+	"version": "1.7.3-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -28,7 +28,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '1.7.2';
+	const PACKAGE_VERSION = '1.7.3-alpha';
 
 	/**
 	 * Initialize My Jetapack

--- a/projects/packages/search/changelog/add-eslint-add-tests-as-jest
+++ b/projects/packages/search/changelog/add-eslint-add-tests-as-jest
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Lint all JS tests. No change to the project itself.
+
+

--- a/projects/packages/search/src/dashboard/components/button/test/index.test.jsx
+++ b/projects/packages/search/src/dashboard/components/button/test/index.test.jsx
@@ -13,14 +13,14 @@ describe( 'Button', function () {
 	};
 	it( 'can render', () => {
 		render( <Button /> );
-		expect( screen.queryByRole( 'button' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button' ) ).toBeInTheDocument();
 	} );
 	it( 'can render compact button', () => {
 		render( <Button compact={ true } /> );
-		expect( screen.queryByRole( 'button' ).className ).toContain( 'is-compact' );
+		expect( screen.getByRole( 'button' ) ).toHaveClass( 'is-compact' );
 	} );
 	it( 'can render with class name passed in', () => {
 		render( <Button { ...testProps } /> );
-		expect( screen.queryByRole( 'button' ).className ).toContain( 'test-class' );
+		expect( screen.getByRole( 'button' ) ).toHaveClass( 'test-class' );
 	} );
 } );

--- a/projects/packages/search/src/dashboard/components/card/test/index.test.jsx
+++ b/projects/packages/search/src/dashboard/components/card/test/index.test.jsx
@@ -10,6 +10,6 @@ import React from 'react';
 describe( 'Card', function () {
 	it( 'can render', () => {
 		render( <Card title="Title" /> );
-		expect( screen.queryByRole( 'heading' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'heading' ) ).toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/search/src/dashboard/components/form-toggle/test/index.test.jsx
+++ b/projects/packages/search/src/dashboard/components/form-toggle/test/index.test.jsx
@@ -14,13 +14,13 @@ describe( 'CompactFormToggle', function () {
 	describe( 'rendering', function () {
 		it( 'can render', () => {
 			render( <CompactFormToggle>Toggle Label</CompactFormToggle> );
-			expect( screen.queryByText( 'Toggle Label' ) ).toBeInTheDocument();
-			expect( screen.getAllByRole( 'checkbox' )[ 0 ].className ).toContain( 'is-compact' );
+			expect( screen.getByText( 'Toggle Label' ) ).toBeInTheDocument();
+			expect( screen.getAllByRole( 'checkbox' )[ 0 ] ).toHaveClass( 'is-compact' );
 		} );
 
 		it( 'can render with class name passed in', () => {
 			render( <CompactFormToggle { ...testProps }>Toggle Label</CompactFormToggle> );
-			expect( screen.getAllByRole( 'checkbox' )[ 0 ].className ).toContain( 'test-class' );
+			expect( screen.getAllByRole( 'checkbox' )[ 0 ] ).toHaveClass( 'test-class' );
 		} );
 	} );
 } );

--- a/projects/packages/search/src/dashboard/components/global-notices/test/index.test.jsx
+++ b/projects/packages/search/src/dashboard/components/global-notices/test/index.test.jsx
@@ -13,7 +13,8 @@ describe( 'GlobalNotices', function () {
 			const { container } = render(
 				<GlobalNotices notices={ [ { id: 1, status: 'success' } ] } />
 			);
-			expect( container.firstChild.className ).toContain( 'global-notices' );
+			// eslint-disable-next-line testing-library/no-node-access
+			expect( container.firstChild ).toHaveClass( 'global-notices' );
 		} );
 	} );
 } );

--- a/projects/packages/search/src/dashboard/components/notice/test/index.test.jsx
+++ b/projects/packages/search/src/dashboard/components/notice/test/index.test.jsx
@@ -15,13 +15,15 @@ describe( 'SimpleNotice', function () {
 		it( 'can render', () => {
 			const { container } = render( <SimpleNotice id="1" status="success" /> );
 			expect(
+				// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 				container.getElementsByClassName( 'dops-notice__icon-wrapper' ).length
 			).toBeGreaterThan( 0 );
 		} );
 
 		it( 'can render with class name passed in', () => {
 			const { container } = render( <SimpleNotice { ...testProps }>Toggle Label</SimpleNotice> );
-			expect( container.firstChild.className ).toContain( 'test-class' );
+			// eslint-disable-next-line testing-library/no-node-access
+			expect( container.firstChild ).toHaveClass( 'test-class' );
 		} );
 	} );
 } );

--- a/projects/packages/search/src/dashboard/components/record-meter/test/index.test.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/test/index.test.jsx
@@ -11,7 +11,6 @@ describe( 'load the app', () => {
 	test( 'container renders', () => {
 		render( <RecordMeter /> );
 
-		const container = screen.queryByTestId( 'record-meter' );
-		expect( container ).toBeInTheDocument();
+		expect( screen.getByTestId( 'record-meter' ) ).toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/search/src/dashboard/components/record-meter/test/record-info.test.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/test/record-info.test.jsx
@@ -41,7 +41,7 @@ const postTypeBreakdown = [
 	},
 ];
 
-describe( 'API data is converted into record info ', () => {
+describe( 'API data is converted into record info', () => {
 	test( 'the total post count equals the post_type_breakdown values summed', () => {
 		const sumValues = obj => Object.values( obj ).reduce( ( a, b ) => a + b );
 		expect( testData.post_count ).toEqual( sumValues( testData.post_type_breakdown ) );
@@ -55,8 +55,8 @@ describe( 'API data is converted into record info ', () => {
 			testData.post_count,
 			maxRecordCount
 		);
-		expect( splitPostTypes.includedItems.length ).toBe( maxRecordCount );
-		expect( splitPostTypes.otherItems.length ).toBe( 2 );
+		expect( splitPostTypes.includedItems ).toHaveLength( maxRecordCount );
+		expect( splitPostTypes.otherItems ).toHaveLength( 2 );
 	} );
 
 	test( 'creates a data object using createData', () => {

--- a/projects/packages/search/src/dashboard/store/actions/test/jetpack-settings.test.js
+++ b/projects/packages/search/src/dashboard/store/actions/test/jetpack-settings.test.js
@@ -7,22 +7,22 @@ describe( 'Jetpack Settings updateJetpackSettings action', () => {
 	const action = updateJetpackSettings( undefined, undefined );
 	test( 'yield setJetpackSettings state to new one', () => {
 		// Create notice 'Updating'.
-		expect( action.next().value.type ).toEqual( 'CREATE_NOTICE' );
+		expect( action.next().value.type ).toBe( 'CREATE_NOTICE' );
 		// Set state updating flag.
-		expect( action.next().value.type ).toEqual( 'SET_JETPACK_SETTINGS' );
+		expect( action.next().value.type ).toBe( 'SET_JETPACK_SETTINGS' );
 		// Set state to the target state.
-		expect( action.next().value.type ).toEqual( 'SET_JETPACK_SETTINGS' );
+		expect( action.next().value.type ).toBe( 'SET_JETPACK_SETTINGS' );
 		// Post new settings to API.
-		expect( action.next().value.type ).toEqual( 'UPDATE_JETPACK_SETTINGS' );
+		expect( action.next().value.type ).toBe( 'UPDATE_JETPACK_SETTINGS' );
 		// Fetch settings from API.
-		expect( action.next().value.type ).toEqual( 'FETCH_JETPACK_SETTINGS' );
+		expect( action.next().value.type ).toBe( 'FETCH_JETPACK_SETTINGS' );
 		// Set fetched setting from above step.
-		expect( action.next().value.type ).toEqual( 'SET_JETPACK_SETTINGS' );
+		expect( action.next().value.type ).toBe( 'SET_JETPACK_SETTINGS' );
 		// Remove 'Updating' notice.
-		expect( action.next().value.type ).toEqual( 'REMOVE_NOTICE' );
+		expect( action.next().value.type ).toBe( 'REMOVE_NOTICE' );
 		// Remove state updating flag.
-		expect( action.next().value.type ).toEqual( 'SET_JETPACK_SETTINGS' );
+		expect( action.next().value.type ).toBe( 'SET_JETPACK_SETTINGS' );
 		// Create success notice.
-		expect( action.next().value.type ).toEqual( 'CREATE_NOTICE' );
+		expect( action.next().value.type ).toBe( 'CREATE_NOTICE' );
 	} );
 } );

--- a/projects/packages/search/src/instant-search/components/test/.eslintrc.js
+++ b/projects/packages/search/src/instant-search/components/test/.eslintrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-};

--- a/projects/packages/search/src/instant-search/lib/test/.eslintrc.js
+++ b/projects/packages/search/src/instant-search/lib/test/.eslintrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-};

--- a/projects/packages/search/src/instant-search/store/test/.eslintrc.js
+++ b/projects/packages/search/src/instant-search/store/test/.eslintrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-};

--- a/projects/packages/wordads/changelog/add-eslint-add-tests-as-jest
+++ b/projects/packages/wordads/changelog/add-eslint-add-tests-as-jest
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Lint all JS tests. No change to the project itself.
+
+

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.2.7",
+	"version": "0.2.8-alpha",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.2.7';
+	const VERSION = '0.2.8-alpha';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/packages/wordads/src/dashboard/components/button/test/index.test.jsx
+++ b/projects/packages/wordads/src/dashboard/components/button/test/index.test.jsx
@@ -13,14 +13,14 @@ describe( 'Button', function () {
 	};
 	it( 'can render', () => {
 		render( <Button /> );
-		expect( screen.queryByRole( 'button' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button' ) ).toBeInTheDocument();
 	} );
 	it( 'can render compact button', () => {
 		render( <Button compact={ true } /> );
-		expect( screen.queryByRole( 'button' ).className ).toContain( 'is-compact' );
+		expect( screen.getByRole( 'button' ) ).toHaveClass( 'is-compact' );
 	} );
 	it( 'can render with class name passed in', () => {
 		render( <Button { ...testProps } /> );
-		expect( screen.queryByRole( 'button' ).className ).toContain( 'test-class' );
+		expect( screen.getByRole( 'button' ) ).toHaveClass( 'test-class' );
 	} );
 } );

--- a/projects/packages/wordads/src/dashboard/components/card/test/index.test.jsx
+++ b/projects/packages/wordads/src/dashboard/components/card/test/index.test.jsx
@@ -10,6 +10,6 @@ import React from 'react';
 describe( 'Card', function () {
 	it( 'can render', () => {
 		render( <Card title="Title" /> );
-		expect( screen.queryByRole( 'heading' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'heading' ) ).toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/wordads/src/dashboard/components/form-toggle/test/index.test.jsx
+++ b/projects/packages/wordads/src/dashboard/components/form-toggle/test/index.test.jsx
@@ -14,13 +14,13 @@ describe( 'CompactFormToggle', function () {
 	describe( 'rendering', function () {
 		it( 'can render', () => {
 			render( <CompactFormToggle>Toggle Label</CompactFormToggle> );
-			expect( screen.queryByText( 'Toggle Label' ) ).toBeInTheDocument();
-			expect( screen.getAllByRole( 'checkbox' )[ 0 ].className ).toContain( 'is-compact' );
+			expect( screen.getByText( 'Toggle Label' ) ).toBeInTheDocument();
+			expect( screen.getAllByRole( 'checkbox' )[ 0 ] ).toHaveClass( 'is-compact' );
 		} );
 
 		it( 'can render with class name passed in', () => {
 			render( <CompactFormToggle { ...testProps }>Toggle Label</CompactFormToggle> );
-			expect( screen.getAllByRole( 'checkbox' )[ 0 ].className ).toContain( 'test-class' );
+			expect( screen.getAllByRole( 'checkbox' )[ 0 ] ).toHaveClass( 'test-class' );
 		} );
 	} );
 } );

--- a/projects/packages/wordads/src/dashboard/components/global-notices/test/index.test.jsx
+++ b/projects/packages/wordads/src/dashboard/components/global-notices/test/index.test.jsx
@@ -13,7 +13,8 @@ describe( 'GlobalNotices', function () {
 			const { container } = render(
 				<GlobalNotices notices={ [ { id: 1, status: 'success' } ] } />
 			);
-			expect( container.firstChild.className ).toContain( 'global-notices' );
+			// eslint-disable-next-line testing-library/no-node-access
+			expect( container.firstChild ).toHaveClass( 'global-notices' );
 		} );
 	} );
 } );

--- a/projects/packages/wordads/src/dashboard/components/notice/test/index.test.jsx
+++ b/projects/packages/wordads/src/dashboard/components/notice/test/index.test.jsx
@@ -15,13 +15,15 @@ describe( 'SimpleNotice', function () {
 		it( 'can render', () => {
 			const { container } = render( <SimpleNotice id="1" status="success" /> );
 			expect(
+				// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
 				container.getElementsByClassName( 'dops-notice__icon-wrapper' ).length
 			).toBeGreaterThan( 0 );
 		} );
 
 		it( 'can render with class name passed in', () => {
 			const { container } = render( <SimpleNotice { ...testProps }>Toggle Label</SimpleNotice> );
-			expect( container.firstChild.className ).toContain( 'test-class' );
+			// eslint-disable-next-line testing-library/no-node-access
+			expect( container.firstChild ).toHaveClass( 'test-class' );
 		} );
 	} );
 } );

--- a/projects/packages/wordads/src/dashboard/store/actions/test/jetpack-settings.test.js
+++ b/projects/packages/wordads/src/dashboard/store/actions/test/jetpack-settings.test.js
@@ -7,22 +7,22 @@ describe( 'Jetpack Settings updateJetpackSettings action', () => {
 	const action = updateJetpackSettings( undefined, undefined );
 	test( 'yield setJetpackSettings state to new one', () => {
 		// Create notice 'Updating'.
-		expect( action.next().value.type ).toEqual( 'CREATE_NOTICE' );
+		expect( action.next().value.type ).toBe( 'CREATE_NOTICE' );
 		// Set state updating flag.
-		expect( action.next().value.type ).toEqual( 'SET_WORDADS_SETTINGS' );
+		expect( action.next().value.type ).toBe( 'SET_WORDADS_SETTINGS' );
 		// Set state to the target state.
-		expect( action.next().value.type ).toEqual( 'SET_WORDADS_SETTINGS' );
+		expect( action.next().value.type ).toBe( 'SET_WORDADS_SETTINGS' );
 		// Post new settings to API.
-		expect( action.next().value.type ).toEqual( 'UPDATE_WORDADS_SETTINGS' );
+		expect( action.next().value.type ).toBe( 'UPDATE_WORDADS_SETTINGS' );
 		// Fetch settings from API.
-		expect( action.next().value.type ).toEqual( 'FETCH_WORDADS_SETTINGS' );
+		expect( action.next().value.type ).toBe( 'FETCH_WORDADS_SETTINGS' );
 		// Set fetched setting from above step.
-		expect( action.next().value.type ).toEqual( 'SET_WORDADS_SETTINGS' );
+		expect( action.next().value.type ).toBe( 'SET_WORDADS_SETTINGS' );
 		// Remove 'Updating' notice.
-		expect( action.next().value.type ).toEqual( 'REMOVE_NOTICE' );
+		expect( action.next().value.type ).toBe( 'REMOVE_NOTICE' );
 		// Remove state updating flag.
-		expect( action.next().value.type ).toEqual( 'SET_WORDADS_SETTINGS' );
+		expect( action.next().value.type ).toBe( 'SET_WORDADS_SETTINGS' );
 		// Create success notice.
-		expect( action.next().value.type ).toEqual( 'CREATE_NOTICE' );
+		expect( action.next().value.type ).toBe( 'CREATE_NOTICE' );
 	} );
 } );

--- a/projects/plugins/jetpack/_inc/client/.eslintrc.js
+++ b/projects/plugins/jetpack/_inc/client/.eslintrc.js
@@ -15,10 +15,4 @@ module.exports = {
 			},
 		],
 	},
-	overrides: [
-		{
-			files: [ '**/test/*.[jt]s?(x)' ],
-			extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-		},
-	],
 };

--- a/projects/plugins/jetpack/changelog/add-eslint-add-tests-as-jest
+++ b/projects/plugins/jetpack/changelog/add-eslint-add-tests-as-jest
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Lint all JS tests. No change to the project itself.
+
+

--- a/projects/plugins/jetpack/extensions/.eslintrc.js
+++ b/projects/plugins/jetpack/extensions/.eslintrc.js
@@ -43,10 +43,4 @@ module.exports = {
 			},
 		],
 	},
-	overrides: [
-		{
-			files: [ '**/test/*.[jt]s?(x)' ],
-			extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-		},
-	],
 };

--- a/projects/plugins/jetpack/modules/.eslintrc.js
+++ b/projects/plugins/jetpack/modules/.eslintrc.js
@@ -43,10 +43,4 @@ module.exports = {
 		'no-undef': 1,
 		'no-extra-boolean-cast': 1,
 	},
-	overrides: [
-		{
-			files: [ '**/test/*.[jt]s?(x)' ],
-			extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-		},
-	],
 };

--- a/tools/cli/skeletons/js-packages/tests/.eslintrc.cjs
+++ b/tools/cli/skeletons/js-packages/tests/.eslintrc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
-};

--- a/tools/cli/skeletons/js-packages/tests/index.test.js
+++ b/tools/cli/skeletons/js-packages/tests/index.test.js
@@ -4,5 +4,4 @@
 // Please don't add new uses of `mocha`, `chai`, `sinon`, `enzyme`, and so on. We're trying to standardize on one testing framework.
 //
 // The default setup is to have files named like "name.test.js" (or .jsx, .ts, or .tsx) in this `tests/` directory.
-// But you could instead put them in `src/`, or put files like "name.js" (or .jsx, .ts, or .tsx) in `__tests__` directories somewhere.
-// In those cases you might want to adapt the eslintrc to apply the "jest" preset to those files accordingly.
+// But you could instead put them in `src/`, or put files like "name.js" (or .jsx, .ts, or .tsx) in `test` or `__tests__` directories somewhere.

--- a/tools/cli/tests/unit/helpers/filter-stream.test.js
+++ b/tools/cli/tests/unit/helpers/filter-stream.test.js
@@ -10,21 +10,21 @@ describe( 'FilterStream', () => {
 		ts.pend = promisify( ts.end );
 
 		await ts.pwrite( 'line 1\n' );
-		expect( ts.read() ).toEqual( 'LINE 1\n' );
+		expect( ts.read() ).toBe( 'LINE 1\n' );
 		await ts.pwrite( 'line 2...' );
-		expect( ts.read() ).toEqual( null );
+		expect( ts.read() ).toBeNull();
 		await ts.pwrite( ' ... done\n' );
-		expect( ts.read() ).toEqual( 'LINE 2... ... DONE\n' );
+		expect( ts.read() ).toBe( 'LINE 2... ... DONE\n' );
 		await ts.pwrite( 'line 3\nline 4\n\nline 5\n' );
-		expect( ts.read() ).toEqual( 'LINE 3\nLINE 4\n\nLINE 5\n' );
+		expect( ts.read() ).toBe( 'LINE 3\nLINE 4\n\nLINE 5\n' );
 		await ts.pwrite( '\nline 6\n' );
-		expect( ts.read() ).toEqual( '\nLINE 6\n' );
+		expect( ts.read() ).toBe( '\nLINE 6\n' );
 		await ts.pwrite( 'line 7\nline 8' );
-		expect( ts.read() ).toEqual( 'LINE 7\n' );
+		expect( ts.read() ).toBe( 'LINE 7\n' );
 		await ts.pwrite( '...\nline 9' );
-		expect( ts.read() ).toEqual( 'LINE 8...\n' );
+		expect( ts.read() ).toBe( 'LINE 8...\n' );
 		await ts.pend();
-		expect( ts.read() ).toEqual( 'LINE 9' );
+		expect( ts.read() ).toBe( 'LINE 9' );
 	} );
 
 	test( 'filters', async () => {
@@ -34,7 +34,7 @@ describe( 'FilterStream', () => {
 
 		await ts.pwrite( 'line 1\nnope\nno\nline 2\nline 3' );
 		await ts.pend();
-		expect( ts.read() ).toEqual( 'line 1\nline 2\nline 3' );
+		expect( ts.read() ).toBe( 'line 1\nline 2\nline 3' );
 	} );
 
 	test( 'filters (2)', async () => {
@@ -44,7 +44,7 @@ describe( 'FilterStream', () => {
 
 		await ts.pwrite( 'nope\nno\nnot this either' );
 		await ts.pend();
-		expect( ts.read() ).toEqual( null );
+		expect( ts.read() ).toBeNull();
 	} );
 
 	test( "doesn't produce a stray line if EOF is a newline", async () => {
@@ -54,7 +54,7 @@ describe( 'FilterStream', () => {
 
 		await ts.pwrite( 'line 1\n' );
 		await ts.pend();
-		expect( ts.read() ).toEqual( '<line 1>\n' );
+		expect( ts.read() ).toBe( '<line 1>\n' );
 	} );
 
 	test( "doesn't produce a stray line if nothing was written", async () => {
@@ -63,7 +63,7 @@ describe( 'FilterStream', () => {
 		ts.pend = promisify( ts.end );
 
 		await ts.pend();
-		expect( ts.read() ).toEqual( null );
+		expect( ts.read() ).toBeNull();
 	} );
 
 	test( "doesn't die from backpressure", async () => {

--- a/tools/cli/tests/unit/helpers/prefix-stream.test.js
+++ b/tools/cli/tests/unit/helpers/prefix-stream.test.js
@@ -8,9 +8,9 @@ describe( 'PrefixStream', () => {
 		const ts = new PrefixStream( { prefix: 'foobar', encoding: 'utf8' } );
 
 		ts.write( 'line 1\n\nline 2' );
-		expect( ts.read() ).toEqual( '[foobar] line 1\n[foobar] \n' );
+		expect( ts.read() ).toBe( '[foobar] line 1\n[foobar] \n' );
 		ts.end();
-		expect( ts.read() ).toEqual( '[foobar] line 2' );
+		expect( ts.read() ).toBe( '[foobar] line 2' );
 	} );
 
 	test( 'prefixes with timing info', async () => {
@@ -34,6 +34,6 @@ describe( 'PrefixStream', () => {
 		const ts = new PrefixStream( { encoding: 'utf8' } );
 
 		ts.write( 'line 1\n' );
-		expect( ts.read() ).toEqual( 'line 1\n' );
+		expect( ts.read() ).toBe( 'line 1\n' );
 	} );
 } );

--- a/tools/cli/tests/unit/helpers/styling.test.js
+++ b/tools/cli/tests/unit/helpers/styling.test.js
@@ -2,8 +2,6 @@ import { chalkJetpackGreen } from '../../../helpers/styling.js';
 
 describe( 'styling', () => {
 	test.skip( 'Text should be returned as green', function () {
-		expect( chalkJetpackGreen( 'Jetpack Green' ) ).toEqual(
-			'\u001b[38;5;41mJetpack Green\u001b[39m'
-		);
+		expect( chalkJetpackGreen( 'Jetpack Green' ) ).toBe( '\u001b[38;5;41mJetpack Green\u001b[39m' );
 	} );
 } );

--- a/tools/js-tools/eslintrc/base.js
+++ b/tools/js-tools/eslintrc/base.js
@@ -46,6 +46,15 @@ module.exports = {
 			files: [ '*.ts', '*.tsx' ],
 			extends: './typescript',
 		},
+		{
+			files: [
+				// Note: Keep the patterns here in sync with tools/js-tools/jest/config.base.js.
+				'**/__tests__/**/*.[jt]s?(x)',
+				'**/?(*.)+(spec|test).[jt]s?(x)',
+				'**/test/*.[jt]s?(x)',
+			],
+			extends: [ require.resolve( 'jetpack-js-tools/eslintrc/jest' ) ],
+		},
 	],
 	plugins: [ 'import', 'prettier', 'jsx-a11y', 'lodash', 'jsdoc', '@typescript-eslint' ],
 	rules: {

--- a/tools/js-tools/jest/config.base.js
+++ b/tools/js-tools/jest/config.base.js
@@ -18,6 +18,7 @@ module.exports = {
 		],
 	},
 	testMatch: [
+		// Note: Keep the patterns here in sync with tools/js-tools/eslintrc/base.js.
 		'<rootDir>/**/__tests__/**/*.[jt]s?(x)',
 		'<rootDir>/**/?(*.)+(spec|test).[jt]s?(x)',
 		'<rootDir>/**/test/*.[jt]s?(x)',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Now that we've got everything using Jest and Testing-Library syntax,
have the base eslint config apply the jest rules for every file named
like a test (i.e. in a `/test/` directory or named like `*.test.js`).

This caught a few more projects that hadn't had the linting set up
already. These are fixed.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-5j2-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?
* Changes look good?