### PR TITLE
jetpack-live-branches: Improve behavior when switching tabs in GH

### DIFF
--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -398,7 +398,9 @@
 			);
 			$( '#jetpack-live-branches' ).remove();
 			$el.append( liveBranches );
-			liveBranches.find( 'input[type=checkbox]' ).on( 'change', onInputChanged );
+			liveBranches
+				.find( 'input[type=checkbox]' )
+				.each( () => this.addEventListener( 'change', onInputChanged ) );
 		}
 
 		/**

--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jetpack Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.22
+// @version      1.23
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @grant        GM_xmlhttpRequest
 // @connect      jurassic.ninja
@@ -15,6 +15,37 @@
 
 ( function () {
 	const $ = jQuery.noConflict();
+	const markdownBodySelector = '.pull-discussion-timeline .markdown-body';
+	let pluginsList = null;
+
+	// Watch for relevant DOM changes that indicate we need to re-run `doit()`:
+	// - Adding a new `.markdown-body`.
+	// - Removing `#jetpack-live-branches`.
+	const observer = new MutationObserver( list => {
+		for ( const m of list ) {
+			for ( const n of m.addedNodes ) {
+				if (
+					( n.matches && n.matches( markdownBodySelector ) ) ||
+					( n.querySelector && n.querySelector( markdownBodySelector ) )
+				) {
+					doit();
+					return;
+				}
+			}
+			for ( const n of m.removedNodes ) {
+				if (
+					n.id === 'jetpack-live-branches' ||
+					( n.querySelector && n.querySelector( '#jetpack-live-branches' ) )
+				) {
+					doit();
+					return;
+				}
+			}
+		}
+	} );
+	observer.observe( document, { subtree: true, childList: true } );
+
+	// Run it on load too.
 	doit();
 
 	/**
@@ -31,8 +62,13 @@
 
 	/** Function. */
 	function doit() {
+		const markdownBody = document.querySelectorAll( markdownBodySelector )[ 0 ];
+		if ( ! markdownBody || markdownBody.querySelector( '#jetpack-live-branches' ) ) {
+			// No body or Live Branches is already there, no need to do it again.
+			return;
+		}
+
 		const host = 'https://jurassic.ninja';
-		const markdownBody = document.querySelectorAll( '.markdown-body' )[ 0 ];
 		const currentBranch = jQuery( '.head-ref:first' ).text();
 		const branchIsForked = currentBranch.includes( ':' );
 		const branchStatus = $( '.gh-header-meta .State' ).text().trim();
@@ -62,7 +98,10 @@
 				'<p><strong>Cannot determine the repository for this PR.</strong></p>'
 			);
 		} else {
-			dofetch( `${ host }/wp-json/jurassic.ninja/jetpack-beta/plugins` )
+			if ( ! pluginsList ) {
+				pluginsList = dofetch( `${ host }/wp-json/jurassic.ninja/jetpack-beta/plugins` );
+			}
+			pluginsList
 				.then( body => {
 					const plugins = [];
 
@@ -225,6 +264,7 @@
 					updateLink();
 				} )
 				.catch( e => {
+					pluginsList = null;
 					appendHtml(
 						markdownBody,
 						// prettier-ignore
@@ -356,8 +396,9 @@
 			const liveBranches = $( '<div id="jetpack-live-branches" />' ).append(
 				`<h2>Jetpack Live Branches</h2> ${ contents }`
 			);
+			$( '#jetpack-live-branches' ).remove();
 			$el.append( liveBranches );
-			$( 'body' ).on( 'change', $el.find( 'input[type=checkbox]' ), onInputChanged );
+			liveBranches.find( 'input[type=checkbox]' ).on( 'change', onInputChanged );
 		}
 
 		/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
GitHub doesn't always reload the page when switching between tabs on a
PR. Use MutationObserver to watch for that and re-add the UI when
needed. This also allows us to preserve the UI when the PR's description
is edited.

Also, avoid showing the UI on pages like the "details" for Codecov's
checks.

It also seems this accidentally fixes #17031.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install the patched version of the script: https://github.com/Automattic/jetpack/raw/fix/jetpack-live-branches-disappearing/tools/jetpack-live-branches/jetpack-live-branches.user.js
* Visit a PR and try various things that can make the UI not show up. Make sure the UI functions (i.e. click checkboxes and see that the link changes) each time.
  * Start from "Conversation" tab. Click to one of the other tabs, then click back. Maybe wait a few seconds first.
  * Start from the "Files" tab, reload, then click to the "Conversation" tab.
  * Edit the PR's description.
  * If the PR's description has a checkbox, check or uncheck the checkbox.
  * Edit the PR's tags.
  * Have the Gardening job edit the PR's tags.
  * Leave a comment on the PR.
* Find the "codecov/patch" Actions check and click its details link. Check that the Jetpack Live Branches UI is no longer inserted into that page.
* Try to reproduce #17031 too.

I've checked this myself with GreaseMonkey on Firefox. Someone using TamperMonkey on Chrome should ensure it works there too.