### PR TITLE
Gather support references: add option to send a Slack message

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -77,3 +77,4 @@ jobs:
           slack_design_channel: ${{ secrets.SLACK_DESIGN_CHANNEL }}
           slack_editorial_channel: ${{ secrets.SLACK_EDITORIAL_CHANNEL }}
           slack_he_triage_channel: ${{ secrets.SLACK_HE_TRIAGE_CHANNEL }}
+          slack_quality_channel: ${{ secrets.SLACK_QUALITY_CHANNEL }}

--- a/projects/github-actions/repo-gardening/README.md
+++ b/projects/github-actions/repo-gardening/README.md
@@ -16,7 +16,7 @@ Here is the current list of tasks handled by this action:
 - Notify Editorial (`notifyEditorial`): Sends a Slack Notification to the Editorial team to request feedback, based on labels applied to a PR.
 - Flag OSS (`flagOss`): flags entries by external contributors, adds an "OSS Citizen" label to the PR, and sends a Slack message.
 - Triage New Issues (`triageNewIssues`): Adds labels to new issues based on issue content.
-- Gather support references (`gatherSupportReferences`): Adds a new comment with a list of all support references on the issue.
+- Gather support references (`gatherSupportReferences`): Adds a new comment with a list of all support references on the issue, and escalates that issue via a Slack message if needed.
 - Reply to customers Reminder ( `replyToCustomersReminder` ): sends a Slack message about closed issues to remind Automatticians to update customers.
 
 Some of the tasks are may not satisfy your needs. If that's the case, you can use the `tasks` option to limit the action to the list of tasks you need in your repo. See the example below to find out more.
@@ -78,6 +78,7 @@ The action relies on the following parameters.
 - (Optional) `slack_editorial_channel` is the Slack public channel ID where messages for the Editorial team will be posted. Again, the value should be stored in a secret.
 - (Optional) `slack_team_channel` is the Slack public channel ID where general notifications about your repo should be posted. Again, the value should be stored in a secret.
 - (Optional) `slack_he_triage_channel` is the Slack public channel ID where messages for the HE Triage team will be posted. The value should be stored in a secret.
+- (Optional) `slack_quality_channel` is the Slack public channel ID where issues needing extra triage / escalation will be sent. The value should be stored in a secret.
 - (Optional) `reply_to_customers_threshold`. It is optional, and defaults to 10. It is the minimum number of support references needed to trigger an alert that we need to reply to customers.
 
 #### How to create a Slack bot and get your SLACK_TOKEN

--- a/projects/github-actions/repo-gardening/action.yml
+++ b/projects/github-actions/repo-gardening/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: "Slack channel ID where general notifications should be sent"
     required: false
     default: ""
+  slack_quality_channel:
+    description: "Slack channel ID where issues needing extra triage / escalation will be sent"
+    required: false
+    default: ""
   tasks:
     description: "Comma-separated selection of task names (function name, camelCase) this action should run. e.g. addLabels,cleanLabels"
     required: false

--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-escalate-issues-with-lots-tickets
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-escalate-issues-with-lots-tickets
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Gather support references: add option to send a Slack message when issuees start gathering a lot of tickets, and would need to be escalated.

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -1,5 +1,7 @@
+const { getInput } = require( '@actions/core' );
 const debug = require( '../../utils/debug' );
 const getComments = require( '../../utils/get-comments' );
+const sendSlackMessage = require( '../../utils/send-slack-message' );
 
 /* global GitHub, WebhookPayloadIssue */
 
@@ -85,12 +87,13 @@ async function getIssueReferences( octokit, owner, repo, number, issueComments )
 /**
  * Build a comment body with a to-do list of all support references on that issue.
  *
- * @param {Array} issueReferences - Array of support references.
- * @param {Set}   checkedRefs     - Set of support references already checked.
+ * @param {Array}   issueReferences     - Array of support references.
+ * @param {Set}     checkedRefs         - Set of support references already checked.
+ * @param {boolean} needsEscalationNote - Whether the issue needs an escalation note.
  * @returns {string} Comment body.
  */
-function buildCommentBody( issueReferences, checkedRefs = new Set() ) {
-	const commentBody = `**Support References**
+function buildCommentBody( issueReferences, checkedRefs = new Set(), needsEscalationNote = false ) {
+	let commentBody = `**Support References**
 
 *This comment is automatically generated. Please do not edit it.*
 
@@ -102,7 +105,126 @@ ${ issueReferences
 	.join( '' ) }
 `;
 
+	// If this issue was escalated, make note of it, so next time we edit that comment, we won't escalate it again.
+	if ( needsEscalationNote === true ) {
+		commentBody += `\n*Note: a notification was sent for this issue.*`;
+	}
+
 	return commentBody;
+}
+
+/**
+ * Build an object containing the slack message and its formatting to send to Slack.
+ *
+ * @param {WebhookPayloadIssue} payload - Issue event payload.
+ * @param {string}              channel - Slack channel ID.
+ * @param {string}              message - Basic message (without the formatting).
+ * @returns {Object} Object containing the slack message and its formatting.
+ */
+function formatSlackMessage( payload, channel, message ) {
+	const { issue, repository } = payload;
+	const { html_url, title } = issue;
+
+	let dris = '@bug_herders';
+	switch ( repository.full_name ) {
+		case 'Automattic/jetpack':
+			dris = '@jpop-da';
+			break;
+		case 'Automattic/zero-bs-crm':
+			dris = '@heysatellite';
+			break;
+	}
+
+	return {
+		channel,
+		blocks: [
+			{
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: message,
+				},
+			},
+			{
+				type: 'divider',
+			},
+			{
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: `${ dris } Could you take a look at it, re-prioritize and escalate if you think that's necessary, and mark this message as :done: once you've done so? Thank you!`,
+				},
+			},
+			{
+				type: 'divider',
+			},
+			{
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: `<${ html_url }|${ title }>`,
+				},
+				accessory: {
+					type: 'button',
+					text: {
+						type: 'plain_text',
+						text: 'View',
+						emoji: true,
+					},
+					value: 'click_review',
+					url: `${ html_url }`,
+					action_id: 'button-action',
+				},
+			},
+		],
+		text: `${ message } -- <${ html_url }|${ title }>`, // Fallback text for display in notifications.
+		mrkdwn: true, // Formatting of the fallback text.
+	};
+}
+
+/**
+ * Check if an issue needs to be escalated to the triage team.
+ *
+ * If our issue has gathered more than 10 tickets,
+ * if we have the necessary Slack tokens,
+ * if we didn't send anything to Slack about that issue yet,
+ * let's send a Slack message to warn the triage team,
+ * and make a note so we don't send it again.
+ *
+ * @param {Array}               issueReferences - Array of support references.
+ * @param {string}              commentBody     - Previous comment ID.
+ * @param {WebhookPayloadIssue} payload         - Issue event payload.
+ * @returns {Promise<boolean>} Was the issue escalated?
+ */
+async function checkForEscalation( issueReferences, commentBody, payload ) {
+	// No Slack tokens, we won't be able to escalate. Bail.
+	const slackToken = getInput( 'slack_token' );
+	const channel = getInput( 'slack_quality_channel' );
+	if ( ! slackToken || ! channel ) {
+		return false;
+	}
+
+	// Issue hasn't gathered more than 10 tickets yet, bail.
+	if ( issueReferences.length < 10 ) {
+		return false;
+	}
+
+	// We already sent a Slack message about this issue, bail.
+	if ( commentBody.includes( 'Note: a notification was sent for this issue.' ) ) {
+		debug(
+			`gather-support-references: Issue ${ payload.issue.number } already escalated to triage team. No need to warn them again.`
+		);
+		return false;
+	}
+
+	debug(
+		`gather-support-references: Issue #${ payload.issue.number } has now gathered more than 10 tickets. It's time to escalate it.`
+	);
+	const message = `:warning: This issue has now gathered more than 10 tickets. It may be time to reconsider its priority.`;
+	const slackMessageFormat = formatSlackMessage( payload, channel, message );
+	await sendSlackMessage( message, channel, slackToken, payload, slackMessageFormat );
+
+	return true;
 }
 
 /**
@@ -136,8 +258,17 @@ async function createOrUpdateComment( payload, octokit, issueReferences, issueCo
 			checkedRefs.add( referenceStatus[ 1 ] );
 		}
 
+		// If our list includes more than 10 tickets,
+		// let's send a Slack message to warn the triage team,
+		// add note it so the list comment mentions that this was escalated.
+		const needsEscalationNote = await checkForEscalation(
+			issueReferences,
+			existingComment.body,
+			payload
+		);
+
 		// Build our comment body, with first the checked references, then the unchecked references.
-		const updatedComment = buildCommentBody( issueReferences, checkedRefs );
+		const updatedComment = buildCommentBody( issueReferences, checkedRefs, needsEscalationNote );
 
 		await octokit.rest.issues.updateComment( {
 			owner: ownerLogin,

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -214,7 +214,7 @@ async function checkForEscalation( issueReferences, commentBody, payload ) {
 		debug(
 			`gather-support-references: Issue ${ payload.issue.number } already escalated to triage team. No need to warn them again.`
 		);
-		return false;
+		return true;
 	}
 
 	debug(

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/readme.md
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/readme.md
@@ -4,6 +4,8 @@ Happiness Engineers can comment on issues to add references to support interacti
 
 This task creates a new comment that lists all support references found in all comments on the issue.
 
+The tasks also monitors the number of support references it has gathered. If it gathered at least 10 issues, it will send a Slack message to the triage team to let them know it may be time to escalate the issue.
+
 ## Rationale
 
 Gathering all references into a single, actionable comment makes it easier to follow-up, without having to hunt for ticket references, especially on issues with a large amount of comments.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

When issuees start gathering a lot of tickets (at least 10), let's send a Slack message so the issue can be escalated if needed.

We only want to send that Slack message so after doing it, we add a note to the comment that lists all support references to indicate it was escalated. Later, we search for that note before we try to send a new one.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

Internal reference: pciE2j-1iy-p2

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

It will be hard to test this in this repo before we merge it, but I ran some tests in a fork. You can see the end result here:
p1659697582408109-slack-CN2FSK7L4