### PR TITLE
Image Extractor: add options to output host and host_reversed fields in extracted media

### DIFF
--- a/projects/plugins/jetpack/changelog/add-add-host-to-image-extractor
+++ b/projects/plugins/jetpack/changelog/add-add-host-to-image-extractor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Media Extractor: Add option to output host and host_reversed fields from extracted media


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In trying to improve indexing of featured images for Jetpack Search, I discovered that we are not currently including the host and host_reversed fields in the output of the media extractor. The upstream components in the Elasticsearch indexing code is expecting these fields to be set.

This is a prerequisite to fixing this issue 7537-gh-Automattic/jpop-issues
Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This change adds a flag to output the host and host_reversed fields when extracting media from posts, as well as the option of whether or not the http protocol should be returned. By excluding the protocol and including the host and hots_reversed fields, we can do some more advanced analytics on the urls we have stored in the Elasticsearch index.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
Testing instructions are included with this wpcom diff D83492-code
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*