### PR TITLE
Search: Adds text description for post type icons

### DIFF
--- a/projects/packages/search/changelog/add-search-add-post-type-icon-descriptions
+++ b/projects/packages/search/changelog/add-search-add-post-type-icon-descriptions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Instant Search: Adds descriptions to post type icons for accessibility purposes

--- a/projects/packages/search/src/instant-search/components/gridicon/index.jsx
+++ b/projects/packages/search/src/instant-search/components/gridicon/index.jsx
@@ -228,7 +228,7 @@ class Gridicon extends Component {
 
 		return (
 			<svg
-				aria-label={ this.props?.description }
+				aria-label={ this.props.description }
 				className={ iconClass }
 				focusable={ this.props.focusable }
 				height={ height }

--- a/projects/packages/search/src/instant-search/components/gridicon/index.jsx
+++ b/projects/packages/search/src/instant-search/components/gridicon/index.jsx
@@ -228,6 +228,7 @@ class Gridicon extends Component {
 
 		return (
 			<svg
+				aria-label={ this.props?.description }
 				className={ iconClass }
 				focusable={ this.props.focusable }
 				height={ height }

--- a/projects/packages/search/src/instant-search/components/post-type-icon.jsx
+++ b/projects/packages/search/src/instant-search/components/post-type-icon.jsx
@@ -1,3 +1,4 @@
+import { __ } from '@wordpress/i18n';
 import React from 'react';
 import arrayOverlap from '../lib/array-overlap';
 import Gridicon from './gridicon';
@@ -47,7 +48,13 @@ const PostTypeIcon = ( { postType, shortcodeTypes, iconSize = 18 } ) => {
 
 	switch ( postType ) {
 		case 'page':
-			return <Gridicon icon="pages" size={ iconSize } />;
+			return (
+				<Gridicon
+					icon="pages"
+					size={ iconSize }
+					description={ __( 'Page icon', 'jetpack-search-pkg' ) }
+				/>
+			);
 		default:
 			if ( hasGallery ) {
 				return <Gridicon icon="image-multiple" size={ iconSize } />;

--- a/projects/packages/search/src/instant-search/components/post-type-icon.jsx
+++ b/projects/packages/search/src/instant-search/components/post-type-icon.jsx
@@ -61,7 +61,7 @@ const PostTypeIcon = ( { postType, shortcodeTypes, iconSize = 18 } ) => {
 					<Gridicon
 						icon="image-multiple"
 						size={ iconSize }
-						description={ __( 'Image icon', 'jetpack-search-pkg' ) }
+						description={ __( 'Image', 'jetpack-search-pkg' ) }
 					/>
 				);
 			}

--- a/projects/packages/search/src/instant-search/components/post-type-icon.jsx
+++ b/projects/packages/search/src/instant-search/components/post-type-icon.jsx
@@ -52,7 +52,7 @@ const PostTypeIcon = ( { postType, shortcodeTypes, iconSize = 18 } ) => {
 				<Gridicon
 					icon="pages"
 					size={ iconSize }
-					description={ __( 'Page icon', 'jetpack-search-pkg' ) }
+					description={ __( 'Page', 'jetpack-search-pkg' ) }
 				/>
 			);
 		default:

--- a/projects/packages/search/src/instant-search/components/post-type-icon.jsx
+++ b/projects/packages/search/src/instant-search/components/post-type-icon.jsx
@@ -57,7 +57,13 @@ const PostTypeIcon = ( { postType, shortcodeTypes, iconSize = 18 } ) => {
 			);
 		default:
 			if ( hasGallery ) {
-				return <Gridicon icon="image-multiple" size={ iconSize } />;
+				return (
+					<Gridicon
+						icon="image-multiple"
+						size={ iconSize }
+						description={ __( 'Image icon', 'jetpack-search-pkg' ) }
+					/>
+				);
 			}
 	}
 


### PR DESCRIPTION
This PR adds a text description for the post-type icons displayed on the instant search overlay. 

Fixes #25138

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* On a site with Jetpack Instant Search enabled, perform a search with /?s=&result_format=minimal.
* Inspect the post-type icons with your browser a11y tools.
* Confirm that all icons have a text description available.

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/30754158/181688209-55e9122e-16c0-4629-bd0f-3c7210634b45.png) | ![image](https://user-images.githubusercontent.com/30754158/181688180-969b21c3-b7b5-4cb1-abe2-4662ff612eeb.png) |


