### PR TITLE
Revert "Search: hide 'Media' from 'Excluded Post Types'"

### DIFF
--- a/projects/packages/search/changelog/revert-24822-fix-hide-media-from-excluded-list
+++ b/projects/packages/search/changelog/revert-24822-fix-hide-media-from-excluded-list
@@ -1,4 +1,4 @@
 Significance: minor
 Type: removed
 
-Search: Open Revert "Search: hide 'Media' from 'Excluded Post Types'"
+Search: re-add 'Media' to 'Excluded Post Types'

--- a/projects/packages/search/changelog/revert-24822-fix-hide-media-from-excluded-list
+++ b/projects/packages/search/changelog/revert-24822-fix-hide-media-from-excluded-list
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Search: Open Revert "Search: hide 'Media' from 'Excluded Post Types'"

--- a/projects/packages/search/changelog/revert-24822-fix-hide-media-from-excluded-list
+++ b/projects/packages/search/changelog/revert-24822-fix-hide-media-from-excluded-list
@@ -1,4 +1,4 @@
 Significance: minor
-Type: removed
+Type: added
 
 Search: re-add 'Media' to 'Excluded Post Types'

--- a/projects/packages/search/src/class-helper.php
+++ b/projects/packages/search/src/class-helper.php
@@ -24,11 +24,6 @@ class Helper {
 	const FILTER_WIDGET_BASE = 'jetpack-search-filters';
 
 	/**
-	 * The post types to hide from 'Excluded post types'.
-	 */
-	const POST_TYPES_TO_HIDE_FROM_EXCLUDED_CHECK_LIST = array( 'attachment' );
-
-	/**
 	 * Create a URL for the current search that doesn't include the "paged" parameter.
 	 *
 	 * @since 5.8.0
@@ -814,13 +809,6 @@ class Helper {
 				'name'          => $obj->labels->name,
 			);
 		}
-		$post_type_labels = array_filter(
-			$post_type_labels,
-			function ( $key ) {
-				return ! in_array( $key, self::POST_TYPES_TO_HIDE_FROM_EXCLUDED_CHECK_LIST, true );
-			},
-			ARRAY_FILTER_USE_KEY
-		);
 
 		$prefix         = Options::OPTION_PREFIX;
 		$posts_per_page = (int) get_option( 'posts_per_page' );

--- a/projects/packages/search/src/customizer/customize-controls/class-excluded-post-types-control.php
+++ b/projects/packages/search/src/customizer/customize-controls/class-excluded-post-types-control.php
@@ -51,7 +51,7 @@ class Excluded_Post_Types_Control extends WP_Customize_Control {
 	 * @return array $post_types An array of strings representing post type names.
 	 */
 	public function get_arrayed_value() {
-		return empty( $this->value() ) ? array() : explode( ',', $this->value() );
+		return explode( ',', $this->value() );
 	}
 
 	/**
@@ -93,13 +93,6 @@ class Excluded_Post_Types_Control extends WP_Customize_Control {
 	 */
 	protected function render_content() {
 		$post_types = get_post_types( array( 'exclude_from_search' => false ), 'objects' );
-		$post_types = array_filter(
-			$post_types,
-			function ( $key ) {
-				return ! in_array( $key, Helper::POST_TYPES_TO_HIDE_FROM_EXCLUDED_CHECK_LIST, true );
-			},
-			ARRAY_FILTER_USE_KEY
-		);
 		if ( count( $post_types ) === 0 ) {
 			return;
 		}


### PR DESCRIPTION
Reverts Automattic/jetpack#24822

#### Changes proposed in this Pull Request:
Revert changes that removed Media from exclude post type list.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
https://github.com/Automattic/jetpack/issues/24681#issuecomment-1192645652
pc062P-Tv#comment-2929-p2

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Ensure Media is back in the list of excluded post types both in Customizer and Customberg

<img width="293" alt="image" src="https://user-images.githubusercontent.com/1425433/181148404-855512b7-8e1b-43a4-8b4e-b0ee691ac63b.png">
<img width="211" alt="image" src="https://user-images.githubusercontent.com/1425433/181148487-0199a9a4-f4e2-4cd0-a370-f2dede333781.png">
