### PR TITLE
Connection: fix site registration for the `connect_url_redirect` webhook.

### DIFF
--- a/projects/packages/connection/changelog/fix-user-connect-second-attempt-registration
+++ b/projects/packages/connection/changelog/fix-user-connect-second-attempt-registration
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix site registration for the `connect_url_redirect` webhook.
+
+

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.41.5';
+	const PACKAGE_VERSION = '1.41.6-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/src/class-webhooks.php
+++ b/projects/packages/connection/src/class-webhooks.php
@@ -181,6 +181,10 @@ class Webhooks {
 		add_filter( 'allowed_redirect_hosts', array( Host::class, 'allow_wpcom_environments' ) );
 
 		if ( ! $this->connection->is_user_connected() ) {
+			if ( ! $this->connection->is_connected() ) {
+				$this->connection->register();
+			}
+
 			$connect_url = add_query_arg( 'from', $from, $this->connection->get_authorization_url( null, $redirect ) );
 
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- no site changes.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Fix site registration for the `connect_url_redirect` webhook.

The bug was introduced in #24529

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
1191179647901802-as-1202582656293827

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

##### Connection flow with WP.com login
1. Disconnect Jetpack, logout of WP.com
2. Connect Jetpack logging into WP.com during the connection flow
3. Confirm it went well.

##### WP.com migration flow
1. Create a JN site with Jetpack Beta, deactivate and delete Jetpack plugin (but keep Jetpack Beta).
2. Go to https://wordpress.com/start/domains and create a WP.com site
3. Go to `https://wordpress.com/setup/import?siteSlug=your-site-slug`, enter your JN site's URL, and proceed with the steps.
4. After clicking the "Jetpack Required - Install Jetpack" button, enter your JN site's credentials and click "Install Jetpack". You will be redirected to the "Invalid request" error page.
5. Go to your JN site and use Jetpack Beta to checkout the branch `fix/user-connect-second-attempt-registration`.
6. Switch back to the tab with the "Jetpack Required - Install Jetpack" button, click on it.
7. You should be shown the "Approve" button page. Click on it and confirm the connection is established successfully.

##### Mobile "Add Site" flow
1. Create new JN site with Jetpack Beta, remove Jetpack plugin.
2. Open the WP.com mobile app, choose to add new site, enter the JN site's URL, then credentials.
3. Click "Stats" on the site's screen, then "Install Jetpack -> Set Up".
4. When it says "Jetpack installed", go to JN site's Jetpack Beta and checkout the branch `fix/user-connect-second-attempt-registration`.
5. Click "Set Up" on the "Jetpack installed" screen. You should see the "Approve" button - click it.
6. Confirm that stats are now enabled.
7. Check the JN site, confirm it's fully connected.