### PR TITLE
Jetpack Social: Update the tagline in the admin page header

### DIFF
--- a/projects/plugins/social/changelog/update-social-tagline
+++ b/projects/plugins/social/changelog/update-social-tagline
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated the tagline on the admin page.

--- a/projects/plugins/social/src/js/components/header/index.js
+++ b/projects/plugins/social/src/js/components/header/index.js
@@ -52,7 +52,7 @@ const Header = () => {
 	return (
 		<Container horizontalSpacing={ 3 } horizontalGap={ 7 } className={ styles.container }>
 			<Col sm={ 4 } md={ 4 } lg={ 5 }>
-				<H3 mt={ 2 }>{ __( 'Post everywhere at any time', 'jetpack-social' ) }</H3>
+				<H3 mt={ 2 }>{ __( 'Write once, post everywhere', 'jetpack-social' ) }</H3>
 				<Actions actions={ actions } />
 			</Col>
 			<Col sm={ 4 } md={ 4 } lg={ { start: 7, end: 12 } }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The tagline currently reads "Post anywhere at anytime", and it should be
"Write once, post everywhere" this change updates it.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

1201611340747558-as-1202637687837796/f

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

* Go to the Jetpack Social admin page
* The tagline in the header will have changed as described above

Before

<img width="503" alt="image" src="https://user-images.githubusercontent.com/96462/180277437-d76ab56e-36cb-4111-8930-a3b22be3eca1.png">

After

<img width="503" alt="image" src="https://user-images.githubusercontent.com/96462/180277510-c6987c1d-e559-450d-8629-d30c56209b0e.png">
