### PR TITLE
Fixing a typo in actions/turnstile/README.md

### DIFF
--- a/.github/actions/turnstile/README.md
+++ b/.github/actions/turnstile/README.md
@@ -50,7 +50,7 @@ jobs:
     token: ${{ github.token }}
 ```
 
-If you want to limit the maximum amount of time spent waiting, use GitHub's [timeout-minutes](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepstimeout-minutes) on the step. If you want to continue if the timeout expires, use GitHub's [contniue-on-error](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error) on the step.
+If you want to limit the maximum amount of time spent waiting, use GitHub's [timeout-minutes](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepstimeout-minutes) on the step. If you want to continue if the timeout expires, use GitHub's [continue-on-error](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error) on the step.
 
 ## How?
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Fixes a typo in `.github/actions/turnstile/README.md`

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

n/a

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Proof-read, the typo changed was the word 'continue' on line 53.

