### PR TITLE
Add fix shorthand GitHub action workflow to fix incorrect Automattic shorthand

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -4,6 +4,8 @@ on:
     types: [opened, reopened, synchronize, edited, labeled, closed]
   issues: # For auto-triage of issues.
     types: [opened, reopened]
+  issue_comment:
+    types: [created]
   push:
     branches:
       - trunk # Every time a PR is merged to trunk.
@@ -32,10 +34,10 @@ jobs:
   #             body: 'Howdy! The Jetpack team has disappeared for a few days to a secret island lair to concoct new ways to make Jetpack one hundred billion percent better. As a result, your Pull Request may not be reviewed right away. Do not worry, we will be back next week to look at your work! Thank you for your understanding.'
   #           })
   repo-gardening:
-    name: "Manage labels and assignees"
+    name: 'Manage labels and assignees'
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
-    timeout-minutes: 10  # 2021-03-12: Successful runs seem to take a few seconds, but can sometimes take a lot longer since we wait for previous runs to complete.
+    timeout-minutes: 10 # 2021-03-12: Successful runs seem to take a few seconds, but can sometimes take a lot longer since we wait for previous runs to complete.
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -66,7 +68,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: "Run the action (assign, manage milestones, for issues and PRs)"
+      - name: 'Run the action (assign, manage milestones, for issues and PRs)'
         uses: ./projects/github-actions/repo-gardening
         env:
           PR_WORKSPACE: ${{ github.workspace }}${{ github.event_name == 'pull_request_target' && '/pr-checkout' || '' }}

--- a/projects/github-actions/repo-gardening/changelog/add-fix-shorthand-github-action-workflow
+++ b/projects/github-actions/repo-gardening/changelog/add-fix-shorthand-github-action-workflow
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+GitHub action to fix incorrect Automattic shorthand formats on issue or PR comments

--- a/projects/github-actions/repo-gardening/src/index.js
+++ b/projects/github-actions/repo-gardening/src/index.js
@@ -8,6 +8,7 @@ const addMilestone = require( './tasks/add-milestone' );
 const assignIssues = require( './tasks/assign-issues' );
 const checkDescription = require( './tasks/check-description' );
 const cleanLabels = require( './tasks/clean-labels' );
+const fixShorthand = require( './tasks/fix-shorthand' );
 const flagOss = require( './tasks/flag-oss' );
 const notifyDesign = require( './tasks/notify-design' );
 const notifyEditorial = require( './tasks/notify-editorial' );
@@ -63,6 +64,11 @@ const automations = [
 		event: 'issues',
 		action: [ 'opened', 'reopened' ],
 		task: triageNewIssues,
+	},
+	{
+		event: 'issue_comment',
+		action: [ 'created' ],
+		task: fixShorthand,
 	},
 ];
 

--- a/projects/github-actions/repo-gardening/src/tasks/fix-shorthand/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/fix-shorthand/index.js
@@ -1,0 +1,48 @@
+const debug = require( '../../debug' );
+
+/* global GitHub, WebhookPayloadIssue */
+
+/**
+ * Find specific plugin impacted by issue, based off issue contents.
+ *
+ * @param {string} body - The issue or PR comment content.
+ * @returns {string} Issue or PR comment with proper Automattic shorthand.
+ */
+function replaceIncorrectShorthand( body ) {
+	let updatedBody;
+
+	const regexForIncorrectHappychatAtTheStart = /(hc|HC)-(\d+)/gm;
+	const regexForIncorrectHappychatAtTheEnd = /(\d+)-HC/gm;
+	const regexForIncorrectZendeskAtTheStart = /(zd|ZD|zd-woothemes|ZD-woothemes)-(\d+)/gm;
+	const regexForIncorrectZendeskAtTheEnd = /(\d+)-(ZD-woothemes|zd|ZD)/gm;
+
+	updatedBody = body.replace( regexForIncorrectHappychatAtTheStart, '$2-hc' );
+	updatedBody = updatedBody.replace( regexForIncorrectHappychatAtTheEnd, '$1-hc' );
+	updatedBody = updatedBody.replace( regexForIncorrectZendeskAtTheStart, '$2-zen' );
+	updatedBody = updatedBody.replace( regexForIncorrectZendeskAtTheEnd, '$1-zen' );
+
+	return updatedBody;
+}
+
+/**
+ * Fix shorthand on issue comments to make the shorthand compatible for Automattic userscripts
+ *
+ * @param {WebhookPayloadIssue} payload - Issue or PR comment event payload.
+ * @param {GitHub}              octokit - Initialized Octokit REST client.
+ */
+async function fixShorthand( payload, octokit ) {
+	const { comment, repository } = payload;
+	const { id } = comment;
+	const { owner } = repository;
+
+	debug( `fix-shorthand: Fixing all incorrect shorthand on the issue comment with the ID ${ id }` );
+
+	await octokit.rest.issues.updateComment( {
+		owner: owner.login,
+		repo: repository.name,
+		comment_id: id,
+		body: replaceIncorrectShorthand( comment.body ),
+	} );
+}
+
+module.exports = fixShorthand;

--- a/projects/github-actions/repo-gardening/src/tasks/fix-shorthand/readme.md
+++ b/projects/github-actions/repo-gardening/src/tasks/fix-shorthand/readme.md
@@ -1,0 +1,7 @@
+# Fix shorthand
+
+This GitHub Action workflow automatically fixes common incorrect shorthand on Automattic support interactions. The fix is not an exhaustive list -- we can add more incorrect formats as they are spotted. This workflow runs only on new comments on issues and PRs. It does not affect issues that are being edited, thus allowing the comment author to edit again if needed.
+
+## Rationale
+
+This is a Automattic-specific workflow that ensures that interaction IDs tracked on our repositories use the proper format that's described on PCYsg-5Xx-p2. Updating to the proper shorthand format will allow Automattic readers with the userscript to navigate to that interaction without having to manually visit it.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



#### Changes proposed in this Pull Request:

- This PR introduces a new GitHub Action workflow task.
- This task automatically fixes common incorrect shorthand of Automattic support interactions. This is not an exhaustive list -- we can add more incorrect formats as they are spotted. This workflow runs only on new comments on issues and PRs. It does not affect issues that are being edited, thus allowing the comment author to edit again if needed.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

- This workflow is inspired by @jeherve's work here to automatically add a priority label to new issues: https://github.com/Automattic/jetpack/pull/24841
- More discussion with Quality Squad here: pciE2j-18N-p2 

#### Does this pull request change what data or activity we track or use?

I am not aware of one.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- The PR will have to be merged first.
- And then, comment on any issue or a PR with an incorrect Happychat or Zendesk shorthand format. Examples: 123-HC, hc-123, zd-123, ZD-123, zd-woothemes-123, ZD-woothemes-123, 123-zd, 123-ZD. 
- Notice that the workflow task automatically fixes that to the correct format: 123-hc and 123-zen.

#### Live examples

Examples can be seen on my fork: https://github.com/arunsathiya/jetpack/issues/3#issuecomment-1173148450