### PR TITLE
Form block: Fix Checkbox Group Option color in Editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-form-block-checkbox-group-color
+++ b/projects/plugins/jetpack/changelog/fix-form-block-checkbox-group-color
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Form block: Fix Checkbox Group color

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
@@ -212,7 +212,7 @@ input.components-text-control__input {
 
 	// TODO: make this a class, @enej
 	[data-type='jetpack/field-select'] & {
-		border: 1px solid rgba( 0, 0, 0, 0.4 );
+		border: 1px solid rgba(0, 0, 0, 0.4);
 		border-radius: 4px;
 		padding: 4px;
 	}
@@ -230,6 +230,7 @@ input.components-text-control__input {
 
 // Duplicated to elevate specificity in order to overwrite core styles
 .jetpack-option__input.jetpack-option__input.jetpack-option__input {
+	color: inherit;
 	border-color: transparent;
 	background: transparent;
 	border-radius: 0;

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
@@ -212,7 +212,7 @@ input.components-text-control__input {
 
 	// TODO: make this a class, @enej
 	[data-type='jetpack/field-select'] & {
-		border: 1px solid rgba(0, 0, 0, 0.4);
+		border: 1px solid rgba( 0, 0, 0, 0.4 );
 		border-radius: 4px;
 		padding: 4px;
 	}
@@ -246,6 +246,11 @@ input.components-text-control__input {
 		box-shadow: none;
 	}
 }
+
+.jetpack-field-multiple.components-base-control {
+	font-size: inherit;
+}
+
 // Duplicated to elevate specificity in order to overwrite calypso styles
 .jetpack-option__remove.jetpack-option__remove {
 	padding: 6px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The proposed change makes the Option (`<input>` element) inside Checkbox Group of the Form block inherit the color.

This addresses the issue #24928 where a couple of styles (including the user agent stylesheet) [were overriding the color selected in the editor](https://github.com/Automattic/jetpack/issues/24928#issuecomment-1172252580).

| Before | After |
| ------------- | ------------- |
| ![Markup on 2022-07-01 at 14:20:27](https://user-images.githubusercontent.com/25105483/176893276-a65801c4-f4e9-43aa-b78c-dc79737c728c.png) | ![Markup on 2022-07-01 at 14:19:02](https://user-images.githubusercontent.com/25105483/176893287-bce248da-f9d9-444b-a13c-798182542314.png) |

Also fixed incorrect font size for labels of multiple field.

| Before | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/1287077/178927391-a12ee029-d355-4d0c-8ae8-3563d146c79f.png) | ![image](https://user-images.githubusercontent.com/1287077/178927402-6b713eb7-5376-4df9-bd11-dd9bfdb76a2a.png) |

#### Other information:

- [ ] ~~Have you written new tests for your changes, if applicable?~~ Not applicable
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No, it does not.

#### Testing instructions:

→ #24928 should not be replicable

Specific steps:
1. Create a post with Form block and a Checkbox Group
2. Add multiple item to the Checkbox Group
3. Change the color in the Form block settings
4. Review the text color of the items in the Checkbox Group - the color set in the previous step should be applied correcly


