### PR TITLE
Admin Menu: Avoid PHP Warnings when parsing badges and count bubbles

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -440,14 +440,14 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		if ( false !== strpos( $title, 'inline-text' ) ) {
 			preg_match( '/<span class="inline-text".+\s?>(.+)<\/span>/', $title, $matches );
 
-			$text = $matches[1];
-			if ( $text ) {
+			if ( ! empty( $matches[1] ) ) {
 				// Keep the text in the item array.
-				$item['inlineText'] = $text;
+				$item['inlineText'] = $matches[1];
 			}
 
 			// Finally remove the markup.
-			$title = trim( str_replace( $matches[0], '', $title ) );
+			$badge = isset( $matches[0] ) ? $matches[0] : '';
+			$title = trim( str_replace( $badge, '', $title ) );
 		}
 
 		if ( false !== strpos( $title, 'awaiting-mod' ) && preg_match( '/<span class="awaiting-mod">(.+)<\/span>/', $title, $matches ) ) {
@@ -457,7 +457,8 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			}
 
 			// Finally remove the markup.
-			$title = trim( str_replace( $matches[0], '', $title ) );
+			$badge = isset( $matches[0] ) ? $matches[0] : '';
+			$title = trim( str_replace( $badge, '', $title ) );
 		}
 
 		// It's important we sanitize the title after parsing data to remove any unexpected markup but keep the content.

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -427,13 +427,10 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	private function parse_menu_item( $title ) {
 		$item = array();
 
-		if ( false !== strpos( $title, 'count-' ) ) {
-			preg_match( '/<span class=".+\s?count-(\d*).+\s?<\/span><\/span>/', $title, $matches );
-
-			$count = absint( $matches[1] );
-			if ( $count > 0 ) {
+		if ( false !== strpos( $title, 'count-' ) && preg_match( '/<span class=".+\s?count-(\d*).+\s?<\/span><\/span>/', $title, $matches ) ) {
+			if ( ! empty( $matches[1] ) && absint( $matches[1] ) > 0 ) {
 				// Keep the counter in the item array.
-				$item['count'] = $count;
+				$item['count'] = absint( $matches[1] );
 			}
 
 			// Finally remove the markup.
@@ -453,13 +450,10 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			$title = trim( str_replace( $matches[0], '', $title ) );
 		}
 
-		if ( false !== strpos( $title, 'awaiting-mod' ) ) {
-			preg_match( '/<span class="awaiting-mod">(.+)<\/span>/', $title, $matches );
-
-			$text = $matches[1];
-			if ( $text ) {
+		if ( false !== strpos( $title, 'awaiting-mod' ) && preg_match( '/<span class="awaiting-mod">(.+)<\/span>/', $title, $matches ) ) {
+			if ( ! empty( $matches[1] ) ) {
 				// Keep the text in the item array.
-				$item['badge'] = $text;
+				$item['badge'] = $matches[1];
 			}
 
 			// Finally remove the markup.

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -434,7 +434,8 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			}
 
 			// Finally remove the markup.
-			$title = trim( str_replace( $matches[0], '', $title ) );
+			$badge = isset( $matches[0] ) ? $matches[0] : '';
+			$title = trim( str_replace( $badge, '', $title ) );
 		}
 
 		if ( false !== strpos( $title, 'inline-text' ) ) {

--- a/projects/plugins/jetpack/changelog/fix-php-warning
+++ b/projects/plugins/jetpack/changelog/fix-php-warning
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Avoid PHP Warnings when parsing badges and count bubbles in admin menu.


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Only enters badge and count handling when they're found.
* Checks whether array indices have content before using it.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to WordPress.com and select a WoA site.
* Make sure it has a pending update or a pending comment.
* Install [the Jetpack Beta Plugin](https://github.com/Automattic/jetpack-beta/releases/download/3.1.2/jetpack-beta.zip) on it.
* In the Toolbar click on "Debug" and then under "Site Graphs" on open.
* Scroll down to the PHP error logs and look for PHP warnings like `PHP Warning: Undefined array key 0 in /wp-content/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php on line 448`
* In wp-admin go to Jetpack > Beta and switch to the `fix/php-warning` branch.
* In a new tab, go to wordpress.com and select the WoA site.
* Go back to Graphana and verify it didn't trigger new PHP warnings.

