### PR TITLE
Search: Fix currency code

### DIFF
--- a/projects/packages/search/changelog/fix-currency-code
+++ b/projects/packages/search/changelog/fix-currency-code
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Change prop key to component for currency code
+Fixed the currency code missing issue for the upsell page

--- a/projects/packages/search/changelog/fix-currency-code
+++ b/projects/packages/search/changelog/fix-currency-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Change prop key to component for currency code

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.16.0",
+	"version": "0.16.1-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.16.0';
+	const VERSION = '0.16.1-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page.jsx
@@ -79,7 +79,7 @@ export default function UpsellPage( { isLoading = false } ) {
 										onCtaClick={ sendToCart }
 										priceAfter={ priceAfter }
 										priceBefore={ priceBefore }
-										pricingCurrencyCode={ priceCurrencyCode }
+										currencyCode={ priceCurrencyCode }
 										title={ __( 'Jetpack Search', 'jetpack-search-pkg' ) }
 									/>
 								</Col>


### PR DESCRIPTION
Fixes #24986 

#### Changes proposed in this Pull Request:
Modify prop key from `pricingCurrencyCode` to `currencyCode` for correct currency code in component `PricingCard`.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
1. Go to a site with only the plugin `Jetpack Search` installed
2. Connect the site to Jetpack, but don't purchase any plan
3. Navigate to URL `/wp-admin/admin.php?page=jetpack-search`
4. Ensure the pricing displaying with the local currency symbol for the user

|  Before   | After  |
|  ----  | ----  |
| ![b](https://user-images.githubusercontent.com/6869813/178511511-a31c2f67-b3ca-4596-a08e-61d424496736.png) | ![f](https://user-images.githubusercontent.com/6869813/178511545-2c28c728-bd33-43a4-b091-4d7fbcbd6136.png) |

