### PR TITLE
Update gallery click behaviour for when image has rounded corners

### DIFF
--- a/projects/plugins/jetpack/changelog/update-gallery-click-behaviour
+++ b/projects/plugins/jetpack/changelog/update-gallery-click-behaviour
@@ -1,4 +1,4 @@
 Significance: minor
-Type: bugifx
+Type: bugfix
 
 Gallery: ensure clicks will navigate to custom URL when image has rounded corners. 

--- a/projects/plugins/jetpack/changelog/update-gallery-click-behaviour
+++ b/projects/plugins/jetpack/changelog/update-gallery-click-behaviour
@@ -1,4 +1,4 @@
 Significance: minor
-Type: enhancement
+Type: bugifx
 
-Gallery: change click behaviour when image is rounded.
+Gallery: ensure clicks will navigate to custom URL when image has rounded corners. 

--- a/projects/plugins/jetpack/changelog/update-gallery-click-behaviour
+++ b/projects/plugins/jetpack/changelog/update-gallery-click-behaviour
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Gallery: change click behaviour when image is rounded.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1608,17 +1608,21 @@
 				// If Gallery is made up of individual Image blocks check for custom link before
 				// loading carousel. The custom link may be the parent or could be a descendant
 				// of the parent if the image has rounded corners.
+				var parentHref = null;
+				if ( grandparent && grandparent.classList.contains( 'wp-block-image' ) {
+					parentHref = parent.getAttribute( 'href' );
+				} else if ( parent && parent.classList.contains( 'wp-block-image' ) && parent.querySelector( 'a' ) ) {
+					parentHref = parent.querySelector( 'a' ).getAttribute( 'href' );
+				}
+				
 				if (
-					( grandparent && grandparent.classList.contains( 'wp-block-image' ) ) ||
-					( parent && parent.classList.contains( 'wp-block-image' ) && parent.querySelector( 'a' ) )
+					parentHref &&
+					parentHref.split( '?' )[ 0 ] !==
+						target.getAttribute( 'data-orig-file' ).split( '?' )[ 0 ] &&
+					parentHref !== target.getAttribute( 'data-permalink' )
 				) {
-					var parentHref = parent.getAttribute( 'href' );
-
-					if ( ! parentHref ) {
-						// The link must be a descendant instead.
-						parentHref = parent.querySelector( 'a' ).getAttribute( 'href' );
-					}
-
+					return;
+				}
 					// If the link does not point to the attachment or media file then assume Image has
 					// a custom link so don't load the carousel.
 					if (

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1606,9 +1606,18 @@
 				var grandparent = parent.parentElement;
 
 				// If Gallery is made up of individual Image blocks check for custom link before
-				// loading carousel.
-				if ( grandparent && grandparent.classList.contains( 'wp-block-image' ) ) {
+				// loading carousel. The custom link may be the parent or could be a descendant
+				// of the parent if the image has rounded corners.
+				if (
+					( grandparent && grandparent.classList.contains( 'wp-block-image' ) ) ||
+					( parent && parent.classList.contains( 'wp-block-image' ) && parent.querySelector( 'a' ) )
+				) {
 					var parentHref = parent.getAttribute( 'href' );
+
+					if ( ! parentHref ) {
+						// The link must be a descendant instead.
+						parentHref = parent.querySelector( 'a' ).getAttribute( 'href' );
+					}
 
 					// If the link does not point to the attachment or media file then assume Image has
 					// a custom link so don't load the carousel.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #https://github.com/Automattic/wp-calypso/issues/65350

#### Changes proposed in this Pull Request:
When clicking into part of an image that has been removed due to the rounded style, the click handling logic will now navigate to the image's custom URL, if there is one, instead of opening the carousel view. If no custom URL exists, the default behaviour of opening the carousel remains. 

![image](https://user-images.githubusercontent.com/6851384/183002006-bedf337f-780f-4ef8-ba4f-aa0418eb713c.png)


#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Test this on a site with Jetpack Beta instead.

1. Navigate to `/wp-admin/admin.php?page=jetpack-beta&plugin=jetpack`
2. Enable this branch:
![image](https://user-images.githubusercontent.com/6851384/183002280-249681d2-75a5-4b16-a3a8-8f5422636128.png)
3. Then follow the [Steps to reproduce in the original issue. ](https://github.com/Automattic/wp-calypso/issues/65350) and verify that the click behaviour has changed and that you are navigated to the custom URL you set. 
