### PR TITLE
Rename hasActiveSiteFeature -> siteHasFeature

### DIFF
--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -145,7 +145,7 @@
 - Number format the number of subscribers in the subscribers panel when publishing a post [#24544]
 - phpcs changes for likes [#24368]
 - Publicize Components: Move the remaining components and hooks required for Jetpack Social [#24464]
-- Refactor to use siteHasFeature to centralize the source of truth to WPCOM_Features. [#24152]
+- Refactor to use hasActiveSiteFeature to centralize the source of truth to WPCOM_Features. [#24152]
 - Sync: Add '_jetpack_blogging_prompt_key' to rest api public metadata via the rest_api_allowed_public_metadata filter [#24515]
 - Jetpack: correct prices in product descriptions [#24461]
 - Updated package dependencies. [#24432]

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -145,7 +145,7 @@
 - Number format the number of subscribers in the subscribers panel when publishing a post [#24544]
 - phpcs changes for likes [#24368]
 - Publicize Components: Move the remaining components and hooks required for Jetpack Social [#24464]
-- Refactor to use hasActiveSiteFeature to centralize the source of truth to WPCOM_Features. [#24152]
+- Refactor to use siteHasFeature to centralize the source of truth to WPCOM_Features. [#24152]
 - Sync: Add '_jetpack_blogging_prompt_key' to rest api public metadata via the rest_api_allowed_public_metadata filter [#24515]
 - Jetpack: correct prices in product descriptions [#24461]
 - Updated package dependencies. [#24432]

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/akismet.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/akismet.jsx
@@ -17,7 +17,7 @@ import { connect } from 'react-redux';
 import { getAkismetData } from 'state/at-a-glance';
 import { hasConnectedOwner, isOfflineMode, connectUser } from 'state/connection';
 import { getApiNonce } from 'state/initial-state';
-import { hasActiveSiteFeature } from 'state/site';
+import { siteHasFeature } from 'state/site';
 
 class DashAkismet extends Component {
 	static propTypes = {
@@ -289,8 +289,8 @@ export default connect(
 			upgradeUrl: getProductDescriptionUrl( state, 'akismet' ),
 			nonce: getApiNonce( state ),
 			hasConnectedOwner: hasConnectedOwner( state ),
-			hasAntiSpam: hasActiveSiteFeature( state, 'antispam' ),
-			hasAkismet: hasActiveSiteFeature( state, 'akismet' ),
+			hasAntiSpam: siteHasFeature( state, 'antispam' ),
+			hasAkismet: siteHasFeature( state, 'akismet' ),
 		};
 	},
 	dispatch => ( {

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/backups.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/backups.jsx
@@ -19,7 +19,7 @@ import { connect } from 'react-redux';
 import { getVaultPressData } from 'state/at-a-glance';
 import { hasConnectedOwner, isOfflineMode, connectUser } from 'state/connection';
 import { getPartnerCoupon, showBackups } from 'state/initial-state';
-import { hasActiveSiteFeature, isFetchingSiteData } from 'state/site';
+import { siteHasFeature, isFetchingSiteData } from 'state/site';
 import { isPluginInstalled } from 'state/site/plugins';
 import BackupGettingStarted from './backup-getting-started';
 import BackupUpgrade from './backup-upgrade';
@@ -417,8 +417,8 @@ export default connect(
 			upgradeUrl: getProductDescriptionUrl( state, 'backup' ),
 			hasConnectedOwner: hasConnectedOwner( state ),
 			isFetchingSite: isFetchingSiteData( state ),
-			hasBackups: hasActiveSiteFeature( state, 'backups' ),
-			hasRealTimeBackups: hasActiveSiteFeature( state, 'real-time-backups' ),
+			hasBackups: siteHasFeature( state, 'backups' ),
+			hasRealTimeBackups: siteHasFeature( state, 'real-time-backups' ),
 			partnerCoupon: getPartnerCoupon( state ),
 		};
 	},

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/search.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/search.jsx
@@ -12,7 +12,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { hasConnectedOwner, isOfflineMode, connectUser } from 'state/connection';
-import { hasActiveSiteFeature, isFetchingSitePurchases } from 'state/site';
+import { siteHasFeature, isFetchingSitePurchases } from 'state/site';
 
 const SEARCH_DESCRIPTION = __(
 	'Incredibly powerful and customizable, Jetpack Search helps your visitors instantly find the right content – right when they need it.',
@@ -198,8 +198,8 @@ export default connect(
 		return {
 			isOfflineMode: isOfflineMode( state ),
 			isFetching: isFetchingSitePurchases( state ),
-			hasClassicSearch: hasActiveSiteFeature( state, 'search' ),
-			hasInstantSearch: hasActiveSiteFeature( state, 'instant-search' ),
+			hasClassicSearch: siteHasFeature( state, 'search' ),
+			hasInstantSearch: siteHasFeature( state, 'instant-search' ),
 			upgradeUrl: getProductDescriptionUrl( state, 'search' ),
 			hasConnectedOwner: hasConnectedOwner( state ),
 		};

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/videopress.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/videopress.jsx
@@ -20,7 +20,7 @@ import {
 	isFetchingSitePurchases,
 	getSitePlan,
 	getVideoPressStorageUsed,
-	hasActiveSiteFeature,
+	siteHasFeature,
 } from 'state/site';
 
 class DashVideoPress extends Component {
@@ -172,9 +172,9 @@ export default connect(
 	state => ( {
 		hasConnectedOwner: hasConnectedOwnerSelector( state ),
 		hasVideoPressFeature:
-			hasActiveSiteFeature( state, 'videopress-1tb-storage' ) ||
-			hasActiveSiteFeature( state, 'videopress-unlimited-storage' ),
-		hasVideoPressUnlimitedStorage: hasActiveSiteFeature( state, 'videopress-unlimited-storage' ),
+			siteHasFeature( state, 'videopress-1tb-storage' ) ||
+			siteHasFeature( state, 'videopress-unlimited-storage' ),
+		hasVideoPressUnlimitedStorage: siteHasFeature( state, 'videopress-unlimited-storage' ),
 		isModuleAvailable: isModuleAvailable( state, 'videopress' ),
 		isOffline: isOfflineMode( state ),
 		isFetching: isFetchingSitePurchases( state ),

--- a/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
@@ -33,7 +33,7 @@ import {
 	userCanManageModules,
 } from 'state/initial-state';
 import { getModuleOverride, getModule } from 'state/modules';
-import { hasActiveSiteFeature, isFetchingSiteData } from 'state/site';
+import { siteHasFeature, isFetchingSiteData } from 'state/site';
 
 export const SettingsCard = props => {
 	const trackBannerClick = feature => {
@@ -434,13 +434,13 @@ export default connect(
 			multisite: isMultisite( state ),
 			inOfflineMode: isOfflineMode( state ),
 			hasConnectedOwner: hasConnectedOwnerSelector( state ),
-			hasAntispam: hasActiveSiteFeature( state, 'antispam' ),
-			hasBackups: hasActiveSiteFeature( state, 'backups' ),
-			hasGoogleAnalytics: hasActiveSiteFeature( state, 'google-analytics' ),
-			hasInstantSearch: hasActiveSiteFeature( state, 'instant-search' ),
-			hasScan: hasActiveSiteFeature( state, 'scan' ),
-			hasVideoPress: hasActiveSiteFeature( state, 'videopress' ),
-			hasWordAds: hasActiveSiteFeature( state, 'wordads' ),
+			hasAntispam: siteHasFeature( state, 'antispam' ),
+			hasBackups: siteHasFeature( state, 'backups' ),
+			hasGoogleAnalytics: siteHasFeature( state, 'google-analytics' ),
+			hasInstantSearch: siteHasFeature( state, 'instant-search' ),
+			hasScan: siteHasFeature( state, 'scan' ),
+			hasVideoPress: siteHasFeature( state, 'videopress' ),
+			hasWordAds: siteHasFeature( state, 'wordads' ),
 		};
 	},
 	dispatch => ( {

--- a/projects/plugins/jetpack/_inc/client/components/support-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/support-card/index.jsx
@@ -20,7 +20,7 @@ import {
 	connectUser,
 } from 'state/connection';
 import { isAtomicSite, isDevVersion as _isDevVersion, getUpgradeUrl } from 'state/initial-state';
-import { hasActiveSiteFeature, isFetchingSiteData } from 'state/site';
+import { siteHasFeature, isFetchingSiteData } from 'state/site';
 
 class SupportCard extends React.Component {
 	static displayName = 'SupportCard';
@@ -156,7 +156,7 @@ export default connect(
 			isCurrentUserLinked: isCurrentUserLinked( state ),
 			isConnectionOwner: isConnectionOwner( state ),
 			hasConnectedOwner: hasConnectedOwner( state ),
-			hasSupport: hasActiveSiteFeature( state, 'support' ),
+			hasSupport: siteHasFeature( state, 'support' ),
 		};
 	},
 	dispatch => ( {

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
@@ -18,7 +18,7 @@ import {
 } from 'state/modules';
 import { updateSettings } from 'state/settings/actions';
 import { getSetting, isUpdatingSetting } from 'state/settings/reducer';
-import { hasActiveSiteFeature } from 'state/site';
+import { siteHasFeature } from 'state/site';
 import {
 	fetchPluginsData,
 	isFetchingPluginsData,
@@ -789,7 +789,7 @@ class MyPlanBody extends React.Component {
 export default connect(
 	state => {
 		return {
-			hasInstantSearch: hasActiveSiteFeature( state, 'instant-search' ),
+			hasInstantSearch: siteHasFeature( state, 'instant-search' ),
 			isFetchingPluginsData: isFetchingPluginsData( state ),
 			isPluginActive: plugin_slug => isPluginActive( state, plugin_slug ),
 			isPluginInstalled: plugin_slug => isPluginInstalled( state, plugin_slug ),

--- a/projects/plugins/jetpack/_inc/client/performance/media.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/media.jsx
@@ -22,7 +22,7 @@ import { isModuleFound as _isModuleFound } from 'state/search';
 import {
 	getSitePlan,
 	getVideoPressStorageUsed,
-	hasActiveSiteFeature,
+	siteHasFeature,
 	isFetchingSitePurchases,
 } from 'state/site';
 
@@ -156,9 +156,9 @@ export default connect( state => {
 		isModuleFound: module_name => _isModuleFound( state, module_name ),
 		sitePlan: getSitePlan( state ),
 		hasVideoPressFeature:
-			hasActiveSiteFeature( state, 'videopress-1tb-storage' ) ||
-			hasActiveSiteFeature( state, 'videopress-unlimited-storage' ),
-		hasVideoPressUnlimitedStorage: hasActiveSiteFeature( state, 'videopress-unlimited-storage' ),
+			siteHasFeature( state, 'videopress-1tb-storage' ) ||
+			siteHasFeature( state, 'videopress-unlimited-storage' ),
+		hasVideoPressUnlimitedStorage: siteHasFeature( state, 'videopress-unlimited-storage' ),
 		hasConnectedOwner: hasConnectedOwnerSelector( state ),
 		isOffline: isOfflineMode( state ),
 		isFetching: isFetchingSitePurchases( state ),

--- a/projects/plugins/jetpack/_inc/client/performance/search.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/search.jsx
@@ -13,7 +13,7 @@ import { connect } from 'react-redux';
 import { isOfflineMode } from 'state/connection';
 import { currentThemeSupports } from 'state/initial-state';
 import { hasUpdatedSetting, isSettingActivated, isUpdatingSetting } from 'state/settings';
-import { hasActiveSiteFeature, isFetchingSitePurchases } from 'state/site';
+import { siteHasFeature, isFetchingSitePurchases } from 'state/site';
 
 const SEARCH_DESCRIPTION = __(
 	'Incredibly powerful and customizable, Jetpack Search helps your visitors instantly find the right content – right when they need it.',
@@ -142,8 +142,8 @@ export default connect( state => {
 	return {
 		isLoading: isFetchingSitePurchases( state ),
 		inOfflineMode: isOfflineMode( state ),
-		hasClassicSearch: hasActiveSiteFeature( state, 'search' ),
-		hasInstantSearch: hasActiveSiteFeature( state, 'instant-search' ),
+		hasClassicSearch: siteHasFeature( state, 'search' ),
+		hasInstantSearch: siteHasFeature( state, 'instant-search' ),
 		failedToEnableSearch:
 			! isSettingActivated( state, 'search' ) &&
 			! isUpdatingSetting( state, 'search' ) &&

--- a/projects/plugins/jetpack/_inc/client/pro-status/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/pro-status/index.jsx
@@ -22,7 +22,7 @@ import { isOfflineMode } from 'state/connection';
 import { getSiteRawUrl, getSiteAdminUrl } from 'state/initial-state';
 import { getRewindStatus } from 'state/rewind';
 import { getScanStatus } from 'state/scan';
-import { getSitePlan, hasActiveSiteFeature, isFetchingSiteData } from 'state/site';
+import { getSitePlan, siteHasFeature, isFetchingSiteData } from 'state/site';
 import { isFetchingPluginsData, isPluginActive, isPluginInstalled } from 'state/site/plugins';
 
 /**
@@ -306,7 +306,7 @@ export default connect( state => {
 		fetchingAkismetData: isFetchingAkismetData( state ),
 		rewindStatus: getRewindStatus( state ),
 		scanStatus: getScanStatus( state ),
-		purchasedVaultPressBackups: hasActiveSiteFeature( state, 'vaultpress-backups' ),
-		purchasedVaultPressScan: hasActiveSiteFeature( state, 'vaultpress-security-scanning' ),
+		purchasedVaultPressBackups: siteHasFeature( state, 'vaultpress-backups' ),
+		purchasedVaultPressScan: siteHasFeature( state, 'vaultpress-security-scanning' ),
 	};
 } )( ProStatus );

--- a/projects/plugins/jetpack/_inc/client/recommendations/sidebar/one-click-restores/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/sidebar/one-click-restores/index.jsx
@@ -6,7 +6,7 @@ import analytics from 'lib/analytics';
 import React, { useCallback, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { getSiteRawUrl } from 'state/initial-state';
-import { hasActiveSiteFeature } from 'state/site';
+import { siteHasFeature } from 'state/site';
 import { SidebarCard } from '../sidebar-card';
 
 import './style.scss';
@@ -98,7 +98,7 @@ const OneClickRestoresComponent = props => {
 };
 
 const OneClickRestores = connect( state => ( {
-	hasRealTimeBackups: hasActiveSiteFeature( state, 'real-time-backups' ),
+	hasRealTimeBackups: siteHasFeature( state, 'real-time-backups' ),
 	siteRawUrl: getSiteRawUrl( state ),
 } ) )( OneClickRestoresComponent );
 

--- a/projects/plugins/jetpack/_inc/client/security/backups-scan.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/backups-scan.jsx
@@ -16,7 +16,7 @@ import { connect } from 'react-redux';
 import { getVaultPressData, getVaultPressScanThreatCount } from 'state/at-a-glance';
 import { showBackups } from 'state/initial-state';
 import { isModuleActivated } from 'state/modules';
-import { hasActiveSiteFeature } from 'state/site';
+import { siteHasFeature } from 'state/site';
 
 class LoadingCard extends Component {
 	render() {
@@ -273,7 +273,7 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 export default connect( state => {
 	return {
 		vaultPressData: getVaultPressData( state ),
-		hasScan: hasActiveSiteFeature( state, 'scan' ),
+		hasScan: siteHasFeature( state, 'scan' ),
 		hasThreats: getVaultPressScanThreatCount( state ),
 		vaultPressActive: isModuleActivated( state, 'vaultpress' ),
 		showBackups: showBackups( state ),

--- a/projects/plugins/jetpack/_inc/client/security/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/index.jsx
@@ -10,7 +10,7 @@ import { isOfflineMode, isUnavailableInOfflineMode, hasConnectedOwner } from 'st
 import { getModule } from 'state/modules';
 import { isModuleFound } from 'state/search';
 import { getSettings } from 'state/settings';
-import { hasActiveSiteFeature } from 'state/site';
+import { siteHasFeature } from 'state/site';
 import { isPluginActive, isPluginInstalled } from 'state/site/plugins';
 import Antispam from './antispam';
 import BackupsScan from './backups-scan';
@@ -120,8 +120,7 @@ export class Security extends Component {
 
 export default connect( state => {
 	return {
-		backupsOnly:
-			hasActiveSiteFeature( state, 'backups' ) && ! hasActiveSiteFeature( state, 'scan' ),
+		backupsOnly: siteHasFeature( state, 'backups' ) && ! siteHasFeature( state, 'scan' ),
 		module: module_name => getModule( state, module_name ),
 		settings: getSettings( state ),
 		isOfflineMode: isOfflineMode( state ),

--- a/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
@@ -37,7 +37,7 @@ import {
 	getSitePlan,
 	hasActiveProductPurchase,
 	hasActiveSecurityPurchase,
-	hasActiveSiteFeature,
+	siteHasFeature,
 	hasActiveAntiSpamPurchase,
 	hasSecurityComparableLegacyPlan,
 } from 'state/site';
@@ -350,8 +350,8 @@ export const getProductSlugForStep = ( state, step ) => {
 			break;
 		case 'videopress':
 			if (
-				! hasActiveSiteFeature( state, 'videopress-1tb-storage' ) &&
-				! hasActiveSiteFeature( state, 'videopress-unlimited-storage' )
+				! siteHasFeature( state, 'videopress-1tb-storage' ) &&
+				! siteHasFeature( state, 'videopress-unlimited-storage' )
 			) {
 				return PLAN_JETPACK_VIDEOPRESS;
 			}
@@ -538,7 +538,7 @@ export const getSidebarCardSlug = state => {
 		return 'upsell';
 	}
 
-	if ( 'awaiting_credentials' === rewindState && ! hasActiveSiteFeature( state, 'scan' ) ) {
+	if ( 'awaiting_credentials' === rewindState && ! siteHasFeature( state, 'scan' ) ) {
 		return 'one-click-restores';
 	}
 

--- a/projects/plugins/jetpack/_inc/client/state/site/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/site/reducer.js
@@ -330,7 +330,7 @@ export function getActiveFeatures( state ) {
  * @param  {string}  featureId - The feature to check.
  * @returns {boolean} True if the feature is active. Otherwise, False.
  */
-export function hasActiveSiteFeature( state, featureId ) {
+export function siteHasFeature( state, featureId ) {
 	const siteFeatures = getActiveFeatures( state );
 
 	return siteFeatures && siteFeatures.indexOf( featureId ) >= 0;

--- a/projects/plugins/jetpack/_inc/client/state/site/test/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/site/test/reducer.js
@@ -1,5 +1,5 @@
 import {
-	hasActiveSiteFeature,
+	siteHasFeature,
 	isDoneFetchingConnectedPlugins,
 	getConnectedPlugins,
 	getConnectedPluginsMap,
@@ -95,19 +95,19 @@ describe( 'site selectors', () => {
 		} );
 	} );
 
-	describe( '#hasActiveSiteFeature()', () => {
+	describe( '#siteHasFeature()', () => {
 		test( 'should return False when feature param is not defined', () => {
-			const activeFeature = hasActiveSiteFeature( inState );
+			const activeFeature = siteHasFeature( inState );
 			expect( activeFeature ).toBe( false );
 		} );
 
 		test( 'should return False when feature is not defined in the active array', () => {
-			const activeFeature = hasActiveSiteFeature( inState, 'unknown-feature' );
+			const activeFeature = siteHasFeature( inState, 'unknown-feature' );
 			expect( activeFeature ).toBe( false );
 		} );
 
 		test( 'should return True when feature is defined in the active array', () => {
-			const activeFeature = hasActiveSiteFeature( inState, 'feature_active_01' );
+			const activeFeature = siteHasFeature( inState, 'feature_active_01' );
 			expect( activeFeature ).toBe( true );
 		} );
 	} );

--- a/projects/plugins/jetpack/changelog/rename-hasActiveSiteFeature
+++ b/projects/plugins/jetpack/changelog/rename-hasActiveSiteFeature
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Rename hasActiveSiteFeature -> siteHasFeature


### PR DESCRIPTION

Fixes #24991

#### Changes proposed in this Pull Request:

* Renames `hasActiveSiteFeature` -> `siteHasFeature`

This was done mechanically:
```
find projects -type f -print0 | xargs -0 --no-run-if-empty -n20 perl -pi -e 's/hasActiveSiteFeature/siteHasFeature/g'
```

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
  - NA
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
  - Not yet

#### Jetpack product discussion

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Unsure

