### PR TITLE
Masterbar: remove empty space between collapsed admin menu and editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-collapsed-admin-menu-css
+++ b/projects/plugins/jetpack/changelog/fix-collapsed-admin-menu-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Masterbar: bugfix removing empty space between folded adminbar and editor

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -37,7 +37,7 @@
 }
 
 @media (min-width: 961px) {
-	.auto-fold .interface-interface-skeleton,
+	body:not(.folded).auto-fold .interface-interface-skeleton,
 	.auto-fold .edit-post-layout .components-editor-notices__snackbar,
 	.jp-dialogue-modern-full__container {
 		left: 272px;


### PR DESCRIPTION
- Fixes https://github.com/Automattic/wp-calypso/issues/65299

#### Changes proposed in this Pull Request:
* Remove empty space between the folded admin menu and the editor on simple sites and atomic sites.
This PR shouldn't affect jetpack sites, only simple sites, and WoA.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?

No, it doesn't.

#### Testing instructions:

**Simple Site**

* Apply this Revision to your sandbox
* Sandbox a simple site
* Go to `/wp-admin/post-new.php`
* Click on the three dots on the top right corner
* Click on `Fullscreen mode`
* Click on `Collapse menu` on the left sidebar/admin menu
* Observe the menu is folded and there is no space between the collapsed menu and the editor

**Atomic Site**

* Go to your atomic site
* Install [Jetpack Beta](https://jetpack.com/download-jetpack-beta/) Plugin
* Go to `Jetpack` > `Jetpack Beta`, choose this branch `fix/collapsed-admin-menu-css` in `Search for a Feature Branch` and activate it.
* Go to `/wp-admin/post-new.php`
* Click on the three dots on the top right corner
* Click on `Fullscreen mode`
* Click on `Collapse menu` on the left sidebar/admin menu
* Observe the menu is folded and there is no space between the collapsed menu and the editor

#### Screencast

https://user-images.githubusercontent.com/779993/181770019-6eb42c89-094e-4496-94f8-d3e02ad01290.mp4


