### PR TITLE
Record Meter: add info link to docs

### DIFF
--- a/projects/packages/search/changelog/add-record-meter-info-link
+++ b/projects/packages/search/changelog/add-record-meter-info-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Record Meter: add info link to docs

--- a/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/notice-box.jsx
@@ -2,7 +2,7 @@
 import { numberFormat } from '@automattic/jetpack-components';
 import { __, sprintf } from '@wordpress/i18n';
 import SimpleNotice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action.jsx';
+import NoticeAction from 'components/notice/notice-action';
 import React from 'react';
 
 import './notice-box.scss';

--- a/projects/packages/search/src/dashboard/components/record-meter/record-count.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/record-count.jsx
@@ -1,9 +1,11 @@
-import { numberFormat } from '@automattic/jetpack-components';
+import { Gridicon, numberFormat } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import React from 'react';
 
 import './record-count.scss';
+
+const DOCS_URL = 'http://example.com';
 
 /**
  * Returns record count component showing current records indexed and max records available for tier.
@@ -55,7 +57,19 @@ export function RecordCount( props ) {
 
 	return (
 		<div data-testid="record-count" className="jp-search-record-count">
-			<p>{ message }</p>
+			<p className="jp-search-record-count__message">
+				{ message }
+				{ DOCS_URL && (
+					<a href={ DOCS_URL } className="jp-search-record-count__info">
+						<Gridicon
+							className="jp-search-record-count__info-icon"
+							icon={ 'info-outline' }
+							size={ 18 }
+						/>
+						<span className="screen-reader-text">{ __( 'More info', 'jetpack-search-pkg' ) }</span>
+					</a>
+				) }
+			</p>
 		</div>
 	);
 }

--- a/projects/packages/search/src/dashboard/components/record-meter/record-count.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/record-count.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import './record-count.scss';
 
-const DOCS_URL = 'http://example.com';
+const DOCS_URL = 'https://jetpack.com/support/search/jetpack-search-record-meter/';
 
 /**
  * Returns record count component showing current records indexed and max records available for tier.

--- a/projects/packages/search/src/dashboard/components/record-meter/record-count.jsx
+++ b/projects/packages/search/src/dashboard/components/record-meter/record-count.jsx
@@ -60,7 +60,11 @@ export function RecordCount( props ) {
 			<p className="jp-search-record-count__message">
 				{ message }
 				{ DOCS_URL && (
-					<a href={ DOCS_URL } className="jp-search-record-count__info">
+					<a
+						href={ DOCS_URL }
+						className="jp-search-record-count__info"
+						title={ __( 'More info', 'jetpack-search-pkg' ) }
+					>
 						<Gridicon
 							className="jp-search-record-count__info-icon"
 							icon={ 'info-outline' }

--- a/projects/packages/search/src/dashboard/components/record-meter/record-count.scss
+++ b/projects/packages/search/src/dashboard/components/record-meter/record-count.scss
@@ -1,8 +1,12 @@
-//
-// Variables
-//
-@import '~@automattic/color-studio/dist/color-variables';
-
-.jp-search-record-count p {
+.jp-search-record-count__message {
 	font-size: 1em;
+}
+
+.jp-search-record-count__info {
+	margin-left: 0.2em;
+	vertical-align: text-top;
+}
+
+.jp-search-record-count__info-icon {
+	fill: inherit;
 }

--- a/projects/packages/search/src/dashboard/components/record-meter/record-count.scss
+++ b/projects/packages/search/src/dashboard/components/record-meter/record-count.scss
@@ -4,7 +4,7 @@
 
 .jp-search-record-count__info {
 	margin-left: 0.2em;
-	vertical-align: text-top;
+	vertical-align: middle;
 }
 
 .jp-search-record-count__info-icon {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Adds an info icon next to the record count in the Record Meter. This icon links to the docs (page not yet added).

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
p8oabR-Tl-p2#comment-6413

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
On a test site with Jetpack Search enabled, visit `/wp-admin/admin.php?page=jetpack-search&features=record-meter`.

Ensure that an info link appears next to your record count, and that the link takes you to the relevant documentation.

<img width="894" alt="Screen Shot 2022-07-08 at 17 37 34" src="https://user-images.githubusercontent.com/17325/177924299-4d394c0d-d8f5-4f3d-a718-16a0b55aa231.png">


