### PR TITLE
Repo gardening: add clarification about automated comment

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-support-references-wording
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-support-references-wording
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Gather support references: add clarification that the comment is automated and should not be edited.

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -93,6 +93,9 @@ async function getIssueReferences( octokit, owner, repo, number, issueComments )
  */
 function buildCommentBody( issueReferences, checkedRefs = new Set() ) {
 	const commentBody = `**Support References**
+
+*This comment is automatically generated. Please do not edit it.*
+
 ${ issueReferences
 	.map(
 		reference => `


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This is a follow-up of #25066. Let's add a sentence to the comment that's automatically generated and posted by the GitHub action, to encourage HEs not to edit the comment directly.

It would look like this:

<img width="544" alt="Screen Shot 2022-07-15 at 12 03 38" src="https://user-images.githubusercontent.com/426388/179203109-079b9f44-3b1a-412f-8f0a-5057b6ecc809.png">


#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

Internal reference: pcLjiI-Rb-p2#comment-834

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Not much to test here, see screenshot above to see how it would look like.
