### PR TITLE
[Package] Jetpack Backup: Fix restore and purchases fetch errors

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-plugin-fetch-errors
+++ b/projects/packages/backup/changelog/fix-backup-plugin-fetch-errors
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: insignificant change to fix error handling
+
+

--- a/projects/packages/backup/src/js/components/Admin.js
+++ b/projects/packages/backup/src/js/components/Admin.js
@@ -32,7 +32,8 @@ const Admin = () => {
 	const [ priceAfter, setPriceAfter ] = useState( 0 );
 	const [ restores, setRestores ] = useState( [] );
 	// To be used on next iteration of review requests
-	const [ , setCurrentPurchases ] = useState( [] );
+	// eslint-disable-next-line no-unused-vars
+	const [ currentPurchases, setCurrentPurchases ] = useState( [] );
 	const { tracks } = useAnalytics();
 
 	const domain = useSelect( select => select( STORE_ID ).getCalypsoSlug(), [] );
@@ -54,7 +55,7 @@ const Admin = () => {
 				setRestores( res );
 			},
 			() => {
-				setRestores( 'Failed to fetch restores' );
+				setRestores( [] );
 			}
 		);
 		apiFetch( { path: '/jetpack/v4/site/current-purchases' } ).then(
@@ -62,7 +63,7 @@ const Admin = () => {
 				setCurrentPurchases( res.data );
 			},
 			() => {
-				setCurrentPurchases( 'Failed to fetch current purchases' );
+				setCurrentPurchases( [] );
 			}
 		);
 		apiFetch( { path: '/jetpack/v4/backup-capabilities' } ).then(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
- Throw error when Restore or Purchases fetch fails
- Stop assigning a string value to an array typed state


#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
1- Create a Jurassic Ninja site with Jetpack Backup plugin
2- Get a subscription and first backup
3- From Settings -> Jetpack constants, change the JETPACK__SANDBOX_DOMAIN to make the connection fail
4- Reload the Backup admin page and confirm that no errors are shown for string assignments on restores and currentPurchases.

