### PR TITLE
Instant Search: Constrain tabbing to the Search overlay when visible.

### DIFF
--- a/projects/packages/search/changelog/fix-search-constrain-tab-loop
+++ b/projects/packages/search/changelog/fix-search-constrain-tab-loop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Instant Search: Constrain tab loop to overlay when visible.

--- a/projects/packages/search/src/instant-search/components/overlay.jsx
+++ b/projects/packages/search/src/instant-search/components/overlay.jsx
@@ -93,13 +93,6 @@ const Overlay = props => {
 				{ __( 'Search results', 'jetpack-search-pkg' ) }
 			</h1>
 			{ children }
-			<button
-				id="jetpack-instant-search__overlay-tab-anchor"
-				className="screen-reader-text assistive-text"
-				onClick={ closeOverlay }
-			>
-				Close Search
-			</button>
 		</div>
 	);
 };

--- a/projects/packages/search/src/instant-search/components/overlay.jsx
+++ b/projects/packages/search/src/instant-search/components/overlay.jsx
@@ -14,6 +14,22 @@ const Overlay = props => {
 			}
 		};
 
+		const handleTabEvent = event => {
+			if ( event.key === 'Tab' ) {
+				// Looking up the searchInput assumes knowledge of another component.
+				const tabAnchor = document.getElementById( 'jetpack-instant-search__overlay-tab-anchor' );
+				const searchInput = document.getElementById( 'jetpack-instant-search__box-input-1' );
+				if ( event.shiftKey === true && event.target === searchInput ) {
+					event.preventDefault();
+					tabAnchor.focus();
+				}
+				if ( event.shiftKey === false && event.target === tabAnchor ) {
+					event.preventDefault();
+					searchInput.focus();
+				}
+			}
+		};
+
 		const closeWithOutsideClick = event => {
 			const resultsContainer = document.getElementsByClassName(
 				'jetpack-instant-search__search-results'
@@ -27,20 +43,29 @@ const Overlay = props => {
 			}
 		};
 
-		window.addEventListener( 'keydown', closeWithEscape );
+		const addEventListeners = () => {
+			window.addEventListener( 'click', closeWithOutsideClick );
+			window.addEventListener( 'keydown', closeWithEscape );
+			window.addEventListener( 'keydown', handleTabEvent );
+		};
+
+		const removeEventListeners = () => {
+			window.removeEventListener( 'click', closeWithOutsideClick );
+			window.removeEventListener( 'keydown', closeWithEscape );
+			window.removeEventListener( 'keydown', handleTabEvent );
+		};
 
 		// Ensures that the click closed handler only fires when the overlay is active.
 		// This ensures it doesn't erroneously intercept filter links or overlay spawner buttons.
 		if ( isVisible ) {
-			window.addEventListener( 'click', closeWithOutsideClick );
+			addEventListeners();
 		} else {
-			window.removeEventListener( 'click', closeWithOutsideClick );
+			removeEventListeners();
 		}
 
 		return () => {
 			// Cleanup on component dismount
-			window.removeEventListener( 'keydown', closeWithEscape );
-			window.removeEventListener( 'click', closeWithOutsideClick );
+			removeEventListeners();
 		};
 	}, [ closeOverlay, isVisible ] );
 
@@ -61,6 +86,13 @@ const Overlay = props => {
 				{ __( 'Search results', 'jetpack-search-pkg' ) }
 			</h1>
 			{ children }
+			<button
+				id="jetpack-instant-search__overlay-tab-anchor"
+				className="screen-reader-text assistive-text"
+				onClick={ closeOverlay }
+			>
+				Close Search
+			</button>
 		</div>
 	);
 };

--- a/projects/packages/search/src/instant-search/components/overlay.jsx
+++ b/projects/packages/search/src/instant-search/components/overlay.jsx
@@ -16,16 +16,23 @@ const Overlay = props => {
 
 		const handleTabEvent = event => {
 			if ( event.key === 'Tab' ) {
+				const overlay = document.getElementsByClassName( 'jetpack-instant-search__overlay' )[ 0 ];
+				const isInsideOverlay = overlay.contains( event.target );
+
 				// Looking up the searchInput assumes knowledge of another component.
-				const tabAnchor = document.getElementById( 'jetpack-instant-search__overlay-tab-anchor' );
 				const searchInput = document.getElementById( 'jetpack-instant-search__box-input-1' );
-				if ( event.shiftKey === true && event.target === searchInput ) {
-					event.preventDefault();
-					tabAnchor.focus();
+				const tabAnchor = document.getElementById( 'jetpack-instant-search__overlay-tab-anchor' );
+				if ( event.shiftKey === true ) {
+					if ( event.target === searchInput || false === isInsideOverlay ) {
+						event.preventDefault();
+						tabAnchor.focus();
+					}
 				}
-				if ( event.shiftKey === false && event.target === tabAnchor ) {
-					event.preventDefault();
-					searchInput.focus();
+				if ( event.shiftKey === false ) {
+					if ( event.target === tabAnchor || false === isInsideOverlay ) {
+						event.preventDefault();
+						searchInput.focus();
+					}
 				}
 			}
 		};

--- a/projects/packages/search/src/instant-search/components/overlay.jsx
+++ b/projects/packages/search/src/instant-search/components/overlay.jsx
@@ -19,20 +19,22 @@ const Overlay = props => {
 				const overlay = document.getElementsByClassName( OVERLAY_CLASS_NAME )[ 0 ];
 				const isInsideOverlay = overlay.contains( event.target );
 
-				// Looking up the searchInput assumes knowledge of another component.
+				// Looking up the focusTrapFirstElement assumes knowledge of another component.
 				// Not currently a constent as it's dynamically generated.
-				const searchInput = document.getElementById( 'jetpack-instant-search__box-input-1' );
-				const tabAnchor = document.getElementById( OVERLAY_FOCUS_ANCHOR_ID );
+				const focusTrapFirstElement = document.getElementById(
+					'jetpack-instant-search__box-input-1'
+				);
+				const focusTrapLastElement = document.getElementById( OVERLAY_FOCUS_ANCHOR_ID );
 				if ( event.shiftKey === true ) {
-					if ( event.target === searchInput || false === isInsideOverlay ) {
+					if ( event.target === focusTrapFirstElement || false === isInsideOverlay ) {
 						event.preventDefault();
-						tabAnchor.focus();
+						focusTrapLastElement.focus();
 					}
 				}
 				if ( event.shiftKey === false ) {
-					if ( event.target === tabAnchor || false === isInsideOverlay ) {
+					if ( event.target === focusTrapLastElement || false === isInsideOverlay ) {
 						event.preventDefault();
-						searchInput.focus();
+						focusTrapFirstElement.focus();
 					}
 				}
 			}

--- a/projects/packages/search/src/instant-search/components/overlay.jsx
+++ b/projects/packages/search/src/instant-search/components/overlay.jsx
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import React, { useEffect } from 'react';
-import { OVERLAY_CLASS_NAME } from '../lib/constants';
+import { OVERLAY_CLASS_NAME, OVERLAY_FOCUS_ANCHOR_ID } from '../lib/constants';
 import './overlay.scss';
 
 const Overlay = props => {
@@ -16,12 +16,13 @@ const Overlay = props => {
 
 		const handleTabEvent = event => {
 			if ( event.key === 'Tab' ) {
-				const overlay = document.getElementsByClassName( 'jetpack-instant-search__overlay' )[ 0 ];
+				const overlay = document.getElementsByClassName( OVERLAY_CLASS_NAME )[ 0 ];
 				const isInsideOverlay = overlay.contains( event.target );
 
 				// Looking up the searchInput assumes knowledge of another component.
+				// Not currently a constent as it's dynamically generated.
 				const searchInput = document.getElementById( 'jetpack-instant-search__box-input-1' );
-				const tabAnchor = document.getElementById( 'jetpack-instant-search__overlay-tab-anchor' );
+				const tabAnchor = document.getElementById( OVERLAY_FOCUS_ANCHOR_ID );
 				if ( event.shiftKey === true ) {
 					if ( event.target === searchInput || false === isInsideOverlay ) {
 						event.preventDefault();

--- a/projects/packages/search/src/instant-search/components/overlay.jsx
+++ b/projects/packages/search/src/instant-search/components/overlay.jsx
@@ -1,6 +1,10 @@
 import { __ } from '@wordpress/i18n';
 import React, { useEffect } from 'react';
-import { OVERLAY_CLASS_NAME, OVERLAY_FOCUS_ANCHOR_ID } from '../lib/constants';
+import {
+	OVERLAY_CLASS_NAME,
+	OVERLAY_SEARCH_BOX_INPUT_CLASS_NAME,
+	OVERLAY_FOCUS_ANCHOR_ID,
+} from '../lib/constants';
 import './overlay.scss';
 
 const Overlay = props => {
@@ -16,15 +20,16 @@ const Overlay = props => {
 
 		const handleTabEvent = event => {
 			if ( event.key === 'Tab' ) {
+				// Looking up the overlay and its first and last elements assumes knowledge of other components.
+				// We currently try to mimimize any side effects by relying on constants for these class names/ids.
 				const overlay = document.getElementsByClassName( OVERLAY_CLASS_NAME )[ 0 ];
 				const isInsideOverlay = overlay.contains( event.target );
-
-				// Looking up the focusTrapFirstElement assumes knowledge of another component.
-				// Not currently a constent as it's dynamically generated.
-				const focusTrapFirstElement = document.getElementById(
-					'jetpack-instant-search__box-input-1'
-				);
+				const focusTrapFirstElement = document.getElementsByClassName(
+					OVERLAY_SEARCH_BOX_INPUT_CLASS_NAME
+				)[ 0 ];
 				const focusTrapLastElement = document.getElementById( OVERLAY_FOCUS_ANCHOR_ID );
+
+				// Trap any Tab key events and make sure focus stays within the overlay.
 				if ( event.shiftKey === true ) {
 					if ( event.target === focusTrapFirstElement || false === isInsideOverlay ) {
 						event.preventDefault();

--- a/projects/packages/search/src/instant-search/components/search-box.jsx
+++ b/projects/packages/search/src/instant-search/components/search-box.jsx
@@ -2,6 +2,7 @@ import { __ } from '@wordpress/i18n';
 // eslint-disable-next-line lodash/import-scope
 import uniqueId from 'lodash/uniqueId';
 import React, { Fragment, useState, useEffect, useRef } from 'react';
+import { OVERLAY_SEARCH_BOX_INPUT_CLASS_NAME } from '../lib/constants';
 import Gridicon from './gridicon';
 import './search-box.scss';
 
@@ -35,7 +36,7 @@ const SearchBox = props => {
 					<input
 						autoComplete="off"
 						id={ inputId }
-						className="search-field jetpack-instant-search__box-input"
+						className={ 'search-field ' + OVERLAY_SEARCH_BOX_INPUT_CLASS_NAME }
 						inputMode="search"
 						// IE11 will immediately fire an onChange event when the placeholder contains a unicode character.
 						// Ensure that the search application is visible before invoking the onChange callback to guard against this.

--- a/projects/packages/search/src/instant-search/components/search-results.jsx
+++ b/projects/packages/search/src/instant-search/components/search-results.jsx
@@ -288,6 +288,9 @@ class SearchResults extends Component {
 						{ this.renderSecondarySection() }
 					</div>
 				</div>
+				<button id="jetpack-instant-search__overlay-tab-anchor" onClick={ this.closeOverlay }>
+					Close Search
+				</button>
 			</div>
 		);
 	}

--- a/projects/packages/search/src/instant-search/components/search-results.jsx
+++ b/projects/packages/search/src/instant-search/components/search-results.jsx
@@ -1,7 +1,7 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
 import React, { Component, Fragment } from 'react';
 import { getConstrastingColor } from '../lib/colors';
-import { MULTISITE_NO_GROUP_VALUE } from '../lib/constants';
+import { MULTISITE_NO_GROUP_VALUE, OVERLAY_FOCUS_ANCHOR_ID } from '../lib/constants';
 import { getAvailableStaticFilters } from '../lib/filters';
 import Gridicon from './gridicon';
 import Notice from './notice';
@@ -288,7 +288,7 @@ class SearchResults extends Component {
 						{ this.renderSecondarySection() }
 					</div>
 				</div>
-				<button id="jetpack-instant-search__overlay-tab-anchor" onClick={ this.closeOverlay }>
+				<button id={ OVERLAY_FOCUS_ANCHOR_ID } onClick={ this.closeOverlay }>
 					Close Search
 				</button>
 			</div>

--- a/projects/packages/search/src/instant-search/components/search-results.scss
+++ b/projects/packages/search/src/instant-search/components/search-results.scss
@@ -31,7 +31,7 @@ $modal-max-width-lg: 95%;
 		right: 0;
 		border: none;
 		background-color: inherit;
-		color: $color-text-light;
+		color: inherit;
 		font-size: 0.7em;
 		font-weight: 400;
 		margin-right: 4px;

--- a/projects/packages/search/src/instant-search/components/search-results.scss
+++ b/projects/packages/search/src/instant-search/components/search-results.scss
@@ -24,6 +24,28 @@ $modal-max-width-lg: 95%;
 		color: $color-text;
 		background: $color-mark-background-default;
 	}
+
+	#jetpack-instant-search__overlay-tab-anchor {
+		position: absolute;
+		bottom: 0;
+		right: 0;
+		border: none;
+		background-color: inherit;
+		color: $color-text-light;
+		font-size: 0.7em;
+		font-weight: 400;
+		margin-right: 4px;
+		margin-bottom: 4px;
+		width: 1px;
+		overflow: hidden;
+		clip: rect( 1px, 1px, 1px, 1px );
+
+		&:focus {
+			clip: auto !important;
+			clip-path: none;
+			width: auto;
+		}
+	}
 }
 
 .jetpack-instant-search__search-results-controls {

--- a/projects/packages/search/src/instant-search/components/search-results.scss
+++ b/projects/packages/search/src/instant-search/components/search-results.scss
@@ -25,7 +25,7 @@ $modal-max-width-lg: 95%;
 		background: $color-mark-background-default;
 	}
 
-	#jetpack-instant-search__overlay-tab-anchor {
+	#jetpack-instant-search__overlay-focus-anchor {
 		position: absolute;
 		bottom: 0;
 		right: 0;

--- a/projects/packages/search/src/instant-search/lib/constants.js
+++ b/projects/packages/search/src/instant-search/lib/constants.js
@@ -4,6 +4,7 @@ export const MULTISITE_NO_GROUP_VALUE = '__NO_GROUP__';
 
 export const SERVER_OBJECT_NAME = 'JetpackInstantSearchOptions';
 export const OVERLAY_CLASS_NAME = 'jetpack-instant-search__overlay';
+export const OVERLAY_SEARCH_BOX_INPUT_CLASS_NAME = 'jetpack-instant-search__box-input';
 export const OVERLAY_FOCUS_ANCHOR_ID = 'jetpack-instant-search__overlay-focus-anchor';
 export const SORT_DIRECTION_ASC = 'ASC';
 export const SORT_DIRECTION_DESC = 'DESC';

--- a/projects/packages/search/src/instant-search/lib/constants.js
+++ b/projects/packages/search/src/instant-search/lib/constants.js
@@ -4,6 +4,7 @@ export const MULTISITE_NO_GROUP_VALUE = '__NO_GROUP__';
 
 export const SERVER_OBJECT_NAME = 'JetpackInstantSearchOptions';
 export const OVERLAY_CLASS_NAME = 'jetpack-instant-search__overlay';
+export const OVERLAY_FOCUS_ANCHOR_ID = 'jetpack-instant-search__overlay-focus-anchor';
 export const SORT_DIRECTION_ASC = 'ASC';
 export const SORT_DIRECTION_DESC = 'DESC';
 export const RESULT_FORMAT_EXPANDED = 'expanded';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #23396.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

- Adds a second event listener that watches for tabs.
- Consolidates event listeners into helper functions.
- Fixes an issue where the overlay would eat any presses of the Escape key, even when not visible.
- Adds a hidden button at the end of the overlay as the "anchor". This is visible to screen readers and we use it as the test when deciding to wrap around. The button becomes visible when focused.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Visit a site with Instant Search enabled.
2. Bring up the Overlay.
3. Tab through the controls until it wraps around.
4. Try shift-tabbing.
5. Confirm that tabbing is constrained to the overlay.

**Note:** Using the Enter key to dismiss the form will cause it to immediately reappear if the input field on the underlying page is active. Using the space key to dismiss works correctly. This is filed separately in #23394.

**Note:** There is some weird behaviour with the "Load more…" button which is not very user friendly at the moment. This should be addressed as part of #19035 and/or #23397.

Example of current behaviour:

https://user-images.githubusercontent.com/40267301/182823496-4bf894ab-baa5-42c6-add5-a67d30d50828.mp4
