### PR TITLE
Related Posts: avoid PHP warnings when visiting AMP post views.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-related-posts-amp-warning
+++ b/projects/plugins/jetpack/changelog/fix-related-posts-amp-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Related Posts: avoid PHP warnings when visiting AMP post views.

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -201,7 +201,7 @@ class Jetpack_RelatedPosts {
 			$this->action_frontend_init_ajax( $excludes );
 		} else {
 			if ( isset( $_GET['relatedposts_hit'], $_GET['relatedposts_origin'], $_GET['relatedposts_position'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- checking if fields are set to setup tracking, nothing is changing on the site.
-				$this->previous_post_id = (int) $_GET['relatedposts_origin']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- fetching a previous post ID for tracking, nothing is changing on the site. 
+				$this->previous_post_id = (int) $_GET['relatedposts_origin']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- fetching a previous post ID for tracking, nothing is changing on the site.
 				$this->log_click( $this->previous_post_id, get_the_ID(), sanitize_text_field( wp_unslash( $_GET['relatedposts_position'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- logging the click for tracking, nothing is changing on the site.
 			}
 
@@ -275,6 +275,7 @@ class Jetpack_RelatedPosts {
 			'postsToShow'       => isset( $rp_settings['size'] ) ? $rp_settings['size'] : 3,
 			/** This filter is already documented in modules/related-posts/jetpack-related-posts.php */
 			'headline'          => apply_filters( 'jetpack_relatedposts_filter_headline', $this->get_headline() ),
+			'isServerRendered'  => true,
 		);
 
 		return $this->render_block( $block_rp_settings );
@@ -479,7 +480,11 @@ EOT;
 			$rows_markup .= $this->render_block_row( $lower_row_posts, $block_attributes );
 		}
 
-		$wrapper_attributes = \WP_Block_Supports::get_instance()->apply_block_supports();
+		if ( empty( $attributes['isServerRendered'] ) ) {
+			// The get_server_rendered_html() path won't register a block,
+			// so only apply block supports when not server rendered.
+			$wrapper_attributes = \WP_Block_Supports::get_instance()->apply_block_supports();
+		}
 
 		$display_markup = sprintf(
 			'<nav class="jp-relatedposts-i2%1$s"%2$s data-layout="%3$s">%4$s%5$s</nav>',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Avoid using `apply_block_supports()` when doing `get_server_rendered_html()` (e.g. for AMP post views), as that code path doesn't actually register a block and can cause PHP warnings as mentioned in #23841 

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

Fixes #23841

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

**Pre-patch:**

- On a Jetpack connected site, make sure the Related Posts module is enabled.
- Try using the Twenty Twenty theme.
- Have the AMP plugin active (I used v2.3.0).
- Make sure you have PHP errors/warnings logged.
- Visit an AMP post view (add `/amp` to the end of the post URL) & observe debug log for warning similar to:

```
PHP Warning:  Trying to access array offset on value of type null in wp-includes/class-wp-block-supports.php 
```
**Post-patch:**

- With changes pulled down, again try visiting an AMP post view which should not generate the PHP warning.
- Try browsing around non-AMP post views and other areas of the site checking for any additional debug output (none should be expected).
