### PR TITLE
VideoPress: Improve layout for upload error message

### DIFF
--- a/projects/plugins/jetpack/changelog/add-improve-upload-error-handling
+++ b/projects/plugins/jetpack/changelog/add-improve-upload-error-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+VideoPress: Improve upload error layout

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/style.scss
@@ -21,6 +21,19 @@
 		line-height: 29px;
 		gap: 10px;
 	}
+
+	&__error-message {
+		margin-top: $grid-unit-30;
+		color: $alert-red;
+		width: 100%;
+	}
+
+	&__error-actions {
+		display: flex;
+		flex-direction: row;
+		margin-top: $grid-unit-30;
+		gap: 10px;
+	}
 }
 
 .videopress-uploader-progress {

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/editor.scss
@@ -53,8 +53,3 @@
 		}
 	}
 }
-
-.jetpack-videopress-upload-error-message {
-	color: $alert-red;
-	width: 100%;
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

It improves the layout when upload fails for some reason (free tier usage, etc..).

Now it shows only the error message and allows the user to retry or cancel.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Introduce `UploadError` and create an `Wrapper` that inserts the logo.
* Introduce `Retry` and `Cancel` buttons.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start `Jetpack`
* Navigate to post edition and insert `VideoPress (beta)` block.
* Simulate some error on upload (ex: Free tier usage).
* You should see error message and retry/cancel buttons.

#### Demo


https://user-images.githubusercontent.com/1663717/177389749-0a17f71e-b0fc-4527-82ec-a4444ba14ac8.mp4
