### PR TITLE
VideoPress: do not show admin upgrade nudge on WoA sites.

### DIFF
--- a/projects/plugins/jetpack/_inc/client/performance/media.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/media.jsx
@@ -157,7 +157,9 @@ export default connect( state => {
 		sitePlan: getSitePlan( state ),
 		hasVideoPressFeature:
 			siteHasFeature( state, 'videopress-1tb-storage' ) ||
-			siteHasFeature( state, 'videopress-unlimited-storage' ),
+			siteHasFeature( state, 'videopress-unlimited-storage' ) ||
+			siteHasFeature( state, 'videopress' ) ||
+			siteHasFeature( state, 'video-hosting' ),
 		hasVideoPressUnlimitedStorage: siteHasFeature( state, 'videopress-unlimited-storage' ),
 		hasConnectedOwner: hasConnectedOwnerSelector( state ),
 		isOffline: isOfflineMode( state ),

--- a/projects/plugins/jetpack/changelog/fix-dashboard-videopress-card-ecommerce
+++ b/projects/plugins/jetpack/changelog/fix-dashboard-videopress-card-ecommerce
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Dashboard: do not show a VideoPress upgrade banner on paid WoA sites.


### PR DESCRIPTION
Fixes #25366

#### Changes proposed in this Pull Request:

On WordPress.com sites, the VideoPress feature is mapped differently. See the WPCOM_Features class to find out more.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

1. Go to wordpress.com/start
2. Go through the steps to create a new WordPress.com site, using an eCommerce plan, or a Business plan. If you have an existing site, even using the Pro plan, where you can use the Jetpack Beta plugin, that works too.
3. Once the site is created, install [the Jetpack Beta Plugin](https://github.com/Automattic/jetpack-beta/releases/download/3.1.2/jetpack-beta.zip) on it.
4. Go to Jetpack > Beta and switch to the `fix/dashboard-videopress-card-ecommerce` branch
5. Go to the Jetpack menu
6. Click on the Settings link at the top right side of the Jetpack dashboard.
7. Click on Performance
8. At the bottom of the page, you will see the VideoPress card. It should show the feature as active, without any upgrade nudge.

