### PR TITLE
SEO Tools: avoid conflicts with SEOPress and SEOKEY

### DIFF
--- a/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
@@ -33,6 +33,22 @@ export const conflictingSeoPluginsList = [
 		name: 'All in One SEO Pack Pro',
 		slug: 'all-in-one-seo-pack-pro/all_in_one_seo_pack.php',
 	},
+	{
+		name: 'SEOPress',
+		slug: 'wp-seopress/seopress.php',
+	},
+	{
+		name: 'SEOPress Pro',
+		slug: 'wp-seopress-pro/seopress-pro.php',
+	},
+	{
+		name: 'SEOKEY',
+		slug: 'seo-key/seo-key.php',
+	},
+	{
+		name: 'SEOKEY Pro',
+		slug: 'seo-key-pro/seo-key.php',
+	},
 ];
 
 export const SEO = withModuleSettingsFormHelpers(

--- a/projects/plugins/jetpack/changelog/update-seo-conflicting-plugins
+++ b/projects/plugins/jetpack/changelog/update-seo-conflicting-plugins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+SEO Tools: avoid conflicts with SEOPress and SEOKEY plugins.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -245,6 +245,10 @@ class Jetpack {
 			'The SEO Framework'              => 'autodescription/autodescription.php',
 			'Rank Math'                      => 'seo-by-rank-math/rank-math.php',
 			'Slim SEO'                       => 'slim-seo/slim-seo.php',
+			'SEOKEY'                         => 'seo-key/seo-key.php',
+			'SEOKEY Pro'                     => 'seo-key-pro/seo-key.php',
+			'SEOPress'                       => 'wp-seopress/seopress.php',
+			'SEOPress Pro'                   => 'wp-seopress-pro/seopress-pro.php',
 		),
 		'verification-tools' => array(
 			'WordPress SEO by Yoast'         => 'wordpress-seo/wp-seo.php',

--- a/projects/plugins/jetpack/modules/seo-tools.php
+++ b/projects/plugins/jetpack/modules/seo-tools.php
@@ -26,6 +26,8 @@ $jetpack_seo_conflicting_plugins = array(
 	'slim-seo/slim-seo.php',
 	'wp-seopress/seopress.php',
 	'wp-seopress-pro/seopress-pro.php',
+	'seo-key/seo-key.php',
+	'seo-key-pro/seo-key.php',
 );
 
 foreach ( $jetpack_seo_conflicting_plugins as $seo_plugin ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Let's let those 2 SEO plugins take precedence over Jetpack's SEO Tools module when they're activated.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

Not much to test here, it's fairly straightforward. If you wanted to give it a try, you could try the following:

* Start on a connected Jetpack site.
* Under Jetpack > Settings > Traffic, enable SEO Tools.
* Customize some of the settings.
* Ensure the settings are visible on the frontend.
* Install and activate the SEOKEY plugin.
* Verify that Jetpack's SEO customizations are no longer visible on the frontend.
