### PR TITLE
Add last_updated blog details field to the site details responses

### DIFF
--- a/projects/plugins/jetpack/changelog/add-last-update-date-to-wpcom-sites-api
+++ b/projects/plugins/jetpack/changelog/add-last-update-date-to-wpcom-sites-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add last_updated API field to the sites endpoint

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -147,6 +147,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'default_ping_status',
 		'software_version',
 		'created_at',
+		'updated_at',
 		'wordads',
 		'publicize_permanently_disabled',
 		'frame_nonce',
@@ -223,6 +224,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		// and defaults to `0000-00-00T00:00:00+00:00` from the Jetpack site.
 		// See https://github.com/Automattic/jetpack/blob/58638f46094b36f5df9cbc4570006544f0ad300c/sal/class.json-api-site-base.php#L387.
 		'created_at',
+		'updated_at',
 	);
 
 	/**
@@ -635,6 +637,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'created_at':
 					$options[ $key ] = $site->get_registered_date();
+					break;
+				case 'updated_at':
+					$options[ $key ] = $site->get_last_update_date();
 					break;
 				case 'wordads':
 					$options[ $key ] = $site->has_wordads();

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -806,6 +806,22 @@ abstract class SAL_Site {
 	}
 
 	/**
+	 * Returns a date/time string with the date the site was last updated, or a default date/time string otherwise.
+	 *
+	 * @return string
+	 **/
+	public function get_last_update_date() {
+		if ( function_exists( 'get_blog_details' ) ) {
+			$blog_details = get_blog_details();
+			if ( ! empty( $blog_details->last_updated ) ) {
+				return WPCOM_JSON_API_Date::format_date( $blog_details->last_updated );
+			}
+		}
+
+		return '0000-00-00T00:00:00+00:00';
+	}
+
+	/**
 	 * Returns an array including the current users relevant capabilities.
 	 *
 	 * @return array


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/65168

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
PR adds the `last_updated` blog details field to the site details responses in a similar fashion to the `created_at` field. The field will be used by the new Sites Dashboard.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

##### Test WP.com API response

* Go to https://developer.wordpress.com/docs/api/console/
* Choose WP.COM API v1.2, GET method
* Enter the API URL: `/me/sites?http_envelope=1&site_visibility=all&include_domain_only=true&site_activity=active&fields=ID%2Coptions&options=created_at%2Cupdated_at`
* Confirm that `updated_at` is filled for returned sites

##### Test Jetpack site response that is proxied via WP.com API

* Go to https://developer.wordpress.com/docs/api/console/
* Choose WP.COM API v1.2, GET method
* Enter the API URL: `/sites/$siteId` where $siteId is ID of site that is connected to WP.com via Jetpack
* Confirm that `updated_at` is filled for the returned site