### PR TITLE
Search: Record Meter, remove feature flag for record meter

### DIFF
--- a/projects/packages/search/changelog/update-search-record-meter-remove-feature-flag
+++ b/projects/packages/search/changelog/update-search-record-meter-remove-feature-flag
@@ -1,4 +1,4 @@
 Significance: minor
-Type: removed
+Type: added
 
 Record Meter: make feature available to all users

--- a/projects/packages/search/changelog/update-search-record-meter-remove-feature-flag
+++ b/projects/packages/search/changelog/update-search-record-meter-remove-feature-flag
@@ -1,4 +1,4 @@
 Significance: minor
 Type: removed
 
-Record Meter: removes feature flag functionality so the record meter is available to all users
+Record Meter: make feature available to all users

--- a/projects/packages/search/changelog/update-search-record-meter-remove-feature-flag
+++ b/projects/packages/search/changelog/update-search-record-meter-remove-feature-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Record Meter: removes feature flag functionality so the record meter is available to all users

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -69,7 +69,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.16.x-dev"
+			"dev-trunk": "0.17.x-dev"
 		},
 		"version-constants": {
 			"::VERSION": "src/class-package.php"

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.16.2",
+	"version": "0.17.0-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.16.2';
+	const VERSION = '0.17.0-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -147,10 +147,6 @@ export default function DashboardPage( { isLoading = false } ) {
 		);
 	};
 
-	const isRecordMeterEnabled = useSelect( select =>
-		select( STORE_ID ).isFeatureEnabled( 'record-meter' )
-	);
-
 	return (
 		<>
 			{ isPageLoading && <Loading /> }
@@ -158,15 +154,13 @@ export default function DashboardPage( { isLoading = false } ) {
 				<div className="jp-search-dashboard-page">
 					{ renderHeader() }
 					{ renderMockedSearchInterface() }
-					{ isRecordMeterEnabled && (
-						<RecordMeter
-							postCount={ postCount }
-							postTypeBreakdown={ postTypeBreakdown }
-							tierMaximumRecords={ tierMaximumRecords }
-							lastIndexedDate={ lastIndexedDate }
-							postTypes={ postTypes }
-						/>
-					) }
+					<RecordMeter
+						postCount={ postCount }
+						postTypeBreakdown={ postTypeBreakdown }
+						tierMaximumRecords={ tierMaximumRecords }
+						lastIndexedDate={ lastIndexedDate }
+						postTypes={ postTypes }
+					/>
 					{ renderModuleControl() }
 					{ renderFooter() }
 					<NoticesList

--- a/projects/plugins/jetpack/changelog/update-search-record-meter-remove-feature-flag
+++ b/projects/plugins/jetpack/changelog/update-search-record-meter-remove-feature-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -37,7 +37,7 @@
 		"automattic/jetpack-publicize": "0.10.x-dev",
 		"automattic/jetpack-redirect": "1.7.x-dev",
 		"automattic/jetpack-roles": "1.4.x-dev",
-		"automattic/jetpack-search": "0.16.x-dev",
+		"automattic/jetpack-search": "0.17.x-dev",
 		"automattic/jetpack-status": "1.14.x-dev",
 		"automattic/jetpack-sync": "1.37.x-dev",
 		"automattic/jetpack-videopress": "0.1.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "35a01cca4d6a6382f2e7bcc8d1d9d0ff",
+    "content-hash": "f598ef1075830021cff70bc125cbc5aa",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1638,7 +1638,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "b5098f84ddf1e3a7f38aa19631b7b101b801aed6"
+                "reference": "7414c854f52cbfa10371971888b88e145408a728"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -1662,7 +1662,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.16.x-dev"
+                    "dev-trunk": "0.17.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"

--- a/projects/plugins/search/changelog/update-search-record-meter-remove-feature-flag
+++ b/projects/plugins/search/changelog/update-search-record-meter-remove-feature-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -9,7 +9,7 @@
 		"automattic/jetpack-config": "1.9.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
 		"automattic/jetpack-my-jetpack": "1.8.x-dev",
-		"automattic/jetpack-search": "0.16.x-dev",
+		"automattic/jetpack-search": "0.17.x-dev",
 		"automattic/jetpack-status": "^1.14",
 		"automattic/jetpack-sync": "1.37.x-dev"
 	},

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "49bfc341a56ea742817458da6c0180ef",
+    "content-hash": "b97583e0d98b36b1bbd7cd95d1dbce65",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -903,7 +903,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "b5098f84ddf1e3a7f38aa19631b7b101b801aed6"
+                "reference": "7414c854f52cbfa10371971888b88e145408a728"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -927,7 +927,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.16.x-dev"
+                    "dev-trunk": "0.17.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"


### PR DESCRIPTION
This PR removes the feature flag for the Search Record Meter so that the Record Meter will be available to all users

#### Changes proposed in this Pull Request:

* Removes feature flag so that record meter can be accessed at `/wp-admin/admin.php?page=jetpack-search` instead of only `/wp-admin/admin.php?page=jetpack-search&features=record-meter`

#### Other information:

- [ x ] Have you written new tests for your changes, if applicable?
- [ x ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* Go to a site with Jetpack Search activated
* Navigate to `/wp-admin/admin.php?page=jetpack-search`
* Ensure the record meter displays correctly on that dashboard

![image](https://user-images.githubusercontent.com/30754158/178409426-c6ac11ca-a51e-4322-9cc3-652ed0b3ef4c.png)


