### PR TITLE
Fix pretest scripts not running for e2e tests

### DIFF
--- a/projects/plugins/boost/changelog/e2e-fix-pre-scripts
+++ b/projects/plugins/boost/changelog/e2e-fix-pre-scripts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+E2E tests: fixed pretest cleanup script not running

--- a/projects/plugins/boost/tests/e2e/package.json
+++ b/projects/plugins/boost/tests/e2e/package.json
@@ -25,7 +25,7 @@
 		"tunnel:reset": "tunnel reset",
 		"tunnel:down": "tunnel down",
 		"tunnel:write-logs": "tunnel logs output/logs/tunnel.log",
-		"pretest": "pnpm run clean",
+		"pretest:run": "pnpm run clean",
 		"test:run": ". ./node_modules/jetpack-e2e-commons/bin/app-password.sh && playwright install && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.cjs",
 		"slack": "NODE_CONFIG_DIR='./config' slack"
 	},

--- a/projects/plugins/jetpack/changelog/e2e-fix-pre-scripts
+++ b/projects/plugins/jetpack/changelog/e2e-fix-pre-scripts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+E2E tests: fixed pretest cleanup script not running

--- a/projects/plugins/jetpack/tests/e2e/package.json
+++ b/projects/plugins/jetpack/tests/e2e/package.json
@@ -27,7 +27,7 @@
 		"tunnel:reset": "tunnel reset",
 		"tunnel:down": "tunnel down",
 		"tunnel:write-logs": "tunnel logs output/logs/tunnel.log",
-		"pretest": "pnpm run clean",
+		"pretest:run": "pnpm run clean",
 		"test:run": ". ./node_modules/jetpack-e2e-commons/bin/app-password.sh && playwright install && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=playwright.config.cjs --retries=2",
 		"test-decrypt-default-config": "openssl enc -md sha1 -aes-256-cbc -d -pass env:CONFIG_KEY -in ./node_modules/jetpack-e2e-commons/config/encrypted.enc -out ./node_modules/jetpack-e2e-commons/config/local.cjs",
 		"test-decrypt-config": "openssl enc -md sha1 -aes-256-cbc -d -pass env:CONFIG_KEY -in ./config/encrypted.enc -out config/local.cjs",

--- a/projects/plugins/search/changelog/e2e-fix-pre-scripts
+++ b/projects/plugins/search/changelog/e2e-fix-pre-scripts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+E2E tests: fixed pretest cleanup script not running

--- a/projects/plugins/search/tests/e2e/package.json
+++ b/projects/plugins/search/tests/e2e/package.json
@@ -24,7 +24,7 @@
 		"tunnel:reset": "tunnel reset",
 		"tunnel:down": "tunnel down",
 		"tunnel:write-logs": "tunnel logs output/logs/tunnel.log",
-		"pretest": "pnpm run clean",
+		"pretest:run": "pnpm run clean",
 		"test:run": ". ./node_modules/jetpack-e2e-commons/bin/app-password.sh && playwright install && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=playwright.config.cjs",
 		"slack": "NODE_CONFIG_DIR='./config' slack"
 	},

--- a/projects/plugins/starter-plugin/changelog/e2e-fix-pre-scripts
+++ b/projects/plugins/starter-plugin/changelog/e2e-fix-pre-scripts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+E2E tests: fixed pretest cleanup script not running

--- a/projects/plugins/starter-plugin/tests/e2e/package.json
+++ b/projects/plugins/starter-plugin/tests/e2e/package.json
@@ -26,7 +26,7 @@
 		"tunnel:reset": "tunnel reset",
 		"tunnel:down": "tunnel down",
 		"tunnel:write-logs": "tunnel logs output/logs/tunnel.log",
-		"pretest": "pnpm run clean",
+		"pretest:run": "pnpm run clean",
 		"test:run": ". ./node_modules/jetpack-e2e-commons/bin/app-password.sh && playwright install && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.cjs",
 		"slack": "NODE_CONFIG_DIR='./config' slack"
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fix the pre tests scripts not being run in e2e tests because they were incorrectly named.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Make sure the `pretest:run` script gets executed when running `test:run`. Check the console for `> pnpm run clean` and `> rm -rf output` output.

