### PR TITLE
[Package]Backup: Add ThemeProvider wrapper to Admin component

### DIFF
--- a/projects/packages/backup/changelog/add-themeProvider-for-adminPage
+++ b/projects/packages/backup/changelog/add-themeProvider-for-adminPage
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Insignificant change to add styling rules
+
+

--- a/projects/packages/backup/src/js/index.js
+++ b/projects/packages/backup/src/js/index.js
@@ -1,3 +1,4 @@
+import { ThemeProvider } from '@automattic/jetpack-components';
 import { createReduxStore, register } from '@wordpress/data';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -17,7 +18,12 @@ function render() {
 		return;
 	}
 
-	ReactDOM.render( <Admin />, container );
+	ReactDOM.render(
+		<ThemeProvider>
+			<Admin />
+		</ThemeProvider>,
+		container
+	);
 }
 
 render();


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add ThemeProvider to the Jetpack Backup Admin component.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1658244302220609-slack-jetpack-agora

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

*  Create Jurassic Ninja site with JP Backup
*  Complete a restore using Jetpack Backup and confirm that the Review message looks like it's expected.

Before:
<img width="1164" alt="Screen Shot 2022-07-19 at 18 59 32" src="https://user-images.githubusercontent.com/16329583/179807669-2f0d89b8-6712-48d1-930a-4f7141e8ce05.png">

After:
<img width="1262" alt="Screen Shot 2022-07-19 at 18 56 41" src="https://user-images.githubusercontent.com/16329583/179807678-82cd8dca-49ec-4a46-a61f-06b320a447fc.png">

