### PR TITLE
Add missing site owner id to fix UI issue in calypso

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-missing-site-owner-causing-ui-issue-in-calypso
+++ b/projects/plugins/jetpack/changelog/fix-missing-site-owner-causing-ui-issue-in-calypso
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+WordPress.com REST API: add missing site owner id to single site REST API response to fix UI issue in Calypso

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -190,6 +190,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 	protected static $jetpack_response_field_additions = array(
 		'subscribers_count',
 		'site_migration',
+		'site_owner',
 	);
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/66212

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

In this PR, I propose to add the `site_owner` key to the WPCOM API REST response that returns single Jetpack site information. In some cases, the missing site owner ID leads to displaying incorrect UI in the Calypso.

##### Tecnical details

When Calypso loads the site’s data using https://public-api.wordpress.com/rest/v1.2/me/sites endpoint, it includes all sites data with the `site_owner` key. Then when it renders UI that relies on that, everything works well.

But sometimes, it reloads site data using separate requests, e.g., https://public-api.wordpress.com/rest/v1.2/sites/$siteId?http_envelope=1. This endpoint doesn’t include `site_owner`, so the value of `siteOwner` in the Calypso store becomes empty, so UI breaks - it displays the edit role form and the delete UI again.

I'm fixing it by adding the missing site owner id to the endpoint that returns single Jetpack site data.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p9F6qB-9M6-p2#comment-48399

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Apply changes from this PR to the WPCOM sandbox (apply related diff)
2. Sandbox the API
3. Create an Atomic site
4. Navigate to WPCOM -> Users
5. Invite a new user as Administrator - another WPCOM account
6. Accept invitation received by email
7. Logged as an invited user, navigate to WPCOM -> Users
8. Click on the site's owner

If UI that allows editing role or deleting user is not displayed, open DevTools, Application -> IndexedDB and remove "redux-state-223526147” node from Calypso database, refresh the page. Confirm that UI that allows editing role or deleting user is not displayed even if `sites/$siteId` request was executed after `me/sites`.

