### PR TITLE
Waf_Endpoints: Fix "Uncaught Error: Class 'Automattic\Jetpack\Waf\WP_Error' not found"

### DIFF
--- a/projects/packages/waf/changelog/fix_waf_namespacing_wp_error
+++ b/projects/packages/waf/changelog/fix_waf_namespacing_wp_error
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fixed
-
-Fix error ‘Automattic\Jetpack\Waf\WP_Error’ not found

--- a/projects/packages/waf/changelog/fix_waf_namespacing_wp_error
+++ b/projects/packages/waf/changelog/fix_waf_namespacing_wp_error
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Fix error ‘Automattic\Jetpack\Waf\WP_Error’ not found

--- a/projects/packages/waf/changelog/vip-fix_waf_namespacing_wp_error
+++ b/projects/packages/waf/changelog/vip-fix_waf_namespacing_wp_error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Correct namespacing error.

--- a/projects/packages/waf/src/class-waf-endpoints.php
+++ b/projects/packages/waf/src/class-waf-endpoints.php
@@ -8,8 +8,8 @@
 namespace Automattic\Jetpack\Waf;
 
 use Automattic\Jetpack\Connection\REST_Connector;
-use WP_REST_Server;
 use WP_Error;
+use WP_REST_Server;
 
 /**
  * Defines our endponts.

--- a/projects/packages/waf/src/class-waf-endpoints.php
+++ b/projects/packages/waf/src/class-waf-endpoints.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Waf;
 
 use Automattic\Jetpack\Connection\REST_Connector;
 use WP_REST_Server;
+use WP_Error;
 
 /**
  * Defines our endponts.


### PR DESCRIPTION
Fixes #24834 due to namespacing issue.

#### Changes proposed in this Pull Request:
Adds a `use` statement to the class `Waf_Endpoints` to access `WP_Error` correctly.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Using a user without the `jetpack_manage_modules` caps, try to access the `jetpack/v4/waf` endpoint and check PHP logs