### PR TITLE
Repo Gardening: add task to gather support references in a comment

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -3,7 +3,7 @@ on:
   pull_request_target: # When a PR is opened, edited, updated, closed, or a label is added.
     types: [opened, reopened, synchronize, edited, labeled, closed]
   issues: # For auto-triage of issues.
-    types: [opened, reopened]
+    types: [opened, reopened, edited]
   issue_comment: # To gather support references in issue comments.
     types: [created]
   push:

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -5,7 +5,7 @@ on:
   issues: # For auto-triage of issues.
     types: [opened, reopened]
   issue_comment: # To gather support references in issue comments.
-    types: [created, edited]
+    types: [created]
   push:
     branches:
       - trunk # Every time a PR is merged to trunk.

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -4,6 +4,8 @@ on:
     types: [opened, reopened, synchronize, edited, labeled, closed]
   issues: # For auto-triage of issues.
     types: [opened, reopened]
+  issue_comment: # To gather support references in issue comments.
+    types: [created, edited]
   push:
     branches:
       - trunk # Every time a PR is merged to trunk.

--- a/projects/github-actions/repo-gardening/README.md
+++ b/projects/github-actions/repo-gardening/README.md
@@ -16,6 +16,7 @@ Here is the current list of tasks handled by this action:
 - Notify Editorial (`notifyEditorial`): Sends a Slack Notification to the Editorial team to request feedback, based on labels applied to a PR.
 - Flag OSS (`flagOss`): flags entries by external contributors, adds an "OSS Citizen" label to the PR, and sends a Slack message.
 - Triage New Issues (`triageNewIssues`): Adds labels to new issues based on issue content.
+- Gather support references (`gatherSupportReferences`): Adds a new comment with a list of all support references on the issue.
 
 Some of the tasks are may not satisfy your needs. If that's the case, you can use the `tasks` option to limit the action to the list of tasks you need in your repo. See the example below to find out more.
 

--- a/projects/github-actions/repo-gardening/changelog/update-ticket-reference-comment
+++ b/projects/github-actions/repo-gardening/changelog/update-ticket-reference-comment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add new task to gather support references in a separate comment.

--- a/projects/github-actions/repo-gardening/src/get-comments.js
+++ b/projects/github-actions/repo-gardening/src/get-comments.js
@@ -1,0 +1,41 @@
+/* global GitHub */
+const debug = require( './debug' );
+
+// Cache for getComments.
+const cache = {};
+
+/**
+ * Get all comments belonging to an issue.
+ *
+ * @param {GitHub} octokit - Initialized Octokit REST client.
+ * @param {string} owner   - Repository owner.
+ * @param {string} repo    - Repository name.
+ * @param {string} number  - Issue number.
+ * @returns {Promise<Array>} Promise resolving to an array of all comments on that given issue.
+ */
+async function getComments( octokit, owner, repo, number ) {
+	const issueComments = [];
+	const cacheKey = `${ owner }/${ repo } #${ number }`;
+	if ( cache[ cacheKey ] ) {
+		debug( `get-comments: Returning list of all comments on ${ cacheKey } from cache.` );
+		return cache[ cacheKey ];
+	}
+
+	debug( `get-comments: Get list of all comments on ${ cacheKey }.` );
+
+	for await ( const response of octokit.paginate.iterator( octokit.rest.issues.listComments, {
+		owner,
+		repo,
+		issue_number: +number,
+		per_page: 100,
+	} ) ) {
+		response.data.map( comment => {
+			issueComments.push( comment );
+		} );
+	}
+
+	cache[ cacheKey ] = issueComments;
+	return issueComments;
+}
+
+module.exports = getComments;

--- a/projects/github-actions/repo-gardening/src/index.js
+++ b/projects/github-actions/repo-gardening/src/index.js
@@ -9,6 +9,7 @@ const assignIssues = require( './tasks/assign-issues' );
 const checkDescription = require( './tasks/check-description' );
 const cleanLabels = require( './tasks/clean-labels' );
 const flagOss = require( './tasks/flag-oss' );
+const gatherSupportReferences = require( './tasks/gather-support-references' );
 const notifyDesign = require( './tasks/notify-design' );
 const notifyEditorial = require( './tasks/notify-editorial' );
 const triageNewIssues = require( './tasks/triage-new-issues' );
@@ -63,6 +64,16 @@ const automations = [
 		event: 'issues',
 		action: [ 'opened', 'reopened' ],
 		task: triageNewIssues,
+	},
+	{
+		event: 'issues',
+		action: [ 'opened', 'reopened', 'edited' ],
+		task: gatherSupportReferences,
+	},
+	{
+		event: 'issue_comment',
+		action: [ 'created' ],
+		task: gatherSupportReferences,
 	},
 ];
 

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -3,6 +3,7 @@ const path = require( 'path' );
 const moment = require( 'moment' );
 const debug = require( '../../debug' );
 const getAffectedChangeloggerProjects = require( '../../get-affected-changelogger-projects' );
+const getComments = require( '../../get-comments' );
 const getFiles = require( '../../get-files' );
 const getLabels = require( '../../get-labels' );
 const getNextValidMilestone = require( '../../get-next-valid-milestone' );
@@ -173,20 +174,15 @@ async function getCheckComment( octokit, owner, repo, number ) {
 
 	debug( `check-description: Looking for a previous comment from this task in our PR.` );
 
-	for await ( const response of octokit.paginate.iterator( octokit.rest.issues.listComments, {
-		owner,
-		repo,
-		issue_number: +number,
-	} ) ) {
-		response.data.map( comment => {
-			if (
-				comment.user.login === 'github-actions[bot]' &&
-				comment.body.includes( '**Thank you for your PR!**' )
-			) {
-				commentID = comment.id;
-			}
-		} );
-	}
+	const comments = await getComments( octokit, owner, repo, number );
+	comments.map( comment => {
+		if (
+			comment.user.login === 'github-actions[bot]' &&
+			comment.body.includes( '**Thank you for your PR!**' )
+		) {
+			commentID = comment.id;
+		}
+	} );
 
 	return commentID;
 }

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -117,15 +117,16 @@ async function createOrUpdateComment( payload, octokit, issueReferences, issueCo
 		} );
 
 		// First, build a list of all references and whether they are checked or not.
-		const listWithStatusMatch = existingCommentBody.match(
+		const listWithStatusMatch = existingCommentBody.matchAll(
 			/(?:-\s\[(?<checked>\s|x)\]\s)(?<ticketId>[0-9]*-(?:hc|zen))/gm
 		);
 		const statusMatches = [ ...listWithStatusMatch ];
+
 		// Build a new array with only checked ticket references.
 		const checkedList = [];
 		for ( const referenceStatus of statusMatches ) {
 			const [ , checked, ticketId ] = referenceStatus;
-			if ( checked !== ' ' ) {
+			if ( checked === 'x' ) {
 				checkedList.push( ticketId );
 			}
 		}

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -112,18 +112,12 @@ async function createOrUpdateComment( payload, octokit, issueReferences, issueCo
 		);
 
 		// First, build a list of all references and whether they are checked or not.
-		const listWithStatusMatch = existingComment.body.matchAll(
-			/(?:-\s\[(?<checked>\s|x)\]\s)(?<ticketId>[0-9]*-(?:hc|zen))/gm
-		);
-		const statusMatches = [ ...listWithStatusMatch ];
+		const listWithStatusMatch = existingComment.body.matchAll( /^-\s\[x\]\s(\S+)/gm );
 
 		// Build a new array with only checked ticket references.
 		const checkedList = [];
-		for ( const referenceStatus of statusMatches ) {
-			const [ , checked, ticketId ] = referenceStatus;
-			if ( checked === 'x' ) {
-				checkedList.push( ticketId );
-			}
+		for ( const referenceStatus of listWithStatusMatch ) {
+			checkedList.push( referenceStatus[ 1 ] );
 		}
 
 		// Remove checked tickets from our existing list of issue references.

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -43,7 +43,12 @@ async function getIssueReferences( octokit, owner, repo, number, issueComments )
 
 	debug( `gather-support-references: Getting references from comments.` );
 	issueComments.map( comment => {
-		ticketReferences.push( ...comment.body.matchAll( referencesRegexP ) );
+		if (
+			comment.user.login !== 'github-actions[bot]' &&
+			! comment.body.includes( '**Support References**' )
+		) {
+			ticketReferences.push( ...comment.body.matchAll( referencesRegexP ) );
+		}
 	} );
 
 	debug( `gather-support-references: Getting references from issue body.` );

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -20,6 +20,7 @@ async function getListComment( octokit, owner, repo, number ) {
 		owner,
 		repo,
 		issue_number: +number,
+		per_page: 100,
 	} ) ) {
 		response.data.map( comment => {
 			if (

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -74,7 +74,7 @@ async function getIssueReferences( octokit, owner, repo, number, issueComments )
 		// xxx-zd and xxx-chat, as well as uppercase versions, are considered as alternate versions.
 		const wrongId = supportId.match( /([0-9]*)-(zd|chat)/i );
 		if ( wrongId ) {
-			const correctedId = `${ wrongId[ 1 ] }-${ wrongId[ 2 ] === 'zd' ? 'zen' : 'hc' }`;
+			const correctedId = `${ wrongId[ 1 ] }-${ wrongId[ 2 ].toLowerCase() === 'zd' ? 'zen' : 'hc' }`;
 			correctedSupportIds.add( correctedId );
 		} else {
 			correctedSupportIds.add( supportId.toLowerCase() );

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -6,18 +6,14 @@ const getComments = require( '../../get-comments' );
 /**
  * Search for a previous comment from this task in our issue.
  *
- * @param {GitHub} octokit - Initialized Octokit REST client.
- * @param {string} owner   - Repository owner.
- * @param {string} repo    - Repository name.
- * @param {string} number  - Issue number.
+ * @param {Array} issueComments - Array of all comments on that issue.
  * @returns {Promise<number>} Promise resolving to a number.
  */
-async function getListComment( octokit, owner, repo, number ) {
+async function getListComment( issueComments ) {
 	let commentID = 0;
 
 	debug( `gather-support-references: Looking for a previous comment from this task in our issue.` );
 
-	const issueComments = await getComments( octokit, owner, repo, number );
 	issueComments.map( comment => {
 		if (
 			comment.user.login === 'github-actions[bot]' &&
@@ -33,18 +29,18 @@ async function getListComment( octokit, owner, repo, number ) {
 /**
  * Scan the contents of the issue as well as all its comments, get all support references, and add them to an array of references.
  *
- * @param {GitHub} octokit - Initialized Octokit REST client.
- * @param {string} owner   - Repository owner.
- * @param {string} repo    - Repository name.
- * @param {string} number  - Issue number.
+ * @param {GitHub} octokit      - Initialized Octokit REST client.
+ * @param {string} owner        - Repository owner.
+ * @param {string} repo         - Repository name.
+ * @param {string} number       - Issue number.
+ * @param {Array} issueComments - Array of all comments on that issue.
  * @returns {Promise<Array>} Promise resolving to an array.
  */
-async function getIssueReferences( octokit, owner, repo, number ) {
+async function getIssueReferences( octokit, owner, repo, number, issueComments ) {
 	const ticketReferences = [];
 	const supportIds = [];
 	const referencesRegexP = /[0-9]*-(?:chat|hc|zen|zd)/gim;
 
-	const issueComments = await getComments( octokit, owner.login, repo, number );
 	debug( `gather-support-references: Getting references from comments.` );
 	issueComments.map( comment => {
 		ticketReferences.push( ...comment.body.matchAll( referencesRegexP ) );
@@ -89,10 +85,11 @@ async function getIssueReferences( octokit, owner, repo, number ) {
  * Creates or updates a comment on issue.
  *
  * @param {WebhookPayloadIssue} payload - Issue event payload.
- * @param {GitHub} octokit - Initialized Octokit REST client.
- * @param {Array} issueReferences - Array of support references.
+ * @param {GitHub} octokit              - Initialized Octokit REST client.
+ * @param {Array} issueReferences       - Array of support references.
+ * @param {Array} issueComments         - Array of all comments on that issue.
  */
-async function createOrUpdateComment( payload, octokit, issueReferences ) {
+async function createOrUpdateComment( payload, octokit, issueReferences, issueComments ) {
 	const { issue, repository } = payload;
 	const { number } = issue;
 	const { name: repo, owner } = repository;
@@ -114,7 +111,7 @@ async function createOrUpdateComment( payload, octokit, issueReferences ) {
 		body: comment,
 	};
 
-	const existingComment = await getListComment( octokit, ownerLogin, repo, number );
+	const existingComment = await getListComment( issueComments );
 
 	// If there is a comment already, update it.
 	if ( existingComment !== 0 ) {
@@ -146,10 +143,11 @@ async function gatherSupportReferences( payload, octokit ) {
 	const { number } = issue;
 	const { name: repo, owner } = repository;
 
-	const issueReferences = await getIssueReferences( octokit, owner, repo, number );
+	const issueComments = await getComments( octokit, owner.login, repo, number );
+	const issueReferences = await getIssueReferences( octokit, owner, repo, number, issueComments );
 	if ( issueReferences.length > 0 ) {
 		debug( `gather-support-references: Found ${ issueReferences.length } references.` );
-		await createOrUpdateComment( payload, octokit, issueReferences );
+		await createOrUpdateComment( payload, octokit, issueReferences, issueComments );
 	}
 }
 

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -44,7 +44,7 @@ async function getIssueReferences( octokit, owner, repo, number, issueComments )
 	debug( `gather-support-references: Getting references from comments.` );
 	issueComments.map( comment => {
 		if (
-			comment.user.login !== 'github-actions[bot]' &&
+			comment.user.login !== 'github-actions[bot]' ||
 			! comment.body.includes( '**Support References**' )
 		) {
 			ticketReferences.push( ...comment.body.matchAll( referencesRegexP ) );

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -109,31 +109,20 @@ async function createOrUpdateComment( payload, octokit, issueReferences, issueCo
 		// First, build a list of all references and whether they are checked or not.
 		const listWithStatusMatch = existingComment.body.matchAll( /^-\s\[x\]\s(\S+)/gm );
 
-		// Build a new array with only checked ticket references.
-		const checkedList = [];
+		// Extract the checked ticket references.
+		const checkedRefs = new Set();
 		for ( const referenceStatus of listWithStatusMatch ) {
-			checkedList.push( referenceStatus[ 1 ] );
+			checkedRefs.add( referenceStatus[ 1 ] );
 		}
-
-		// Remove checked tickets from our existing list of issue references.
-		const uncheckedList = issueReferences.filter(
-			reference => ! checkedList.includes( reference )
-		);
 
 		// Build our comment body, with first the checked references, then the unchecked references.
 		const updatedComment = `**Support References**
-${ checkedList
+${ issueReferences
 	.map(
-		checkedTicket => `
-- [x] ${ checkedTicket }`
+		reference => `
+- [${ checkedRefs.has( reference ) ? 'x' : ' ' }] ${ reference }`
 	)
-	.join( '' ) }${ uncheckedList
-			.map(
-				uncheckedTicket => `
-- [ ] ${ uncheckedTicket }`
-			)
-			.join( '' ) }
-
+	.join( '' ) }
 `;
 
 		await octokit.rest.issues.updateComment( {

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -108,10 +108,10 @@ async function createOrUpdateComment( payload, octokit, issueReferences ) {
 	const ownerLogin = owner.login;
 
 	const comment = `**Support References**
-
 	${ issueReferences.map(
-		reference => `- [ ] ${ reference }
-	`
+		reference => `
+- [ ] ${ reference }
+`
 	) }
 
 	`;

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -1,0 +1,164 @@
+const debug = require( '../../debug' );
+
+/* global GitHub, WebhookPayloadIssue */
+
+/**
+ * Search for a previous comment from this task in our issue.
+ *
+ * @param {GitHub} octokit - Initialized Octokit REST client.
+ * @param {string} owner   - Repository owner.
+ * @param {string} repo    - Repository name.
+ * @param {string} number  - Issue number.
+ * @returns {Promise<number>} Promise resolving to a number.
+ */
+async function getListComment( octokit, owner, repo, number ) {
+	let commentID = 0;
+
+	debug( `gather-support-references: Looking for a previous comment from this task in our issue.` );
+
+	for await ( const response of octokit.paginate.iterator( octokit.rest.issues.listComments, {
+		owner,
+		repo,
+		issue_number: +number,
+	} ) ) {
+		response.data.map( comment => {
+			if (
+				comment.user.login === 'github-actions[bot]' &&
+				comment.body.includes( '**Support References**' )
+			) {
+				commentID = comment.id;
+			}
+		} );
+	}
+
+	return commentID;
+}
+
+/**
+ * Scan the contents of the issue as well as all its comments, get all support references, and add them to an array of references.
+ *
+ * @param {GitHub} octokit - Initialized Octokit REST client.
+ * @param {string} owner   - Repository owner.
+ * @param {string} repo    - Repository name.
+ * @param {string} number  - Issue number.
+ * @returns {Promise<Array>} Promise resolving to an array.
+ */
+async function getIssueReferences( octokit, owner, repo, number ) {
+	const ticketReferences = [];
+	const supportIds = [];
+	const referencesRegexP = /[0-9]*-(?:chat|hc|zen|zd)/gim;
+
+	debug( `gather-support-references: Getting references from comments.` );
+	for await ( const response of octokit.paginate.iterator( octokit.rest.issues.listComments, {
+		owner,
+		repo,
+		issue_number: +number,
+	} ) ) {
+		response.data.map( comment => {
+			ticketReferences.push( ...comment.body.matchAll( referencesRegexP ) );
+		} );
+	}
+
+	debug( `gather-support-references: Getting references from issue body.` );
+	const {
+		data: { body },
+	} = await octokit.rest.issues.get( {
+		owner: owner.login,
+		repo,
+		issue_number: +number,
+	} );
+	ticketReferences.push( ...body.matchAll( referencesRegexP ) );
+
+	// Buid a first array with only the support IDs we've collected.
+	ticketReferences.map( reference => {
+		supportIds.push( reference[ 0 ] );
+	} );
+
+	// That array can still include duplicates, or references that are not formatted quite properly.
+	// Let's build a final array with unique and correct support IDs.
+	const correctedSupportIds = [];
+	supportIds.map( supportId => {
+		// xxx-zen and xxx-hc are the preferred formats for tickets and chats.
+		// xxx-zd and xxx-chat, as well as uppercase versions, are considered as alternate versions.
+		const wrongId = supportId.match( /([0-9]*)-(zd|chat)/i );
+		if ( wrongId ) {
+			const correctedId = `${ wrongId[ 1 ] }-${ wrongId[ 2 ] === 'zd' ? 'zen' : 'hc' }`;
+			if ( ! correctedSupportIds.includes( correctedId ) ) {
+				correctedSupportIds.push( correctedId );
+			}
+		} else if ( ! correctedSupportIds.includes( supportId.toLowerCase() ) ) {
+			correctedSupportIds.push( supportId.toLowerCase() );
+		}
+	} );
+
+	return correctedSupportIds;
+}
+
+/**
+ * Creates or updates a comment on PR.
+ *
+ * @param {WebhookPayloadIssue} payload - Pull request event payload.
+ * @param {GitHub} octokit - Initialized Octokit REST client.
+ * @param {Array} issueReferences - Array of support references.
+ */
+async function createOrUpdateComment( payload, octokit, issueReferences ) {
+	const { issue, repository } = payload;
+	const { number } = issue;
+	const { name: repo, owner } = repository;
+	const ownerLogin = owner.login;
+
+	const comment = `**Support References**
+
+	${ issueReferences.map(
+		reference => `- [ ] ${ reference }
+	`
+	) }
+
+	`;
+
+	const commentOpts = {
+		owner: ownerLogin,
+		repo,
+		body: comment,
+	};
+
+	const existingComment = await getListComment( octokit, ownerLogin, repo, number );
+
+	// If there is a comment already, update it.
+	if ( existingComment !== 0 ) {
+		debug(
+			`gather-support-references: update comment ID ${ existingComment } with our new list of references.`
+		);
+		await octokit.rest.issues.updateComment( {
+			...commentOpts,
+			comment_id: +existingComment,
+		} );
+	} else {
+		// If no comment was published before, publish one now.
+		debug( `gather-support-references: Posting comment to issue #${ number }` );
+		await octokit.rest.issues.createComment( {
+			...commentOpts,
+			issue_number: +number,
+		} );
+	}
+}
+
+/**
+ * Post or update a comment with a to-do list of all support references on that issue.
+ *
+ * @param {WebhookPayloadIssue} payload - Issue or issue comment event payload.
+ * @param {GitHub}              octokit - Initialized Octokit REST client.
+ */
+async function gatherSupportReferences( payload, octokit ) {
+	const { issue, repository } = payload;
+	const { number } = issue;
+	const { name: repo, owner } = repository;
+
+	const issueReferences = await getIssueReferences( octokit, owner, repo, number );
+	if ( issueReferences.length > 0 ) {
+		debug( `gather-support-references: Found ${ issueReferences.length } references.` );
+		await createOrUpdateComment( payload, octokit, issueReferences );
+	}
+}
+
+module.exports = gatherSupportReferences;

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -50,7 +50,7 @@ async function getIssueReferences( octokit, owner, repo, number ) {
 
 	debug( `gather-support-references: Getting references from comments.` );
 	for await ( const response of octokit.paginate.iterator( octokit.rest.issues.listComments, {
-		owner,
+		owner: owner.login,
 		repo,
 		issue_number: +number,
 	} ) ) {

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -41,7 +41,6 @@ async function getListComment( issueComments ) {
  */
 async function getIssueReferences( octokit, owner, repo, number, issueComments ) {
 	const ticketReferences = [];
-	const supportIds = [];
 	const referencesRegexP = /[0-9]*-(?:chat|hc|zen|zd)/gim;
 
 	debug( `gather-support-references: Getting references from issue body.` );
@@ -64,15 +63,11 @@ async function getIssueReferences( octokit, owner, repo, number, issueComments )
 		}
 	} );
 
-	// Buid a first array with only the support IDs we've collected.
-	ticketReferences.map( reference => {
-		supportIds.push( reference[ 0 ] );
-	} );
-
-	// That array can still include duplicates, or references that are not formatted quite properly.
-	// Let's build a final array with unique and correct support IDs.
+	// Let's build a array with unique and correct support IDs, formatted properly.
 	const correctedSupportIds = new Set();
-	supportIds.map( supportId => {
+	ticketReferences.map( reference => {
+		const supportId = reference[ 0 ];
+
 		// xxx-zen and xxx-hc are the preferred formats for tickets and chats.
 		// xxx-zd and xxx-chat, as well as uppercase versions, are considered as alternate versions.
 		const wrongId = supportId.match( /([0-9]*)-(zd|chat)/i );

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -44,16 +44,6 @@ async function getIssueReferences( octokit, owner, repo, number, issueComments )
 	const supportIds = [];
 	const referencesRegexP = /[0-9]*-(?:chat|hc|zen|zd)/gim;
 
-	debug( `gather-support-references: Getting references from comments.` );
-	issueComments.map( comment => {
-		if (
-			comment.user.login !== 'github-actions[bot]' ||
-			! comment.body.includes( '**Support References**' )
-		) {
-			ticketReferences.push( ...comment.body.matchAll( referencesRegexP ) );
-		}
-	} );
-
 	debug( `gather-support-references: Getting references from issue body.` );
 	const {
 		data: { body },
@@ -63,6 +53,16 @@ async function getIssueReferences( octokit, owner, repo, number, issueComments )
 		issue_number: +number,
 	} );
 	ticketReferences.push( ...body.matchAll( referencesRegexP ) );
+
+	debug( `gather-support-references: Getting references from comments.` );
+	issueComments.map( comment => {
+		if (
+			comment.user.login !== 'github-actions[bot]' ||
+			! comment.body.includes( '**Support References**' )
+		) {
+			ticketReferences.push( ...comment.body.matchAll( referencesRegexP ) );
+		}
+	} );
 
 	// Buid a first array with only the support IDs we've collected.
 	ticketReferences.map( reference => {

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -95,9 +95,9 @@ async function getIssueReferences( octokit, owner, repo, number ) {
 }
 
 /**
- * Creates or updates a comment on PR.
+ * Creates or updates a comment on issue.
  *
- * @param {WebhookPayloadIssue} payload - Pull request event payload.
+ * @param {WebhookPayloadIssue} payload - Issue event payload.
  * @param {GitHub} octokit - Initialized Octokit REST client.
  * @param {Array} issueReferences - Array of support references.
  */

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -108,11 +108,12 @@ async function createOrUpdateComment( payload, octokit, issueReferences ) {
 	const ownerLogin = owner.login;
 
 	const comment = `**Support References**
-	${ issueReferences.map(
-		reference => `
-- [ ] ${ reference }
-`
-	) }
+	${ issueReferences
+		.map(
+			reference => `
+- [ ] ${ reference }`
+		)
+		.join( '' ) }
 
 	`;
 

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -63,22 +63,20 @@ async function getIssueReferences( octokit, owner, repo, number, issueComments )
 
 	// That array can still include duplicates, or references that are not formatted quite properly.
 	// Let's build a final array with unique and correct support IDs.
-	const correctedSupportIds = [];
+	const correctedSupportIds = new Set();
 	supportIds.map( supportId => {
 		// xxx-zen and xxx-hc are the preferred formats for tickets and chats.
 		// xxx-zd and xxx-chat, as well as uppercase versions, are considered as alternate versions.
 		const wrongId = supportId.match( /([0-9]*)-(zd|chat)/i );
 		if ( wrongId ) {
 			const correctedId = `${ wrongId[ 1 ] }-${ wrongId[ 2 ] === 'zd' ? 'zen' : 'hc' }`;
-			if ( ! correctedSupportIds.includes( correctedId ) ) {
-				correctedSupportIds.push( correctedId );
-			}
-		} else if ( ! correctedSupportIds.includes( supportId.toLowerCase() ) ) {
-			correctedSupportIds.push( supportId.toLowerCase() );
+			correctedSupportIds.add( correctedId );
+		} else {
+			correctedSupportIds.add( supportId.toLowerCase() );
 		}
 	} );
 
-	return correctedSupportIds;
+	return [ ...correctedSupportIds ];
 }
 
 /**

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/readme.md
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/readme.md
@@ -1,0 +1,9 @@
+# Gather support references
+
+Happiness Engineers can comment on issues to add references to support interactions with customers that would like to be updated whenever the problem is solved.
+
+This task creates a new comment that lists all support references found in all comments on the issue.
+
+## Rationale
+
+Gathering all references into a single, actionable comment makes it easier to follow-up, without having to hunt for ticket references, especially on issues with a large amount of comments.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Gather all support references in the original issue and all comments on the issue.
- Build a list of unique, correct support references from that list of HE-provided references.
- Post that list into a new comment.
- Update that list whenever the issue is updated, reopened, or a new issue comment is created.

**Notes**

- We do not want to update the comment when an issue comment is edited; doing so would stop someone from checking the boxes in that very comment, their changes would get reverted every time.
- We currently support a few support formats, regardless of case: xxx-chat, xxx-hc, xxx-zen, xxx-zd, xxx-zd-woothemes. We do not support references of the following format (yet): hc-xxx, zd-xxx.
- This allows us to tackle the problem #24947 meant to fix, with a different approach.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

Internal references:
- pciE2j-18N-p2
- pcLjiI-QJ-p2#comment-806

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

This will need to be merged before we can test this. You can see this in action in this issue:
https://github.com/jeherve/jetpack/issues/43