### PR TITLE
jetpack (block editor): Only add `x-wp-api-fetch-from-editor` on non-CORS reqs

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-add-editor-header-only-on-non-cors
+++ b/projects/plugins/jetpack/changelog/fix-add-editor-header-only-on-non-cors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Editor: Only add `x-wp-api-fetch-from-editor` header on non-CORS requests.

--- a/projects/plugins/jetpack/extensions/editor.js
+++ b/projects/plugins/jetpack/extensions/editor.js
@@ -29,6 +29,30 @@ if (
 
 // Register middleware for @wordpress/api-fetch to indicate the fetch is coming from the editor.
 apiFetch.use( ( options, next ) => {
+	// Skip explicit cors requests.
+	if ( options.mode === 'cors' ) {
+		return next( options );
+	}
+
+	// If a URL is set, skip if it's not same-origin.
+	// @see https://html.spec.whatwg.org/multipage/origin.html#same-origin
+	if ( options.url ) {
+		try {
+			const url = new URL( options.url, location.href );
+			if (
+				url.protocol !== location.protocol ||
+				url.hostname !== location.hostname ||
+				url.port !== location.port
+			) {
+				return next( options );
+			}
+		} catch {
+			// Huh? Skip it.
+			return next( options );
+		}
+	}
+
+	// Ok, add header.
 	if ( ! options.headers ) {
 		options.headers = {};
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
It turns out that `@wordpress/api-fetch` is used for cross-origin
requests too. We (probably) only need the added header for same-origin
requests, so detect for that.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1657539716330009-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* ?