### PR TITLE
Search:  Redirect to the Search Dashboard on activation only when Jetpack plugin does not exist

### DIFF
--- a/projects/plugins/search/changelog/fix-search-admin-error-on-activation-with-jetpack-plugin
+++ b/projects/plugins/search/changelog/fix-search-admin-error-on-activation-with-jetpack-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: Redirect to the Search Dashboard on activation only when Jetpack plugin does not exist

--- a/projects/plugins/search/src/class-jetpack-search-plugin.php
+++ b/projects/plugins/search/src/class-jetpack-search-plugin.php
@@ -90,7 +90,8 @@ class Jetpack_Search_Plugin {
 			}
 		}
 
-		if ( JETPACK_SEARCH_PLUGIN__FILE_RELATIVE_PATH === $plugin ) {
+		// Redirect to the Search Dashboard only when Jetpack plugin is not activated.
+		if ( JETPACK_SEARCH_PLUGIN__FILE_RELATIVE_PATH === $plugin && ! class_exists( 'Jetpack' ) ) {
 			wp_safe_redirect( esc_url( admin_url( 'admin.php?page=jetpack-search' ) ) );
 			exit;
 		}


### PR DESCRIPTION
Fixes #25322 

#### Changes proposed in this Pull Request:
When Search plugin co-exists with Jetpack plugin, the Search submenu is not added before site connection, and Search plugin redirects user to Search dashboard on activation. As a result, user ends up with a permission denied message.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Open a site with Jetpack plugin activated, Search plugin not activated, and site not connected
- Open plugins page, activate Search plugin
- Ensure you are not redirected ( stays on plugins page )
- Disable Search and Jetpack plugin
- Activate Search plugin
- Ensure you are redirected to Search Dashboard