### PR TITLE
Tools: Update generate command to set correct composer.json type

### DIFF
--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -509,6 +509,7 @@ async function createComposerJson( composerJson, answers ) {
 			composerJson.extra[ 'branch-alias' ] = composerJson.extra[ 'branch-alias' ] || {};
 			composerJson.extra[ 'branch-alias' ][ 'dev-trunk' ] = '0.1.x-dev';
 			composerJson.extra.textdomain = name;
+			composerJson.type = 'jetpack-library';
 			break;
 		case 'plugin':
 			composerJson.extra = composerJson.extra || {};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Makes sure generate command sets the composer.json type for packages to `jetpack-library` since it sets a textdomain. *

#### Other information:

- [X ] Have you written new tests for your changes, if applicable?
- [X ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Generate a new package using `jetpack generate package --name test` and make sure its composer.json's type is set to `jetpack-library` instead of `library`
* make sure `Linting / Project structure (pull_request) ` passes on #24965

