### PR TITLE
JS Components: Add full width option on Button component

### DIFF
--- a/projects/js-packages/components/changelog/add-button-full-width
+++ b/projects/js-packages/components/changelog/add-button-full-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+JS Components: Add fullWidth prop to Button

--- a/projects/js-packages/components/components/button/index.tsx
+++ b/projects/js-packages/components/components/button/index.tsx
@@ -24,6 +24,7 @@ export const Button: React.FC< ButtonProps > = ( {
 	isExternalLink,
 	className: propsClassName,
 	text,
+	fullWidth,
 	...componentProps
 } ) => {
 	const className = classNames( styles.button, propsClassName, {
@@ -32,6 +33,7 @@ export const Button: React.FC< ButtonProps > = ( {
 		[ styles.icon ]: Boolean( icon ),
 		[ styles.loading ]: isLoading,
 		[ styles.regular ]: weight === 'regular',
+		[ styles[ 'full-width' ] ]: fullWidth,
 	} );
 
 	const externalIconSize = size === 'normal' ? 20 : 16;

--- a/projects/js-packages/components/components/button/stories/Button.mdx
+++ b/projects/js-packages/components/components/button/stories/Button.mdx
@@ -15,7 +15,7 @@ Below is the current available props for `Button`.
 
 ### variant
 
-It accepts 4 variants types: `primary`, `secondary`, `link`, `external-link`.
+It accepts 4 variant types: `primary`, `secondary`, `link`, `external-link`.
 
 <Canvas withSource="open">
   <Story id="js-packages-components-button--button-primary" />
@@ -35,13 +35,13 @@ It accepts 2 size types: `normal` and `small`.
 
 ### weight
 
-It accepts 2 size types: `bold` and `regular`. `bold` as default.
+It accepts 2 weight types: `bold` and `regular`. `bold` as default.
 
 ### icon
 
-It accepts an SVG, Component or string.
+It accepts a SVG, Component or string.
 
-You could the ones from [@wordpress/icons](https://github.com/WordPress/gutenberg/blob/trunk/packages/icons/src/index.js).
+You could use the ones from [@wordpress/icons](https://github.com/WordPress/gutenberg/blob/trunk/packages/icons/src/index.js).
 
 <Canvas withSource="open">
   <Story id="js-packages-components-button--icon" />
@@ -49,7 +49,7 @@ You could the ones from [@wordpress/icons](https://github.com/WordPress/gutenber
 
 ### iconSize
 
-It define the size of the icon, it needs to be a number.
+It defines the size of the icon, it needs to be a number.
 
 ### disabled
 
@@ -61,7 +61,7 @@ Disables the button removing cursor-pointer effect.
 
 ### isDestructive
 
-Set button on destructive state, which change the color for red.
+Set button on destructive state, which changes the color to red.
 
 <Canvas withSource="open">
   <Story id="js-packages-components-button--destructive" />
@@ -77,8 +77,16 @@ Set button on loading state, which applies a centered spinner.
 
 ### text
 
-It applies an text before children, it could be use together or alone.
+It applies a text before children, it could be used together or alone.
 
 <Canvas>
   <Button text="My Text">My Children</Button>
+</Canvas>
+
+### fullWidth
+
+Stretches the button take up the full width of the container.
+
+<Canvas withSource="open">
+  <Story id="js-packages-components-button--full-width" />
 </Canvas>

--- a/projects/js-packages/components/components/button/stories/Button.mdx
+++ b/projects/js-packages/components/components/button/stories/Button.mdx
@@ -39,7 +39,7 @@ It accepts 2 weight types: `bold` and `regular`. `bold` as default.
 
 ### icon
 
-It accepts a SVG, Component or string.
+It accepts an SVG, Component or string.
 
 You could use the ones from [@wordpress/icons](https://github.com/WordPress/gutenberg/blob/trunk/packages/icons/src/index.js).
 
@@ -77,7 +77,7 @@ Set button on loading state, which applies a centered spinner.
 
 ### text
 
-It applies a text before children, it could be used together or alone.
+It applies a text before children, it could be used together or on its own.
 
 <Canvas>
   <Button text="My Text">My Children</Button>
@@ -85,7 +85,7 @@ It applies a text before children, it could be used together or alone.
 
 ### fullWidth
 
-Stretches the button take up the full width of the container.
+Stretches the button to take up the full width of the container.
 
 <Canvas withSource="open">
   <Story id="js-packages-components-button--full-width" />

--- a/projects/js-packages/components/components/button/stories/index.tsx
+++ b/projects/js-packages/components/components/button/stories/index.tsx
@@ -9,7 +9,7 @@ import styles from './style.module.scss';
 const { Icon: WPIcon, ...icons } = allIcons;
 const { check, cloud } = icons;
 
-const DisableVariant = {
+const disableVariant = {
 	variant: {
 		table: {
 			disable: true,
@@ -17,7 +17,7 @@ const DisableVariant = {
 	},
 };
 
-const DisableDisabled = {
+const disableDisabled = {
 	disabled: {
 		table: {
 			disable: true,
@@ -25,7 +25,7 @@ const DisableDisabled = {
 	},
 };
 
-const DisableIsDestructive = {
+const disableIsDestructive = {
 	isDestructive: {
 		table: {
 			disable: true,
@@ -33,7 +33,7 @@ const DisableIsDestructive = {
 	},
 };
 
-const DisableIsLoading = {
+const disableIsLoading = {
 	isLoading: {
 		table: {
 			disable: true,
@@ -41,7 +41,7 @@ const DisableIsLoading = {
 	},
 };
 
-const DisableIcon = {
+const disableIcon = {
 	icon: {
 		table: {
 			disable: true,
@@ -51,6 +51,14 @@ const DisableIcon = {
 
 const disableClassName = {
 	className: {
+		table: {
+			disable: true,
+		},
+	},
+};
+
+const disableFullWidth = {
+	fullWidth: {
 		table: {
 			disable: true,
 		},
@@ -111,6 +119,7 @@ _default.args = {
 	isLoading: false,
 	disabled: false,
 	isDestructive: false,
+	fullWidth: false,
 	children: 'Once upon a time… a button story',
 };
 
@@ -118,11 +127,12 @@ const Template = args => <Button { ...args } />;
 
 export const ButtonPrimary = Template.bind( {} );
 ButtonPrimary.argTypes = {
-	...DisableVariant,
-	...DisableDisabled,
-	...DisableIcon,
-	...DisableIsLoading,
-	...DisableIsDestructive,
+	...disableVariant,
+	...disableDisabled,
+	...disableIcon,
+	...disableIsLoading,
+	...disableIsDestructive,
+	...disableFullWidth,
 };
 ButtonPrimary.args = {
 	size: 'normal',
@@ -132,12 +142,13 @@ ButtonPrimary.args = {
 
 export const ButtonSecondary = Template.bind( {} );
 ButtonSecondary.argTypes = {
-	...DisableVariant,
-	...DisableDisabled,
-	...DisableIcon,
-	...DisableIsLoading,
-	...DisableIsDestructive,
+	...disableVariant,
+	...disableDisabled,
+	...disableIcon,
+	...disableIsLoading,
+	...disableIsDestructive,
 	...disableClassName,
+	...disableFullWidth,
 };
 ButtonSecondary.args = {
 	size: 'normal',
@@ -147,12 +158,13 @@ ButtonSecondary.args = {
 
 export const ButtonLink = Template.bind( {} );
 ButtonLink.argTypes = {
-	...DisableVariant,
-	...DisableDisabled,
-	...DisableIcon,
-	...DisableIsLoading,
-	...DisableIsDestructive,
+	...disableVariant,
+	...disableDisabled,
+	...disableIcon,
+	...disableIsLoading,
+	...disableIsDestructive,
 	...disableClassName,
+	...disableFullWidth,
 };
 ButtonLink.args = {
 	size: 'normal',
@@ -162,11 +174,12 @@ ButtonLink.args = {
 
 export const Icon = Template.bind( {} );
 Icon.argTypes = {
-	...DisableIcon,
-	...DisableDisabled,
-	...DisableIsLoading,
-	...DisableIsDestructive,
+	...disableIcon,
+	...disableDisabled,
+	...disableIsLoading,
+	...disableIsDestructive,
 	...disableClassName,
+	...disableFullWidth,
 };
 Icon.args = {
 	size: 'normal',
@@ -177,10 +190,12 @@ Icon.args = {
 
 export const Disabled = Template.bind( {} );
 Disabled.argTypes = {
-	...DisableDisabled,
-	...DisableIsDestructive,
-	...DisableIsLoading,
+	...disableDisabled,
+	...disableIsDestructive,
+	...disableIsLoading,
 	...disableClassName,
+	...disableFullWidth,
+	...disableIcon,
 };
 Disabled.args = {
 	size: 'normal',
@@ -191,10 +206,12 @@ Disabled.args = {
 
 export const Destructive = Template.bind( {} );
 Destructive.argTypes = {
-	...DisableIsDestructive,
-	...DisableIsLoading,
-	...DisableDisabled,
+	...disableIsDestructive,
+	...disableIsLoading,
+	...disableDisabled,
 	...disableClassName,
+	...disableFullWidth,
+	...disableIcon,
 };
 Destructive.args = {
 	size: 'normal',
@@ -205,16 +222,33 @@ Destructive.args = {
 
 export const Loading = Template.bind( {} );
 Loading.argTypes = {
-	...DisableIsDestructive,
-	...DisableIsLoading,
-	...DisableDisabled,
+	...disableIsDestructive,
+	...disableIsLoading,
+	...disableDisabled,
 	...disableClassName,
+	...disableFullWidth,
+	...disableIcon,
 };
 Loading.args = {
 	size: 'normal',
 	children: 'Jetpack Button',
 	variant: 'primary',
 	isLoading: true,
+};
+
+export const FullWidth = Template.bind( {} );
+FullWidth.argTypes = {
+	...disableIsDestructive,
+	...disableIsLoading,
+	...disableDisabled,
+	...disableClassName,
+	...disableIcon,
+};
+FullWidth.args = {
+	size: 'normal',
+	children: 'Jetpack Button',
+	variant: 'primary',
+	fullWidth: true,
 };
 
 export const VariantsAndProps = () => {
@@ -336,6 +370,15 @@ export const VariantsAndProps = () => {
 				{ variants.map( variant => (
 					<Col sm={ 4 } md={ 2 } lg={ 3 }>
 						<Button { ...ButtonPrimary.args } variant={ variant } isLoading />
+					</Col>
+				) ) }
+
+				<Col className={ styles[ 'row-instance' ] } sm={ 4 } md={ 2 } lg={ 3 }>
+					<Text size="body-extra-small">fullWidth</Text>
+				</Col>
+				{ variants.map( variant => (
+					<Col sm={ 4 } md={ 2 } lg={ 3 }>
+						<Button { ...ButtonPrimary.args } variant={ variant } fullWidth />
 					</Col>
 				) ) }
 			</Container>

--- a/projects/js-packages/components/components/button/style.module.scss
+++ b/projects/js-packages/components/components/button/style.module.scss
@@ -42,6 +42,11 @@
 		font-weight: 400;
 	}
 
+	// Full Width
+	&.full-width {
+		min-width: 100%;
+	}
+
 	// SPECIFICS
 	// PRIMARY AND SECONDARY
 

--- a/projects/js-packages/components/components/button/types.ts
+++ b/projects/js-packages/components/components/button/types.ts
@@ -11,6 +11,7 @@ type JetpackButtonBaseProps = {
 	size?: 'normal' | 'small';
 	text?: string;
 	weight?: 'bold' | 'regular';
+	fullWidth?: boolean;
 };
 
 type JetpackLinkProps = Omit< Button.AnchorProps, 'size' | 'variant' > & {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds the `fullWidth` _prop_ to the `Button` component.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `cd projects/js-packages/storybook && pnpm run storybook:dev`
* Confirm that all the stories of `Button` component work as expected
* Confirm that the `fullWidth` control makes the button stretch to the full width of the container
* Check the consumers of `Button` and confirm that they work as expected
* Check for any regression

![Screenshot_2022-08-02_13-53-42](https://user-images.githubusercontent.com/8486249/182431108-3588e505-51d2-4c29-ab0c-68d5d427e742.png)

`fullWidth: false`:
![Screenshot_2022-08-02_13-53-15](https://user-images.githubusercontent.com/8486249/182431113-ea568407-e49b-4604-bb36-7c0a515aac3d.png)

`fullWidth: true`:
![Screenshot_2022-08-02_13-53-27](https://user-images.githubusercontent.com/8486249/182431111-f7c7acf9-a706-4096-9d52-f27d3d404d92.png)




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202678208143769