### PR TITLE
Add hooks for podcast feed fetches

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -283,7 +283,7 @@ class Jetpack_Podcast_Helper {
 		 *
 		 * @param string $podcast_url URL for the podcast's RSS feed.
 		 *
-		 * @since $next-version$
+		 * @since $$next-version$$
 		 */
 		do_action( 'jetpack_podcast_pre_fetch', $this->feed );
 
@@ -304,9 +304,9 @@ class Jetpack_Podcast_Helper {
 		 * Note that this action runs after other hooks added by Jetpack have been removed.
 		 *
 		 * @param string             $podcast_url URL for the podcast's RSS feed.
-		 * @param SimplePie|WP_Error $result Either the SimplePie RSS object or an error.
+		 * @param SimplePie|WP_Error $rss Either the SimplePie RSS object or an error.
 		 *
-		 * @since $next-version$
+		 * @since $$next-version$$
 		 */
 		do_action( 'jetpack_podcast_post_fetch', $this->feed, $rss );
 

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -277,6 +277,16 @@ class Jetpack_Podcast_Helper {
 		// Add action: detect the podcast feed from the provided feed URL.
 		add_action( 'wp_feed_options', array( __CLASS__, 'set_podcast_locator' ) );
 
+		/**
+		 * Allow callers to set up any desired hooks when we fetch the content for a podcast.
+		 * The `jetpack_podcast_post_fetch` action can be used to perform cleanup.
+		 *
+		 * @param string $podcast_url URL for the podcast's RSS feed.
+		 *
+		 * @since $next-version$
+		 */
+		do_action( 'jetpack_podcast_pre_fetch', $this->feed );
+
 		// Fetch the feed.
 		$rss = fetch_feed( $this->feed );
 
@@ -285,6 +295,20 @@ class Jetpack_Podcast_Helper {
 		if ( true === $force_refresh ) {
 			remove_action( 'wp_feed_options', array( __CLASS__, 'reset_simplepie_cache' ) );
 		}
+
+		/**
+		 * Allow callers to identify when we have completed fetching a specified podcast feed.
+		 * This makes it possible to clean up any actions or filters that were set up using the
+		 * `jetpack_podcast_pre_fetch` action.
+		 *
+		 * Note that this action runs after other hooks added by Jetpack have been removed.
+		 *
+		 * @param string             $podcast_url URL for the podcast's RSS feed.
+		 * @param SimplePie|WP_Error $result Either the SimplePie RSS object or an error.
+		 *
+		 * @since $next-version$
+		 */
+		do_action( 'jetpack_podcast_post_fetch', $this->feed, $rss );
 
 		if ( is_wp_error( $rss ) ) {
 			return new WP_Error( 'invalid_url', __( 'Your podcast couldn\'t be embedded. Please double check your URL.', 'jetpack' ) );

--- a/projects/plugins/jetpack/changelog/add-hooks-for-podcast-feed-fetches
+++ b/projects/plugins/jetpack/changelog/add-hooks-for-podcast-feed-fetches
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add new `jetpack_podcast_pre_fetch` and `jetpack_podcast_post_fetch` actions to make it possible for users to set up code that runs for podcast fetches.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:

* This PR adds two new actions, `jetpack_podcast_pre_fetch` and `jetpack_podcast_post_fetch`, which run immediately before and after we attempt to run a fetch for a podcast RSS feed in `Jetpack_Podcast_Helper`.

The main driver for the two actions is to make it possible for additional hooks to be set up during these fetches. For WordPress.com, we plan to use the hooks to set up instrumentation around RSS fetches so we can understand how many outbound HTTP requests we're making, and what HTTP response codes we're getting. (We plan to do this by hooking into the `http_response` filter in WordPress core.)

In terms of implementation, another approach could be to add a filter that returns a list of callbacks to add, and we'd then automatically remove each of those callbacks, but it feels like that could be overly complicated.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
   * I don't think I can write effective unit tests for this, as the code between the two hooks calls the `fetch_feed()` function, and I am not sure if it is possible to stub that out for testing purposes.
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

This is not technically a product feature so much as adding a technical hook for developer use.

#### Does this pull request change what data or activity we track or use?

No, this PR does not change any data or activity tracking.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

##### Setup

To get this set up, you're going to need the following:
* A running WordPress install that has the Jetpack plugin installed, active, and connected to WordPress.com. The site must also have the Gutenberg plugin installed and active
* You will also need to install the Jetpack Beta plugin
* You will also need to be able to perform the following actions on your site (which can be achieved via the listed plugins):
   - Add custom PHP code -- you can do this very easily using the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin
   - View the PHP error log -- you can do this easily using the [Error Log Monitor](https://wordpress.org/plugins/error-log-monitor/) plugin

##### Testing steps

* Navigate to `/wp-admin/`
* Navigate to _Jetpack_ -> _Jetpack Beta_ via the left nav
* On the Jetpack Beta page, type in `add/hooks-for-podcast-feed-fetches` to the search field with the text "Search for a Jetpack Feature Branch", and click on the "Activate" button that appears next to that branch
* You should now see "Active" displayed alongside the branch description
* Add the following custom code snippet to your site. If you are using Code Snippets, you can do that via _Code Snippets_ -> _Add New_ in the left nav.
```php
add_action( 'jetpack_podcast_pre_fetch', function ( $podcast_url ) {
	error_log( "jetpack_podcast_pre_fetch called with podcast_url=$podcast_url" );
} );

add_action( 'jetpack_podcast_post_fetch', function ( $podcast_url, $result ) {
	error_log( "jetpack_podcast_post_fetch called with \$podcast_url=$podcast_url and get_class( \$result )=" . get_class( $result ) );
}, 10, 2 );
```
  - Note that this code should run for all requests
  - If you're using Code Snippets, give the script a name and ensure that it is saved and activated
* Navigate to `/wp-admin/`, and verify that you can see your PHP error log. If needed clear the log to make it easier to see new entries.
* Navigate to _Posts_ -> _Add New_ via the left nav
* Add the "Podcast Player" block to your new post
* Paste a podcast URL into the input field -- you can use `https://distributed.blog/category/podcast/feed/` -- and click on the "Embed" button
* Navigate to `/wp-admin/` and verify that the relevant actions were called as expected -- note that they may be called more than once