### PR TITLE
My Jetpack: Add button to ProductCard with absent plugin

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -34,7 +34,7 @@ const ActionButton = ( {
 } ) => {
 	if ( ! admin ) {
 		return (
-			<Button { ...buttonState } size="small" weight="regular">
+			<Button { ...buttonState } size="small" variant="link" weight="regular">
 				{
 					/* translators: placeholder is product name. */
 					sprintf( __( 'Learn about %s', 'jetpack-my-jetpack' ), name )
@@ -52,7 +52,7 @@ const ActionButton = ( {
 	switch ( status ) {
 		case PRODUCT_STATUSES.ABSENT:
 			return (
-				<Button { ...buttonState } size="small" weight="regular">
+				<Button { ...buttonState } size="small" variant="link" weight="regular">
 					{
 						/* translators: placeholder is product name. */
 						sprintf( __( 'Add %s', 'jetpack-my-jetpack' ), name )

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -34,12 +34,12 @@ const ActionButton = ( {
 } ) => {
 	if ( ! admin ) {
 		return (
-			<span className={ styles[ 'action-link-button' ] }>
+			<Button { ...buttonState } size="small" weight="regular">
 				{
 					/* translators: placeholder is product name. */
 					sprintf( __( 'Learn about %s', 'jetpack-my-jetpack' ), name )
 				}
-			</span>
+			</Button>
 		);
 	}
 
@@ -52,12 +52,12 @@ const ActionButton = ( {
 	switch ( status ) {
 		case PRODUCT_STATUSES.ABSENT:
 			return (
-				<span className={ styles[ 'action-link-button' ] }>
+				<Button { ...buttonState } size="small" weight="regular">
 					{
 						/* translators: placeholder is product name. */
 						sprintf( __( 'Add %s', 'jetpack-my-jetpack' ), name )
 					}
-				</span>
+				</Button>
 			);
 		case PRODUCT_STATUSES.NEEDS_PURCHASE:
 			return (

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.test.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.test.jsx
@@ -4,15 +4,28 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import * as stories from './stories';
 
-const { Default } = composeStories( stories );
+const { Default, Absent } = composeStories( stories );
 
 describe( 'ProductCard', () => {
-	test( 'calls onManage', async () => {
-		const user = userEvent.setup();
-		const onManage = jest.fn();
-		render( <Default onManage={ onManage } /> );
-		const actionButton = screen.getByRole( 'button', { name: 'Manage' } );
-		await user.click( actionButton );
-		expect( onManage ).toHaveBeenCalled();
+	describe( 'when the product is active', () => {
+		test( 'calls onManage', async () => {
+			const user = userEvent.setup();
+			const onManage = jest.fn();
+			render( <Default onManage={ onManage } /> );
+			const actionButton = screen.getByRole( 'button', { name: 'Manage' } );
+			await user.click( actionButton );
+			expect( onManage ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'when the plugin is absent', () => {
+		test( 'calls onAdd', async () => {
+			const user = userEvent.setup();
+			const onAdd = jest.fn();
+			render( <Absent onAdd={ onAdd } /> );
+			const actionButton = screen.getByRole( 'button', { name: 'Add Backup' } );
+			await user.click( actionButton );
+			expect( onAdd ).toHaveBeenCalled();
+		} );
 	} );
 } );

--- a/projects/packages/my-jetpack/_inc/components/product-card/stories/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/stories/index.jsx
@@ -42,3 +42,9 @@ const DefaultArgs = {
 
 export const Default = Template.bind( {} );
 Default.args = DefaultArgs;
+
+export const Absent = Template.bind( {} );
+Absent.args = {
+	...DefaultArgs,
+	status: PRODUCT_STATUSES.ABSENT,
+};

--- a/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
@@ -19,10 +19,6 @@
 
 		&:hover {
 			background-color: var( --jp-white );
-
-			.action-link-button {
-				text-decoration-thickness: var(--jp-underline-thickness);
-			}
 		}
 
 		&:focus {
@@ -57,10 +53,6 @@
 	margin-top: calc( var(--spacing-base) * 2 ); // 16px
 	min-height: var(--actions-size);
 	flex-wrap: wrap;
-}
-
-.action-link-button{
-	text-decoration: underline;
 }
 
 .status {

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-add-product-button
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-add-product-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: changed link used in ProductCard component to a button when the plugin is absent

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "1.8.1",
+	"version": "1.8.2-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -28,7 +28,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '1.8.1';
+	const PACKAGE_VERSION = '1.8.2-alpha';
 
 	/**
 	 * Initialize My Jetapack


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Changes the `Add <Plugin>` element from a `span` to a `Button`.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the `My Jetpack` page
* Check that the link `Add <Plugin>` works as before in a card with an absent plugin

Storybook:
* Start `storybook`
* Navigate to `Packages > My Jetpack > Product Card > Absent`
* Check that the link `Add Backup` works as before

Before | After
------|------
![Screenshot_2022-07-22_15-45-25-before-story](https://user-images.githubusercontent.com/8486249/180511642-23a63806-e51f-400e-a705-375e5c7f7a9d.png) | ![Screenshot_2022-07-25_10-56-37-after-story-review](https://user-images.githubusercontent.com/8486249/180795965-44e1592d-f099-4c06-abdd-f3802060edd7.png)

Before | After
------|------
![Screenshot_2022-07-22_15-46-17-before](https://user-images.githubusercontent.com/8486249/180511938-2a866808-19f2-4d80-a1c7-4472b3d61f2d.png) | ![Screenshot_2022-07-25_11-01-24-after-review](https://user-images.githubusercontent.com/8486249/180796149-9ad11e85-4532-4c08-9e85-e8bd1f7d0cd3.png)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202624432767024