### PR TITLE
Protect: Fix PHP notices by adding report data property checks

### DIFF
--- a/projects/plugins/protect/changelog/fix-protect-report-data-property-checks
+++ b/projects/plugins/protect/changelog/fix-protect-report-data-property-checks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Minor bug fix - added isset() checks for report data properties

--- a/projects/plugins/protect/src/class-status.php
+++ b/projects/plugins/protect/src/class-status.php
@@ -301,12 +301,14 @@ class Status {
 	 */
 	private static function normalize_report_data( $report_data ) {
 		$installed_plugins    = Plugins_Installer::get_plugins();
-		$report_data->plugins = self::merge_installed_and_checked_lists( $installed_plugins, $report_data->plugins, array( 'type' => 'plugin' ) );
+		$last_report_plugins  = isset( $report_data->plugins ) ? $report_data->plugins : new stdClass();
+		$report_data->plugins = self::merge_installed_and_checked_lists( $installed_plugins, $last_report_plugins, array( 'type' => 'plugin' ) );
 
 		$installed_themes    = Sync_Functions::get_themes();
-		$report_data->themes = self::merge_installed_and_checked_lists( $installed_themes, $report_data->themes, array( 'type' => 'theme' ) );
+		$last_report_themes  = isset( $report_data->themes ) ? $report_data->themes : new stdClass();
+		$report_data->themes = self::merge_installed_and_checked_lists( $installed_themes, $last_report_themes, array( 'type' => 'theme' ) );
 
-		$report_data->core = self::normalize_core_information( $report_data->core );
+		$report_data->core = self::normalize_core_information( isset( $report_data->core ) ? $report_data->core : new stdClass() );
 
 		$all_items       = array_merge( $report_data->plugins, $report_data->themes, array( $report_data->core ) );
 		$unchecked_items = array_filter(

--- a/projects/plugins/protect/src/class-status.php
+++ b/projects/plugins/protect/src/class-status.php
@@ -392,7 +392,7 @@ class Status {
 		global $wp_version;
 
 		$core = new \stdClass();
-		if ( $core_check && $core_check->version === $wp_version ) {
+		if ( isset( $core_check->version ) && $core_check->version === $wp_version ) {
 			$core       = $core_check;
 			$core->name = 'WordPress';
 			$core->type = 'core';

--- a/projects/plugins/protect/src/class-status.php
+++ b/projects/plugins/protect/src/class-status.php
@@ -301,14 +301,14 @@ class Status {
 	 */
 	private static function normalize_report_data( $report_data ) {
 		$installed_plugins    = Plugins_Installer::get_plugins();
-		$last_report_plugins  = isset( $report_data->plugins ) ? $report_data->plugins : new stdClass();
+		$last_report_plugins  = isset( $report_data->plugins ) ? $report_data->plugins : new \stdClass();
 		$report_data->plugins = self::merge_installed_and_checked_lists( $installed_plugins, $last_report_plugins, array( 'type' => 'plugin' ) );
 
 		$installed_themes    = Sync_Functions::get_themes();
-		$last_report_themes  = isset( $report_data->themes ) ? $report_data->themes : new stdClass();
+		$last_report_themes  = isset( $report_data->themes ) ? $report_data->themes : new \stdClass();
 		$report_data->themes = self::merge_installed_and_checked_lists( $installed_themes, $last_report_themes, array( 'type' => 'theme' ) );
 
-		$report_data->core = self::normalize_core_information( isset( $report_data->core ) ? $report_data->core : new stdClass() );
+		$report_data->core = self::normalize_core_information( isset( $report_data->core ) ? $report_data->core : new \stdClass() );
 
 		$all_items       = array_merge( $report_data->plugins, $report_data->themes, array( $report_data->core ) );
 		$unchecked_items = array_filter(

--- a/projects/plugins/protect/src/class-status.php
+++ b/projects/plugins/protect/src/class-status.php
@@ -308,7 +308,7 @@ class Status {
 		$last_report_themes  = isset( $report_data->themes ) ? $report_data->themes : new \stdClass();
 		$report_data->themes = self::merge_installed_and_checked_lists( $installed_themes, $last_report_themes, array( 'type' => 'theme' ) );
 
-		$report_data->core = self::normalize_core_information( isset( $report_data->core ) ? $report_data->core : new \stdClass() );
+		$report_data->core = self::normalize_core_information( isset( $report_data->core ) ? $report_data->core : false );
 
 		$all_items       = array_merge( $report_data->plugins, $report_data->themes, array( $report_data->core ) );
 		$unchecked_items = array_filter(

--- a/projects/plugins/protect/src/class-status.php
+++ b/projects/plugins/protect/src/class-status.php
@@ -308,7 +308,7 @@ class Status {
 		$last_report_themes  = isset( $report_data->themes ) ? $report_data->themes : new \stdClass();
 		$report_data->themes = self::merge_installed_and_checked_lists( $installed_themes, $last_report_themes, array( 'type' => 'theme' ) );
 
-		$report_data->core = self::normalize_core_information( isset( $report_data->core ) ? $report_data->core : false );
+		$report_data->core = self::normalize_core_information( isset( $report_data->core ) ? $report_data->core : new \stdClass() );
 
 		$all_items       = array_merge( $report_data->plugins, $report_data->themes, array( $report_data->core ) );
 		$unchecked_items = array_filter(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
In line with #25053, a number of PHP notices and warnings are presented in particular circumstances for unset object properties in relation to the Protect report on the initial report generation when Jetpack is not installed and connnected. This PR adds checks for each of the associated report data properties to address these situations and ensures that report data output is always properly formed.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* An `isset()` check is added for the `plugins`, `themes`, and `core` properties of the `$report_data` object. If it is determined that any of the properties are not effectively set, a `new StdClass()` is provided as the default value.

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- 1201069996155224-as-1202607631700449

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a [Jurassic Ninja](https://jurassic.ninja/) testing site w/ Jetpack installed
* When the instance is ready, log in and go to Plugins and install the [Jetpack Beta plugin](https://jetpack.com/download-jetpack-beta/)
* Once the beta plugin is activated, deactivate Jetpack from the Plugins page in `wp-admin`
* Proceed to activate the Latest Stable version of Jetpack Protect from the Jetpack Beta plugin page link in `wp-admin`
* Proceed to Jetpack > Protect to generate your initial status report
* After the first scan of the site completes, refresh the page
* Verify that you are presented with the following PHP notices and warnings related to unset status report object properties:
   * Most commonly visible: 
   * <img width="1547" alt="Screen Shot on 2022-07-18 at 12-51-51" src="https://user-images.githubusercontent.com/43220201/179605659-2de6d003-70a7-43c3-b93d-41f642193135.png">
   * Less commonly visible: 
   * <img width="1451" alt="Screen Shot on 2022-07-18 at 12-52-57" src="https://user-images.githubusercontent.com/43220201/179605804-ab1cb686-4f0a-483e-8f2b-f389d79e2496.png">
* Open up the Jetpack Beta plugin page once again
* For Jetpack Protect, search for and activate the current Feature Branch and refresh the page
* Verify that all PHP notices and warnings are resolved
* Visit Jetpack > Protect and ensure that the latest report is correctly formatted and displays accordingly 

