### PR TITLE
Jetpack: sync theme compat files with wpcom

### DIFF
--- a/projects/plugins/jetpack/changelog/update-sync-theme-compat-with-wpcom
+++ b/projects/plugins/jetpack/changelog/update-sync-theme-compat-with-wpcom
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Sync theme compat files with wpcom
+
+

--- a/projects/plugins/jetpack/modules/theme-tools/compat/twentyfifteen.css
+++ b/projects/plugins/jetpack/modules/theme-tools/compat/twentyfifteen.css
@@ -259,6 +259,20 @@ iframe[id*="twitter-widget-"] {
 	margin-bottom: 1.6em;
 }
 
+/**
+ * Responsive Videos
+ */
+
+ .jetpack-video-wrapper {
+	margin-bottom: 1.6em;
+}
+
+.jetpack-video-wrapper > embed,
+.jetpack-video-wrapper > iframe,
+.jetpack-video-wrapper > object,
+.jetpack-video-wrapper > .wp-video {
+	margin-bottom: 0;
+}
 
 /**
  * Jetpack Comments

--- a/projects/plugins/jetpack/modules/theme-tools/compat/twentyfourteen.css
+++ b/projects/plugins/jetpack/modules/theme-tools/compat/twentyfourteen.css
@@ -18,6 +18,10 @@
 	margin: 0;
 }
 
+div.jp-relatedposts .jp-relatedposts-headline em:after {
+	content: ":";
+}
+
 #page .entry-content div.sharedaddy h3,
 #page .entry-summary div.sharedaddy h3,
 #page .entry-content h3.sd-title,
@@ -147,6 +151,10 @@ img[id*="botd"] {
 
 .widget_authors li:last-child {
 	margin-bottom: 0;
+}
+
+.widget_authors img {
+	margin-right: 5px;
 }
 
 /* Contact Info Widget */

--- a/projects/plugins/jetpack/modules/theme-tools/compat/twentytwenty.css
+++ b/projects/plugins/jetpack/modules/theme-tools/compat/twentytwenty.css
@@ -290,11 +290,6 @@
  * .com Toolbar
  */
 
-/* fix wordpress.com notification iframe width */
-iframe#wpnt-notes-iframe2.wide {
-	width: auto !important;
-}
-
 /* fix site position when overflow nav modal  */
 .admin-bar {
 	position: unset !important;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Syncs up the Jetpack-side theme compat files with wpcom, prerequisite for #25238

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
 n/a

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

Proofread, these are minor CSS changes that just got out of sync with wpcom.

