### PR TITLE
cli: Detect if run from another checkout

### DIFF
--- a/tools/cli/bin/jetpack.js
+++ b/tools/cli/bin/jetpack.js
@@ -2,7 +2,18 @@
 
 import process from 'process';
 import { fileURLToPath } from 'url';
-import { compareComposerVersion } from '../helpers/checkEnvironment.js';
+import { checkCliLocation, compareComposerVersion } from '../helpers/checkEnvironment.js';
+
+/**
+ * Checks for executing the CLI within a different monorepo checkout.
+ */
+try {
+	await checkCliLocation();
+} catch ( error ) {
+	console.error( error );
+	console.error( 'Something unexpected happened. See error above.' );
+	process.exit( 1 );
+}
 
 /**
  * Checks to make sure we're on the right version of composer.

--- a/tools/cli/commands/cli.js
+++ b/tools/cli/commands/cli.js
@@ -11,12 +11,20 @@ import { chalkJetpackGreen } from '../helpers/styling.js';
  * Show us the status of the cli, such as the currenet linked directory.
  */
 function cliStatus() {
-	console.log(
-		chalkJetpackGreen(
-			'Jetpack CLI is currently linked to ' +
-				fileURLToPath( new URL( `../../../`, import.meta.url ) )
-		)
-	);
+	if ( process.env.JETPACK_CLI_DID_REEXEC ) {
+		console.log(
+			chalkJetpackGreen(
+				'Jetpack CLI is apparently linked to ' + process.env.JETPACK_CLI_DID_REEXEC
+			)
+		);
+	} else {
+		console.log(
+			chalkJetpackGreen(
+				'Jetpack CLI is currently linked to ' +
+					fileURLToPath( new URL( `../../../`, import.meta.url ) )
+			)
+		);
+	}
 	console.log( 'To change the linked directory of the CLI, run `pnpm jetpack cli link` ' );
 }
 /**

--- a/tools/cli/helpers/checkEnvironment.js
+++ b/tools/cli/helpers/checkEnvironment.js
@@ -86,7 +86,7 @@ export async function checkCliLocation() {
 
 		console.log(
 			chalk.yellow(
-				`Jetpack CLI was linked to ${ thisRoot }, but a Jetpack Monorepo checkout was found at ${ dir }. Executing the CLI from there instead.`
+				`Jetpack CLI was linked to ${ thisRoot }, but a Jetpack Monorepo checkout was found at ${ dir }. Executing the CLI from ${ dir }.`
 			)
 		);
 

--- a/tools/cli/helpers/checkEnvironment.js
+++ b/tools/cli/helpers/checkEnvironment.js
@@ -1,7 +1,10 @@
 import child_process from 'child_process';
 import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import chalk from 'chalk';
 import * as envfile from 'envfile';
+import execa from 'execa';
 import semver from 'semver';
 
 /**
@@ -50,5 +53,51 @@ export async function compareComposerVersion() {
 			chalk.yellow( `To fix, you can run 'composer self-update ${ monorepoComposerVersion }'` )
 		);
 		process.exit( 1 );
+	}
+}
+
+/**
+ * Check for whether the CLI is being run from within a different monorepo checkout.
+ *
+ * If so, this will shell out to the correct CLI, then return.
+ */
+export async function checkCliLocation() {
+	// Did our caller already do this? Don't check again.
+	if ( process.env.JETPACK_CLI_DID_REEXEC ) {
+		return;
+	}
+
+	// Use `path.dirname()` to ensure same trailing-slash behavior as is used below.
+	const thisRoot = path.dirname( fileURLToPath( new URL( '../../', import.meta.url ) ) );
+
+	for (
+		let olddir = null, dir = process.cwd();
+		dir !== olddir;
+		olddir = dir, dir = path.dirname( dir )
+	) {
+		const exe = path.join( dir, 'tools/cli/bin/jetpack.js' );
+		if ( ! fs.existsSync( exe ) ) {
+			continue;
+		}
+
+		if ( dir === thisRoot ) {
+			return;
+		}
+
+		console.log(
+			chalk.yellow(
+				`Jetpack CLI was linked to ${ thisRoot }, but a Jetpack Monorepo checkout was found at ${ dir }. Executing the CLI from there instead.`
+			)
+		);
+
+		// Alas node doesn't expose `execve()` or the like, so this seems the best we can do without messing with native function call stuff.
+		const res = await execa.node( exe, process.argv.slice( 2 ), {
+			env: {
+				JETPACK_CLI_DID_REEXEC: thisRoot,
+			},
+			stdio: [ 'inherit', 'inherit', 'inherit' ],
+			reject: false,
+		} );
+		process.exit( res.exitCode );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The CLI "link" feature is useful if you only use one checkout, but it
can cause confusion if you ever try to use a second checkout.

We can DWIM by having the CLI check if the cwd is within another
monorepo checkout, and if so run that checkout's copy of the CLI instead
of the linked copy. This winds up having to be done in a halfway-hacky
manner since node doesn't expose C's `exec()` family of functions, but
it should work.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1656943329124669/1656935252.843069-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Have done the CLI linking thing described at e.g. [tools/cli/README.md](https://github.com/Automattic/jetpack/blob/trunk/tools/cli/README.md#installation).
* Check out this PR in your normal monorepo checkout.
* Check out an additional copy of the monorepo somewhere. Check out this PR there too.
* Run `jetpack install --root` in the copy. Check that `vendor/` now exists in the copy.
* Run `jetpack cli status` in the copy. Check that the output is accurate and makes sense, i.e. it doesn't claim to be linked to the copy.