### PR TITLE
VIdeoPress v6: Fix setting the id attribute after upload

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-set-id-attribute
+++ b/projects/plugins/jetpack/changelog/fix-set-id-attribute
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/index.js
@@ -89,7 +89,6 @@ const VideoPressUploader = ( { blockProps, attributes, setAttributes } ) => {
 
 	/**
 	 * Handler to add a video via an URL.
-	 * todo: finish the implementation
 	 *
 	 * @param {string} videoUrl - URL of the video to attach
 	 */

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/hooks/use-uploader.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/hooks/use-uploader.js
@@ -45,7 +45,7 @@ export const useResumableUploader = ( { onError, onProgress, onSuccess, key } ) 
 				const mediaId = res.getHeader( MEDIA_ID_HEADER );
 				const src = res.getHeader( SRC_URL_HEADER );
 				if ( guid && mediaId && src ) {
-					onSuccess && onSuccess( { mediaId: Number( mediaId ), guid, src } );
+					onSuccess && onSuccess( { id: Number( mediaId ), guid, src } );
 					return;
 				}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix the ID attribute not being saved after video is uploaded
* I also deleted on `todo` comment that was addressed already

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
NA

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a new VideoPress block and upload a video
* Check the code and confirm the `id` attribute is there, and it matches the ID of the attachment post created for the video
![2022-07-04_16-03](https://user-images.githubusercontent.com/971483/177207662-c4ea14d2-dfce-4401-9153-a2c397fdda38.png)




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202547900351282