### PR TITLE
Stats: Prevent Traffic page from not loading by checking if stats are enabled

### DIFF
--- a/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
@@ -39,8 +39,10 @@ class SiteStatsComponent extends React.Component {
 			roles_subscriber: includes( roles, 'subscriber', false ),
 		};
 
-		this.addCustomRolesState( roles );
-		this.addCustomCountRolesState( countRoles );
+		if ( roles ) {
+			this.addCustomCountRolesState( countRoles );
+			this.addCustomRolesState( roles );
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-custom-roles-admin-issue
+++ b/projects/plugins/jetpack/changelog/fix-custom-roles-admin-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Site Stats: Fixes an issue with the traffic page not loading when stats is not enabled.


### PR DESCRIPTION


#### Changes proposed in this Pull Request:

* This PR - https://github.com/Automattic/jetpack/pull/24887/ - introduced a new issue on sites that didn't have the stats module enabled. In that case, the Settings > Traffic page wouldn't properly load and console errors would show.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

n/a

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Testing with the Beta plugin installed on a test site (with Bleeding Edge active), disable Stats from this page: `/wp-admin/admin.php?page=jetpack_modules`
* Visit the Jetpack Settings > Traffic page (`/wp-admin/admin.php?page=jetpack#/traffic`) and you should notice the page won't load properly
* You should also notice console errors similar to this: ` Uncaught TypeError: Cannot read properties of undefined (reading 'forEach') at S.addCustomRolesState`
* Then, apply this PR. You should now be able to load the traffic page.
* Check that the functionality of the PR still works as expected (see testing instructions [here](https://github.com/Automattic/jetpack/pull/24887)).
