### PR TITLE
VP Block: Add support to pause and resume upload

### DIFF
--- a/projects/plugins/jetpack/changelog/add-videopress-stop-resume-upload
+++ b/projects/plugins/jetpack/changelog/add-videopress-stop-resume-upload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+VPBlock: Add support to pause/resume upload

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/index.js
@@ -23,6 +23,8 @@ const UploadProgress = ( { progress, file, paused, onPauseOrResume } ) => {
 	const roundedProgress = Math.round( progress );
 	const cssWidth = { width: `${ roundedProgress }%` };
 
+	const resumeText = __( 'Resume', 'jetpack' );
+	const pauseText = __( 'Pause', 'jetpack' );
 	const fileSizeLabel = filesize( file?.size );
 	const escapedFileName = escapeHTML( file?.name );
 	const fileNameLabel = createInterpolateElement(
@@ -49,7 +51,7 @@ const UploadProgress = ( { progress, file, paused, onPauseOrResume } ) => {
 					<div className="videopress-upload__percent-complete">{ `${ roundedProgress }%` }</div>
 					{ roundedProgress < 100 && (
 						<Button variant="link" onClick={ onPauseOrResume }>
-							{ paused ? __( 'Resume', 'jetpack' ) : __( 'Pause', 'jetpack' ) }
+							{ paused ? resumeText : pauseText }
 						</Button>
 					) }
 				</div>

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6/components/videopress-uploader/index.js
@@ -49,7 +49,7 @@ const UploadProgress = ( { progress, file, paused, onPauseOrResume } ) => {
 					<div className="videopress-upload__percent-complete">{ `${ roundedProgress }%` }</div>
 					{ roundedProgress < 100 && (
 						<Button variant="link" onClick={ onPauseOrResume }>
-							{ paused ? 'Resume' : 'Pause' }
+							{ paused ? __( 'Resume', 'jetpack' ) : __( 'Pause', 'jetpack' ) }
 						</Button>
 					) }
 				</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Add support for `pause/resume` the video for VideoPress. This keeps the work on maintaining the current features at the new VP block.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add `pauseResume` method to `stop` and `continue` upload.
* Add `handleUpload` as false into the media placeholder to avoid two uploads handlers, which causes one of them not to be paused.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate `VideoPress (beta)` block.
* Navigate to post and insert it.
* Upload a new video, pause it, and resume.
* Remove the block and add it from the media library.
* Tries to add no videopress video from media library (should cause an error).

#### Demo

https://user-images.githubusercontent.com/1663717/182253069-24fb6a64-383c-48a2-84d4-9880adf3ca97.mov