### PR TITLE
Remove conditional analytics event

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
@@ -10,7 +10,6 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Plugins_Installer;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
-use Automattic\Jetpack\Tracking;
 
 /**
  * Contains utilities related to the Jetpack Recommendations.
@@ -328,8 +327,6 @@ class Jetpack_Recommendations {
 		if ( ! in_array( $recommendation_name, $conditional_recommendations, true ) ) {
 			array_push( $conditional_recommendations, $recommendation_name );
 			Jetpack_Options::update_option( self::CONDITIONAL_RECOMMENDATIONS_OPTION, $conditional_recommendations );
-			$tracking = new Tracking();
-			$tracking->record_user_event( 'recommendations_conditional_recommendation_enabled', array( 'feature' => $recommendation_name ) );
 		}
 	}
 

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
@@ -325,7 +325,7 @@ class Jetpack_Recommendations {
 
 		$conditional_recommendations = Jetpack_Options::get_option( self::CONDITIONAL_RECOMMENDATIONS_OPTION, array() );
 		if ( ! in_array( $recommendation_name, $conditional_recommendations, true ) ) {
-			array_push( $conditional_recommendations, $recommendation_name );
+			$conditional_recommendations[] = $recommendation_name;
 			Jetpack_Options::update_option( self::CONDITIONAL_RECOMMENDATIONS_OPTION, $conditional_recommendations );
 		}
 	}

--- a/projects/plugins/jetpack/changelog/update-recommendation-analytics
+++ b/projects/plugins/jetpack/changelog/update-recommendation-analytics
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update analytics


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR removes the `recommendations_conditional_recommendation_enabled ` analytics event.
* It also simplifies the array logic when enabling a new conditional recommendation.

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pbNhbs-3aX-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
One analytics event is removed.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Testing this change will focus on making sure conditional recommendations are still enabled properly with the updated code.
* Check out this PR on your test site
* Reset the Jetpack Options from the Jetpack dashboard
* Reload the Jetpack dashboard and confirm that there is not a red badge next to the "Recommendations" tab on the dashboard.
* Publish a new post on your test site, this will enable the conditional recommendation for Publicize.
* Return to the Jetpack dashboard, you should see a red "1" badge next to the "Recommendations" tab, indicating that there is a new recommendation.