### PR TITLE
[Package] Jetpack Backup: add review request component

### DIFF
--- a/projects/packages/backup/changelog/add-component-review-request
+++ b/projects/packages/backup/changelog/add-component-review-request
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: No significant change
+
+

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -241,7 +241,32 @@ class Jetpack_Backup {
 					'permission_callback' => __CLASS__ . '::backups_permissions_callback',
 				)
 			);
+
+		// Get and set value of dismissed_backup_review_request option
+		register_rest_route(
+			'jetpack/v4',
+			'/site/dismissed-review-request',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => __CLASS__ . '::get_dismissed_backup_review_request',
+					'permission_callback' => __CLASS__ . '::backups_permissions_callback',
+				),
+				array(
+					'methods'             => \WP_REST_Server::EDITABLE,
+					'callback'            => __CLASS__ . '::set_dismissed_backup_review_request',
+					'permission_callback' => __CLASS__ . '::backups_permissions_callback',
+					'args'                => array(
+						'dismissed_value' => array(
+							'required' => true,
+							'type'     => 'boolean',
+						),
+					),
+				),
+			)
+		);
 	}
+
 	/**
 	 * The backup calls should only occur from a signed in admin user
 	 *
@@ -367,18 +392,6 @@ class Jetpack_Backup {
 	}
 
 	/**
-	 * Removes plugin from the connection manager
-	 * If it's the last plugin using the connection, the site will be disconnected.
-	 *
-	 * @access public
-	 * @static
-	 */
-	public static function plugin_deactivation() {
-		$manager = new Connection_Manager( 'jetpack-backup' );
-		$manager->remove_connection();
-	}
-
-	/**
 	 * Returns the result of `/sites/%d/purchases` endpoint call.
 	 *
 	 * @return array of site purchases.
@@ -413,4 +426,43 @@ class Jetpack_Backup {
 			)
 		);
 	}
+
+	/**
+	 * Returns the value of the dismissed_backup_review_request Jetack option.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @return bool option value.
+	 */
+	public static function get_dismissed_backup_review_request() {
+		return rest_ensure_response(
+			\Jetpack_Options::get_option( 'dismissed_backup_review_request' )
+		);
+	}
+
+	/**
+	 * Set value of the dismissed_backup_review_request Jetack option.
+	 *
+	 * @access public
+	 * @static
+	 * @param bool $request used ot update value of the option.
+	 * @return void
+	 */
+	public static function set_dismissed_backup_review_request( $request ) {
+		\Jetpack_Options::update_option( 'dismissed_backup_review_request', $request['dismissed_value'] );
+	}
+
+	/**
+	 * Removes plugin from the connection manager
+	 * If it's the last plugin using the connection, the site will be disconnected.
+	 *
+	 * @access public
+	 * @static
+	 */
+	public static function plugin_deactivation() {
+		$manager = new Connection_Manager( 'jetpack-backup' );
+		$manager->remove_connection();
+	}
+
 }

--- a/projects/packages/backup/src/js/components/Admin.js
+++ b/projects/packages/backup/src/js/components/Admin.js
@@ -3,7 +3,6 @@ import {
 	AdminSection,
 	AdminSectionHero,
 	Container,
-	ContextualUpgradeTrigger,
 	Col,
 	getRedirectUrl,
 	PricingCard,
@@ -17,6 +16,7 @@ import useAnalytics from '../hooks/useAnalytics';
 import useConnection from '../hooks/useConnection';
 import { STORE_ID } from '../store';
 import Backups from './Backups';
+import ReviewRequest from './review-request';
 import './admin-style.scss';
 import './masthead/masthead-style.scss';
 
@@ -172,7 +172,7 @@ const Admin = () => {
 
 	const ReviewMessage = () => (
 		<Col lg={ 6 } md={ 4 }>
-			<ContextualUpgradeTrigger
+			<ReviewRequest
 				description={ 'Was it easy to restore your site?' }
 				cta={ createInterpolateElement(
 					__(

--- a/projects/packages/backup/src/js/components/review-request/README.md
+++ b/projects/packages/backup/src/js/components/review-request/README.md
@@ -1,0 +1,41 @@
+# Review request
+
+Component designed to prompt for a plugin review after a successful event.
+
+## Usage
+
+```jsx
+import { ReviewRequest } from '@automattic/jetpack-components';
+
+<ReviewRequest
+	description="Related to the successful event"
+	cta="Text action line requesting a review"
+	onClick={ () => ... }
+/>
+```
+
+## Props
+
+### description
+
+A text giving context for a user related to the successful event".
+
+- Type: `String`
+- Default: `""`
+- Required: `true`
+
+### cta
+
+Text action line, recommending the next tier
+
+- Type: `String`
+- Default: `""`
+- Required: `true`
+
+### onClick
+
+Callback that will be called when the user click/tap into the ReviewRequest
+
+- Type: `Function`
+- Default: `undefined`
+- Required: `true`

--- a/projects/packages/backup/src/js/components/review-request/index.tsx
+++ b/projects/packages/backup/src/js/components/review-request/index.tsx
@@ -1,0 +1,53 @@
+import { Text } from '@automattic/jetpack-components';
+import apiFetch from '@wordpress/api-fetch';
+import { Icon, arrowRight } from '@wordpress/components';
+import { useState, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import styles from './style.module.scss';
+import { ReviewRequestBaseProps } from './types';
+import type React from 'react';
+
+const ReviewRequest: React.FC< ReviewRequestBaseProps > = ( { description, cta, onClick } ) => {
+	const [ dismissedReview, setDismissedReview ] = useState( true );
+
+	// Fetch the dismiss status from Jetpack Options
+	useEffect( () => {
+		apiFetch( { path: '/jetpack/v4/site/dismissed-review-request' } ).then(
+			res => {
+				setDismissedReview( res );
+			},
+			() => {
+				setDismissedReview( true );
+			}
+		);
+	}, [] );
+
+	const dismissMessage = () => {
+		apiFetch( {
+			path: '/jetpack/v4/site/dismissed-review-request',
+			method: 'POST',
+			data: { dismissed_value: true },
+		} ).then( setDismissedReview( true ) );
+	};
+
+	if ( dismissedReview ) {
+		return <></>;
+	}
+	return (
+		<>
+			<button className={ styles.rr } onClick={ onClick } role="link">
+				<div>
+					<Text>{ description }</Text>
+					<Text className={ styles.cta }>{ cta }</Text>
+				</div>
+				<Icon icon={ arrowRight } className={ styles.icon } size={ 30 } />
+			</button>
+			{ /* eslint-disable-next-line react/jsx-no-bind */ }
+			<a role="button" href="#" onClick={ dismissMessage } className={ styles.dismiss }>
+				{ __( 'Dismiss', 'jetpack-backup-pkg' ) }
+			</a>
+		</>
+	);
+};
+
+export default ReviewRequest;

--- a/projects/packages/backup/src/js/components/review-request/index.tsx
+++ b/projects/packages/backup/src/js/components/review-request/index.tsx
@@ -1,6 +1,5 @@
 import { Text } from '@automattic/jetpack-components';
 import apiFetch from '@wordpress/api-fetch';
-import { Icon, arrowRight } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import styles from './style.module.scss';
@@ -35,16 +34,19 @@ const ReviewRequest: React.FC< ReviewRequestBaseProps > = ( { description, cta, 
 	}
 	return (
 		<>
-			<button className={ styles.rr } onClick={ onClick } role="link">
+			<button
+				className={ `${ styles.rr } ${ styles.emojisPseudo }` }
+				onClick={ onClick }
+				role="link"
+			>
 				<div>
 					<Text>{ description }</Text>
 					<Text className={ styles.cta }>{ cta }</Text>
 				</div>
-				<Icon icon={ arrowRight } className={ styles.icon } size={ 30 } />
 			</button>
 			{ /* eslint-disable-next-line react/jsx-no-bind */ }
 			<a role="button" href="#" onClick={ dismissMessage } className={ styles.dismiss }>
-				{ __( 'Dismiss', 'jetpack-backup-pkg' ) }
+				{ __( 'Maybe later', 'jetpack-backup-pkg' ) }
 			</a>
 		</>
 	);

--- a/projects/packages/backup/src/js/components/review-request/stories/index.tsx
+++ b/projects/packages/backup/src/js/components/review-request/stories/index.tsx
@@ -1,0 +1,17 @@
+import { action } from '@storybook/addon-actions';
+import ReviewRequest from '../index';
+
+export default {
+	title: 'Backup/Components/Review Request',
+	component: ReviewRequest,
+};
+
+const Template = args => <ReviewRequest { ...args } />;
+
+export const Default = Template.bind( {} );
+Default.args = {
+	description:
+		'What triggered the review request (i.e. Jetpack Backup completed a successful restore)',
+	cta: 'Text action line, asking for a review',
+	onClick: action( 'onClick' ),
+};

--- a/projects/packages/backup/src/js/components/review-request/style.module.scss
+++ b/projects/packages/backup/src/js/components/review-request/style.module.scss
@@ -32,12 +32,22 @@
 	font-weight: 600;
 }
 
-.icon {
-	fill: var(--jp-green-40);
-	transition: transform .1s ease-out;
-}
-
 .dismiss {
 	font-size: 0.75em;
 	padding: calc( var(--spacing-base) * 2 ) calc( var(--spacing-base) * 3 );
+}
+
+.emojisPseudo {
+
+	&:after {
+		font-size:xx-large;
+		content: "\01F600"; // 😀
+	}
+
+	&:hover,
+	&:focus {
+		&:after {
+		content: "\01F60D"; // 😍
+		}
+	}
 }

--- a/projects/packages/backup/src/js/components/review-request/style.module.scss
+++ b/projects/packages/backup/src/js/components/review-request/style.module.scss
@@ -1,0 +1,43 @@
+.rr {
+	border: 2px solid var(--jp-green-40);
+	border-radius: var(--jp-border-radius);
+	padding: calc( var(--spacing-base) * 2 ) calc( var(--spacing-base) * 3 );
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: calc( var(--spacing-base) * 3 );
+	cursor: pointer;
+	text-align: left;
+	background: none;
+	margin: 0;
+	width: 100%;
+
+	&:focus, &:active {
+		outline-color: var(--jp-black);
+	}
+
+	&:hover {
+		& .icon {
+			transform: translateX( calc( var(--spacing-base) * 2 ) );
+		}
+
+		& .cta {
+			text-decoration: underline;
+			text-decoration-thickness: 2px;
+		}
+	}
+}
+
+.cta {
+	font-weight: 600;
+}
+
+.icon {
+	fill: var(--jp-green-40);
+	transition: transform .1s ease-out;
+}
+
+.dismiss {
+	font-size: 0.75em;
+	padding: calc( var(--spacing-base) * 2 ) calc( var(--spacing-base) * 3 );
+}

--- a/projects/packages/backup/src/js/components/review-request/types.ts
+++ b/projects/packages/backup/src/js/components/review-request/types.ts
@@ -1,0 +1,7 @@
+export type ReviewRequestBaseProps = {
+	description: string;
+	cta: string;
+	onClick: () => void;
+	isDismissed: boolean;
+	onDissmiss: () => void;
+};

--- a/projects/packages/connection/changelog/add-component-review-request
+++ b/projects/packages/connection/changelog/add-component-review-request
@@ -1,4 +1,5 @@
-Significance: minor
+Significance: patch
 Type: added
+Comment: Insignificant change. Adding a Jetpack Option
 
-Add review-request component
+

--- a/projects/packages/connection/changelog/add-component-review-request
+++ b/projects/packages/connection/changelog/add-component-review-request
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add review-request component

--- a/projects/packages/connection/legacy/class-jetpack-options.php
+++ b/projects/packages/connection/legacy/class-jetpack-options.php
@@ -126,6 +126,7 @@ class Jetpack_Options {
 			'has_seen_wc_connection_modal',        // (bool) Whether the site has displayed the WooCommerce Connection modal
 			'partner_coupon',                      // (string) A Jetpack partner issued coupon to promote a sale together with Jetpack.
 			'partner_coupon_added',                // (string) A date for when `partner_coupon` was added, so we can auto-purge after a certain time interval.
+			'dismissed_backup_review_request',            // (bool) Determines if the plugin review request is dismissed.
 		);
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Create ReviewRequest component to prompt for a plugin review after a successful event:

<img width="1192" alt="Screen Shot 2022-07-22 at 01 25 20" src="https://user-images.githubusercontent.com/16329583/180331206-12d358d0-dee1-4f24-a6cc-acdab721b3e1.png">


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Stop using ContextualUpgradeTrigger to ask for plugin review
* Add option to dismiss message
* Add JetpackOption to save dismiss value

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
P2 discussion: pbuNQi-3bh-p2
P2 project thread: pbuNQi-3eS-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
- Create Jurassic Ninja site. You can use this link:
https://jurassic.ninja/create?jetpack-beta&branches.jetpack-backup=add/component-review-request&wp-debug-log
You can add &nojetpack at the end to run it without the JP plugin.
- Buy a Backup subscription and complete the initial backup
- Go to cloud.jetpack.com, add the SSH credentials and run a restore
- Once the restore is completed, verify that the message asking for a review is visible and that the link points to the plugin review page
- Click on the dismiss button and the component should hide
- Refresh the page and the component should not show
