### PR TITLE
Instant Search: Fix keyboard handling on search options.

### DIFF
--- a/projects/packages/search/changelog/fix-search-sort-options-keyboard-handling
+++ b/projects/packages/search/changelog/fix-search-sort-options-keyboard-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Instant Search: Fix keyboard handling of sort options.

--- a/projects/packages/search/src/instant-search/components/search-sort.jsx
+++ b/projects/packages/search/src/instant-search/components/search-sort.jsx
@@ -5,13 +5,6 @@ import { getSortOptions } from '../lib/sort';
 import './search-sort.scss';
 
 export default class SearchSort extends Component {
-	handleKeyPress = event => {
-		if ( this.props.value !== event.currentTarget.value && event.key === 'Enter' ) {
-			event.preventDefault();
-			this.props.onChange( event.currentTarget.dataset.value );
-		}
-	};
-
 	handleClick = event => {
 		if ( this.props.value !== event.currentTarget.value ) {
 			event.preventDefault();
@@ -65,19 +58,16 @@ export default class SearchSort extends Component {
 			>
 				<div className="screen-reader-text">{ __( 'Sort by: ', 'jetpack-search-pkg' ) }</div>
 				{ [ ...sortOptions.entries() ].map( ( [ sortKey, label ] ) => (
-					<a
+					<button
 						className={ `jetpack-instant-search__search-sort-option ${
 							this.props.value === sortKey ? 'is-selected' : ''
 						}` }
 						data-value={ sortKey }
 						key={ sortKey }
 						onClick={ this.handleClick }
-						onKeyPress={ this.handleKeyPress }
-						role="button"
-						tabIndex={ 0 }
 					>
 						{ label }
-					</a>
+					</button>
 				) ) }
 			</div>
 		);

--- a/projects/packages/search/src/instant-search/components/search-sort.scss
+++ b/projects/packages/search/src/instant-search/components/search-sort.scss
@@ -54,6 +54,8 @@
 	padding: 0 2px 0 2px;
 	color: $color-text-lighter;
 	text-decoration: none;
+	border: 0px;
+	background-color: inherit;
 
 	&::after {
 		content: '·';


### PR DESCRIPTION
Addresses the Relevance, Newest, and Oldest links. Now using HTML buttons instead of anchors with some minor CSS tweaks to keep them looking pretty. As buttons, they get the proper default keyboard handling and are recognized in the tab-loop more consistently.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #23393.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

- The Relevance, Newest, and Oldest links now respond to the default keyboard keys.
- They have been changed from anchor elements to button elements.
- Firefox now includes them in the tab loop. Previously they were ignored despite having the "role=button" attribute set.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

On any site with a Jetpack Search plan:

1. Visit the Instant Search overlay.
2. Enter a search term. This should update the results and focus the text field.
3. Now tab from the text input field to the "Relevance • Newest • Oldest" links.
4. Confirm they are, in fact, accessible via tabbing.
5. Confirm you can trigger an update by either Return or Space keys.


**Note:** Input is ignored if that option is already selected so hitting space/return on the currently selected option will not trigger a refresh.

Demo:

https://user-images.githubusercontent.com/40267301/180366004-1e7f4412-c66d-43a6-b03b-b268198631b8.mp4

