### PR TITLE
Plans: Sync mirror repo information with package.

### DIFF
--- a/projects/packages/plans/changelog/update-jetpack-plans-composer-details
+++ b/projects/packages/plans/changelog/update-jetpack-plans-composer-details
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add mirror repository information to package info.

--- a/projects/packages/plans/composer.json
+++ b/projects/packages/plans/composer.json
@@ -43,6 +43,11 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"extra": {
+		"autotagger": true,
+		"mirror-repo": "Automattic/jetpack-plans",
+		"changelogger": {
+			"link-template": "https://github.com/Automattic/jetpack-plans/compare/v${old}...v${new}"
+		},
 		"branch-alias": {
 			"dev-trunk": "0.1.x-dev"
 		}

--- a/projects/packages/plans/package.json
+++ b/projects/packages/plans/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-plans",
-	"version": "0.1.1",
+	"version": "0.1.2-alpha",
 	"description": "Fetch information about Jetpack Plans from wpcom",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/plans/#readme",
 	"bugs": {

--- a/projects/plugins/jetpack/changelog/update-jetpack-plans-composer-details
+++ b/projects/plugins/jetpack/changelog/update-jetpack-plans-composer-details
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updating composer.lock.

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1364,7 +1364,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "4512affdc11dc64e1911a81dbdde1d842d38e41d"
+                "reference": "9626b5de811b426fa7e2b6c9d123217da16f95fc"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.41"
@@ -1377,6 +1377,11 @@
             },
             "type": "library",
             "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-plans",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-plans/compare/v${old}...v${new}"
+                },
                 "branch-alias": {
                     "dev-trunk": "0.1.x-dev"
                 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* This PR brings across information that is in the[ jetpack-plans mirror repo](https://github.com/Automattic/jetpack-plans), to ensure the package and the mirror repo are in sync - similarly to what was [done here](https://github.com/Automattic/jetpack/pull/25071) for VideoPress.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

p1658237219448209-slack-C01U2KGS2PQ

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Is CI happy?
* Does the information match between the [mirror repo](https://github.com/Automattic/jetpack-plans) and [plans package](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/plans)?
* ^ At the moment it doesn't, because `package.json` in the mirror repo does not have the engines listed that are included here and similarly `composer.json` in the mirror repo does not have the repositories information that is included here. Should this extra info be removed here?

