### PR TITLE
Connection: Remove calls to deprecated methods

### DIFF
--- a/projects/packages/abtest/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/packages/abtest/changelog/update-connection-deprecated-method-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/abtest/composer.json
+++ b/projects/packages/abtest/composer.json
@@ -4,7 +4,7 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-connection": "^1.41",
+		"automattic/jetpack-connection": "^1.42",
 		"automattic/jetpack-error": "^1.3"
 	},
 	"require-dev": {

--- a/projects/packages/backup/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/packages/backup/changelog/update-connection-deprecated-method-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/backup/composer.json
+++ b/projects/packages/backup/composer.json
@@ -9,7 +9,7 @@
 		"automattic/jetpack-autoloader": "^2.11",
 		"automattic/jetpack-composer-plugin": "^1.1",
 		"automattic/jetpack-config": "^1.9",
-		"automattic/jetpack-connection": "^1.41",
+		"automattic/jetpack-connection": "^1.42",
 		"automattic/jetpack-connection-ui": "^2.4",
 		"automattic/jetpack-identity-crisis": "^0.8",
 		"automattic/jetpack-my-jetpack": "^1.8",

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.6.0';
+	const PACKAGE_VERSION = '1.6.1-alpha';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/connection-ui/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/packages/connection-ui/changelog/update-connection-deprecated-method-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/connection-ui/composer.json
+++ b/projects/packages/connection-ui/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"automattic/jetpack-assets": "^1.17",
-		"automattic/jetpack-connection": "^1.41",
+		"automattic/jetpack-connection": "^1.42",
 		"automattic/jetpack-constants": "^1.6",
 		"automattic/jetpack-device-detection": "^1.4",
 		"automattic/jetpack-identity-crisis": "^0.8"

--- a/projects/packages/connection-ui/package.json
+++ b/projects/packages/connection-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-connection-manager-ui",
-	"version": "2.4.12",
+	"version": "2.4.13-alpha",
 	"description": "Jetpack Connection Manager UI",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/connection/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/packages/connection/changelog/update-connection-deprecated-method-cleanup
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+Removed deprecated method calls

--- a/projects/packages/connection/composer.json
+++ b/projects/packages/connection/composer.json
@@ -64,7 +64,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "1.41.x-dev"
+			"dev-trunk": "1.42.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -1846,7 +1846,7 @@ class Manager {
 				'scope'                 => $signed_role,
 				'user_email'            => $user->user_email,
 				'user_login'            => $user->user_login,
-				'is_active'             => $this->is_active(), // TODO Deprecate this.
+				'is_active'             => $this->has_connected_owner(), // TODO Deprecate this.
 				'jp_version'            => Constants::get_constant( 'JETPACK__VERSION' ),
 				'auth_type'             => $auth_type,
 				'secret'                => $secrets['secret_1'],

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.41.8-alpha';
+	const PACKAGE_VERSION = '1.42.0-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.41.7';
+	const PACKAGE_VERSION = '1.42.0-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -302,7 +302,7 @@ class REST_Connector {
 		$connection = new Manager();
 
 		$connection_status = array(
-			'isActive'          => $connection->is_active(), // TODO deprecate this.
+			'isActive'          => $connection->has_connected_owner(), // TODO deprecate this.
 			'isStaging'         => $status->is_staging_site(),
 			'isRegistered'      => $connection->is_connected(),
 			'isUserConnected'   => $connection->is_user_connected(),

--- a/projects/packages/connection/tests/php/test_Manager_unit.php
+++ b/projects/packages/connection/tests/php/test_Manager_unit.php
@@ -75,33 +75,38 @@ class ManagerTest extends TestCase {
 	}
 
 	/**
-	 * Test the `is_active` functionality when connected.
+	 * Test the `has_connected_owner` functionality when connected.
 	 *
-	 * @covers Automattic\Jetpack\Connection\Manager::is_active
+	 * @covers Automattic\Jetpack\Connection\Manager::has_connected_owner
 	 */
-	public function test_is_active_when_connected() {
-		$access_token = (object) array(
-			'secret'           => 'abcd1234',
-			'external_user_id' => 1,
+	public function test_has_connected_owner_when_connected() {
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'admin',
+				'user_pass'  => 'pass',
+				'user_email' => 'admin@admin.com',
+				'role'       => 'administrator',
+			)
 		);
-		$this->tokens->expects( $this->once() )
-			->method( 'get_access_token' )
-			->will( $this->returnValue( $access_token ) );
 
-		$this->assertTrue( $this->manager->is_active() );
+		$this->manager->method( 'get_connection_owner_id' )
+			->withAnyParameters()
+			->willReturn( $admin_id );
+
+		$this->assertTrue( $this->manager->has_connected_owner() );
 	}
 
 	/**
-	 * Test the `is_active` functionality when not connected.
+	 * Test the `has_connected_owner` functionality when not connected.
 	 *
-	 * @covers Automattic\Jetpack\Connection\Manager::is_active
+	 * @covers Automattic\Jetpack\Connection\Manager::has_connected_owner
 	 */
-	public function test_is_active_when_not_connected() {
-		$this->tokens->expects( $this->once() )
-			->method( 'get_access_token' )
-			->will( $this->returnValue( false ) );
+	public function test_has_connected_owner_when_not_connected() {
+		$this->manager->method( 'get_connection_owner_id' )
+			->withAnyParameters()
+			->willReturn( false );
 
-		$this->assertFalse( $this->manager->is_active() );
+		$this->assertFalse( $this->manager->has_connected_owner() );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/test_Manager_unit.php
+++ b/projects/packages/connection/tests/php/test_Manager_unit.php
@@ -75,6 +75,36 @@ class ManagerTest extends TestCase {
 	}
 
 	/**
+	 * Test the `is_active` functionality when connected.
+	 *
+	 * @covers Automattic\Jetpack\Connection\Manager::is_active
+	 */
+	public function test_is_active_when_connected() {
+		$access_token = (object) array(
+			'secret'           => 'abcd1234',
+			'external_user_id' => 1,
+		);
+		$this->tokens->expects( $this->once() )
+			->method( 'get_access_token' )
+			->will( $this->returnValue( $access_token ) );
+
+		$this->assertTrue( $this->manager->is_active() );
+	}
+
+	/**
+	 * Test the `is_active` functionality when not connected.
+	 *
+	 * @covers Automattic\Jetpack\Connection\Manager::is_active
+	 */
+	public function test_is_active_when_not_connected() {
+		$this->tokens->expects( $this->once() )
+			->method( 'get_access_token' )
+			->will( $this->returnValue( false ) );
+
+		$this->assertFalse( $this->manager->is_active() );
+	}
+
+	/**
 	 * Test the `has_connected_owner` functionality when connected.
 	 *
 	 * @covers Automattic\Jetpack\Connection\Manager::has_connected_owner

--- a/projects/packages/heartbeat/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/packages/heartbeat/changelog/update-connection-deprecated-method-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/heartbeat/composer.json
+++ b/projects/packages/heartbeat/composer.json
@@ -4,7 +4,7 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-connection": "^1.41"
+		"automattic/jetpack-connection": "^1.42"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.2"

--- a/projects/packages/identity-crisis/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/packages/identity-crisis/changelog/update-connection-deprecated-method-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/identity-crisis/composer.json
+++ b/projects/packages/identity-crisis/composer.json
@@ -4,7 +4,7 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-connection": "^1.41",
+		"automattic/jetpack-connection": "^1.42",
 		"automattic/jetpack-constants": "^1.6",
 		"automattic/jetpack-status": "^1.14",
 		"automattic/jetpack-logo": "^1.5",

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.8.18",
+	"version": "0.8.19-alpha",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -28,7 +28,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.8.18';
+	const PACKAGE_VERSION = '0.8.19-alpha';
 
 	/**
 	 * Instance of the object.

--- a/projects/packages/jitm/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/packages/jitm/changelog/update-connection-deprecated-method-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/jitm/composer.json
+++ b/projects/packages/jitm/composer.json
@@ -6,7 +6,7 @@
 	"require": {
 		"automattic/jetpack-a8c-mc-stats": "^1.4",
 		"automattic/jetpack-assets": "^1.17",
-		"automattic/jetpack-connection": "^1.41",
+		"automattic/jetpack-connection": "^1.42",
 		"automattic/jetpack-device-detection": "^1.4",
 		"automattic/jetpack-logo": "^1.5",
 		"automattic/jetpack-partner": "^1.7",

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '2.2.22';
+	const PACKAGE_VERSION = '2.2.23-alpha';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/licensing/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/packages/licensing/changelog/update-connection-deprecated-method-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/licensing/composer.json
+++ b/projects/packages/licensing/composer.json
@@ -4,7 +4,7 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-connection": "^1.41"
+		"automattic/jetpack-connection": "^1.42"
 	},
 	"require-dev": {
 		"automattic/wordbless": "@dev",

--- a/projects/packages/my-jetpack/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/packages/my-jetpack/changelog/update-connection-deprecated-method-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -6,7 +6,7 @@
 	"require": {
 		"automattic/jetpack-admin-ui": "^0.2",
 		"automattic/jetpack-assets": "^1.17",
-		"automattic/jetpack-connection": "^1.41",
+		"automattic/jetpack-connection": "^1.42",
 		"automattic/jetpack-licensing": "^1.7",
 		"automattic/jetpack-plugins-installer": "^0.1",
 		"automattic/jetpack-redirect": "^1.7",

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "1.8.2",
+	"version": "1.8.3-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -28,7 +28,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '1.8.2';
+	const PACKAGE_VERSION = '1.8.3-alpha';
 
 	/**
 	 * Initialize My Jetapack

--- a/projects/packages/options/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/packages/options/changelog/update-connection-deprecated-method-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/options/composer.json
+++ b/projects/packages/options/composer.json
@@ -4,7 +4,7 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-connection": "^1.41"
+		"automattic/jetpack-connection": "^1.42"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.0.3",

--- a/projects/packages/partner/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/packages/partner/changelog/update-connection-deprecated-method-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/partner/composer.json
+++ b/projects/packages/partner/composer.json
@@ -4,7 +4,7 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-connection": "^1.41",
+		"automattic/jetpack-connection": "^1.42",
 		"automattic/jetpack-status": "^1.14"
 	},
 	"require-dev": {

--- a/projects/packages/plans/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/packages/plans/changelog/update-connection-deprecated-method-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/plans/composer.json
+++ b/projects/packages/plans/composer.json
@@ -4,7 +4,7 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-connection": "^1.41"
+		"automattic/jetpack-connection": "^1.42"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.0.3",

--- a/projects/packages/plans/package.json
+++ b/projects/packages/plans/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-plans",
-	"version": "0.1.2",
+	"version": "0.1.3-alpha",
 	"description": "Fetch information about Jetpack Plans from wpcom",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/plans/#readme",
 	"bugs": {

--- a/projects/packages/publicize/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/packages/publicize/changelog/update-connection-deprecated-method-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/publicize/composer.json
+++ b/projects/packages/publicize/composer.json
@@ -4,7 +4,7 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-connection": "^1.41",
+		"automattic/jetpack-connection": "^1.42",
 		"automattic/jetpack-autoloader": "^2.11",
 		"automattic/jetpack-config": "^1.9"
 	},

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.10.0",
+	"version": "0.10.1-alpha",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/search/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/packages/search/changelog/update-connection-deprecated-method-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -4,7 +4,7 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-connection": "^1.41",
+		"automattic/jetpack-connection": "^1.42",
 		"automattic/jetpack-assets": "^1.17",
 		"automattic/jetpack-constants": "^1.6",
 		"automattic/jetpack-status": "^1.14",

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.17.0",
+	"version": "0.17.1-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.17.0';
+	const VERSION = '0.17.1-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/sync/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/packages/sync/changelog/update-connection-deprecated-method-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -4,7 +4,7 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-connection": "^1.41",
+		"automattic/jetpack-connection": "^1.42",
 		"automattic/jetpack-constants": "^1.6",
 		"automattic/jetpack-identity-crisis": "^0.8",
 		"automattic/jetpack-password-checker": "^0.2",

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.37.0';
+	const PACKAGE_VERSION = '1.37.1-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/tracking/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/packages/tracking/changelog/update-connection-deprecated-method-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/tracking/composer.json
+++ b/projects/packages/tracking/composer.json
@@ -6,7 +6,7 @@
 	"require": {
 		"automattic/jetpack-assets": "^1.17",
 		"automattic/jetpack-status": "^1.14",
-		"automattic/jetpack-connection": "^1.41"
+		"automattic/jetpack-connection": "^1.42"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.2"

--- a/projects/packages/videopress/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/packages/videopress/changelog/update-connection-deprecated-method-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/videopress/composer.json
+++ b/projects/packages/videopress/composer.json
@@ -4,7 +4,7 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-connection": "^1.41",
+		"automattic/jetpack-connection": "^1.42",
 		"automattic/jetpack-plans": "^0.1"
 	},
 	"require-dev": {

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.1.2",
+	"version": "0.1.3-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/wordads/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/packages/wordads/changelog/update-connection-deprecated-method-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/wordads/composer.json
+++ b/projects/packages/wordads/composer.json
@@ -4,7 +4,7 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-connection": "^1.41",
+		"automattic/jetpack-connection": "^1.42",
 		"automattic/jetpack-assets": "^1.17",
 		"automattic/jetpack-constants": "^1.6",
 		"automattic/jetpack-status": "^1.14",

--- a/projects/plugins/backup/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/plugins/backup/changelog/update-connection-deprecated-method-cleanup
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -235,7 +235,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "832297b7afd145f36b2f85f841c0a6c2899d925a"
+                "reference": "d4900d96239e6921723093abc5d62d3ad7d64b76"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -243,7 +243,7 @@
                 "automattic/jetpack-autoloader": "^2.11",
                 "automattic/jetpack-composer-plugin": "^1.1",
                 "automattic/jetpack-config": "^1.9",
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-connection-ui": "^2.4",
                 "automattic/jetpack-identity-crisis": "^0.8",
                 "automattic/jetpack-my-jetpack": "^1.8",
@@ -405,7 +405,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "01d5b265a224c9288f48e64e6b7b67da96153470"
+                "reference": "8a9bab4e931dda19cbc24c8e14e774c366197b52"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -433,7 +433,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.41.x-dev"
+                    "dev-trunk": "1.42.x-dev"
                 }
             },
             "autoload": {
@@ -477,11 +477,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection-ui",
-                "reference": "27deb922f067e857abcafd916689a37909363a93"
+                "reference": "7e4c5d153a7468b9a16c31e7e34f842838270b5e"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-device-detection": "^1.4",
                 "automattic/jetpack-identity-crisis": "^0.8"
@@ -627,11 +627,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/identity-crisis",
-                "reference": "aaea6d07b044cb92e781e5249faf5bba8d9ae7bd"
+                "reference": "3b32bfa5df795280c2a81b5473d5023e469aac65"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-logo": "^1.5",
                 "automattic/jetpack-status": "^1.14"
@@ -699,10 +699,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/licensing",
-                "reference": "348638bac8d79921522959013f0e226fb1cfa283"
+                "reference": "f9aa3a965f3dfe304c49cda710afa654b237d2ac"
             },
             "require": {
-                "automattic/jetpack-connection": "^1.41"
+                "automattic/jetpack-connection": "^1.42"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -801,12 +801,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "8736fe871409ed1de26a0e668833261853ce1c31"
+                "reference": "e9eb7acd69a43c30c6e7fcbe062aaa4e666df022"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
                 "automattic/jetpack-assets": "^1.17",
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-licensing": "^1.7",
                 "automattic/jetpack-plugins-installer": "^0.1",
@@ -1137,10 +1137,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "829beb9898247ce84f1a39f6d8a8b6b04b468ef3"
+                "reference": "a302ad3bc019fc4103fb6eb3c3a0ef6536fbd085"
             },
             "require": {
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-identity-crisis": "^0.8",
                 "automattic/jetpack-password-checker": "^0.2",

--- a/projects/plugins/boost/app/lib/class-connection.php
+++ b/projects/plugins/boost/app/lib/class-connection.php
@@ -119,14 +119,7 @@ class Connection {
 			return true;
 		}
 
-		// Temporary hack for Jetpack < 9.2 compatibility without notices.
-		if ( method_exists( $this->manager, 'is_connected' ) ) {
-			$is_connected = $this->manager->is_connected();
-		} else {
-			$is_connected = $this->manager->is_registered();
-		}
-
-		return $is_connected;
+		return $this->manager->is_connected();
 	}
 
 	/**

--- a/projects/plugins/boost/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/plugins/boost/changelog/update-connection-deprecated-method-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -19,7 +19,7 @@
 		"automattic/jetpack-autoloader": "2.11.x-dev",
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.9.x-dev",
-		"automattic/jetpack-connection": "1.41.x-dev",
+		"automattic/jetpack-connection": "1.42.x-dev",
 		"automattic/jetpack-my-jetpack": "1.8.x-dev",
 		"automattic/jetpack-device-detection": "1.4.x-dev",
 		"automattic/jetpack-lazy-images": "2.1.x-dev",

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e632bb69a6da9220615e24db0af9275c",
+    "content-hash": "70531bcc4c759f9538fde95b54e01bc8",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -324,7 +324,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "01d5b265a224c9288f48e64e6b7b67da96153470"
+                "reference": "8a9bab4e931dda19cbc24c8e14e774c366197b52"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -352,7 +352,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.41.x-dev"
+                    "dev-trunk": "1.42.x-dev"
                 }
             },
             "autoload": {
@@ -553,10 +553,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/licensing",
-                "reference": "348638bac8d79921522959013f0e226fb1cfa283"
+                "reference": "f9aa3a965f3dfe304c49cda710afa654b237d2ac"
             },
             "require": {
-                "automattic/jetpack-connection": "^1.41"
+                "automattic/jetpack-connection": "^1.42"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -608,12 +608,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "8736fe871409ed1de26a0e668833261853ce1c31"
+                "reference": "e9eb7acd69a43c30c6e7fcbe062aaa4e666df022"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
                 "automattic/jetpack-assets": "^1.17",
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-licensing": "^1.7",
                 "automattic/jetpack-plugins-installer": "^0.1",

--- a/projects/plugins/jetpack/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/plugins/jetpack/changelog/update-connection-deprecated-method-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -1585,14 +1585,6 @@ class Jetpack {
 	 * @return bool is the site connection ready to be used?
 	 */
 	public static function is_connection_ready() {
-		$is_connected = false;
-
-		if ( method_exists( self::connection(), 'is_connected' ) ) {
-			$is_connected = self::connection()->is_connected();
-		} elseif ( method_exists( self::connection(), 'is_registered' ) ) {
-			$is_connected = self::connection()->is_registered();
-		}
-
 		/**
 		 * Allows filtering whether the connection is ready to be used. If true, this will enable the Jetpack UI and modules
 		 *
@@ -1603,7 +1595,7 @@ class Jetpack {
 		 * @param bool                                  $is_connection_ready Is the connection ready?
 		 * @param Automattic\Jetpack\Connection\Manager $connection_manager Instance of the Manager class, can be used to check the connection status.
 		 */
-		return apply_filters( 'jetpack_is_connection_ready', $is_connected, self::connection() );
+		return apply_filters( 'jetpack_is_connection_ready', self::connection()->is_connected(), self::connection() );
 	}
 
 	/**

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -1569,7 +1569,7 @@ class Jetpack {
 	 * @return bool
 	 */
 	public static function is_active() {
-		return self::connection()->is_active();
+		return self::connection()->has_connected_owner();
 	}
 
 	/**

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -20,7 +20,7 @@
 		"automattic/jetpack-compat": "1.7.x-dev",
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.9.x-dev",
-		"automattic/jetpack-connection": "1.41.x-dev",
+		"automattic/jetpack-connection": "1.42.x-dev",
 		"automattic/jetpack-connection-ui": "2.4.x-dev",
 		"automattic/jetpack-constants": "1.6.x-dev",
 		"automattic/jetpack-device-detection": "1.4.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f598ef1075830021cff70bc125cbc5aa",
+    "content-hash": "bf02c8cb32ebe09a499f7b2f8f6d1bad",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -59,10 +59,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/abtest",
-                "reference": "e8b7fa7220033b155538df2cb1db8b07b4879e37"
+                "reference": "d454b98a3a87709fd60071978ff7e8867a95dfe1"
             },
             "require": {
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-error": "^1.3"
             },
             "require-dev": {
@@ -290,7 +290,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "832297b7afd145f36b2f85f841c0a6c2899d925a"
+                "reference": "d4900d96239e6921723093abc5d62d3ad7d64b76"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -298,7 +298,7 @@
                 "automattic/jetpack-autoloader": "^2.11",
                 "automattic/jetpack-composer-plugin": "^1.1",
                 "automattic/jetpack-config": "^1.9",
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-connection-ui": "^2.4",
                 "automattic/jetpack-identity-crisis": "^0.8",
                 "automattic/jetpack-my-jetpack": "^1.8",
@@ -551,7 +551,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "01d5b265a224c9288f48e64e6b7b67da96153470"
+                "reference": "8a9bab4e931dda19cbc24c8e14e774c366197b52"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -579,7 +579,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.41.x-dev"
+                    "dev-trunk": "1.42.x-dev"
                 }
             },
             "autoload": {
@@ -623,11 +623,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection-ui",
-                "reference": "27deb922f067e857abcafd916689a37909363a93"
+                "reference": "7e4c5d153a7468b9a16c31e7e34f842838270b5e"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-device-detection": "^1.4",
                 "automattic/jetpack-identity-crisis": "^0.8"
@@ -869,11 +869,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/identity-crisis",
-                "reference": "aaea6d07b044cb92e781e5249faf5bba8d9ae7bd"
+                "reference": "3b32bfa5df795280c2a81b5473d5023e469aac65"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-logo": "^1.5",
                 "automattic/jetpack-status": "^1.14"
@@ -941,12 +941,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "344a3403c3771dbae85e9124a1edeb75738625f7"
+                "reference": "eb821e571515220e101590e8fe512ba1a32cc1b5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
                 "automattic/jetpack-assets": "^1.17",
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-device-detection": "^1.4",
                 "automattic/jetpack-logo": "^1.5",
                 "automattic/jetpack-partner": "^1.7",
@@ -1071,10 +1071,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/licensing",
-                "reference": "348638bac8d79921522959013f0e226fb1cfa283"
+                "reference": "f9aa3a965f3dfe304c49cda710afa654b237d2ac"
             },
             "require": {
-                "automattic/jetpack-connection": "^1.41"
+                "automattic/jetpack-connection": "^1.42"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -1173,12 +1173,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "8736fe871409ed1de26a0e668833261853ce1c31"
+                "reference": "e9eb7acd69a43c30c6e7fcbe062aaa4e666df022"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
                 "automattic/jetpack-assets": "^1.17",
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-licensing": "^1.7",
                 "automattic/jetpack-plugins-installer": "^0.1",
@@ -1256,10 +1256,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/partner",
-                "reference": "a233d365b630104b03ad7844d436b25f584c4d96"
+                "reference": "23ff6396f4020d9f7e2c7a97824232cc575efa25"
             },
             "require": {
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-status": "^1.14"
             },
             "require-dev": {
@@ -1364,10 +1364,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "809832f1f38116dccd1cb347c46ab9b77f846f99"
+                "reference": "5d6f96f0b36b8b9dce26cdc423e07f84420d4639"
             },
             "require": {
-                "automattic/jetpack-connection": "^1.41"
+                "automattic/jetpack-connection": "^1.42"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -1476,12 +1476,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/publicize",
-                "reference": "986946b7200ecb8e135121a000a88bd7f0b4b76d"
+                "reference": "3e910dc444d18300c312eba59d106d50127f85de"
             },
             "require": {
                 "automattic/jetpack-autoloader": "^2.11",
                 "automattic/jetpack-config": "^1.9",
-                "automattic/jetpack-connection": "^1.41"
+                "automattic/jetpack-connection": "^1.42"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -1638,12 +1638,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "7414c854f52cbfa10371971888b88e145408a728"
+                "reference": "588935b48ee9dc97f6b3dc13644feb8a9bf28f66"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
                 "automattic/jetpack-config": "^1.9",
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-my-jetpack": "^1.8",
                 "automattic/jetpack-status": "^1.14"
@@ -1769,10 +1769,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "829beb9898247ce84f1a39f6d8a8b6b04b468ef3"
+                "reference": "a302ad3bc019fc4103fb6eb3c3a0ef6536fbd085"
             },
             "require": {
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-identity-crisis": "^0.8",
                 "automattic/jetpack-password-checker": "^0.2",
@@ -1832,10 +1832,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/videopress",
-                "reference": "5eb4002752f478cccf1364a59e0974698c20d557"
+                "reference": "d45d56ef8c8bee9430756945be1e511509d7dcd9"
             },
             "require": {
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-plans": "^0.1"
             },
             "require-dev": {
@@ -1948,12 +1948,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/wordads",
-                "reference": "93a65f5247aa28556393723ce3df35a8aa4d2bf1"
+                "reference": "d302b27e415caf3de02e53a6cb4b625b1574430e"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
                 "automattic/jetpack-config": "^1.9",
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-status": "^1.14"
             },

--- a/projects/plugins/protect/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/plugins/protect/changelog/update-connection-deprecated-method-cleanup
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -324,7 +324,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "01d5b265a224c9288f48e64e6b7b67da96153470"
+                "reference": "8a9bab4e931dda19cbc24c8e14e774c366197b52"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -352,7 +352,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.41.x-dev"
+                    "dev-trunk": "1.42.x-dev"
                 }
             },
             "autoload": {
@@ -444,11 +444,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/identity-crisis",
-                "reference": "aaea6d07b044cb92e781e5249faf5bba8d9ae7bd"
+                "reference": "3b32bfa5df795280c2a81b5473d5023e469aac65"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-logo": "^1.5",
                 "automattic/jetpack-status": "^1.14"
@@ -516,10 +516,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/licensing",
-                "reference": "348638bac8d79921522959013f0e226fb1cfa283"
+                "reference": "f9aa3a965f3dfe304c49cda710afa654b237d2ac"
             },
             "require": {
-                "automattic/jetpack-connection": "^1.41"
+                "automattic/jetpack-connection": "^1.42"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -618,12 +618,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "8736fe871409ed1de26a0e668833261853ce1c31"
+                "reference": "e9eb7acd69a43c30c6e7fcbe062aaa4e666df022"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
                 "automattic/jetpack-assets": "^1.17",
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-licensing": "^1.7",
                 "automattic/jetpack-plugins-installer": "^0.1",
@@ -954,10 +954,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "829beb9898247ce84f1a39f6d8a8b6b04b468ef3"
+                "reference": "a302ad3bc019fc4103fb6eb3c3a0ef6536fbd085"
             },
             "require": {
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-identity-crisis": "^0.8",
                 "automattic/jetpack-password-checker": "^0.2",

--- a/projects/plugins/search/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/plugins/search/changelog/update-connection-deprecated-method-cleanup
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -324,7 +324,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "01d5b265a224c9288f48e64e6b7b67da96153470"
+                "reference": "8a9bab4e931dda19cbc24c8e14e774c366197b52"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -352,7 +352,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.41.x-dev"
+                    "dev-trunk": "1.42.x-dev"
                 }
             },
             "autoload": {
@@ -444,11 +444,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/identity-crisis",
-                "reference": "aaea6d07b044cb92e781e5249faf5bba8d9ae7bd"
+                "reference": "3b32bfa5df795280c2a81b5473d5023e469aac65"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-logo": "^1.5",
                 "automattic/jetpack-status": "^1.14"
@@ -516,10 +516,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/licensing",
-                "reference": "348638bac8d79921522959013f0e226fb1cfa283"
+                "reference": "f9aa3a965f3dfe304c49cda710afa654b237d2ac"
             },
             "require": {
-                "automattic/jetpack-connection": "^1.41"
+                "automattic/jetpack-connection": "^1.42"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -618,12 +618,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "8736fe871409ed1de26a0e668833261853ce1c31"
+                "reference": "e9eb7acd69a43c30c6e7fcbe062aaa4e666df022"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
                 "automattic/jetpack-assets": "^1.17",
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-licensing": "^1.7",
                 "automattic/jetpack-plugins-installer": "^0.1",
@@ -903,12 +903,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "7414c854f52cbfa10371971888b88e145408a728"
+                "reference": "588935b48ee9dc97f6b3dc13644feb8a9bf28f66"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
                 "automattic/jetpack-config": "^1.9",
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-my-jetpack": "^1.8",
                 "automattic/jetpack-status": "^1.14"
@@ -1034,10 +1034,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "829beb9898247ce84f1a39f6d8a8b6b04b468ef3"
+                "reference": "a302ad3bc019fc4103fb6eb3c3a0ef6536fbd085"
             },
             "require": {
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-identity-crisis": "^0.8",
                 "automattic/jetpack-password-checker": "^0.2",

--- a/projects/plugins/social/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/plugins/social/changelog/update-connection-deprecated-method-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -12,7 +12,7 @@
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
 		"automattic/jetpack-publicize": "0.10.x-dev",
 		"automattic/jetpack-options": "1.16.x-dev",
-		"automattic/jetpack-connection": "1.41.x-dev",
+		"automattic/jetpack-connection": "1.42.x-dev",
 		"automattic/jetpack-my-jetpack": "1.8.x-dev",
 		"automattic/jetpack-sync": "1.37.x-dev",
 		"automattic/jetpack-status": "1.14.x-dev"

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5aacc672edc32a40e7379a63275e1c2d",
+    "content-hash": "936b659ff3d0540bb72e4b33e3d92658",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -324,7 +324,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "01d5b265a224c9288f48e64e6b7b67da96153470"
+                "reference": "8a9bab4e931dda19cbc24c8e14e774c366197b52"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -352,7 +352,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.41.x-dev"
+                    "dev-trunk": "1.42.x-dev"
                 }
             },
             "autoload": {
@@ -444,11 +444,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/identity-crisis",
-                "reference": "aaea6d07b044cb92e781e5249faf5bba8d9ae7bd"
+                "reference": "3b32bfa5df795280c2a81b5473d5023e469aac65"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-logo": "^1.5",
                 "automattic/jetpack-status": "^1.14"
@@ -516,10 +516,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/licensing",
-                "reference": "348638bac8d79921522959013f0e226fb1cfa283"
+                "reference": "f9aa3a965f3dfe304c49cda710afa654b237d2ac"
             },
             "require": {
-                "automattic/jetpack-connection": "^1.41"
+                "automattic/jetpack-connection": "^1.42"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -618,12 +618,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "8736fe871409ed1de26a0e668833261853ce1c31"
+                "reference": "e9eb7acd69a43c30c6e7fcbe062aaa4e666df022"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
                 "automattic/jetpack-assets": "^1.17",
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-licensing": "^1.7",
                 "automattic/jetpack-plugins-installer": "^0.1",
@@ -701,10 +701,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/options",
-                "reference": "29e8f7c0ff1bbc3a0feefc41887ccf3d884bbf66"
+                "reference": "5b199d7331baa2bdbf9c630444b536f03ac9b1cf"
             },
             "require": {
-                "automattic/jetpack-connection": "^1.41"
+                "automattic/jetpack-connection": "^1.42"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -844,12 +844,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/publicize",
-                "reference": "986946b7200ecb8e135121a000a88bd7f0b4b76d"
+                "reference": "3e910dc444d18300c312eba59d106d50127f85de"
             },
             "require": {
                 "automattic/jetpack-autoloader": "^2.11",
                 "automattic/jetpack-config": "^1.9",
-                "automattic/jetpack-connection": "^1.41"
+                "automattic/jetpack-connection": "^1.42"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -1057,10 +1057,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "829beb9898247ce84f1a39f6d8a8b6b04b468ef3"
+                "reference": "a302ad3bc019fc4103fb6eb3c3a0ef6536fbd085"
             },
             "require": {
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-identity-crisis": "^0.8",
                 "automattic/jetpack-password-checker": "^0.2",

--- a/projects/plugins/starter-plugin/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/plugins/starter-plugin/changelog/update-connection-deprecated-method-cleanup
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -324,7 +324,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "01d5b265a224c9288f48e64e6b7b67da96153470"
+                "reference": "8a9bab4e931dda19cbc24c8e14e774c366197b52"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -352,7 +352,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.41.x-dev"
+                    "dev-trunk": "1.42.x-dev"
                 }
             },
             "autoload": {
@@ -444,11 +444,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/identity-crisis",
-                "reference": "aaea6d07b044cb92e781e5249faf5bba8d9ae7bd"
+                "reference": "3b32bfa5df795280c2a81b5473d5023e469aac65"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-logo": "^1.5",
                 "automattic/jetpack-status": "^1.14"
@@ -516,10 +516,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/licensing",
-                "reference": "348638bac8d79921522959013f0e226fb1cfa283"
+                "reference": "f9aa3a965f3dfe304c49cda710afa654b237d2ac"
             },
             "require": {
-                "automattic/jetpack-connection": "^1.41"
+                "automattic/jetpack-connection": "^1.42"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -618,12 +618,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "8736fe871409ed1de26a0e668833261853ce1c31"
+                "reference": "e9eb7acd69a43c30c6e7fcbe062aaa4e666df022"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
                 "automattic/jetpack-assets": "^1.17",
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-licensing": "^1.7",
                 "automattic/jetpack-plugins-installer": "^0.1",
@@ -954,10 +954,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "829beb9898247ce84f1a39f6d8a8b6b04b468ef3"
+                "reference": "a302ad3bc019fc4103fb6eb3c3a0ef6536fbd085"
             },
             "require": {
-                "automattic/jetpack-connection": "^1.41",
+                "automattic/jetpack-connection": "^1.42",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-identity-crisis": "^0.8",
                 "automattic/jetpack-password-checker": "^0.2",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Implement the changes outlined in #24654 by removing calls to a number of deprecated methods in Connection. The changes will affect the following:
* Boost
* Connection Package 
* Jetpack

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
* N/A

#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:

##### Authorization URL
1. Disconnect Jetpack
2. Go to the "Jetpack Debug" plugin, activate "REST API Tester", and send a GET request to `connection/authorize_url`.
3. Confirm that you see the `{ "authorizeUrl": "https://jetpack.wordpress.com/..." }` and the URL contains empty `is_active` GET-parameter.
4. Connect Jetpack in site-only mode (e.g. by connecting it fully and then removing the user tokens), repeat step 3. Confirm that `is_active` is still empty.
5. Connect the user, making Jetpack fully connected. Repeat step 3, confirm that `is_active` is now shown as `is_active=1`.

##### Connection Status
1. On your testing site, comment out the `jetpack_connection_status` filter found [here](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/jetpack/class-jetpack-connection-status.php#L19) to ensure that the filter does not affect the testing results.
2. Use the same "REST API Tester" to send a GET request to the `connection` endpoint (`/jetpack/v4/connection`).
3. Confirm that `isActive` is shown correctly in all three scenarios:
- Not connected: `false`
- Site-only mode: `false`
- Fully connected: `true`
4. Remove the comment added in step 1.

##### Jetpack Boost
1. Disconnect Jetpack
2. Activate Jetpack Boost, go to "Jetpack -> Boost", and confirm that you see the connection screen with "Get Started" button.
3. Click "Get Started", that will connect you in site-only mode. Confirm that you see the Boost functionality now.
4. Go to Jetpack and connect the user. Go back to Boost and confirm that you still see the Boost functionality.