### PR TITLE
E2E tests: fix isElementVisible not waiting until timeout

### DIFF
--- a/tools/e2e-commons/pages/page-actions.js
+++ b/tools/e2e-commons/pages/page-actions.js
@@ -299,7 +299,13 @@ export default class PageActions {
 	 */
 	async isElementVisible( selector, timeout = this.timeout ) {
 		logger.action( `Checking if element '${ selector }' is visible` );
-		return await this.page.isVisible( selector, { timeout } );
+		try {
+			await this.page.locator( selector ).waitFor( { timeout } );
+			return true;
+		} catch ( e ) {
+			logger.warn( `Element '${ selector }' was not visible. Waited for ${ timeout }ms` );
+			return false;
+		}
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Refactor `isElementVisible()` so it waits until timeout if the element is not found or visible. 
This function previously used Playwright's `isVisible()`, which now has the `timeout` parameter deprecated and is being ignored. In our e2e test, this problem was by a `page.waitForTimeout()` which was removed by #25118 

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* All e2e tests should pass