### PR TITLE
Jetpack: update the VideoPressIcon path for v6

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-vpblock-icon-dependency
+++ b/projects/plugins/jetpack/changelog/update-jetpack-vpblock-icon-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: update the VideoPressIcon path for v6

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/index.js
@@ -9,8 +9,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { VideoPressIcon as icon } from '../../../../../shared/icons';
 import { useResumableUploader } from '../../hooks/use-uploader.js';
+import { VideoPressIcon as icon } from '../icons/index.js';
 
 const ALLOWED_MEDIA_TYPES = [ 'video' ];
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/index.js
@@ -5,8 +5,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { VideoPressIcon as icon } from '../../../shared/icons';
 import attributes from './attributes';
+import { VideoPressIcon as icon } from './components/icons';
 import edit from './edit';
 import save from './save';
 import './style.scss';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up of https://github.com/Automattic/jetpack/pull/24974.
Jetpack: update the VideoPressIcon path for v6

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack: update the VideoPressIcon path for v6

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to block editor
* Add/edit a VideoPress block
* Confirm the icon is there



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202549473142209