### PR TITLE
RNA Gridicon: Change `title` to `desc`

### DIFF
--- a/projects/js-packages/components/changelog/fix-grid-icon-description
+++ b/projects/js-packages/components/changelog/fix-grid-icon-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Gridicon: Change title to desc

--- a/projects/js-packages/components/components/gridicon/index.jsx
+++ b/projects/js-packages/components/components/gridicon/index.jsx
@@ -34,49 +34,49 @@ class Gridicon extends Component {
 		return false;
 	}
 
-	getSVGTitle( icon ) {
-		// Enable overriding title with falsy/truthy values.
-		if ( 'title' in this.props ) {
-			return this.props.title ? <title>{ this.props.title }</title> : null;
+	getSVGDescription( icon ) {
+		// Enable overriding desc with falsy/truthy values.
+		if ( 'description' in this.props ) {
+			return this.props.description;
 		}
 
 		switch ( icon ) {
 			default:
-				return null;
+				return '';
 			case 'gridicons-audio':
-				return <title>{ __( 'Has audio.', 'jetpack' ) }</title>;
+				return __( 'Has audio.', 'jetpack' );
 			case 'gridicons-calendar':
-				return <title>{ __( 'Is an event.', 'jetpack' ) }</title>;
+				return __( 'Is an event.', 'jetpack' );
 			case 'gridicons-cart':
-				return <title>{ __( 'Is a product.', 'jetpack' ) }</title>;
+				return __( 'Is a product.', 'jetpack' );
 			case 'chevron-down':
-				return <title>{ __( 'Show filters', 'jetpack' ) }</title>;
+				return __( 'Show filters', 'jetpack' );
 			case 'gridicons-comment':
-				return <title>{ __( 'Matching comment.', 'jetpack' ) }</title>;
+				return __( 'Matching comment.', 'jetpack' );
 			case 'gridicons-cross':
-				return <title>{ __( 'Close.', 'jetpack' ) }</title>;
+				return __( 'Close.', 'jetpack' );
 			case 'gridicons-filter':
-				return <title>{ __( 'Toggle search filters.', 'jetpack' ) }</title>;
+				return __( 'Toggle search filters.', 'jetpack' );
 			case 'gridicons-folder':
-				return <title>{ __( 'Category', 'jetpack' ) }</title>;
+				return __( 'Category', 'jetpack' );
 			case 'gridicons-info':
 			case 'gridicons-info-outline':
-				return <title>{ __( 'Information.', 'jetpack' ) }</title>;
+				return __( 'Information.', 'jetpack' );
 			case 'gridicons-image-multiple':
-				return <title>{ __( 'Has multiple images.', 'jetpack' ) }</title>;
+				return __( 'Has multiple images.', 'jetpack' );
 			case 'gridicons-image':
-				return <title>{ __( 'Has an image.', 'jetpack' ) }</title>;
+				return __( 'Has an image.', 'jetpack' );
 			case 'gridicons-page':
-				return <title>{ __( 'Page', 'jetpack' ) }</title>;
+				return __( 'Page', 'jetpack' );
 			case 'gridicons-post':
-				return <title>{ __( 'Post', 'jetpack' ) }</title>;
+				return __( 'Post', 'jetpack' );
 			case 'gridicons-jetpack-search':
 			case 'gridicons-search':
-				return <title>{ __( 'Magnifying Glass', 'jetpack' ) }</title>;
+				return __( 'Magnifying Glass', 'jetpack' );
 			case 'gridicons-tag':
-				return <title>{ __( 'Tag', 'jetpack' ) }</title>;
+				return __( 'Tag', 'jetpack' );
 			case 'gridicons-video':
-				return <title>{ __( 'Has a video.', 'jetpack' ) }</title>;
+				return __( 'Has a video.', 'jetpack' );
 		}
 	}
 
@@ -236,6 +236,8 @@ class Gridicon extends Component {
 		}
 		iconClass = iconClass.join( ' ' );
 
+		const description = this.getSVGDescription( icon );
+
 		return (
 			<svg
 				className={ iconClass }
@@ -248,7 +250,7 @@ class Gridicon extends Component {
 				xmlns="http://www.w3.org/2000/svg"
 				aria-hidden={ this.props[ 'aria-hidden' ] }
 			>
-				{ this.getSVGTitle( icon ) }
+				{ description ? <desc>{ description }</desc> : null }
 				{ this.renderIcon( icon ) }
 			</svg>
 		);

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.16.7",
+	"version": "0.16.8-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
Using `title` inside `svg` goes against [W3C](https://www.w3.org/TR/html401/struct/global.html#h-7.4.2).

#### Changes proposed in this Pull Request:
* Change `<title/>` to `<desc />`.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

* Start Storybook by running `cd projects/js-packages/storybook && pnpm run storybook:dev`
* Go to `Gridicon` story.
* Confirm that you see `<desc />` tag instead of `<title />`.


| BEFORE | AFTER |
| - | - |
| <img width="956" alt="Screenshot 2022-07-13 at 4 00 57 PM" src="https://user-images.githubusercontent.com/18226415/178713977-4ae0e84e-01da-42ee-8cb8-2760e8859b26.png"> | <img width="951" alt="Screenshot 2022-07-13 at 4 02 03 PM" src="https://user-images.githubusercontent.com/18226415/178713832-cd3de324-47a8-4065-9cab-a49fae3fb220.png"> |

