### PR TITLE
tools: Add mirror repo check to changelogger-release.sh

### DIFF
--- a/tools/changelogger-release.sh
+++ b/tools/changelogger-release.sh
@@ -97,6 +97,17 @@ function releaseProject {
 	local I="$4"
 
 	cd "$BASE/projects/$SLUG"
+
+	# If it's being depended on by something (and not a js-package), check that it has a mirror repo set up.
+	# Can't do the release without one.
+	if [[ -n "$FROM" && "$SLUG" != js-packages/* ]] &&
+		! jq -e '.extra["mirror-repo"] // null' composer.json > /dev/null
+	then
+		error "${I}Cannot release $SLUG as it has no mirror repo configured!"
+		info "${I}See https://github.com/Automattic/jetpack/blob/trunk/docs/monorepo.md#mirror-repositories for details."
+		exit 1
+	fi
+
 	local CHANGES_DIR="$(jq -r '.extra.changelogger["changes-dir"] // "changelog"' composer.json)"
 	if [[ ! -d "$CHANGES_DIR" || -z "$(ls -- "$CHANGES_DIR")" ]]; then
 		if [[ -z "$FROM" ]]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Two weeks in a row now we've run into problems because we run
changelogger-release.sh, then try to run the release branch script and
it breaks because a package is missing a mirror repo.

Let's avoid that in the future by having changelogger-release.sh fail if
a package is missing the mirror repo config. But don't fail if we're
"releasing" the package directly. And don't fail on js-packages, as
those currently have different rules (and mostly lack mirrors).

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1658237453081579/1658237219.448209-slack-C01U2KGS2PQ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Check out `bf330177b^` and cherry-pick this change. Also run `export COMPOSER_ROOT_VERSION=dev-trunk` so composer won't get confused.

Test 1:
* Run `jetpack release plugins/jetpack changelog -a --add-pr-num`. It should fail with an error message about `packages/plans` not having a mirror repo.

Run `git restore .` to clean up any changes left behind, or redo the checkout and cherry-pick.

Test 2:
* Run `composer --working-dir=projects/packages/plans config extra.mirror-repo Automattic/jetpack-plans` to add the mirror repo setting.
* Run `jetpack release plugins/jetpack changelog -a --add-pr-num`. Now it should succeed.

Run `git restore .` to clean up any changes left behind, or redo the checkout and cherry-pick.

Test 3:
* Run `jetpack release packages/plans changelog -s`. That should succeed.
* Commit those changes to prepare for testing the next step.
* Run `jetpack release plugins/jetpack changelog -a --add-pr-num`. It should fail (again) with an error message about `packages/plans` not having a mirror repo.