### PR TITLE
Search: Fix header letter spacing

### DIFF
--- a/projects/packages/search/changelog/fix-header-letter-spacing
+++ b/projects/packages/search/changelog/fix-header-letter-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Reset letter spacing for header tags

--- a/projects/packages/search/src/instant-search/components/overlay.scss
+++ b/projects/packages/search/src/instant-search/components/overlay.scss
@@ -44,6 +44,10 @@ $overlay-horizontal-padding-lg: 3em;
 		padding: $overlay-vertical-padding-lg $overlay-horizontal-padding-lg;
 	}
 
+	h1, h2, h3, h4, h5, h6 {
+		@include remove-header-styling();
+	}
+
 	&.is-hidden {
 		background: transparent;
 		opacity: 0;

--- a/projects/packages/search/src/instant-search/lib/styles/_mixins.scss
+++ b/projects/packages/search/src/instant-search/lib/styles/_mixins.scss
@@ -104,3 +104,7 @@ $customberg-container-selector: '.jp-search-configure-app-wrapper' !default;
 		outline: none;
 	}
 }
+
+@mixin remove-header-styling() {
+	letter-spacing: inherit;
+}


### PR DESCRIPTION
Fixes #24852 

#### Changes proposed in this Pull Request:
Reset header `letter-spacing` to `inherit` to override styles inherited from the theme. The PR introduces a mixin `remove-header-styling` to do so.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
1. Open a website with Jetpack Subscription
2. Import the style from a site which has the issue (e.g. https://johnmenadue.com/?s=hi ); Run the code in Browser console:
```JavaScript
var cssId = 'myCss';  // you could encode the css path itself to generate id..
if (!document.getElementById(cssId))
{
    var head  = document.getElementsByTagName('head')[0];
    var link  = document.createElement('link');
    link.id   = cssId;
    link.rel  = 'stylesheet';
    link.type = 'text/css';
    link.href = 'https://johnmenadue.com/wp-content/themes/pearls/css/style.css?ver=1.0';
    link.media = 'all';
    head.appendChild(link);
}
```
3. Ensure the header looks okay

|Before|After|
|------|------|
|![image](https://user-images.githubusercontent.com/1425433/177240918-d2684a4b-0d5b-40ba-8eec-257e743f417e.png)|![image](https://user-images.githubusercontent.com/1425433/177241110-c964782b-5ddf-4f7a-84a2-6655c56faf3b.png)|



