### PR TITLE
Fix react/jsx runtime for jest/tests

### DIFF
--- a/projects/js-packages/components/changelog/update-tests-fix-jsx-runtime
+++ b/projects/js-packages/components/changelog/update-tests-fix-jsx-runtime
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+JS Components: Removed unnecessary React imports in tests after using automatic runtime in jest config

--- a/projects/js-packages/components/components/action-button/test/component.jsx
+++ b/projects/js-packages/components/components/action-button/test/component.jsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import ActionButton from '../index';
 
 describe( 'ActionButton', () => {

--- a/projects/js-packages/components/components/jetpack-footer/test/component.jsx
+++ b/projects/js-packages/components/components/jetpack-footer/test/component.jsx
@@ -1,5 +1,4 @@
 import { render } from '@testing-library/react';
-import React from 'react';
 import JetpackFooter from '../index';
 
 describe( 'JetpackFooter', () => {

--- a/projects/js-packages/components/components/jetpack-logo/test/component.tsx
+++ b/projects/js-packages/components/components/jetpack-logo/test/component.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import JetpackLogo from '../index';
 
 describe( 'JetpackLogo', () => {

--- a/projects/js-packages/components/components/pricing-card/test/component.jsx
+++ b/projects/js-packages/components/components/pricing-card/test/component.jsx
@@ -1,6 +1,5 @@
 import { jest } from '@jest/globals';
 import { render, screen, cleanup } from '@testing-library/react/pure';
-import React from 'react';
 import PricingCard from '../index';
 
 // Note we're using @testing-library/react/pure here to disable the automatic cleanup.

--- a/projects/js-packages/components/components/record-meter-bar/test/component.tsx
+++ b/projects/js-packages/components/components/record-meter-bar/test/component.tsx
@@ -1,5 +1,4 @@
 import { render, queryByAttribute } from '@testing-library/react';
-import React from 'react';
 import RecordMeterBar, { RecordMeterBarProps } from '../index';
 
 const getRecordBarItems = ( container: HTMLElement ) => {

--- a/projects/js-packages/components/components/spinner/test/component.jsx
+++ b/projects/js-packages/components/components/spinner/test/component.jsx
@@ -1,5 +1,4 @@
 import { render } from '@testing-library/react';
-import React from 'react';
 import Spinner from '../index';
 
 describe( 'Spinner', () => {

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.16.5",
+	"version": "0.16.6-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/tools/js-tools/jest/config.base.js
+++ b/tools/js-tools/jest/config.base.js
@@ -11,7 +11,7 @@ module.exports = {
 			require.resolve( 'babel-jest' ),
 			{
 				presets: [
-					require.resolve( '@babel/preset-react' ),
+					[ require.resolve( '@babel/preset-react' ), { runtime: 'automatic' } ],
 					require.resolve( '@babel/preset-typescript' ),
 				],
 			},


### PR DESCRIPTION
We already use automatic runtime for react/jsx in our components and in all the bundler configs. Same is reflected in ESLint configs where we have `react/react-in-jsx-scope` rule set to `off`.
However, this doesn't happen in jest/tests and we unnecessarily need to import React in event test that uses JSX.
This PR aims to remove the need for importing React in every test component to make the behaviour consistent with our normal UI components.

#### Changes proposed in this Pull Request:
- Set [`runtime`](https://babeljs.io/docs/en/babel-preset-react#runtime) option to `'automatic'` for `@babel/preset-react` in `tools/js-tools/jest/config.base.js`
- Remove unnecessary React imports from RNA component tests

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

* Simply run `jetpack test` for RNA components and any other plugins/packages
* Confirm that the tests pass and there are no `React is not defined` errors
* Run `jetpack build --all`
* Confirm that build is successful


**Next:** There are certain packages which still use `classic` runtime for `@babel/preset-react` for UI components. It would be better to update their configs as well to make it same throughout the codebase.

<details>
<summary>Here are a couple of changes needed for that.</summary>

```diff
diff --git a/projects/js-packages/webpack-config/src/babel-preset.js b/projects/js-packages/webpack-config/src/babel-preset.js
index 56241b3116..0320e743b9 100644
--- a/projects/js-packages/webpack-config/src/babel-preset.js
+++ b/projects/js-packages/webpack-config/src/babel-preset.js
@@ -30,7 +30,7 @@ module.exports = ( api, opts = {} ) => {
                ret.presets.push( PresetEnv( opts.presetEnv ) );
        }
        if ( opts.presetReact !== false ) {
-               ret.presets.push( [ require.resolve( '@babel/preset-react' ), opts.presetReact ] );
+               ret.presets.push( [ require.resolve( '@babel/preset-react' ), { runtime: 'automatic', ...opts.presetReact } ] );
        }
        if ( opts.presetTypescript !== false ) {
                ret.presets.push( [ require.resolve( '@babel/preset-typescript' ), opts.presetTypescript ] );
diff --git a/projects/packages/search/tools/babel.config.js b/projects/packages/search/tools/babel.config.js
index 1104967ba3..e2e0230dd9 100644
--- a/projects/packages/search/tools/babel.config.js
+++ b/projects/packages/search/tools/babel.config.js
@@ -11,6 +11,7 @@ module.exports = api => {
                                                useBuiltIns: 'usage',
                                        },
                                        pluginReplaceTextdomain: { textdomain: 'jetpack-search-pkg' },
+                                       presetReact: { runtime: 'classic' },
                                },
                        ],
                ],
```

`packages/search` being an exception because it looks like it uses `preact` and thus `automatic` runtime won't work for it.
</details>