### PR TITLE
E2E tests: disable dedicated sync e2e test

### DIFF
--- a/projects/plugins/jetpack/changelog/e2e-disable-dedicated-sync-test
+++ b/projects/plugins/jetpack/changelog/e2e-disable-dedicated-sync-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+E2E tests: disable broken dedicated sync e2e test

--- a/projects/plugins/jetpack/tests/e2e/specs/sync/sync.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/sync/sync.test.js
@@ -97,7 +97,7 @@ test.describe( 'Sync', () => {
 		} );
 	} );
 
-	test( 'Dedicated Sync Flow', async ( { page } ) => {
+	test.skip( 'Dedicated Sync Flow', async ( { page } ) => {
 		await test.step( 'Enable Dedicated Sync', async () => {
 			const dedicatedSyncEnabled = await enableDedicatedSync();
 			expect( dedicatedSyncEnabled ).toMatch( 'Success' );

--- a/tools/e2e-commons/.eslintrc.cjs
+++ b/tools/e2e-commons/.eslintrc.cjs
@@ -21,5 +21,6 @@ module.exports = {
 	},
 	rules: {
 		'no-console': 0,
+		'playwright/no-skipped-test': 0,
 	},
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Dedicated Sync Flow has a very high failure rate. Skip the test until a proper fix is in place.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
1201642007924219-as-1202530637866855

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* `Dedicated Sync Flow` e2e test should be skipped