### PR TITLE
E2E tests: don't throw if isElementVisible matches more elements

### DIFF
--- a/tools/e2e-commons/pages/page-actions.js
+++ b/tools/e2e-commons/pages/page-actions.js
@@ -295,12 +295,12 @@ export default class PageActions {
 	 *
 	 * @param {string} selector
 	 * @param {number} timeout
-	 * @return {Promise<boolean>} true if element is visible, false otherwise
+	 * @return {Promise<boolean>} true if at least one element with the given selector is visible, false otherwise
 	 */
 	async isElementVisible( selector, timeout = this.timeout ) {
 		logger.action( `Checking if element '${ selector }' is visible` );
 		try {
-			await this.page.locator( selector ).waitFor( { timeout } );
+			await this.page.locator( selector ).first().waitFor( { timeout } );
 			return true;
 		} catch ( e ) {
 			logger.warn( `Element '${ selector }' was not visible. Waited for ${ timeout }ms` );

--- a/tools/e2e-commons/pages/page-actions.js
+++ b/tools/e2e-commons/pages/page-actions.js
@@ -299,7 +299,13 @@ export default class PageActions {
 	 */
 	async isElementVisible( selector, timeout = this.timeout ) {
 		logger.action( `Checking if element '${ selector }' is visible` );
-		return await this.page.isVisible( selector, { timeout } );
+		try {
+			await this.page.locator( selector ).waitFor( { timeout } );
+			return true;
+		} catch ( e ) {
+			logger.warn( `Element '${ selector }' was not visible. Waited for ${ timeout }ms` );
+			return false;
+		}
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This should fix a problem introduced by #25121. When using a selector matching more than one element, isElementVisible will throw an error, because Playwright uses strict mode with locators.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* All e2e tests should pass