### PR TITLE
Add Backup retention disclaimer to product card

### DIFF
--- a/projects/packages/backup/changelog/add-backup-disclaimer-text-to-product-card
+++ b/projects/packages/backup/changelog/add-backup-disclaimer-text-to-product-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/backup/composer.json
+++ b/projects/packages/backup/composer.json
@@ -12,7 +12,7 @@
 		"automattic/jetpack-connection": "^1.42",
 		"automattic/jetpack-connection-ui": "^2.4",
 		"automattic/jetpack-identity-crisis": "^0.8",
-		"automattic/jetpack-my-jetpack": "^1.8",
+		"automattic/jetpack-my-jetpack": "^1.9",
 		"automattic/jetpack-sync": "^1.37",
 		"automattic/jetpack-status": "^1.14"
 	},

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.7.0';
+	const PACKAGE_VERSION = '1.7.1-alpha';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -15,6 +15,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Icon, check, plus } from '@wordpress/icons';
 import classnames from 'classnames';
 import React, { useCallback } from 'react';
+import useAnalytics from '../../hooks/use-analytics';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import { useProduct } from '../../hooks/use-product';
 import getProductCheckoutUrl from '../../utils/get-product-checkout-url';
@@ -92,6 +93,8 @@ const ProductDetailCard = ( { slug, onClick, trackButtonClick, className, suppor
 	} = pricingForUi;
 	const { isUserConnected } = useMyJetpackConnection();
 
+	const { recordEvent } = useAnalytics();
+
 	/*
 	 * Product needs purchase when:
 	 * - it's not free
@@ -132,6 +135,16 @@ const ProductDetailCard = ( { slug, onClick, trackButtonClick, className, suppor
 			onClick();
 		}
 	}, [ onClick, trackButtonClick ] );
+
+	const disclaimerClickHandler = useCallback(
+		id => {
+			recordEvent( 'jetpack_myjetpack_product_card_disclaimer_click', {
+				id: id,
+				product: slug,
+			} );
+		},
+		[ slug, recordEvent ]
+	);
 
 	/**
 	 * Temporary ProductIcon component.
@@ -236,7 +249,7 @@ const ProductDetailCard = ( { slug, onClick, trackButtonClick, className, suppor
 				) }
 
 				{ disclaimers.length > 0 && (
-					<div class={ styles.disclaimers }>
+					<div className={ styles.disclaimers }>
 						{ disclaimers.map( ( disclaimer, id ) => {
 							const { text, link_text = null, url = null } = disclaimer;
 
@@ -244,7 +257,14 @@ const ProductDetailCard = ( { slug, onClick, trackButtonClick, className, suppor
 								<Text key={ `disclaimer-${ id }` } component="p" variant="body-small">
 									{ `${ text } ` }
 									{ url && link_text && (
-										<ExternalLink href={ url } target="_blank" rel="noopener noreferrer">
+										<ExternalLink
+											// Ignoring rule so I can pass ID to analytics in order to tell which disclaimer was clicked if there is more than one
+											/* eslint-disable react/jsx-no-bind */
+											onClick={ () => disclaimerClickHandler( id ) }
+											href={ url }
+											target="_blank"
+											rel="noopener noreferrer"
+										>
 											{ link_text }
 										</ExternalLink>
 									) }

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -72,6 +72,7 @@ const ProductDetailCard = ( { slug, onClick, trackButtonClick, className, suppor
 		title,
 		longDescription,
 		features,
+		disclaimers,
 		pricingForUi,
 		isBundle,
 		supportedProducts,
@@ -232,6 +233,25 @@ const ProductDetailCard = ( { slug, onClick, trackButtonClick, className, suppor
 							sprintf( __( 'Add %s', 'jetpack-my-jetpack' ), title )
 						}
 					</Text>
+				) }
+
+				{ disclaimers.length > 0 && (
+					<div class={ styles.disclaimers }>
+						{ disclaimers.map( ( disclaimer, id ) => {
+							const { text, link_text = null, url = null } = disclaimer;
+
+							return (
+								<Text key={ `disclaimer-${ id }` } component="p" variant="body-small">
+									{ `${ text } ` }
+									{ url && link_text && (
+										<ExternalLink href={ url } target="_blank" rel="noopener noreferrer">
+											{ link_text }
+										</ExternalLink>
+									) }
+								</Text>
+							);
+						} ) }
+					</div>
 				) }
 
 				{ isBundle && hasRequiredPlan && (

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/style.module.scss
@@ -92,6 +92,10 @@
 	}
 }
 
+.disclaimers {
+	margin-top: calc( var( --spacing-base ) * 2 );
+}
+
 .price-container {
 	display: flex;
 	flex-wrap: wrap;

--- a/projects/packages/my-jetpack/changelog/add-backup-disclaimer-text-to-product-card
+++ b/projects/packages/my-jetpack/changelog/add-backup-disclaimer-text-to-product-card
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Make product cards compatible with disclaimers and add disclaimer for backup card

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -72,7 +72,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "1.8.x-dev"
+			"dev-trunk": "1.9.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "1.8.3-alpha",
+	"version": "1.9.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -28,7 +28,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '1.8.3-alpha';
+	const PACKAGE_VERSION = '1.9.0-alpha';
 
 	/**
 	 * Initialize My Jetapack

--- a/projects/packages/my-jetpack/src/products/class-backup.php
+++ b/projects/packages/my-jetpack/src/products/class-backup.php
@@ -89,8 +89,23 @@ class Backup extends Hybrid_Product {
 		return array(
 			_x( 'Real-time cloud backups', 'Backup Product Feature', 'jetpack-my-jetpack' ),
 			_x( '10GB of backup storage', 'Backup Product Feature', 'jetpack-my-jetpack' ),
-			_x( '30-day archive & activity log', 'Backup Product Feature', 'jetpack-my-jetpack' ),
+			_x( '30-day archive & activity log*', 'Backup Product Feature', 'jetpack-my-jetpack' ),
 			_x( 'One-click restores', 'Backup Product Feature', 'jetpack-my-jetpack' ),
+		);
+	}
+
+	/**
+	 * Get disclaimers corresponding to a feature
+	 *
+	 * @return array Backup disclaimers list
+	 */
+	public static function get_disclaimers() {
+		return array(
+			array(
+				'text'      => _x( '* Subject to your usage and storage limit.', 'Backup Product Disclaimer', 'jetpack-my-jetpack' ),
+				'link_text' => _x( 'Learn more', 'Backup Product Disclaimer', 'jetpack-my-jetpack' ),
+				'url'       => Redirect::get_url( 'jetpack-faq-backup-disclaimer' ),
+			),
 		);
 	}
 

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -118,6 +118,7 @@ abstract class Product {
 			'description'              => static::get_description(),
 			'long_description'         => static::get_long_description(),
 			'features'                 => static::get_features(),
+			'disclaimers'              => static::get_disclaimers(),
 			'status'                   => static::get_status(),
 			'pricing_for_ui'           => static::get_pricing_for_ui(),
 			'is_bundle'                => static::is_bundle_product(),
@@ -197,6 +198,15 @@ abstract class Product {
 	 */
 	public static function get_wpcom_product_slug() {
 		return null;
+	}
+
+	/**
+	 * Get the disclaimers corresponding to a feature
+	 *
+	 * @return ?array
+	 */
+	public static function get_disclaimers() {
+		return array();
 	}
 
 	/**

--- a/projects/packages/search/changelog/add-backup-disclaimer-text-to-product-card
+++ b/projects/packages/search/changelog/add-backup-disclaimer-text-to-product-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -9,7 +9,7 @@
 		"automattic/jetpack-constants": "^1.6",
 		"automattic/jetpack-status": "^1.14",
 		"automattic/jetpack-config": "^1.9",
-		"automattic/jetpack-my-jetpack": "^1.8"
+		"automattic/jetpack-my-jetpack": "^1.9"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.2",

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.17.1",
+	"version": "0.17.2-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.17.1';
+	const VERSION = '0.17.2-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/plugins/backup/changelog/add-backup-disclaimer-text-to-product-card
+++ b/projects/plugins/backup/changelog/add-backup-disclaimer-text-to-product-card
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -235,7 +235,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "ad9614052911e2faa1b2b18151c8115b7290da63"
+                "reference": "27f972a622b69b97eb108b1e55d370d33f9aae8b"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -246,7 +246,7 @@
                 "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-connection-ui": "^2.4",
                 "automattic/jetpack-identity-crisis": "^0.8",
-                "automattic/jetpack-my-jetpack": "^1.8",
+                "automattic/jetpack-my-jetpack": "^1.9",
                 "automattic/jetpack-status": "^1.14",
                 "automattic/jetpack-sync": "^1.37"
             },
@@ -801,7 +801,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e9eb7acd69a43c30c6e7fcbe062aaa4e666df022"
+                "reference": "d24d6bfa18b6d361aa9a05355e739df7e329a024"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -826,7 +826,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.8.x-dev"
+                    "dev-trunk": "1.9.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/add-backup-disclaimer-text-to-product-card
+++ b/projects/plugins/boost/changelog/add-backup-disclaimer-text-to-product-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -20,7 +20,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.9.x-dev",
 		"automattic/jetpack-connection": "1.42.x-dev",
-		"automattic/jetpack-my-jetpack": "1.8.x-dev",
+		"automattic/jetpack-my-jetpack": "1.9.x-dev",
 		"automattic/jetpack-device-detection": "1.4.x-dev",
 		"automattic/jetpack-lazy-images": "2.1.x-dev",
 		"tedivm/jshrink": "1.4.0"

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "70531bcc4c759f9538fde95b54e01bc8",
+    "content-hash": "aa37696a0571c2b7baeab398e39c64db",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -608,7 +608,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e9eb7acd69a43c30c6e7fcbe062aaa4e666df022"
+                "reference": "d24d6bfa18b6d361aa9a05355e739df7e329a024"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -633,7 +633,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.8.x-dev"
+                    "dev-trunk": "1.9.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-product-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-product-card/index.jsx
@@ -16,6 +16,7 @@ const JetpackProductCard = props => {
 		productSlug,
 		description,
 		features,
+		disclaimer,
 		currencyCode,
 		price,
 		discountedPrice,
@@ -91,6 +92,15 @@ const JetpackProductCard = props => {
 				<Button className={ buttonClasses } href={ checkoutUrl } onClick={ onClick }>
 					{ checkoutText }
 				</Button>
+
+				{ disclaimer && (
+					<p className="jp-product-card__disclaimer">
+						{ `${ disclaimer.text } ` }
+						<a href={ disclaimer.url } target="_blank" rel="noreferrer">
+							{ disclaimer.link_text }
+						</a>
+					</p>
+				) }
 			</div>
 
 			{ hasMedia && (
@@ -119,6 +129,7 @@ JetpackProductCard.propTypes = {
 	productSlug: PropTypes.string.isRequired,
 	description: PropTypes.string,
 	features: PropTypes.array,
+	disclaimer: PropTypes.object,
 	icon: PropTypes.element,
 	callToAction: PropTypes.string,
 	priority: PropTypes.string,

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-product-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-product-card/index.jsx
@@ -43,6 +43,12 @@ const JetpackProductCard = props => {
 		} );
 	}, [ productSlug ] );
 
+	const onDisclaimerClick = useCallback( () => {
+		analytics.tracks.recordEvent( 'jetpack_product_card_disclaimer_click', {
+			type: productSlug,
+		} );
+	}, [ productSlug ] );
+
 	const classes = classNames( {
 		'jp-product-card': true,
 		'jp-product-card--has-media': hasMedia,
@@ -96,7 +102,12 @@ const JetpackProductCard = props => {
 				{ disclaimer && (
 					<p className="jp-product-card__disclaimer">
 						{ `${ disclaimer.text } ` }
-						<a href={ disclaimer.url } target="_blank" rel="noreferrer">
+						<a
+							onClick={ onDisclaimerClick }
+							href={ disclaimer.url }
+							target="_blank"
+							rel="noreferrer"
+						>
 							{ disclaimer.link_text }
 						</a>
 					</p>

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-product-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-product-card/index.jsx
@@ -1,4 +1,5 @@
 import { ProductPrice } from '@automattic/jetpack-components';
+import { ExternalLink } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import classNames from 'classnames';
 import Button from 'components/button';
@@ -102,14 +103,14 @@ const JetpackProductCard = props => {
 				{ disclaimer && (
 					<p className="jp-product-card__disclaimer">
 						{ `${ disclaimer.text } ` }
-						<a
+						<ExternalLink
 							onClick={ onDisclaimerClick }
 							href={ disclaimer.url }
 							target="_blank"
-							rel="noreferrer"
+							rel="noopener noreferrer"
 						>
 							{ disclaimer.link_text }
-						</a>
+						</ExternalLink>
 					</p>
 				) }
 			</div>

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-product-card/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-product-card/style.scss
@@ -111,6 +111,10 @@
 	}
 }
 
+.jp-product-card__disclaimer {
+	margin-bottom: 0;
+}
+
 .jp-product-card__checkout {
 	align-self: flex-start;
 	font-size: rem( 16px );

--- a/projects/plugins/jetpack/_inc/client/product-descriptions/product-description/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/product-descriptions/product-description/index.jsx
@@ -77,6 +77,7 @@ const renderProduct = ( product, offers, priority, hasRelatedPlan ) => {
 			productSlug={ product.slug }
 			description={ product.description }
 			features={ product.features }
+			disclaimer={ product.disclaimer }
 			currencyCode={ product.currencyCode }
 			price={ price / 12 }
 			discountedPrice={ discountedPrice && discountedPrice !== price ? discountedPrice / 12 : null }

--- a/projects/plugins/jetpack/_inc/client/product-descriptions/product-description/test/fixtures.js
+++ b/projects/plugins/jetpack/_inc/client/product-descriptions/product-description/test/fixtures.js
@@ -19,9 +19,14 @@ export function buildInitialState() {
 						features: [
 							'Real-time cloud backups',
 							'10GB of backup storage',
-							'30-day archive & activity log',
+							'30-day archive & activity log*',
 							'One-click restores',
 						],
+						disclaimer: {
+							text: '* Subject to your usage and storage limit.',
+							link_text: 'Learn more',
+							url: 'https://cloud.jetpack.com/pricing#backup-storage-limits-faq',
+						},
 					},
 					scan: {
 						title: 'Jetpack Scan',

--- a/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
@@ -557,6 +557,7 @@ export function getProductsForPurchase( state ) {
 			key: key,
 			description: product.description,
 			features: product.features,
+			disclaimer: product.disclaimer,
 			available: get( jetpackProducts, [ product.slug, 'available' ], false ),
 			currencyCode: get( jetpackProducts, [ product.slug, 'currency_code' ], '' ),
 			showPromotion: product.show_promotion,

--- a/projects/plugins/jetpack/changelog/add-backup-disclaimer-text-to-product-card
+++ b/projects/plugins/jetpack/changelog/add-backup-disclaimer-text-to-product-card
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add disclaimer text and link to the backup product card that links to an FAQ on the Pricing page

--- a/projects/plugins/jetpack/changelog/add-backup-disclaimer-text-to-product-card#2
+++ b/projects/plugins/jetpack/changelog/add-backup-disclaimer-text-to-product-card#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -6720,8 +6720,13 @@ endif;
 			'features'          => array(
 				_x( 'Real-time cloud backups', 'Backup Product Feature', 'jetpack' ),
 				_x( '10GB of backup storage', 'Backup Product Feature', 'jetpack' ),
-				_x( '30-day archive & activity log', 'Backup Product Feature', 'jetpack' ),
+				_x( '30-day archive & activity log*', 'Backup Product Feature', 'jetpack' ),
 				_x( 'One-click restores', 'Backup Product Feature', 'jetpack' ),
+			),
+			'disclaimer'        => array(
+				'text'      => __( '* Subject to your usage and storage limit.', 'jetpack' ),
+				'link_text' => __( 'Learn more', 'jetpack' ),
+				'url'       => 'https://cloud.jetpack.com/pricing#backup-storage-limits-faq',
 			),
 		);
 

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -6726,7 +6726,7 @@ endif;
 			'disclaimer'        => array(
 				'text'      => __( '* Subject to your usage and storage limit.', 'jetpack' ),
 				'link_text' => __( 'Learn more', 'jetpack' ),
-				'url'       => 'https://cloud.jetpack.com/pricing#backup-storage-limits-faq',
+				'url'       => Redirect::get_url( 'jetpack-faq-backup-disclaimer' ),
 			),
 		);
 

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -31,7 +31,7 @@
 		"automattic/jetpack-lazy-images": "2.1.x-dev",
 		"automattic/jetpack-licensing": "1.7.x-dev",
 		"automattic/jetpack-logo": "1.5.x-dev",
-		"automattic/jetpack-my-jetpack": "1.8.x-dev",
+		"automattic/jetpack-my-jetpack": "1.9.x-dev",
 		"automattic/jetpack-partner": "1.7.x-dev",
 		"automattic/jetpack-plugins-installer": "0.1.x-dev",
 		"automattic/jetpack-publicize": "0.10.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "231a0dd3e4c61e4fcc9f2c7bc9c1075e",
+    "content-hash": "0684843a6938bb85296bb1ffe5cacab1",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -290,7 +290,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "ad9614052911e2faa1b2b18151c8115b7290da63"
+                "reference": "27f972a622b69b97eb108b1e55d370d33f9aae8b"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -301,7 +301,7 @@
                 "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-connection-ui": "^2.4",
                 "automattic/jetpack-identity-crisis": "^0.8",
-                "automattic/jetpack-my-jetpack": "^1.8",
+                "automattic/jetpack-my-jetpack": "^1.9",
                 "automattic/jetpack-status": "^1.14",
                 "automattic/jetpack-sync": "^1.37"
             },
@@ -1173,7 +1173,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e9eb7acd69a43c30c6e7fcbe062aaa4e666df022"
+                "reference": "d24d6bfa18b6d361aa9a05355e739df7e329a024"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -1198,7 +1198,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.8.x-dev"
+                    "dev-trunk": "1.9.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"
@@ -1638,14 +1638,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "588935b48ee9dc97f6b3dc13644feb8a9bf28f66"
+                "reference": "337732f64cedc4867035224ac4d9e527fa047cee"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
                 "automattic/jetpack-config": "^1.9",
                 "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
-                "automattic/jetpack-my-jetpack": "^1.8",
+                "automattic/jetpack-my-jetpack": "^1.9",
                 "automattic/jetpack-status": "^1.14"
             },
             "require-dev": {

--- a/projects/plugins/protect/changelog/add-backup-disclaimer-text-to-product-card
+++ b/projects/plugins/protect/changelog/add-backup-disclaimer-text-to-product-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/protect/composer.json
+++ b/projects/plugins/protect/composer.json
@@ -11,7 +11,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.9.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-my-jetpack": "1.8.x-dev",
+		"automattic/jetpack-my-jetpack": "1.9.x-dev",
 		"automattic/jetpack-plugins-installer": "0.1.x-dev",
 		"automattic/jetpack-sync": "1.37.x-dev"
 	},

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "827f069b3100f295ac2e6ef678cce0f2",
+    "content-hash": "3267c81a0051c15c66c19b6ad61f5805",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -618,7 +618,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e9eb7acd69a43c30c6e7fcbe062aaa4e666df022"
+                "reference": "d24d6bfa18b6d361aa9a05355e739df7e329a024"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -643,7 +643,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.8.x-dev"
+                    "dev-trunk": "1.9.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/add-backup-disclaimer-text-to-product-card
+++ b/projects/plugins/search/changelog/add-backup-disclaimer-text-to-product-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -8,7 +8,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.9.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-my-jetpack": "1.8.x-dev",
+		"automattic/jetpack-my-jetpack": "1.9.x-dev",
 		"automattic/jetpack-search": "0.17.x-dev",
 		"automattic/jetpack-status": "^1.14",
 		"automattic/jetpack-sync": "1.37.x-dev"

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b97583e0d98b36b1bbd7cd95d1dbce65",
+    "content-hash": "9cedb83ec7ebaa5105f74542f49881f8",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -618,7 +618,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e9eb7acd69a43c30c6e7fcbe062aaa4e666df022"
+                "reference": "d24d6bfa18b6d361aa9a05355e739df7e329a024"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -643,7 +643,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.8.x-dev"
+                    "dev-trunk": "1.9.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"
@@ -903,14 +903,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "588935b48ee9dc97f6b3dc13644feb8a9bf28f66"
+                "reference": "337732f64cedc4867035224ac4d9e527fa047cee"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
                 "automattic/jetpack-config": "^1.9",
                 "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
-                "automattic/jetpack-my-jetpack": "^1.8",
+                "automattic/jetpack-my-jetpack": "^1.9",
                 "automattic/jetpack-status": "^1.14"
             },
             "require-dev": {

--- a/projects/plugins/social/changelog/add-backup-disclaimer-text-to-product-card
+++ b/projects/plugins/social/changelog/add-backup-disclaimer-text-to-product-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -13,7 +13,7 @@
 		"automattic/jetpack-publicize": "0.10.x-dev",
 		"automattic/jetpack-options": "1.16.x-dev",
 		"automattic/jetpack-connection": "1.42.x-dev",
-		"automattic/jetpack-my-jetpack": "1.8.x-dev",
+		"automattic/jetpack-my-jetpack": "1.9.x-dev",
 		"automattic/jetpack-sync": "1.37.x-dev",
 		"automattic/jetpack-status": "1.14.x-dev"
 	},

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "936b659ff3d0540bb72e4b33e3d92658",
+    "content-hash": "8beffb0bfb01aa7ffcf9d6d10bb88a4a",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -618,7 +618,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e9eb7acd69a43c30c6e7fcbe062aaa4e666df022"
+                "reference": "d24d6bfa18b6d361aa9a05355e739df7e329a024"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -643,7 +643,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.8.x-dev"
+                    "dev-trunk": "1.9.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/add-backup-disclaimer-text-to-product-card
+++ b/projects/plugins/starter-plugin/changelog/add-backup-disclaimer-text-to-product-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/starter-plugin/composer.json
+++ b/projects/plugins/starter-plugin/composer.json
@@ -10,7 +10,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.9.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-my-jetpack": "1.8.x-dev",
+		"automattic/jetpack-my-jetpack": "1.9.x-dev",
 		"automattic/jetpack-sync": "1.37.x-dev"
 	},
 	"require-dev": {

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b4cf0ceff591f05ab6bc2929d520f8c7",
+    "content-hash": "ae8dd496f5ec46f34bc89a976cb2d287",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -618,7 +618,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e9eb7acd69a43c30c6e7fcbe062aaa4e666df022"
+                "reference": "d24d6bfa18b6d361aa9a05355e739df7e329a024"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -643,7 +643,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.8.x-dev"
+                    "dev-trunk": "1.9.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/videopress/changelog/add-backup-disclaimer-text-to-product-card
+++ b/projects/plugins/videopress/changelog/add-backup-disclaimer-text-to-product-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/videopress/composer.json
+++ b/projects/plugins/videopress/composer.json
@@ -10,7 +10,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.9.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-my-jetpack": "1.8.x-dev",
+		"automattic/jetpack-my-jetpack": "1.9.x-dev",
 		"automattic/jetpack-sync": "1.37.x-dev"
 	},
 	"require-dev": {

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b59608382a0c7fdfe6785ef592b90a81",
+    "content-hash": "f3304a1b834aabc1dfe79bb7ae40c1f7",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -618,7 +618,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "e9eb7acd69a43c30c6e7fcbe062aaa4e666df022"
+                "reference": "d24d6bfa18b6d361aa9a05355e739df7e329a024"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -643,7 +643,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.8.x-dev"
+                    "dev-trunk": "1.9.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"


### PR DESCRIPTION
Add a disclaimer to a feature of Jetpack Backup that links to an FAQ on the [pricing page](https://cloud.jetpack.com/pricing).

#### Changes proposed in this Pull Request

Add an optional "disclaimer" field to the product cards that appears underneath the CTA on the card. The iteration is to add a disclaimer to one of the features for Jetpack Backup, but could be used for other disclaimers in the future if needed. 

This links to the [pricing page](https://cloud.jetpack.com/pricing) and jumps to the FAQ question and opens it for the user. 

#### Other information:

Updated test fixture for `ProductDescription` component. Don't think my updates broke the test, but still thought it best to update

#### Jetpack product discussion

pbuNQi-3b3-p2

#### Does this pull request change what data or activity we track or use?
Yes it adds a tracking event to track how many clicks the "Learn now" link gets

#### Testing instructions:

* Checkout this branch via `git switch add/backup-disclaimer-text-to-product-card`
* Get your local dev environment up and running and go to http://localhost/wp-admin/admin.php?page=jetpack#/product/backup (or replace http://localhost with your jurassic tube URL, though that isn't necessary for this PR)
* Ensure the disclaimer shows up at the bottom of the Jetpack Backup product card below the CTA
![Screen Shot 2022-07-25 at 2 18 55 PM](https://user-images.githubusercontent.com/65001528/180867042-2f671222-4881-497e-8a9e-7099a76b29a4.jpg)
* Click on the `Learn more` link and ensure it takes you to https://cloud.jetpack.com/pricing#backup-storage-limits-faq and jumps you down to the faq and opens it
* Go to `/wp-admin/admin.php?page=my-jetpack#/add-backup` and confirm the same disclaimer shows up below the CTA on the product card
![Screen Shot 2022-08-02 at 5 34 23 PM](https://user-images.githubusercontent.com/65001528/182493982-b2dc4e7e-7eb3-46b8-a611-b96af9d5ed37.jpg)
* Click on the `Learn more` link and confirm it jumps to https://cloud.jetpack.com/pricing#backup-storage-limits-faq and jumps you down to the faq and opens it