### PR TITLE
Edit/jetpack security plan recommendation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9886,7 +9886,7 @@ packages:
   /axios/0.26.1:
     resolution: {integrity: sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==}
     dependencies:
-      follow-redirects: 1.15.1
+      follow-redirects: 1.15.1_debug@4.3.4
     transitivePeerDependencies:
       - debug
     dev: false
@@ -13396,7 +13396,6 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.4
-    dev: true
 
   /for-in/1.0.2:
     resolution: {integrity: sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9886,7 +9886,7 @@ packages:
   /axios/0.26.1:
     resolution: {integrity: sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==}
     dependencies:
-      follow-redirects: 1.15.1_debug@4.3.4
+      follow-redirects: 1.15.1
     transitivePeerDependencies:
       - debug
     dev: false
@@ -13396,6 +13396,7 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.4
+    dev: true
 
   /for-in/1.0.2:
     resolution: {integrity: sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==}

--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -96,7 +96,7 @@ const recommendationsRoutes = [
 	'/recommendations/creative-mail',
 	'/recommendations/site-accelerator',
 	'/recommendations/publicize',
-	'/recommendations/security-plan',
+	'/recommendations/protect',
 	'/recommendations/anti-spam',
 	'/recommendations/videopress',
 	'/recommendations/backup-plan',
@@ -495,7 +495,7 @@ class Main extends React.Component {
 			case '/recommendations/creative-mail':
 			case '/recommendations/site-accelerator':
 			case '/recommendations/publicize':
-			case '/recommendations/security-plan':
+			case '/recommendations/protect':
 			case '/recommendations/anti-spam':
 			case '/recommendations/videopress':
 			case '/recommendations/backup-plan':

--- a/projects/plugins/jetpack/_inc/client/recommendations/constants.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/constants.js
@@ -9,7 +9,7 @@ export const RECOMMENDATION_WIZARD_STEP = {
 	CREATIVE_MAIL: 'creative-mail',
 	SITE_ACCELERATOR: 'site-accelerator',
 	PUBLICIZE: 'publicize',
-	SECURITY_PLAN: 'security-plan',
+	SECURITY_PLAN: 'protect',
 	ANTI_SPAM: 'anti-spam',
 	VIDEOPRESS: 'videopress',
 	BACKUP_PLAN: 'backup-plan',

--- a/projects/plugins/jetpack/_inc/client/recommendations/constants.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/constants.js
@@ -9,6 +9,7 @@ export const RECOMMENDATION_WIZARD_STEP = {
 	CREATIVE_MAIL: 'creative-mail',
 	SITE_ACCELERATOR: 'site-accelerator',
 	PUBLICIZE: 'publicize',
+	SECURITY_PLAN: 'security-plan',
 	PROTECT: 'protect',
 	ANTI_SPAM: 'anti-spam',
 	VIDEOPRESS: 'videopress',

--- a/projects/plugins/jetpack/_inc/client/recommendations/constants.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/constants.js
@@ -9,7 +9,7 @@ export const RECOMMENDATION_WIZARD_STEP = {
 	CREATIVE_MAIL: 'creative-mail',
 	SITE_ACCELERATOR: 'site-accelerator',
 	PUBLICIZE: 'publicize',
-	SECURITY_PLAN: 'protect',
+	PROTECT: 'protect',
 	ANTI_SPAM: 'anti-spam',
 	VIDEOPRESS: 'videopress',
 	BACKUP_PLAN: 'backup-plan',

--- a/projects/plugins/jetpack/_inc/client/recommendations/constants.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/constants.js
@@ -9,7 +9,6 @@ export const RECOMMENDATION_WIZARD_STEP = {
 	CREATIVE_MAIL: 'creative-mail',
 	SITE_ACCELERATOR: 'site-accelerator',
 	PUBLICIZE: 'publicize',
-	SECURITY_PLAN: 'security-plan',
 	PROTECT: 'protect',
 	ANTI_SPAM: 'anti-spam',
 	VIDEOPRESS: 'videopress',

--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
@@ -41,6 +41,13 @@ export const mapStateToSummaryFeatureProps = ( state, featureSlug ) => {
 				summaryActivateButtonLabel: __( 'Enable', 'jetpack' ),
 				configLink: '#/settings?term=related%20posts',
 			};
+		case 'protect':
+			return {
+				configureButtonLabel: __( 'Settings', 'jetpack' ),
+				displayName: __( 'Jetpack Protect', 'jetpack' ),
+				summaryActivateButtonLabel: __( 'Install', 'jetpack' ),
+				configLink: getSiteAdminUrl( state ) + 'admin.php?page=jetpack#/recommendations/summary', //page=jetpack-protect',
+			};
 		case 'site-accelerator':
 			return {
 				configureButtonLabel: __( 'Settings', 'jetpack' ),
@@ -84,12 +91,6 @@ export const mapStateToSummaryResourceProps = ( state, resourceSlug ) => {
 				ctaLabel: __( 'Read More', 'jetpack' ),
 				ctaLink: getRedirectUrl( 'jetpack-blog-backups-101' ),
 			};
-		case 'security-plan':
-			return {
-				displayName: __( 'Site Security', 'jetpack' ),
-				ctaLabel: __( 'Read More', 'jetpack' ),
-				ctaLink: getRedirectUrl( 'jetpack-blog-wordpress-security-for-beginners' ),
-			};
 		case 'anti-spam':
 			return {
 				displayName: __( 'Spam Management', 'jetpack' ),
@@ -131,6 +132,14 @@ export const mapDispatchToProps = ( dispatch, featureSlug ) => {
 			return {
 				activateFeature: () => {
 					return dispatch( updateSettings( { 'related-posts': true } ) );
+				},
+			};
+		case 'protect':
+			return {
+				activateFeature: () => {
+					return restApi.installPlugin( 'protect', 'recommendations' ).then( () => {
+						dispatch( fetchPluginsData() );
+					} );
 				},
 			};
 		case 'site-accelerator':
@@ -266,24 +275,15 @@ export const getStepContent = stepSlug => {
 				descriptionLink: getRedirectUrl( 'jetpack-blog-social-sharing' ),
 				ctaText: __( 'Enable Social Media Sharing', 'jetpack' ),
 			};
-		case 'security-plan':
+		case 'protect':
 			return {
 				question: __( 'With more plugins comes more responsibility.', 'jetpack' ),
 				description: __(
-					'As you add plugins to your site, you have to start thinking about vulnerabilities, failed updates, and incompatible plugins. You should ensure that the plugins you install:',
+					'As you add plugins to your site, you have to start thinking about vulnerabilities.<br /><br /><strong>Jetpack Protect</strong> is a free security solution for WordPress that runs automated scans on your site and warns you about vulnerabilities.<br /><br />Focus on running your business while we protect your site with Jetpack Protect. <ExternalLink>Learn More</ExternalLink>.',
 					'jetpack'
 				),
-				descriptionList: [
-					__( 'Have good user ratings', 'jetpack' ),
-					__( 'Are compatible with the most recent version of WordPress', 'jetpack' ),
-					__( 'Are developed by teams that respond to support requests promptly', 'jetpack' ),
-				],
-				descriptionSecondary: __(
-					'Or let Jetpack handle your security and backups so you can focus on your business.',
-					'jetpack'
-				),
-				ctaText: __( 'Read WordPress Security for Beginners', 'jetpack' ),
-				ctaLink: getRedirectUrl( 'jetpack-blog-wordpress-security-for-beginners' ),
+				descriptionLink: getRedirectUrl( 'jetpack-protect-assistant-recommendation' ),
+				ctaText: __( 'Install Protect for Free', 'jetpack' ),
 			};
 		case 'anti-spam':
 			return {
@@ -390,7 +390,7 @@ export const getProductCardDataStepOverrides = ( state, productSlug, stepSlug ) 
 				return {
 					productCardTitle: __( 'Your site is growing. It’s time for a security plan.', 'jetpack' ),
 				};
-			} else if ( stepSlug === 'security-plan' ) {
+			} else if ( stepSlug === 'protect' ) {
 				return {
 					productCardTitle: __(
 						'Jetpack Security gives you complete site protection and backups.',

--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
@@ -137,7 +137,7 @@ export const mapDispatchToProps = ( dispatch, featureSlug ) => {
 		case 'protect':
 			return {
 				activateFeature: () => {
-					return restApi.installPlugin( 'protect', 'recommendations' ).then( () => {
+					return restApi.installPlugin( 'jetpack-protect', 'recommendations' ).then( () => {
 						dispatch( fetchPluginsData() );
 					} );
 				},

--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
@@ -46,7 +46,7 @@ export const mapStateToSummaryFeatureProps = ( state, featureSlug ) => {
 				configureButtonLabel: __( 'Settings', 'jetpack' ),
 				displayName: __( 'Jetpack Protect', 'jetpack' ),
 				summaryActivateButtonLabel: __( 'Install', 'jetpack' ),
-				configLink: getSiteAdminUrl( state ) + 'admin.php?page=jetpack#/recommendations/summary', //page=jetpack-protect',
+				configLink: getSiteAdminUrl( state ) + 'admin.php?page=jetpack-protect',
 			};
 		case 'site-accelerator':
 			return {

--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
@@ -43,7 +43,7 @@ export const mapStateToSummaryFeatureProps = ( state, featureSlug ) => {
 			};
 		case 'protect':
 			return {
-				configureButtonLabel: __( 'Dashboard', 'jetpack' ),
+				configureButtonLabel: __( 'Settings', 'jetpack' ),
 				displayName: __( 'Jetpack Protect', 'jetpack' ),
 				summaryActivateButtonLabel: __( 'Install', 'jetpack' ),
 				configLink: getSiteAdminUrl( state ) + 'admin.php?page=jetpack-protect',

--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
@@ -43,7 +43,7 @@ export const mapStateToSummaryFeatureProps = ( state, featureSlug ) => {
 			};
 		case 'protect':
 			return {
-				configureButtonLabel: __( 'Settings', 'jetpack' ),
+				configureButtonLabel: __( 'Dashboard', 'jetpack' ),
 				displayName: __( 'Jetpack Protect', 'jetpack' ),
 				summaryActivateButtonLabel: __( 'Install', 'jetpack' ),
 				configLink: getSiteAdminUrl( state ) + 'admin.php?page=jetpack-protect',

--- a/projects/plugins/jetpack/_inc/client/recommendations/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/index.jsx
@@ -61,7 +61,7 @@ const RecommendationsComponent = props => {
 		case RECOMMENDATION_WIZARD_STEP.PUBLICIZE:
 			redirectPath = '/publicize';
 			break;
-		case RECOMMENDATION_WIZARD_STEP.SECURITY_PLAN:
+		case RECOMMENDATION_WIZARD_STEP.PROTECT:
 			redirectPath = '/protect';
 			break;
 		case RECOMMENDATION_WIZARD_STEP.ANTI_SPAM:

--- a/projects/plugins/jetpack/_inc/client/recommendations/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/index.jsx
@@ -62,7 +62,7 @@ const RecommendationsComponent = props => {
 			redirectPath = '/publicize';
 			break;
 		case RECOMMENDATION_WIZARD_STEP.SECURITY_PLAN:
-			redirectPath = '/security-plan';
+			redirectPath = '/protect';
 			break;
 		case RECOMMENDATION_WIZARD_STEP.ANTI_SPAM:
 			redirectPath = '/anti-spam';
@@ -134,8 +134,8 @@ const RecommendationsComponent = props => {
 					<Route path="/recommendations/publicize">
 						<FeaturePrompt stepSlug="publicize" isNew={ isNew( 'publicize' ) } />
 					</Route>
-					<Route path="/recommendations/security-plan">
-						<ResourcePrompt stepSlug="security-plan" isNew={ isNew( 'security-plan' ) } />
+					<Route path="/recommendations/protect">
+						<FeaturePrompt stepSlug="protect" isNew={ isNew( 'protect' ) } />
 					</Route>
 					<Route path="/recommendations/anti-spam">
 						<ResourcePrompt stepSlug="anti-spam" isNew={ isNew( 'anti-spam' ) } />

--- a/projects/plugins/jetpack/_inc/client/recommendations/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/index.jsx
@@ -79,12 +79,9 @@ const RecommendationsComponent = props => {
 		case RECOMMENDATION_WIZARD_STEP.SUMMARY:
 			redirectPath = '/summary';
 			break;
-		// Any old recommendations no longer in use should redirect to /summary
-		case RECOMMENDATION_WIZARD_STEP.SECURITY_PLAN:
+		default:
 			redirectPath = '/summary';
 			break;
-		default:
-			throw `Unknown step ${ step } in RecommendationsComponent`;
 	}
 
 	// Check to see if a step slug is "new" - has not been viewed yet.

--- a/projects/plugins/jetpack/_inc/client/recommendations/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/index.jsx
@@ -79,6 +79,10 @@ const RecommendationsComponent = props => {
 		case RECOMMENDATION_WIZARD_STEP.SUMMARY:
 			redirectPath = '/summary';
 			break;
+		// Any old recommendations no longer in use should redirect to /summary
+		case RECOMMENDATION_WIZARD_STEP.SECURITY_PLAN:
+			redirectPath = '/summary';
+			break;
 		default:
 			throw `Unknown step ${ step } in RecommendationsComponent`;
 	}

--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/prompt-layout/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/prompt-layout/index.jsx
@@ -87,7 +87,7 @@ PromptLayoutComponent.propTypes = {
 	description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ).isRequired,
 	illustration: PropTypes.string,
 	illustrationClassName: PropTypes.string,
-	progressBar: PropTypes.element.isRequired,
+	progressBar: PropTypes.element,
 	question: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ).isRequired,
 	content: PropTypes.element,
 	sidebarCard: PropTypes.element,

--- a/projects/plugins/jetpack/_inc/client/recommendations/sidebar/product-spotlight/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/sidebar/product-spotlight/index.jsx
@@ -41,8 +41,8 @@ const ProductSpotlightComponent = props => {
 						<h3 className="jp-recommendations-discount-card__heading">{ productCardTitle }</h3>
 						{ productCardList && (
 							<ul className="jp-recommendations-discount-card__feature-list">
-								{ productCardList.map( listItem => {
-									return <li>{ listItem }</li>;
+								{ productCardList.map( ( listItem, id ) => {
+									return <li key={ `feature-${ id }` }>{ listItem }</li>;
 								} ) }
 							</ul>
 						) }
@@ -69,7 +69,7 @@ const ProductSpotlightComponent = props => {
 	);
 };
 
-ProductSpotlightComponent.PropTypes = {
+ProductSpotlightComponent.propTypes = {
 	productSlug: PropTypes.string.isRequired,
 };
 

--- a/projects/plugins/jetpack/_inc/client/recommendations/sidebar/product-spotlight/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/sidebar/product-spotlight/index.jsx
@@ -41,8 +41,8 @@ const ProductSpotlightComponent = props => {
 						<h3 className="jp-recommendations-discount-card__heading">{ productCardTitle }</h3>
 						{ productCardList && (
 							<ul className="jp-recommendations-discount-card__feature-list">
-								{ productCardList.map( ( listItem, id ) => {
-									return <li key={ `feature-${ id }` }>{ listItem }</li>;
+								{ productCardList.map( ( listItem, index ) => {
+									return <li key={ `feature-${ index }` }>{ listItem }</li>;
 								} ) }
 							</ul>
 						) }

--- a/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
@@ -289,7 +289,7 @@ const stepToNextStep = {
 	'creative-mail': 'site-accelerator',
 	'site-accelerator': 'publicize',
 	publicize: 'summary',
-	'security-plan': 'summary',
+	protect: 'summary',
 	'anti-spam': 'summary',
 	videopress: 'summary',
 	'backup-plan': 'summary',
@@ -307,7 +307,7 @@ export const stepToRoute = {
 	'creative-mail': '#/recommendations/creative-mail',
 	'site-accelerator': '#/recommendations/site-accelerator',
 	publicize: '#/recommendations/publicize',
-	'security-plan': '#/recommendations/security-plan',
+	protect: '#/recommendations/protect',
 	'anti-spam': '#/recommendations/anti-spam',
 	videopress: '#/recommendations/videopress',
 	'backup-plan': '#/recommendations/backup-plan',
@@ -345,6 +345,8 @@ export const isFeatureActive = ( state, featureSlug ) => {
 			return !! getSetting( state, 'photon' ) && getSetting( state, 'photon-cdn' );
 		case 'woocommerce':
 			return !! isPluginActive( state, 'woocommerce/woocommerce.php' );
+		case 'protect':
+			return !! isPluginActive( state, 'protect/jetpack-protect.php' );
 		case 'publicize':
 			return !! getSetting( state, 'publicize' );
 		case 'videopress':
@@ -373,7 +375,7 @@ export const isProductSuggestionsAvailable = state => {
 export const getProductSlugForStep = ( state, step ) => {
 	switch ( step ) {
 		case 'publicize':
-		case 'security-plan':
+		case 'protect':
 			if ( ! hasActiveSecurityPurchase( state ) && ! hasSecurityComparableLegacyPlan( state ) ) {
 				return PLAN_JETPACK_SECURITY_T1_YEARLY;
 			}
@@ -432,7 +434,11 @@ const isStepEligibleToShow = ( state, step ) => {
 			return hasConnectedOwner( state ) && ! isFeatureActive( state, step );
 		case 'publicize':
 			return isConditionalRecommendationEnabled( state, step ) && ! isFeatureActive( state, step );
-		case 'security-plan':
+		case 'protect':
+			return (
+				isConditionalRecommendationEnabled( state, step ) &&
+				! isPluginActive( state, 'protect/jetpack-protect.php' )
+			);
 		case 'anti-spam':
 		case 'backup-plan':
 			return isConditionalRecommendationEnabled( state, step );
@@ -527,8 +533,8 @@ const isFeatureEligibleToShowInSummary = ( state, slug ) => {
 		case 'boost':
 			return isConditionalRecommendationEnabled( state, slug ) || isFeatureActive( state, slug );
 		case 'publicize':
+		case 'protect':
 			return isConditionalRecommendationEnabled( state, slug ) || isFeatureActive( state, slug );
-		case 'security-plan':
 		case 'anti-spam':
 		case 'backup-plan':
 			return isConditionalRecommendationEnabled( state, slug );
@@ -546,6 +552,7 @@ export const getSummaryFeatureSlugs = state => {
 		'related-posts',
 		'creative-mail',
 		'site-accelerator',
+		'protect',
 		'publicize',
 		'videopress',
 		'boost',
@@ -573,7 +580,7 @@ export const getSummaryFeatureSlugs = state => {
 };
 
 export const getSummaryResourceSlugs = state => {
-	const resourceSlugs = [ 'security-plan', 'anti-spam', 'backup-plan' ];
+	const resourceSlugs = [ 'anti-spam', 'backup-plan' ];
 
 	return resourceSlugs.filter( slug => isFeatureEligibleToShowInSummary( state, slug ) );
 };

--- a/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
@@ -346,7 +346,7 @@ export const isFeatureActive = ( state, featureSlug ) => {
 		case 'woocommerce':
 			return !! isPluginActive( state, 'woocommerce/woocommerce.php' );
 		case 'protect':
-			return !! isPluginActive( state, 'protect/jetpack-protect.php' );
+			return !! isPluginActive( state, 'jetpack-protect/jetpack-protect.php' );
 		case 'publicize':
 			return !! getSetting( state, 'publicize' );
 		case 'videopress':
@@ -437,7 +437,7 @@ const isStepEligibleToShow = ( state, step ) => {
 		case 'protect':
 			return (
 				isConditionalRecommendationEnabled( state, step ) &&
-				! isPluginActive( state, 'protect/jetpack-protect.php' )
+				! isPluginActive( state, 'jetpack-protect/jetpack-protect.php' )
 			);
 		case 'anti-spam':
 		case 'backup-plan':

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
@@ -222,8 +222,8 @@ class Jetpack_Recommendations {
 			$has_scan_product   = count( array_intersect( array( 'jetpack_scan', 'jetpack_scan_monthly' ), $products ) ) > 0;
 			$has_scan           = $plan_supports_scan || $has_scan_product;
 
-			// Check for a plan or product that enables protect.
-			$has_protect = Plugins_Installer::is_plugin_active( 'protect/jetpack-protect.php' ) || Plugins_Installer::is_plugin_active( 'jetpack-protect/jetpack-protect.php' );
+			// Check if Jetpack Protect plugin is already active.
+			$has_protect = Plugins_Installer::is_plugin_active( 'jetpack-protect/jetpack-protect.php' );
 
 			if ( ! $has_scan && ! $has_protect ) {
 				self::enable_conditional_recommendation( self::PROTECT_RECOMMENDATION );

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
@@ -21,12 +21,12 @@ use Automattic\Jetpack\Status\Host;
  * Jetpack_Recommendations class
  */
 class Jetpack_Recommendations {
-	const PUBLICIZE_RECOMMENDATION     = 'publicize';
-	const PROTECT_RECOMMENDATION = 'protect';
-	const ANTI_SPAM_RECOMMENDATION     = 'anti-spam';
-	const VIDEOPRESS_RECOMMENDATION    = 'videopress';
-	const BACKUP_PLAN_RECOMMENDATION   = 'backup-plan';
-	const BOOST_RECOMMENDATION         = 'boost';
+	const PUBLICIZE_RECOMMENDATION   = 'publicize';
+	const PROTECT_RECOMMENDATION     = 'protect';
+	const ANTI_SPAM_RECOMMENDATION   = 'anti-spam';
+	const VIDEOPRESS_RECOMMENDATION  = 'videopress';
+	const BACKUP_PLAN_RECOMMENDATION = 'backup-plan';
+	const BOOST_RECOMMENDATION       = 'boost';
 
 	const CONDITIONAL_RECOMMENDATIONS_OPTION = 'recommendations_conditional';
 	const CONDITIONAL_RECOMMENDATIONS        = array(

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
@@ -223,7 +223,7 @@ class Jetpack_Recommendations {
 			$has_scan           = $plan_supports_scan || $has_scan_product;
 
 			// Check if Jetpack Protect plugin is already active.
-			$has_protect = Plugins_Installer::is_plugin_active( 'jetpack-protect/jetpack-protect.php' );
+			$has_protect = Plugins_Installer::is_plugin_active( 'jetpack-protect/jetpack-protect.php' ) || Plugins_Installer::is_plugin_active( 'protect/jetpack-protect.php' );
 
 			if ( ! $has_scan && ! $has_protect ) {
 				self::enable_conditional_recommendation( self::PROTECT_RECOMMENDATION );

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
@@ -23,7 +23,7 @@ use Automattic\Jetpack\Status\Host;
 class Jetpack_Recommendations {
 
 	const PUBLICIZE_RECOMMENDATION     = 'publicize';
-	const SECURITY_PLAN_RECOMMENDATION = 'security-plan';
+	const SECURITY_PLAN_RECOMMENDATION = 'protect';
 	const ANTI_SPAM_RECOMMENDATION     = 'anti-spam';
 	const VIDEOPRESS_RECOMMENDATION    = 'videopress';
 	const BACKUP_PLAN_RECOMMENDATION   = 'backup-plan';

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
@@ -21,9 +21,8 @@ use Automattic\Jetpack\Status\Host;
  * Jetpack_Recommendations class
  */
 class Jetpack_Recommendations {
-
 	const PUBLICIZE_RECOMMENDATION     = 'publicize';
-	const SECURITY_PLAN_RECOMMENDATION = 'protect';
+	const PROTECT_RECOMMENDATION = 'protect';
 	const ANTI_SPAM_RECOMMENDATION     = 'anti-spam';
 	const VIDEOPRESS_RECOMMENDATION    = 'videopress';
 	const BACKUP_PLAN_RECOMMENDATION   = 'backup-plan';
@@ -32,7 +31,7 @@ class Jetpack_Recommendations {
 	const CONDITIONAL_RECOMMENDATIONS_OPTION = 'recommendations_conditional';
 	const CONDITIONAL_RECOMMENDATIONS        = array(
 		self::PUBLICIZE_RECOMMENDATION,
-		self::SECURITY_PLAN_RECOMMENDATION,
+		self::PROTECT_RECOMMENDATION,
 		self::ANTI_SPAM_RECOMMENDATION,
 		self::VIDEOPRESS_RECOMMENDATION,
 		self::BACKUP_PLAN_RECOMMENDATION,
@@ -229,7 +228,7 @@ class Jetpack_Recommendations {
 			$has_scan           = $plan_supports_scan || $has_scan_product;
 
 			if ( ! $has_scan || ! $has_backup || ! $has_anti_spam ) {
-				self::enable_conditional_recommendation( self::SECURITY_PLAN_RECOMMENDATION );
+				self::enable_conditional_recommendation( self::PROTECT_RECOMMENDATION );
 			}
 		}
 	}

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
@@ -205,6 +205,7 @@ class Jetpack_Recommendations {
 			'creative-mail.php',
 			'jetpack-backup.php',
 			'jetpack-boost.php',
+			'jetpack-protect.php',
 			'crowdsignal.php',
 			'vaultpress.php',
 			'woocommerce.php',

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-recommendations.php
@@ -214,20 +214,17 @@ class Jetpack_Recommendations {
 		$plugin_file = $path_parts ? array_pop( $path_parts ) : $plugin;
 
 		if ( ! in_array( $plugin_file, $plugin_whitelist, true ) ) {
-			$products              = array_column( Jetpack_Plan::get_products(), 'product_slug' );
-			$has_anti_spam_product = count( array_intersect( array( 'jetpack_anti_spam', 'jetpack_anti_spam_monthly' ), $products ) ) > 0;
-			$has_anti_spam         = is_plugin_active( 'akismet/akismet.php' ) || Jetpack_Plan::supports( 'antispam' ) || $has_anti_spam_product;
-
-			// Check the backup state.
-			$rewind_state = get_transient( 'jetpack_rewind_state' );
-			$has_backup   = $rewind_state && in_array( $rewind_state->state, array( 'awaiting_credentials', 'provisioning', 'active' ), true );
+			$products = array_column( Jetpack_Plan::get_products(), 'product_slug' );
 
 			// Check for a plan or product that enables scan.
 			$plan_supports_scan = Jetpack_Plan::supports( 'scan' );
 			$has_scan_product   = count( array_intersect( array( 'jetpack_scan', 'jetpack_scan_monthly' ), $products ) ) > 0;
 			$has_scan           = $plan_supports_scan || $has_scan_product;
 
-			if ( ! $has_scan || ! $has_backup || ! $has_anti_spam ) {
+			// Check for a plan or product that enables protect.
+			$has_protect = Plugins_Installer::is_plugin_active( 'protect/jetpack-protect.php' ) || Plugins_Installer::is_plugin_active( 'jetpack-protect/jetpack-protect.php' );
+
+			if ( ! $has_scan && ! $has_protect ) {
 				self::enable_conditional_recommendation( self::PROTECT_RECOMMENDATION );
 			}
 		}

--- a/projects/plugins/jetpack/changelog/edit-jetpack-security-plan-recommendation
+++ b/projects/plugins/jetpack/changelog/edit-jetpack-security-plan-recommendation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Enhancement: Update security plan recommendation to promote Jetpack Protect to increase installs


### PR DESCRIPTION
#### Summary

This changes the `security-plan` recommendation to a Jetpack Protect recommendation that auto-installs Protect when the CTA is selected

#### Changes proposed in this Pull Request:

This PR switches out the `security-plan` recommendation with a new `protect` one. Instead of linking to a blog post about security, this CTA will auto-install Jetpack Protect. The body of the recommendation has been rewritten to be related to Jetpack Protect and links to the [Jetpack Protect landing page](https://jetpack.com/protect)

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
P2: pbNhbs-3dM-p2

#### Does this pull request change what data or activity we track or use?

No additional tracking, these recommendations use the same set of tracking rules, this one is just going to be tracked as the 'protect' recommendation instead of the 'security-plan' one.

#### Testing instructions:

1. On your Jetpack test site, start by resetting the Jetpack options. If you are using a development version of Jetpack, this option should be available in the footer on the Jetpack Dashboard.
2. In the code, navigate to `projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js` to line 118. Here, change the `jetpack-protect` plugin being installed to `protect` so we install the Protect plugin with the most recent changes that have not been released yet ( this PR will have to wait until Protect releases again in order to work correctly )
3. Navigate to the plugins library and install and active any plugin that you want.
4. Navigate back to the Jetpack dashboard, you should see a red "1" bade next to the "Recommendations" navigation item indicating that a new recommendation is available.
![image](https://user-images.githubusercontent.com/65001528/185452340-063de7ce-4a10-4c0c-8c58-6de27143d8a8.png)
5. Click on the recommendations navigation item. You should now see the recommendation for Jetpack Protect. There should be a green "New" badge showing on this step.
![image](https://user-images.githubusercontent.com/65001528/185452437-e781a885-bf79-4c66-bb60-8a85d351f483.png)
6. Click on the `Learn More` external link and confirm it goes to https://jetpack.com/protect
7. Click on the `Get Jetpack Security` CTA and confirm it takes you to the checkout with Jetpack Security in the cart
![Screen Shot 2022-08-22 at 9 29 35 AM](https://user-images.githubusercontent.com/65001528/185959864-e3396f89-726f-42f5-812e-62ee4325be6e.jpg)
8. Finally, click on the main CTA. It should take you to the Summary and after a couple of sections, show Jetpack Protect installed with a CTA to go to the settings
![image](https://user-images.githubusercontent.com/65001528/185455048-7dbef826-eff6-4308-ae85-142905451dc9.png)
9. Click on the Settings CTA and it should take you to the Jetpack Protect Dashboard
![image](https://user-images.githubusercontent.com/65001528/185455168-05b818cc-83fb-4233-9398-c7d0b1d3c34f.png)

