### PR TITLE
Jetpack: VPBlock: emit events to window where bridge runs

### DIFF
--- a/projects/plugins/jetpack/changelog/update-my-jetpack-vpblock-minor-bridge-iteration
+++ b/projects/plugins/jetpack/changelog/update-my-jetpack-vpblock-minor-bridge-iteration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: VPBlock: emit events to window where bridge runs

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
@@ -46,6 +46,10 @@ export default function VideoPressPlayer( {
 	const ref = useRef();
 	const { maxWidth, caption, videoRatio } = attributes;
 
+	// Pick up iFrame and sandbox window references.
+	const iFrameDomReference = ref?.current?.querySelector( 'iframe' );
+	const sandboxWindow = iFrameDomReference?.contentWindow;
+
 	/*
 	 * Temporary height is used to set the height of the video
 	 * as soon as the block is rendered into the canvas,
@@ -91,10 +95,15 @@ export default function VideoPressPlayer( {
 	}, [] );
 
 	useEffect( () => {
-		window.addEventListener( 'onVideoPressLoadingState', onVideoLoadingStateHandler );
+		if ( ! sandboxWindow ) {
+			return;
+		}
+
+		sandboxWindow.addEventListener( 'onVideoPressLoadingState', onVideoLoadingStateHandler );
+
 		return () =>
-			window.removeEventListener( 'onVideoPressLoadingState', onVideoLoadingStateHandler );
-	}, [ onVideoLoadingStateHandler ] );
+			sandboxWindow?.removeEventListener( 'onVideoPressLoadingState', onVideoLoadingStateHandler );
+	}, [ onVideoLoadingStateHandler, sandboxWindow ] );
 
 	const onBlockResize = useCallback(
 		( event, direction, domElement ) => {

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-player/index.js
@@ -94,6 +94,15 @@ export default function VideoPressPlayer( {
 		setIsVideoLoaded( detail?.state === 'loaded' );
 	}, [] );
 
+	// set video is loaded as False, when html is not available.
+	useEffect( () => {
+		if ( html ) {
+			return;
+		}
+
+		setIsVideoLoaded( false );
+	}, [ html ] );
+
 	useEffect( () => {
 		if ( ! sandboxWindow ) {
 			return;
@@ -103,7 +112,7 @@ export default function VideoPressPlayer( {
 
 		return () =>
 			sandboxWindow?.removeEventListener( 'onVideoPressLoadingState', onVideoLoadingStateHandler );
-	}, [ onVideoLoadingStateHandler, sandboxWindow ] );
+	}, [ onVideoLoadingStateHandler, sandboxWindow, html ] );
 
 	const onBlockResize = useCallback(
 		( event, direction, domElement ) => {

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/Readme.md
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/Readme.md
@@ -18,10 +18,10 @@ const preview = useSelect(
 const { html } = preview;
 ```
 
-Once the code gets, it's rendered via creating a Sandbox instance where the code to process is defined via the HTML property mentioned above:
+Once the code gets, it's rendered via creating a Sandbox instance where the code to process is defined via the `html` property mentioned above:
 
 ```jsx
-<Sandbox html={ videoPlayerHtml } />
+<Sandbox html={ html } />
 ```
 
 The most relevant thing to raise up here is the fact the video player is rendered into two nested iFrames levels. The <Sandbox /> component does one, and the other is provided by the VideoPress player API.
@@ -48,7 +48,7 @@ Funnily, it happens in the our scenario of the block editor: It renders the raw 
 </div>
 ```
 
-### Solution
+### The Bridge
 
 This bridge script listens and re-emits the events, communicating the VideoPress player with the VideoPress Block. It's sent to the child iFrame through the `scripts` property of the Sandbox component, which takes over to run it in that context.
 
@@ -108,6 +108,23 @@ The bridge triggers the following custom events:
 #### vpBlockActionPause
 
 #### vpBlockActionPause
+
+### Actions
+
+```es6
+// Pause the video after ten seconds.
+setTimeout( () => {
+	iFrameDom?.contentWindow?.postMessage( {
+		event: 'vpBlockActionPause',
+	} );
+}, 10000 );
+```
+
+#### vpBlockActionPlay
+
+#### vpBlockActionPause
+
+#### vpBlockActionSetCurrentTim
 
 ## Debug
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/scripts/vp-block-bridge/index.js
@@ -59,17 +59,17 @@ const rawScript = `
 				name: 'onVideoPressToggleFullscreen',
 				type: 'event',
 			},
-			'vpblock_action_play': {
+			'vpBlockActionPlay': {
 				name: 'vpBlockActionPlay',
 				type: 'action',
 				videoPressAction: 'videopress_action_play',
 			},
-			'vpblock_action_pause': {
+			'vpBlockActionPause': {
 				name: 'vpBlockActionPause',
 				type: 'action',
 				videoPressAction: 'videopress_action_pause',
 			},
-			'vpblock_action_set_currenttime': {
+			'vpBlockActionSetCurrentTime': {
 				name: 'vpBlockActionPause',
 				type: 'action',
 				videoPressAction: 'videopress_action_set_currenttime',
@@ -110,7 +110,14 @@ const rawScript = `
 
 				debug( '🌉 %o [%s] ➜ %o', originalEventName, guid, vpEventName );
 
-				window.parent.dispatchEvent( videoPressBlockEvent );
+				// Dispatch custom event in iFrame window...
+				window.dispatchEvent( videoPressBlockEvent );
+
+				// ...and also dipatch to the parent window,
+				// in case it exists.
+				if ( window?.parent && window.parent !== window ) {
+					window.parent.dispatchEvent( videoPressBlockEvent );
+				}
 			}
 
 			if ( vpEventType === 'action' ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR iterates over the VideoPress bridge script. The suggestion is to be able to emit events to the window object where the bridge runs. Currently, it emits only to its parent, something that's ok for under some circumstances we'd like to emit to its window object too.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack: VPBlock: emit events to window where bridge runs

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Block editor
* Create a new VideoPress beta block
* Add a vide
* Confirm you see the `Loading...` element until the video is loaded.

Use debug() tool to confirm the video loaded state is properly caught:

```
localStorage.setItem( 'debug', 'jetpack:vp-block*' )
```
<img width="730" alt="image" src="https://user-images.githubusercontent.com/77539/180082290-c8410294-aeaa-44cb-9e46-b85697692fc8.png">





---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202624432767017