### PR TITLE
[Boost] Fix script type detection regexp

### DIFF
--- a/projects/plugins/boost/app/features/optimizations/render-blocking-js/class-render-blocking-js.php
+++ b/projects/plugins/boost/app/features/optimizations/render-blocking-js/class-render-blocking-js.php
@@ -210,7 +210,7 @@ class Render_Blocking_JS implements Feature {
 			'~<!--.*?-->~si',
 
 			// Scripts with application/json type
-			'~<script.*type=(?<q>["\']*)application/json\k<q>.*>.*</script>~si',
+			'~<script\s+[^\>]*type=(?<q>["\']*)application/json\k<q>.*>.*</script>~si',
 		);
 
 		return preg_replace_callback(

--- a/projects/plugins/boost/app/features/optimizations/render-blocking-js/class-render-blocking-js.php
+++ b/projects/plugins/boost/app/features/optimizations/render-blocking-js/class-render-blocking-js.php
@@ -210,7 +210,7 @@ class Render_Blocking_JS implements Feature {
 			'~<!--.*?-->~si',
 
 			// Scripts with application/json type
-			'~<script\s+[^\>]*type=(?<q>["\']*)application/json\k<q>.*>.*</script>~si',
+			'~<script\s+[^\>]*type=(?<q>["\']*)application/json\k<q>.*?>.*?</script>~si',
 		);
 
 		return preg_replace_callback(

--- a/projects/plugins/boost/changelog/fix-boost-script-exclusions
+++ b/projects/plugins/boost/changelog/fix-boost-script-exclusions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed detection of application/json scripts for exclusion from deferred JS


### PR DESCRIPTION
When a `<link>` tag with `type="application/json"` is wedged between two script tags, Boost's JS deferral feature can sometimes mis-identify the whole block as one script tag with the `application/json` type. This can lead to some scripts disappearing from the resultant page.

This PR fixes the issue by tightening up the regexp used to detect the `type` of script tags.

#### Changes proposed in this Pull Request:
* Correct an overly loose regexp used to detect the `type` of script tags when considering exclusions.

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Install Jetpack Boost alongside these plugins and activate them all:
  * Asgaros Forum
  * ProfileGrid, and
  * RegistrationMagic
* Verify that the script `http://jetpack.thingalon.com/fresh-51/wp-content/plugins/profilegrid-user-profiles-groups-and-communities/public/js/profile-magic-public.js` is in the resultant output, and the site works correctly.
* Alternately, test the regex changed in this PR against this test HTML code:
```
<script></script>
<link type="application/json"></link>
<script></script>
```