### PR TITLE
Search: retire results overlay trigger

### DIFF
--- a/projects/packages/search/changelog/fix-search-retire-results-overlay-trigger
+++ b/projects/packages/search/changelog/fix-search-retire-results-overlay-trigger
@@ -1,4 +1,4 @@
 Significance: minor
-Type: deprecated
+Type: removed
 
 Search: remove 'results' overlay trigger

--- a/projects/packages/search/changelog/fix-search-retire-results-overlay-trigger
+++ b/projects/packages/search/changelog/fix-search-retire-results-overlay-trigger
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+Search: remove 'results' overlay trigger

--- a/projects/packages/search/compatibility/search-0.17.0.php
+++ b/projects/packages/search/compatibility/search-0.17.0.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Compatibility for Jetpack Search version <= 0.17.0.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search\Compatibility\Jetpack;
+
+// @todo find the appropriate filter for settings update
+// add_filter( 'option_sidebars_widgets', __NAMESPACE__ . '\update_deprecated_results_overlay_trigger', 10, 2 );
+
+/**
+ * We've retired the 'results' overlay trigger and want to migrate users to the similar 'immediate' setting.
+ */
+function update_deprecated_results_overlay_trigger( /*$sidebars_widgets*/ ) {
+	// update results > immediate
+}

--- a/projects/packages/search/compatibility/search-0.17.0.php
+++ b/projects/packages/search/compatibility/search-0.17.0.php
@@ -7,12 +7,13 @@
 
 namespace Automattic\Jetpack\Search\Compatibility\Jetpack;
 
-// @todo find the appropriate filter for settings update
-// add_filter( 'option_sidebars_widgets', __NAMESPACE__ . '\update_deprecated_results_overlay_trigger', 10, 2 );
+add_filter( 'option_jetpack_search_overlay_trigger', __NAMESPACE__ . '\map_results_overlay_trigger', 10, 2 );
 
 /**
  * We've retired the 'results' overlay trigger and want to migrate users to the similar 'immediate' setting.
+ *
+ * @param string $overlay_trigger Overlay trigger.
  */
-function update_deprecated_results_overlay_trigger( /*$sidebars_widgets*/ ) {
-	// update results > immediate
+function map_results_overlay_trigger( $overlay_trigger ) {
+	return 'results' === $overlay_trigger ? Automattic\Jetpack\Search\Options::OVERLAY_TRIGGER_IMMEDIATE : $overlay_trigger;
 }

--- a/projects/packages/search/compatibility/search-0.17.0.php
+++ b/projects/packages/search/compatibility/search-0.17.0.php
@@ -15,5 +15,5 @@ add_filter( 'option_jetpack_search_overlay_trigger', __NAMESPACE__ . '\map_resul
  * @param string $overlay_trigger Overlay trigger.
  */
 function map_results_overlay_trigger( $overlay_trigger ) {
-	return 'results' === $overlay_trigger ? Automattic\Jetpack\Search\Options::OVERLAY_TRIGGER_IMMEDIATE : $overlay_trigger;
+	return 'results' === $overlay_trigger ? \Automattic\Jetpack\Search\Options::OVERLAY_TRIGGER_IMMEDIATE : $overlay_trigger;
 }

--- a/projects/packages/search/src/class-options.php
+++ b/projects/packages/search/src/class-options.php
@@ -46,7 +46,6 @@ class Options {
 	 * @var string
 	 */
 	const OVERLAY_TRIGGER_IMMEDIATE = 'immediate';
-	const OVERLAY_TRIGGER_RESULTS   = 'results';
 	const OVERLAY_TRIGGER_SUBMIT    = 'submit';
 	const DEFAULT_OVERLAY_TRIGGER   = self::OVERLAY_TRIGGER_SUBMIT;
 

--- a/projects/packages/search/src/class-options.php
+++ b/projects/packages/search/src/class-options.php
@@ -50,6 +50,14 @@ class Options {
 	const DEFAULT_OVERLAY_TRIGGER   = self::OVERLAY_TRIGGER_SUBMIT;
 
 	/**
+	 * Deprecated overlay trigger.
+	 *
+	 * @var string
+	 * @deprecated since 11.3
+	 */
+	const OVERLAY_TRIGGER_RESULTS = 'results';
+
+	/**
 	 * Returns a boolean for whether instant search is enabled.
 	 *
 	 * @since 8.3.0

--- a/projects/packages/search/src/customberg/components/sidebar/sidebar-options.jsx
+++ b/projects/packages/search/src/customberg/components/sidebar/sidebar-options.jsx
@@ -100,7 +100,7 @@ export default function SidebarOptions() {
 							value: 'submit',
 						},
 						{
-							label: __( 'Open when the user starts typing', 'jetpack-search-pkg' ),
+							label: __( 'Open when user starts typing', 'jetpack-search-pkg' ),
 							value: 'immediate',
 						},
 					] }

--- a/projects/packages/search/src/customberg/components/sidebar/sidebar-options.jsx
+++ b/projects/packages/search/src/customberg/components/sidebar/sidebar-options.jsx
@@ -96,16 +96,12 @@ export default function SidebarOptions() {
 					value={ trigger }
 					options={ [
 						{
+							label: __( 'Open when user submits the form (recommended)', 'jetpack-search-pkg' ),
+							value: 'submit',
+						},
+						{
 							label: __( 'Open when the user starts typing', 'jetpack-search-pkg' ),
 							value: 'immediate',
-						},
-						{
-							label: __( 'Open when results are available', 'jetpack-search-pkg' ),
-							value: 'results',
-						},
-						{
-							label: __( 'Open when user submits the form', 'jetpack-search-pkg' ),
-							value: 'submit',
 						},
 					] }
 					onChange={ setTrigger }

--- a/projects/packages/search/src/customizer/class-customizer.php
+++ b/projects/packages/search/src/customizer/class-customizer.php
@@ -128,9 +128,8 @@ class Customizer {
 				'section'     => $section_id,
 				'type'        => 'select',
 				'choices'     => array(
+					Options::OVERLAY_TRIGGER_SUBMIT    => __( 'Open when user submits the form (recommended)', 'jetpack-search-pkg' ),
 					Options::OVERLAY_TRIGGER_IMMEDIATE => __( 'Open when user starts typing', 'jetpack-search-pkg' ),
-					Options::OVERLAY_TRIGGER_RESULTS   => __( 'Open when results are available', 'jetpack-search-pkg' ),
-					Options::OVERLAY_TRIGGER_SUBMIT    => __( 'Open when user submits the form', 'jetpack-search-pkg' ),
 				),
 			)
 		);

--- a/projects/packages/search/src/initializers/class-initializer.php
+++ b/projects/packages/search/src/initializers/class-initializer.php
@@ -90,6 +90,7 @@ class Initializer {
 			require_once Package::get_installed_path() . 'compatibility/jetpack.php';
 		}
 		require_once Package::get_installed_path() . 'compatibility/search-0.15.2.php';
+		require_once Package::get_installed_path() . 'compatibility/search-0.17.0.php';
 	}
 
 	/**

--- a/projects/packages/search/src/instant-search/components/dom-event-handler.jsx
+++ b/projects/packages/search/src/instant-search/components/dom-event-handler.jsx
@@ -139,12 +139,8 @@ export default class DomEventHandler extends Component {
 
 		this.props.setSearchQuery( event.target.value );
 
-		if ( this.props.overlayOptions.overlayTrigger === 'immediate' ) {
+		if ( [ 'immediate', 'results' ].includes( this.props.overlayOptions.overlayTrigger ) ) {
 			this.props.showResults();
-		}
-
-		if ( this.props.overlayOptions.overlayTrigger === 'results' ) {
-			this.props.response?.results && this.props.showResults();
 		}
 	}, 200 );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/20849.

One of the three overlay trigger options a user can choose is 'when results loaded'. This opens the modal when the first API call with results has returned.

This is not ideal because:

* The timing is based on API speed/network conditions and not user input
* The modal opening can come as a surprise to the user

Furthermore, this option actually feels fairly similar in practice to the "When user starts typing" trigger.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR removes the 'when results are loaded' overlay trigger.

For any users who have already chosen to use this setting, it uses the 'immediate' trigger instead as the behavior is similar.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Visit the Customizer and ensure the 'when results loaded' option is not displayed.
* Visit Customberg and ensure the 'when results loaded' option is not displayed.
* On a test site you have previously set to 'when results loaded', switch to this branch and then start typing in a search input on the front end of the site. The modal should appear immediately.

