### PR TITLE
VideoPress: avoid PHP notices when metadata is missing.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-videopress-notices
+++ b/projects/plugins/jetpack/changelog/fix-videopress-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: avoid PHP notices when inserting videos that miss some metadata.

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-edit-attachment.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-edit-attachment.php
@@ -186,7 +186,7 @@ class VideoPress_Edit_Attachment {
 
 		$fields['post_excerpt']['label'] = _x( 'Description', 'A header for the short description display', 'jetpack' );
 		$fields['post_excerpt']['input'] = 'textarea';
-		$fields['post_excerpt']['value'] = $info->description;
+		$fields['post_excerpt']['value'] = ! empty( $info->description ) ? $info->descrption : '';
 
 		$fields['is_videopress_attachment'] = array(
 			'input' => 'hidden',
@@ -310,7 +310,7 @@ HTML;
 			"attachments-{$info->post_id}-displayembed",
 			"attachments[{$info->post_id}][display_embed]",
 			__( 'Display share menu and allow viewers to copy a link or embed this video', 'jetpack' ),
-			$info->display_embed
+			isset( $info->display_embed ) ? $info->display_embed : 0
 		);
 	}
 
@@ -375,7 +375,8 @@ HTML;
 			'R-17'  => 'R',
 		);
 
-		$displayed_rating = $info->rating;
+		$displayed_rating = isset( $info->rating ) ? $info->rating : 'G';
+
 		// X-18 was previously supported but is now removed to better comply with our TOS.
 		if ( 'X-18' === $displayed_rating ) {
 			$displayed_rating = 'R-17';

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-edit-attachment.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-edit-attachment.php
@@ -375,7 +375,7 @@ HTML;
 			'R-17'  => 'R',
 		);
 
-		$displayed_rating = isset( $info->rating ) ? $info->rating : 'G';
+		$displayed_rating = isset( $info->rating ) ? $info->rating : null;
 
 		// X-18 was previously supported but is now removed to better comply with our TOS.
 		if ( 'X-18' === $displayed_rating ) {

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-edit-attachment.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-edit-attachment.php
@@ -164,6 +164,11 @@ class VideoPress_Edit_Attachment {
 		unset( $fields['url'] );
 		unset( $fields['post_content'] );
 
+		// If a video isn't attached to any specific post, manually add a post ID.
+		if ( ! isset( $info->post_id ) ) {
+			$info->post_id = 0;
+		}
+
 		if ( isset( $file_statuses['ogg'] ) && 'done' === $file_statuses['ogg'] ) {
 			$v_name     = preg_replace( '/\.\w+/', '', basename( $info->path ) );
 			$video_name = $v_name . '_fmt1.ogv';

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
@@ -339,7 +339,10 @@ class VideoPress_Player {
 			$html .= ' lang="' . esc_attr( $this->video->language ) . '"';
 		}
 		$html .= '>';
-		if ( ! isset( $this->options['freedom'] ) || $this->options['freedom'] === false ) {
+		if (
+			( ! isset( $this->options['freedom'] ) || $this->options['freedom'] === false )
+			&& isset( $this->video->videos, $this->video->videos->mp4 )
+		) {
 			$mp4 = $this->video->videos->mp4->url;
 			if ( ! empty( $mp4 ) ) {
 				$html .= '<source src="' . esc_url( $mp4 ) . '" type="video/mp4; codecs=&quot;' . esc_attr( $this->video->videos->mp4->codecs ) . '&quot;" />';
@@ -347,7 +350,7 @@ class VideoPress_Player {
 			unset( $mp4 );
 		}
 
-		if ( isset( $this->video->videos->ogv ) ) {
+		if ( isset( $this->video->videos, $this->video->videos->ogv ) ) {
 			$ogg = $this->video->videos->ogv->url;
 			if ( ! empty( $ogg ) ) {
 				$html .= '<source src="' . esc_url( $ogg ) . '" type="video/ogg; codecs=&quot;' . esc_attr( $this->video->videos->ogv->codecs ) . '&quot;" />';

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
@@ -350,7 +350,7 @@ class VideoPress_Player {
 			unset( $mp4 );
 		}
 
-		if ( isset( $this->video->videos, $this->video->videos->ogv ) ) {
+		if ( isset( $this->video->videos->ogv ) ) {
 			$ogg = $this->video->videos->ogv->url;
 			if ( ! empty( $ogg ) ) {
 				$html .= '<source src="' . esc_url( $ogg ) . '" type="video/ogg; codecs=&quot;' . esc_attr( $this->video->videos->ogv->codecs ) . '&quot;" />';

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
@@ -341,7 +341,7 @@ class VideoPress_Player {
 		$html .= '>';
 		if (
 			( ! isset( $this->options['freedom'] ) || $this->options['freedom'] === false )
-			&& isset( $this->video->videos, $this->video->videos->mp4 )
+			&& isset( $this->video->videos->mp4 )
 		) {
 			$mp4 = $this->video->videos->mp4->url;
 			if ( ! empty( $mp4 ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

In some scenarios, either when viewing a video on a site's RSS feed, or when trying to insert a video in the editor, the following errors come up:

- When viewing a post in an RSS feed with an old video, inserted into the old editor as a shortcode years ago
```
E_NOTICE: Trying to get property 'mp4' of non-object
in /wp-content/plugins/jetpack/modules/videopress/class.videopress-player.php:340
E_NOTICE: Trying to get property 'url' of non-object
in /wp-content/plugins/jetpack/modules/videopress/class.videopress-player.php:340
```

- When opening the Media Library modal in the block editor after picking the Video block (some of the videos on the site were previously uploaded directly to the media library, and not in a post):
```
PHP Warning:  Undefined property: stdClass::$post_id
in wp-content/plugins/jetpack-dev/modules/videopress/class.videopress-edit-attachment.php on line 306
PHP Warning:  Undefined property: stdClass::$display_embed
in wp-content/plugins/jetpack-dev/modules/videopress/class.videopress-edit-attachment.php on line 308
PHP Warning:  Undefined property: stdClass::$post_id
in wp-content/plugins/jetpack-dev/modules/videopress/class.videopress-edit-attachment.php on line 320
PHP Warning:  Undefined property: stdClass::$post_id
in wp-content/plugins/jetpack-dev/modules/videopress/class.videopress-edit-attachment.php on line 321
PHP Warning:  Undefined property: stdClass::$rating
in wp-content/plugins/jetpack-dev/modules/videopress/class.videopress-edit-attachment.php on line 373
PHP Warning:  Undefined property: stdClass::$post_id
in wp-content/plugins/jetpack-dev/modules/videopress/class.videopress-edit-attachment.php on line 380
PHP Warning:  Undefined property: stdClass::$post_id
in wp-content/plugins/jetpack-dev/modules/videopress/class.videopress-edit-attachment.php on line 381
PHP Warning:  Undefined property: stdClass::$post_id
in wp-content/plugins/jetpack-dev/modules/videopress/class.videopress-edit-attachment.php on line 380
```

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

* No

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

I was personally only able to reproduce the second set of notices.

* You'll need a site with an active plan, where VideoPress is active, where you've uploaded videos via Media > Library.
* Go to Posts > Add New
* Add a Video block
* Make sure you see no notices in your logs.
