### PR TITLE
Jetpack: replace local Loading by Spinner in VideoPress block v6

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-vpblock-remove-loading-dep
+++ b/projects/plugins/jetpack/changelog/update-jetpack-vpblock-remove-loading-dep
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: replace local Loading by Spinner in VideoPress block v6

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/index.js
@@ -1,9 +1,15 @@
+/**
+ * External dependencies
+ */
 import { getBlobByURL, isBlobURL } from '@wordpress/blob';
 import { BlockIcon, MediaPlaceholder } from '@wordpress/block-editor';
+import { Spinner } from '@wordpress/components';
 import { useState, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
 import { VideoPressIcon as icon } from '../../../../../shared/icons';
-import Loading from '../../../loading';
 import { useResumableUploader } from '../../hooks/use-uploader.js';
 
 const ALLOWED_MEDIA_TYPES = [ 'video' ];
@@ -137,7 +143,8 @@ const VideoPressUploader = ( { blockProps, attributes, setAttributes } ) => {
 		return (
 			<>
 				<div { ...blockProps }>
-					<Loading text={ __( '(2) Uploading file to backend…', 'jetpack' ) } />;
+					<Spinner />
+					<div>{ __( '(2) Uploading file to backend…', 'jetpack' ) }</div>
 				</div>
 			</>
 		);
@@ -148,7 +155,8 @@ const VideoPressUploader = ( { blockProps, attributes, setAttributes } ) => {
 		return (
 			<>
 				<div { ...blockProps }>
-					<Loading text={ __( '(3) Uploading file to VideoPress…', 'jetpack' ) } />;
+					<Spinner />
+					<div>{ __( '(3) Uploading file to VideoPress…', 'jetpack' ) }</div>
 				</div>
 			</>
 		);

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -3,6 +3,7 @@
  */
 
 import { useBlockProps } from '@wordpress/block-editor';
+import { Spinner } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useState, useCallback, useRef } from '@wordpress/element';
@@ -11,7 +12,6 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import Loading from '../loading';
 import { getVideoPressUrl } from '../url';
 import VideoPressInspectorControls from './components/inspector-controls';
 import VideoPressPlayer from './components/videopress-player';
@@ -181,7 +181,8 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 		return (
 			<>
 				<div { ...blockProps }>
-					<Loading text={ __( '(4) Generating preview…', 'jetpack' ) } />;
+					<Spinner />
+					<div>{ __( '(4) Generating preview…', 'jetpack' ) }</div>
 					<div>
 						Attempt: <strong>{ isGeneratingPreview }</strong>
 					</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR replaces the local Loading by Spinner in VideoPress block v6. We're going to improve the UI for now now let's remove the local dependency.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* replace local Loading by Spinner in VideoPress block v6

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to block editor
* Create a VideoPress block
* Upload a video
* Confirm you still see the ugly loading state, but this time with the core Spinner component
<img width="663" alt="image" src="https://user-images.githubusercontent.com/77539/177584978-7c19d2c6-eee2-4c6a-80b0-e1cd656ddbc8.png">




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202549473142198