### PR TITLE
removes default value from dont_change_homepage argument

### DIFF
--- a/projects/plugins/jetpack/changelog/change-default-arg-theme-mine
+++ b/projects/plugins/jetpack/changelog/change-default-arg-theme-mine
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+WordPress.com REST API: Remove default for 'dont_change_homepage' in the '/sites/%s/themes/mine' endpoint.

--- a/projects/plugins/jetpack/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -42,7 +42,7 @@ new Jetpack_JSON_API_Themes_Active_Endpoint(
 		),
 		'request_format'          => array(
 			'theme'                => '(string) The ID of the theme that should be activated',
-			'dont_change_homepage' => '(bool=false) Whether the homepage of the site should be replaced with the theme homepage',
+			'dont_change_homepage' => '(bool) Whether the homepage of the site should be replaced with the theme homepage',
 		),
 		'response_format'         => Jetpack_JSON_API_Themes_Endpoint::$_response_format,
 		'allow_jetpack_site_auth' => true,


### PR DESCRIPTION
This PR is a follow up to [this other one](https://github.com/Automattic/jetpack/pull/25070). We need to remove the default value for the `dont_change_homepage` argument since the checks that are already in place check for the existence of this argument not the value. Changing this logic would end up being more complex down the road.

For more context see: paYKcK-1Mb-p2#comment-1395

#### Testing instructions:
1. Set up a Jurassic Ninja site.
2. Connect it to WP.com.
3. Connect to your JN site through ssh.
4. Add this snippet to the bottom of `/srv/users/[USER]/apps/[USER]/public/wp-load.php`.
```
add_action('jetpack_pre_switch_theme', function($arg1, $args ) {
        error_log( var_export( $arg1, true ) );
        error_log( var_export( $args, true ) );
}, 10, 2);
```
5. Run `tail -F /srv/users/[USER]/apps/[USER]/public/wp-content/debug.log`.
6. Go to the calypso.live link on [this PR](https://github.com/Automattic/wp-calypso/pull/65060#issuecomment-1169193604) and select your JN site.
7. Go to the theme showcase.
8. Select the `twenty twenty` theme and press `Activate` <img width="295" alt="image" src="https://user-images.githubusercontent.com/375980/178521703-29218e6c-d938-4981-90c2-8c3928e0e375.png">
9. Verify this is the output in the log when selecting the preserve option:
```
[12-Jul-2022 15:01:49 UTC] 'twentytwenty'
[12-Jul-2022 15:01:49 UTC] array (
  'theme' => 'twentytwenty',
  'dont_change_homepage' => true,
)
```
10. Verify this is the output in the log when selecting the replace homepage option:
```
[12-Jul-2022 15:01:49 UTC] 'twentytwenty'
[12-Jul-2022 15:01:49 UTC] array (
  'theme' => 'twentytwenty',
)
```

#### Does this pull request change what data or activity we track or use?
No.

Related to https://github.com/Automattic/wp-calypso/issues/56869