### PR TITLE
Search: Cutting a Beta for 1.0.1 Release

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9794,7 +9794,7 @@ packages:
     resolution: {integrity: sha512-WpAmaKbMNmS3OProfHIdJiNleNJdgUrJfbKArXua28QF7+0CoZjlLn0lp6vlc+dl5r2/X9GQiQRQQU4BzSa69w==}
 
   /concat-map/0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
 
   /concat-with-sourcemaps/1.1.0:
     resolution: {integrity: sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==}

--- a/projects/plugins/search/CHANGELOG.md
+++ b/projects/plugins/search/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1-beta] - 2022-07-12
+### Changed
+- E2E tests: bump @playwright/test and allure-playwright versions
+- Renaming master to trunk.
+- Renaming `master` references to `trunk`
+- Updated package dependencies.
+
+### Fixed
+- E2E tests: fixed pretest cleanup script not running
+- Search: update plugin README
+
 ## 1.0.0 - 2022-05-30
 ### Added
 - Initial release.
+
+[1.0.1-beta]: https://github.com/Automattic/jetpack-search-plugin/compare/v1.0.0...v1.0.1-beta

--- a/projects/plugins/search/changelog/add-post_content_sync
+++ b/projects/plugins/search/changelog/add-post_content_sync
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/search/changelog/e2e-bump-playwright-1.22.2
+++ b/projects/plugins/search/changelog/e2e-bump-playwright-1.22.2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-E2E tests: bump @playwright/test and allure-playwright versions

--- a/projects/plugins/search/changelog/e2e-fix-pre-scripts
+++ b/projects/plugins/search/changelog/e2e-fix-pre-scripts
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-E2E tests: fixed pretest cleanup script not running

--- a/projects/plugins/search/changelog/fix-config-package-prefer-stable
+++ b/projects/plugins/search/changelog/fix-config-package-prefer-stable
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/fix-hide-unsupported-taxonomies-from-widget-filters
+++ b/projects/plugins/search/changelog/fix-hide-unsupported-taxonomies-from-widget-filters
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/search/changelog/fix-sort-triggers-search-overlay
+++ b/projects/plugins/search/changelog/fix-sort-triggers-search-overlay
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/search/changelog/fix-use-plain-remote-request-for-pricing
+++ b/projects/plugins/search/changelog/fix-use-plain-remote-request-for-pricing
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/fix-use-plain-remote-request-for-pricing#2
+++ b/projects/plugins/search/changelog/fix-use-plain-remote-request-for-pricing#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/fix-user-connect-second-attempt-redirect
+++ b/projects/plugins/search/changelog/fix-user-connect-second-attempt-redirect
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/search/changelog/remove-claim-of-support-for-node-14
+++ b/projects/plugins/search/changelog/remove-claim-of-support-for-node-14
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove claim of support for node 14. No change to the project, and in particular note the engines are stripped before pushing to the mirror repo.
-
-

--- a/projects/plugins/search/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/search/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/search/changelog/renovate-lock-file-maintenance#2
+++ b/projects/plugins/search/changelog/renovate-lock-file-maintenance#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/search/changelog/update-monorepo-master-refs-primary
+++ b/projects/plugins/search/changelog/update-monorepo-master-refs-primary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Renaming master to trunk.

--- a/projects/plugins/search/changelog/update-monorepo-master-refs-secondary
+++ b/projects/plugins/search/changelog/update-monorepo-master-refs-secondary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Renaming `master` references to `trunk`

--- a/projects/plugins/search/changelog/update-my-jetpack-update-products-cards-disposition
+++ b/projects/plugins/search/changelog/update-my-jetpack-update-products-cards-disposition
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/search/changelog/update-pnpm-7.5.0
+++ b/projects/plugins/search/changelog/update-pnpm-7.5.0
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove `.engines.pnpm` from `package.json`. It's not needed, as pnpm always checks the monorepo root `package.json` anyway. Further, `.engines` is stripped from the mirror repos.
-
-

--- a/projects/plugins/search/changelog/update-search-readme-formatting
+++ b/projects/plugins/search/changelog/update-search-readme-formatting
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Search: update plugin README

--- a/projects/plugins/search/changelog/update-sync-must-sync-data-settings
+++ b/projects/plugins/search/changelog/update-sync-must-sync-data-settings
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/search/changelog/update-to-pnpm-7
+++ b/projects/plugins/search/changelog/update-to-pnpm-7
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Use pnpm 7.
-
-

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -60,7 +60,7 @@
 	},
 	"config": {
 		"sort-packages": true,
-		"autoloader-suffix": "b462338fb66be23595d68a93345c9e3d_jetpack_searchⓥ1_0_1_alpha",
+		"autoloader-suffix": "b462338fb66be23595d68a93345c9e3d_jetpack_searchⓥ1_0_1_beta",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true,

--- a/projects/plugins/search/jetpack-search.php
+++ b/projects/plugins/search/jetpack-search.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Search
  * Plugin URI: https://jetpack.com/search/
  * Description: A cloud-powered replacement for WordPress' search.
- * Version: 1.0.1-alpha
+ * Version: 1.0.1-beta
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later
@@ -26,7 +26,7 @@ define( 'JETPACK_SEARCH_PLUGIN__DIR', plugin_dir_path( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__FILE', __FILE__ );
 define( 'JETPACK_SEARCH_PLUGIN__FILE_RELATIVE_PATH', plugin_basename( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__SLUG', 'jetpack-search' );
-define( 'JETPACK_SEARCH_PLUGIN__VERSION', '1.0.1-alpha' );
+define( 'JETPACK_SEARCH_PLUGIN__VERSION', '1.0.1-beta' );
 
 defined( 'JETPACK_CLIENT__AUTH_LOCATION' ) || define( 'JETPACK_CLIENT__AUTH_LOCATION', 'header' );
 

--- a/projects/plugins/search/readme.txt
+++ b/projects/plugins/search/readme.txt
@@ -111,9 +111,17 @@ You can purchase a Search subscription directly through this plugin or via the [
 5. Manage all of your Jetpack products, including Search, in a single place.
 
 == Changelog ==
-### 1.0.0 - 2022-05-30
-#### Added
-- Initial release.
+### 1.0.1-beta - 2022-07-12
+#### Changed
+- E2E tests: bump @playwright/test and allure-playwright versions
+- Renaming master to trunk.
+- Renaming `master` references to `trunk`
+- Updated package dependencies.
+
+#### Fixed
+- E2E tests: fixed pretest cleanup script not running
+- Search: update plugin README
+
 == Testimonials ==
 
 “I like having a search experience that is sortable, filterable, and feels like it's integrated natively into the site. Jetpack Search does all of this, but most importantly, it returns great results without heavy configuration.” - Chris Coyier, Web Design Expert (codepen.io / ShopTalk Show)


### PR DESCRIPTION
This PR makes the necessary changelog and readme file changes to cut a Beta for 1.0.1 Release

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
check that everything changed looks correct as per the 'Releasing Jetpack Monorepo Plugins' FG page. Particularly:
* that the changelog data looks correct
* the “Stable tag:” version at the top of the readme.txt file is the latest stable version of the plugin (not the new 1.0.1 version we're releasing)