### PR TITLE
E2E tests: remove page.waitForTimeout()

### DIFF
--- a/tools/e2e-commons/helpers/plan-helper.js
+++ b/tools/e2e-commons/helpers/plan-helper.js
@@ -525,19 +525,19 @@ function getPlan( type ) {
 
 export async function syncPlanData( page ) {
 	let isSame = false;
-	let frPlan = null;
-	let bkPlan = null;
+	let fePlan = null;
+	let bePlan = null;
 
 	// todo set a limit here to avoid infinite loop in case plans are never the same?
 	do {
 		await page.reload( { waitFor: 'domcontentloaded' } );
 
 		// eslint-disable-next-line no-undef, camelcase
-		frPlan = await page.evaluate( () => Initial_State.siteData.plan.product_slug );
+		fePlan = await page.evaluate( () => Initial_State.siteData.plan.product_slug );
 		const planJson = await execWpCommand( 'option get jetpack_active_plan --format=json' );
-		bkPlan = JSON.parse( planJson );
+		bePlan = JSON.parse( planJson );
 
-		logger.debug( `PLANS: frontend: ${ frPlan }, backend: ${ bkPlan.product_slug }` );
-		isSame = frPlan.trim() === bkPlan.product_slug.trim();
+		logger.debug( `PLANS: frontend: ${ fePlan }, backend: ${ bePlan.product_slug }` );
+		isSame = fePlan.trim() === bePlan.product_slug.trim();
 	} while ( ! isSame );
 }

--- a/tools/e2e-commons/helpers/plan-helper.js
+++ b/tools/e2e-commons/helpers/plan-helper.js
@@ -528,7 +528,7 @@ export async function syncPlanData( page ) {
 	let fePlan = null;
 	let bePlan = null;
 
-	// todo set a limit here to avoid infinite loop in case plans are never the same?
+	let i = 0;
 	do {
 		await page.reload( { waitFor: 'domcontentloaded' } );
 
@@ -539,5 +539,6 @@ export async function syncPlanData( page ) {
 
 		logger.debug( `PLANS: frontend: ${ fePlan }, backend: ${ bePlan.product_slug }` );
 		isSame = fePlan.trim() === bePlan.product_slug.trim();
-	} while ( ! isSame );
+		i = i + 1;
+	} while ( ! isSame && i < 5 );
 }

--- a/tools/e2e-commons/helpers/plan-helper.js
+++ b/tools/e2e-commons/helpers/plan-helper.js
@@ -538,5 +538,5 @@ export async function syncPlanData( page ) {
 		logger.debug( `PLANS: frontend: ${ fePlan }, backend: ${ bePlan.product_slug }` );
 		isSame = fePlan.trim() === bePlan.product_slug.trim();
 		i = i + 1;
-	} while ( ! isSame || i < 5 );
+	} while ( ! isSame && i < 5 );
 }

--- a/tools/e2e-commons/helpers/plan-helper.js
+++ b/tools/e2e-commons/helpers/plan-helper.js
@@ -537,10 +537,7 @@ export async function syncPlanData( page ) {
 		const planJson = await execWpCommand( 'option get jetpack_active_plan --format=json' );
 		bkPlan = JSON.parse( planJson );
 
-		logger.info( `PLANS: frontend: ${ frPlan }, backend: ${ bkPlan.product_slug }` );
+		logger.debug( `PLANS: frontend: ${ frPlan }, backend: ${ bkPlan.product_slug }` );
 		isSame = frPlan.trim() === bkPlan.product_slug.trim();
 	} while ( ! isSame );
-
-	// eslint-disable-next-line playwright/no-wait-for-timeout
-	await page.waitForTimeout( 1000 );
 }

--- a/tools/e2e-commons/helpers/plan-helper.js
+++ b/tools/e2e-commons/helpers/plan-helper.js
@@ -540,5 +540,5 @@ export async function syncPlanData( page ) {
 		logger.debug( `PLANS: frontend: ${ fePlan }, backend: ${ bePlan.product_slug }` );
 		isSame = fePlan.trim() === bePlan.product_slug.trim();
 		i = i + 1;
-	} while ( ! isSame && i < 5 );
+	} while ( ! isSame || i < 5 );
 }

--- a/tools/e2e-commons/helpers/plan-helper.js
+++ b/tools/e2e-commons/helpers/plan-helper.js
@@ -526,17 +526,15 @@ function getPlan( type ) {
 export async function syncPlanData( page ) {
 	let isSame = false;
 	let fePlan = null;
-	let bePlan = null;
+
+	const planJson = await execWpCommand( 'option get jetpack_active_plan --format=json' );
+	const bePlan = JSON.parse( planJson );
 
 	let i = 0;
 	do {
 		await page.reload( { waitFor: 'domcontentloaded' } );
-
 		// eslint-disable-next-line no-undef, camelcase
 		fePlan = await page.evaluate( () => Initial_State.siteData.plan.product_slug );
-		const planJson = await execWpCommand( 'option get jetpack_active_plan --format=json' );
-		bePlan = JSON.parse( planJson );
-
 		logger.debug( `PLANS: frontend: ${ fePlan }, backend: ${ bePlan.product_slug }` );
 		isSame = fePlan.trim() === bePlan.product_slug.trim();
 		i = i + 1;

--- a/tools/e2e-commons/helpers/utils-helper.cjs
+++ b/tools/e2e-commons/helpers/utils-helper.cjs
@@ -94,13 +94,8 @@ async function activateModule( page, module ) {
 	const modulesList = JSON.parse( await execWpCommand( activeModulesCmd ) );
 
 	if ( ! modulesList.includes( module ) ) {
-		throw new Error( `${ module } failed to activate` );
+		throw new Error( `Failed to activate module ${ module }!` );
 	}
-
-	// todo we shouldn't have page references in here. these methods could be called without a browser being opened
-	// eslint-disable-next-line playwright/no-wait-for-timeout
-	await page.waitForTimeout( 1000 );
-	await page.reload( { waitUntil: 'domcontentloaded' } );
 
 	return true;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Follow-up to [24376#issuecomment-1128036025](https://github.com/Automattic/jetpack/pull/24376#issuecomment-1128036025).
Removed all (2) calls to `page.waitForTImeout()`, breaking `playwright/no-wait-timeout` eslint rule. Both calls were unnecessary.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
1156386383419466-as-1202291410523573

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* E2E tests should pass