### PR TITLE
Jetpack: handle VPBlock loading state listening the VideoPress API events

### DIFF
--- a/projects/plugins/jetpack/changelog/update-my-jetpack-vpblock-improve-getting-video-player-ux
+++ b/projects/plugins/jetpack/changelog/update-my-jetpack-vpblock-improve-getting-video-player-ux
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: handle Loading state listeging vp events

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
@@ -66,8 +66,17 @@ export default function VideoPressPlayer( {
 			return setTemporaryHeight( 'auto' );
 		}
 
+		if ( ! videoRatio ) {
+			return;
+		}
+
 		// When no preview is available, set the height of the video.
 		setTemporaryHeight( ( ref.current.offsetWidth * videoRatio ) / 100 );
+
+		setTimeout( () => {
+			// HACK: recalculated in case the sidebar is opened.
+			setTemporaryHeight( ( ref.current.offsetWidth * videoRatio ) / 100 );
+		}, 0 );
 
 		/*
 		 * Also, when no preview, consider the video is no loaded yet.

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
@@ -5,6 +5,10 @@ import { RichText } from '@wordpress/block-editor';
 import { ResizableBox, SandBox } from '@wordpress/components';
 import { useCallback, useRef, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import debugFactory from 'debug';
+/**
+ * Internal dependencies
+ */
 import vpBlockBridge from '../../scripts/vp-block-bridge';
 
 // Global scripts array to be run in the Sandbox context.
@@ -24,6 +28,9 @@ if ( window.videopressAjax ) {
 		window.videopressAjax.bridgeUrl
 	);
 }
+
+// Define a debug instance for block bridge.
+window.debugBridgeInstance = debugFactory( 'jetpack:vp-block:bridge' );
 
 // Load VideoPressBlock bridge script.
 globalScripts.push( vpBlockBridge );

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
@@ -74,7 +74,7 @@ export default function VideoPressPlayer( {
 		setTemporaryHeight( ( ref.current.offsetWidth * videoRatio ) / 100 );
 
 		setTimeout( () => {
-			// HACK: recalculated in case the sidebar is opened.
+			// Recalculated in case the sidebar is opened.
 			setTemporaryHeight( ( ref.current.offsetWidth * videoRatio ) / 100 );
 		}, 0 );
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
@@ -118,7 +118,11 @@ export default function VideoPressPlayer( {
 				{ ! isSelected && <div className="jetpack-videopress-player__overlay" /> }
 				<div className="jetpack-videopress-player__wrapper" ref={ ref } style={ style }>
 					<SandBox html={ html } scripts={ [ ...globalScripts, ...scripts ] } />
-					<div className="jetpack-videopress-player__loading">{ __( 'Loading…', 'jetpack' ) }</div>
+					{ temporaryHeight !== 'auto' && (
+						<div className="jetpack-videopress-player__loading">
+							{ __( 'Loading…', 'jetpack' ) }
+						</div>
+					) }
 				</div>
 			</ResizableBox>
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
@@ -5,6 +5,7 @@ import { RichText } from '@wordpress/block-editor';
 import { ResizableBox, SandBox } from '@wordpress/components';
 import { useCallback, useRef, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import vpBlockBridge from '../../scripts/vp-block-bridge';
 
 // Global scripts array to be run in the Sandbox context.
 const globalScripts = [];
@@ -23,6 +24,9 @@ if ( window.videopressAjax ) {
 		window.videopressAjax.bridgeUrl
 	);
 }
+
+// Load VideoPressBlock bridge script.
+globalScripts.push( vpBlockBridge );
 
 export default function VideoPressPlayer( {
 	html,

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
@@ -50,7 +50,7 @@ export default function VideoPressPlayer( {
 	 * Temporary height is used to set the height of the video
 	 * as soon as the block is rendered into the canvas,
 	 * while the preview fetching process is happening,
-	 * trying to remove the flicker effect.
+	 * trying to reduce the flicker effectas much as possible
 	 *
 	 * Once the preview is fetched, the temporary heihgt is ignored.
 	 */
@@ -60,16 +60,24 @@ export default function VideoPressPlayer( {
 			return;
 		}
 
-		if ( temporaryHeight === 'auto' ) {
+		if ( preview ) {
 			return;
 		}
 
-		if ( preview ) {
-			return setTemporaryHeight( 'auto' );
-		}
-
+		// When no preview is available, set the height of the video.
 		setTemporaryHeight( ( ref.current.offsetWidth * videoRatio ) / 100 );
-	}, [ ref, setTemporaryHeight, temporaryHeight, videoRatio, preview ] );
+	}, [ ref, videoRatio, preview ] );
+
+	useEffect( () => {
+		window.addEventListener( 'onVideoPressLoadingState', ( { detail } ) => {
+			const { state } = detail;
+
+			// Once the video is loaded, delegate the height to the player (iFrame)
+			setTemporaryHeight(
+				state !== 'loaded' ? ( ref.current.offsetWidth * videoRatio ) / 100 : 'auto'
+			);
+		} );
+	}, [ videoRatio ] );
 
 	const onBlockResize = useCallback(
 		( event, direction, domElement ) => {

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
@@ -50,7 +50,7 @@ export default function VideoPressPlayer( {
 	 * Temporary height is used to set the height of the video
 	 * as soon as the block is rendered into the canvas,
 	 * while the preview fetching process is happening,
-	 * trying to reduce the flicker effects much as possible
+	 * trying to reduce the flicker effects as much as possible
 	 *
 	 * Once the preview is fetched, the temporary heihgt is ignored.
 	 */

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
@@ -6,6 +6,24 @@ import { ResizableBox, SandBox } from '@wordpress/components';
 import { useCallback, useRef, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
+// Global scripts array to be run in the Sandbox context.
+const globalScripts = [];
+
+// Populate scripts array with videopresAjaxURLBlob blobal var.
+if ( window.videopressAjax ) {
+	const videopresAjaxURLBlob = new Blob(
+		[ `var videopressAjax = ${ JSON.stringify( window.videopressAjax ) };` ],
+		{
+			type: 'text/javascript',
+		}
+	);
+
+	globalScripts.push(
+		URL.createObjectURL( videopresAjaxURLBlob ),
+		window.videopressAjax.bridgeUrl
+	);
+}
+
 export default function VideoPressPlayer( {
 	html,
 	isSelected,
@@ -58,18 +76,6 @@ export default function VideoPressPlayer( {
 		[ setAttributes ]
 	);
 
-	// Populate scripts array with videopresAjaxURLBlob blobal var.
-	if ( window.videopressAjax ) {
-		const videopresAjaxURLBlob = new Blob(
-			[ `var videopressAjax = ${ JSON.stringify( window.videopressAjax ) };` ],
-			{
-				type: 'text/javascript',
-			}
-		);
-
-		scripts.push( URL.createObjectURL( videopresAjaxURLBlob ), window.videopressAjax.bridgeUrl );
-	}
-
 	const style = {};
 	if ( temporaryHeight !== 'auto' ) {
 		style.height = temporaryHeight || 200;
@@ -92,7 +98,7 @@ export default function VideoPressPlayer( {
 			>
 				{ ! isSelected && <div className="jetpack-videopress-player__overlay" /> }
 				<div className="jetpack-videopress-player__wrapper" ref={ ref } style={ style }>
-					<SandBox html={ html } scripts={ scripts } />
+					<SandBox html={ html } scripts={ [ ...globalScripts, ...scripts ] } />
 					<div className="jetpack-videopress-player__loading">{ __( 'Loading…', 'jetpack' ) }</div>
 				</div>
 			</ResizableBox>

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
@@ -50,7 +50,7 @@ export default function VideoPressPlayer( {
 	 * Temporary height is used to set the height of the video
 	 * as soon as the block is rendered into the canvas,
 	 * while the preview fetching process is happening,
-	 * trying to reduce the flicker effectas much as possible
+	 * trying to reduce the flicker effects much as possible
 	 *
 	 * Once the preview is fetched, the temporary heihgt is ignored.
 	 */

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/Readme.md
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/Readme.md
@@ -1,6 +1,6 @@
 # VideoPress Block bridge
 
-This library escentially provides a way to connect events and methods defined by the videopress player from/to the VideoPress block.
+This library essentially provides a way to connect events and methods defined by the Video Press player API from/to the VideoPress block.
 
 ## Background
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/Readme.md
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/Readme.md
@@ -1,0 +1,98 @@
+# VideoPress Block bridge
+
+This library escentially provides a way to connect events and methods defined by the videopress player from/to the VideoPress block.
+
+## Background
+
+### How the player is rendered
+
+From the PoV of the edit component of the VPBlock, the first step to implement the player is getting the raw HTML code provided by the VideoPress server via the `getEmbedPreview()` embed core-data selector.
+It's HTML code that basically defines an iFrame element with relevant attributes about the video.
+
+```jsx
+const preview = useSelect(
+	select => select( coreStore ).getEmbedPreview( videoPressUrl ),
+	[ videoPressUrl ]
+);
+
+const { html } = preview;
+```
+
+Once the code gets, it's rendered via creating a Sandbox instance where the code to process is defined via the HTML property mentioned above:
+
+```jsx
+<Sandbox html={ videoPlayerHtml } />
+```
+
+The most relevant thing to raise up here is the fact the video player is rendered into two nested iFrames levels. The <Sandbox /> component does one, and the other is provided by the VideoPress player API.
+
+### Connect the block with the player
+
+The VideoPress player API triggers events to its `window` object and its `window parent` object when they are different to communicate the video with the consumer, in our case, the VideoPress block.
+
+However, it doesn't connect with the `top` object reference meaning that if the player is nested via iFrames in more than two levels, it won't be possible to connect with the player from the higher level.
+
+Funnily, it happens in the our scenario of the block editor: It renders the raw HTML provided by VideoPress (which is an iFrame) via the Sandbox (which uses an iFrame too), producing the structure of the following elements:
+
+```html
+<div class="wp-block wp-block-jetpack-videopress">
+	<iframe class="components-sandbox">
+		#document
+			// ...
+			<iframe src"<videopress-embed-url>">
+				#document
+					//...
+					<video src="<video-source>" />
+			</iframe>
+	</iframe>
+</div>
+```
+
+### Solution
+
+This bridge script listens and re-emits the events, communicating the VideoPress player with the VideoPress Block. It's sent to the child iFrame through the `scripts` property of the Sandbox component, which takes over to run it in that context.
+
+```jsx
+import { SandBox } from '@wordpress/components';
+import vpBlockBridge from './scripts/vp-block-bridge';
+
+<Sandbox html={ videoPlayerHtml } scritps=[ vpBlockBridge ] />
+```
+
+## Bridge API
+
+```jsx
+import vpBlockBridge from './scripts/vp-block-bridge';
+
+function VPBlockEdit() {
+	useEffect( () => {
+		window.addEventListener( 'onVideoPressPlaying', event => {
+			console.log( 'video is playing...' );
+		} );
+	}, [] );
+
+	return (
+		<Sandbox html={ embedHtml } scritps={ [ vpBlockBridge ] } />
+	);
+}
+```
+
+### Events
+
+The bridge triggers the following custom events:
+
+#### onVideoPressProgress
+
+#### onVideoPressLoadingState
+
+#### onVideoPressPlaying
+
+#### onVideoPressPause
+
+#### onVideoPressPeeking
+
+#### onVideoPressResize
+
+#### onVideoPressVolumechange
+
+#### onVideoPressEnded

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/Readme.md
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/Readme.md
@@ -96,3 +96,13 @@ The bridge triggers the following custom events:
 #### onVideoPressVolumechange
 
 #### onVideoPressEnded
+
+## Debug
+
+To debug the bridge actions you'd like to create a debug instance stored in the `debugBridgeInstance` window property:
+
+```es6
+import debugFactory from 'debug';
+
+window.debugBridgeInstance = debugFactory( 'jetpack:vp-block:bridge' );
+```

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/Readme.md
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/Readme.md
@@ -81,21 +81,32 @@ function VPBlockEdit() {
 
 The bridge triggers the following custom events:
 
-#### onVideoPressProgress
-
-#### onVideoPressLoadingState
-
 #### onVideoPressPlaying
 
 #### onVideoPressPause
 
-#### onVideoPressPeeking
+#### onVideoPressSeeking
 
 #### onVideoPressResize
 
-#### onVideoPressVolumechange
+#### onVideoPressVolumeChange
 
 #### onVideoPressEnded
+
+#### onVideoPressTimeUpdate
+
+#### onVideoPressDurationChange
+
+#### onVideoPressProgress
+
+#### onVideoPressLoadingState
+
+### Actions
+
+#### vpBlockActionPlay
+
+#### vpBlockActionPause
+#### vpBlockActionPause
 
 ## Debug
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/Readme.md
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/Readme.md
@@ -106,6 +106,7 @@ The bridge triggers the following custom events:
 #### vpBlockActionPlay
 
 #### vpBlockActionPause
+
 #### vpBlockActionPause
 
 ## Debug

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/index.js
@@ -15,28 +15,36 @@ const rawScript = `
 
 		// Allowed events emitted by the videopress API.
 		const videoPressEventsMap = {
-			'playing': {
+			'videopress_playing': {
 				name: 'onVideoPressPlaying',
 				type: 'event',
 			},
-			'pause': {
+			'videopress_pause': {
 				name: 'onVideoPressPause',
 				type: 'event',
 			},
-			'seeking': {
+			'videopress_seeking': {
 				name: 'onVideoPressSeeking',
 				type: 'event',
 			},
-			'resize': {
+			'videopress_resize': {
 				name: 'onVideoPressResize',
 				type: 'event',
 			},
-			'volumechange': {
+			'videopress_volumechange': {
 				name: 'onVideoPressVolumeChange',
 				type: 'event',
 			},
-			'ended': {
+			'videopress_ended': {
 				name: 'onVideoPressEnded',
+				type: 'event',
+			},
+			'videopress_timeupdate': {
+				name: 'onVideoPressTimeUpdate',
+				type: 'event',
+			},
+			'videopress_durationchange': {
+				name: 'onVideoPressDurationChange',
 				type: 'event',
 			},
 			'videopress_progress': {
@@ -47,7 +55,10 @@ const rawScript = `
 				name: 'onVideoPressLoadingState',
 				type: 'event',
 			},
-
+			videopress_toggle_fullscreen: {
+				name: 'onVideoPressToggleFullscreen',
+				type: 'event',
+			},
 			'vpblock_action_play': {
 				name: 'vpBlockActionPlay',
 				type: 'action',
@@ -70,6 +81,7 @@ const rawScript = `
 		window.addEventListener( 'message', ( ev ) => {
 			const { data } = ev;
 			const eventName = data.event;
+			console.log( 'eventName: ', eventName );
 			if ( ! allowedVideoPressEvents.includes( eventName ) ) {
 				return;
 			}

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/index.js
@@ -7,6 +7,10 @@ const rawScript = `
 		debug( '🌉 🛠 building the bridge' );
 
 		const videoPressIFrame = document.querySelector('iframe');
+		if ( ! videoPressIFrame?.contentWindow ) {
+			return;
+		}
+
 		const videoPressWindow = videoPressIFrame.contentWindow;
 
 		// Allowed events emitted by the videopress API.

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/index.js
@@ -1,0 +1,112 @@
+const rawScript = `
+	if ( ! window?.debug ) {
+		window.debug = window.parent?.debugBridgeInstance ?? ( () => {} );
+	}
+
+	function initWPBlockBridge() {
+		const videoPressIFrame = document.querySelector('iframe');
+		const videoPressWindow = videoPressIFrame.contentWindow;
+
+		// Allowed events emitted by the videopress API.
+		const videoPressEventsMap = {
+			'playing': {
+				name: 'onVideoPressPlaying',
+				type: 'event',
+			},
+			'pause': {
+				name: 'onVideoPressPause',
+				type: 'event',
+			},
+			'seeking': {
+				name: 'onVideoPressSeeking',
+				type: 'event',
+			},
+			'resize': {
+				name: 'onVideoPressResize',
+				type: 'event',
+			},
+			'volumechange': {
+				name: 'onVideoPressVolumeChange',
+				type: 'event',
+			},
+			'ended': {
+				name: 'onVideoPressEnded',
+				type: 'event',
+			},
+			'videopress_progress': {
+				name: 'onVideoPressProgress',
+				type: 'event',
+			},
+			'videopress_loading_state': {
+				name: 'onVideoPressLoadingState',
+				type: 'event',
+			},
+
+			'vpblock_action_play': {
+				name: 'vpBlockActionPlay',
+				type: 'action',
+				videoPressAction: 'videopress_action_play',
+			},
+			'vpblock_action_pause': {
+				name: 'vpBlockActionPause',
+				type: 'action',
+				videoPressAction: 'videopress_action_pause',
+			},
+			'vpblock_action_set_currenttime': {
+				name: 'vpBlockActionPause',
+				type: 'action',
+				videoPressAction: 'videopress_action_set_currenttime',
+			},
+		};
+
+		const allowedVideoPressEvents = Object.keys( videoPressEventsMap );
+
+		window.addEventListener( 'message', ( ev ) => {
+			const { data } = ev;
+			const eventName = data.event;
+			if ( ! allowedVideoPressEvents.includes( eventName ) ) {
+				return;
+			}
+			
+			// Rename event with the 'onVideoPress' prefix.
+			const vpEvent = videoPressEventsMap[ eventName ];
+			const { name: vpEventName, type: vpEventType, videoPressAction } = vpEvent;
+
+			// Dispatch event to top when it's an event
+			if ( vpEventType === 'event' ) {
+				// It preferrs to use the guid instead of the id.
+				const guid = data.id;
+				const originalEventName = data.event;
+	
+				// clean event data object
+				delete data.event;
+				delete data.id;
+	
+				// Emite custom event with the event data.
+				const videoPressBlockEvent = new CustomEvent( vpEventName, {
+					detail: {
+						...data,
+						originalEventName,
+						guid,
+					},
+				} );
+
+				debug( '-> dispatching %o (%o)', originalEventName, eventName );
+
+				window.parent.dispatchEvent( videoPressBlockEvent );
+			}
+
+			if ( vpEventType === 'action' ) {
+				// Overwrite event from -> to
+				data.event = videoPressAction;
+
+				debug( 'recieve %o -> dispatching %o [%o]', eventName, videoPressAction, data );
+				videoPressWindow.postMessage( data, '*' );
+			}
+		} );
+	}
+
+	initWPBlockBridge();
+`;
+
+export default URL.createObjectURL( new Blob( [ rawScript ], { type: 'text/javascript' } ) );

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/index.js
@@ -4,6 +4,8 @@ const rawScript = `
 	}
 
 	function initWPBlockBridge() {
+		debug( '🌉 🛠 building the bridge' );
+
 		const videoPressIFrame = document.querySelector('iframe');
 		const videoPressWindow = videoPressIFrame.contentWindow;
 
@@ -91,7 +93,7 @@ const rawScript = `
 					},
 				} );
 
-				debug( '-> dispatching %o (%o)', originalEventName, eventName );
+				debug( '🌉 %o ➜ %o', originalEventName, vpEventName );
 
 				window.parent.dispatchEvent( videoPressBlockEvent );
 			}
@@ -100,7 +102,7 @@ const rawScript = `
 				// Overwrite event from -> to
 				data.event = videoPressAction;
 
-				debug( 'recieve %o -> dispatching %o [%o]', eventName, videoPressAction, data );
+				debug( '🌉 recieve %o -> dispatching %o [%o]', eventName, videoPressAction, data );
 				videoPressWindow.postMessage( data, '*' );
 			}
 		} );

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/index.js
@@ -81,7 +81,6 @@ const rawScript = `
 		window.addEventListener( 'message', ( ev ) => {
 			const { data } = ev;
 			const eventName = data.event;
-			console.log( 'eventName: ', eventName );
 			if ( ! allowedVideoPressEvents.includes( eventName ) ) {
 				return;
 			}

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/index.js
@@ -97,7 +97,7 @@ const rawScript = `
 					},
 				} );
 
-				debug( '🌉 %o ➜ %o', originalEventName, vpEventName );
+				debug( '🌉 %o [%s] ➜ %o', originalEventName, guid, vpEventName );
 
 				window.parent.dispatchEvent( videoPressBlockEvent );
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The most significant changes here are not UI improvements but the way the block communicates with the VideoPress player. We'd say the UI enhancement is a use case for VPBlock bridge implementation.

## VPBlock bridge

This library essentially provides a way to connect events and methods defined by the Video Press player API from/to the VideoPress block.

The PR has a [doc that explains](https://github.com/Automattic/jetpack/blob/570fded71d2f8348fbed4bc56ad47fbe1ff3f1fb/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/Readme.md) a little bit more about the bridge idea.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack: handle VPBlock loading state listening the VideoPress API events
  * Introduce the vp-block-bridge
  * use this bridge to listening VideoPress API Events
  * listen onVideoPressPlaying to handle the Loading state

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* Go to block editor context
* Open the dev console
* Ensure the activate the `verbose` option there
<img width="182" alt="image" src="https://user-images.githubusercontent.com/77539/178841046-3b142933-ceb2-4b11-ad39-306472daa250.png">

* Set the `debug` namespace with `'jetpack:vp-block*` to see the bridge logs.
```
localStorage.setItem( 'debug', 'jetpack:vp-block*' )
```
* Create a new VP Block
* Upload a video
* Confirm you see the event logs

https://user-images.githubusercontent.com/77539/178972862-7ed50732-881c-428c-8fae-90df61bf5fd7.mov

<img width="531" alt="image" src="https://user-images.githubusercontent.com/77539/178971492-3dd007f0-6b02-4d5f-b3c9-b34483d52f8c.png">

* About the `Loading...` element.
* Confirm it appears when the video is not loaded and disappears once it's loaded.

https://user-images.githubusercontent.com/77539/178972055-24acaa98-cfaf-4860-83ab-f183e357f769.mov




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202594505483457