### PR TITLE
Repo Gardening: stop gathering Live Chat references.

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-support-references-chat
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-support-references-chat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Gather support references: stop gathering Live Chat references.

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -41,7 +41,7 @@ async function getListComment( issueComments ) {
  */
 async function getIssueReferences( octokit, owner, repo, number, issueComments ) {
 	const ticketReferences = [];
-	const referencesRegexP = /[0-9]*-(?:chat|hc|zen|zd)/gim;
+	const referencesRegexP = /[0-9]*-(?:zen|zd)/gim;
 
 	debug( `gather-support-references: Getting references from issue body.` );
 	const {
@@ -68,13 +68,11 @@ async function getIssueReferences( octokit, owner, repo, number, issueComments )
 	ticketReferences.map( reference => {
 		const supportId = reference[ 0 ];
 
-		// xxx-zen and xxx-hc are the preferred formats for tickets and chats.
-		// xxx-zd and xxx-chat, as well as uppercase versions, are considered as alternate versions.
-		const wrongId = supportId.match( /([0-9]*)-(zd|chat)/i );
+		// xxx-zen is the preferred format for tickets.
+		// xxx-zd, as well as its uppercase version, is considered an alternate version.
+		const wrongId = supportId.match( /([0-9]*)-zd/i );
 		if ( wrongId ) {
-			const correctedId = `${ wrongId[ 1 ] }-${
-				wrongId[ 2 ].toLowerCase() === 'zd' ? 'zen' : 'hc'
-			}`;
+			const correctedId = `${ wrongId[ 1 ] }-zen`;
 			correctedSupportIds.add( correctedId );
 		} else {
 			correctedSupportIds.add( supportId.toLowerCase() );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This is a follow-up of #25103.

Live Chat support references, while still used widely in issues, are being deprecated, and we should now encourage the use of ticket references only. As a result, let's not add any chat references to the automated comment.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

Internal reference:
- pcLjiI-Rb-p2#comment-842

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Not much can be tested on this repo before this gets merged. Until then, you can check this issue for an example:
https://github.com/jeherve/jetpack/issues/43
