### PR TITLE
Search Record Meter: Remove all dismissable logic and styling from notice boxes

### DIFF
--- a/projects/packages/search/changelog/update-search-record-meter-remove-dismissable-notice-boxes
+++ b/projects/packages/search/changelog/update-search-record-meter-remove-dismissable-notice-boxes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Record Meter: Remove dissmissable functionality and design from notice boxes

--- a/projects/packages/search/changelog/update-search-record-meter-remove-dismissable-notice-boxes
+++ b/projects/packages/search/changelog/update-search-record-meter-remove-dismissable-notice-boxes
@@ -1,4 +1,4 @@
 Significance: patch
 Type: removed
 
-Record Meter: Remove dissmissable functionality and design from notice boxes
+Record Meter: Remove dismissable functionality and design from notice boxes

--- a/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
@@ -2,12 +2,11 @@
 import { __, sprintf } from '@wordpress/i18n';
 import SimpleNotice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action.jsx';
-import React, { useState } from 'react';
+import React from 'react';
 
 import './notice-box.scss';
 
 const CLOSE_TO_LIMIT_PERCENT = 0.8;
-const DISMISSED_NOTICES = 'jetpack-search-dismissed-notices';
 
 const getNotices = ( tierMaximumRecords = null ) => {
 	const recordLimit =
@@ -71,10 +70,6 @@ const getNotices = ( tierMaximumRecords = null ) => {
 export function NoticeBox( props ) {
 	const activeNoticeIds = [];
 	const NOTICES = getNotices( props.tierMaximumRecords );
-	const [ showNotice, setShowNotice ] = useState( true );
-
-	// deal with sessionStorage for ensuring dismissed notice boxes are not re-displayed
-	const dismissedNoticesString = sessionStorage.getItem( DISMISSED_NOTICES ) ?? '';
 
 	const DATA_NOT_VALID = '1',
 		HAS_NOT_BEEN_INDEXED = '2',
@@ -82,28 +77,21 @@ export function NoticeBox( props ) {
 		CLOSE_TO_LIMIT = '3';
 
 	// check if data is valid
-	props.hasValidData === false &&
-		! dismissedNoticesString.includes( DATA_NOT_VALID ) &&
-		activeNoticeIds.push( DATA_NOT_VALID );
+	props.hasValidData === false && activeNoticeIds.push( DATA_NOT_VALID );
 
 	// check site has been indexed
-	props.hasBeenIndexed === false &&
-		! dismissedNoticesString.includes( HAS_NOT_BEEN_INDEXED ) &&
-		activeNoticeIds.push( HAS_NOT_BEEN_INDEXED );
+	props.hasBeenIndexed === false && activeNoticeIds.push( HAS_NOT_BEEN_INDEXED );
 
 	// check at least one indexable item
-	props.hasItems === false &&
-		! dismissedNoticesString.includes( NO_INDEXABLE_ITEMS ) &&
-		activeNoticeIds.push( NO_INDEXABLE_ITEMS );
+	props.hasItems === false && activeNoticeIds.push( NO_INDEXABLE_ITEMS );
 
 	// check if close to reaching limit
 	typeof props.tierMaximumRecords === 'number' &&
 		props.recordCount > props.tierMaximumRecords * CLOSE_TO_LIMIT_PERCENT &&
 		props.recordCount < props.tierMaximumRecords &&
-		! dismissedNoticesString.includes( CLOSE_TO_LIMIT ) &&
 		activeNoticeIds.push( CLOSE_TO_LIMIT );
 
-	if ( activeNoticeIds.length < 1 || ! showNotice ) {
+	if ( activeNoticeIds.length < 1 ) {
 		return null;
 	}
 
@@ -113,20 +101,13 @@ export function NoticeBox( props ) {
 		? 'jp-search-notice-box jp-search-notice-box__important'
 		: 'jp-search-notice-box';
 
-	const dismissNoticeBox = () => {
-		setShowNotice( false );
-		if ( ! dismissedNoticesString.includes( notice.id ) ) {
-			sessionStorage.setItem( DISMISSED_NOTICES, dismissedNoticesString + notice.id );
-		}
-	};
-
 	return (
 		<SimpleNotice
 			isCompact={ false }
 			status={ 'is-info' }
 			className={ noticeBoxClassName }
-			onDismissClick={ dismissNoticeBox }
 			icon={ 'info-outline' }
+			showDismiss={ false }
 		>
 			{ notice.header && <h3 className="dops-notice__header">{ notice.header }</h3> }
 			{ notice.message && <span className="dops-notice__body">{ notice.message }</span> }

--- a/projects/packages/search/src/dashboard/components/record-meter/notice-box.scss
+++ b/projects/packages/search/src/dashboard/components/record-meter/notice-box.scss
@@ -21,8 +21,7 @@
 	padding-top: 16px;
 }
 
-.jp-search-record-meter .jp-search-notice-box > span.dops-notice__icon-wrapper,
-.jp-search-record-meter .dops-notice__dismiss {
+.jp-search-record-meter .jp-search-notice-box > span.dops-notice__icon-wrapper {
 	background-color: rgba( 255, 255, 255, 0 );
 	padding: 0;
 }
@@ -60,12 +59,6 @@
 	}
 }
 
-.jp-search-notice-box .dops-notice__dismiss > svg,
-.jp-search-notice-box .dops-notice__dismiss > svg:hover {
-	color: black;
-	padding: 0;
-}
-
 .jp-search-notice-box .dops-notice__icon-wrapper {
 	color: #000;
 	flex-grow: 0;
@@ -80,10 +73,6 @@
 .jp-search-notice-box__important .dops-notice__action,
 .jp-search-notice-box__important .dops-notice__header {
 	color: $studio-red-50;
-}
-
-.jp-search-notice-box__important .dops-notice__dismiss > svg {
-	fill: $studio-red-50;
 }
 
 .jp-search-notice-box > .dops-notice__icon-wrapper > svg {


### PR DESCRIPTION
This PR removes all dismissable logic and styling from record meter notice boxes

#### Changes proposed in this Pull Request:

* Removes logic for keeping notice boxes dismissed
* Removes CSS for dismiss buttons/icons
* Passes `showDismiss={ false }` to the `SimpleNoticeBox` component

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
we chatted about this in the CFT at `wp.me/p8oabR-Tl#comment-6412`

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* Go to` /wp-admin/admin.php?page=jetpack-search&features=record-meter` on your test site with Search enabled.
* Trigger the different notice box behaviors by toggling off/on the altered states to trigger the different notices using a React tools browser inspector. Or alternatively, test on a testing site to trigger the notices. One such way is to check once when Search is first added and has not been indexed, then again a little later once it has been indexed by deleting all existing posts/pages from the site. to get the 'no search records / has not been indexed' notice. 

![image](https://user-images.githubusercontent.com/30754158/176798834-9c8a5ce0-d9d3-4c3e-b7f2-d3627157dca0.png)

* Ensure that in all cases, the notice box does not show an 'X' dismiss icon in the top right corner

![image](https://user-images.githubusercontent.com/30754158/176798511-5912ca3c-4d73-4d2d-80d3-80829fa0385c.png)

