### PR TITLE
(WIP) Search Config Page: fix overlapping Admin Menu issue

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-overlapping-ui
+++ b/projects/plugins/jetpack/changelog/fix-overlapping-ui
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Search Config Page: fix overlapping Admin menu issue (Calypso: #64369)

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -30,14 +30,14 @@
  * Fixes Gutenberg in not fullscreen mode.
  */
  @media (min-width: 783px) {
-	.interface-interface-skeleton,
+	 body:not(.folded) #jp-search-configure .interface-interface-skeleton,
+	 .interface-interface-skeleton,
 	.edit-post-layout .components-editor-notices__snackbar {
 		left: 272px;
 	}
 }
 
 @media (min-width: 961px) {
-	.auto-fold  #jp-search-configure .interface-interface-skeleton,
 	.auto-fold .interface-interface-skeleton,
 	.auto-fold .edit-post-layout .components-editor-notices__snackbar,
 	.jp-dialogue-modern-full__container {

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -37,6 +37,7 @@
 }
 
 @media (min-width: 961px) {
+	#jp-search-configure  .interface-interface-skeleton,
 	.auto-fold .interface-interface-skeleton,
 	.auto-fold .edit-post-layout .components-editor-notices__snackbar,
 	.jp-dialogue-modern-full__container {

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -37,7 +37,7 @@
 }
 
 @media (min-width: 961px) {
-	#jp-search-configure  .interface-interface-skeleton,
+	.auto-fold  #jp-search-configure .interface-interface-skeleton,
 	.auto-fold .interface-interface-skeleton,
 	.auto-fold .edit-post-layout .components-editor-notices__snackbar,
 	.jp-dialogue-modern-full__container {


### PR DESCRIPTION
Fixes [#64369](https://github.com/Automattic/wp-calypso/issues/64369)

#### Changes proposed in this Pull Request:
Make a rule in`masterbar/admin-menu/admin-menu.css` more specific, so it takes precedence over a rule in the`edit-widgets` package, which currently means that the Admin Menu obscures some of the content on the Jetpack Search Config page. 

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

You will need **Jetpack Search** enabled on an Atomic site with **Jetpack Beta** installed. 

1. First verify there is an issue by navigating to `wp-admin/admin.php?page=jetpack-search-configure`
2. Make sure the Admin menu is expanded and you should see that it obscures part of the content section as noted in [#64369` ](https://github.com/Automattic/wp-calypso/issues/64369). You should see something like this:
![image](https://user-images.githubusercontent.com/6851384/181716709-42fbbb60-7d35-4d1b-8fee-091080f41126.png)
3. Next go to Jetpack Beta and choose to manage the Jetpack plugin. Switch to the branch used in this PR
![image](https://user-images.githubusercontent.com/6851384/181717793-e34f5642-4146-45a8-8c41-ca86fdb3179a.png)
4. Return to  to `wp-admin/admin.php?page=jetpack-search-configure` and verify that the issue is resolved. Also verify that the new CSS selector is present in Dev Tools
![image](https://user-images.githubusercontent.com/6851384/181718731-0398a7f6-fdec-4c75-9550-c4465d9eb842.png)
![image](https://user-images.githubusercontent.com/6851384/181718793-ea0b79e2-a7ac-49ad-b2e2-a0ac43c06e04.png)

In addition, you can check that the change works for `rtl` mode CSS (auto-generated); and behaves correctly when the menu is collapsed. 
``
