### PR TITLE
Replace `softprops/turnstyle` with a local rewrite

### DIFF
--- a/.github/actions/turnstile/README.md
+++ b/.github/actions/turnstile/README.md
@@ -1,0 +1,80 @@
+# Turnstile
+
+Ensure that previous runs of the current workflow for the current branch have completed before proceeding with the current run.
+
+## Why?
+
+GitHub Actions has [very limited ability](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency) to control concurrency of workflow or job runs:
+You can have just one pending run that waits for an in-progress run to complete, with any additional submissions cancelling a previous pending run.
+You can optionally cancel the in-progress run when a new run is submitted.
+
+You can't have _multiple_ pending runs queued, as needed for something like building and pushing each commit to a mirror repo where you want to try to preserve the commit history as closely as possible.
+You also can't directly run some initial steps in parallel before engaging the concurrency, although you could use multiple jobs (along with outputs and artifacts) to do it.
+
+## Example
+
+```yaml
+name: Deploy
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build
+        run: npm build
+
+      - name: Wait for earlier in-progress runs so deploys happen in order
+        uses: ./.github/actions/turnstile
+
+      - name: Deploy
+        run: ...
+```
+
+## Usage
+
+```yaml
+- uses: ./.github/actions/turnstile
+  with:
+    # Polling interval, in seconds.
+    poll-interval: 60
+
+    # GitHub access token. Defaults to `github.token`.
+    token: ${{ github.token }}
+```
+
+If you want to limit the maximum amount of time spent waiting, use GitHub's [timeout-minutes](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepstimeout-minutes) on the step. If you want to continue if the timeout expires, use GitHub's [contniue-on-error](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error) on the step.
+
+## How?
+
+Using the current run's run ID, it first hits GitHub's [workflow run API](https://docs.github.com/en/rest/actions/workflow-runs#get-a-workflow-run) to fetch the workflow ID and head branch.
+
+Then it hits the [list workflow runs API](https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs) to fetch up to 100 in-progress runs of the workflow for the branch. If any are returned with a lower run ID number, it sleeps for 60 seconds and repeats.
+
+### Caveats
+
+- If there are somehow more than 100 in-progress runs of the workflow, only the first 100 will be checked.
+- Queued or pending runs will not be waited for.
+- If you re-run a job it reuses the same run ID. Thus it won't wait for later jobs that are already in progress.
+- If you often have many runs waiting on each other, the API calls involved could use up your [rate limit](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting).
+- If your Actions usage is [metered](https://github.com/features/actions#pricing-details) (i.e. you've copied this into a private repo), the time spent waiting will cost you minutes.
+- This is something of a hack. GitHub could do this sort of thing much better if they wanted to.
+
+## Inspiration
+
+This is inspired by https://github.com/softprops/turnstyle, which does much the same thing.
+
+Differences:
+
+- Written in bash rather than js, mainly to avoid requiring an install step.
+- Fewer options.
+- Comprehensive information on the API calls to allow for debugging.
+- More efficient determination of the workflow ID and branch.
+- Token as an input (with default) rather than as an environment variable.

--- a/.github/actions/turnstile/action.yml
+++ b/.github/actions/turnstile/action.yml
@@ -1,0 +1,51 @@
+name: "Turnstile"
+description: "Wait for any previous workflow runs to complete"
+inputs:
+  poll-interval:
+    description: "Polling interval, in seconds."
+    default: 60
+  token:
+    description: "Access token. Defaults to `github.token`."
+    default: ${{ github.token }}
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        INTERVAL: ${{ inputs.poll-interval }}
+        TOKEN: ${{ inputs.token }}
+      run: |
+        echo '::group::Fetch workflow info from run ID'
+        JSON="$(curl -v -L --get \
+          --header "Authorization: token $TOKEN" \
+          --url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+        )"
+        echo "$JSON"
+        jq -e '.workflow_id' <<<"$JSON" &> /dev/null || { echo "🤯 API response does not have .workflow_id"; exit 1; }
+        echo '::endgroup::'
+
+        WORKFLOW_ID="$(jq -r '.workflow_id' <<<"$JSON")"
+        BRANCH="$(jq -r '.head_branch' <<<"$JSON")"
+        echo "Workflow ID: $WORKFLOW_ID"
+        echo "Branch: $BRANCH"
+
+        while true; do
+          echo '::group::Checking for previous runs in progress'
+          JSON="$(curl -v -L --get \
+            --header "Authorization: token $TOKEN" \
+            --url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/workflows/${WORKFLOW_ID}/runs" \
+            --data-urlencode "branch=$BRANCH" \
+            --data-urlencode "status=in_progress" \
+            --data-urlencode "per_page=100" \
+          )"
+          echo "$JSON"
+          jq -e '.workflow_runs | type == "array"' <<<"$JSON" &> /dev/null || { echo "🤯 API response does not have .workflow_runs array"; exit 1; }
+          echo '::endgroup::'
+          RUNS="$(jq -r -e --argjson id "$GITHUB_RUN_ID" '[ .workflow_runs[] | select( .id < $id ) | .html_url ] | join( " " )' <<<"$JSON")"
+          if [[ -z "$RUNS" ]]; then
+            echo '👉 No earlier runs in progress!'
+            break
+          fi
+          echo "✋ Waiting for runs in progress: $RUNS"
+          sleep "$INTERVAL"
+        done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -272,9 +272,7 @@ jobs:
         timeout-minutes: 1  # 2021-01-18: Successful runs seem to take a few seconds
 
       - name: Wait for prior instances of the workflow to finish
-        uses: softprops/turnstyle@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/turnstile
 
       - name: Push changed projects
         uses: ./monorepo/projects/github-actions/push-to-mirrors

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -62,9 +62,7 @@ jobs:
           path: ./pr-checkout
 
       - name: Wait for prior instances of the workflow to finish
-        uses: softprops/turnstyle@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/turnstile
 
       - name: "Run the action (assign, manage milestones, for issues and PRs)"
         uses: ./projects/github-actions/repo-gardening

--- a/.github/workflows/pr-is-up-to-date.yml
+++ b/.github/workflows/pr-is-up-to-date.yml
@@ -64,9 +64,7 @@ jobs:
 
       - name: Wait for prior instances of the workflow to finish
         if: github.event_name == 'push' && github.ref == 'refs/heads/trunk'
-        uses: softprops/turnstyle@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/turnstile
 
       - name: Check whether the tag needs updating for trunk commit
         if: github.event_name == 'push' && github.ref == 'refs/heads/trunk'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We recently had an issue where turnstyle was allowing jobs to run in
parallel, which proved impossible to debug as that action does not log
any details of the API calls.

Also upstream seems unresponsive to PRs.

So, let's reimplement this locally. Not planning on releasing it
publicly at this time, but we could if someone wants it.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1656336776235309/1656308103.612489-slack-CBG1CP4EN
p1656362962222539-slack-C034JEXD1RD

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Copy this into a test repo somewhere, use it in a workflow that takes a bit to complete, and trigger that workflow multiple times in quick succession. See that the later runs waited appropriately.
  * Or look where I did that: [1](https://github.com/anomiex/testing/runs/7344435614?check_suite_focus=true) [2](https://github.com/anomiex/testing/runs/7344442846?check_suite_focus=true) [3](https://github.com/anomiex/testing/runs/7344445665?check_suite_focus=true) [4](https://github.com/anomiex/testing/runs/7344719477?check_suite_focus=true)