### PR TITLE
Lazy Images: do not attempt to lazy load in embeds

### DIFF
--- a/projects/packages/lazy-images/changelog/fix-lazy-images-embeds
+++ b/projects/packages/lazy-images/changelog/fix-lazy-images-embeds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Do not attempt to lazy-load images in embeds.

--- a/projects/packages/lazy-images/src/lazy-images.php
+++ b/projects/packages/lazy-images/src/lazy-images.php
@@ -135,8 +135,11 @@ class Jetpack_Lazy_Images {
 	 * @return void
 	 */
 	public function setup_filters() {
-		// Do not lazy-load images in RSS feeds.
-		if ( is_feed() ) {
+		// Do not lazy-load images in RSS feeds or embeds.
+		if (
+			is_feed()
+			|| is_embed()
+		) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #24976

#### Changes proposed in this Pull Request:

Our scripts aren't enqueued there, so let's not attempt to lazy-load.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* You'll need 2 sites:
    * One (site A) running the Beta with this branch, connected to WordPress.com and with the Lazy Images module active.
    * One (Site B) without Jetpack.
* On Site A, create a new post, with a featured image. Hit publish. Copy link to that post.
* On Site B, create a new post with just a link to that post.
* With this branch active, the featured image should be displayed in the post embed in that post.
* with stable, the featured image does not appear.
