### PR TITLE
Jetpack: tweak VideoPress block layout markup and styles

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-wpblock-improve-markup-and-sizes
+++ b/projects/plugins/jetpack/changelog/update-jetpack-wpblock-improve-markup-and-sizes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: tweak vpblock layout markup and styles

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
@@ -1,30 +1,20 @@
 /**
  * External dependencies
  */
-import { RichText, useBlockProps } from '@wordpress/block-editor';
+import { RichText } from '@wordpress/block-editor';
 import { ResizableBox, SandBox } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import classNames from 'classnames';
 
 export default function VideoPressPlayer( {
 	html,
-	isUpdatingPreview,
 	isSelected,
 	attributes,
 	setAttributes,
 	scripts = [],
-	className,
 } ) {
 	// @todo: implemen maxWidth
-	const { align, maxWidth, caption } = attributes;
-
-	const blockProps = useBlockProps( {
-		className: classNames( className, 'jetpack-videopress-player', {
-			[ `align${ align }` ]: align,
-			[ 'is-updating-preview' ]: isUpdatingPreview,
-		} ),
-	} );
+	const { maxWidth, caption } = attributes;
 
 	const onBlockResize = useCallback(
 		( event, direction, domElement ) => {
@@ -55,7 +45,7 @@ export default function VideoPressPlayer( {
 	}
 
 	return (
-		<figure { ...blockProps }>
+		<figure className="jetpack-videopress-player">
 			<ResizableBox
 				enable={ {
 					top: false,
@@ -68,7 +58,7 @@ export default function VideoPressPlayer( {
 				style={ { margin: 'auto' } }
 				onResizeStop={ onBlockResize }
 			>
-				{ ! isSelected && <div className="wp-block-jetpack-videopress__overlay" /> }
+				{ ! isSelected && <div className="jetpack-videopress-player__overlay" /> }
 				<SandBox html={ html } scripts={ scripts } />
 			</ResizableBox>
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -34,6 +34,7 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 		src,
 		guid,
 		cacheHtml,
+		align,
 	} = attributes;
 
 	const videoPressUrl = getVideoPressUrl( guid, {
@@ -154,6 +155,7 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 
 	const videoPlayerBlockProps = useBlockProps( {
 		className: classNames( 'wp-block-jetpack-videopress', {
+			[ `align${ align }` ]: align,
 			'is-updating-preview': ! previewHtml,
 		} ),
 	} );

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -7,6 +7,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useState, useCallback, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import classNames from 'classnames';
 /**
  * Internal dependencies
  */
@@ -151,6 +152,12 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 		className: 'wp-block-jetpack-videopress is-placeholder-container',
 	} );
 
+	const videoPlayerBlockProps = useBlockProps( {
+		className: classNames( 'wp-block-jetpack-videopress', {
+			'is-updating-preview': ! previewHtml,
+		} ),
+	} );
+
 	/*
 	 * 1 - Initial block state. Show VideoPressUploader when:
 	 *     - no src attribute,
@@ -183,7 +190,7 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 
 	// X - Show VideoPress player. @todo: finish
 	return (
-		<>
+		<div { ...videoPlayerBlockProps }>
 			<VideoPressInspectorControls attributes={ attributes } setAttributes={ setAttributes } />
 			<VideoPressPlayer
 				html={ html }
@@ -194,6 +201,6 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 				isSelected={ isSelected }
 				className="wp-block-jetpack-videopress"
 			/>
-		</>
+		</div>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/editor.scss
@@ -21,10 +21,14 @@
 
 
 	&.is-updating-preview {
-		opacity: 0.5;
+		opacity: 0.5; // @todo: consider improve this state in the UI
 	}
 
-	.wp-block-jetpack-videopress__overlay {
+	.jetpack-videopress-player {
+		margin: 0;
+	}
+
+	.jetpack-videopress-player__overlay {
 		position: absolute;
 		top: 0;
 		left: 0;
@@ -32,10 +36,6 @@
 		height: 100%;
 		background-color: transparent;
 		z-index: 1;
-	}
-
-	&.videopress-player {
-		margin: 0;
 	}
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/save.js
@@ -53,7 +53,7 @@ export default function save( { attributes } ) {
 	}
 
 	return (
-		<figure { ...blockProps }>
+		<figure { ...blockProps } style={ style }>
 			<div className="jetpack-videopress-player__wrapper">
 				{ `\n${ videoPressUrl }\n` /* URL needs to be on its own line. */ }
 			</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR iterates over the layout of the VideoPress to improve the markup and styles that define its dimensions. Also, restores saving these data that, for some reason, were removed.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack: tweak VideoPress block layout markup and styles

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to block editor
* Add a VideoPress block
* Upload a video
* Confirm the width of the video stretches until it occupies the whole width (unless you set custom size)

before | after
------|-------
<img width="685" alt="image" src="https://user-images.githubusercontent.com/77539/176949406-809dfa8f-8b9d-4a45-80d2-8bfa60a91a37.png"> | <img width="686" alt="image" src="https://user-images.githubusercontent.com/77539/176949601-51b2adbb-f702-4dfc-a31d-ad59ceafde07.png">

* Confirm that after setting a custom width and saving the post, the size is applied in the front-end.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202528984222004