### PR TITLE
Search: Consistent design for focus states in Search overlay

### DIFF
--- a/projects/packages/search/changelog/update-search-overlay-focus-borders
+++ b/projects/packages/search/changelog/update-search-overlay-focus-borders
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Instant search: updates overlay focus elements for design consistency

--- a/projects/packages/search/src/instant-search/components/search-box.scss
+++ b/projects/packages/search/src/instant-search/components/search-box.scss
@@ -76,7 +76,8 @@ input.jetpack-instant-search__box-input.search-field {
 	}
 
 	&:focus {
-		outline: auto 1px -webkit-focus-ring-color !important; /* this won't work without !important */
+		outline: 1px auto Highlight;
+		outline: 1px auto -webkit-focus-ring-color !important; /* this won't work without !important */
 	}
 }
 

--- a/projects/packages/search/src/instant-search/components/search-box.scss
+++ b/projects/packages/search/src/instant-search/components/search-box.scss
@@ -76,10 +76,7 @@ input.jetpack-instant-search__box-input.search-field {
 	}
 
 	&:focus {
-		box-shadow: 0 0 1px 3px rgba( 59, 153, 252, 0.7 );
-		box-shadow: 0 0 0 3px activeborder; /* for Chrome */
-		box-shadow: 0 0 0 3px -moz-mac-focusring; /* for Firefox */
-		outline: auto 0 -webkit-focus-ring-color; /* Webkit, Safari */
+		outline: auto 1px -webkit-focus-ring-color !important; /* this won't work without !important */
 	}
 }
 

--- a/projects/packages/search/src/instant-search/components/search-box.scss
+++ b/projects/packages/search/src/instant-search/components/search-box.scss
@@ -76,7 +76,7 @@ input.jetpack-instant-search__box-input.search-field {
 	}
 
 	&:focus {
-		outline: 1px dotted;
+		outline: -webkit-focus-ring-color auto 1px;
 	}
 }
 

--- a/projects/packages/search/src/instant-search/components/search-box.scss
+++ b/projects/packages/search/src/instant-search/components/search-box.scss
@@ -76,7 +76,10 @@ input.jetpack-instant-search__box-input.search-field {
 	}
 
 	&:focus {
-		outline: -webkit-focus-ring-color auto 1px;
+		box-shadow: 0 0 1px 3px rgba( 59, 153, 252, 0.7 );
+		box-shadow: 0 0 0 3px activeborder; /* for Chrome */
+		box-shadow: 0 0 0 3px -moz-mac-focusring; /* for Firefox */
+		outline: auto 0 -webkit-focus-ring-color; /* Webkit, Safari */
 	}
 }
 

--- a/projects/packages/search/src/instant-search/components/search-results.scss
+++ b/projects/packages/search/src/instant-search/components/search-results.scss
@@ -229,7 +229,7 @@ button.jetpack-instant-search__overlay-close {
 	background-color: transparent !important;
 
 	&:focus {
-		outline: -webkit-focus-ring-color auto 1px;
+		outline: auto 1px -webkit-focus-ring-color !important; /* this won't work without !important */
 	}
 
 	svg.gridicon {

--- a/projects/packages/search/src/instant-search/components/search-results.scss
+++ b/projects/packages/search/src/instant-search/components/search-results.scss
@@ -229,7 +229,8 @@ button.jetpack-instant-search__overlay-close {
 	background-color: transparent !important;
 
 	&:focus {
-		outline: auto 1px -webkit-focus-ring-color !important; /* this won't work without !important */
+		outline: 1px auto Highlight;
+		outline: 1px auto -webkit-focus-ring-color !important; /* this won't work without !important */
 	}
 
 	svg.gridicon {

--- a/projects/packages/search/src/instant-search/components/search-results.scss
+++ b/projects/packages/search/src/instant-search/components/search-results.scss
@@ -229,7 +229,7 @@ button.jetpack-instant-search__overlay-close {
 	background-color: transparent !important;
 
 	&:focus {
-		outline: 1px dotted;
+		outline: -webkit-focus-ring-color auto 1px;
 	}
 
 	svg.gridicon {


### PR DESCRIPTION
This PR adds `-webkit-focus-ring-color` outline styling to the overlay `clear` and `close` elements. This ensures on focus, each element on the overlay has a consistent look. 

Fixes #23402

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* open a site with an active Jetpack Search subscription and trigger the search overlay. 
* using the `tab` button to navigate through the focusable elements, ensure they all have a consistent look (this varies by browser, generally a blue glow outline with rounded edges)

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/30754158/180710602-670ec0fa-d3e4-4dce-aa08-a51fcbec83f7.png)  | ![image](https://user-images.githubusercontent.com/30754158/180711304-c7cccded-61db-4a6e-962b-ed61a2bec018.png)  |





