### PR TITLE
Jetpack: replace the fallback thumbnail with a Loading element

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-vpblock-remove-thumbnail-fallback
+++ b/projects/plugins/jetpack/changelog/update-jetpack-vpblock-remove-thumbnail-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: replace fallback thumbail by a Loading element

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
@@ -72,8 +72,8 @@ export default function VideoPressPlayer( {
 
 	const style = {};
 	if ( temporaryHeight !== 'auto' ) {
-		style.height = temporaryHeight;
-		style.paddingBottom = 12;
+		style.height = temporaryHeight || 200;
+		style.paddingBottom = temporaryHeight ? 12 : 0;
 	}
 
 	return (

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
@@ -12,7 +12,6 @@ export default function VideoPressPlayer( {
 	attributes,
 	setAttributes,
 	scripts = [],
-	thumbnail,
 	preview,
 } ) {
 	const ref = useRef();
@@ -94,11 +93,7 @@ export default function VideoPressPlayer( {
 				{ ! isSelected && <div className="jetpack-videopress-player__overlay" /> }
 				<div className="jetpack-videopress-player__wrapper" ref={ ref } style={ style }>
 					<SandBox html={ html } scripts={ scripts } />
-					<img
-						src={ thumbnail }
-						alt={ __( 'Video thumbnail', 'jetpack' ) }
-						className="jetpack-videopress-player__thumbnail"
-					/>
+					<div className="jetpack-videopress-player__loading">{ __( 'Loading…', 'jetpack' ) }</div>
 				</div>
 			</ResizableBox>
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/editor.scss
@@ -27,13 +27,22 @@
 			z-index: 1;
 		}
 
-		img.jetpack-videopress-player__thumbnail {
+		.jetpack-videopress-player__loading {
 			object-fit: cover;			
 			position: absolute;
 			z-index: 0;
 			top: 0;
 			left: 0;
 			width: 100%;
+			height: 100%;
+			display: flex;
+			justify-content: center;
+			align-items: center;
+			font-size: 13px;
+			animation-name: fadeIn;
+			animation-duration: 0.5s;
+			animation-direction: alternate;
+			animation-iteration-count: infinite;
 		}
 	}
 }
@@ -50,4 +59,9 @@
 	.components-placeholder__fieldset {
 		min-height: 82px;
 	}
+}
+
+@keyframes fadeIn {
+    from { opacity: 0.2; }
+    to   { opacity: 0.8; }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR replaces the fallback image that the block shows when the preview is ready with a "Loading..." static element. It results less intrusive and more solid in terms of UX.
The next follow-up PR will hide the loading element when the video is ready.

Spoiler alert: the PR removes an attribute breaking the block. Expected.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack: replace the fallback thumbnail with a Loading element

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Block editor
* Upload a new video
* Pay attention to the "Loading ..." element


https://user-images.githubusercontent.com/77539/178784385-6994d46e-5378-4ab5-bb75-49871ec9fad0.mov



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202594505483442