### PR TITLE
Instant Search: prevent hidden submit button appearing on focus

### DIFF
--- a/projects/packages/search/changelog/fix-search-button-appears-on-focus
+++ b/projects/packages/search/changelog/fix-search-button-appears-on-focus
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Instant Search: prevent hidden submit button appearing on focus

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.16.1",
+	"version": "0.16.2-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.16.1';
+	const VERSION = '0.16.2-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/instant-search/components/search-box.jsx
+++ b/projects/packages/search/src/instant-search/components/search-box.jsx
@@ -55,7 +55,7 @@ const SearchBox = props => {
 						/>
 					) }
 
-					<button className="screen-reader-text assistive-text">
+					<button className="screen-reader-text assistive-text" tabIndex="-1">
 						{ __( 'Search', 'jetpack-search-pkg' ) }
 					</button>
 				</label>


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/23401.

#### Changes proposed in this Pull Request:
#23401 describes that, if you tab through the elements in the modal using the keyboard, a hidden submit button appears on focus:

![image](https://user-images.githubusercontent.com/42279181/157994962-cea723e4-3521-4454-80f4-14e4c179ea7f.gif)

This PR removes the hidden submit button from the tab order, so that the button no longer appears on focus.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. On a test site with Jetpack Instant Search enabled, visit `/?s=` to open the search modal.
2. Type into the search modal.
3. Tab twice.
4. Verify that a submit button does not appear.
