### PR TITLE
Make default payment block plan names dynamic

### DIFF
--- a/projects/plugins/jetpack/changelog/update-payment-button-product-names
+++ b/projects/plugins/jetpack/changelog/update-payment-button-product-names
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+When adding a payment plan, the plan name field will update according to the other options selected, unless it's already been modified.

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/inspector-control.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/inspector-control.js
@@ -14,11 +14,12 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { lock } from '@wordpress/icons';
+import { useEffect } from 'react';
 import { store as membershipProductsStore } from '../../../store/membership-products';
 import { CURRENCY_OPTIONS } from '../../currencies';
 import { API_STATE_NOT_REQUESTING, API_STATE_REQUESTING } from './constants';
 import { useProductManagementContext } from './context';
-import { getMessageByProductType } from './utils';
+import { getMessageByProductType, getTitleByProps } from './utils';
 
 const DEFAULT_CURRENCY = 'USD';
 const DEFAULT_PRICE = 5;
@@ -41,6 +42,7 @@ export default function ProductManagementInspectorControl() {
 	const [ title, setTitle ] = useState(
 		getMessageByProductType( 'default new product title', productType )
 	);
+	const [ isCustomTitle, setIsCustomTitle ] = useState( false );
 	const [ currency, setCurrency ] = useState( DEFAULT_CURRENCY );
 	const [ price, setPrice ] = useState( DEFAULT_PRICE );
 	const [ interval, setInterval ] = useState( DEFAULT_INTERVAL );
@@ -71,9 +73,8 @@ export default function ProductManagementInspectorControl() {
 			success => {
 				setApiState( API_STATE_NOT_REQUESTING );
 				if ( success ) {
-					const defaultTitle = getMessageByProductType( 'default new product title', productType );
 					setPrice( DEFAULT_PRICE );
-					setTitle( defaultTitle );
+					setIsCustomTitle( false );
 					setInterval( DEFAULT_INTERVAL );
 					setIsMarkedAsDonation( DEFAULT_IS_MARKED_AS_DONATION );
 					setIsCustomAmount( DEFAULT_IS_CUSTOM_AMOUNT );
@@ -82,6 +83,15 @@ export default function ProductManagementInspectorControl() {
 			}
 		);
 	};
+
+	useEffect( () => {
+		// If the user has manually selected a title then that should be left as-is, don't overwrite it
+		if ( isCustomTitle ) {
+			return;
+		}
+		setTitle( getTitleByProps( isMarkedAsDonation, interval ) );
+		setIsCustomTitle( false );
+	}, [ interval, isMarkedAsDonation, isCustomTitle ] );
 
 	return (
 		<InspectorControls>
@@ -112,7 +122,10 @@ export default function ProductManagementInspectorControl() {
 								<TextControl
 									id="new-product-title"
 									label={ __( 'Name', 'jetpack' ) }
-									onChange={ value => setTitle( value ) }
+									onChange={ value => {
+										setTitle( value );
+										setIsCustomTitle( true );
+									} }
 									value={ title }
 								/>
 							</PanelRow>

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/utils.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/utils.js
@@ -91,3 +91,17 @@ const messages = {
 export function getMessageByProductType( message, productType = PRODUCT_TYPE_PAYMENT_PLAN ) {
 	return messages?.[ message ]?.[ productType ] || null;
 }
+
+const titles = {
+	'false,1 month': __( 'Monthly Subscription', 'jetpack' ),
+	'true,1 month': __( 'Monthly Donation', 'jetpack' ),
+	'false,1 year': __( 'Yearly Subscription', 'jetpack' ),
+	'true,1 year': __( 'Yearly Donation', 'jetpack' ),
+	'false,one-time': __( 'Subscription', 'jetpack' ),
+	'true,one-time': __( 'Donation', 'jetpack' ),
+};
+
+export function getTitleByProps( isDonation, interval ) {
+	const key = [ isDonation, interval ];
+	return titles[ key ] ?? '';
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Partly fixes #24074 but a similar change will be needed in Calypso

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
    
When adding a new plan, the plan name will update depending upon the payment options selected - whether it's a donation  and what the payment frequency is.
    
This aids users in naming their plans appropriately and reduces the likelihood of having umpteen plans called 'Monthly subscription' when they're nothing of the sort.
    
If the user explicitly chooses a name then that is respected and not overwritten.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Start a JN site or apply the wpcom generated diff from the message below
2. On a site with a paid plan, go to Gutenberg
3. Insert a Payment button block
4. Follow prompts to connect to Stripe
5. Select the payment button block
6. Click the plan
7. In the block inspector (sidebar on the right) fiddle around with the Interval and "Mark this payment plan as a donation" fields and watch the title change
8. Change the title manually
9. Fiddle with the fields again, and watch the title not change
10. Add the plan you created, watch the default plan title change back to be appropriate with the interval / donation fields

#### Demo

https://user-images.githubusercontent.com/93301/183080456-d4de0cca-4596-472b-8ba1-3099983c33fe.mp4


