### PR TITLE
My Jetpack: Change button used in ProductCard component

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -1,5 +1,4 @@
-import { Text } from '@automattic/jetpack-components';
-import { Button } from '@wordpress/components';
+import { Text, Button } from '@automattic/jetpack-components';
 import { __, sprintf } from '@wordpress/i18n';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
@@ -62,25 +61,25 @@ const ActionButton = ( {
 			);
 		case PRODUCT_STATUSES.NEEDS_PURCHASE:
 			return (
-				<Button { ...buttonState } onClick={ onAdd }>
+				<Button { ...buttonState } size="small" onClick={ onAdd }>
 					{ __( 'Purchase', 'jetpack-my-jetpack' ) }
 				</Button>
 			);
 		case PRODUCT_STATUSES.ACTIVE:
 			return (
-				<Button { ...buttonState } variant="secondary" onClick={ onManage }>
+				<Button { ...buttonState } size="small" variant="secondary" onClick={ onManage }>
 					{ __( 'Manage', 'jetpack-my-jetpack' ) }
 				</Button>
 			);
 		case PRODUCT_STATUSES.ERROR:
 			return (
-				<Button { ...buttonState } onClick={ onFixConnection }>
+				<Button { ...buttonState } size="small" onClick={ onFixConnection }>
 					{ __( 'Fix connection', 'jetpack-my-jetpack' ) }
 				</Button>
 			);
 		case PRODUCT_STATUSES.INACTIVE:
 			return (
-				<Button { ...buttonState } variant="secondary" onClick={ onActivate }>
+				<Button { ...buttonState } size="small" variant="secondary" onClick={ onActivate }>
 					{ __( 'Activate', 'jetpack-my-jetpack' ) }
 				</Button>
 			);

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -61,25 +61,37 @@ const ActionButton = ( {
 			);
 		case PRODUCT_STATUSES.NEEDS_PURCHASE:
 			return (
-				<Button { ...buttonState } size="small" onClick={ onAdd }>
+				<Button { ...buttonState } size="small" weight="regular" onClick={ onAdd }>
 					{ __( 'Purchase', 'jetpack-my-jetpack' ) }
 				</Button>
 			);
 		case PRODUCT_STATUSES.ACTIVE:
 			return (
-				<Button { ...buttonState } size="small" variant="secondary" onClick={ onManage }>
+				<Button
+					{ ...buttonState }
+					size="small"
+					weight="regular"
+					variant="secondary"
+					onClick={ onManage }
+				>
 					{ __( 'Manage', 'jetpack-my-jetpack' ) }
 				</Button>
 			);
 		case PRODUCT_STATUSES.ERROR:
 			return (
-				<Button { ...buttonState } size="small" onClick={ onFixConnection }>
+				<Button { ...buttonState } size="small" weight="regular" onClick={ onFixConnection }>
 					{ __( 'Fix connection', 'jetpack-my-jetpack' ) }
 				</Button>
 			);
 		case PRODUCT_STATUSES.INACTIVE:
 			return (
-				<Button { ...buttonState } size="small" variant="secondary" onClick={ onActivate }>
+				<Button
+					{ ...buttonState }
+					size="small"
+					weight="regular"
+					variant="secondary"
+					onClick={ onActivate }
+				>
 					{ __( 'Activate', 'jetpack-my-jetpack' ) }
 				</Button>
 			);

--- a/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
@@ -49,13 +49,6 @@
 	flex-grow: 1;
 }
 
-.button {
-	font-size: var(--font-body-extra-small);
-	border-radius: var(--jp-border-radius);
-	height: var(--actions-size);
-	line-height: var(--actions-size);
-}
-
 .actions {
 	display: flex;
 	align-items: center;

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-product-card-button
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-product-card-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: changed button used in ProductCard component from WordPress to Jetpack default

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "1.8.0",
+	"version": "1.8.1-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -28,7 +28,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '1.8.0';
+	const PACKAGE_VERSION = '1.8.1-alpha';
 
 	/**
 	 * Initialize My Jetapack


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
Changes which `Button` component is used by the `ProductCard` component, switching its import from `@wordpress/components` to `@automattic/jetpack-components`. The visual changes are more pronounced in the storybook, as it is not re-styled there. 

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start `storybook`
* Navigate to `Packages > My Jetpack > Product Card`
* Check if the button is black instead of blue

Before | After
------|------
![Screenshot_2022-07-20_14-41-35-before-story](https://user-images.githubusercontent.com/8486249/180047654-85434cc8-6125-4878-8a0d-f93e09e7ff2b.png) |  ![Screenshot_2022-07-20_14-41-35-after-story](https://user-images.githubusercontent.com/8486249/180047752-8acb6796-dbc7-4e62-be0f-4b209993e6d9.png)

Before | After
------|------
![Screenshot_2022-07-20_14-26-05-before](https://user-images.githubusercontent.com/8486249/180047680-320e4936-f62d-49bc-bda3-f7b21575ca8c.png) | ![Screenshot_2022-07-20_14-26-22-after](https://user-images.githubusercontent.com/8486249/180047772-a823fb96-1885-47bb-9e5f-cf12cff9a866.png)



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202640362053502