### PR TITLE
Updating initializer handling module

### DIFF
--- a/projects/packages/config/changelog/update-videopress-initializer
+++ b/projects/packages/config/changelog/update-videopress-initializer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Initialize VideoPress package from the Config pkg

--- a/projects/packages/config/src/class-config.php
+++ b/projects/packages/config/src/class-config.php
@@ -20,6 +20,7 @@ use Automattic\Jetpack\Post_List\Post_List as Post_List;
 use Automattic\Jetpack\Publicize\Publicize_Setup as Publicize_Setup;
 use Automattic\Jetpack\Search\Initializer as Jetpack_Search_Main;
 use Automattic\Jetpack\Sync\Main as Sync_Main;
+use Automattic\Jetpack\VideoPress\Initializer as VideoPress_Pkg_Initializer;
 use Automattic\Jetpack\Waf\Waf_Initializer as Jetpack_Waf_Main;
 use Automattic\Jetpack\WordAds\Initializer as Jetpack_WordAds_Main;
 
@@ -47,6 +48,7 @@ class Config {
 		'publicize'       => false,
 		'wordads'         => false,
 		'waf'             => false,
+		'videopress'      => false,
 	);
 
 	/**
@@ -132,6 +134,10 @@ class Config {
 		if ( $this->config['waf'] ) {
 			$this->ensure_class( 'Automattic\Jetpack\Waf\Waf_Initializer' )
 				&& $this->ensure_feature( 'waf' );
+		}
+
+		if ( $this->config['videopress'] ) {
+			$this->ensure_class( 'Automattic\Jetpack\VideoPress\Initializer' ) && $this->ensure_feature( 'videopress' );
 		}
 	}
 
@@ -274,6 +280,15 @@ class Config {
 	 */
 	protected function enable_waf() {
 		Jetpack_Waf_Main::init();
+
+		return true;
+	}
+
+	/**
+	 * Enables VideoPress.
+	 */
+	protected function enable_videopress() {
+		VideoPress_Pkg_Initializer::init();
 
 		return true;
 	}

--- a/projects/packages/videopress/changelog/update-videopress-initializer
+++ b/projects/packages/videopress/changelog/update-videopress-initializer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.1.3",
+	"version": "0.1.4-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -19,8 +19,12 @@ class Initializer {
 	 */
 	public static function init() {
 		if ( ! did_action( 'videopress_init' ) ) {
-			self::register_oembed_providers();
-			new WPCOM_REST_API_V2_Endpoint_VideoPress();
+
+			self::unconditional_initialization();
+
+			if ( Status::is_active() ) {
+				self::active_initialization();
+			}
 		}
 
 		/**
@@ -29,6 +33,25 @@ class Initializer {
 		 * @since 0.1.1
 		 */
 		do_action( 'videopress_init' );
+	}
+
+	/**
+	 * Initialize VideoPress features that should be initialized whenever VideoPress is present, even if the module is not active
+	 *
+	 * @return void
+	 */
+	private static function unconditional_initialization() {
+		Module_Control::init();
+		new WPCOM_REST_API_V2_Endpoint_VideoPress();
+	}
+
+	/**
+	 * Initialize VideoPress features that should be initialized only when the module is active
+	 *
+	 * @return void
+	 */
+	private static function active_initialization() {
+		self::register_oembed_providers();
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-module-control.php
+++ b/projects/packages/videopress/src/class-module-control.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Jetpack VideoPress: Module_Control class
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+/**
+ * To handle VideoPress module statuses
+ */
+class Module_Control {
+
+	/**
+	 * Initializer
+	 *
+	 * This method should onlybe called once by the Initializer class. Do not call this method again.
+	 */
+	public static function init() {
+		add_filter( 'jetpack_get_available_standalone_modules', array( __CLASS__, 'add_videopress_to_array' ), 10, 1 );
+		if ( Status::is_standalone_plugin_active() ) {
+			// If the stand-alone plugin is active, videopress module will always be considered active.
+			add_filter( 'jetpack_active_modules', array( __CLASS__, 'add_videopress_to_array' ), 10, 2 );
+		}
+	}
+
+	/**
+	 * Adds videopress to the list of available/active modules
+	 *
+	 * @param array $modules Array with modules slugs.
+	 * @return array
+	 */
+	public static function add_videopress_to_array( $modules ) {
+		return array_merge( array( 'videopress' ), $modules );
+	}
+}

--- a/projects/packages/videopress/src/class-status.php
+++ b/projects/packages/videopress/src/class-status.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * The class that provides information about VideoPress Status
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+use Jetpack;
+
+/**
+ * The class that provides information about VideoPress Status
+ */
+class Status {
+
+	/**
+	 * Returns whether VideoPress is active either as a Jetpack module or as a stand alone plugin
+	 *
+	 * @return boolean
+	 */
+	public static function is_active() {
+		return self::is_jetpack_active() || self::is_standalone_plugin_active();
+	}
+
+	/**
+	 * Returns whether the Jetpack plugin and its VideoPress module are active
+	 *
+	 * @return boolean
+	 */
+	public static function is_jetpack_active() {
+		return class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'videopress' );
+	}
+
+	/**
+	 * Checks whether the VideoPress stand alone plugin is active
+	 *
+	 * @return boolean
+	 */
+	public static function is_standalone_plugin_active() {
+		$possible_folders = array(
+			'videopress', // monorepo.
+			'jetpack-videopress', // production.
+			'jetpack-videopress-dev', // Jetpack Beta.
+		);
+		foreach ( $possible_folders as $folder ) {
+			if ( is_plugin_active( $folder . '/jetpack-videopress.php' ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/projects/packages/videopress/src/class-status.php
+++ b/projects/packages/videopress/src/class-status.php
@@ -38,16 +38,6 @@ class Status {
 	 * @return boolean
 	 */
 	public static function is_standalone_plugin_active() {
-		$possible_folders = array(
-			'videopress', // monorepo.
-			'jetpack-videopress', // production.
-			'jetpack-videopress-dev', // Jetpack Beta.
-		);
-		foreach ( $possible_folders as $folder ) {
-			if ( is_plugin_active( $folder . '/jetpack-videopress.php' ) ) {
-				return true;
-			}
-		}
-		return false;
+		return class_exists( 'Jetpack_Videopress_Plugin' );
 	}
 }

--- a/projects/plugins/jetpack/changelog/update-videopress-initializer
+++ b/projects/plugins/jetpack/changelog/update-videopress-initializer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -38,7 +38,6 @@ use Automattic\Jetpack\Sync\Health;
 use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
-use Automattic\Jetpack\VideoPress\Initializer as VideoPress_Initializer;
 
 /*
 Options:
@@ -830,6 +829,7 @@ class Jetpack {
 				'jitm',
 				'sync',
 				'waf',
+				'videopress',
 			)
 			as $feature
 		) {
@@ -924,7 +924,6 @@ class Jetpack {
 
 		Partner::init();
 		My_Jetpack_Initializer::init();
-		VideoPress_Initializer::init();
 
 		/**
 		 * Fires when Jetpack is fully loaded and ready. This is the point where it's safe

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -38,6 +38,7 @@ use Automattic\Jetpack\Sync\Health;
 use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
+use Automattic\Jetpack\VideoPress\Initializer as VideoPress_Initializer;
 
 /*
 Options:
@@ -923,6 +924,7 @@ class Jetpack {
 
 		Partner::init();
 		My_Jetpack_Initializer::init();
+		VideoPress_Initializer::init();
 
 		/**
 		 * Fires when Jetpack is fully loaded and ready. This is the point where it's safe

--- a/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
+++ b/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
@@ -2,7 +2,6 @@
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Client;
-use Automattic\Jetpack\VideoPress\Initializer as VideoPress_Initializer;
 use Automattic\Jetpack\VideoPress\Options as VideoPress_Options;
 use Automattic\Jetpack\VideoPress\XMLRPC;
 
@@ -45,7 +44,6 @@ class Jetpack_VideoPress {
 	private function __construct() {
 		add_action( 'init', array( $this, 'on_init' ) );
 		add_action( 'jetpack_deactivate_module_videopress', array( $this, 'jetpack_module_deactivated' ) );
-		VideoPress_Initializer::init();
 	}
 
 	/**

--- a/projects/plugins/videopress/changelog/update-videopress-initializer
+++ b/projects/plugins/videopress/changelog/update-videopress-initializer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Initialize VideoPress package from the Config pkg

--- a/projects/plugins/videopress/composer.json
+++ b/projects/plugins/videopress/composer.json
@@ -11,7 +11,8 @@
 		"automattic/jetpack-config": "1.9.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
 		"automattic/jetpack-my-jetpack": "1.9.x-dev",
-		"automattic/jetpack-sync": "1.37.x-dev"
+		"automattic/jetpack-sync": "1.37.x-dev",
+		"automattic/jetpack-videopress": "0.1.x-dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.0.3",

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f3304a1b834aabc1dfe79bb7ae40c1f7",
+    "content-hash": "06b0d5cb62c5e575dd616679033415b4",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -748,6 +748,67 @@
             }
         },
         {
+            "name": "automattic/jetpack-plans",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/plans",
+                "reference": "5d6f96f0b36b8b9dce26cdc423e07f84420d4639"
+            },
+            "require": {
+                "automattic/jetpack-connection": "^1.42"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "^3.2",
+                "automattic/jetpack-status": "^1.14",
+                "automattic/wordbless": "@dev",
+                "yoast/phpunit-polyfills": "1.0.3"
+            },
+            "type": "library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-plans",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-plans/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "post-update-cmd": [
+                    "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\""
+                ],
+                "build-production": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ],
+                "build-development": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Fetch information about Jetpack Plans from wpcom",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-plugins-installer",
             "version": "dev-trunk",
             "dist": {
@@ -1007,6 +1068,64 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Everything needed to allow syncing to the WP.com infrastructure.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-videopress",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/videopress",
+                "reference": "eae6b38717b44f6259ae3be3026aa3cd920af678"
+            },
+            "require": {
+                "automattic/jetpack-connection": "^1.42",
+                "automattic/jetpack-plans": "^0.1"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "^3.2",
+                "yoast/phpunit-polyfills": "1.0.3"
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-videopress",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "textdomain": "jetpack-videopress-pkg"
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "build-production": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ],
+                "build-development": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "VideoPress package",
             "transport-options": {
                 "relative": true
             }
@@ -3219,16 +3338,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.0.10",
+            "version": "v6.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "d8d41b93c16f1da2f2d4b9209b7de78c4d203642"
+                "reference": "09b8e50f09bf0e5bbde9b61b19d7f53751114725"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/d8d41b93c16f1da2f2d4b9209b7de78c4d203642",
-                "reference": "d8d41b93c16f1da2f2d4b9209b7de78c4d203642",
+                "url": "https://api.github.com/repos/symfony/console/zipball/09b8e50f09bf0e5bbde9b61b19d7f53751114725",
+                "reference": "09b8e50f09bf0e5bbde9b61b19d7f53751114725",
                 "shasum": ""
             },
             "require": {
@@ -3294,7 +3413,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.0.10"
+                "source": "https://github.com/symfony/console/tree/v6.0.11"
             },
             "funding": [
                 {
@@ -3310,7 +3429,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-26T13:01:22+00:00"
+            "time": "2022-07-22T14:17:38+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -3644,16 +3763,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v6.0.8",
+            "version": "v6.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "d074154ea8b1443a96391f6e39f9e547b2dd01b9"
+                "reference": "44270a08ccb664143dede554ff1c00aaa2247a43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/d074154ea8b1443a96391f6e39f9e547b2dd01b9",
-                "reference": "d074154ea8b1443a96391f6e39f9e547b2dd01b9",
+                "url": "https://api.github.com/repos/symfony/process/zipball/44270a08ccb664143dede554ff1c00aaa2247a43",
+                "reference": "44270a08ccb664143dede554ff1c00aaa2247a43",
                 "shasum": ""
             },
             "require": {
@@ -3685,7 +3804,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.0.8"
+                "source": "https://github.com/symfony/process/tree/v6.0.11"
             },
             "funding": [
                 {
@@ -3701,7 +3820,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-12T16:11:42+00:00"
+            "time": "2022-06-27T17:10:44+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -3787,16 +3906,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.0.10",
+            "version": "v6.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "1b3adf02a0fc814bd9118d7fd68a097a599ebc27"
+                "reference": "042b6bf0f6ccca6d456a0572eb788cfb8b1ff809"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/1b3adf02a0fc814bd9118d7fd68a097a599ebc27",
-                "reference": "1b3adf02a0fc814bd9118d7fd68a097a599ebc27",
+                "url": "https://api.github.com/repos/symfony/string/zipball/042b6bf0f6ccca6d456a0572eb788cfb8b1ff809",
+                "reference": "042b6bf0f6ccca6d456a0572eb788cfb8b1ff809",
                 "shasum": ""
             },
             "require": {
@@ -3852,7 +3971,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.0.10"
+                "source": "https://github.com/symfony/string/tree/v6.0.11"
             },
             "funding": [
                 {
@@ -3868,7 +3987,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-26T16:34:50+00:00"
+            "time": "2022-07-27T15:50:26+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -4105,7 +4224,8 @@
         "automattic/jetpack-config": 20,
         "automattic/jetpack-identity-crisis": 20,
         "automattic/jetpack-my-jetpack": 20,
-        "automattic/jetpack-sync": 20
+        "automattic/jetpack-sync": 20,
+        "automattic/jetpack-videopress": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/projects/plugins/videopress/jetpack-videopress.php
+++ b/projects/plugins/videopress/jetpack-videopress.php
@@ -115,4 +115,4 @@ add_filter(
 register_deactivation_hook( __FILE__, array( 'Jetpack_Videopress', 'plugin_deactivation' ) );
 
 // Main plugin class.
-new Jetpack_Videopress();
+new Jetpack_Videopress_Plugin();

--- a/projects/plugins/videopress/jetpack-videopress.php
+++ b/projects/plugins/videopress/jetpack-videopress.php
@@ -112,7 +112,7 @@ add_filter(
 	}
 );
 
-register_deactivation_hook( __FILE__, array( 'Jetpack_Videopress', 'plugin_deactivation' ) );
+register_deactivation_hook( __FILE__, array( 'Jetpack_Videopress_Plugin', 'plugin_deactivation' ) );
 
 // Main plugin class.
 new Jetpack_Videopress_Plugin();

--- a/projects/plugins/videopress/src/class-jetpack-videopress-plugin.php
+++ b/projects/plugins/videopress/src/class-jetpack-videopress-plugin.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Sync\Data_Settings;
 /**
  * Class Jetpack_Videopress
  */
-class Jetpack_Videopress {
+class Jetpack_Videopress_Plugin {
 
 	/**
 	 * Constructor.
@@ -58,6 +58,8 @@ class Jetpack_Videopress {
 
 				// Identity crisis package.
 				$config->ensure( 'identity_crisis' );
+
+				$config->ensure( 'videopress' );
 			},
 			1
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR changes how the VideoPress package is initialized by the Jetpack plugin and starts initializing it from the VideoPress plugin.

It also handles the videopress module state depending on which plugin is installed.

* If Jetpack plugin is active: the module will be enabled or disabled depending on the choice the user makes on the Settings page or in the My Jetpack page to activate or not the module
* If the VideoPress standalone plugin is active: the module will always be considered active

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
NA

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start with a site with Jetpack active and connected

We are going to run some tests in the UI and some tests on the WP Shell CLI (`wp shell`)

* Go to Jetpack > Settings, search for video, and make sure videopress is disabled
* On WP shell: `( new Automattic\Jetpack\Modules() )->is_active('videopress');` should return false
* `Automattic\Jetpack\VideoPress\Status::is_active();` should also return false.
* On the Settings page, activate videopress
* Run the same two commands above and they should return true this time
* On the Settings page, deactivate videopress
* Activate the VideoPress plugin
* Run the same two commands again and they should return true.
* Go to Jetpack Settgins and search for video. Verify that videopress is displayed as active and that the toggle to disable it is not active (you can not disable videopress)

![Captura de tela de 2022-08-04 17-20-27](https://user-images.githubusercontent.com/971483/182945157-79825c74-459f-49a4-a0a2-1016871db6a7.png)

* Deactivate Jetpack plugin
* Go to WP CLI and run the two commands again. They should still return true while videopress plugin is active



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202708227705595