### PR TITLE
Search: Add focus state on search input field

### DIFF
--- a/projects/packages/search/changelog/udpdate-search-focus-state-on-search-input
+++ b/projects/packages/search/changelog/udpdate-search-focus-state-on-search-input
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Instant Search: add focus border to search input field

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.21.0",
+	"version": "0.21.1-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.21.0';
+	const VERSION = '0.21.1-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/instant-search/components/search-app.scss
+++ b/projects/packages/search/src/instant-search/components/search-app.scss
@@ -120,7 +120,7 @@ body.enable-search-modal .cover-modal.show-modal.search-modal.active {
 		}
 
 		&:focus {
-			outline: solid thin $color-dark-layout-borders;
+			outline: dotted thin $color-layout-borders;
 		}
 	}
 

--- a/projects/packages/search/src/instant-search/components/search-app.scss
+++ b/projects/packages/search/src/instant-search/components/search-app.scss
@@ -118,6 +118,10 @@ body.enable-search-modal .cover-modal.show-modal.search-modal.active {
 			background: $color-dark-modal-background; // necessary to override theme styles
 			color: $color-dark-text;
 		}
+
+		&:focus {
+			outline: solid thin $color-dark-layout-borders;
+		}
 	}
 
 	.jetpack-instant-search__search-results {

--- a/projects/packages/search/src/instant-search/components/search-box.scss
+++ b/projects/packages/search/src/instant-search/components/search-box.scss
@@ -69,13 +69,13 @@ input.jetpack-instant-search__box-input.search-field {
 	width: 60px;
 	word-wrap: normal;
 
-	&:hover {
+	&:hover,
+	&:focus {
 		color: $color-text-light;
 	}
 
 	&:focus {
 		@include apply-overlay-focus-styling();
-		color: $color-text-light;
 	}
 }
 
@@ -96,6 +96,7 @@ input.jetpack-instant-search__box-input.search-field {
 	&:focus {
 		outline: solid thin $color-layout-borders;
 		border-radius: 5px;
+		outline-offset: inherit;
 	}
 
 	&::-webkit-search-results-button,

--- a/projects/packages/search/src/instant-search/components/search-box.scss
+++ b/projects/packages/search/src/instant-search/components/search-box.scss
@@ -85,12 +85,17 @@ input.jetpack-instant-search__box-input.search-field {
 	outline-style: none;
 	border: none;
 	box-shadow: none;
+	padding: 0px 10px;
 
 	&:hover,
 	&:focus {
 		border: none;
 		box-shadow: none;
-		outline-style: none;
+	}
+
+	&:focus {
+		outline: 1px auto Highlight;
+		outline: 1px auto -webkit-focus-ring-color !important; /* this won't work without !important */
 	}
 
 	&::-webkit-search-results-button,

--- a/projects/packages/search/src/instant-search/components/search-box.scss
+++ b/projects/packages/search/src/instant-search/components/search-box.scss
@@ -95,7 +95,7 @@ input.jetpack-instant-search__box-input.search-field {
 
 	&:focus {
 		outline: 1px auto Highlight;
-		outline: 1px auto -webkit-focus-ring-color !important; /* this won't work without !important */
+		outline: 1px auto -webkit-focus-ring-color;
 	}
 
 	&::-webkit-search-results-button,

--- a/projects/packages/search/src/instant-search/components/search-box.scss
+++ b/projects/packages/search/src/instant-search/components/search-box.scss
@@ -94,9 +94,12 @@ input.jetpack-instant-search__box-input.search-field {
 	}
 
 	&:focus {
-		outline: solid thin $color-layout-borders;
+		outline: dotted thin $color-dark-layout-borders;
 		border-radius: 5px;
 		outline-offset: inherit;
+		margin-left: -50px;
+		padding-left: 60px;
+		margin-right: 5px;
 	}
 
 	&::-webkit-search-results-button,

--- a/projects/packages/search/src/instant-search/components/search-box.scss
+++ b/projects/packages/search/src/instant-search/components/search-box.scss
@@ -94,8 +94,9 @@ input.jetpack-instant-search__box-input.search-field {
 	}
 
 	&:focus {
-		outline: 1px auto Highlight;
-		outline: 1px auto -webkit-focus-ring-color;
+		outline: solid thin Highlight;
+		outline: solid thin -webkit-focus-ring-color;
+		border-radius: 5px;
 	}
 
 	&::-webkit-search-results-button,

--- a/projects/packages/search/src/instant-search/components/search-box.scss
+++ b/projects/packages/search/src/instant-search/components/search-box.scss
@@ -94,8 +94,7 @@ input.jetpack-instant-search__box-input.search-field {
 	}
 
 	&:focus {
-		outline: solid thin Highlight;
-		outline: solid thin -webkit-focus-ring-color;
+		outline: solid thin $color-layout-borders;
 		border-radius: 5px;
 	}
 

--- a/projects/packages/search/src/instant-search/components/search-box.scss
+++ b/projects/packages/search/src/instant-search/components/search-box.scss
@@ -69,13 +69,13 @@ input.jetpack-instant-search__box-input.search-field {
 	width: 60px;
 	word-wrap: normal;
 
-	&:hover,
-	&:focus {
+	&:hover {
 		color: $color-text-light;
 	}
 
 	&:focus {
 		@include apply-overlay-focus-styling();
+		color: $color-text-light;
 	}
 }
 


### PR DESCRIPTION
This PR adds a system-default focus ring to the search input element on the instant search overlay. 

Fixes #23398

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* Go to a site with an active Search subscription, and trigger the search overlay
* Focus on the search input field, either by keyboard tab or mouse click. 
* Ensure the focus ring displays correctly, then disappears when the focus is shifted to a different element
* Test in both light, and dark mode to ensure the focus ring color matches the rest of the overlay colors. 

| dark mode  | light mode |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/30754158/186106425-1d3656ec-a99f-4756-b52c-f063eb86a9a8.png)  | ![image](https://user-images.githubusercontent.com/30754158/186106685-9c95dfa0-48df-43a6-a88e-8f3ea757984e.png)  |


