### PR TITLE
Publicize/Plans: Use plans package in publicize to determine if a feature is available. 

### DIFF
--- a/projects/packages/plans/changelog/add-jetpack-social-plan-changes
+++ b/projects/packages/plans/changelog/add-jetpack-social-plan-changes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Tweaked the supports method of the plans package to refresh the plan data.

--- a/projects/packages/plans/composer.json
+++ b/projects/packages/plans/composer.json
@@ -49,7 +49,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-plans/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.1.x-dev"
+			"dev-trunk": "0.2.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/plans/package.json
+++ b/projects/packages/plans/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-plans",
-	"version": "0.1.3",
+	"version": "0.2.0-alpha",
 	"description": "Fetch information about Jetpack Plans from wpcom",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/plans/#readme",
 	"bugs": {

--- a/projects/packages/plans/src/class-current-plan.php
+++ b/projects/packages/plans/src/class-current-plan.php
@@ -10,6 +10,7 @@
 namespace Automattic\Jetpack;
 
 use Automattic\Jetpack\Connection\Client;
+use Jetpack_Options;
 
 /**
  * Provides methods methods for fetching the site's plan and products from WordPress.com.
@@ -250,8 +251,8 @@ class Current_Plan {
 
 		// get available features if Jetpack is active.
 		if ( class_exists( 'Jetpack' ) ) {
-			foreach ( Jetpack::get_available_modules() as $module_slug ) {
-				$module = Jetpack::get_module( $module_slug );
+			foreach ( \Jetpack::get_available_modules() as $module_slug ) {
+				$module = \Jetpack::get_module( $module_slug );
 				if ( ! isset( $module ) || ! is_array( $module ) ) {
 					continue;
 				}
@@ -324,11 +325,17 @@ class Current_Plan {
 	 * @static
 	 *
 	 * @param string $feature The module or feature to check.
+	 * @param bool   $refresh_from_wpcom Refresh the local plan cache from wpcom.
 	 *
 	 * @return bool True if plan supports feature, false if not
 	 */
-	public static function supports( $feature ) {
+	public static function supports( $feature, $refresh_from_wpcom = false ) {
 		// Hijack the feature eligibility check on WordPress.com sites since they are gated differently.
+
+		if ( $refresh_from_wpcom ) {
+			self::refresh_from_wpcom();
+		}
+
 		$should_wpcom_gate_feature = (
 			function_exists( 'wpcom_site_has_feature' ) &&
 			function_exists( 'wpcom_feature_exists' ) &&

--- a/projects/packages/plans/src/class-current-plan.php
+++ b/projects/packages/plans/src/class-current-plan.php
@@ -211,9 +211,8 @@ class Current_Plan {
 	 */
 	public static function refresh_from_wpcom() {
 		// Make the API request.
-		$args = array( 'headers' => array() );
 
-		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d', Jetpack_Options::get_option( 'id' ) ) . '?force=wpcom', '1.1', $args );
+		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d', Jetpack_Options::get_option( 'id' ) ) . '?force=wpcom', '1.1' );
 		return self::update_from_sites_response( $response );
 	}
 

--- a/projects/packages/plans/src/class-current-plan.php
+++ b/projects/packages/plans/src/class-current-plan.php
@@ -211,9 +211,9 @@ class Current_Plan {
 	 */
 	public static function refresh_from_wpcom() {
 		// Make the API request.
-		$request  = sprintf( '/sites/%d', Jetpack_Options::get_option( 'id' ) );
-		$response = Client::wpcom_json_api_request_as_blog( $request, '1.1' );
+		$args = array( 'headers' => array() );
 
+		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d', Jetpack_Options::get_option( 'id' ) ) . '?force=wpcom', '1.1', $args );
 		return self::update_from_sites_response( $response );
 	}
 
@@ -330,12 +330,11 @@ class Current_Plan {
 	 * @return bool True if plan supports feature, false if not
 	 */
 	public static function supports( $feature, $refresh_from_wpcom = false ) {
-		// Hijack the feature eligibility check on WordPress.com sites since they are gated differently.
-
 		if ( $refresh_from_wpcom ) {
 			self::refresh_from_wpcom();
 		}
 
+		// Hijack the feature eligibility check on WordPress.com sites since they are gated differently.
 		$should_wpcom_gate_feature = (
 			function_exists( 'wpcom_site_has_feature' ) &&
 			function_exists( 'wpcom_feature_exists' ) &&

--- a/projects/packages/videopress/changelog/add-jetpack-social-plan-changes
+++ b/projects/packages/videopress/changelog/add-jetpack-social-plan-changes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/videopress/composer.json
+++ b/projects/packages/videopress/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"automattic/jetpack-connection": "^1.42",
-		"automattic/jetpack-plans": "^0.1"
+		"automattic/jetpack-plans": "^0.2"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.0.3",

--- a/projects/plugins/jetpack/changelog/add-jetpack-social-plan-changes
+++ b/projects/plugins/jetpack/changelog/add-jetpack-social-plan-changes
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1364,7 +1364,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "5d6f96f0b36b8b9dce26cdc423e07f84420d4639"
+                "reference": "65e9320ea13c29b16053c4badaa93962e46f9b0a"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.42"
@@ -1383,7 +1383,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-plans/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.1.x-dev"
+                    "dev-trunk": "0.2.x-dev"
                 }
             },
             "autoload": {
@@ -1832,11 +1832,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/videopress",
-                "reference": "eae6b38717b44f6259ae3be3026aa3cd920af678"
+                "reference": "69c89b4ab937ece56706973e7174c90ab4492039"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.42",
-                "automattic/jetpack-plans": "^0.1"
+                "automattic/jetpack-plans": "^0.2"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",

--- a/projects/plugins/social/changelog/add-jetpack-social-plan-changes
+++ b/projects/plugins/social/changelog/add-jetpack-social-plan-changes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Tweaked the supports method of the plans package to refresh the plan data.

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -16,7 +16,7 @@
 		"automattic/jetpack-my-jetpack": "2.0.x-dev",
 		"automattic/jetpack-sync": "1.37.x-dev",
 		"automattic/jetpack-status": "1.14.x-dev",
-		"automattic/jetpack-plans": "0.1.x-dev"
+		"automattic/jetpack-plans": "0.2.x-dev"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.2",

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -15,7 +15,8 @@
 		"automattic/jetpack-connection": "1.42.x-dev",
 		"automattic/jetpack-my-jetpack": "2.0.x-dev",
 		"automattic/jetpack-sync": "1.37.x-dev",
-		"automattic/jetpack-status": "1.14.x-dev"
+		"automattic/jetpack-status": "1.14.x-dev",
+		"automattic/jetpack-plans": "0.1.x-dev"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.2",

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3d07cad6ebb17cc8e9d6e6cb56c3dc95",
+    "content-hash": "bbb68e8c9f508bca8d229efc269544b6",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -783,6 +783,67 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Password Checker.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-plans",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/plans",
+                "reference": "5d6f96f0b36b8b9dce26cdc423e07f84420d4639"
+            },
+            "require": {
+                "automattic/jetpack-connection": "^1.42"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "^3.2",
+                "automattic/jetpack-status": "^1.14",
+                "automattic/wordbless": "@dev",
+                "yoast/phpunit-polyfills": "1.0.3"
+            },
+            "type": "library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-plans",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-plans/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "post-update-cmd": [
+                    "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\""
+                ],
+                "build-production": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ],
+                "build-development": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Fetch information about Jetpack Plans from wpcom",
             "transport-options": {
                 "relative": true
             }
@@ -4453,7 +4514,8 @@
         "automattic/jetpack-connection": 20,
         "automattic/jetpack-my-jetpack": 20,
         "automattic/jetpack-sync": 20,
-        "automattic/jetpack-status": 20
+        "automattic/jetpack-status": 20,
+        "automattic/jetpack-plans": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bbb68e8c9f508bca8d229efc269544b6",
+    "content-hash": "a3739d076bb628e00e14581bda2033ee",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -793,7 +793,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "5d6f96f0b36b8b9dce26cdc423e07f84420d4639"
+                "reference": "65e9320ea13c29b16053c4badaa93962e46f9b0a"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.42"
@@ -812,7 +812,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-plans/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.1.x-dev"
+                    "dev-trunk": "0.2.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -40,6 +40,7 @@ class Jetpack_Social {
 	 */
 	public function __construct( $connection_manager = null ) {
 		// Set up the REST authentication hooks.
+
 		Connection_Rest_Authentication::init();
 		$page_suffix = Admin_Menu::add_menu(
 			__( 'Jetpack Social', 'jetpack-social' ),
@@ -49,6 +50,7 @@ class Jetpack_Social {
 			array( $this, 'plugin_settings_page' ),
 			99
 		);
+
 		add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );
 		// Init Jetpack packages and ConnectionUI.
 		add_action(

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -40,7 +40,6 @@ class Jetpack_Social {
 	 */
 	public function __construct( $connection_manager = null ) {
 		// Set up the REST authentication hooks.
-
 		Connection_Rest_Authentication::init();
 		$page_suffix = Admin_Menu::add_menu(
 			__( 'Jetpack Social', 'jetpack-social' ),
@@ -50,7 +49,6 @@ class Jetpack_Social {
 			array( $this, 'plugin_settings_page' ),
 			99
 		);
-
 		add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );
 		// Init Jetpack packages and ConnectionUI.
 		add_action(

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -14,6 +14,7 @@ use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
+use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
 use Automattic\Jetpack\Status;
@@ -40,7 +41,6 @@ class Jetpack_Social {
 	public function __construct( $connection_manager = null ) {
 		// Set up the REST authentication hooks.
 		Connection_Rest_Authentication::init();
-
 		$page_suffix = Admin_Menu::add_menu(
 			__( 'Jetpack Social', 'jetpack-social' ),
 			_x( 'Social', 'The Jetpack Social product name, without the Jetpack prefix', 'jetpack-social' ),
@@ -50,7 +50,6 @@ class Jetpack_Social {
 			99
 		);
 		add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );
-
 		// Init Jetpack packages and ConnectionUI.
 		add_action(
 			'plugins_loaded',
@@ -145,8 +144,9 @@ class Jetpack_Social {
 	public function initial_state() {
 		global $publicize;
 
-		$shares = $publicize->get_publicize_shares_info( Jetpack_Options::get_option( 'id' ) );
-
+		$shares                  = $publicize->get_publicize_shares_info( Jetpack_Options::get_option( 'id' ) );
+		$refresh_plan_from_wpcom = true;
+		$show_nudge              = ! Current_Plan::supports( 'social-shares-1000', $refresh_plan_from_wpcom );
 		return array(
 			'siteData'        => array(
 				'apiRoot'           => esc_url_raw( rest_url() ),
@@ -161,6 +161,7 @@ class Jetpack_Social {
 				'adminUrl'    => esc_url_raw( $publicize->publicize_connections_url( 'jetpack-social-connections-admin-page' ) ),
 			),
 			'sharesData'      => ! is_wp_error( $shares ) ? $shares : null,
+			'showNudge'       => $show_nudge,
 		);
 	}
 

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -52,6 +52,7 @@ class Jetpack_Social {
 		);
 
 		add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );
+
 		// Init Jetpack packages and ConnectionUI.
 		add_action(
 			'plugins_loaded',
@@ -80,6 +81,7 @@ class Jetpack_Social {
 
 		// Activate the module as the plugin is activated
 		add_action( 'admin_init', array( $this, 'do_plugin_activation_activities' ) );
+
 		add_action(
 			'plugins_loaded',
 			function () {

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -41,6 +41,7 @@ class Jetpack_Social {
 	public function __construct( $connection_manager = null ) {
 		// Set up the REST authentication hooks.
 		Connection_Rest_Authentication::init();
+
 		$page_suffix = Admin_Menu::add_menu(
 			__( 'Jetpack Social', 'jetpack-social' ),
 			_x( 'Social', 'The Jetpack Social product name, without the Jetpack prefix', 'jetpack-social' ),
@@ -49,6 +50,7 @@ class Jetpack_Social {
 			array( $this, 'plugin_settings_page' ),
 			99
 		);
+
 		add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );
 		// Init Jetpack packages and ConnectionUI.
 		add_action(

--- a/projects/plugins/videopress/changelog/add-jetpack-social-plan-changes
+++ b/projects/plugins/videopress/changelog/add-jetpack-social-plan-changes
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -753,7 +753,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "5d6f96f0b36b8b9dce26cdc423e07f84420d4639"
+                "reference": "65e9320ea13c29b16053c4badaa93962e46f9b0a"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.42"
@@ -772,7 +772,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-plans/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.1.x-dev"
+                    "dev-trunk": "0.2.x-dev"
                 }
             },
             "autoload": {
@@ -1078,11 +1078,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/videopress",
-                "reference": "eae6b38717b44f6259ae3be3026aa3cd920af678"
+                "reference": "69c89b4ab937ece56706973e7174c90ab4492039"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.42",
-                "automattic/jetpack-plans": "^0.1"
+                "automattic/jetpack-plans": "^0.2"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
In the Jetpack Social plugin, we are going to check if a paid feature is available.  We are going to use the 'Current_Plan' package. 

Once this PR is merged, I will work on deprecating `Jetpack_Plan` in the Jetpack Plugin in a new PR and use the `Current_Plan` package instead. 


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Made the Current_Plans package usage
* Add a param `refresh_plan_from_wpcom` to the `supports` method which will enable the method to optionally force refresh the plans cache before getting the plans data.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pdWQjU-4i-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You can error_log($show_nudge)  and see that's it's true
* Buy the Jetpack Social Basic plan by visiting this link https://wordpress.com/checkout/following-jambu.jurassic.ninja/jetpack_social_monthly), replacing following-jambu.jurassic.ninja with your Jetpack Site name
* You can error_log($show_nudge)  and see that's it's false
* Make sure you test this with the Jetpack Plugin deactivated (Jetpack Social plugin should be activated)


