### PR TITLE
Subscriptions: format the number of subscribers in block controls

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscriptions-number-format-controls
+++ b/projects/plugins/jetpack/changelog/fix-subscriptions-number-format-controls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscriptions: format the number of subscribers displayed in the block editor's controls.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
@@ -1,3 +1,4 @@
+import { numberFormat } from '@automattic/jetpack-components';
 import { isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import {
 	ContrastChecker,
@@ -63,7 +64,7 @@ export default function SubscriptionControls( {
 								subscriberCount,
 								'jetpack'
 							),
-							subscriberCount
+							numberFormat( subscriberCount )
 						),
 						{ span: <span style={ { textDecoration: 'underline' } } /> }
 					) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

In other places, we format the number so it can be displayed properly regardless of the language. Let's apply the same logic here, to fix display problems like on this screenshot:

<img width="302" alt="Screen Shot 2022-07-12 at 11 48 42" src="https://user-images.githubusercontent.com/426388/178463245-421d39df-1aa2-49f3-8888-905ab661376e.png">


#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start with a site connected to WordPress.com, with the Subscriptions module active.
    * It is best if your site already has a fair number of subscribers. If that's not the case, you can hardcode a large number here: https://github.com/Automattic/jetpack/blob/9d5c7e977ed1d7dca695b263f73eaaa58a239306/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/subscribers.php#L70-L72
* Go to Posts > Add New
* Add a new subscribe block to the post.
* In the editor's sidebar, check the number of subscribers displayed; it should be displayed properly.
