### PR TITLE
Jetpack: improve VideoPress Block placeholders

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-vpblock-polish-placeholder-block-state
+++ b/projects/plugins/jetpack/changelog/update-jetpack-vpblock-polish-placeholder-block-state
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Jetpack: improve VPBlock placeholder:wq
+Jetpack: improve VideoPress Block placeholders

--- a/projects/plugins/jetpack/changelog/update-jetpack-vpblock-polish-placeholder-block-state
+++ b/projects/plugins/jetpack/changelog/update-jetpack-vpblock-polish-placeholder-block-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: improve VPBlock placeholder:wq

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/index.js
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import { getBlobByURL, isBlobURL } from '@wordpress/blob';
-import { useBlockProps, BlockIcon, MediaPlaceholder } from '@wordpress/block-editor';
-import { Button, Icon } from '@wordpress/components';
+import { BlockIcon, MediaPlaceholder } from '@wordpress/block-editor';
+import { Button, Icon, Placeholder } from '@wordpress/components';
 import { createInterpolateElement, useCallback, useState } from '@wordpress/element';
 import { escapeHTML } from '@wordpress/escape-html';
 import { __, sprintf } from '@wordpress/i18n';
@@ -12,23 +12,22 @@ import filesize from 'filesize';
  * Internal dependencies
  */
 import { useResumableUploader } from '../../hooks/use-uploader.js';
+import { description, title } from '../../index.js';
 import { VideoPressIcon } from '../icons';
 import './style.scss';
 
 const ALLOWED_MEDIA_TYPES = [ 'video' ];
 
-const UploadWrapper = ( { children } ) => {
-	const blockProps = useBlockProps( { className: 'videopress-uploader' } );
-	return (
-		<div { ...blockProps }>
-			<div className="videopress-uploader__logo">
-				<Icon icon={ VideoPressIcon } />
-				<div>{ __( 'VideoPress', 'jetpack' ) }</div>
-			</div>
-			{ children }
-		</div>
-	);
-};
+const UploadWrapper = ( { children } ) => (
+	<Placeholder
+		icon={ <Icon icon={ VideoPressIcon } /> }
+		label={ title }
+		instructions={ description }
+		className="videopress-uploader"
+	>
+		{ children }
+	</Placeholder>
+);
 
 const UploadProgress = ( { progress, file } ) => {
 	const roundedProgress = Math.round( progress );
@@ -252,7 +251,8 @@ const VideoPressUploader = ( { attributes, setAttributes } ) => {
 		<MediaPlaceholder
 			icon={ <BlockIcon icon={ VideoPressIcon } /> }
 			labels={ {
-				title: __( 'VideoPress', 'jetpack' ),
+				title,
+				instructions: description,
 			} }
 			onSelect={ onSelectVideo }
 			onSelectURL={ onSelectURL }

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/index.js
@@ -3,7 +3,7 @@
  */
 import { getBlobByURL, isBlobURL } from '@wordpress/blob';
 import { BlockIcon, MediaPlaceholder } from '@wordpress/block-editor';
-import { Button, Icon, Placeholder } from '@wordpress/components';
+import { Button, Placeholder } from '@wordpress/components';
 import { createInterpolateElement, useCallback, useState } from '@wordpress/element';
 import { escapeHTML } from '@wordpress/escape-html';
 import { __, sprintf } from '@wordpress/i18n';
@@ -18,12 +18,10 @@ import './style.scss';
 
 const ALLOWED_MEDIA_TYPES = [ 'video' ];
 
+const vpPlaceholderIcon = () => <span className="block-editor-block-icon">{ VideoPressIcon }</span>;
+
 const UploadWrapper = ( { children } ) => (
-	<Placeholder
-		icon={ <Icon icon={ VideoPressIcon } /> }
-		label={ title }
-		className="videopress-uploader"
-	>
+	<Placeholder icon={ vpPlaceholderIcon } label={ title } className="videopress-uploader">
 		{ children }
 	</Placeholder>
 );

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/index.js
@@ -22,7 +22,6 @@ const UploadWrapper = ( { children } ) => (
 	<Placeholder
 		icon={ <Icon icon={ VideoPressIcon } /> }
 		label={ title }
-		instructions={ description }
 		className="videopress-uploader"
 	>
 		{ children }

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/index.js
@@ -3,11 +3,12 @@
  */
 import { getBlobByURL, isBlobURL } from '@wordpress/blob';
 import { BlockIcon, MediaPlaceholder } from '@wordpress/block-editor';
-import { Button, Placeholder } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { createInterpolateElement, useCallback, useState } from '@wordpress/element';
 import { escapeHTML } from '@wordpress/escape-html';
 import { __, sprintf } from '@wordpress/i18n';
 import filesize from 'filesize';
+import { UploadWrapper } from '../../edit.js';
 /**
  * Internal dependencies
  */
@@ -17,14 +18,6 @@ import { VideoPressIcon } from '../icons';
 import './style.scss';
 
 const ALLOWED_MEDIA_TYPES = [ 'video' ];
-
-const vpPlaceholderIcon = () => <span className="block-editor-block-icon">{ VideoPressIcon }</span>;
-
-const UploadWrapper = ( { children } ) => (
-	<Placeholder icon={ vpPlaceholderIcon } label={ title } className="videopress-uploader">
-		{ children }
-	</Placeholder>
-);
 
 const UploadProgress = ( { progress, file } ) => {
 	const roundedProgress = Math.round( progress );
@@ -246,6 +239,7 @@ const VideoPressUploader = ( { attributes, setAttributes } ) => {
 	// Default view to select file to upload
 	return (
 		<MediaPlaceholder
+			className="is-videopress-placeholder"
 			icon={ <BlockIcon icon={ VideoPressIcon } /> }
 			labels={ {
 				title,

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/style.scss
@@ -1,18 +1,6 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
 .videopress-uploader {
-	background: $white;
-	color: $gray-900;
-	font-family: $default-font;
-	box-sizing: border-box;
-	display: flex;
-	flex-direction: column;
-	align-items: flex-start;
-	padding: 20px;
-	border: 1px solid $gray-900;
-	border-radius: 2px;
-	font-size: $default-font-size;
-
 	&__logo {
 		display: flex;
 		flex-direction: row;

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/style.scss
@@ -13,7 +13,6 @@
 	flex-direction: column;
 	width: 100%;
 	align-items: center;
-	margin-top: $grid-unit-30;
 
 	&__file-info {
 		display: flex;

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/style.scss
@@ -1,26 +1,10 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
 .videopress-uploader {
-	&__logo {
-		display: flex;
-		flex-direction: row;
-		align-items: center;
-		font-size: 24px;
-		line-height: 29px;
-		gap: 10px;
-	}
-
 	&__error-message {
-		margin-top: $grid-unit-30;
 		color: $alert-red;
 		width: 100%;
-	}
-
-	&__error-actions {
-		display: flex;
-		flex-direction: row;
-		margin-top: $grid-unit-30;
-		gap: 10px;
+		margin-bottom: 1em;
 	}
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -238,7 +238,7 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 		return (
 			<UploadWrapper>
 				<div role="alert" aria-live="assertive" className="videopress-uploader__error-message">
-					{ __( 'Impossible to get a video preview after ten attempts. Show error.', 'jetpack' ) }
+					{ __( 'Impossible to get a video preview after ten attempts.', 'jetpack' ) }
 				</div>
 				<div className="videopress-uploader__error-actions">
 					<Button variant="primary" onClick={ invalidateResolution }>

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -188,10 +188,6 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 	] );
 
 	const blockProps = useBlockProps( {
-		className: 'wp-block-jetpack-videopress is-videopress-placeholder-container',
-	} );
-
-	const videoPlayerBlockProps = useBlockProps( {
 		className: classNames( 'wp-block-jetpack-videopress', {
 			[ `align${ align }` ]: align,
 			'is-updating-preview': ! previewHtml,
@@ -243,7 +239,7 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 
 	// X - Show VideoPress player. @todo: finish
 	return (
-		<div { ...videoPlayerBlockProps }>
+		<div { ...blockProps }>
 			<VideoPressInspectorControls attributes={ attributes } setAttributes={ setAttributes } />
 			<VideoPressPlayer
 				html={ html }

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -3,7 +3,7 @@
  */
 
 import { useBlockProps } from '@wordpress/block-editor';
-import { Spinner } from '@wordpress/components';
+import { Spinner, Placeholder, Button } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useState, useCallback, useRef } from '@wordpress/element';
@@ -13,13 +13,27 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import { getVideoPressUrl } from '../url';
+import { VideoPressIcon } from './components/icons';
 import VideoPressInspectorControls from './components/inspector-controls';
 import VideoPressPlayer from './components/videopress-player';
 import VideoPressUploader from './components/videopress-uploader';
+import { title } from '.';
 
 import './editor.scss';
 
 const VIDEO_PREVIEW_ATTEMPTS_LIMIT = 10;
+
+const vpPlaceholderIcon = () => <span className="block-editor-block-icon">{ VideoPressIcon }</span>;
+
+export const UploadWrapper = ( { children } ) => (
+	<Placeholder
+		icon={ vpPlaceholderIcon }
+		label={ title }
+		className="videopress-uploader is-videopress-placeholder"
+	>
+		{ children }
+	</Placeholder>
+);
 
 export default function VideoPressEdit( { attributes, setAttributes, isSelected } ) {
 	const {
@@ -211,29 +225,35 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 		generatingPreviewCounter < VIDEO_PREVIEW_ATTEMPTS_LIMIT
 	) {
 		return (
-			<>
-				<div { ...blockProps }>
-					<Spinner />
-					<div>{ __( '(4) Generating preview…', 'jetpack' ) }</div>
-					<div>
-						Attempt: <strong>{ generatingPreviewCounter }</strong>
-					</div>
-				</div>
-			</>
+			<UploadWrapper>
+				<Spinner />
+				{ __( 'Generating preview…', 'jetpack' ) }
+				<strong> { generatingPreviewCounter }</strong>
+			</UploadWrapper>
 		);
 	}
 
 	// 5 - Generating video preview
 	if ( generatingPreviewCounter >= VIDEO_PREVIEW_ATTEMPTS_LIMIT && ! preview ) {
 		return (
-			<div { ...blockProps }>
-				<div>
-					{ __(
-						'(5) Impossible to get a video preview after ten attempts. Show error.',
-						'jetpack'
-					) }
+			<UploadWrapper>
+				<div role="alert" aria-live="assertive" className="videopress-uploader__error-message">
+					{ __( 'Impossible to get a video preview after ten attempts. Show error.', 'jetpack' ) }
 				</div>
-			</div>
+				<div className="videopress-uploader__error-actions">
+					<Button variant="primary" onClick={ invalidateResolution }>
+						{ __( 'Try again', 'jetpack' ) }
+					</Button>
+					<Button
+						variant="secondary"
+						onClick={ () => {
+							setAttributes( { src: undefined, id: undefined, guid: undefined } );
+						} }
+					>
+						{ __( 'Cancel', 'jetpack' ) }
+					</Button>
+				</div>
+			</UploadWrapper>
 		);
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/edit.js
@@ -188,7 +188,7 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected 
 	] );
 
 	const blockProps = useBlockProps( {
-		className: 'wp-block-jetpack-videopress is-placeholder-container',
+		className: 'wp-block-jetpack-videopress is-videopress-placeholder-container',
 	} );
 
 	const videoPlayerBlockProps = useBlockProps( {

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/editor.scss
@@ -37,3 +37,9 @@
 		}
 	}
 }
+
+.is-videopress-placeholder {
+	.components-placeholder__fieldset {
+		min-height: 82px;
+	}
+}

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/editor.scss
@@ -3,22 +3,6 @@
 .wp-block-jetpack-videopress {
 	position: relative;
 
-	&.is-placeholder-container {
-		background: $white;
-		color: $gray-900;
-		font-family: $default-font;
-		box-sizing: border-box;
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
-		align-items: flex-start;
-		padding: 20px;
-		border: 1px solid $gray-900;
-		border-radius: 2px;
-		font-size: $default-font-size;
-		min-height: 200px;
-	}
-
 	.jetpack-videopress-player {
 		margin: 0;
 	}
@@ -52,4 +36,22 @@
 			width: 100%;
 		}
 	}
+}
+
+// A class to apply to the video press main element
+// when the video is not ready yet: uploading, generating preview, etc
+.is-videopress-placeholder-container {
+	background: $white;
+	color: $gray-900;
+	font-family: $default-font;
+	box-sizing: border-box;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: flex-start;
+	padding: 20px;
+	border: 1px solid $gray-900;
+	border-radius: 2px;
+	font-size: $default-font-size;
+	min-height: 200px;
 }

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/editor.scss
@@ -37,21 +37,3 @@
 		}
 	}
 }
-
-// A class to apply to the video press main element
-// when the video is not ready yet: uploading, generating preview, etc
-.is-videopress-placeholder-container {
-	background: $white;
-	color: $gray-900;
-	font-family: $default-font;
-	box-sizing: border-box;
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	align-items: flex-start;
-	padding: 20px;
-	border: 1px solid $gray-900;
-	border-radius: 2px;
-	font-size: $default-font-size;
-	min-height: 200px;
-}

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/index.js
@@ -13,12 +13,14 @@ import './style.scss';
 
 export const name = 'videopress-block';
 export const title = __( 'VideoPress', 'jetpack' );
+export const description = __(
+	'Embed a video from your media library or upload a new one with VideoPress.',
+	'jetpack'
+);
+
 export const settings = {
 	title,
-	description: __(
-		'Embed a video from your media library or upload a new one with VideoPress.',
-		'jetpack'
-	),
+	description,
 	icon,
 	category: 'media',
 	edit,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR improves the placeholder instances when the video is still not ready to use, such as uploading, generating preview, with errors, etc. The most relevant change here is using the core [Placeholder](https://github.com/WordPress/gutenberg/tree/trunk/packages/components/src/placeholder) used to implement the UI.
In some way, these changes raise up other visual issues when generating the preview. Something to be handled in follow-up tasks.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack: improve VideoPress Block placeholders

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Upload a video file
* Take a look at the different states until the player is rendered. Some of the improvements is to keep the same styles for the common sections of the placeholder. For instance, the block icon, title, min-height ...

State | Screenshot
------|------
Initial state | <img width="660" alt="image" src="https://user-images.githubusercontent.com/77539/178342089-e5890c9a-ab80-424b-ac70-6ff41748fc5e.png">
Something went wrong | <img width="667" alt="image" src="https://user-images.githubusercontent.com/77539/178342223-c817374b-64aa-4c35-8c4b-2e685d82bbb8.png">
Uploading | <img width="665" alt="image" src="https://user-images.githubusercontent.com/77539/178342301-06c966ff-ccad-4c10-8a3b-93608b168eba.png">
Generating preview | <img width="661" alt="image" src="https://user-images.githubusercontent.com/77539/178342466-1f50078c-1605-4d94-be8d-a1851b499086.png">



<img width="115" alt="image" src="https://user-images.githubusercontent.com/77539/178343004-6b9f84b3-ac8a-4eb7-a943-d6e4a75595d4.png">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202583661192516