### PR TITLE
Make AAG Backup card more clear about realtime backups.

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
@@ -179,7 +179,6 @@
 }
 
 .jp-at-a-glance__stats-ctas {
-
 	display: flex;
 	flex-direction: row;
 	align-items: center;
@@ -246,8 +245,7 @@
 
 .jp-at-a-glance__stats-view-link:focus {
 	outline: 0;
-	box-shadow: 0 0 0 1px #4f94d4, 0 0 2px 1px rgba(30, 140, 190, 0.8);
-
+	box-shadow: 0 0 0 1px #4f94d4, 0 0 2px 1px rgba( 30, 140, 190, 0.8 );
 }
 
 // heavy flexbox nesting below, careful! – @jeffgolenski
@@ -462,4 +460,10 @@
 
 .jp-dash-item__videopress-storage {
 	margin-top: 1em;
+}
+
+.jp-dash-item__action-links {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px 26px;
 }

--- a/projects/plugins/jetpack/changelog/update-backup-aag-card
+++ b/projects/plugins/jetpack/changelog/update-backup-aag-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update text and add link to the Backup aag card.


### PR DESCRIPTION
This PR updates the the text in the AAG Backup card (when Backup Realtime is activated), making it more clear that backups are triggered in real-tme as the site is edited or changed.
Also added an additional CTA link pointing to the site's backup & restore points in the wordpress.com Activity Log.

#### Changes proposed in this Pull Request:

**Before**  

![](https://user-images.githubusercontent.com/11078128/176783910-f2087146-ce4a-4c17-836c-db06371cd156.png)

**After**
![](https://user-images.githubusercontent.com/11078128/176783921-e3040d5a-33be-4c99-82ee-beb08ea105b8.png)


#### Jetpack product discussion
- [PT: Real-time backup — Make sure it is clear for users that their site is currently backed up with real-time](p1HpG7-gb4-p2)
- [Make it clear for users that their site is backed up in real-time – i2 Designs](p1HpG7-gkG-p2#jetpack-plugin)


#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

- Spin up a JN site with Jetpack Beta, using Jetpack branch `update/backup-aag-card`.  
- Connect Jetpack and purchase Backup (or Security) with credits.
- Go to `https://cloud.jetpack.com/settings/:site?action=edit` (replace `:site` with your JN site slug) and enter your **JN site server credentials**.
- Navigate to the Jetpack Dashboard (At a glance) page.
- Scroll down to the "Backup" card.  Verify the Backups card looks like the design as discussed here: p1HpG7-gkG-p2#jetpack-plugin (Figma design is also posted there also).
- Verify the "Learn more" link points to [Real-Time Backups Become a Reality With Jetpack](https://jetpack.com/blog/real-time-backups-become-a-reality-with-jetpack/) and the tracking event fires when clicked.
- Verify the "View your site's backups" link points to your site's backups in Jetpack Cloud. Verify the tracking event fires when clicked.
- Verify the "View your most recent restore points" link points to your site's restore points in the Activity Log. Verify the tracking event fires when clicked.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202580352248672