### PR TITLE
My Jetpack: Fix error handling in purchases endpoint

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-purchases-rest-error-response
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-purchases-rest-error-response
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: My Jetpack: Fix error handling in purchases endpoint
+
+

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "1.7.3",
+	"version": "1.7.4-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -28,7 +28,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '1.7.3';
+	const PACKAGE_VERSION = '1.7.4-alpha';
 
 	/**
 	 * Initialize My Jetapack

--- a/projects/packages/my-jetpack/src/class-rest-purchases.php
+++ b/projects/packages/my-jetpack/src/class-rest-purchases.php
@@ -67,8 +67,7 @@ class REST_Purchases {
 		$response_code     = wp_remote_retrieve_response_code( $response );
 		$body              = json_decode( wp_remote_retrieve_body( $response ) );
 
-		if ( is_wp_error( $response ) || empty( $response['body'] ) ||
-			200 !== $response_code ) {
+		if ( is_wp_error( $response ) || empty( $response['body'] ) || 200 !== $response_code ) {
 			return new \WP_Error( 'site_data_fetch_failed', 'Site data fetch failed', array( 'status' => $response_code ? $response_code : 400 ) );
 		}
 

--- a/projects/packages/my-jetpack/src/class-rest-purchases.php
+++ b/projects/packages/my-jetpack/src/class-rest-purchases.php
@@ -67,7 +67,8 @@ class REST_Purchases {
 		$response_code     = wp_remote_retrieve_response_code( $response );
 		$body              = json_decode( wp_remote_retrieve_body( $response ) );
 
-		if ( is_wp_error( $response ) || empty( $response['body'] ) ) {
+		if ( is_wp_error( $response ) || empty( $response['body'] ) ||
+			200 !== $response_code ) {
 			return new \WP_Error( 'site_data_fetch_failed', 'Site data fetch failed', array( 'status' => $response_code ? $response_code : 400 ) );
 		}
 


### PR DESCRIPTION
In My Jetpack, when an error occurs while fetching the Site purchases from WPCOM the UI displays a blank page instead of an error.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* `REST_Purchases::get_site_current_purchases`: Update the response check to take into account the corresponding HTTP status code. Treat non 200 status codes as error.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
- In your sandbox modify the response from the Site purchases endpoint to return an error **with a non empty response body**.

**Before**
* Go to My Jetpack and confirm the UI is broken:
<img width="821" alt="Screenshot 2022-07-07 at 15 42 57" src="https://user-images.githubusercontent.com/1758399/177776471-e43864be-70a4-40d7-bccb-92ff6fb41dbc.png">


**After**
* Go to My Jetpack and confirm the UI displays the following error:
<img width="1310" alt="Screenshot 2022-07-07 at 15 40 07" src="https://user-images.githubusercontent.com/1758399/177776502-38a79629-3fcc-42fd-a129-1751a72638ef.png">

