### PR TITLE
Search: Add author filter

### DIFF
--- a/projects/packages/search/changelog/add-author_filtering
+++ b/projects/packages/search/changelog/add-author_filtering
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add filter author support

--- a/projects/packages/search/changelog/add-author_filtering
+++ b/projects/packages/search/changelog/add-author_filtering
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Add filter author support
+Add author filtering support

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -69,7 +69,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.19.x-dev"
+			"dev-trunk": "0.20.x-dev"
 		},
 		"version-constants": {
 			"::VERSION": "src/class-package.php"

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.19.0-alpha",
+	"version": "0.20.0-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.19.0",
+	"version": "0.19.0-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-helper.php
+++ b/projects/packages/search/src/class-helper.php
@@ -235,6 +235,10 @@ class Helper {
 				$name = _x( 'Post Types', 'label for filtering posts', 'jetpack-search-pkg' );
 				break;
 
+			case 'author':
+				$name = _x( 'Authors', 'label for filtering posts', 'jetpack-search-pkg' );
+				break;
+
 			case 'date_histogram':
 				$modified_fields = array(
 					'post_modified',

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.19.0-alpha';
+	const VERSION = '0.20.0-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.19.0';
+	const VERSION = '0.19.0-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/class-template-tags.php
+++ b/projects/packages/search/src/class-template-tags.php
@@ -182,6 +182,9 @@ class Template_Tags {
 			case 'post_type':
 				$data_base = 'data-filter-type="post_types" ';
 				break;
+			case 'author':
+				$data_base = 'data-filter-type="authors" ';
+				break;
 			case 'date_histogram':
 				if ( $filter['buckets'][0]['query_vars']['monthnum'] ) {
 					$data_base = 'data-filter-type="month_post_date" ';
@@ -205,6 +208,9 @@ class Template_Tags {
 						break;
 					case 'post_type':
 						$data_str .= 'data-val="' . esc_attr( $item['query_vars']['post_type'] ) . '"';
+						break;
+					case 'author':
+						$data_str .= 'data-val="' . esc_attr( $item['query_vars']['author'] ) . '"';
 						break;
 					case 'date_histogram':
 						if ( $item['query_vars']['monthnum'] ) {

--- a/projects/packages/search/src/classic-search/class-classic-search.php
+++ b/projects/packages/search/src/classic-search/class-classic-search.php
@@ -1235,6 +1235,11 @@ class Classic_Search {
 
 					break;
 
+				case 'author':
+					$this->add_author_aggregation_to_es_query_builder( $aggregation, $label, $builder );
+
+					break;
+
 				case 'date_histogram':
 					$this->add_date_histogram_aggregation_to_es_query_builder( $aggregation, $label, $builder );
 
@@ -1295,6 +1300,27 @@ class Classic_Search {
 			array(
 				'terms' => array(
 					'field' => 'post_type',
+					'size'  => min( (int) $aggregation['count'], $this->max_aggregations_count ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Given an individual author aggregation, add it to the query builder object for use in Elasticsearch.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @param array                                        $aggregation The aggregation to add to the query builder.
+	 * @param string                                       $label       The 'label' (unique id) for this aggregation.
+	 * @param Automattic\Jetpack\Search\WPES\Query_Builder $builder     The builder instance that is creating the Elasticsearch query.
+	 */
+	public function add_author_aggregation_to_es_query_builder( array $aggregation, $label, $builder ) {
+		$builder->add_aggs(
+			$label,
+			array(
+				'terms' => array(
+					'field' => 'author_login_slash_name',
 					'size'  => min( (int) $aggregation['count'], $this->max_aggregations_count ),
 				),
 			)
@@ -1560,6 +1586,26 @@ class Classic_Search {
 							} else {
 								$remove_url = Helper::remove_query_arg( 'post_type' );
 							}
+						}
+
+						break;
+
+					// The filter `author` is NOT supported in Classic Search. This is used to be compatible for filters in the Footer section with Instant Search.
+					case 'author':
+						$name = preg_split( '/\/(.+)/', $item['key'] )[0];
+
+						if ( ! $name ) {
+							continue 2;  // switch() is considered a looping structure.
+						}
+
+						$query_vars = array(
+							'author' => $name,
+						);
+
+						if ( ! empty( $name ) ) {
+							$active = true;
+
+							$remove_url = Helper::remove_query_arg( 'author' );
 						}
 
 						break;

--- a/projects/packages/search/src/classic-search/class-classic-search.php
+++ b/projects/packages/search/src/classic-search/class-classic-search.php
@@ -1309,7 +1309,7 @@ class Classic_Search {
 	/**
 	 * Given an individual author aggregation, add it to the query builder object for use in Elasticsearch.
 	 *
-	 * @since 5.0.0
+	 * @since $$next-version$$
 	 *
 	 * @param array                                        $aggregation The aggregation to add to the query builder.
 	 * @param string                                       $label       The 'label' (unique id) for this aggregation.
@@ -1590,7 +1590,7 @@ class Classic_Search {
 
 						break;
 
-					// The filter `author` is NOT supported in Classic Search. This is used to be compatible for filters in the Footer section with Instant Search.
+					// The `author` filter is NOT supported in Classic Search. This is used to keep the compatibility for filters outside the overlay with Instant Search.
 					case 'author':
 						$name = preg_split( '/\/(.+)/', $item['key'] )[0];
 

--- a/projects/packages/search/src/classic-search/class-classic-search.php
+++ b/projects/packages/search/src/classic-search/class-classic-search.php
@@ -1592,9 +1592,15 @@ class Classic_Search {
 
 					// The `author` filter is NOT supported in Classic Search. This is used to keep the compatibility for filters outside the overlay with Instant Search.
 					case 'author':
-						$name = preg_split( '/\/(.+)/', $item['key'] )[0];
+						$split_names = preg_split( '/\/(.?)/', $item['key'] );
 
-						if ( ! $name ) {
+						$name = '';
+
+						if ( false !== $split_names ) {
+							$name = $split_names[0];
+						}
+
+						if ( empty( $name ) ) {
 							continue 2;  // switch() is considered a looping structure.
 						}
 
@@ -1602,11 +1608,9 @@ class Classic_Search {
 							'author' => $name,
 						);
 
-						if ( ! empty( $name ) ) {
-							$active = true;
+						$active = true;
 
-							$remove_url = Helper::remove_query_arg( 'author' );
-						}
+						$remove_url = Helper::remove_query_arg( 'author' );
 
 						break;
 

--- a/projects/packages/search/src/instant-search/class-instant-search.php
+++ b/projects/packages/search/src/instant-search/class-instant-search.php
@@ -661,12 +661,6 @@ class Instant_Search extends Classic_Search {
 			);
 		}
 
-		$settings['filters'][] = array(
-			'name'  => '',
-			'type'  => 'author',
-			'count' => 5,
-		);
-
 		// Grab a maximum of 3 taxonomies.
 		$taxonomies = array_slice(
 			get_taxonomies(

--- a/projects/packages/search/src/instant-search/class-instant-search.php
+++ b/projects/packages/search/src/instant-search/class-instant-search.php
@@ -661,6 +661,12 @@ class Instant_Search extends Classic_Search {
 			);
 		}
 
+		$settings['filters'][] = array(
+			'name'  => '',
+			'type'  => 'author',
+			'count' => 5,
+		);
+
 		// Grab a maximum of 3 taxonomies.
 		$taxonomies = array_slice(
 			get_taxonomies(

--- a/projects/packages/search/src/instant-search/components/search-filter.jsx
+++ b/projects/packages/search/src/instant-search/components/search-filter.jsx
@@ -35,6 +35,8 @@ export default class SearchFilter extends Component {
 	getIdentifier() {
 		if ( this.props.type === 'postType' ) {
 			return 'post_types';
+		} else if ( this.props.type === 'author' ) {
+			return 'authors';
 		} else if ( this.props.type === 'date' ) {
 			// (month || year)_(post_date || post_date_gmt || post_modified || post_modified_gmt )
 			// Ex: month_post_date_gmt
@@ -110,6 +112,30 @@ export default class SearchFilter extends Component {
 		);
 	};
 
+	renderAuthor = ( { key, doc_count: count } ) => {
+		const [ slug, name ] = key && key.split( /\/(.+)/ );
+
+		return (
+			<div>
+				<input
+					checked={ this.isChecked( slug ) }
+					disabled={ ! this.isChecked( slug ) && count === 0 }
+					id={ `${ this.idPrefix }-authors-${ slug }` }
+					name={ slug }
+					onChange={ this.toggleFilter }
+					type="checkbox"
+					className="jetpack-instant-search__search-filter-list-input"
+				/>
+				<label
+					htmlFor={ `${ this.idPrefix }-authors-${ slug }` }
+					className="jetpack-instant-search__search-filter-list-label"
+				>
+					{ strip( name ) } ({ count })
+				</label>
+			</div>
+		);
+	};
+
 	renderTaxonomy = ( { key, doc_count: count } ) => {
 		// Taxonomy keys contain slug and name separated by a slash
 		const [ slug, name ] = key && key.split( /\/(.+)/ );
@@ -171,6 +197,10 @@ export default class SearchFilter extends Component {
 		return this.props.aggregation.buckets.map( this.renderPostType );
 	}
 
+	renderAuthors() {
+		return this.props.aggregation.buckets.map( this.renderAuthor );
+	}
+
 	renderTaxonomies() {
 		return this.props.aggregation.buckets.map( this.renderTaxonomy );
 	}
@@ -195,6 +225,7 @@ export default class SearchFilter extends Component {
 						<div className="jetpack-instant-search__search-filter-list">
 							{ this.props.type === 'date' && this.renderDates() }
 							{ this.props.type === 'postType' && this.renderPostTypes() }
+							{ this.props.type === 'author' && this.renderAuthors() }
 							{ this.props.type === 'taxonomy' && this.renderTaxonomies() }
 						</div>
 					) }

--- a/projects/packages/search/src/instant-search/lib/api.js
+++ b/projects/packages/search/src/instant-search/lib/api.js
@@ -86,6 +86,9 @@ function generateAggregation( filter ) {
 		case 'post_type': {
 			return { terms: { field: filter.type, size: filter.count } };
 		}
+		case 'author': {
+			return { terms: { field: 'author_login_slash_name', size: filter.count } };
+		}
 	}
 }
 
@@ -125,6 +128,9 @@ export function generateDateRangeFilter( fieldName, input, type ) {
 const filterKeyToEsFilter = new Map( [
 	// Post type
 	[ 'post_types', postType => ( { term: { post_type: postType } } ) ],
+
+	// Author
+	[ 'authors', author => ( { term: { author_login: author } } ) ],
 
 	// Built-in taxonomies
 	[ 'category', category => ( { term: { 'category.slug': category } } ) ],

--- a/projects/packages/search/src/instant-search/lib/filters.js
+++ b/projects/packages/search/src/instant-search/lib/filters.js
@@ -3,6 +3,8 @@ import { SERVER_OBJECT_NAME } from './constants';
 // NOTE: This list is missing custom taxonomy names.
 //       getFilterKeys must be used to get the conclusive list of valid filter keys.
 export const FILTER_KEYS = Object.freeze( [
+	// Authors
+	'authors',
 	// Post types
 	'post_types',
 	// Built-in taxonomies
@@ -119,6 +121,8 @@ export function mapFilterToFilterKey( filter ) {
 		return `${ filter.taxonomy }`;
 	} else if ( filter.type === 'post_type' ) {
 		return 'post_types';
+	} else if ( filter.type === 'author' ) {
+		return 'authors';
 	} else if ( filter.type === 'group' ) {
 		return filter.filter_id;
 	}
@@ -149,6 +153,10 @@ export function mapFilterKeyToFilter( filterKey ) {
 		return {
 			type: 'post_type',
 		};
+	} else if ( filterKey === 'authors' ) {
+		return {
+			type: 'author',
+		};
 	} else if ( filterKey === 'group' ) {
 		return {
 			type: 'group',
@@ -174,6 +182,8 @@ export function mapFilterToType( filter ) {
 		return 'taxonomy';
 	} else if ( filter.type === 'post_type' ) {
 		return 'postType';
+	} else if ( filter.type === 'author' ) {
+		return 'author';
 	} else if ( filter.type === 'group' ) {
 		return 'group';
 	}

--- a/projects/packages/search/src/instant-search/lib/test/filters.test.js
+++ b/projects/packages/search/src/instant-search/lib/test/filters.test.js
@@ -22,9 +22,11 @@ describe( 'getFilterKeys', () => {
 			{ filters: [ { type: 'taxonomy', taxonomy: 'subject' } ] },
 			{ filters: [ { type: 'date_histogram', field: 'post_date', interval: 'year' } ] },
 			{ filters: [ { type: 'post_type' } ] },
+			{ filters: [ { type: 'author' } ] },
 		];
 		const widgetsOutsideOverlay = [ { filters: [ { type: 'taxonomy', taxonomy: 'post_tag' } ] } ];
 		expect( getFilterKeys( widgets, widgetsOutsideOverlay ) ).toEqual( [
+			'authors',
 			'post_types',
 			'category',
 			'post_format',
@@ -52,11 +54,13 @@ describe( 'getSelectableFilterKeys', () => {
 			{ filters: [ { type: 'taxonomy', taxonomy: 'category' } ] },
 			{ filters: [ { type: 'date_histogram', field: 'post_date', interval: 'year' } ] },
 			{ filters: [ { type: 'post_type' } ] },
+			{ filters: [ { type: 'author' } ] },
 		];
 		expect( getSelectableFilterKeys( widgets ) ).toEqual( [
 			'category',
 			'year_post_date',
 			'post_types',
+			'authors',
 		] );
 	} );
 } );
@@ -75,6 +79,7 @@ describe( 'getUnselectableFilterKeys', () => {
 			{ filters: [ { type: 'taxonomy', taxonomy: 'post_tag' } ] },
 			{ filters: [ { type: 'date_histogram', field: 'post_date', interval: 'year' } ] },
 			{ filters: [ { type: 'post_type' } ] },
+			{ filters: [ { type: 'author' } ] },
 		];
 		expect( getUnselectableFilterKeys( widgets ) ).toEqual( [
 			'category',
@@ -138,6 +143,11 @@ describe( 'mapFilterKeyToFilter', () => {
 	test( 'handles post types filter key', () => {
 		expect( mapFilterKeyToFilter( 'post_types' ) ).toEqual( {
 			type: 'post_type',
+		} );
+	} );
+	test( 'handles author filter key', () => {
+		expect( mapFilterKeyToFilter( 'authors' ) ).toEqual( {
+			type: 'author',
 		} );
 	} );
 	test( 'handles taxonomies-related filter keys', () => {

--- a/projects/packages/search/src/widgets/class-search-widget.php
+++ b/projects/packages/search/src/widgets/class-search-widget.php
@@ -661,6 +661,13 @@ class Search_Widget extends \WP_Widget {
 							'count' => $count,
 						);
 						break;
+					case 'author':
+						$filters[] = array(
+							'name'  => sanitize_text_field( $new_instance['filter_name'][ $index ] ),
+							'type'  => 'author',
+							'count' => $count,
+						);
+						break;
 					case 'date_histogram':
 						$filters[] = array(
 							'name'     => sanitize_text_field( $new_instance['filter_name'][ $index ] ),
@@ -950,6 +957,9 @@ class Search_Widget extends \WP_Widget {
 						</option>
 						<option value="post_type" <?php $this->render_widget_option_selected( 'type', $args['type'], 'post_type', $is_template ); ?>>
 							<?php esc_html_e( 'Post Type', 'jetpack-search-pkg' ); ?>
+						</option>
+						<option value="author" <?php $this->render_widget_option_selected( 'type', $args['type'], 'author', $is_template ); ?>>
+							<?php esc_html_e( 'Author', 'jetpack-search-pkg' ); ?>
 						</option>
 						<option value="date_histogram" <?php $this->render_widget_option_selected( 'type', $args['type'], 'date_histogram', $is_template ); ?>>
 							<?php esc_html_e( 'Date', 'jetpack-search-pkg' ); ?>

--- a/projects/packages/search/src/widgets/class-search-widget.php
+++ b/projects/packages/search/src/widgets/class-search-widget.php
@@ -870,7 +870,7 @@ class Search_Widget extends \WP_Widget {
 			<?php if ( ! Helper::are_filters_by_widget_disabled() ) : ?>
 				<div class="jetpack-search-filters-widget__filters">
 					<?php foreach ( (array) $instance['filters'] as $filter ) : ?>
-						<?php $this->render_widget_edit_filter( $filter ); ?>
+						<?php $this->render_widget_edit_filter( $filter, false, true ); ?>
 					<?php endforeach; ?>
 				</div>
 				<p class="jetpack-search-filters-widget__add-filter-wrapper">
@@ -879,7 +879,7 @@ class Search_Widget extends \WP_Widget {
 					</a>
 				</p>
 				<script class="jetpack-search-filters-widget__filter-template" type="text/template">
-					<?php $this->render_widget_edit_filter( array(), true ); ?>
+					<?php $this->render_widget_edit_filter( array(), true, true ); ?>
 				</script>
 				<noscript>
 					<p class="jetpack-search-filters-help">
@@ -928,9 +928,10 @@ class Search_Widget extends \WP_Widget {
 	 *
 	 * @param array $filter      The filter to render.
 	 * @param bool  $is_template Whether this is for an Underscore template or not.
+	 * @param bool  $is_instant_search Whether this site enables Instant Search or not.
 	 * @since 5.7.0
 	 */
-	public function render_widget_edit_filter( $filter, $is_template = false ) {
+	public function render_widget_edit_filter( $filter, $is_template = false, $is_instant_search = false ) {
 		$args = wp_parse_args(
 			$filter,
 			array(
@@ -946,7 +947,9 @@ class Search_Widget extends \WP_Widget {
 
 		$args['name_placeholder'] = Helper::generate_widget_filter_name( $args );
 
-		?>
+		// Hide filter author set from Instant Search widget for Classic Search widget
+		if ( $is_instant_search || 'author' !== $args['type'] ) :
+			?>
 		<div class="jetpack-search-filters-widget__filter is-<?php $this->render_widget_attr( 'type', $args['type'], $is_template ); ?>">
 			<p class="jetpack-search-filters-widget__type-select">
 				<label>
@@ -958,9 +961,11 @@ class Search_Widget extends \WP_Widget {
 						<option value="post_type" <?php $this->render_widget_option_selected( 'type', $args['type'], 'post_type', $is_template ); ?>>
 							<?php esc_html_e( 'Post Type', 'jetpack-search-pkg' ); ?>
 						</option>
+						<?php if ( $is_instant_search ) : ?>
 						<option value="author" <?php $this->render_widget_option_selected( 'type', $args['type'], 'author', $is_template ); ?>>
 							<?php esc_html_e( 'Author', 'jetpack-search-pkg' ); ?>
 						</option>
+						<?php endif; ?>
 						<option value="date_histogram" <?php $this->render_widget_option_selected( 'type', $args['type'], 'date_histogram', $is_template ); ?>>
 							<?php esc_html_e( 'Date', 'jetpack-search-pkg' ); ?>
 						</option>
@@ -1062,7 +1067,8 @@ class Search_Widget extends \WP_Widget {
 				<a href="#" class="delete"><?php esc_html_e( 'Remove', 'jetpack-search-pkg' ); ?></a>
 			</p>
 		</div>
-		<?php
+			<?php
+		endif;
 	}
 
 	/**

--- a/projects/packages/search/src/widgets/class-search-widget.php
+++ b/projects/packages/search/src/widgets/class-search-widget.php
@@ -947,7 +947,7 @@ class Search_Widget extends \WP_Widget {
 
 		$args['name_placeholder'] = Helper::generate_widget_filter_name( $args );
 
-		// Hide filter author set from Instant Search widget for Classic Search widget
+		// Hide author filter when Instant Search is turned off.
 		if ( $is_instant_search || 'author' !== $args['type'] ) :
 			?>
 		<div class="jetpack-search-filters-widget__filter is-<?php $this->render_widget_attr( 'type', $args['type'], $is_template ); ?>">

--- a/projects/packages/search/src/widgets/class-search-widget.php
+++ b/projects/packages/search/src/widgets/class-search-widget.php
@@ -948,8 +948,10 @@ class Search_Widget extends \WP_Widget {
 		$args['name_placeholder'] = Helper::generate_widget_filter_name( $args );
 
 		// Hide author filter when Instant Search is turned off.
-		if ( $is_instant_search || 'author' !== $args['type'] ) :
-			?>
+		if ( ! $is_instant_search && 'author' === $args['type'] ) :
+			return;
+		endif;
+		?>
 		<div class="jetpack-search-filters-widget__filter is-<?php $this->render_widget_attr( 'type', $args['type'], $is_template ); ?>">
 			<p class="jetpack-search-filters-widget__type-select">
 				<label>
@@ -1068,7 +1070,6 @@ class Search_Widget extends \WP_Widget {
 			</p>
 		</div>
 			<?php
-		endif;
 	}
 
 	/**

--- a/projects/packages/search/src/widgets/css/search-widget-admin-ui.css
+++ b/projects/packages/search/src/widgets/css/search-widget-admin-ui.css
@@ -47,6 +47,11 @@
 	display: none;
 }
 
+/* When author type is selected, remove the other controls */
+.jetpack-search-filters-widget__filter.is-author .jetpack-search-filters-widget__taxonomy-select {
+	display: none;
+}
+
 /* When date is selected, remove the other controls */
 .jetpack-search-filters-widget__filter.is-date_histogram .jetpack-search-filters-widget__date-histogram-select {
 	display: inline;

--- a/projects/plugins/jetpack/changelog/add-author_filtering
+++ b/projects/plugins/jetpack/changelog/add-author_filtering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/add-author_filtering#2
+++ b/projects/plugins/jetpack/changelog/add-author_filtering#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -37,7 +37,7 @@
 		"automattic/jetpack-publicize": "0.11.x-dev",
 		"automattic/jetpack-redirect": "1.7.x-dev",
 		"automattic/jetpack-roles": "1.4.x-dev",
-		"automattic/jetpack-search": "0.19.x-dev",
+		"automattic/jetpack-search": "0.20.x-dev",
 		"automattic/jetpack-status": "1.14.x-dev",
 		"automattic/jetpack-sync": "1.37.x-dev",
 		"automattic/jetpack-videopress": "0.2.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c852a0c045e6d1e76598b1463e641d10",
+    "content-hash": "ec5e424bd04b2293241da07b219524b8",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b5929adfeae1419a2e4487e743025ae1",
+    "content-hash": "c852a0c045e6d1e76598b1463e641d10",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1638,7 +1638,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "dce2ca66e301a94854e5eabb3e5b5fd57a512650"
+                "reference": "80452a5f3fdd3e20ee9a4d36849734f45812356a"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -1662,7 +1662,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.19.x-dev"
+                    "dev-trunk": "0.20.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"

--- a/projects/plugins/search/changelog/add-author_filtering
+++ b/projects/plugins/search/changelog/add-author_filtering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/search/changelog/add-author_filtering#2
+++ b/projects/plugins/search/changelog/add-author_filtering#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -9,7 +9,7 @@
 		"automattic/jetpack-config": "1.9.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
 		"automattic/jetpack-my-jetpack": "2.0.x-dev",
-		"automattic/jetpack-search": "0.19.x-dev",
+		"automattic/jetpack-search": "0.20.x-dev",
 		"automattic/jetpack-status": "^1.14",
 		"automattic/jetpack-sync": "1.37.x-dev"
 	},

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e68f2bf5e040956a4ba69434065a5cff",
+    "content-hash": "75773c962ac0e751c42beaa6a21c48e7",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -903,7 +903,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "dce2ca66e301a94854e5eabb3e5b5fd57a512650"
+                "reference": "80452a5f3fdd3e20ee9a4d36849734f45812356a"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -927,7 +927,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.19.x-dev"
+                    "dev-trunk": "0.20.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The changes for author filtering have affected several scopes of Jetpack Search as follows:
* Add filter author to Jetpack Search widget
* Update API client to support field `author_login_slash_name` and key `author_login` for searching
* Display author filters on Jetpack Search overlay

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

pcNPJE-12t-p2

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

1. Please follow instructions in `D85365-code` for API sandbox server updates
2. Visit the local self-hosted site
3. Go to the widgets setting page `/wp-admin/widgets.php` and add the author filter
<img width="2389" alt="w" src="https://user-images.githubusercontent.com/6869813/183438359-0398d983-1f69-4cdc-b7b5-0bb9300f9638.png">

4. Go to the search result page with query parameter `?s=` which has results to display their authors
5. Check if authors of search results are displayed as filters

|  Before   | After  |
|  ----  | ----  |
| <img width="2363" alt="before" src="https://user-images.githubusercontent.com/6869813/183370823-ffdaadef-97d4-4d5f-818b-5a3b65c7027e.png"> | <img width="2359" alt="after" src="https://user-images.githubusercontent.com/6869813/183371158-886fa4d6-075b-467b-a04a-05b1143d45ae.png"> |


