### PR TITLE
Fix Jetpack Protect admin toolbar icon display

### DIFF
--- a/projects/plugins/protect/changelog/fix-protect-admin-toolbar-icon-display
+++ b/projects/plugins/protect/changelog/fix-protect-admin-toolbar-icon-display
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix protect admin toolbar icon display when Jetpack enabled and connected

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -217,7 +217,7 @@ class Jetpack_Protect {
 		if ( $total > 0 ) {
 			$args = array(
 				'id'    => 'jetpack-protect',
-				'title' => '<span class="ab-icon noticon jp-protect-icon"></span><span class="ab-label">' . $total . '</span>',
+				'title' => '<span class="ab-icon jp-protect-icon"></span><span class="ab-label">' . $total . '</span>',
 				'href'  => admin_url( 'admin.php?page=jetpack-protect' ),
 				'meta'  => array(
 					// translators: %d is the number of vulnerabilities found.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
- When Jetpack Protect has identified vulnerabilities, an associated icon is displayed in the WordPress toolbar specifying the number currently found. When the Jetpack plugin is installed/activated and effectively connected to WordPress.com, the display of the Jetpack Protect icon is negatively affected.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Remove the `noticon` class from the Jetpack Protect admin toolbar icon element that is causing the conflict.

#### Other information:

- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- 1201069996155224-as-1202599243120010

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a test site with Jetpack installed/active and connected to WordPress.com, install the [Jetpack Beta Tester](https://jetpack.com/download-jetpack-beta/) plugin
* Install a plugin that contains a known vulnerability for testing (eg. WooCommerce v3.0.0 [here](https://wordpress.org/plugins/woocommerce/advanced/))
* Activate Jetpack Protect and visit **Jetpack > Protect** in `wp-admin` to generate a status report
* Verify that the vulnerability was identified and that the associated Protect icon displays incorrectly in the admin toolbar
* Proceed to **Jetpack > Jetpack Beta** in `wp-admin` and select the `Manage` button next to Jetpack Protect
* Search for and activate this Feature Branch for testing 
* Verify that the Jetpack Protect icon now displays correctly in the admin toolbar

