### PR TITLE
Hide sharing buttons in Blog Posts block in the editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sharing-buttons-in-editor
+++ b/projects/plugins/jetpack/changelog/fix-sharing-buttons-in-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sharing buttons are now hidden in Blog Posts block in editor

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
@@ -942,6 +942,11 @@ function sharing_display( $text = '', $echo = false ) {
 		return $text;
 	}
 
+	// Prevent from rendering sharing buttons in block which is fetched from REST endpoint by editor
+	if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+		return $text;
+	}
+
 	// Don't output flair on excerpts.
 	if ( in_array( 'get_the_excerpt', (array) $wp_current_filter, true ) ) {
 		return $text;

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
@@ -944,7 +944,7 @@ function sharing_display( $text = '', $echo = false ) {
 
 	// Prevent from rendering sharing buttons in block which is fetched from REST endpoint by editor
 	if ( defined( 'REST_REQUEST' ) && REST_REQUEST &&
-		isset( $_GET['context'] ) && 'edit' === $_GET['context'] ) {
+		isset( $_GET['context'] ) && 'edit' === $_GET['context'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		return $text;
 	}
 

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
@@ -943,7 +943,8 @@ function sharing_display( $text = '', $echo = false ) {
 	}
 
 	// Prevent from rendering sharing buttons in block which is fetched from REST endpoint by editor
-	if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+	if ( defined( 'REST_REQUEST' ) && REST_REQUEST &&
+		isset( $_GET['context'] ) && 'edit' === $_GET['context'] ) {
 		return $text;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/25329

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Blog Posts block is rendered in the editor via REST request and still displays sharing buttons. I'm adding additional checks to remove those from the editor, to match frontend behavior.

#### Other information:

- [ ] ~~Have you written new tests for your changes, if applicable?~~
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Start a Jetpack environment
2. Go to WP Admin
3. Install a WordPress.com Editing Toolkit plugin
4. Enable Sharing buttons in Jetpack -> Settings -> Sharing (works in Jetpack's offline mode)
5. Configure sharing buttons to display them on "Front Page, Archive Pages, and Search Results", "Posts", and "Pages"
6. Add a new page with a Blog Posts block (and not Posts Lists)
7. Confirm sharing buttons are not displayed under each post in the list of posts in the block shown in the editor

<img width="892" alt="Screen Shot 2022-08-01 at 12 42 04" src="https://user-images.githubusercontent.com/727413/182131345-64d130c1-b943-474f-86ef-b4cf8dfabd03.png">

Alternatively, use an Atomic site with the Jetpack Beta plugin and use this PR branch there.

