### PR TITLE
Janitorial: release packages and plugins

### DIFF
--- a/projects/js-packages/eslint-changed/CHANGELOG.md
+++ b/projects/js-packages/eslint-changed/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2022-07-06
+### Changed
+- Convert code to ESM. [#24626]
+- Remove use of `pnpx` in preparation for pnpm 7.0. [#24210]
+- Renaming `master` references to `trunk`. [#24712, #24661]
+- Reorder JS imports for `import/order` eslint rule. [#24601]
+- Updated package dependencies. [#24045]
+- Use `jest` for tests. [#24626]
+
+### Fixed
+- Fix debug output. [#24819]
+- Fix interaction of `--in-diff-only` (or lack thereof) and listing of files on the command line. [#24626]
+
 ## [2.0.2] - 2022-04-18
 ### Changed
 - Update package.json metadata.
@@ -46,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Created as a tool within the monorepo.
 
+[2.0.3]: https://github.com/Automattic/eslint-changed/compare/2.0.2...2.0.3
 [2.0.2]: https://github.com/Automattic/eslint-changed/compare/2.0.1...2.0.2
 [2.0.1]: https://github.com/Automattic/eslint-changed/compare/2.0.0...2.0.1
 [2.0.0]: https://github.com/Automattic/eslint-changed/compare/1.0.1...2.0.0

--- a/projects/js-packages/eslint-changed/changelog/add-eslint-add-tests-as-jest
+++ b/projects/js-packages/eslint-changed/changelog/add-eslint-add-tests-as-jest
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Lint all JS tests. No change to the project itself.
-
-

--- a/projects/js-packages/eslint-changed/changelog/add-eslint-import-order
+++ b/projects/js-packages/eslint-changed/changelog/add-eslint-import-order
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Reorder JS imports for `import/order` eslint rule.

--- a/projects/js-packages/eslint-changed/changelog/fix-eslint-changed-debug-output
+++ b/projects/js-packages/eslint-changed/changelog/fix-eslint-changed-debug-output
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix debug output.

--- a/projects/js-packages/eslint-changed/changelog/remove-claim-of-support-for-node-14
+++ b/projects/js-packages/eslint-changed/changelog/remove-claim-of-support-for-node-14
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
-
-

--- a/projects/js-packages/eslint-changed/changelog/update-changelogger-add-pr-num
+++ b/projects/js-packages/eslint-changed/changelog/update-changelogger-add-pr-num
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/eslint-changed/changelog/update-eslint-changed-esm
+++ b/projects/js-packages/eslint-changed/changelog/update-eslint-changed-esm
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Convert code to ESM.

--- a/projects/js-packages/eslint-changed/changelog/update-eslint-changed-esm#2
+++ b/projects/js-packages/eslint-changed/changelog/update-eslint-changed-esm#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Use `jest` for tests.

--- a/projects/js-packages/eslint-changed/changelog/update-eslint-changed-esm#3
+++ b/projects/js-packages/eslint-changed/changelog/update-eslint-changed-esm#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix interaction of `--in-diff-only` (or lack thereof) and listing of files on the command line.

--- a/projects/js-packages/eslint-changed/changelog/update-jest-resolver-handle-imports
+++ b/projects/js-packages/eslint-changed/changelog/update-jest-resolver-handle-imports
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Adjust Jest config. No change to the package.
-
-

--- a/projects/js-packages/eslint-changed/changelog/update-monorepo-master-refs-primary
+++ b/projects/js-packages/eslint-changed/changelog/update-monorepo-master-refs-primary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Renaming `master` references to `trunk` in a test.

--- a/projects/js-packages/eslint-changed/changelog/update-monorepo-master-refs-secondary
+++ b/projects/js-packages/eslint-changed/changelog/update-monorepo-master-refs-secondary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Renaming `master` references to `trunk`

--- a/projects/js-packages/eslint-changed/changelog/update-remove-use-of-pnpx
+++ b/projects/js-packages/eslint-changed/changelog/update-remove-use-of-pnpx
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Remove use of `pnpx` in preparation for pnpm 7.0.

--- a/projects/js-packages/eslint-changed/changelog/update-to-pnpm-7
+++ b/projects/js-packages/eslint-changed/changelog/update-to-pnpm-7
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Use pnpm 7.
-
-

--- a/projects/js-packages/eslint-changed/package.json
+++ b/projects/js-packages/eslint-changed/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/eslint-changed",
-	"version": "2.0.3-alpha",
+	"version": "2.0.3",
 	"description": "Run eslint on files, but only report warnings and errors from lines that were changed.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/eslint-changed/#readme",
 	"type": "module",

--- a/projects/js-packages/eslint-changed/src/cli.js
+++ b/projects/js-packages/eslint-changed/src/cli.js
@@ -6,7 +6,7 @@ import { Command } from 'commander';
 import { ESLint } from 'eslint';
 import parseDiff from 'parse-diff';
 
-const APP_VERSION = '2.0.3-alpha';
+const APP_VERSION = '2.0.3';
 
 /**
  * Create a Commander instance.

--- a/projects/js-packages/eslint-config-target-es/CHANGELOG.md
+++ b/projects/js-packages/eslint-config-target-es/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2022-07-06
+### Changed
+- Reorder JS imports for `import/order` eslint rule. [#24601]
+- Update package.json metadata. [#23990]
+- Updated package dependencies.
+
 ## [1.0.2] - 2022-04-05
 ### Removed
 - Removed eslint from devDependencies
@@ -18,5 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[1.0.3]: https://github.com/Automattic/eslint-config-target-es/compare/1.0.2...1.0.3
 [1.0.2]: https://github.com/Automattic/eslint-config-target-es/compare/1.0.1...1.0.2
 [1.0.1]: https://github.com/Automattic/eslint-config-target-es/compare/1.0.0...1.0.1

--- a/projects/js-packages/eslint-config-target-es/changelog/add-eslint-add-tests-as-jest
+++ b/projects/js-packages/eslint-config-target-es/changelog/add-eslint-add-tests-as-jest
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Lint all JS tests. No change to the project itself.
-
-

--- a/projects/js-packages/eslint-config-target-es/changelog/add-eslint-import-order
+++ b/projects/js-packages/eslint-config-target-es/changelog/add-eslint-import-order
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Reorder JS imports for `import/order` eslint rule.

--- a/projects/js-packages/eslint-config-target-es/changelog/add-jsconfig-to-js-packages
+++ b/projects/js-packages/eslint-config-target-es/changelog/add-jsconfig-to-js-packages
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Add `jsconfig.json` file for typescript and vscode support. Not included in the mirror.
-
-

--- a/projects/js-packages/eslint-config-target-es/changelog/add-lint-package-json-urls
+++ b/projects/js-packages/eslint-config-target-es/changelog/add-lint-package-json-urls
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package.json metadata.

--- a/projects/js-packages/eslint-config-target-es/changelog/remove-claim-of-support-for-node-14
+++ b/projects/js-packages/eslint-config-target-es/changelog/remove-claim-of-support-for-node-14
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
-
-

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-eslint-packages
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-eslint-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-mdn-browser-compat-data-4.x
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-mdn-browser-compat-data-4.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/eslint-config-target-es/changelog/renovate-mdn-browser-compat-data-4.x#2
+++ b/projects/js-packages/eslint-config-target-es/changelog/renovate-mdn-browser-compat-data-4.x#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/eslint-config-target-es/changelog/update-changelogger-add-pr-num
+++ b/projects/js-packages/eslint-config-target-es/changelog/update-changelogger-add-pr-num
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/eslint-config-target-es/changelog/update-to-pnpm-7
+++ b/projects/js-packages/eslint-config-target-es/changelog/update-to-pnpm-7
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Use pnpm 7.
-
-

--- a/projects/js-packages/eslint-config-target-es/package.json
+++ b/projects/js-packages/eslint-config-target-es/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/eslint-config-target-es",
-	"version": "1.0.3-alpha",
+	"version": "1.0.3",
 	"description": "ESLint sharable config to activate eslint-plugin-es checks based on browserslist targets.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/eslint-config-target-es/README.md#readme",
 	"bugs": {

--- a/projects/js-packages/storybook/CHANGELOG.md
+++ b/projects/js-packages/storybook/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 - 2022-07-06
+### Added
+- Add 'Jetpack Dashboard' background color. [#22597]
+- Added TypeScript support. [#23522]
+- Add missing JavaScript dependencies. [#24096]
+- Add missing JS peer dependencies. [#23456]
+- Declare cross-project build dependencies to ensure that the storybook is rebuilt when those are changed. [#22718]
+- Storybook: Add protect into storybook projects list. [#23780]
+- Test that projects in `storybook/projects.js` are listed as extra build dependencies in composer.json. [#24188]
+- Try using `storybook-addon-turbo-build` to speed up the build. [#22774]
+
+### Changed
+- Reorder JS imports for `import/order` eslint rule. [#24601]
+- Storybook: Remove base-styles in favor of ThemeProvider [#23386]
+- Update package.json metadata. [#23990]
+- Updated package dependencies.
+
+### Removed
+- Disable generation of sourcemaps. [#22743]
+- Remove unneeded dependencies. [#23391]
+
+### Fixed
+- Fix styles defined by the ThemeProvider in the storybook stories [#24527]
+
 ## 0.1.0 - 2022-02-01
 ### Added
 - Added addons-essentials to the dependencies

--- a/projects/js-packages/storybook/changelog/2022-03-02-15-33-29-111457
+++ b/projects/js-packages/storybook/changelog/2022-03-02-15-33-29-111457
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/2022-03-08-16-31-41-492673
+++ b/projects/js-packages/storybook/changelog/2022-03-08-16-31-41-492673
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/2022-03-15-14-43-04-217296
+++ b/projects/js-packages/storybook/changelog/2022-03-15-14-43-04-217296
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/add-build-only-changed-projects
+++ b/projects/js-packages/storybook/changelog/add-build-only-changed-projects
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Declare cross-project build dependencies to ensure that the storybook is rebuilt when those are changed.

--- a/projects/js-packages/storybook/changelog/add-eslint-import-order
+++ b/projects/js-packages/storybook/changelog/add-eslint-import-order
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Reorder JS imports for `import/order` eslint rule.

--- a/projects/js-packages/storybook/changelog/add-jetpack-10.7-a.3-release
+++ b/projects/js-packages/storybook/changelog/add-jetpack-10.7-a.3-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/add-jetpack-10.8-a.9-release
+++ b/projects/js-packages/storybook/changelog/add-jetpack-10.8-a.9-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/add-jsconfig-to-js-packages
+++ b/projects/js-packages/storybook/changelog/add-jsconfig-to-js-packages
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Add `jsconfig.json` file for typescript and vscode support. Not included in the mirror.
-
-

--- a/projects/js-packages/storybook/changelog/add-lint-package-json-urls
+++ b/projects/js-packages/storybook/changelog/add-lint-package-json-urls
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package.json metadata.

--- a/projects/js-packages/storybook/changelog/add-protect
+++ b/projects/js-packages/storybook/changelog/add-protect
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Storybook: Add protect into storybook projects list

--- a/projects/js-packages/storybook/changelog/add-social-product-icon
+++ b/projects/js-packages/storybook/changelog/add-social-product-icon
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/add-storybook-no-sourcemap
+++ b/projects/js-packages/storybook/changelog/add-storybook-no-sourcemap
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Disable generation of sourcemaps.

--- a/projects/js-packages/storybook/changelog/add-ts-support
+++ b/projects/js-packages/storybook/changelog/add-ts-support
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added TypeScript support

--- a/projects/js-packages/storybook/changelog/fix-js-dep-updates
+++ b/projects/js-packages/storybook/changelog/fix-js-dep-updates
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/fix-missing-js-peer-deps
+++ b/projects/js-packages/storybook/changelog/fix-missing-js-peer-deps
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add missing JS peer dependencies.

--- a/projects/js-packages/storybook/changelog/fix-quotes-skeleton
+++ b/projects/js-packages/storybook/changelog/fix-quotes-skeleton
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fixed incomplete quote
-
-

--- a/projects/js-packages/storybook/changelog/fix-storybook-test-deps
+++ b/projects/js-packages/storybook/changelog/fix-storybook-test-deps
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Test that projects in `storybook/projects.js` are listed as extra build dependencies in composer.json.

--- a/projects/js-packages/storybook/changelog/move-service-icons-to-js-package
+++ b/projects/js-packages/storybook/changelog/move-service-icons-to-js-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/remove-claim-of-support-for-node-14
+++ b/projects/js-packages/storybook/changelog/remove-claim-of-support-for-node-14
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
-
-

--- a/projects/js-packages/storybook/changelog/remove-most-pnpm-hoisting
+++ b/projects/js-packages/storybook/changelog/remove-most-pnpm-hoisting
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add missing JavaScript dependencies.

--- a/projects/js-packages/storybook/changelog/remove-wpcalypso-import-docblock-comments
+++ b/projects/js-packages/storybook/changelog/remove-wpcalypso-import-docblock-comments
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove `wpcalypso/import-docblock` comments. No change to behavior.
-
-

--- a/projects/js-packages/storybook/changelog/rename-reach-to-social
+++ b/projects/js-packages/storybook/changelog/rename-reach-to-social
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/storybook/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-babel-monorepo#2
+++ b/projects/js-packages/storybook/changelog/renovate-babel-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-babel-monorepo#3
+++ b/projects/js-packages/storybook/changelog/renovate-babel-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-babel-monorepo#4
+++ b/projects/js-packages/storybook/changelog/renovate-babel-monorepo#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-babel-monorepo#5
+++ b/projects/js-packages/storybook/changelog/renovate-babel-monorepo#5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/js-packages/storybook/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-postcss-8.x
+++ b/projects/js-packages/storybook/changelog/renovate-postcss-8.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-postcss-8.x#2
+++ b/projects/js-packages/storybook/changelog/renovate-postcss-8.x#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-storybook-monorepo
+++ b/projects/js-packages/storybook/changelog/renovate-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-storybook-monorepo#2
+++ b/projects/js-packages/storybook/changelog/renovate-storybook-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-typescript-4.x
+++ b/projects/js-packages/storybook/changelog/renovate-typescript-4.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-typescript-4.x#2
+++ b/projects/js-packages/storybook/changelog/renovate-typescript-4.x#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-webpack-5.x
+++ b/projects/js-packages/storybook/changelog/renovate-webpack-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#10
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#10
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#2
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#3
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#4
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#5
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#6
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#6
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#7
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#7
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#8
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#8
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#9
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#9
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo-2
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo-2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/try-storybook-addon-turbo-build
+++ b/projects/js-packages/storybook/changelog/try-storybook-addon-turbo-build
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Try using `storybook-addon-turbo-build` to speed up the build.

--- a/projects/js-packages/storybook/changelog/update-changelogger-add-pr-num
+++ b/projects/js-packages/storybook/changelog/update-changelogger-add-pr-num
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/update-components-add-is-external-link-prop
+++ b/projects/js-packages/storybook/changelog/update-components-add-is-external-link-prop
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/update-components-add-theme-provider-stories
+++ b/projects/js-packages/storybook/changelog/update-components-add-theme-provider-stories
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/update-components-alter-tsx
+++ b/projects/js-packages/storybook/changelog/update-components-alter-tsx
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/update-dashboard-assistant
+++ b/projects/js-packages/storybook/changelog/update-dashboard-assistant
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/update-js-components-introduce-text-spacing-props
+++ b/projects/js-packages/storybook/changelog/update-js-components-introduce-text-spacing-props
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/update-js-components-theme-provider-handling
+++ b/projects/js-packages/storybook/changelog/update-js-components-theme-provider-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix styles defined by the ThemeProvider in the storybook stories

--- a/projects/js-packages/storybook/changelog/update-js-tools-deps-and-eslint-config
+++ b/projects/js-packages/storybook/changelog/update-js-tools-deps-and-eslint-config
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update eslint config. No material change to the package itself.
-
-

--- a/projects/js-packages/storybook/changelog/update-move-my-jetpack-product-icons-into-components
+++ b/projects/js-packages/storybook/changelog/update-move-my-jetpack-product-icons-into-components
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/update-pnpm-version
+++ b/projects/js-packages/storybook/changelog/update-pnpm-version
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update minimum pnpm version. No change to the project itself.
-
-

--- a/projects/js-packages/storybook/changelog/update-product-offer-error-placeholder
+++ b/projects/js-packages/storybook/changelog/update-product-offer-error-placeholder
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/update-rm-unneeded-storybook-deps
+++ b/projects/js-packages/storybook/changelog/update-rm-unneeded-storybook-deps
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Remove unneeded dependencies.

--- a/projects/js-packages/storybook/changelog/update-rna-text-component
+++ b/projects/js-packages/storybook/changelog/update-rna-text-component
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/update-storybook-add-jetpack-dashboard-bg-color
+++ b/projects/js-packages/storybook/changelog/update-storybook-add-jetpack-dashboard-bg-color
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add 'Jetpack Dashboard' background color

--- a/projects/js-packages/storybook/changelog/update-storybook-theme-provider
+++ b/projects/js-packages/storybook/changelog/update-storybook-theme-provider
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Storybook: Remove base-styles in favor of ThemeProvider

--- a/projects/js-packages/storybook/changelog/update-to-pnpm-7
+++ b/projects/js-packages/storybook/changelog/update-to-pnpm-7
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Use pnpm 7.
-
-

--- a/projects/js-packages/storybook/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/js-packages/storybook/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.
-

--- a/projects/js-packages/storybook/package.json
+++ b/projects/js-packages/storybook/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-storybook",
-	"version": "0.2.0-alpha",
+	"version": "0.2.0",
 	"description": "Jetpack components storybook",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/storybook/#readme",
 	"bugs": {

--- a/projects/packages/analyzer/CHANGELOG.md
+++ b/projects/packages/analyzer/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.1] - 2022-07-06
+### Changed
+- Renaming `master` references to `trunk`. [#24712]
+- Updated package dependencies. [#24045]
+
 ## [1.7.0] - 2022-02-23
 ### Added
 - API for anayzer service
@@ -81,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Jetpack code analyzer
 
+[1.7.1]: https://github.com/Automattic/jetpack-analyzer/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/Automattic/jetpack-analyzer/compare/v1.6.2...v1.7.0
 [1.6.2]: https://github.com/Automattic/jetpack-analyzer/compare/v1.6.1...v1.6.2
 [1.6.1]: https://github.com/Automattic/jetpack-analyzer/compare/v1.6.0...v1.6.1

--- a/projects/packages/analyzer/changelog/update-changelogger-add-pr-num
+++ b/projects/packages/analyzer/changelog/update-changelogger-add-pr-num
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/analyzer/changelog/update-monorepo-master-refs-primary
+++ b/projects/packages/analyzer/changelog/update-monorepo-master-refs-primary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Renaming master references to trunk, to work with the GitHub default branch name changing to trunk.

--- a/projects/packages/analyzer/changelog/update-monorepo-master-refs-secondary
+++ b/projects/packages/analyzer/changelog/update-monorepo-master-refs-secondary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Renaming `master` references to `trunk`

--- a/projects/packages/codesniffer/CHANGELOG.md
+++ b/projects/packages/codesniffer/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.0] - 2022-07-06
+### Added
+- Added lint to ensure httponly is set (or intentionally ignored) on setcookie. [#24418]
+- Import rules from `WordPress` instead of `WordPress-Core`, `WordPress-Docs`, and `WordPress-Extra` individually. This adds two new rules. [#23932]
+
+### Changed
+- Renaming master to trunk. [#24661]
+- Rulesets: allow the use of lowercase WordPress. [#24363]
+- Updated package dependencies.
+
+### Fixed
+- Detect classes like `WP_Test_.*_Case` as test case base classes too. [#24027]
+
 ## [2.5.0] - 2022-04-05
 ### Added
 - Add sniff to disallow relative file includes.
@@ -89,6 +102,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Codesniffer: Add a package to hold our coding standard
 
+[2.6.0]: https://github.com/Automattic/jetpack-codesniffer/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/Automattic/jetpack-codesniffer/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/Automattic/jetpack-codesniffer/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/Automattic/jetpack-codesniffer/compare/v2.2.1...v2.3.0

--- a/projects/packages/codesniffer/Jetpack/Sniffs/Functions/SetCookieSniff.php
+++ b/projects/packages/codesniffer/Jetpack/Sniffs/Functions/SetCookieSniff.php
@@ -15,7 +15,7 @@ use WordPressCS\WordPress\AbstractFunctionParameterSniff;
  *
  * @package Automattic/jetpack-coding-standards
  *
- * @since   $$next-version$$
+ * @since   2.6.0
  */
 class SetCookieSniff extends AbstractFunctionParameterSniff {
 
@@ -31,7 +31,7 @@ class SetCookieSniff extends AbstractFunctionParameterSniff {
 	 *
 	 * @link http://php.net/setcookie
 	 *
-	 * @since $$next-version$$
+	 * @since 2.6.0
 	 *
 	 * @var array <string function_name> => array( <bool always needed ?>, <int parameter number ?> )
 	 */
@@ -45,7 +45,7 @@ class SetCookieSniff extends AbstractFunctionParameterSniff {
 	/**
 	 * Process the parameters of a matched function.
 	 *
-	 * @since $$next-version$$
+	 * @since 2.6.0
 	 *
 	 * @param int    $stackPtr        The position of the current token in the stack.
 	 * @param string $group_name      The name of the group which was matched.

--- a/projects/packages/codesniffer/changelog/add-check-for-httponly
+++ b/projects/packages/codesniffer/changelog/add-check-for-httponly
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added lint to ensure httponly is set (or intentionally ignored) on setcookie.

--- a/projects/packages/codesniffer/changelog/add-codesniffer-missing-wp-rules
+++ b/projects/packages/codesniffer/changelog/add-codesniffer-missing-wp-rules
@@ -1,5 +1,0 @@
-Significance: minor
-Type: added
-Comment: Prepare for adding missing WordPress rules.
-
-Import rules from `WordPress` instead of `WordPress-Core`, `WordPress-Docs`, and `WordPress-Extra` individually. This adds two new rules.

--- a/projects/packages/codesniffer/changelog/fix-codesniffer-composer-dev-deps
+++ b/projects/packages/codesniffer/changelog/fix-codesniffer-composer-dev-deps
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix dev dep on WPCS to point at our fork rather than their dev-develop. Even though we're depending on a specific old commit, Composer gets confused now that their dev-develop depends on newer PHPCS than we can currently use. No change to the package itself.
-
-

--- a/projects/packages/codesniffer/changelog/fix-phpcs-in-jetpack-tests
+++ b/projects/packages/codesniffer/changelog/fix-phpcs-in-jetpack-tests
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Detect classes like `WP_Test_.*_Case` as test case base classes too.

--- a/projects/packages/codesniffer/changelog/renovate-mediawiki-mediawiki-codesniffer-39.x
+++ b/projects/packages/codesniffer/changelog/renovate-mediawiki-mediawiki-codesniffer-39.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/codesniffer/changelog/update-changelogger-add-pr-num
+++ b/projects/packages/codesniffer/changelog/update-changelogger-add-pr-num
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/codesniffer/changelog/update-monorepo-master-refs-primary
+++ b/projects/packages/codesniffer/changelog/update-monorepo-master-refs-primary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Renaming master to trunk.

--- a/projects/packages/codesniffer/changelog/update-ruleset-wordpress
+++ b/projects/packages/codesniffer/changelog/update-ruleset-wordpress
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Rulesets: allow the use of lowercase WordPress.

--- a/projects/packages/heartbeat/CHANGELOG.md
+++ b/projects/packages/heartbeat/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2022-07-06
+### Changed
+- Renaming master to trunk. [#24661]
+- Updated package dependencies.
+
+### Deprecated
+- Removed Heartbeat by hoisting it into Connection. [#23910]
+
 ## [1.4.1] - 2022-04-12
 ### Changed
 - Updated package dependencies.
@@ -104,6 +112,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use new heartbeat package
 - Creates the Jetpack Heartbeat package
 
+[1.5.0]: https://github.com/Automattic/jetpack-heartbeat/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/Automattic/jetpack-heartbeat/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/Automattic/jetpack-heartbeat/compare/v1.3.15...v1.4.0
 [1.3.15]: https://github.com/Automattic/jetpack-heartbeat/compare/v1.3.14...v1.3.15

--- a/projects/packages/heartbeat/changelog/fix-user-connect-second-attempt-redirect
+++ b/projects/packages/heartbeat/changelog/fix-user-connect-second-attempt-redirect
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/heartbeat/changelog/hoist-heartbeat
+++ b/projects/packages/heartbeat/changelog/hoist-heartbeat
@@ -1,4 +1,0 @@
-Significance: minor
-Type: deprecated
-
-Removed Heartbeat by hoisting it into Connection.

--- a/projects/packages/heartbeat/changelog/hoist-heartbeat#2
+++ b/projects/packages/heartbeat/changelog/hoist-heartbeat#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/heartbeat/changelog/hoist-heartbeat#3
+++ b/projects/packages/heartbeat/changelog/hoist-heartbeat#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/heartbeat/changelog/hoist-options
+++ b/projects/packages/heartbeat/changelog/hoist-options
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/heartbeat/changelog/update-changelogger-add-pr-num
+++ b/projects/packages/heartbeat/changelog/update-changelogger-add-pr-num
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/heartbeat/changelog/update-monorepo-master-refs-primary
+++ b/projects/packages/heartbeat/changelog/update-monorepo-master-refs-primary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Renaming master to trunk.

--- a/projects/packages/ignorefile/CHANGELOG.md
+++ b/projects/packages/ignorefile/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2022-07-06
+### Changed
+- Renaming master to trunk. [#24661]
+- Updated package dependencies. [#24045]
+
 ## [1.0.1] - 2022-03-01
 ### Changed
 - Switch to pcov for code coverage.
@@ -14,4 +19,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[1.0.2]: https://github.com/Automattic/ignorefile/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/Automattic/ignorefile/compare/v1.0.0...v1.0.1

--- a/projects/packages/ignorefile/changelog/fix-composer-dep-or
+++ b/projects/packages/ignorefile/changelog/fix-composer-dep-or
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Composer prefers `||` in version ranges, use that instead of `|`.
-
-

--- a/projects/packages/ignorefile/changelog/update-changelogger-add-pr-num
+++ b/projects/packages/ignorefile/changelog/update-changelogger-add-pr-num
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/ignorefile/changelog/update-monorepo-master-refs-primary
+++ b/projects/packages/ignorefile/changelog/update-monorepo-master-refs-primary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Renaming master to trunk.

--- a/projects/packages/phpcs-filter/CHANGELOG.md
+++ b/projects/packages/phpcs-filter/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.2 - 2022-07-06
+### Changed
+- Renaming master to trunk. [#24661]
+- Updated package dependencies. [#24045]
+
 ## 1.0.1 - 2022-03-01
 ### Changed
 - Switch to pcov for code coverage.

--- a/projects/packages/phpcs-filter/changelog/update-changelogger-add-pr-num
+++ b/projects/packages/phpcs-filter/changelog/update-changelogger-add-pr-num
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/phpcs-filter/changelog/update-monorepo-master-refs-primary
+++ b/projects/packages/phpcs-filter/changelog/update-monorepo-master-refs-primary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Renaming master to trunk.

--- a/projects/packages/plans/CHANGELOG.md
+++ b/projects/packages/plans/CHANGELOG.md
@@ -5,3 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.0 - 2022-07-06
+### Added
+- Add support for WordPress.com Starter plan. [#24496]
+- Package created. [#23503]
+
+### Changed
+- Renaming master to trunk. [#24661]
+- Updated package dependencies.
+
+### Deprecated
+- Moved the options class into Connection. [#24095]

--- a/projects/packages/plans/changelog/add-action-based-recommendations
+++ b/projects/packages/plans/changelog/add-action-based-recommendations
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/plans/changelog/add-lint-package-json-urls
+++ b/projects/packages/plans/changelog/add-lint-package-json-urls
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package.json metadata.

--- a/projects/packages/plans/changelog/add-starter-plan
+++ b/projects/packages/plans/changelog/add-starter-plan
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add support for WordPress.com Starter plan.

--- a/projects/packages/plans/changelog/extract-jetpack-plans
+++ b/projects/packages/plans/changelog/extract-jetpack-plans
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Package created

--- a/projects/packages/plans/changelog/fix-user-connect-second-attempt-redirect
+++ b/projects/packages/plans/changelog/fix-user-connect-second-attempt-redirect
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/plans/changelog/hoist-heartbeat
+++ b/projects/packages/plans/changelog/hoist-heartbeat
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/plans/changelog/hoist-heartbeat#2
+++ b/projects/packages/plans/changelog/hoist-heartbeat#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/plans/changelog/hoist-options
+++ b/projects/packages/plans/changelog/hoist-options
@@ -1,4 +1,0 @@
-Significance: patch
-Type: deprecated
-
-Moved the options class into Connection.

--- a/projects/packages/plans/changelog/hoist-options#2
+++ b/projects/packages/plans/changelog/hoist-options#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/plans/changelog/remove-claim-of-support-for-node-14
+++ b/projects/packages/plans/changelog/remove-claim-of-support-for-node-14
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
-
-

--- a/projects/packages/plans/changelog/try-token-domain-lock
+++ b/projects/packages/plans/changelog/try-token-domain-lock
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/plans/changelog/update-add-to-status-package
+++ b/projects/packages/plans/changelog/update-add-to-status-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/plans/changelog/update-changelogger-add-pr-num
+++ b/projects/packages/plans/changelog/update-changelogger-add-pr-num
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/plans/changelog/update-monorepo-master-refs-primary
+++ b/projects/packages/plans/changelog/update-monorepo-master-refs-primary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Renaming master to trunk.

--- a/projects/packages/plans/changelog/update-remove-remaining-in-place-conntections
+++ b/projects/packages/plans/changelog/update-remove-remaining-in-place-conntections
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/plans/changelog/update-to-pnpm-7
+++ b/projects/packages/plans/changelog/update-to-pnpm-7
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Use pnpm 7.
-
-

--- a/projects/packages/plans/package.json
+++ b/projects/packages/plans/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-plans",
-	"version": "0.1.0-alpha",
+	"version": "0.1.0",
 	"description": "Fetch information about Jetpack Plans from wpcom",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/plans/#readme",
 	"bugs": {

--- a/projects/packages/post-list/CHANGELOG.md
+++ b/projects/packages/post-list/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2022-07-06
+### Changed
+- PHPCS: fix `WordPress.Security.ValidatedSanitizedInput`. [#23942]
+- Renaming master to trunk. [#24661]
+- Updated package dependencies. [#24045]
+
 ## [0.3.0] - 2022-02-01
 ### Changed
 - Build: remove unneeded files from production build.
@@ -51,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the default columns displayed on the post and page list screens
 - Refactored thumbnail preview to function server side. All javascript removed.
 
+[0.3.1]: https://github.com/automattic/jetpack-post-list/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/automattic/jetpack-post-list/compare/v0.2.4...v0.3.0
 [0.2.4]: https://github.com/automattic/jetpack-post-list/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/automattic/jetpack-post-list/compare/v0.2.2...v0.2.3

--- a/projects/packages/post-list/changelog/fix-non-jetpack-WordPress.Security.ValidatedSanitizedInput
+++ b/projects/packages/post-list/changelog/fix-non-jetpack-WordPress.Security.ValidatedSanitizedInput
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`

--- a/projects/packages/post-list/changelog/remove-gulp-🎉
+++ b/projects/packages/post-list/changelog/remove-gulp-🎉
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Clean up obsolete export-ignore attributes.
-
-

--- a/projects/packages/post-list/changelog/update-changelogger-add-pr-num
+++ b/projects/packages/post-list/changelog/update-changelogger-add-pr-num
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/post-list/changelog/update-monorepo-master-refs-primary
+++ b/projects/packages/post-list/changelog/update-monorepo-master-refs-primary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Renaming master to trunk.

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Post_List;
  */
 class Post_List {
 
-	const PACKAGE_VERSION = '0.3.1-alpha';
+	const PACKAGE_VERSION = '0.3.1';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/tracking/CHANGELOG.md
+++ b/projects/packages/tracking/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.10] - 2022-07-06
+### Changed
+- Renaming master to trunk. [#24661]
+- Updated package dependencies.
+
+### Deprecated
+- Moved the options class into Connection. [#24095]
+
 ## [1.14.9] - 2022-04-26
 ### Changed
 - Updated package dependencies.
@@ -242,6 +250,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Create package for Jetpack Tracking
 
+[1.14.10]: https://github.com/Automattic/jetpack-tracking/compare/v1.14.9...v1.14.10
 [1.14.9]: https://github.com/Automattic/jetpack-tracking/compare/v1.14.8...v1.14.9
 [1.14.8]: https://github.com/Automattic/jetpack-tracking/compare/v1.14.7...v1.14.8
 [1.14.7]: https://github.com/Automattic/jetpack-tracking/compare/v1.14.6...v1.14.7

--- a/projects/packages/tracking/changelog/fix-user-connect-second-attempt-redirect
+++ b/projects/packages/tracking/changelog/fix-user-connect-second-attempt-redirect
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/tracking/changelog/hoist-options
+++ b/projects/packages/tracking/changelog/hoist-options
@@ -1,4 +1,0 @@
-Significance: patch
-Type: deprecated
-
-Moved the options class into Connection.

--- a/projects/packages/tracking/changelog/hoist-options#2
+++ b/projects/packages/tracking/changelog/hoist-options#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/tracking/changelog/update-monorepo-master-refs-primary
+++ b/projects/packages/tracking/changelog/update-monorepo-master-refs-primary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Renaming master to trunk.

--- a/projects/plugins/always-use-jetpack-open-graph/CHANGELOG.md
+++ b/projects/plugins/always-use-jetpack-open-graph/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.2] - 2022-07-06
 ### Added
-- Added to the repo [#23387]
+- Add plugin temporarily to the Jetpack monorepo for automated SVN/WPorg testing. [#23387]
 
 ### Changed
 - Renaming master to trunk. [#24661]

--- a/projects/plugins/always-use-jetpack-open-graph/CHANGELOG.md
+++ b/projects/plugins/always-use-jetpack-open-graph/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2022-07-06
+### Added
+- Added to the repo [#23387]
+
+### Changed
+- Renaming master to trunk. [#24661]
+- Updated package dependencies.
+
 ## 1.0.1 - 2017-04-10
 
 - Minor fixes.
@@ -12,3 +20,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 1.0.0 - 2014-02-03
 
 - Initial release.
+
+[1.0.2]: https://github.com/Automattic/jetpack-always-use-jetpack-open-graph/compare/v1.0.1...v1.0.2

--- a/projects/plugins/always-use-jetpack-open-graph/always-use-jetpack-open-graph.php
+++ b/projects/plugins/always-use-jetpack-open-graph/always-use-jetpack-open-graph.php
@@ -3,7 +3,7 @@
  * Plugin Name: Always Use Open Graph with Jetpack
  * Plugin URI: https://kraft.blog/
  * Description: Jetpack automatically disables its Open Graph tags when there's a known plugin that already adds Open Graph tags, which is good. Sometimes, though, you might want to use Jetpack's version instead. Even if you disable the tags in the conflicting plugin, Jetpack won't add Open Graph tags without being told to do so.
- * Version: 1.0.2-alpha
+ * Version: 1.0.2
  * Author: Brandon Kraft
  * Author Email: public@brandonkraft.com
  * License: GPLv2 or later

--- a/projects/plugins/always-use-jetpack-open-graph/changelog/2022-04-12-14-16-16-873461
+++ b/projects/plugins/always-use-jetpack-open-graph/changelog/2022-04-12-14-16-16-873461
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/always-use-jetpack-open-graph/changelog/add-always-use
+++ b/projects/plugins/always-use-jetpack-open-graph/changelog/add-always-use
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added to the repo

--- a/projects/plugins/always-use-jetpack-open-graph/changelog/fix-composer-dep-or
+++ b/projects/plugins/always-use-jetpack-open-graph/changelog/fix-composer-dep-or
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/always-use-jetpack-open-graph/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/always-use-jetpack-open-graph/changelog/renovate-lock-file-maintenance
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/always-use-jetpack-open-graph/changelog/renovate-lock-file-maintenance#2
+++ b/projects/plugins/always-use-jetpack-open-graph/changelog/renovate-lock-file-maintenance#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/always-use-jetpack-open-graph/changelog/renovate-lock-file-maintenance#3
+++ b/projects/plugins/always-use-jetpack-open-graph/changelog/renovate-lock-file-maintenance#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/always-use-jetpack-open-graph/changelog/update-changelogger-add-pr-num
+++ b/projects/plugins/always-use-jetpack-open-graph/changelog/update-changelogger-add-pr-num
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/always-use-jetpack-open-graph/changelog/update-composer-2.3
+++ b/projects/plugins/always-use-jetpack-open-graph/changelog/update-composer-2.3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/always-use-jetpack-open-graph/changelog/update-monorepo-master-refs-primary
+++ b/projects/plugins/always-use-jetpack-open-graph/changelog/update-monorepo-master-refs-primary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Renaming master to trunk.

--- a/projects/plugins/always-use-jetpack-open-graph/changelog/update-use-package-publicize
+++ b/projects/plugins/always-use-jetpack-open-graph/changelog/update-use-package-publicize
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/always-use-jetpack-open-graph/readme.txt
+++ b/projects/plugins/always-use-jetpack-open-graph/readme.txt
@@ -31,7 +31,7 @@ Jetpack's implementation of Open Graph and Twitter Card tags is the same as what
 == Changelog ==
 ### 1.0.2 - 2022-07-06
 #### Added
-- Added to the repo
+- Add plugin temporarily to the Jetpack monorepo for automated SVN/WPorg testing.
 
 #### Changed
 - Renaming master to trunk.

--- a/projects/plugins/always-use-jetpack-open-graph/readme.txt
+++ b/projects/plugins/always-use-jetpack-open-graph/readme.txt
@@ -29,11 +29,10 @@ This is great for when you want to use the awesome WP SEO by Yoast plugin or oth
 Jetpack's implementation of Open Graph and Twitter Card tags is the same as what's used on WordPress.com. There's a team of folks who are keeping watch on Facebook and Twitter changes, then improving the code. WP SEO and other plugins do a great job with SEO, so this plugin helps everyone play together nicer.
 
 == Changelog ==
+### 1.0.2 - 2022-07-06
+#### Added
+- Added to the repo
 
-= 1.0 =
-* Initial Release.
-
-== Upgrade Notice ==
-
-= 1.0 =
-First official release.
+#### Changed
+- Renaming master to trunk.
+- Updated package dependencies.

--- a/projects/plugins/debug-helper/CHANGELOG.md
+++ b/projects/plugins/debug-helper/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.4.0] - 2022-07-06
 ### Added
-- Added several enhancements to the Autoloader debugger module that make debugging easier. [#23927]
 - Added the Autoloader debugger helper to the Debug tool. [#23726]
 - Add Protect helper module. [#24805]
 - Debug helper plugin: add debug helper page for Jetpack modules. [#24456]

--- a/projects/plugins/debug-helper/CHANGELOG.md
+++ b/projects/plugins/debug-helper/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2022-07-06
+### Added
+- Added several enhancements to the Autoloader debugger module that make debugging easier. [#23927]
+- Added the Autoloader debugger helper to the Debug tool. [#23726]
+- Add Protect helper module. [#24805]
+- Debug helper plugin: add debug helper page for Jetpack modules. [#24456]
+
+### Changed
+- PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`. [#23942]
+- Renaming master to trunk. [#24661]
+- Updated package dependencies.
+
 ## [1.3.0] - 2022-03-01
 ### Added
 - Add a Sync Data Settings page, which displays the data settings provided by each Sync data filter.
@@ -49,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial version.
 
+[1.4.0]: https://github.com/Automattic/jetpack-debug-helper/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/Automattic/jetpack-debug-helper/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/Automattic/jetpack-debug-helper/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/Automattic/jetpack-debug-helper/compare/v1.0.1...v1.1.0

--- a/projects/plugins/debug-helper/changelog/2022-03-09-12-05-23-224573
+++ b/projects/plugins/debug-helper/changelog/2022-03-09-12-05-23-224573
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/debug-helper/changelog/2022-04-12-14-16-28-468342
+++ b/projects/plugins/debug-helper/changelog/2022-04-12-14-16-28-468342
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/debug-helper/changelog/add-autoloader-debugger
+++ b/projects/plugins/debug-helper/changelog/add-autoloader-debugger
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added the Autoloader debugger helper to the Debug tool.

--- a/projects/plugins/debug-helper/changelog/add-autoloader-debugger-enhancements
+++ b/projects/plugins/debug-helper/changelog/add-autoloader-debugger-enhancements
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added several enhancements to the Autoloader debugger module that make debugging easier.

--- a/projects/plugins/debug-helper/changelog/add-debug-helper-modules-page
+++ b/projects/plugins/debug-helper/changelog/add-debug-helper-modules-page
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Debug helper plugin: Add debug helper page for Jetpack modules.

--- a/projects/plugins/debug-helper/changelog/add-protect-helper-module
+++ b/projects/plugins/debug-helper/changelog/add-protect-helper-module
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add Protect helper module

--- a/projects/plugins/debug-helper/changelog/fix-composer-dep-or
+++ b/projects/plugins/debug-helper/changelog/fix-composer-dep-or
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/debug-helper/changelog/fix-non-jetpack-WordPress.Security.ValidatedSanitizedInput
+++ b/projects/plugins/debug-helper/changelog/fix-non-jetpack-WordPress.Security.ValidatedSanitizedInput
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`

--- a/projects/plugins/debug-helper/changelog/remove-wpcalypso-import-docblock-comments
+++ b/projects/plugins/debug-helper/changelog/remove-wpcalypso-import-docblock-comments
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove `wpcalypso/import-docblock` comments. No change to behavior.
-
-

--- a/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance#2
+++ b/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance#3
+++ b/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance#4
+++ b/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/debug-helper/changelog/update-changelogger-add-pr-num
+++ b/projects/plugins/debug-helper/changelog/update-changelogger-add-pr-num
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/debug-helper/changelog/update-composer-2.3
+++ b/projects/plugins/debug-helper/changelog/update-composer-2.3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/debug-helper/changelog/update-monorepo-master-refs-primary
+++ b/projects/plugins/debug-helper/changelog/update-monorepo-master-refs-primary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Renaming master to trunk.

--- a/projects/plugins/debug-helper/changelog/update-use-package-publicize
+++ b/projects/plugins/debug-helper/changelog/update-use-package-publicize
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/debug-helper/plugin.php
+++ b/projects/plugins/debug-helper/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack Debug Tools
  * Description: Give me a Jetpack connection, and I'll break it every way possible.
  * Author: Automattic - Jetpack Crew
- * Version: 1.4.0-alpha
+ * Version: 1.4.0
  * Text Domain: jetpack
  *
  * @package automattic/jetpack-debug-helper.
@@ -33,7 +33,7 @@ define( 'JETPACK_DEBUG_HELPER_BASE_PLUGIN_FILE', __FILE__ );
  * The plugin version.
  * Increase that if you do any edits to ensure refreshing the cached assets.
  */
-define( 'JETPACK_DEBUG_HELPER_VERSION', '1.4.0-alpha' );
+define( 'JETPACK_DEBUG_HELPER_VERSION', '1.4.0' );
 
 /**
  * Include file names from the modules directory here.

--- a/projects/plugins/starter-plugin/CHANGELOG.md
+++ b/projects/plugins/starter-plugin/CHANGELOG.md
@@ -5,3 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.0 - 2022-07-06
+### Added
+- Add activation and deactivation hooks. [#24250]
+- E2E tests boilerplate. [#24723]
+- Enable beta plugin support. [#23836]
+- Initial release. [#23434]
+
+### Changed
+- Changed the method used to disconnect. [#24299]
+- Configure Sync with the minimal amount of data. [#23759]
+- Janitorial: require a more recent version of WordPress now that WP 6.0 is coming out. [#24083]
+- Remove use of `pnpx` in preparation for pnpm 7.0. [#24210]
+- Renaming master to trunk. [#24661]
+- Renaming `master` references to `trunk`. [#24712]
+- Reorder JS imports for `import/order` eslint rule. [#24601]
+- Updated package dependencies.
+
+### Fixed
+- Jetpack CLI: correctly replace project description and release-branch-prefix. [#23911]
+- Updated .gitattributes file so it is able to build properly by the CI build jobs. [#23591]

--- a/projects/plugins/starter-plugin/changelog/2022-04-12-14-18-17-717339
+++ b/projects/plugins/starter-plugin/changelog/2022-04-12-14-18-17-717339
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-action-based-recommendations
+++ b/projects/plugins/starter-plugin/changelog/add-action-based-recommendations
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-blogging-prompts-post-meta-sync
+++ b/projects/plugins/starter-plugin/changelog/add-blogging-prompts-post-meta-sync
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-build-packages-connection
+++ b/projects/plugins/starter-plugin/changelog/add-build-packages-connection
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-composer-plugin-modifies-install-path-flag
+++ b/projects/plugins/starter-plugin/changelog/add-composer-plugin-modifies-install-path-flag
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-e2e-setup-to-starter-plugin
+++ b/projects/plugins/starter-plugin/changelog/add-e2e-setup-to-starter-plugin
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-E2E tests boilerplate

--- a/projects/plugins/starter-plugin/changelog/add-eslint-import-order
+++ b/projects/plugins/starter-plugin/changelog/add-eslint-import-order
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Reorder JS imports for `import/order` eslint rule.

--- a/projects/plugins/starter-plugin/changelog/add-generate-from-starter-plugin
+++ b/projects/plugins/starter-plugin/changelog/add-generate-from-starter-plugin
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-initial release

--- a/projects/plugins/starter-plugin/changelog/add-generate-from-starter-plugin#2
+++ b/projects/plugins/starter-plugin/changelog/add-generate-from-starter-plugin#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-generate-from-starter-plugin#3
+++ b/projects/plugins/starter-plugin/changelog/add-generate-from-starter-plugin#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-get-connected-plugins-resolver
+++ b/projects/plugins/starter-plugin/changelog/add-get-connected-plugins-resolver
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-licensing-skeleton-to-my-jetpack
+++ b/projects/plugins/starter-plugin/changelog/add-licensing-skeleton-to-my-jetpack
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-lint-package-json-urls
+++ b/projects/plugins/starter-plugin/changelog/add-lint-package-json-urls
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package.json metadata.

--- a/projects/plugins/starter-plugin/changelog/add-my-jetpack-activation-filter
+++ b/projects/plugins/starter-plugin/changelog/add-my-jetpack-activation-filter
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-post_content_sync
+++ b/projects/plugins/starter-plugin/changelog/add-post_content_sync
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-project-structure-check-for-jetpack-library
+++ b/projects/plugins/starter-plugin/changelog/add-project-structure-check-for-jetpack-library
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-security-recommendation
+++ b/projects/plugins/starter-plugin/changelog/add-security-recommendation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-social-product-icon
+++ b/projects/plugins/starter-plugin/changelog/add-social-product-icon
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-social-to-my-jetpack
+++ b/projects/plugins/starter-plugin/changelog/add-social-to-my-jetpack
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-starter-to-beta
+++ b/projects/plugins/starter-plugin/changelog/add-starter-to-beta
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Enable beta plugin support

--- a/projects/plugins/starter-plugin/changelog/add-sync-search-options
+++ b/projects/plugins/starter-plugin/changelog/add-sync-search-options
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/fix-config-package-prefer-stable
+++ b/projects/plugins/starter-plugin/changelog/fix-config-package-prefer-stable
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/fix-js-dep-updates
+++ b/projects/plugins/starter-plugin/changelog/fix-js-dep-updates
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/fix-monorepo-version-refs-lint
+++ b/projects/plugins/starter-plugin/changelog/fix-monorepo-version-refs-lint
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/fix-use-plain-remote-request-for-pricing
+++ b/projects/plugins/starter-plugin/changelog/fix-use-plain-remote-request-for-pricing
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/fix-user-connect-second-attempt-redirect
+++ b/projects/plugins/starter-plugin/changelog/fix-user-connect-second-attempt-redirect
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/fix-vs-code-eslint-prettier
+++ b/projects/plugins/starter-plugin/changelog/fix-vs-code-eslint-prettier
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/fix-vs-code-eslint-prettier#2
+++ b/projects/plugins/starter-plugin/changelog/fix-vs-code-eslint-prettier#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/fix-waf-activation-hooks
+++ b/projects/plugins/starter-plugin/changelog/fix-waf-activation-hooks
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/fix-webpack-deterministic-ids
+++ b/projects/plugins/starter-plugin/changelog/fix-webpack-deterministic-ids
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/hoist-heartbeat
+++ b/projects/plugins/starter-plugin/changelog/hoist-heartbeat
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/hoist-heartbeat#2
+++ b/projects/plugins/starter-plugin/changelog/hoist-heartbeat#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/hoist-heartbeat#3
+++ b/projects/plugins/starter-plugin/changelog/hoist-heartbeat#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/hoist-heartbeat#4
+++ b/projects/plugins/starter-plugin/changelog/hoist-heartbeat#4
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/hoist-options
+++ b/projects/plugins/starter-plugin/changelog/hoist-options
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/hoist-options#2
+++ b/projects/plugins/starter-plugin/changelog/hoist-options#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/hoist-options#3
+++ b/projects/plugins/starter-plugin/changelog/hoist-options#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/hoist-tracking-rebase
+++ b/projects/plugins/starter-plugin/changelog/hoist-tracking-rebase
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/move-gutenber-base-styles
+++ b/projects/plugins/starter-plugin/changelog/move-gutenber-base-styles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/move-gutenber-base-styles#2
+++ b/projects/plugins/starter-plugin/changelog/move-gutenber-base-styles#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/move-service-icons-to-js-package
+++ b/projects/plugins/starter-plugin/changelog/move-service-icons-to-js-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/remove-claim-of-support-for-node-14
+++ b/projects/plugins/starter-plugin/changelog/remove-claim-of-support-for-node-14
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
-
-

--- a/projects/plugins/starter-plugin/changelog/remove-wpcalypso-import-docblock-comments
+++ b/projects/plugins/starter-plugin/changelog/remove-wpcalypso-import-docblock-comments
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove `wpcalypso/import-docblock` comments. No change to behavior.
-
-

--- a/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo
+++ b/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo#2
+++ b/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo#3
+++ b/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo#4
+++ b/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#2
+++ b/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#3
+++ b/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-packagist-composer-composer-vulnerability
+++ b/projects/plugins/starter-plugin/changelog/renovate-packagist-composer-composer-vulnerability
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/renovate-webpack-5.x
+++ b/projects/plugins/starter-plugin/changelog/renovate-webpack-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#2
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#3
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#4
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#5
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#6
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#6
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo-2
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo-2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/revert-dedicated-sync
+++ b/projects/plugins/starter-plugin/changelog/revert-dedicated-sync
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/try-token-domain-lock
+++ b/projects/plugins/starter-plugin/changelog/try-token-domain-lock
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/try-token-domain-lock#2
+++ b/projects/plugins/starter-plugin/changelog/try-token-domain-lock#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-add-to-status-package
+++ b/projects/plugins/starter-plugin/changelog/update-add-to-status-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-assistant-discount-card
+++ b/projects/plugins/starter-plugin/changelog/update-assistant-discount-card
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-changelogger-add-pr-num
+++ b/projects/plugins/starter-plugin/changelog/update-changelogger-add-pr-num
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-components-add-is-external-link-prop
+++ b/projects/plugins/starter-plugin/changelog/update-components-add-is-external-link-prop
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-components-add-theme-provider-stories
+++ b/projects/plugins/starter-plugin/changelog/update-components-add-theme-provider-stories
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-components-alter-tsx
+++ b/projects/plugins/starter-plugin/changelog/update-components-alter-tsx
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-composer-2.3
+++ b/projects/plugins/starter-plugin/changelog/update-composer-2.3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-disconnection-methods
+++ b/projects/plugins/starter-plugin/changelog/update-disconnection-methods
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Changed the method used to disconnect

--- a/projects/plugins/starter-plugin/changelog/update-external-link-instances
+++ b/projects/plugins/starter-plugin/changelog/update-external-link-instances
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-js-components-introduce-text-spacing-props
+++ b/projects/plugins/starter-plugin/changelog/update-js-components-introduce-text-spacing-props
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-licensing-to-my-jetpack
+++ b/projects/plugins/starter-plugin/changelog/update-licensing-to-my-jetpack
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-licensing-to-my-jetpack#2
+++ b/projects/plugins/starter-plugin/changelog/update-licensing-to-my-jetpack#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-monorepo-master-refs-primary
+++ b/projects/plugins/starter-plugin/changelog/update-monorepo-master-refs-primary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Renaming master to trunk.

--- a/projects/plugins/starter-plugin/changelog/update-monorepo-master-refs-secondary
+++ b/projects/plugins/starter-plugin/changelog/update-monorepo-master-refs-secondary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Renaming `master` references to `trunk`

--- a/projects/plugins/starter-plugin/changelog/update-move-active-modules-to-sync-callables
+++ b/projects/plugins/starter-plugin/changelog/update-move-active-modules-to-sync-callables
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-move-my-jetpack-product-icons-into-components
+++ b/projects/plugins/starter-plugin/changelog/update-move-my-jetpack-product-icons-into-components
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-my-jetpack-add-license-screen
+++ b/projects/plugins/starter-plugin/changelog/update-my-jetpack-add-license-screen
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-my-jetpack-add-protect-product-data
+++ b/projects/plugins/starter-plugin/changelog/update-my-jetpack-add-protect-product-data
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-my-jetpack-licensing-default-feature-flag-state
+++ b/projects/plugins/starter-plugin/changelog/update-my-jetpack-licensing-default-feature-flag-state
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-my-jetpack-update-products-cards-disposition
+++ b/projects/plugins/starter-plugin/changelog/update-my-jetpack-update-products-cards-disposition
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-phpcs-inc-lib-part-3
+++ b/projects/plugins/starter-plugin/changelog/update-phpcs-inc-lib-part-3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-pnpm-version
+++ b/projects/plugins/starter-plugin/changelog/update-pnpm-version
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update minimum pnpm version. No change to the project itself.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-product-offer-error-placeholder
+++ b/projects/plugins/starter-plugin/changelog/update-product-offer-error-placeholder
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-release-my-jetpack-1.0
+++ b/projects/plugins/starter-plugin/changelog/update-release-my-jetpack-1.0
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-remove-remaining-in-place-conntections
+++ b/projects/plugins/starter-plugin/changelog/update-remove-remaining-in-place-conntections
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-remove-use-of-pnpx
+++ b/projects/plugins/starter-plugin/changelog/update-remove-use-of-pnpx
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Remove use of `pnpx` in preparation for pnpm 7.0.

--- a/projects/plugins/starter-plugin/changelog/update-starter-plugin-cleanup
+++ b/projects/plugins/starter-plugin/changelog/update-starter-plugin-cleanup
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Jetpack CLI: correctly replace project description and release-branch-prefix.

--- a/projects/plugins/starter-plugin/changelog/update-starter-plugin-git-attributes-for-proper-building
+++ b/projects/plugins/starter-plugin/changelog/update-starter-plugin-git-attributes-for-proper-building
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Updated .gitattributes file so it is able to build properly by the CI build jobs

--- a/projects/plugins/starter-plugin/changelog/update-starter-plugin-hooks
+++ b/projects/plugins/starter-plugin/changelog/update-starter-plugin-hooks
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add actiavtion and deactivation hooks

--- a/projects/plugins/starter-plugin/changelog/update-starter-plugin-sync
+++ b/projects/plugins/starter-plugin/changelog/update-starter-plugin-sync
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Configure Sync with the minimal amount of data

--- a/projects/plugins/starter-plugin/changelog/update-sync-dedicated-endpoint
+++ b/projects/plugins/starter-plugin/changelog/update-sync-dedicated-endpoint
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-sync-must-sync-data-settings
+++ b/projects/plugins/starter-plugin/changelog/update-sync-must-sync-data-settings
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-to-pnpm-7
+++ b/projects/plugins/starter-plugin/changelog/update-to-pnpm-7
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Use pnpm 7.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-use-package-publicize
+++ b/projects/plugins/starter-plugin/changelog/update-use-package-publicize
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-use-workspace-imports-for-js-tools
+++ b/projects/plugins/starter-plugin/changelog/update-use-workspace-imports-for-js-tools
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Use workspace for imports from js-tools. Monorepo tooling only, no change to the package.
-

--- a/projects/plugins/starter-plugin/changelog/update-wp-compat-60
+++ b/projects/plugins/starter-plugin/changelog/update-wp-compat-60
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Janitorial: require a more recent version of WordPress now that WP 6.0 is coming out.

--- a/projects/plugins/starter-plugin/composer.json
+++ b/projects/plugins/starter-plugin/composer.json
@@ -68,6 +68,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_starter_pluginⓥ0_1_0_alpha"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_starter_pluginⓥ0_1_0"
 	}
 }

--- a/projects/plugins/starter-plugin/jetpack-starter-plugin.php
+++ b/projects/plugins/starter-plugin/jetpack-starter-plugin.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Starter Plugin
  * Plugin URI: https://wordpress.org/plugins/jetpack-starter-plugin
  * Description: plugin--description.
- * Version: 0.1.0-alpha
+ * Version: 0.1.0
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Periodic janitorial releases:

```
* js-packages/eslint-changed has change entries from 71 days ago (e.g. update-changelogger-add-pr-num)
* js-packages/eslint-config-target-es has change entries from 88 days ago (e.g. add-jsconfig-to-js-packages)
* js-packages/storybook has change entries from 154 days ago (e.g. update-storybook-add-jetpack-dashboard-bg-color)

* packages/analyzer has change entries from 71 days ago (e.g. update-changelogger-add-pr-num)
* packages/codesniffer has change entries from 82 days ago (e.g. add-codesniffer-missing-wp-rules)
* packages/heartbeat has change entries from 76 days ago (e.g. hoist-heartbeat)
* packages/ignorefile has change entries from 110 days ago (e.g. fix-composer-dep-or)
* packages/phpcs-filter has change entries from 71 days ago (e.g. update-changelogger-add-pr-num)
* packages/plans has change entries from 96 days ago (e.g. extract-jetpack-plans)
* packages/post-list has change entries from 89 days ago (e.g. remove-gulp-🎉)
* packages/tracking has change entries from 70 days ago (e.g. hoist-options)

* plugins/always-use-jetpack-open-graph has change entries from 113 days ago (e.g. add-always-use)
* plugins/debug-helper has change entries from 118 days ago (e.g. 2022-03-09-12-05-23-224573)
* plugins/starter-plugin has change entries from 104 days ago (e.g. add-generate-from-starter-plugin)
```

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

n/a

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

Proofread.

