### PR TITLE
VaultPress: janitorial release for v2.2.2

### DIFF
--- a/projects/plugins/vaultpress/CHANGELOG.md
+++ b/projects/plugins/vaultpress/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.2.2 - 2022-07-06
+### Changed
+- Build: do not ship PHPCS configuration file. [#22604]
+- Janitorial: require a more recent version of WordPress now that WP 6.0 is coming out. [#24083]
+- Renaming `master` references to `trunk`. [#24712]
+- Updated composer.lock [#22920]
+- Updated package dependencies.
+
 ## 2.2.1 - 2022-02-01
 ### Changed
 - Colors: update colors to match the latest iterations of our brand.
@@ -9,7 +17,6 @@ All notable changes to this project will be documented in this file.
 - Set `convertDeprecationsToExceptions` true in PHPUnit config.
 - Switch to pcov for code coverage.
 - Updated package dependencies.
-
 
 ## 2.2.0 - 2021-10-11
 ### Changed

--- a/projects/plugins/vaultpress/changelog/2022-03-09-12-05-39-624624
+++ b/projects/plugins/vaultpress/changelog/2022-03-09-12-05-39-624624
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/vaultpress/changelog/2022-04-12-14-16-55-169323
+++ b/projects/plugins/vaultpress/changelog/2022-04-12-14-16-55-169323
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/vaultpress/changelog/add-analytics-super-props
+++ b/projects/plugins/vaultpress/changelog/add-analytics-super-props
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/vaultpress/changelog/add-jetpack-10.7-a-5-changelog
+++ b/projects/plugins/vaultpress/changelog/add-jetpack-10.7-a-5-changelog
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated composer.lock

--- a/projects/plugins/vaultpress/changelog/add-search-auto-config-to-activation
+++ b/projects/plugins/vaultpress/changelog/add-search-auto-config-to-activation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/vaultpress/changelog/fix-composer-dep-or
+++ b/projects/plugins/vaultpress/changelog/fix-composer-dep-or
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/vaultpress/changelog/fix-search-auto-add-search-input
+++ b/projects/plugins/vaultpress/changelog/fix-search-auto-add-search-input
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/vaultpress/changelog/hoist-jetpack-terms-of-service
+++ b/projects/plugins/vaultpress/changelog/hoist-jetpack-terms-of-service
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/vaultpress/changelog/hoist-jetpack-terms-of-service#2
+++ b/projects/plugins/vaultpress/changelog/hoist-jetpack-terms-of-service#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/vaultpress/changelog/remove-upgrade-handler
+++ b/projects/plugins/vaultpress/changelog/remove-upgrade-handler
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#2
+++ b/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#3
+++ b/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#4
+++ b/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#4
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#5
+++ b/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#6
+++ b/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#6
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/start-vaultpress-222-cycle
+++ b/projects/plugins/vaultpress/changelog/start-vaultpress-222-cycle
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Core: start new release cycle.

--- a/projects/plugins/vaultpress/changelog/update-changelogger-add-pr-num
+++ b/projects/plugins/vaultpress/changelog/update-changelogger-add-pr-num
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/update-composer-2.3
+++ b/projects/plugins/vaultpress/changelog/update-composer-2.3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/vaultpress/changelog/update-disconnect-dialog-initial-state
+++ b/projects/plugins/vaultpress/changelog/update-disconnect-dialog-initial-state
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/vaultpress/changelog/update-monorepo-master-refs-primary
+++ b/projects/plugins/vaultpress/changelog/update-monorepo-master-refs-primary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Renaming master to trunk.

--- a/projects/plugins/vaultpress/changelog/update-monorepo-master-refs-secondary
+++ b/projects/plugins/vaultpress/changelog/update-monorepo-master-refs-secondary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Renaming `master` references to `trunk`

--- a/projects/plugins/vaultpress/changelog/update-use-connection-redirect-uri
+++ b/projects/plugins/vaultpress/changelog/update-use-connection-redirect-uri
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/vaultpress/changelog/update-use-package-publicize
+++ b/projects/plugins/vaultpress/changelog/update-use-package-publicize
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/vaultpress/changelog/update-vaultpress-excluded-file
+++ b/projects/plugins/vaultpress/changelog/update-vaultpress-excluded-file
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Build: do not ship PHPCS configuration file

--- a/projects/plugins/vaultpress/changelog/update-wp-compat-60
+++ b/projects/plugins/vaultpress/changelog/update-wp-compat-60
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Janitorial: require a more recent version of WordPress now that WP 6.0 is coming out.

--- a/projects/plugins/vaultpress/composer.json
+++ b/projects/plugins/vaultpress/composer.json
@@ -38,7 +38,7 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"config": {
-		"autoloader-suffix": "9559eef123208b7d1b9c15b978567267_vaultpressⓥ2_2_2_alpha",
+		"autoloader-suffix": "9559eef123208b7d1b9c15b978567267_vaultpressⓥ2_2_2",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true
 		}

--- a/projects/plugins/vaultpress/readme.txt
+++ b/projects/plugins/vaultpress/readme.txt
@@ -48,11 +48,13 @@ A VaultPress subscription is for a single WordPress site. You can purchase addit
 Yes, VaultPress supports Multisite installs. Each site will require its own subscription.
 
 == Changelog ==
-### 2.2.1 - 2022-02-01
+### 2.2.2 - 2022-07-06
 #### Changed
-- Colors: update colors to match the latest iterations of our brand.
-- General: update WordPress tested up to version, since the plugin works with WordPress 5.9.
-
+- Build: do not ship PHPCS configuration file.
+- Janitorial: require a more recent version of WordPress now that WP 6.0 is coming out.
+- Renaming `master` references to `trunk`.
+- Updated composer.lock
+- Updated package dependencies.
 
 --------
 

--- a/projects/plugins/vaultpress/vaultpress.php
+++ b/projects/plugins/vaultpress/vaultpress.php
@@ -3,7 +3,7 @@
  * Plugin Name: VaultPress
  * Plugin URI: http://vaultpress.com/?utm_source=plugin-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0
  * Description: Protect your content, themes, plugins, and settings with <strong>realtime backup</strong> and <strong>automated security scanning</strong> from <a href="http://vaultpress.com/?utm_source=wp-admin&amp;utm_medium=plugin-description&amp;utm_campaign=1.0" rel="nofollow">VaultPress</a>. Activate, enter your registration key, and never worry again. <a href="http://vaultpress.com/help/?utm_source=wp-admin&amp;utm_medium=plugin-description&amp;utm_campaign=1.0" rel="nofollow">Need some help?</a>
- * Version: 2.2.2-alpha
+ * Version: 2.2.2
  * Author: Automattic
  * Author URI: http://vaultpress.com/?utm_source=author-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0
  * License: GPL2+
@@ -17,7 +17,7 @@
 defined( 'ABSPATH' ) || die();
 
 define( 'VAULTPRESS__MINIMUM_PHP_VERSION', '5.6' );
-define( 'VAULTPRESS__VERSION', '2.2.2-alpha' );
+define( 'VAULTPRESS__VERSION', '2.2.2' );
 define( 'VAULTPRESS__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Periodic janitorial changelog/release:

```
≽ tools/find-unreleased-projects.sh 60
* plugins/vaultpress has change entries from 155 days ago (e.g. start-vaultpress-222-cycle)
```

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

n/a

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

Proofread.
