### PR TITLE
Janitorial: Releasing new version of github-actions/push-to-mirrors

### DIFF
--- a/projects/github-actions/push-to-mirrors/CHANGELOG.md
+++ b/projects/github-actions/push-to-mirrors/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 2022-08-03
+### Added
+- Log the fetched base revision when preparing the push.
+
+### Changed
+- Renaming `master` references to `main`
+- Updated package dependencies.
+- Update version of `actions/checkout` in doc example.
+
 ## [1.0.3] - 2022-02-09
 ### Changed
 - Core: update description and metadata before to publish to marketplace.
@@ -30,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
+[1.0.4]: https://github.com/Automattic/action-push-to-mirrors/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/Automattic/action-push-to-mirrors/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/Automattic/action-push-to-mirrors/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/Automattic/action-push-to-mirrors/compare/v1.0.0...v1.0.1

--- a/projects/github-actions/push-to-mirrors/changelog/add-push-to-mirrors-logging
+++ b/projects/github-actions/push-to-mirrors/changelog/add-push-to-mirrors-logging
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Log the fetched base revision when preparing the push.

--- a/projects/github-actions/push-to-mirrors/changelog/renovate-major-symfony
+++ b/projects/github-actions/push-to-mirrors/changelog/renovate-major-symfony
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/github-actions/push-to-mirrors/changelog/update-actions-to-node16
+++ b/projects/github-actions/push-to-mirrors/changelog/update-actions-to-node16
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update version of `actions/checkout` in doc example.

--- a/projects/github-actions/push-to-mirrors/changelog/update-changelogger-add-pr-num
+++ b/projects/github-actions/push-to-mirrors/changelog/update-changelogger-add-pr-num
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/github-actions/push-to-mirrors/changelog/update-monorepo-master-refs-secondary
+++ b/projects/github-actions/push-to-mirrors/changelog/update-monorepo-master-refs-secondary
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Renaming `master` references to `main`


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Releasing a new version of `github-actions/push-to-mirrors`:
`* github-actions/push-to-mirrors has change entries from 146 days ago (e.g. add-push-to-mirrors-logging)
`

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

n/a

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Double check new version in the push-to-mirrors changelog.

