### PR TITLE
Repo gardening: automatically add in progress label if the PR is created as draft

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -1,7 +1,7 @@
 name: Gardening
 on:
   pull_request_target: # When a PR is opened, edited, updated, closed, or a label is added.
-    types: [opened, reopened, synchronize, edited, labeled, closed]
+    types: [opened, reopened, synchronize, edited, labeled, closed, converted_to_draft]
   issues: # For auto-triage of issues.
     types: [opened, reopened, edited]
   issue_comment: # To gather support references in issue comments.

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -1,7 +1,7 @@
 name: Gardening
 on:
   pull_request_target: # When a PR is opened, edited, updated, closed, or a label is added.
-    types: [opened, reopened, synchronize, edited, labeled, closed, converted_to_draft]
+    types: [opened, reopened, synchronize, edited, labeled, closed ]
   issues: # For auto-triage of issues.
     types: [opened, reopened, edited]
   issue_comment: # To gather support references in issue comments.

--- a/projects/github-actions/repo-gardening/changelog/update-gardening-add-in-progress-for-draft-pr
+++ b/projects/github-actions/repo-gardening/changelog/update-gardening-add-in-progress-for-draft-pr
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Labels: add [Status] In Progress label for draft PRs

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -86,9 +86,10 @@ function cleanName( name ) {
  * @param {string} owner   - Repository owner.
  * @param {string} repo    - Repository name.
  * @param {string} number  - PR number.
+ * @param {boolean} isDraft  - Whether the pull request is a draft.
  * @returns {Promise<Array>} Promise resolving to an array of keywords we'll search for.
  */
-async function getLabelsToAdd( octokit, owner, repo, number ) {
+async function getLabelsToAdd( octokit, owner, repo, number, isDraft ) {
 	const keywords = new Set();
 
 	// Get next valid milestone.
@@ -223,6 +224,11 @@ async function getLabelsToAdd( octokit, owner, repo, number ) {
 		if ( e2e ) {
 			keywords.add( 'E2E Tests' );
 		}
+
+		// Add '[Status] In Progress' for draft PRs
+		if ( isDraft ) {
+			keywords.add( '[Status] In Progress' );
+		}
 	} );
 
 	return [ ...keywords ];
@@ -235,11 +241,12 @@ async function getLabelsToAdd( octokit, owner, repo, number ) {
  * @param {GitHub}                    octokit - Initialized Octokit REST client.
  */
 async function addLabels( payload, octokit ) {
-	const { number, repository } = payload;
+	const { number, repository, pull_request } = payload;
 	const { owner, name } = repository;
 
 	// Get labels to add to the PR.
-	const labels = await getLabelsToAdd( octokit, owner.login, name, number );
+	const isDraft = !! ( pull_request && pull_request.draft );
+	const labels = await getLabelsToAdd( octokit, owner.login, name, number, isDraft );
 
 	if ( ! labels.length ) {
 		debug( 'add-labels: Could not find labels to add to that PR. Aborting' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

When a PR is created as draft, automatically add the label '[Status] In Progress'

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* I don't know how to test this until it gets merged.

