### PR TITLE
Number Formatting: add new function to format a number to a short format

### DIFF
--- a/projects/js-packages/components/changelog/add-short-number-format-function
+++ b/projects/js-packages/components/changelog/add-short-number-format-function
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+JS Components: Add function to format numbers in a short format specific to locale

--- a/projects/js-packages/components/components/short-number-format/README.md
+++ b/projects/js-packages/components/components/short-number-format/README.md
@@ -1,5 +1,23 @@
-# shortNumberFormat
+shortNumberFormat
+=========
 
-This utility function can be used to format numbers so they are displayed in a short format expected for a specific locale.
+This utility function can be used to format numbers so they are displayed in a short format expected for a specific 
+locale.
 
-For example, a large number such as `12345` would be displayed as `12.3 K` in US English.
+For example, a large number such as `12345` would be displayed as `12.3 K` in US English, and as `12,3 k` in FR French.
+
+The function relies on `Intl.NumberFormat` to format the numbers, based on the locale information available in 
+WordPress, or based on the browser locale as a fallback
+
+## General Usage:
+
+```js
+import { shortNumberFormat } from '@automattic/jetpack-components';
+
+render() {
+	const number = '123456';
+	return (
+		<>{ shortNumberFormat( number ) } </>
+	);
+}
+```

--- a/projects/js-packages/components/components/short-number-format/README.md
+++ b/projects/js-packages/components/components/short-number-format/README.md
@@ -1,0 +1,5 @@
+# shortNumberFormat
+
+This utility function can be used to format numbers so they are displayed in a short format expected for a specific locale.
+
+For example, a large number such as `12345` would be displayed as `12.3 K` in US English.

--- a/projects/js-packages/components/components/short-number-format/index.js
+++ b/projects/js-packages/components/components/short-number-format/index.js
@@ -1,0 +1,32 @@
+/**
+ * Internal dependencies
+ */
+
+import { getUserLocale } from '../../lib/locale';
+
+/**
+ * Format a number using the locale in use by the user viewing the page in a short format
+ *
+ * @param {number} number - The number to format
+ * @returns {string} Formatted number.
+ */
+
+const shortNumberFormat = number => {
+	// Check if the shortened number will be less than 3 digits
+	const length = Math.ceil( Math.log10( Math.abs( number ) ) ) % 3;
+
+	// Gets the locale details from WordPress or browser locale as fallback
+	const locale = getUserLocale();
+
+	let options = {};
+
+	if ( length > 0 ) {
+		options = { notation: 'compact', maximumFractionDigits: 1 };
+	} else {
+		options = { notation: 'compact', maximumFractionDigits: 0 };
+	}
+
+	return new Intl.NumberFormat( locale, options ).format( number );
+};
+
+export default shortNumberFormat;


### PR DESCRIPTION
This function is to solve issue #24554 utilizing the Intl.NumberFormat function to shorten long numbers to a specific locale. Similarly to the wp-calypso implementation it will output numbers with 1 decimal if less than 3 digits.

#### Changes proposed in this Pull Request:
- Adds function to return large numbers formatted as a short string

#### Does this pull request change what data or activity we track or use?
This is pulling the user locale from getUserLocale, but other than that no.

#### Testing instructions
- import shortNumberFormat from @automattic/jetpack-components
- Call shortNumberFormat(number) with different WP locales set to get formatted string

I'm new to developing for Jetpack, I'm not sure the best way to test this.