### PR TITLE
VideoPress: Include private videos URL in VideoPress block (v6) GUID parser

### DIFF
--- a/projects/plugins/jetpack/changelog/update-url-guid-from-url-videopress-block-v6
+++ b/projects/plugins/jetpack/changelog/update-url-guid-from-url-videopress-block-v6
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Included private videos URL in VideoPress block (v6) GUID parser

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -208,10 +208,17 @@ export default function VideoPressEdit( { attributes, setAttributes } ) {
 		onSuccess: setAttributes,
 	} );
 
+	// Returns true if the object represents a valid host for a VideoPress video.
+	// Private vidoes are hosted under video.wordpress.com
+	const isValidVideoPressUrl = urlObject => {
+		const validHosts = [ 'videopress.com', 'video.wordpress.com' ];
+		return urlObject.protocol === 'https:' && validHosts.includes( urlObject.host );
+	};
+
 	const getGuidFromVideoUrl = url => {
 		try {
 			const urlObject = new URL( url );
-			if ( urlObject.protocol === 'https:' && urlObject.host === 'videopress.com' ) {
+			if ( isValidVideoPressUrl( urlObject ) ) {
 				const videoGuid = urlObject.pathname.match( /^\/v\/([a-zA-Z0-9]+)$/ );
 				return videoGuid.length === 2 ? videoGuid[ 1 ] : false;
 			}


### PR DESCRIPTION
Takes in account host for private videos

Fixes https://github.com/Automattic/jetpack/pull/24911/files#r911359910

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Includes `video.wordpress.com` when validating inserted URL

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?


#### Does this pull request change what data or activity we track or use?
no
#### Testing instructions:
1. Checkout this branch
1. Add a VideoPress block
2. Click "Insert from URL"
4. Enter a valid private video URL like https://video.wordpress.com/v/hWw5qcpF
3. Confirm you don't get an error about the URL.

The video does not load for some reason. There is something else on the proxy side returning 404 for the thumbnail. e.g. https://roasted-landfowl.jurassic.ninja/wp-json/oembed/1.0/proxy?url=https%3A%2F%2Fvideo.wordpress.com%2Fv%2FhWw5qcpF&_locale=user

It's returning `{"code":"oembed_invalid_url","message":"Not Found","data":{"status":404}}`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202518480088424