### PR TITLE
DevEx Improvement | Disable postcss deprecation notices

### DIFF
--- a/projects/packages/search/changelog/update-disable-postcss-deprecation-notices
+++ b/projects/packages/search/changelog/update-disable-postcss-deprecation-notices
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: It's not related to end-user changes
+
+

--- a/projects/packages/search/postcss.config.js
+++ b/projects/packages/search/postcss.config.js
@@ -6,6 +6,7 @@ module.exports = () => ( {
 			// @TODO: Drop `preserve: false` workaround if possible
 			// See https://github.com/Automattic/jetpack/pull/13854#issuecomment-550898168
 			preserve: false,
+			disableDeprecationNotice: true,
 		},
 		autoprefixer: {},
 	},

--- a/projects/packages/wordads/changelog/update-disable-postcss-deprecation-notices
+++ b/projects/packages/wordads/changelog/update-disable-postcss-deprecation-notices
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: It's not related to end-user changes
+
+

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.2.10",
+	"version": "0.2.11-alpha",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/postcss.config.js
+++ b/projects/packages/wordads/postcss.config.js
@@ -6,6 +6,7 @@ module.exports = () => ( {
 			// @TODO: Drop `preserve: false` workaround if possible
 			// See https://github.com/Automattic/jetpack/pull/13854#issuecomment-550898168
 			preserve: false,
+			disableDeprecationNotice: true,
 		},
 		autoprefixer: {},
 	},

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.2.10';
+	const VERSION = '0.2.11-alpha';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-disable-postcss-deprecation-notices
+++ b/projects/plugins/jetpack/changelog/update-disable-postcss-deprecation-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Disabled postcss deprecation notices for build

--- a/projects/plugins/jetpack/tools/postcss.config.js
+++ b/projects/plugins/jetpack/tools/postcss.config.js
@@ -12,6 +12,7 @@ module.exports = () => ( {
 			// where people were confused about what was going on when calypso-build stopped
 			// including a postcss.config.js like this by default.
 			preserve: false,
+			disableDeprecationNotice: true,
 		},
 		autoprefixer: {},
 	},

--- a/projects/plugins/social/changelog/update-disable-postcss-deprecation-notices
+++ b/projects/plugins/social/changelog/update-disable-postcss-deprecation-notices
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: It's not related to end-user changes
+
+

--- a/projects/plugins/social/postcss.config.js
+++ b/projects/plugins/social/postcss.config.js
@@ -12,6 +12,7 @@ module.exports = () => ( {
 			// where people were confused about what was going on when calypso-build stopped
 			// including a postcss.config.js like this by default.
 			preserve: false,
+			disableDeprecationNotice: true,
 		},
 		autoprefixer: {},
 	},


### PR DESCRIPTION
This PR disables postcss deprecation notices for `postcss-custom-properties` which pollute the build output and makes it difficult to find the actual cause for a build failure.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add [`disableDeprecationNotice` prop](https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-custom-properties#disabledeprecationnotice) to `postcss-custom-properties` in all `postcss.config.js` files

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
p1652844600270609-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

- Run `jetpack build plugins/jetpack -v` to see a much cleaner build output