### PR TITLE
Twitter Gather: make endpoint restricted to contributors

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-tweetstorm-gather.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-tweetstorm-gather.php
@@ -56,8 +56,47 @@ class WPCOM_REST_API_V2_Endpoint_Tweetstorm_Gather extends WP_REST_Controller {
 				'private_site_security_settings' => array(
 					'allow_blog_token_access' => true,
 				),
-				'permission_callback'            => '__return_true',
+				'permission_callback'            => array( $this, 'tweetstorm_permissions_check' ),
 			)
+		);
+	}
+
+	/**
+	 * Checks if a given request is allowed to gather tweets.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return true|WP_Error True if the request has access to gather tweets from a thread, WP_Error object otherwise.
+	 */
+	public function tweetstorm_permissions_check( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$blog_id = get_current_blog_id();
+
+		/*
+		 * User hitting the endpoint hosted on their Jetpack site, from their Jetpack site,
+		 * or hitting the endpoint hosted on WPCOM, from their WPCOM site.
+		 */
+		if ( current_user_can_for_blog( $blog_id, 'edit_posts' ) ) {
+			return true;
+		}
+
+		// Jetpack hitting the endpoint hosted on WPCOM, from a Jetpack site with a blog token.
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			if ( is_jetpack_site( $blog_id ) ) {
+				if ( ! class_exists( 'WPCOM_REST_API_V2_Endpoint_Jetpack_Auth' ) ) {
+					require_once __DIR__ . '/jetpack-auth.php';
+				}
+
+				$jp_auth_endpoint = new WPCOM_REST_API_V2_Endpoint_Jetpack_Auth();
+				if ( true === $jp_auth_endpoint->is_jetpack_authorized_for_site() ) {
+					return true;
+				}
+			}
+		}
+
+		return new WP_Error(
+			'rest_forbidden',
+			__( 'Sorry, you are not allowed to gather tweets on this site.', 'jetpack' ),
+			array( 'status' => rest_authorization_required_code() )
 		);
 	}
 

--- a/projects/plugins/jetpack/changelog/update-twitter-gather-endpoint-availability
+++ b/projects/plugins/jetpack/changelog/update-twitter-gather-endpoint-availability
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Gathering Twitter Threads: ensure that only contributors can access the endpoint to unroll threads.


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

There are three ways that this endpoint can be hit:

- User hitting the endpoint hosted on WPCOM, from their WPCOM site.
- Jetpack hitting the endpoint hosted on WPCOM, from a Jetpack site.
- User hitting the endpoint hosted on their Jetpack site, from their Jetpack site.

Let's lock it down for everybody else.

Internal references:

- D82201-code
- r248698-wpcom

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

- p3btAN-1Fc-p2

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

This is worth testing:

- On a private WoA site
- On a Jetpack site

**Steps:**

* Start with a site connected to WordPress.com.
* in a new post, paste a URL to a Twitter thread, such as `https://twitter.com/jeherve/status/1517640631941746688`
* Click on the Unroll button; it should work.

