### PR TITLE
E2E tests: cancel partner plan when resetting WordPress install

### DIFF
--- a/projects/plugins/jetpack/changelog/e2e-cancel-partner-plan
+++ b/projects/plugins/jetpack/changelog/e2e-cancel-partner-plan
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+E2E tests: cancel partner plan when resetting test environment

--- a/projects/plugins/jetpack/tests/e2e/specs/connection/connection.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/connection/connection.test.js
@@ -10,16 +10,12 @@ import { prerequisitesBuilder } from 'jetpack-e2e-commons/env/index.js';
 test.describe( 'Connection', () => {
 	test.beforeEach( async ( { page } ) => {
 		await prerequisitesBuilder( page )
+			.withCleanEnv()
 			.withLoggedIn( true )
 			.withWpComLoggedIn( true )
-			.withConnection( false )
 			.build();
 		await DashboardPage.visit( page );
 		await ( await Sidebar.init( page ) ).selectJetpack();
-	} );
-
-	test.afterEach( async ( { page } ) => {
-		await prerequisitesBuilder( page ).withCleanEnv().build();
 	} );
 
 	test( 'Site only', async ( { page } ) => {

--- a/tools/e2e-commons/helpers/utils-helper.cjs
+++ b/tools/e2e-commons/helpers/utils-helper.cjs
@@ -43,6 +43,7 @@ function execSyncShellCommand( cmd ) {
 
 async function resetWordpressInstall() {
 	const cmd = 'pnpm e2e-env reset';
+	await cancelPartnerPlan();
 	execSyncShellCommand( cmd );
 }
 
@@ -78,6 +79,13 @@ async function provisionJetpackStartConnection( userId, plan = 'free', user = 'w
 	await execWpCommand( 'jetpack status' );
 
 	return true;
+}
+
+async function cancelPartnerPlan() {
+	logger.step( `Cancelling partner plan` );
+	const [ clientID, clientSecret ] = config.get( 'jetpackStartSecrets' );
+	const cmd = `sh /usr/local/src/jetpack-monorepo/tools/partner-cancel.sh -- --partner_id=${ clientID } --partner_secret=${ clientSecret } --allow-root`;
+	await execContainerShellCommand( cmd );
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Add a step to cancel any partner plan when the test environment is reset. When a partner plan is attached, the plans page is skipped during a reconnection flow, causing flakiness.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
pd5faL-58-p2#comment-120

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Run an e2e test that requires a connection (block, or post-connection), then run the `Connection -> Classic` test. 
This should work: `pnpm test:run -g "mailchimp" && pnpm test:run -g "classic"`