### PR TITLE
Google Docs Embed block: switch to stricter check for URL

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-url-google-docs-embed
+++ b/projects/plugins/jetpack/changelog/fix-url-google-docs-embed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Google Docs Embed block: switch to a stricter check for Google Docs URLs.

--- a/projects/plugins/jetpack/extensions/blocks/google-docs-embed/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/google-docs-embed/edit.js
@@ -36,7 +36,8 @@ const GsuiteBlockEdit = props => {
 		 * @returns {string} The variation.
 		 */
 		const detectVariation = () => {
-			const matches = url.match( '^(http|https)://(docs.google.com)/(.*)/d/' );
+			const regex = /^(http|https):\/\/(docs\.google\.com)\/(.*)\/d\//;
+			const matches = url.match( regex );
 
 			switch ( matches[ 3 ] ) {
 				case 'document':


### PR DESCRIPTION
Follow-up to #24628

#### Changes proposed in this Pull Request:

* Let's ensure URLs are Google.com URLs in the block editor.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* On site with Beta blocks active;
* Go to Posts > Add New
* Paste `https://docs.google.com/document/d/1v9Xdr4TYQYr-mHbkIS9f_kCpffo1nCcHgovcqUSXklw/edit`
* Ensure the URL gets transformed into a Google Docs Embed block.

