### PR TITLE
Protect: Fix PHP warning from unset status $item->checked

### DIFF
--- a/projects/plugins/protect/changelog/fix-protect-undefined-checked
+++ b/projects/plugins/protect/changelog/fix-protect-undefined-checked
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Minor bug fix - no logic changed, just added an isset() check.
+
+

--- a/projects/plugins/protect/src/class-status.php
+++ b/projects/plugins/protect/src/class-status.php
@@ -312,7 +312,7 @@ class Status {
 		$unchecked_items = array_filter(
 			$all_items,
 			function ( $item ) {
-				return ! $item->checked;
+				return ! isset( $item->checked ) || ! $item->checked;
 			}
 		);
 		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds an `isset()` check to prevent a PHP warning from being thrown when `$item->checked` is not set.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1657545663522529-slack-C02TQF5VAJD

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Protect page and validate that the `uncheckedItems` value is correct, using either Redux dev tools or by validating that the UI is displayed correctly.
* Validate that all tests pass.