### PR TITLE
Janitorial: release GH actions

### DIFF
--- a/projects/github-actions/pr-is-up-to-date/CHANGELOG.md
+++ b/projects/github-actions/pr-is-up-to-date/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2022-07-06
+### Added
+- Added the ability to check against multiple tags. [#22925]
+
+### Changed
+- BREAKING: Changed the default value for the `status` input. [#22925]
+- Renaming `master` references to `main` where relevant. [#24712, #24661]
+- Updated package dependencies. [#24045]
+
+### Fixed
+- Disable automatic garbage collection, like GitHub's checkout action does for its own checkouts. [#23047]
+- Fix documentation of the token parameter in README.md. [#22793]
+- Remove a stray comma. [#23046]
+- Speed up processing of tag push with paths. [#23123]
+- Try and fix source file not found error by specifying path. [#23022]
+
 ## [1.0.3] - 2022-02-09
 ### Changed
 - Core: update description and metadata before to publish to marketplace.
@@ -22,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[2.0.0]: https://github.com/Automattic/action-pr-is-up-to-date/compare/v1.0.3...v2.0.0
 [1.0.3]: https://github.com/Automattic/action-pr-is-up-to-date/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/Automattic/action-pr-is-up-to-date/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/Automattic/action-pr-is-up-to-date/compare/v1.0.0...v1.0.1

--- a/projects/github-actions/pr-is-up-to-date/changelog/add-pr-is-up-to-date-disable-automatic-gc
+++ b/projects/github-actions/pr-is-up-to-date/changelog/add-pr-is-up-to-date-disable-automatic-gc
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Disable automatic garbage collection, like GitHub's checkout action does for its own checkouts.

--- a/projects/github-actions/pr-is-up-to-date/changelog/fix-pr-is-up-to-date-doc
+++ b/projects/github-actions/pr-is-up-to-date/changelog/fix-pr-is-up-to-date-doc
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix documentation of the token parameter in README.md.

--- a/projects/github-actions/pr-is-up-to-date/changelog/fix-pr-is-up-to-date-stray-comma
+++ b/projects/github-actions/pr-is-up-to-date/changelog/fix-pr-is-up-to-date-stray-comma
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Remove a stray comma.

--- a/projects/github-actions/pr-is-up-to-date/changelog/fix-pr-up-to-date-workflow-timeout
+++ b/projects/github-actions/pr-is-up-to-date/changelog/fix-pr-up-to-date-workflow-timeout
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Speed up processing of tag push with paths.

--- a/projects/github-actions/pr-is-up-to-date/changelog/update-changelogger-add-pr-num
+++ b/projects/github-actions/pr-is-up-to-date/changelog/update-changelogger-add-pr-num
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/github-actions/pr-is-up-to-date/changelog/update-monorepo-master-refs-primary
+++ b/projects/github-actions/pr-is-up-to-date/changelog/update-monorepo-master-refs-primary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Renaming `master` to `main` in tests.

--- a/projects/github-actions/pr-is-up-to-date/changelog/update-monorepo-master-refs-secondary
+++ b/projects/github-actions/pr-is-up-to-date/changelog/update-monorepo-master-refs-secondary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Renaming `master` references to `main` where relevant

--- a/projects/github-actions/pr-is-up-to-date/changelog/update-pr-is-up-to-date-multiple-tags
+++ b/projects/github-actions/pr-is-up-to-date/changelog/update-pr-is-up-to-date-multiple-tags
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added the ability to check against multiple tags.

--- a/projects/github-actions/pr-is-up-to-date/changelog/update-pr-is-up-to-date-multiple-tags#2
+++ b/projects/github-actions/pr-is-up-to-date/changelog/update-pr-is-up-to-date-multiple-tags#2
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-BREAKING: Changed the default value for the `status` input.

--- a/projects/github-actions/pr-is-up-to-date/changelog/update-try-to-fix-run-sh
+++ b/projects/github-actions/pr-is-up-to-date/changelog/update-try-to-fix-run-sh
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Try and fix source file not found error by specifying path.

--- a/projects/github-actions/repo-gardening/CHANGELOG.md
+++ b/projects/github-actions/repo-gardening/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2022-07-06
+### Added
+- Automatically add a Priority label based off the contents of an issue. [#24841]
+
+### Changed
+- Detect Renovate PRs created by self-hosted renovate. [#23307]
+- Fusion comment bot: update wording to avoid confusion. [#23666]
+- Renaming `master` references to `trunk`. [#24712, #24661]
+- Reorder JS imports for `import/order` eslint rule. [#24601]
+- Triage: update priority logic to follow issue priority matrix. [#24913]
+- Updated package dependencies. [#24045, #24573]
+- Use the node16 runner instead of the deprecated node12 runner. [#23389]
+- WordPress.com Commit reminder: clarify wording of the message to help contributors. [#24860]
+
+### Fixed
+- Milestone management: avoid throwing an error when a valid milestone cannot be found. Abort task instead. [#22937]
+- Only hit the milestones endpoint once per run. [#23126]
+- Triage: only add priority label when one does not exist yet. [#24910]
+- When a file is renamed, treat both the old and new names as modified. [#23354]
+
 ## [2.0.2] - 2022-02-09
 ### Changed
 - Core: update description and metadata before to publish to marketplace.
@@ -83,6 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
+[3.0.0]: https://github.com/Automattic/action-repo-gardening/compare/v2.0.2...v3.0.0
 [2.0.2]: https://github.com/Automattic/action-repo-gardening/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/Automattic/action-repo-gardening/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/Automattic/action-repo-gardening/compare/v1.4.0...v2.0.0

--- a/projects/github-actions/repo-gardening/changelog/add-eslint-import-order
+++ b/projects/github-actions/repo-gardening/changelog/add-eslint-import-order
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Reorder JS imports for `import/order` eslint rule.

--- a/projects/github-actions/repo-gardening/changelog/add-renovate-self-hosted
+++ b/projects/github-actions/repo-gardening/changelog/add-renovate-self-hosted
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Detect Renovate PRs created by self-hosted renovate.

--- a/projects/github-actions/repo-gardening/changelog/fix-clarify-expected-changeset-id
+++ b/projects/github-actions/repo-gardening/changelog/fix-clarify-expected-changeset-id
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-WordPress.com Commit reminder: clarify wording of the message to help contributors.

--- a/projects/github-actions/repo-gardening/changelog/fix-gardening-cache-milestones
+++ b/projects/github-actions/repo-gardening/changelog/fix-gardening-cache-milestones
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Only hit the milestones endpoint once per run.

--- a/projects/github-actions/repo-gardening/changelog/fix-repo-gardening-changelog-check
+++ b/projects/github-actions/repo-gardening/changelog/fix-repo-gardening-changelog-check
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-When a file is renamed, treat both the old and new names as modified.

--- a/projects/github-actions/repo-gardening/changelog/fix-repo-gardening-milestone-error
+++ b/projects/github-actions/repo-gardening/changelog/fix-repo-gardening-milestone-error
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Milestone management: avoid throwing an error when a valid milestone cannot be found. Abort task instead.

--- a/projects/github-actions/repo-gardening/changelog/remove-claim-of-support-for-node-14
+++ b/projects/github-actions/repo-gardening/changelog/remove-claim-of-support-for-node-14
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
-
-

--- a/projects/github-actions/repo-gardening/changelog/remove-wpcalypso-import-docblock-comments
+++ b/projects/github-actions/repo-gardening/changelog/remove-wpcalypso-import-docblock-comments
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove `wpcalypso/import-docblock` comments. No change to behavior.
-
-

--- a/projects/github-actions/repo-gardening/changelog/renovate-github-api-packages
+++ b/projects/github-actions/repo-gardening/changelog/renovate-github-api-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/github-actions/repo-gardening/changelog/renovate-npm-moment-vulnerability
+++ b/projects/github-actions/repo-gardening/changelog/renovate-npm-moment-vulnerability
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/github-actions/repo-gardening/changelog/update-actions-to-node16
+++ b/projects/github-actions/repo-gardening/changelog/update-actions-to-node16
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-Use the node16 runner instead of the deprecated node12 runner.

--- a/projects/github-actions/repo-gardening/changelog/update-changelogger-add-pr-num
+++ b/projects/github-actions/repo-gardening/changelog/update-changelogger-add-pr-num
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/github-actions/repo-gardening/changelog/update-gardening-fusion-comment
+++ b/projects/github-actions/repo-gardening/changelog/update-gardening-fusion-comment
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Fusion comment bot: update wording to avoid confusion.

--- a/projects/github-actions/repo-gardening/changelog/update-monorepo-master-refs-primary
+++ b/projects/github-actions/repo-gardening/changelog/update-monorepo-master-refs-primary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Renaming master references to trunk in GH action files, to work with the GitHub default branch name changing to trunk.

--- a/projects/github-actions/repo-gardening/changelog/update-monorepo-master-refs-secondary
+++ b/projects/github-actions/repo-gardening/changelog/update-monorepo-master-refs-secondary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Renaming `master` references to `trunk`

--- a/projects/github-actions/repo-gardening/changelog/update-pnpm-version
+++ b/projects/github-actions/repo-gardening/changelog/update-pnpm-version
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update minimum pnpm version. No change to the project itself.
-
-

--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-severity
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-severity
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Automatically add a Priority label based off the contents of an issue

--- a/projects/github-actions/repo-gardening/changelog/update-to-pnpm-7
+++ b/projects/github-actions/repo-gardening/changelog/update-to-pnpm-7
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Use pnpm 7.
-
-

--- a/projects/github-actions/repo-gardening/changelog/update-triage-priority
+++ b/projects/github-actions/repo-gardening/changelog/update-triage-priority
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Triage: only add priority label when one does not exist yet.

--- a/projects/github-actions/repo-gardening/changelog/update-triage-priority-matrix
+++ b/projects/github-actions/repo-gardening/changelog/update-triage-priority-matrix
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Triage: update priority logic to follow issue priority matrix.

--- a/projects/github-actions/repo-gardening/package.json
+++ b/projects/github-actions/repo-gardening/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "repo-gardening",
-	"version": "3.0.0-alpha",
+	"version": "3.0.0",
 	"description": "Manage Pull Requests and issues in your Open Source project (automate labelling, milestones, feedback to PR authors, ...)",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/github-actions/required-review/CHANGELOG.md
+++ b/projects/github-actions/required-review/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2022-07-06
+### Changed
+- Reorder JS imports for `import/order` eslint rule. [#24601]
+- The `token` parameter was effectively required, as the default `GITHUB_TOKEN` lacks the ability to read team membership. The parameter is now explicitly required. [#23995]
+- Updated package dependencies. [#24045, #24573]
+- Use the node16 runner instead of the deprecated node12 runner. [#23389]
+
+### Fixed
+- Fix handling of re-reviews, only look at the latest review per user. [#24000]
+
 ## [2.2.2] - 2022-02-09
 ### Changed
 - Core: update description and metadata before to publish to marketplace.
@@ -39,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
+[3.0.0]: https://github.com/Automattic/action-required-review/compare/v2.2.2...v3.0.0
 [2.2.2]: https://github.com/Automattic/action-required-review/compare/v2.2.1...v2.2.2
 [2.2.1]: https://github.com/Automattic/action-required-review/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/Automattic/action-required-review/compare/v2.1.0...v2.2.0

--- a/projects/github-actions/required-review/changelog/add-eslint-import-order
+++ b/projects/github-actions/required-review/changelog/add-eslint-import-order
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Reorder JS imports for `import/order` eslint rule.

--- a/projects/github-actions/required-review/changelog/fix-required-review-rereview
+++ b/projects/github-actions/required-review/changelog/fix-required-review-rereview
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix handling of re-reviews, only look at the latest review per user.

--- a/projects/github-actions/required-review/changelog/remove-claim-of-support-for-node-14
+++ b/projects/github-actions/required-review/changelog/remove-claim-of-support-for-node-14
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
-
-

--- a/projects/github-actions/required-review/changelog/renovate-github-api-packages
+++ b/projects/github-actions/required-review/changelog/renovate-github-api-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/github-actions/required-review/changelog/update-actions-to-node16
+++ b/projects/github-actions/required-review/changelog/update-actions-to-node16
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-Use the node16 runner instead of the deprecated node12 runner.

--- a/projects/github-actions/required-review/changelog/update-changelogger-add-pr-num
+++ b/projects/github-actions/required-review/changelog/update-changelogger-add-pr-num
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/github-actions/required-review/changelog/update-pnpm-version
+++ b/projects/github-actions/required-review/changelog/update-pnpm-version
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update minimum pnpm version. No change to the project itself.
-
-

--- a/projects/github-actions/required-review/changelog/update-required-review-needs-token
+++ b/projects/github-actions/required-review/changelog/update-required-review-needs-token
@@ -1,4 +1,0 @@
-Significance: major
-Type: changed
-
-The `token` parameter was effectively required, as the default `GITHUB_TOKEN` lacks the ability to read team membership. The parameter is now explicitly required.

--- a/projects/github-actions/required-review/changelog/update-to-pnpm-7
+++ b/projects/github-actions/required-review/changelog/update-to-pnpm-7
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Use pnpm 7.
-
-

--- a/projects/github-actions/required-review/package.json
+++ b/projects/github-actions/required-review/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "required-review",
-	"version": "3.0.0-alpha",
+	"version": "3.0.0",
 	"description": "Check that a Pull Request has reviews from required teams.",
 	"main": "index.js",
 	"author": "Automattic",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Periodic janitorial release:

```
≽ tools/find-unreleased-projects.sh 60                 
* github-actions/push-to-mirrors has change entries from 118 days ago (e.g. add-push-to-mirrors-logging)
* github-actions/repo-gardening has change entries from 139 days ago (e.g. fix-repo-gardening-milestone-error)
* github-actions/required-review has change entries from 114 days ago (e.g. update-actions-to-node16)
```

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

n/a

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

Proofread.
