### PR TITLE
Jetpack Social: Add class to fetch settings endpoint

### DIFF
--- a/projects/packages/publicize/changelog/add-jetpack-social-fetch-settings-endpoint
+++ b/projects/packages/publicize/changelog/add-jetpack-social-fetch-settings-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add class to fetch Publicize/Social data from WPCOM

--- a/projects/packages/publicize/composer.json
+++ b/projects/packages/publicize/composer.json
@@ -51,7 +51,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.9.x-dev"
+			"dev-trunk": "0.10.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.9.0",
+	"version": "0.10.0-alpha",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/publicize/tests/php/test-shares.php
+++ b/projects/packages/publicize/tests/php/test-shares.php
@@ -1,0 +1,91 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Automattic\Jetpack\Publicize;
+
+use Automattic\Jetpack\Connection\Tokens;
+use Automattic\Jetpack\Constants;
+use Jetpack_Options;
+use WorDBless\BaseTestCase;
+
+/**
+ * Unit tests for the Shares class.
+ *
+ * @package automattic/jetpack-publicize
+ */
+class Test_Shares extends BaseTestCase {
+	/**
+	 * Get a sample response
+	 *
+	 * @return object
+	 */
+	public function get_sample_response() {
+		return (object) array(
+			'is_share_limit_enabled' => true,
+		);
+	}
+
+	/**
+	 * Return a sample wpcom status response.
+	 *
+	 * @return array
+	 */
+	public function return_sample_response() {
+		return array(
+			'body'     => wp_json_encode( $this->get_sample_response() ),
+			'response' => array(
+				'code'    => 200,
+				'message' => '',
+			),
+		);
+	}
+
+	/**
+	 * Mock site connection
+	 */
+	public function mock_connection() {
+		( new Tokens() )->update_blog_token( 'test.test' );
+		Jetpack_Options::update_option( 'id', 123 );
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+	}
+
+	/**
+	 * Test while site is not connected
+	 */
+	public function test_get_data_not_connected() {
+		$shares = new Shares();
+
+		add_filter( 'pre_http_request', array( $this, 'return_sample_response' ) );
+		$data = $shares->get_data();
+		remove_filter( 'pre_http_request', array( $this, 'return_sample_response' ) );
+
+		$this->assertSame( 'site_not_connected', $data->get_error_code() );
+	}
+
+	/**
+	 * Test getting data with site connected.
+	 */
+	public function test_get_data_connected() {
+		$this->mock_connection();
+		$shares = new Shares();
+
+		add_filter( 'pre_http_request', array( $this, 'return_sample_response' ) );
+		$data = $shares->get_data();
+		remove_filter( 'pre_http_request', array( $this, 'return_sample_response' ) );
+
+		$this->assertEquals( $this->get_sample_response(), $data );
+	}
+
+	/**
+	 * Test is share limit enabled.
+	 */
+	public function test_is_share_limit_enabled() {
+		$this->mock_connection();
+		$shares = new Shares();
+
+		add_filter( 'pre_http_request', array( $this, 'return_sample_response' ) );
+		$is_share_limit_enabled = $shares->is_share_limit_enabled();
+		remove_filter( 'pre_http_request', array( $this, 'return_sample_response' ) );
+
+		$this->assertTrue( $is_share_limit_enabled );
+	}
+}

--- a/projects/plugins/jetpack/changelog/add-jetpack-social-fetch-settings-endpoint
+++ b/projects/plugins/jetpack/changelog/add-jetpack-social-fetch-settings-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -34,7 +34,7 @@
 		"automattic/jetpack-my-jetpack": "1.8.x-dev",
 		"automattic/jetpack-partner": "1.7.x-dev",
 		"automattic/jetpack-plugins-installer": "0.1.x-dev",
-		"automattic/jetpack-publicize": "0.9.x-dev",
+		"automattic/jetpack-publicize": "0.10.x-dev",
 		"automattic/jetpack-redirect": "1.7.x-dev",
 		"automattic/jetpack-roles": "1.4.x-dev",
 		"automattic/jetpack-search": "0.16.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "58988e6b65c011e6f0d341b0adebc225",
+    "content-hash": "f64bce07fb36c76aa20a04c7b95241bf",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1471,7 +1471,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/publicize",
-                "reference": "3efee4f16d823ad43051cb901d32a37ba3ac5eaf"
+                "reference": "7cc6ff0c9e937d45341627d55b425b0743b11500"
             },
             "require": {
                 "automattic/jetpack-autoloader": "^2.11",
@@ -1492,7 +1492,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/add-jetpack-social-fetch-settings-endpoint
+++ b/projects/plugins/social/changelog/add-jetpack-social-fetch-settings-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added functionality to fetch settings from WPCOM

--- a/projects/plugins/social/changelog/add-jetpack-social-fetch-settings-endpoint
+++ b/projects/plugins/social/changelog/add-jetpack-social-fetch-settings-endpoint
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Added functionality to fetch settings from WPCOM
+Use new class in Publicize package to fetch data

--- a/projects/plugins/social/changelog/add-jetpack-social-fetch-settings-endpoint#2
+++ b/projects/plugins/social/changelog/add-jetpack-social-fetch-settings-endpoint#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -10,7 +10,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.9.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-publicize": "0.9.x-dev",
+		"automattic/jetpack-publicize": "0.10.x-dev",
 		"automattic/jetpack-options": "1.16.x-dev",
 		"automattic/jetpack-connection": "1.41.x-dev",
 		"automattic/jetpack-my-jetpack": "1.8.x-dev",

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "19b8bee5baffcc128f58fd93e556c2c1",
+    "content-hash": "4338c125599fa41fb9434cfb79f5f047",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -844,7 +844,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/publicize",
-                "reference": "3efee4f16d823ad43051cb901d32a37ba3ac5eaf"
+                "reference": "7cc6ff0c9e937d45341627d55b425b0743b11500"
             },
             "require": {
                 "automattic/jetpack-autoloader": "^2.11",
@@ -865,7 +865,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -16,6 +16,7 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
 use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
+use Automattic\Jetpack\Social\Settings;
 use Automattic\Jetpack\Status;
 
 /**
@@ -147,19 +148,20 @@ class Jetpack_Social {
 
 		$shares_count = $publicize->get_publicize_shares_count( Jetpack_Options::get_option( 'id' ) );
 		return array(
-			'siteData'        => array(
+			'siteData'           => array(
 				'apiRoot'           => esc_url_raw( rest_url() ),
 				'apiNonce'          => wp_create_nonce( 'wp_rest' ),
 				'registrationNonce' => wp_create_nonce( 'jetpack-registration-nonce' ),
 			),
-			'jetpackSettings' => array(
+			'jetpackSettings'    => array(
 				'publicize_active' => ( new Modules() )->is_active( self::JETPACK_PUBLICIZE_MODULE_SLUG ),
 			),
-			'connectionData'  => array(
+			'connectionData'     => array(
 				'connections' => $publicize->get_all_connections_for_user(), // TODO: Sanitize the array
 				'adminUrl'    => esc_url_raw( $publicize->publicize_connections_url( 'jetpack-social-connections-admin-page' ) ),
 			),
-			'sharesCount'     => ! is_wp_error( $shares_count ) ? $shares_count : null,
+			'sharesCount'        => ! is_wp_error( $shares_count ) ? $shares_count : null,
+			'displaySharesMeter' => Settings::should_display_shares_meter(),
 		);
 	}
 

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -16,7 +16,7 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
 use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
-use Automattic\Jetpack\Social\Settings;
+use Automattic\Jetpack\Publicize\Shares;
 use Automattic\Jetpack\Status;
 
 /**
@@ -148,20 +148,20 @@ class Jetpack_Social {
 
 		$shares_count = $publicize->get_publicize_shares_count( Jetpack_Options::get_option( 'id' ) );
 		return array(
-			'siteData'           => array(
+			'siteData'          => array(
 				'apiRoot'           => esc_url_raw( rest_url() ),
 				'apiNonce'          => wp_create_nonce( 'wp_rest' ),
 				'registrationNonce' => wp_create_nonce( 'jetpack-registration-nonce' ),
 			),
-			'jetpackSettings'    => array(
+			'jetpackSettings'   => array(
 				'publicize_active' => ( new Modules() )->is_active( self::JETPACK_PUBLICIZE_MODULE_SLUG ),
 			),
-			'connectionData'     => array(
+			'connectionData'    => array(
 				'connections' => $publicize->get_all_connections_for_user(), // TODO: Sanitize the array
 				'adminUrl'    => esc_url_raw( $publicize->publicize_connections_url( 'jetpack-social-connections-admin-page' ) ),
 			),
-			'sharesCount'        => ! is_wp_error( $shares_count ) ? $shares_count : null,
-			'displaySharesMeter' => Settings::should_display_shares_meter(),
+			'sharesCount'       => ! is_wp_error( $shares_count ) ? $shares_count : null,
+			'shareLimitEnabled' => ( new Shares() )->is_share_limit_enabled(),
 		);
 	}
 

--- a/projects/plugins/social/src/class-settings.php
+++ b/projects/plugins/social/src/class-settings.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Class to handle fetching the settings of Jetpack Social
+ *
+ * @package automattic/jetpack-social-plugin
+ */
+
+namespace Automattic\Jetpack\Social;
+
+use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Jetpack_Options;
+use WP_Error;
+
+/**
+ * Class that handles fetching the settings from the WPCOM servers
+ */
+class Settings {
+	/**
+	 * WPCOM endpoint
+	 *
+	 * @var string
+	 */
+	const REST_API_BASE = '/sites/%d/jetpack-social';
+
+	/**
+	 * Memoization for the current settings
+	 *
+	 * @var null|array
+	 */
+	public static $settings = null;
+
+	/**
+	 * Gets the WPCOM API endpoint
+	 *
+	 * @return WP_Error|string
+	 */
+	public static function get_api_url() {
+		$blog_id      = Jetpack_Options::get_option( 'id' );
+		$is_connected = ( new Connection_Manager() )->is_connected();
+
+		if ( ! $blog_id || ! $is_connected ) {
+			return new WP_Error( 'site_not_connected' );
+		}
+
+		return sprintf( self::REST_API_BASE, $blog_id );
+	}
+
+	/**
+	 * Fetch settings
+	 *
+	 * @return WP_Error|array
+	 */
+	public static function get_settings() {
+		if ( self::$settings !== null ) {
+			return self::$settings;
+		}
+
+		$api_url = self::get_api_url();
+		if ( is_wp_error( $api_url ) ) {
+			return $api_url;
+		}
+
+		$response = Client::wpcom_json_api_request_as_blog(
+			self::get_api_url(),
+			'2',
+			array( 'method' => 'GET' ),
+			null,
+			'wpcom'
+		);
+
+		$response_code = wp_remote_retrieve_response_code( $response );
+
+		if ( is_wp_error( $response ) || 200 !== $response_code || empty( $response['body'] ) ) {
+			return new WP_Error( 'failed_fetching_status', 'Failed to fetch Jetpack Social settings data from server', array( 'status' => $response_code ) );
+		}
+
+		self::$settings = json_decode( wp_remote_retrieve_body( $response ) );
+		return self::$settings;
+	}
+
+	/**
+	 * Checks if we should display the shares meter
+	 *
+	 * @return bool
+	 */
+	public static function should_display_shares_meter() {
+		$settings = self::get_settings();
+
+		if ( is_wp_error( $settings ) ) {
+			return false;
+		}
+
+		return (bool) $settings->display_shares_meter;
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add class to fetch the shares data for Publicize/Jetpack Social from WPCOM servers.
* Pass the `shareLimitEnabled` variable to the JS.

#### Other information:

- [X] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `projects/packages/publicize`
* Make sure all tests pass (`composer run phpunit`)