### PR TITLE
Jetpack: register VideoPress block from its editor.js file

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-vpblock-fix-registering-block-issue
+++ b/projects/plugins/jetpack/changelog/update-jetpack-vpblock-fix-registering-block-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: register VideoPress block from its editor.js file

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -22,6 +22,7 @@ import deprecatedV4 from './deprecated/v4';
 import withVideoPressEdit from './edit';
 import withVideoPressSave from './save';
 import videoPressBlockExampleImage from './videopress-block-example-image.jpg';
+import './v6/editor';
 
 import './editor.scss';
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -14,7 +14,6 @@ import { useContext } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import { every } from 'lodash';
-import registerJetpackBlock from '../../shared/register-jetpack-block';
 import { VideoPressBlockContext } from './components';
 import deprecatedV1 from './deprecated/v1';
 import deprecatedV2 from './deprecated/v2';
@@ -22,7 +21,6 @@ import deprecatedV3 from './deprecated/v3';
 import deprecatedV4 from './deprecated/v4';
 import withVideoPressEdit from './edit';
 import withVideoPressSave from './save';
-import { name as videoPressBlockName, settings as videoPressBlockSettings } from './v6';
 import videoPressBlockExampleImage from './videopress-block-example-image.jpg';
 
 import './editor.scss';
@@ -388,6 +386,3 @@ const addVideoPressSupport = ( settings, name ) => {
  * @see packages/block-editor/src/hooks/align.js
  */
 addFilter( 'blocks.registerBlockType', 'jetpack/videopress', addVideoPressSupport, 5 );
-
-// Register VideoPress block.
-registerJetpackBlock( videoPressBlockName, videoPressBlockSettings );

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/editor.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import registerJetpackBlock from '../shared/register-jetpack-block';
+import registerJetpackBlock from '../../../shared/register-jetpack-block';
 import { name, settings } from '.';
 
 registerJetpackBlock( name, settings );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR updates how the new VideoPress block is registered. Currently (without these changes), it's registered in the current editor.js file. This is not optimal.
What we propose here is to register the block straight in the `v6/editor.js` file, and import it from wherever we want.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack: register VideoPress block from its editor.js file

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Just confirm that after these changes, the new VideoPress block is still available and works as expected.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202698198760030