### PR TITLE
Jetpack: Porting back 11.2 changelog and readme updates to trunk

### DIFF
--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
-## 11.2-beta - 2022-07-26
+## 11.2 - 2022-08-02
 ### Enhancements
 - Native block inserter: only display blocks under a Jetpack heading if the host app is WordPress. [#25155]
 - VideoPress Block (beta): add block transforms for the VideoPress block. [#25154]
@@ -13,6 +13,7 @@
 - Connection: fix Jetpack redirect after registration. [#25135]
 - Masterbar: ensure that the WordPress.com Add Ons menu item doesn't display on Jetpack-connected sites. [#25085]
 - Sharing: ensure that sharing buttons are not displayed for excerpts. [#24896]
+- Sharing: hide button information in Blog Posts block in editor. [#25346]
 - Slideshow Block: support wide and full alignment options. [#25107]
 - Subscribe block: fix support for allowed HTML tags in submit button. [#25114]
 - VideoPress: avoid PHP notices when inserting videos that miss some metadata. [#25129]
@@ -22,6 +23,7 @@
 - Cleanup old videopress player code (D75134-code). [#23384]
 - E2E tests: cancel partner plan when resetting test environment. [#25264]
 - Init 11.2-a.6 cycle. [#25126]
+- Jetpack 11.2 changelog editorial [#25276]
 - Jetpack 11.2-a.5 changelog editorial. [#25128]
 - Publicize: Remove folder from modules. [#25049]
 - Search: remove Calypso search page link in admin menu for simple sites. [#25149]

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## [11.2] - 2022-08-02
 ### Enhancements
-- Native block inserter: only display blocks under a Jetpack heading if the host app is WordPress. [#25155]
+- Native Block Inserter: only display blocks under a Jetpack heading if the host app is WordPress. [#25155]
 - VideoPress Block (beta): add block transforms for the VideoPress block. [#25154]
 
 ### Bug fixes
@@ -15,7 +15,7 @@
 - Sharing: ensure that sharing buttons are not displayed for excerpts. [#24896]
 - Sharing: hide button information in Blog Posts block in editor. [#25346]
 - Slideshow Block: support wide and full alignment options. [#25107]
-- Subscribe block: fix support for allowed HTML tags in submit button. [#25114]
+- Subscribe Block: fix support for allowed HTML tags in submit button. [#25114]
 - VideoPress: avoid PHP notices when inserting videos that miss some metadata. [#25129]
 
 ### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
@@ -30,7 +30,7 @@
 - Update analytics. [#25257]
 - Updated package dependencies. [#24929]
 - Updating composer.lock. [#25142]
-- VideoPress block (beta): under the hood improvements such as emit events to window where bridge runs. [#25148]
+- VideoPress Block (beta): under the hood improvements such as emit events to window where bridge runs. [#25148]
 - WordPress.com REST API: remove default for 'dont_change_homepage' in the '/sites/%s/themes/mine' endpoint. [#25141]
 
 ## 11.2-a.5 - 2022-07-19

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
-## 11.2 - 2022-08-02
+## [11.2] - 2022-08-02
 ### Enhancements
 - Native block inserter: only display blocks under a Jetpack heading if the host app is WordPress. [#25155]
 - VideoPress Block (beta): add block transforms for the VideoPress block. [#25154]
@@ -6859,6 +6859,7 @@ Other bugfixes and enhancements at https://github.com/Automattic/jetpack/commits
 
 - Initial release
 
+[11.2]: https://wp.me/p1moTy-JYL
 [11.1]: https://wp.me/p1moTy-Juo
 [11.0]: https://wp.me/p1moTy-IbF
 [10.9]: https://wp.me/p1moTy-EHd

--- a/projects/plugins/jetpack/changelog/fix-sharing-buttons-in-editor
+++ b/projects/plugins/jetpack/changelog/fix-sharing-buttons-in-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Sharing buttons are now hidden in Blog Posts block in editor

--- a/projects/plugins/jetpack/changelog/update-jp-11.2-changelog-editorial
+++ b/projects/plugins/jetpack/changelog/update-jp-11.2-changelog-editorial
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack 11.2 changelog editorial

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack - WP Security, Backup, Speed, & Growth ===
 Contributors: automattic, adamkheckler, adrianmoldovanwp, aduth, akirk, allendav, alternatekev, andy, annamcphee, annezazu, apeatling, arcangelini, azaozz, batmoo, barry, beaulebens, biskobe, blobaugh, bjorsch, brbrr, cainm, cena, cfinke, chaselivingston, chellycat, clickysteve, csonnek, danielbachhuber, davoraltman, daniloercoli, delawski, designsimply, dllh, drawmyface, dsmart, dzver, ebinnion, egregor, eliorivero, enej, eoigal, erania-pinnera, ethitter, fgiannar, gcorne, georgestephanis, gibrown, goldsounds, hew, hugobaeta, hypertextranch, iammattthomas, iandunn, jblz, jasmussen, jeffgolenski, jeherve, jenhooks, jenia, jessefriedman, jgs, jkudish, jmdodd, joanrho, johnjamesjacoby, jshreve, kbrownkd, keoshi, koke, kraftbj, lancewillett, leogermani, lschuyler, macmanx, martinremy, matt, matveb, mattwiebe, maverick3x6, mcsf, mdawaffe, mdbitz, MichaelArestad, migueluy, mikeyarce, mkaz, nancythanki, nickmomrik, obenland, oskosk, pento, professor44, rachelsquirrel, rdcoll, ryancowles, richardmuscat, richardmtl, robertbpugh, roccotripaldi, samhotchkiss, samiff, scarstocea, scottsweb, sdixon194, sdquirk, sermitr, simison, stephdau, tmoorewp, tyxla, Viper007Bond, westi, yoavf, zinigor
 Tags: Security, backup, Woo, malware, scan, spam, CDN, search, social
-Stable tag: 11.1.2
+Stable tag: 11.2
 Requires at least: 5.9
 Requires PHP: 5.6
 Tested up to: 6.0

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -242,20 +242,42 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 4. Promote your newest posts, pages, and products across your social media channels.
 
 == Changelog ==
-### 11.2-beta - 2022-07-26
+### 11.2 - 2022-08-02
 #### Enhancements
+- Blocks: enable Jetpack block collection for the native editor block inserter (on self hosted Jetpack sites).
+- Connection: make sure pre-existing settings are respected on plugin activation.
+- Form Block: add a lock to the contact form submit button.
 - Native block inserter: only display blocks under a Jetpack heading if the host app is WordPress.
-- VideoPress Block (beta): add block transforms for the VideoPress block.
+- Podcast Player: add new actions to make it possible for users to set up code that runs for podcast fetches.
+- VideoPress Block (beta): mutiple UI enhancements including error messaging, markup, layout and behavior. Currently a JETPACK_BETA_BLOCKS feature.
+
+
+#### Improved compatibility
+- Admin UI: add h1 page headings for better screen reader navigation.
+- Custom Post Types: change Nova functions to public to re-allow hooking.
 
 #### Bug fixes
 - Admin menu: display the translations for the plan name.
 - Comments: avoid PHP Notice when using Jetpack's Comment form feature when your site is no longer properly connected to WordPress.com.
 - Connection: fix Jetpack redirect after registration.
+- Form Block: prevent error notice when processing submission from 404 page.
+- Form block: fix Checkbox Group option color.
+- Form block: preserve line breaks in form submissions.
+- Gathering Twitter Threads: ensure that only contributors can access the endpoint to unroll threads.
 - Masterbar: ensure that the WordPress.com Add Ons menu item doesn't display on Jetpack-connected sites.
+- Masterbar: fix All Posts dashboard redirect issue when switching between classic and default editor views.
+- Product Descriptions: fix search price on Search Product Description by accounting for sale coupons and ensuring the correct JP Search tier is shown.
+- Related Posts: avoid PHP warnings when visiting AMP post views.
 - Sharing: ensure that sharing buttons are not displayed for excerpts.
-- Slideshow Block: add a bit of CSS to support align wide and align full.
+- Sharing: hide button information in Blog Posts block in editor.
+- Slideshow Block: override container display to prevent a gap between slideshow and contents.
+- Slideshow Block: support wide and full alignment options.
+- Stats: allow custom user role stats settings to be properly recognized and saved.
+- Stats: fix dashboard widget form name to allow form choices to be saved.
 - Subscribe block: fix support for allowed HTML tags in submit button.
+- Subscriptions: format the number of subscribers displayed in the block editor's controls.
 - VideoPress: avoid PHP notices when inserting videos that miss some metadata.
+- VideoPress: fix bug when getting the video preview of the VideoPress block.
 
 --------
 

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -247,7 +247,7 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 - Blocks: enable Jetpack block collection for the native editor block inserter (on self hosted Jetpack sites).
 - Connection: make sure pre-existing settings are respected on plugin activation.
 - Form Block: add a lock to the contact form submit button.
-- Native block inserter: only display blocks under a Jetpack heading if the host app is WordPress.
+- Native Block Inserter: only display blocks under a Jetpack heading if the host app is WordPress.
 - Podcast Player: add new actions to make it possible for users to set up code that runs for podcast fetches.
 - VideoPress Block (beta): mutiple UI enhancements including error messaging, markup, layout and behavior. Currently a JETPACK_BETA_BLOCKS feature.
 
@@ -261,8 +261,8 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 - Comments: avoid PHP Notice when using Jetpack's Comment form feature when your site is no longer properly connected to WordPress.com.
 - Connection: fix Jetpack redirect after registration.
 - Form Block: prevent error notice when processing submission from 404 page.
-- Form block: fix Checkbox Group option color.
-- Form block: preserve line breaks in form submissions.
+- Form Block: fix Checkbox Group option color.
+- Form Block: preserve line breaks in form submissions.
 - Gathering Twitter Threads: ensure that only contributors can access the endpoint to unroll threads.
 - Masterbar: ensure that the WordPress.com Add Ons menu item doesn't display on Jetpack-connected sites.
 - Masterbar: fix All Posts dashboard redirect issue when switching between classic and default editor views.
@@ -274,7 +274,7 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 - Slideshow Block: support wide and full alignment options.
 - Stats: allow custom user role stats settings to be properly recognized and saved.
 - Stats: fix dashboard widget form name to allow form choices to be saved.
-- Subscribe block: fix support for allowed HTML tags in submit button.
+- Subscribe Block: fix support for allowed HTML tags in submit button.
 - Subscriptions: format the number of subscribers displayed in the block editor's controls.
 - VideoPress: avoid PHP notices when inserting videos that miss some metadata.
 - VideoPress: fix bug when getting the video preview of the VideoPress block.


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* This PR includes the changelog and readme updates that were added to the Jetpack 11.2 release, so that they can be ported back to trunk (plus the readme.txt version update).

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

n/a

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Shouldn't need anything changed as it would differ from the production version, however if there is anything glaring it's likely worth fixing that up. Plus confirm the readme.txt stable tag is 11.2.

