### PR TITLE
Repo Gardening: create a new "Reply to customers Reminder" task

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -3,7 +3,7 @@ on:
   pull_request_target: # When a PR is opened, edited, updated, closed, or a label is added.
     types: [opened, reopened, synchronize, edited, labeled, closed ]
   issues: # For auto-triage of issues.
-    types: [opened, reopened, edited]
+    types: [opened, reopened, edited, closed]
   issue_comment: # To gather support references in issue comments.
     types: [created]
   push:
@@ -76,3 +76,4 @@ jobs:
           slack_team_channel: ${{ secrets.SLACK_TEAM_CHANNEL }}
           slack_design_channel: ${{ secrets.SLACK_DESIGN_CHANNEL }}
           slack_editorial_channel: ${{ secrets.SLACK_EDITORIAL_CHANNEL }}
+          slack_he_triage_channel: ${{ secrets.SLACK_HE_TRIAGE_CHANNEL }}

--- a/projects/github-actions/repo-gardening/README.md
+++ b/projects/github-actions/repo-gardening/README.md
@@ -73,11 +73,14 @@ The action relies on the following parameters.
 
 - (Required) `github_token` is a GitHub Access Token used to access GitHub's API. The user account associated with the token is the one that will be seen as posting the checkDescription comment, adding and removing labels, and so on. If omitted, the standard token for the github-actions bot will be used.
 - (Optional) `tasks` allows for running selected tasks instead of the full suite. The value is a comma-separated list of task identifiers. You can find the list of the different tasks (and what event it's attached to) in `src/index.js`.
-- (Optional) `slack_token` is the Auth token of a bot that is installed on your Slack workspace. The token should be stored in a [secret](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
+- (Optional) `slack_token` is the Auth token of a bot that is installed on your Slack workspace. The token should be stored in a [secret](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository). See the instructions below to create a bot.
 - (Optional) `slack_design_channel` is the Slack public channel ID where messages for the design team will be posted. Again, the value should be stored in a secret.
 - (Optional) `slack_editorial_channel` is the Slack public channel ID where messages for the Editorial team will be posted. Again, the value should be stored in a secret.
 - (Optional) `slack_team_channel` is the Slack public channel ID where general notifications about your repo should be posted. Again, the value should be stored in a secret.
 - (Optional) `slack_he_triage_channel` is the Slack public channel ID where messages for the HE Triage team will be posted. The value should be stored in a secret.
+- (Optional) `reply_to_customers_threshold`. It is optional, and defaults to 10. It is the minimum number of support references needed to trigger an alert that we need to reply to customers.
+
+#### How to create a Slack bot and get your SLACK_TOKEN
 
 To create a bot and get your `SLACK_TOKEN`, follow [the general instructions here](https://slack.com/intl/en-hu/help/articles/115005265703-Create-a-bot-for-your-workspace):
 

--- a/projects/github-actions/repo-gardening/README.md
+++ b/projects/github-actions/repo-gardening/README.md
@@ -17,6 +17,7 @@ Here is the current list of tasks handled by this action:
 - Flag OSS (`flagOss`): flags entries by external contributors, adds an "OSS Citizen" label to the PR, and sends a Slack message.
 - Triage New Issues (`triageNewIssues`): Adds labels to new issues based on issue content.
 - Gather support references (`gatherSupportReferences`): Adds a new comment with a list of all support references on the issue.
+- Reply to customers Reminder ( `replyToCustomersReminder` ): sends a Slack message about closed issues to remind Automatticians to update customers.
 
 Some of the tasks are may not satisfy your needs. If that's the case, you can use the `tasks` option to limit the action to the list of tasks you need in your repo. See the example below to find out more.
 
@@ -76,6 +77,7 @@ The action relies on the following parameters.
 - (Optional) `slack_design_channel` is the Slack public channel ID where messages for the design team will be posted. Again, the value should be stored in a secret.
 - (Optional) `slack_editorial_channel` is the Slack public channel ID where messages for the Editorial team will be posted. Again, the value should be stored in a secret.
 - (Optional) `slack_team_channel` is the Slack public channel ID where general notifications about your repo should be posted. Again, the value should be stored in a secret.
+- (Optional) `slack_he_triage_channel` is the Slack public channel ID where messages for the HE Triage team will be posted. The value should be stored in a secret.
 
 To create a bot and get your `SLACK_TOKEN`, follow [the general instructions here](https://slack.com/intl/en-hu/help/articles/115005265703-Create-a-bot-for-your-workspace):
 

--- a/projects/github-actions/repo-gardening/action.yml
+++ b/projects/github-actions/repo-gardening/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: "Slack channel ID where messages for the Editorial team will be sent"
     required: false
     default: ""
+  slack_he_triage_channel:
+    description: "Slack channel ID where messages for the HE Triage team will be sent"
+    required: false
+    default: ""
   slack_team_channel:
     description: "Slack channel ID where general notifications should be sent"
     required: false

--- a/projects/github-actions/repo-gardening/action.yml
+++ b/projects/github-actions/repo-gardening/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: "GitHub access token"
     required: true
     default: ${{ github.token }}
+  reply_to_customers_threshold:
+    description: "Minimum of support references needed to trigger a reminder to batch-reply to customers. Default to 10."
+    required: false
+    default: "10"
   slack_token:
     description: "Slack Bot access token"
     required: false

--- a/projects/github-actions/repo-gardening/changelog/add-issue-bulk-reply
+++ b/projects/github-actions/repo-gardening/changelog/add-issue-bulk-reply
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+New task: Reply to customers Reminder -- PSends a Slack message to remind triage teams to reply to customers once an issue has been closed.

--- a/projects/github-actions/repo-gardening/changelog/add-issue-bulk-reply
+++ b/projects/github-actions/repo-gardening/changelog/add-issue-bulk-reply
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-New task: Reply to customers Reminder -- PSends a Slack message to remind triage teams to reply to customers once an issue has been closed.
+New task: Reply to customers Reminder -- Sends a Slack message to remind triage teams to reply to customers once an issue has been closed.

--- a/projects/github-actions/repo-gardening/src/index.js
+++ b/projects/github-actions/repo-gardening/src/index.js
@@ -9,6 +9,7 @@ const flagOss = require( './tasks/flag-oss' );
 const gatherSupportReferences = require( './tasks/gather-support-references' );
 const notifyDesign = require( './tasks/notify-design' );
 const notifyEditorial = require( './tasks/notify-editorial' );
+const replyToCustomersReminder = require( './tasks/reply-to-customers-reminder' );
 const triageNewIssues = require( './tasks/triage-new-issues' );
 const wpcomCommitReminder = require( './tasks/wpcom-commit-reminder' );
 const debug = require( './utils/debug' );
@@ -74,6 +75,11 @@ const automations = [
 		event: 'issue_comment',
 		action: [ 'created' ],
 		task: gatherSupportReferences,
+	},
+	{
+		event: 'issues',
+		action: [ 'closed' ],
+		task: replyToCustomersReminder,
 	},
 ];
 

--- a/projects/github-actions/repo-gardening/src/tasks/reply-to-customers-reminder/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/reply-to-customers-reminder/index.js
@@ -165,7 +165,7 @@ ${
 	full_name.match( /^Automattic\/(jetpack|zero-bs-crm|themes)$/i )
 		? `
 
-**Note**: Before you send follow-up replies, you'll want to make sure the fix has been deployed to all customers. Check the Pull Request that closed the issue to see when the fix will be deployed to customers.`
+Before you send follow-up replies, you'll want to make sure the fix has been deployed to all customers. Check the Pull Request that closed the issue to see when the fix will be deployed to customers.`
 		: ''
 }`;
 

--- a/projects/github-actions/repo-gardening/src/tasks/reply-to-customers-reminder/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/reply-to-customers-reminder/index.js
@@ -30,6 +30,7 @@ async function hasHighPriorityLabel( octokit, owner, repo, number ) {
  * @returns {Promise<boolean>} Promise resolving to boolean.
  */
 async function hasManySupportReferences( issueComments ) {
+	let isWidelySpreadIssue = false;
 	issueComments.map( comment => {
 		if (
 			comment.user.login === 'github-actions[bot]' &&
@@ -38,12 +39,12 @@ async function hasManySupportReferences( issueComments ) {
 			// Count the number of to-do items in the comment.
 			const countReferences = comment.body.split( '- [ ] ' ).length - 1;
 			if ( countReferences > 10 ) {
-				return true;
+				isWidelySpreadIssue = true;
 			}
 		}
 	} );
 
-	return false;
+	return isWidelySpreadIssue;
 }
 
 /**

--- a/projects/github-actions/repo-gardening/src/tasks/reply-to-customers-reminder/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/reply-to-customers-reminder/index.js
@@ -59,8 +59,18 @@ async function hasManySupportReferences( issueComments ) {
  * @returns {Object} Object containing the slack message and its formatting.
  */
 function formatSlackMessage( payload, channel, message ) {
-	const { issue } = payload;
+	const { issue, repository } = payload;
 	const { html_url, title } = issue;
+
+	let dris = '@bug_herders';
+	switch ( repository.full_name ) {
+		case 'Automattic/jetpack':
+			dris = '@jpop-da';
+			break;
+		case 'Automattic/zero-bs-crm':
+			dris = '@heysatellite';
+			break;
+	}
 
 	return {
 		channel,
@@ -79,7 +89,7 @@ function formatSlackMessage( payload, channel, message ) {
 				type: 'section',
 				text: {
 					type: 'mrkdwn',
-					text: 'cc @bug_herders',
+					text: `cc ${ dris }`,
 				},
 			},
 			{

--- a/projects/github-actions/repo-gardening/src/tasks/reply-to-customers-reminder/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/reply-to-customers-reminder/index.js
@@ -119,7 +119,7 @@ function formatSlackMessage( payload, channel, message ) {
 async function replyToCustomersReminder( payload, octokit ) {
 	const { issue, repository } = payload;
 	const { number } = issue;
-	const { owner, name: repo } = repository;
+	const { full_name, owner, name: repo } = repository;
 	const ownerLogin = owner.login;
 
 	const slackToken = getInput( 'slack_token' );
@@ -160,8 +160,15 @@ async function replyToCustomersReminder( payload, octokit ) {
 	}
 
 	debug( `reply-to-customers-reminder: Sending in Slack message about #${ number }.` );
-	const message =
-		'This high priority issue was recently closed. It is now time to send follow-up replies to all impacted customers.';
+	const message = `This high priority issue was recently closed. It is now time to send follow-up replies to all impacted customers.
+${
+	full_name.match( /^Automattic\/(jetpack|zero-bs-crm|themes)$/i )
+		? `
+
+**Note**: Before you send follow-up replies, you'll want to make sure the fix has been deployed to all customers. Check the Pull Request that closed the issue to see when the fix will be deployed to customers.`
+		: ''
+}`;
+
 	const slackMessageFormat = formatSlackMessage( payload, channel, message );
 	await sendSlackMessage( message, channel, slackToken, payload, slackMessageFormat );
 }

--- a/projects/github-actions/repo-gardening/src/tasks/reply-to-customers-reminder/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/reply-to-customers-reminder/index.js
@@ -1,0 +1,164 @@
+const { getInput, setFailed } = require( '@actions/core' );
+const debug = require( '../../utils/debug' );
+const getComments = require( '../../utils/get-comments' );
+const getLabels = require( '../../utils/get-labels' );
+const sendSlackMessage = require( '../../utils/send-slack-message' );
+
+/* global GitHub, WebhookPayloadIssue */
+
+/**
+ * Check for a High or Blocker Priority label on an issue.
+ *
+ * @param {GitHub} octokit - Initialized Octokit REST client.
+ * @param {string} owner   - Repository owner.
+ * @param {string} repo    - Repository name.
+ * @param {string} number  - Issue number.
+ * @returns {Promise<boolean>} Promise resolving to boolean.
+ */
+async function hasHighPriorityLabel( octokit, owner, repo, number ) {
+	const labels = await getLabels( octokit, owner, repo, number );
+
+	return labels.some( label => label === '[Pri] High' || label === '[Pri] BLOCKER' );
+}
+
+/**
+ * Check if the issue has a comment with a list of support references,
+ * and more than 10 support references listed there.
+ * We only count the number of unanswered support references, since they're the ones we'll need to contact.
+ *
+ * @param {Array} issueComments - Array of all comments on that issue.
+ * @returns {Promise<boolean>} Promise resolving to boolean.
+ */
+async function hasManySupportReferences( issueComments ) {
+	issueComments.map( comment => {
+		if (
+			comment.user.login === 'github-actions[bot]' &&
+			comment.body.includes( '**Support References**' )
+		) {
+			// Count the number of to-do items in the comment.
+			const countReferences = comment.body.split( '- [ ] ' ).length - 1;
+			if ( countReferences > 10 ) {
+				return true;
+			}
+		}
+	} );
+
+	return false;
+}
+
+/**
+ * Build an object containing the slack message and its formatting to send to Slack.
+ *
+ * @param {WebhookPayloadIssue} payload - Issue event payload.
+ * @param {string}              channel - Slack channel ID.
+ * @param {string}              message - Basic message (without the formatting).
+ * @returns {Object} Object containing the slack message and its formatting.
+ */
+function formatSlackMessage( payload, channel, message ) {
+	const { issue } = payload;
+	const { html_url, title } = issue;
+
+	return {
+		channel,
+		blocks: [
+			{
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: message,
+				},
+			},
+			{
+				type: 'divider',
+			},
+			{
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: 'cc @bug_herders',
+				},
+			},
+			{
+				type: 'divider',
+			},
+			{
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: `<${ html_url }|${ title }>`,
+				},
+				accessory: {
+					type: 'button',
+					text: {
+						type: 'plain_text',
+						text: 'View',
+						emoji: true,
+					},
+					value: 'click_review',
+					url: `${ html_url }`,
+					action_id: 'button-action',
+				},
+			},
+		],
+		text: `${ message } -- <${ html_url }|${ title }>`, // Fallback text for display in notifications.
+		mrkdwn: true, // Formatting of the fallback text.
+	};
+}
+
+/**
+ * Send a Slack message about high priority closed issues impacting a lot of customers,
+ * to remind Automatticians to update customers.
+ *
+ * @param {WebhookPayloadIssue} payload - Issue event payload.
+ * @param {GitHub}              octokit - Initialized Octokit REST client.
+ */
+async function replyToCustomersReminder( payload, octokit ) {
+	const { issue, repository } = payload;
+	const { number } = issue;
+	const { owner, name: repo } = repository;
+	const ownerLogin = owner.login;
+
+	const slackToken = getInput( 'slack_token' );
+	if ( ! slackToken ) {
+		setFailed(
+			`reply-to-customers-reminder: Input slack_token is required but missing. Aborting.`
+		);
+		return;
+	}
+
+	const channel = getInput( 'slack_he_triage_channel' );
+	if ( ! channel ) {
+		setFailed(
+			`reply-to-customers-reminder: Input slack_he_triage_channel is required but missing. Aborting.`
+		);
+		return;
+	}
+
+	// Check if the issue has a "High" or "BLOCKER" priority.
+	const isHighPriorityIssue = await hasHighPriorityLabel( octokit, ownerLogin, repo, number );
+	if ( ! isHighPriorityIssue ) {
+		debug(
+			`reply-to-customers-reminder: #${ number } is not labeled as a high priority issue. Aborting.`
+		);
+		return;
+	}
+
+	// Check if the issue has a comment with a list of support references,
+	// and more than 10 support references listed there.
+	const issueComments = await getComments( octokit, ownerLogin, repo, number );
+	const isWidelySpreadIssue = await hasManySupportReferences( issueComments );
+	if ( ! isWidelySpreadIssue ) {
+		debug(
+			`reply-to-customers-reminder: #${ number } has fewer than 10 support references. Aborting.`
+		);
+		return;
+	}
+
+	debug( `reply-to-customers-reminder: Sending in Slack message about #${ number }.` );
+	const message =
+		'This high priority issue was recently closed. It is now time to send follow-up replies to all impacted customers.';
+	const slackMessageFormat = formatSlackMessage( payload, channel, message );
+	await sendSlackMessage( message, channel, slackToken, payload, slackMessageFormat );
+}
+
+module.exports = replyToCustomersReminder;

--- a/projects/github-actions/repo-gardening/src/tasks/reply-to-customers-reminder/readme.md
+++ b/projects/github-actions/repo-gardening/src/tasks/reply-to-customers-reminder/readme.md
@@ -8,7 +8,7 @@ The Slack message is sent in the following conditions:
 
 - When the issue is closed.
 - The issue must have one of the following labels: `[Pri] High` , `[Pri] BLOCKER`.
-- The issue must have > 10 gathered support references.
+- The issue must have at least a certain number of gathered support references. That number can be customized via the `reply_to_customers_threshold` parameter, and defaults to 10.
 
 This task relies on 2 extra parameters, passed to the action: `slack_token` and `slack_he_triage_channel`.
 

--- a/projects/github-actions/repo-gardening/src/tasks/reply-to-customers-reminder/readme.md
+++ b/projects/github-actions/repo-gardening/src/tasks/reply-to-customers-reminder/readme.md
@@ -1,0 +1,17 @@
+# Reply to Customers Reminder
+
+When a high priority issue gets closed, we'll remind the support triage team via Slack, so they can now reply to all the customers impacted by this issue.
+
+This is only useful when used in combination with the `gatherSupportReferences` task.
+
+The Slack message is sent in the following conditions:
+
+- When the issue is closed.
+- The issue must have one of the following labels: `[Pri] High` , `[Pri] BLOCKER`.
+- The issue must have > 10 gathered support references.
+
+This task relies on 2 extra parameters, passed to the action: `slack_token` and `slack_he_triage_channel`.
+
+## Rationale
+
+If we warn the triage team as soon as an issue gets closed, they can make sure to reply to customers in a timely manner.

--- a/projects/github-actions/repo-gardening/src/utils/send-slack-message.js
+++ b/projects/github-actions/repo-gardening/src/utils/send-slack-message.js
@@ -13,57 +13,61 @@ const fetch = require( 'node-fetch' );
  * @returns {Promise<boolean>} Promise resolving to a boolean, whether message was successfully posted or not.
  */
 async function sendSlackMessage( message, channel, token, payload, customMessageFormat = {} ) {
-	const { pull_request, repository } = payload;
-	const { html_url, title, user } = pull_request;
+	let slackMessage = '';
 
-	const slackMessage =
-		Object.keys( customMessageFormat ).length > 0
-			? customMessageFormat
-			: {
-					channel,
-					blocks: [
-						{
-							type: 'section',
-							text: {
-								type: 'mrkdwn',
-								text: `${ message }`,
-							},
+	// If we have a custom message format, use it.
+	if ( Object.keys( customMessageFormat ).length > 0 ) {
+		slackMessage = customMessageFormat;
+	} else {
+		const { pull_request, repository } = payload;
+		const { html_url, title, user } = pull_request;
+
+		slackMessage = {
+			channel,
+			blocks: [
+				{
+					type: 'section',
+					text: {
+						type: 'mrkdwn',
+						text: `${ message }`,
+					},
+				},
+				{
+					type: 'divider',
+				},
+				{
+					type: 'section',
+					text: {
+						type: 'mrkdwn',
+						text: `PR created by ${ user.login } in the <${ repository.html_url }|${ repository.full_name }> repo.`,
+					},
+				},
+				{
+					type: 'divider',
+				},
+				{
+					type: 'section',
+					text: {
+						type: 'mrkdwn',
+						text: `<${ html_url }|${ title }>`,
+					},
+					accessory: {
+						type: 'button',
+						text: {
+							type: 'plain_text',
+							text: 'Review',
+							emoji: true,
 						},
-						{
-							type: 'divider',
-						},
-						{
-							type: 'section',
-							text: {
-								type: 'mrkdwn',
-								text: `PR created by ${ user.login } in the <${ repository.html_url }|${ repository.full_name }> repo.`,
-							},
-						},
-						{
-							type: 'divider',
-						},
-						{
-							type: 'section',
-							text: {
-								type: 'mrkdwn',
-								text: `<${ html_url }|${ title }>`,
-							},
-							accessory: {
-								type: 'button',
-								text: {
-									type: 'plain_text',
-									text: 'Review',
-									emoji: true,
-								},
-								value: 'click_review',
-								url: `${ html_url }`,
-								action_id: 'button-action',
-							},
-						},
-					],
-					text: `${ message } -- <${ html_url }|${ title }>`, // Fallback text for display in notifications.
-					mrkdwn: true, // Formatting of the fallback text.
-			  };
+						value: 'click_review',
+						url: `${ html_url }`,
+						action_id: 'button-action',
+					},
+				},
+			],
+			text: `${ message } -- <${ html_url }|${ title }>`, // Fallback text for display in notifications.
+			mrkdwn: true, // Formatting of the fallback text.
+		};
+	}
 
 	const slackRequest = await fetch( 'https://slack.com/api/chat.postMessage', {
 		method: 'POST',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This new task will run when issues get closed.

It will check for a few things:
- Is the issue important (has a High or Blocker priority label)?
- Does it have a comment listing support references, where at least 10 answered (unchecked) support references are listed (that number can be customized via an action input)?

If it finds such a comment, it will attempt to post a message in a Slack channel (specified in a GitHub secret, so it can be different for each repo), asking the triage team to reply to all those tickets.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

Internal reference: pcLjiI-Ro-p2

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

This is a bit hard to test until it's been merged. You can check the outcome here with the changes from this PR pushed to a fork of this repo:

p1658746047426189-slack-CN2FSK7L4