### PR TITLE
E2E tests: remove the Search package build step for Jetpack plugin tests

### DIFF
--- a/projects/plugins/jetpack/changelog/e2e-dont-build-search
+++ b/projects/plugins/jetpack/changelog/e2e-dont-build-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+E2E tests: remove the search package build step

--- a/projects/plugins/jetpack/tests/e2e/package.json
+++ b/projects/plugins/jetpack/tests/e2e/package.json
@@ -14,7 +14,7 @@
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic",
 	"scripts": {
-		"build": "pnpm jetpack build packages/search plugins/jetpack -v --no-pnpm-install --production",
+		"build": "pnpm jetpack build plugins/jetpack -v --no-pnpm-install --production",
 		"clean": "rm -rf output",
 		"config:decrypt": "pnpm test-decrypt-default-config && pnpm test-decrypt-config",
 		"distclean": "rm -rf node_modules",


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

Remove the step building the Search package for Jetpack e2e tests. This step is no longer required since the Search tests were moved to a different project.


#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- All Jetpack plugin e2e tests should still pass

