### PR TITLE
Payment button: Use block API v2

### DIFF
--- a/projects/plugins/jetpack/changelog/migrate-recurring-payments-block-api-v2
+++ b/projects/plugins/jetpack/changelog/migrate-recurring-payments-block-api-v2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+The Payment button block uses now the Block API v2 to simplify the overall markup

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/edit.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/edit.jsx
@@ -1,5 +1,5 @@
 import { getJetpackExtensionAvailability } from '@automattic/jetpack-shared-extension-utils';
-import { InnerBlocks } from '@wordpress/block-editor';
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 import { Button, ExternalLink, Placeholder } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
@@ -63,8 +63,29 @@ export default function Edit( { attributes, clientId, context, setAttributes } )
 	const showJetpackUpgradeNudge =
 		!! upgradeUrl && ! hasWpcomUpgradeNudge && ! isPremiumContentChild;
 
+	const blockProps = useBlockProps();
+	const innerBlocksProps = useInnerBlocksProps(
+		{},
+		{
+			template: [
+				[
+					'jetpack/button',
+					{
+						element: 'a',
+						passthroughAttributes: {
+							uniqueId: 'uniqueId',
+							url: 'url',
+						},
+					},
+				],
+			],
+			templateLock: 'all',
+			templateInsertUpdatesSelection: true,
+		}
+	);
+
 	return (
-		<div className="wp-block-jetpack-recurring-payments">
+		<div { ...blockProps }>
 			{ showControls && (
 				<ProductManagementControls
 					blockName={ BLOCK_NAME }
@@ -73,7 +94,6 @@ export default function Edit( { attributes, clientId, context, setAttributes } )
 					setSelectedProductId={ updateSubscriptionPlan }
 				/>
 			) }
-
 			{ showJetpackUpgradeNudge && (
 				<Placeholder
 					icon={ icon }
@@ -94,23 +114,7 @@ export default function Edit( { attributes, clientId, context, setAttributes } )
 				</Placeholder>
 			) }
 			<StripeNudge blockName={ BLOCK_NAME } />
-			<InnerBlocks
-				template={ [
-					[
-						'jetpack/button',
-						{
-							element: 'a',
-							passthroughAttributes: {
-								uniqueId: 'uniqueId',
-								url: 'url',
-							},
-						},
-					],
-				] }
-				templateLock="all"
-				__experimentalCaptureToolbars={ true }
-				templateInsertUpdatesSelection={ false }
-			/>
+			<div { ...innerBlocksProps } />
 		</div>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/editor.scss
@@ -115,4 +115,9 @@
 	.wp-block-jetpack-membership-button_notification {
 		display: block;
 	}
+
+	.wp-block[data-type='jetpack/button'] {
+		margin-top: 0;
+		margin-bottom: 0;
+	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/index.js
@@ -1,5 +1,4 @@
 import { isAtomicSite, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
-import { InnerBlocks } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { Path, Rect, SVG, G, ExternalLink } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
@@ -8,6 +7,7 @@ import { getIconColor } from '../../shared/block-icons';
 import { isPriceValid } from '../../shared/currencies';
 import deprecatedV1 from './deprecated/v1';
 import edit from './edit';
+import save from './save';
 import './editor.scss';
 
 export const name = 'recurring-payments';
@@ -27,6 +27,7 @@ const supportLink =
 		: 'https://jetpack.com/support/jetpack-blocks/payments-block/';
 
 export const settings = {
+	apiVersion: 2,
 	title,
 	icon: {
 		src: icon,
@@ -89,11 +90,7 @@ export const settings = {
 		},
 	},
 	edit,
-	save: ( { className } ) => (
-		<div className={ className }>
-			<InnerBlocks.Content />
-		</div>
-	),
+	save,
 	supports: {
 		html: false,
 		__experimentalExposeControlsToChildren: true,

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/save.js
@@ -1,0 +1,6 @@
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+
+export default function save() {
+	const innerBlocksProps = useInnerBlocksProps.save( useBlockProps.save() );
+	return <div { ...innerBlocksProps } />;
+}

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/test/edit.js
@@ -6,7 +6,7 @@ import Edit from '../edit';
 
 jest.mock( '@wordpress/block-editor', () => ( {
 	...jest.requireActual( '@wordpress/block-editor' ),
-	InnerBlocks: () => <button>Mocked button</button>,
+	useBlockProps: jest.fn(),
 } ) );
 
 // Mock the @wordpress/edit-post, used internally to resolve the fallback URL.


### PR DESCRIPTION
Required by https://github.com/Automattic/jetpack/pull/25297

#### Changes proposed in this Pull Request:

This PR migrates the Payment button block (`jetpack/recurring-payments`) to the [Block API v2](https://github.com/WordPress/gutenberg/blob/958a1c2fffceb174720fb2f3887cd246172973ca/docs/reference-guides/block-api/block-api-versions.md#version-2--wordpress-56) in order to simplify the overall markup in the editor which will help us to implement a Payment buttons block container.

Before
```html
<div class="wp-block" data-type="jetpack/recurring-payments">
  <div class="wp-block-jetpack-recurring-payments">
    <div class="block-editor-inner-blocks">
      <div class="block-editor-block-list__layout">
        <div class="wp-block" data-type="jetpack/button" />
      </div>
    </div>
  </div>
</div>
```

After
```html
<div class="wp-block wp-block-jetpack-recurring-payments" data-type="jetpack/recurring-payments">
  <div class="block-editor-block-list__layout">
    <div class="wp-block" data-type="jetpack/button"/>
  </div>
</div>
```

This was initially implemented in https://github.com/Automattic/jetpack/pull/25297, but I decided to open a separate PR to facilitate the review.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
No.

#### Does this pull request change what data or activity we track or use?
N/A.

#### Testing instructions:

Since this PR doesn't introduce any behavior or aesthetic change, you mainly need to double check that there are no regressions for the Payment button block.

- [Spin up a Jurassic Ninja site running this branch](https://jurassic.ninja/create/?jetpack-beta&branches.jetpack=migrate/recurring-payments-block-api-v2).
- Set up Jetpack and start with a Free plan.
- Go to `/wp-admin/post-new.php`.
- Insert a Payment Button block.
- Make sure you're asked to upgrade.
- Upgrade your plan.
- Make sure you're asked to connect to Stripe.
- Connect to Stripe (check PCYsg-lW4-p2#sandbox-method if you want to avoid entering real data).
- Publish the post.
- Make sure the different payment button are visible as expected.
- Go to Jetpack > Jetpack Beta and switch to Bleeding edge.
- Create a new post and insert some Payment button blocks.
- Go to Jetpack > Jetpack Beta and switch back to this branch.
- Edit the post you created before.
- Make sure the Payment button blocks still work.

