### PR TITLE
Comments: avoid PHP notice when Jetpack's connection is broken.

### DIFF
--- a/projects/packages/connection/changelog/fix-comments-notice
+++ b/projects/packages/connection/changelog/fix-comments-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tokens: edit return doc to highlight possibility of returning WP_Error.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.41.6';
+	const PACKAGE_VERSION = '1.41.7-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/src/class-tokens.php
+++ b/projects/packages/connection/src/class-tokens.php
@@ -364,7 +364,7 @@ class Tokens {
 	 * @param string|false $token_key If provided, check that the token matches the provided input.
 	 * @param bool|true    $suppress_errors If true, return a falsy value when the token isn't found; When false, return a descriptive WP_Error when the token isn't found.
 	 *
-	 * @return object|false
+	 * @return object|false|WP_Error
 	 */
 	public function get_access_token( $user_id = false, $token_key = false, $suppress_errors = true ) {
 		if ( $this->is_locked() ) {

--- a/projects/plugins/jetpack/changelog/fix-comments-notice
+++ b/projects/plugins/jetpack/changelog/fix-comments-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Comments: avoid PHP Notice when using Jetpack's Comment form feature owhen your site is no longer properly connected to WordPress.com.

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -311,7 +311,12 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 			$params['has_cookie_consent']  = (int) ! empty( $commenter['comment_author_email'] );
 		}
 
-		$blog_token        = ( new Tokens() )->get_access_token();
+		$blog_token = ( new Tokens() )->get_access_token();
+		// If we have no token, bail.
+		if ( ! $blog_token || is_wp_error( $blog_token ) ) {
+			return;
+		}
+
 		list( $token_key ) = explode( '.', $blog_token->secret, 2 );
 		// Prophylactic check: anything else should never happen.
 		if ( $token_key && $token_key !== $blog_token->secret ) {

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -184,6 +184,24 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 		return preg_replace( '#src=([\'"])[^\'"]+\\1#', 'src=\\1' . esc_url( set_url_scheme( $this->photon_avatar( $foreign_avatar, $size ), 'https' ) ) . '\\1', $avatar );
 	}
 
+	/**
+	 * Get the site's blog token.
+	 * This can be used to bypass Comments entirely if Jetpack is not properly connected.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool|object False if not properly connected. Object with the blog token if connected.
+	 */
+	private function get_blog_token() {
+		$blog_token = ( new Tokens() )->get_access_token();
+		// If we have no token, bail.
+		if ( ! $blog_token || is_wp_error( $blog_token ) ) {
+			return false;
+		}
+
+		return $blog_token;
+	}
+
 	/** Output Methods ********************************************************/
 
 	/**
@@ -208,6 +226,11 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 			return;
 		}
 
+		// If the Jetpack connection is not healthy, bail.
+		if ( ! $this->get_blog_token() ) {
+			return;
+		}
+
 		// Add some JS to the footer.
 		add_action( 'wp_footer', array( $this, 'watch_comment_parent' ), 100 );
 
@@ -223,6 +246,12 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 	public function comment_form_after() {
 		/** This filter is documented in modules/comments/comments.php */
 		if ( ! apply_filters( 'jetpack_comment_form_enabled_for_' . get_post_type(), true ) ) {
+			return;
+		}
+
+		$blog_token = $this->get_blog_token();
+		// If the Jetpack connection is not healthy, bail.
+		if ( ! $blog_token ) {
 			return;
 		}
 
@@ -309,12 +338,6 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 			$commenter                     = wp_get_current_commenter();
 			$params['show_cookie_consent'] = (int) has_action( 'set_comment_cookies', 'wp_set_comment_cookies' );
 			$params['has_cookie_consent']  = (int) ! empty( $commenter['comment_author_email'] );
-		}
-
-		$blog_token = ( new Tokens() )->get_access_token();
-		// If we have no token, bail.
-		if ( ! $blog_token || is_wp_error( $blog_token ) ) {
-			return;
 		}
 
 		list( $token_key ) = explode( '.', $blog_token->secret, 2 );

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -558,7 +558,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 		}
 
 		$blog_token = ( new Tokens() )->get_access_token( false, $post_array['token_key'] );
-		if ( ! $blog_token ) {
+		if ( ! $blog_token || is_wp_error( $blog_token ) ) {
 			wp_die( esc_html__( 'Unknown security token.', 'jetpack' ), 400 );
 		}
 		$check = self::sign_remote_comment_parameters( $post_array, $blog_token->secret );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This should solve notices like this one:

```
E_NOTICE Trying to get property 'secret' of non-object
/wp-content/plugins/jetpack/modules/comments/comments.php:315

E_NOTICE Trying to get property 'secret' of non-object
/wp-content/plugins/jetpack/modules/comments/comments.php:333
```

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

* No

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

I'm not quite sure how to reproduce the notices yet.

* You would need to start with a site that's connected to WordPress.com, and where you've activated the Comments module under Jetpack > Settings > Discussion
* Then you would have to break or delete the blog token.
* Then, on the frontend of the site when logged out, visit a post where comments are opened.
* You should see the default comment form.

