### PR TITLE
sync: Add new WP core 'block-templates' theme feature to sync whitelist

### DIFF
--- a/projects/packages/sync/changelog/fix-default_theme_support_whitelist
+++ b/projects/packages/sync/changelog/fix-default_theme_support_whitelist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add new WordPress core `block-templates` theme feature to `Defaults::$default_theme_support_whitelist`

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -797,6 +797,7 @@ class Defaults {
 	public static $default_theme_support_whitelist = array(
 		'align-wide',
 		'automatic-feed-links',
+		'block-templates',
 		'custom-background',
 		'custom-header',
 		'custom-logo',

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.36.0';
+	const PACKAGE_VERSION = '1.36.1-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Shortly after core added the new theme feature, one of our tests started
failing with a message "Theme Sync Error. Please add the following
block-templates to Defaults::$default_theme_support_whitelist".

So let's do that.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1657035470336089-slack-C034JEXD1RD
p1657038120167379-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
:shrug:

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy now?
* I guess this adds something new to what's synced. I have no idea what exactly or how to check that.