### PR TITLE
Admin menu: display the translations for the plan name

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-admin-menu-plan-translation
+++ b/projects/plugins/jetpack/changelog/fix-admin-menu-plan-translation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Admin menu: display the translations for the plan name

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -144,7 +144,7 @@ class Admin_Menu extends Base_Admin_Menu {
 				$site_upgrades = sprintf(
 					$site_upgrades,
 					__( 'Upgrades', 'jetpack' ),
-					$plan
+					__( $plan ),
 				);
 			} else {
 				$site_upgrades = __( 'Upgrades', 'jetpack' );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -145,7 +145,7 @@ class Admin_Menu extends Base_Admin_Menu {
 					$site_upgrades,
 					__( 'Upgrades', 'jetpack' ),
 					// phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
-					__( $plan ),
+					__( $plan, 'jetpack' )
 				);
 			} else {
 				$site_upgrades = __( 'Upgrades', 'jetpack' );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -144,6 +144,7 @@ class Admin_Menu extends Base_Admin_Menu {
 				$site_upgrades = sprintf(
 					$site_upgrades,
 					__( 'Upgrades', 'jetpack' ),
+					// phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
 					__( $plan ),
 				);
 			} else {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Ports the changes implemented in D83967-code to display the translated plan name for languages which have translations for them (such as Japanese or Arabic)

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Refer to D83967-code

