### PR TITLE
Show review request for sites with +3 months subs

### DIFF
--- a/projects/packages/backup/changelog/add-review-request-after-months
+++ b/projects/packages/backup/changelog/add-review-request-after-months
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Added condition to display review message
+
+

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -247,20 +247,17 @@ class Jetpack_Backup {
 			'jetpack/v4',
 			'/site/dismissed-review-request',
 			array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => __CLASS__ . '::get_dismissed_backup_review_request',
-					'permission_callback' => __CLASS__ . '::backups_permissions_callback',
-				),
-				array(
-					'methods'             => \WP_REST_Server::EDITABLE,
-					'callback'            => __CLASS__ . '::set_dismissed_backup_review_request',
-					'permission_callback' => __CLASS__ . '::backups_permissions_callback',
-					'args'                => array(
-						'dismissed_value' => array(
-							'required' => true,
-							'type'     => 'boolean',
-						),
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => __CLASS__ . '::manage_dismissed_backup_review_request',
+				'permission_callback' => __CLASS__ . '::backups_permissions_callback',
+				'args'                => array(
+					'option_name'    => array(
+						'required' => true,
+						'type'     => 'string',
+					),
+					'should_dismiss' => array(
+						'required' => true,
+						'type'     => 'boolean',
 					),
 				),
 			)
@@ -410,47 +407,31 @@ class Jetpack_Backup {
 			return self::get_failed_fetch_error();
 		}
 
-		// Decode the results.
-		$results = json_decode( $response['body'], true );
-
-		// Bail if there were no results or purchase details returned.
-		if ( ! is_array( $results ) ) {
-			return self::get_failed_fetch_error();
-		}
-
 		return rest_ensure_response(
-			array(
-				'code'    => 'success',
-				'message' => esc_html__( 'Site purchases correctly received.', 'jetpack-backup-pkg' ),
-				'data'    => $results,
-			)
+			json_decode( $response['body'], true )
 		);
-	}
 
-	/**
-	 * Returns the value of the dismissed_backup_review_request Jetack option.
-	 *
-	 * @access public
-	 * @static
-	 *
-	 * @return bool option value.
-	 */
-	public static function get_dismissed_backup_review_request() {
-		return rest_ensure_response(
-			\Jetpack_Options::get_option( 'dismissed_backup_review_request' )
-		);
 	}
 
 	/**
 	 * Set value of the dismissed_backup_review_request Jetack option.
+	 * Get value if should_dismiss is false
 	 *
 	 * @access public
 	 * @static
-	 * @param bool $request used ot update value of the option.
-	 * @return void
+	 * @param array $request arguments should_dismiss and option_name.
+	 * @return bool|void bool with value of option if value is requested, void if updated.
 	 */
-	public static function set_dismissed_backup_review_request( $request ) {
-		\Jetpack_Options::update_option( 'dismissed_backup_review_request', $request['dismissed_value'] );
+	public static function manage_dismissed_backup_review_request( $request ) {
+
+		if ( ! $request['should_dismiss'] ) {
+
+			return rest_ensure_response(
+				\Jetpack_Options::get_option( 'dismissed_backup_review_' . $request['option_name'] )
+			);
+		}
+
+		\Jetpack_Options::update_option( 'dismissed_backup_review_' . $request['option_name'], true );
 	}
 
 	/**

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.6.0';
+	const PACKAGE_VERSION = '1.6.1-alpha';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/backup/src/js/components/review-request/README.md
+++ b/projects/packages/backup/src/js/components/review-request/README.md
@@ -2,27 +2,19 @@
 
 Component designed to prompt for a plugin review after a successful event.
 
-## Usage
+## Usage ( currently part of Backup components )
 
 ```jsx
-import { ReviewRequest } from '@automattic/jetpack-components';
-
+import { ReviewRequest } from './review-request';
 <ReviewRequest
-	description="Related to the successful event"
 	cta="Text action line requesting a review"
 	onClick={ () => ... }
+	requestReason="The motive for the one we are asking for a review"
+	reviewText="Text related to the successful interaction"
 />
 ```
 
 ## Props
-
-### description
-
-A text giving context for a user related to the successful event".
-
-- Type: `String`
-- Default: `""`
-- Required: `true`
 
 ### cta
 
@@ -38,4 +30,20 @@ Callback that will be called when the user click/tap into the ReviewRequest
 
 - Type: `Function`
 - Default: `undefined`
+- Required: `true`
+
+### requestReason
+
+Text indicating the reason for the one we are requesting a review.
+
+- Type: `String`
+- Default: `""`
+- Required: `true`
+
+### reviewText
+
+A text giving context for a user related to the successful event".
+
+- Type: `String`
+- Default: `""`
 - Required: `true`

--- a/projects/packages/backup/src/js/components/review-request/index.tsx
+++ b/projects/packages/backup/src/js/components/review-request/index.tsx
@@ -6,12 +6,24 @@ import styles from './style.module.scss';
 import { ReviewRequestBaseProps } from './types';
 import type React from 'react';
 
-const ReviewRequest: React.FC< ReviewRequestBaseProps > = ( { description, cta, onClick } ) => {
+const ReviewRequest: React.FC< ReviewRequestBaseProps > = ( {
+	cta,
+	onClick,
+	requestReason,
+	reviewText,
+} ) => {
 	const [ dismissedReview, setDismissedReview ] = useState( true );
 
 	// Fetch the dismiss status from Jetpack Options
 	useEffect( () => {
-		apiFetch( { path: '/jetpack/v4/site/dismissed-review-request' } ).then(
+		apiFetch( {
+			path: '/jetpack/v4/site/dismissed-review-request',
+			method: 'POST',
+			data: {
+				option_name: requestReason,
+				should_dismiss: false,
+			},
+		} ).then(
 			res => {
 				setDismissedReview( res );
 			},
@@ -19,19 +31,24 @@ const ReviewRequest: React.FC< ReviewRequestBaseProps > = ( { description, cta, 
 				setDismissedReview( true );
 			}
 		);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
 	const dismissMessage = () => {
 		apiFetch( {
 			path: '/jetpack/v4/site/dismissed-review-request',
 			method: 'POST',
-			data: { dismissed_value: true },
+			data: {
+				option_name: requestReason,
+				should_dismiss: true,
+			},
 		} ).then( setDismissedReview( true ) );
 	};
 
-	if ( dismissedReview ) {
+	if ( dismissedReview || requestReason === '' ) {
 		return <></>;
 	}
+
 	return (
 		<>
 			<button
@@ -40,7 +57,7 @@ const ReviewRequest: React.FC< ReviewRequestBaseProps > = ( { description, cta, 
 				role="link"
 			>
 				<div>
-					<Text>{ description }</Text>
+					<Text>{ reviewText }</Text>
 					<Text className={ styles.cta }>{ cta }</Text>
 				</div>
 			</button>

--- a/projects/packages/backup/src/js/components/review-request/stories/index.tsx
+++ b/projects/packages/backup/src/js/components/review-request/stories/index.tsx
@@ -10,8 +10,7 @@ const Template = args => <ReviewRequest { ...args } />;
 
 export const Default = Template.bind( {} );
 Default.args = {
-	description:
-		'What triggered the review request (i.e. Jetpack Backup completed a successful restore)',
 	cta: 'Text action line, asking for a review',
 	onClick: action( 'onClick' ),
+	requestReason: 'What triggered the review request (i.e. restore)',
 };

--- a/projects/packages/backup/src/js/components/review-request/types.ts
+++ b/projects/packages/backup/src/js/components/review-request/types.ts
@@ -1,7 +1,6 @@
 export type ReviewRequestBaseProps = {
-	description: string;
 	cta: string;
 	onClick: () => void;
-	isDismissed: boolean;
-	onDissmiss: () => void;
+	requestReason: string;
+	reviewText: string;
 };

--- a/projects/packages/connection/changelog/add-review-request-after-months
+++ b/projects/packages/connection/changelog/add-review-request-after-months
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Added condition to display review message
+
+

--- a/projects/packages/connection/legacy/class-jetpack-options.php
+++ b/projects/packages/connection/legacy/class-jetpack-options.php
@@ -126,7 +126,9 @@ class Jetpack_Options {
 			'has_seen_wc_connection_modal',        // (bool) Whether the site has displayed the WooCommerce Connection modal
 			'partner_coupon',                      // (string) A Jetpack partner issued coupon to promote a sale together with Jetpack.
 			'partner_coupon_added',                // (string) A date for when `partner_coupon` was added, so we can auto-purge after a certain time interval.
-			'dismissed_backup_review_request',            // (bool) Determines if the plugin review request is dismissed.
+			'dismissed_backup_review_restore',     // (bool) Determines if the component review request is dismissed for successful restore requests.
+			'dismissed_backup_review_time_based',  // (bool) Determines if the component review request is dismissed for subscription time based requests.
+
 		);
 	}
 

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.41.7';
+	const PACKAGE_VERSION = '1.41.8-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Display the review request component when a user has a Backup subscription older than 3 months. 
Change the message of the review request if we ask for a review after a successful restore or after 3 months of active subscription.

Expected message:
<img width="1661" alt="Screen Shot 2022-07-27 at 00 02 18" src="https://user-images.githubusercontent.com/16329583/181120121-367937e7-3a6b-4fb3-9138-8ea38f12fa28.png">

#### Jetpack product discussion
P2 discussion: pbuNQi-3bh-p2
P2 project thread: pbuNQi-3eS-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
* If you have a test site with a Backup subscription older than 3 months where this patch can be applied, apply it and check that the message is visible
* Click on the link and confirm that you're taken to the WordPress.org Jetpack Backup plugin review page
* Click on dismiss and confirm that the review request disappears
* Reload the page and confirm that the message is not there anymore
* If you don't have such a test site, ping me and I'll grant you access to test sites with 3+ months of active Backup sub.

