### PR TITLE
Instant Search: Make current search option visible to screen readers.

### DIFF
--- a/projects/packages/search/changelog/fix-search-options-current-selection-a11y
+++ b/projects/packages/search/changelog/fix-search-options-current-selection-a11y
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Instant Search: Add indicator of currently selected search option for screen readers.

--- a/projects/packages/search/src/instant-search/components/search-sort.jsx
+++ b/projects/packages/search/src/instant-search/components/search-sort.jsx
@@ -62,6 +62,7 @@ export default class SearchSort extends Component {
 				{ [ ...sortOptions.entries() ].map( ( [ sortKey, label ] ) => (
 					<>
 						<button
+							aria-current={ this.props.value === sortKey ? 'true' : 'false' }
 							className={ `jetpack-instant-search__search-sort-option ${
 								this.props.value === sortKey ? 'is-selected' : ''
 							}` }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Adds the `aria-current="true"` value to the currently selected search option making it accessible to screen readers.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Visit the Instant Search overlay and…

1. Select one of Relevance, Newest, Oldest.
2. Open the inspector and confirm that the `aria-current` value is set to `true`.
3. Change sort options and confirm the attributes update accordingly.

![AriaCurrentSnap](https://user-images.githubusercontent.com/40267301/180382615-879c43e5-4c18-492c-9afa-6b87e3b383bb.png)
