### PR TITLE
My Jetpack: Show global notice on Connection errors

### DIFF
--- a/projects/js-packages/connection/changelog/add-my-jetpack-connection-errors-poc
+++ b/projects/js-packages/connection/changelog/add-my-jetpack-connection-errors-poc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+My Jetpack: Display connection error in UI

--- a/projects/js-packages/connection/components/use-connection/index.jsx
+++ b/projects/js-packages/connection/components/use-connection/index.jsx
@@ -22,6 +22,7 @@ export default ( {
 		userIsConnecting,
 		userConnectionData,
 		connectedPlugins,
+		connectionErrors,
 		isRegistered,
 		isUserConnected,
 		hasConnectedOwner,
@@ -30,6 +31,7 @@ export default ( {
 		userIsConnecting: select( STORE_ID ).getUserIsConnecting(),
 		userConnectionData: select( STORE_ID ).getUserConnectionData(),
 		connectedPlugins: select( STORE_ID ).getConnectedPlugins(),
+		connectionErrors: select( STORE_ID ).getConnectionErrors(),
 		...select( STORE_ID ).getConnectionStatus(),
 	} ) );
 
@@ -102,5 +104,6 @@ export default ( {
 		userConnectionData,
 		hasConnectedOwner,
 		connectedPlugins,
+		connectionErrors,
 	};
 };

--- a/projects/js-packages/connection/state/actions.jsx
+++ b/projects/js-packages/connection/state/actions.jsx
@@ -13,6 +13,7 @@ const CONNECT_USER = 'CONNECT_USER';
 const FETCH_AUTHORIZATION_URL = 'FETCH_AUTHORIZATION_URL';
 const SET_CONNECTED_PLUGINS = 'SET_CONNECTED_PLUGINS';
 const REFRESH_CONNECTED_PLUGINS = 'REFRESH_CONNECTED_PLUGINS';
+const SET_CONNECTION_ERRORS = 'SET_CONNECTION_ERRORS';
 
 const setConnectionStatus = connectionStatus => {
 	return { type: SET_CONNECTION_STATUS, connectionStatus };
@@ -52,6 +53,10 @@ const fetchAuthorizationUrl = redirectUri => {
 
 const setConnectedPlugins = connectedPlugins => {
 	return { type: SET_CONNECTED_PLUGINS, connectedPlugins };
+};
+
+const setConnectionErrors = connectionErrors => {
+	return { type: SET_CONNECTION_ERRORS, connectionErrors };
 };
 
 /**
@@ -123,6 +128,7 @@ const actions = {
 	connectUser,
 	setConnectedPlugins,
 	refreshConnectedPlugins,
+	setConnectionErrors,
 };
 
 export {
@@ -139,5 +145,6 @@ export {
 	CONNECT_USER,
 	SET_CONNECTED_PLUGINS,
 	REFRESH_CONNECTED_PLUGINS,
+	SET_CONNECTION_ERRORS,
 	actions as default,
 };

--- a/projects/js-packages/connection/state/reducers.jsx
+++ b/projects/js-packages/connection/state/reducers.jsx
@@ -8,6 +8,7 @@ import {
 	SET_REGISTRATION_ERROR,
 	SET_AUTHORIZATION_URL,
 	SET_CONNECTED_PLUGINS,
+	SET_CONNECTION_ERRORS,
 } from './actions';
 
 const connectionStatus = ( state = {}, action ) => {
@@ -82,6 +83,15 @@ const userConnectionData = ( state, action ) => {
 	}
 };
 
+const connectionErrors = ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SET_CONNECTION_ERRORS:
+			return action.connectionErrors;
+	}
+
+	return state;
+};
+
 const reducers = combineReducers( {
 	connectionStatus,
 	connectionStatusIsFetching,
@@ -91,6 +101,7 @@ const reducers = combineReducers( {
 	authorizationUrl,
 	userConnectionData,
 	connectedPlugins,
+	connectionErrors,
 } );
 
 export default reducers;

--- a/projects/js-packages/connection/state/selectors.jsx
+++ b/projects/js-packages/connection/state/selectors.jsx
@@ -13,6 +13,7 @@ const connectionSelectors = {
 	getAuthorizationUrl: state => state.authorizationUrl || false,
 	getUserConnectionData: state => state.userConnectionData || false,
 	getConnectedPlugins: state => state.connectedPlugins || [],
+	getConnectionErrors: state => state.connectionErrors || [],
 };
 
 const selectors = {

--- a/projects/packages/connection/changelog/add-my-jetpack-connection-errors-poc
+++ b/projects/packages/connection/changelog/add-my-jetpack-connection-errors-poc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+My Jetpack: Display connection error in UI

--- a/projects/packages/connection/src/class-initial-state.php
+++ b/projects/packages/connection/src/class-initial-state.php
@@ -38,6 +38,7 @@ class Initial_State {
 			'connectedPlugins'   => REST_Connector::get_connection_plugins( false ),
 			'wpVersion'          => $wp_version,
 			'siteSuffix'         => ( new Status() )->get_site_suffix(),
+			'connectionErrors'   => Error_Handler::get_instance()->get_verified_errors(),
 		);
 	}
 

--- a/projects/packages/my-jetpack/_inc/hooks/use-connection-watcher/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-connection-watcher/index.js
@@ -16,7 +16,12 @@ export default function useConnectionWatcher() {
 	const productsThatRequiresUserConnection = useSelect( select =>
 		select( STORE_ID ).getProductsThatRequiresUserConnection()
 	);
-	const { isSiteConnected, topJetpackMenuItemUrl, hasConnectedOwner } = useMyJetpackConnection();
+	const {
+		isSiteConnected,
+		topJetpackMenuItemUrl,
+		hasConnectedOwner,
+		connectionErrors,
+	} = useMyJetpackConnection();
 
 	const requiresUserConnection =
 		! hasConnectedOwner && productsThatRequiresUserConnection.length > 0;
@@ -62,4 +67,20 @@ export default function useConnectionWatcher() {
 			} );
 		}
 	}, [ message, requiresUserConnection, navToConnection, setGlobalNotice ] );
+
+	useEffect( () => {
+		if ( connectionErrors.length ) {
+			setGlobalNotice( __( 'Your Jetpack Connection is broken', 'jetpack-my-jetpack' ), {
+				status: 'error',
+				actions: [
+					{
+						label: __( 'Fix Jetpack Connection', 'jetpack-my-jetpack' ),
+						onClick: navToConnection,
+						variant: 'link',
+						noDefaultClasses: true,
+					},
+				],
+			} );
+		}
+	}, [ message, connectionErrors, navToConnection, setGlobalNotice ] );
 }

--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-connection-errors-poc
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-connection-errors-poc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+My Jetpack: Display connection error in UI


### PR DESCRIPTION
DO NOT MERGE THIS!

POC PR for handling Connection errors in My Jetpack

Only deals with displaying the error not actually fixing the connection.

We might want to consider introducing a priority logic in My Jetpack's global notices as with the current implementation, assuming a connection error, we'll probably only see the "There was an error fetching your purchases information. Check your site connectivity and try again." global notice which overrides the connection related notice.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

