### PR TITLE
E2E tests: Attempt to fix flaky Sync Dedicated flow test

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-e2e-dedicated-sync-flow
+++ b/projects/plugins/jetpack/changelog/fix-e2e-dedicated-sync-flow
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: E2E test fix
+
+

--- a/projects/plugins/jetpack/tests/e2e/helpers/sync-helper.js
+++ b/projects/plugins/jetpack/tests/e2e/helpers/sync-helper.js
@@ -11,6 +11,11 @@ export async function disableSync() {
 	return execWpCommand( 'jetpack sync disable' );
 }
 
+export async function resetSync() {
+	logger.sync( 'Resetting sync' );
+	return execWpCommand( 'jetpack sync reset' );
+}
+
 export async function getSyncStatus() {
 	logger.sync( 'Checking sync status' );
 	return execWpCommand( 'jetpack sync status' );

--- a/projects/plugins/jetpack/tests/e2e/specs/sync/sync.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/sync/sync.test.js
@@ -3,6 +3,7 @@ import { execWpCommand } from 'jetpack-e2e-commons/helpers/utils-helper.cjs';
 import {
 	enableSync,
 	disableSync,
+	resetSync,
 	enableDedicatedSync,
 	disableDedicatedSync,
 	isSyncQueueEmpty,
@@ -39,6 +40,7 @@ test.describe( 'Sync', () => {
 
 	test.afterEach( async () => {
 		await test.step( 'Reset Sync defaults', async () => {
+			await resetSync();
 			await enableSync();
 			await disableDedicatedSync();
 		} );
@@ -97,7 +99,7 @@ test.describe( 'Sync', () => {
 		} );
 	} );
 
-	test.skip( 'Dedicated Sync Flow', async ( { page } ) => {
+	test( 'Dedicated Sync Flow', async ( { page } ) => {
 		await test.step( 'Enable Dedicated Sync', async () => {
 			const dedicatedSyncEnabled = await enableDedicatedSync();
 			expect( dedicatedSyncEnabled ).toMatch( 'Success' );


### PR DESCRIPTION
Fix Sync flaky E2E test

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Introduces reset of Sync (aka resets Sync locks) after each Sync related E2E test.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
N/A

