### PR TITLE
Add: Support for honoring DNT in Google Analytics

### DIFF
--- a/projects/plugins/jetpack/changelog/add-google-analytics-honor-dnt
+++ b/projects/plugins/jetpack/changelog/add-google-analytics-honor-dnt
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Added support for the Google Analytics feature to honor the DNT sent by the browser. It is enabled by filtering `jetpack_honor_dnt_header_for_wga` to true.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -135,6 +135,7 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint extends WPCOM_JSON_API_Site_Set
 		return array(
 			'code'                          => '',
 			'anonymize_ip'                  => false,
+			'honor_dnt'                     => false,
 			'ec_track_purchases'            => false,
 			'ec_track_add_to_cart'          => false,
 			'enh_ec_tracking'               => false,

--- a/projects/plugins/jetpack/modules/google-analytics/classes/class-jetpack-google-amp-analytics.php
+++ b/projects/plugins/jetpack/modules/google-analytics/classes/class-jetpack-google-amp-analytics.php
@@ -25,7 +25,7 @@ class Jetpack_Google_AMP_Analytics {
 
 	/**
 	 * Maybe load the hooks.
-	 * Checks if its AMP request, if WooCommerce is available, if DNT is disabled, if there's tracking code and in tracking is enabled.
+	 * Checks if its AMP request, if WooCommerce is available, if DNT is disabled, if there's tracking code and if tracking is enabled.
 	 */
 	public function maybe_load_hooks() {
 		if ( ! class_exists( 'Jetpack_AMP_Support' ) || ! Jetpack_AMP_Support::is_amp_request() ) {

--- a/projects/plugins/jetpack/modules/google-analytics/classes/class-jetpack-google-amp-analytics.php
+++ b/projects/plugins/jetpack/modules/google-analytics/classes/class-jetpack-google-amp-analytics.php
@@ -25,7 +25,7 @@ class Jetpack_Google_AMP_Analytics {
 
 	/**
 	 * Maybe load the hooks.
-	 * Checks if its AMP request, if WooCommerce is available, if there's tracking code and in tracking is enabled.
+	 * Checks if its AMP request, if WooCommerce is available, if DNT is disabled, if there's tracking code and in tracking is enabled.
 	 */
 	public function maybe_load_hooks() {
 		if ( ! class_exists( 'Jetpack_AMP_Support' ) || ! Jetpack_AMP_Support::is_amp_request() ) {
@@ -37,6 +37,10 @@ class Jetpack_Google_AMP_Analytics {
 		}
 
 		if ( ! Jetpack_Google_Analytics_Options::has_tracking_code() ) {
+			return;
+		}
+
+		if ( Jetpack_Google_Analytics_Utils::is_dnt_enabled() ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -70,8 +70,11 @@ class Jetpack_Google_Analytics_Legacy {
 			return;
 		}
 
-		// If we're in the admin_area, return without inserting code.
-		if ( is_admin() ) {
+		// If we're in the admin_area or DNT is honored and enabled, return without inserting code.
+		if (
+			is_admin()
+			|| Jetpack_Google_Analytics_Utils::is_dnt_enabled()
+		) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-options.php
+++ b/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-options.php
@@ -57,6 +57,15 @@ class Jetpack_Google_Analytics_Options {
 	}
 
 	/**
+	 * Get the 'honor_dnt' option used by both legacy and universal analytics.
+	 *
+	 * @return bool
+	 */
+	public static function honor_dnt_is_enabled() {
+		return (bool) self::get_option( 'honor_dnt' );
+	}
+
+	/**
 	 * Get the 'ec_track_purchases' eCommerce option used by both legacy and universal analytics
 	 *
 	 * @return bool

--- a/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-options.php
+++ b/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-options.php
@@ -62,7 +62,7 @@ class Jetpack_Google_Analytics_Options {
 	 * @return bool
 	 */
 	public static function honor_dnt_is_enabled() {
-		return (bool) self::get_option( 'honor_dnt' );
+		return (bool) static::get_option( 'honor_dnt' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-universal.php
+++ b/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-universal.php
@@ -52,8 +52,11 @@ class Jetpack_Google_Analytics_Universal {
 			return;
 		}
 
-		// If we're in the admin_area, return without inserting code.
-		if ( is_admin() ) {
+		// If we're in the admin_area or DNT is honored and enabled, return without inserting code.
+		if (
+			is_admin()
+			|| Jetpack_Google_Analytics_Utils::is_dnt_enabled()
+		) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-utils.php
+++ b/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-utils.php
@@ -75,7 +75,7 @@ class Jetpack_Google_Analytics_Utils {
 		 * Filter the option which decides honor DNT or not.
 		 *
 		 * @module google-analytics
-		 * @since $next-version$
+		 * @since $$next-version$$
 		 *
 		 * @param bool $honor_dnt Honors DNT for clients who don't want to be tracked. Set to true to enable.
 		 */

--- a/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-utils.php
+++ b/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-utils.php
@@ -64,4 +64,31 @@ class Jetpack_Google_Analytics_Utils {
 
 		return $product->get_sku() ? $product->get_sku() : '#' . $product->get_id();
 	}
+
+	/**
+	 * Checks if filter is set and dnt is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_dnt_enabled() {
+		/**
+		 * Filter the option which decides honor DNT or not.
+		 *
+		 * @module google-analytics
+		 * @since $next-version$
+		 *
+		 * @param bool $honor_dnt Honors DNT for clients who don't want to be tracked. Set to true to enable.
+		 */
+		if ( false === apply_filters( 'jetpack_honor_dnt_header_for_wga', Jetpack_Google_Analytics_Options::honor_dnt_is_enabled() ) ) {
+			return false;
+		}
+
+		foreach ( $_SERVER as $name => $value ) {
+			if ( 'http_dnt' === strtolower( $name ) && 1 === (int) $value ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/google-analytics/test-class.google-analytics.php
+++ b/projects/plugins/jetpack/tests/php/modules/google-analytics/test-class.google-analytics.php
@@ -163,4 +163,60 @@ class WP_Test_Jetpack_Google_Analytics extends WP_UnitTestCase {
 			$actual
 		);
 	}
+
+	/**
+	 * Verify functionality of DNT header handling.
+	 */
+	public function test_is_dnt_enabled() {
+		$func_return_true      = function () {
+			return true;
+		};
+		$func_return_false     = function () {
+			return false;
+		};
+		$func_enable_honor_dnt = function ( $option ) {
+			$option['honor_dnt'] = true;
+			return $option;
+		};
+
+		// Test defaults
+		unset( $_SERVER['HTTP_DNT'] );
+		$this->assertFalse( Jetpack_Google_Analytics_Utils::is_dnt_enabled() );
+		$_SERVER['HTTP_DNT'] = 0;
+		$this->assertFalse( Jetpack_Google_Analytics_Utils::is_dnt_enabled() );
+		$_SERVER['HTTP_DNT'] = 1;
+		$this->assertFalse( Jetpack_Google_Analytics_Utils::is_dnt_enabled() );
+
+		// Test ignore DNT header.
+		add_filter( 'jetpack_honor_dnt_header_for_wga', $func_return_false );
+		unset( $_SERVER['HTTP_DNT'] );
+		$this->assertFalse( Jetpack_Google_Analytics_Utils::is_dnt_enabled() );
+		$_SERVER['HTTP_DNT'] = 0;
+		$this->assertFalse( Jetpack_Google_Analytics_Utils::is_dnt_enabled() );
+		$_SERVER['HTTP_DNT'] = 1;
+		$this->assertFalse( Jetpack_Google_Analytics_Utils::is_dnt_enabled() );
+		remove_filter( 'jetpack_honor_dnt_header_for_wga', $func_return_false );
+
+		// Test honor DNT header.
+		add_filter( 'jetpack_honor_dnt_header_for_wga', $func_return_true );
+		unset( $_SERVER['HTTP_DNT'] );
+		$this->assertFalse( Jetpack_Google_Analytics_Utils::is_dnt_enabled() );
+		$_SERVER['HTTP_DNT'] = 0;
+		$this->assertFalse( Jetpack_Google_Analytics_Utils::is_dnt_enabled() );
+		$_SERVER['HTTP_DNT'] = 1;
+		$this->assertTrue( Jetpack_Google_Analytics_Utils::is_dnt_enabled() );
+		remove_filter( 'jetpack_honor_dnt_header_for_wga', $func_return_true );
+
+		// Test filter overrides option.
+		add_filter( 'pre_option_jetpack_wga', $func_enable_honor_dnt );
+		add_filter( 'jetpack_honor_dnt_header_for_wga', $func_return_false );
+		unset( $_SERVER['HTTP_DNT'] );
+		$this->assertFalse( Jetpack_Google_Analytics_Utils::is_dnt_enabled() );
+		$_SERVER['HTTP_DNT'] = 0;
+		$this->assertFalse( Jetpack_Google_Analytics_Utils::is_dnt_enabled() );
+		$_SERVER['HTTP_DNT'] = 1;
+		$this->assertFalse( Jetpack_Google_Analytics_Utils::is_dnt_enabled() );
+		remove_filter( 'jetpack_honor_dnt_header_for_wga', $func_return_false );
+		remove_filter( 'pre_option_jetpack_wga', $func_enable_honor_dnt );
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Implement support for the Google Analytics feature to honor the DNT header sent by browsers as outlined in #17176. To enable support for honoring the DNT header, filter `jetpack_honor_dnt_header_for_wga` to `true`.

The changes will affect the following:
* Jetpack

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
* TODO

#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:
1. Disable any plugins or theme features that add a Google Analytics tracking code.
2. Activate and fully connect Jetpack.
3. Activate the Google Analytics feature (this may require upgrading your Jetpack plan).
4. Go to Tools > Marketing, scroll to the Google section, and enable the "Add Google" toggle.
5. Enter a valid value in the "Google Analytics Measurement ID" input and save the Google settings.
6. Add the following code to the bottom of the `projects/plugins/jetpack/jetpack.php` file:
```
add_filter( 'jetpack_honor_dnt_header_for_wga', function() { return true; } );
```
7. Ensure that the browser you are testing with has DNT disabled. Instructions for controlling DNT: [Chrome](https://support.google.com/chrome/answer/2790761), [Firefox](https://support.mozilla.org/en-US/kb/how-do-i-turn-do-not-track-feature), [Safari](https://appletoolbox.com/safari-do-not-track-settings/), [Edge](https://aboutdevice.com/enable-or-disable-do-not-track-dnt-on-microsoft-edge-browser/). You can verify if DNT is enabled or disabled in your browser by visiting [this site](https://allaboutdnt.com/) and looking at the top-right of the page. It will either say "Do Not Track is ON" or "You are being tracked". Note: If you have any privacy or ad-blocking add-ons/extensions installed on your browser, these may also modify DNT. If you run into any testing issues, first confirm that you disable anything that may add or remove the DNT header regardless of the browser setting.
8. Visit the home page of your testing site, view the page source, and confirm that the Google Analytics tracking code is present. You should see output similar to the following before the `</head>` tag:
```
<!-- Jetpack Google Analytics -->
<script async src='[https://www.googletagmanager.com/gtag/js?id=G-123](view-source:https://www.googletagmanager.com/gtag/js?id=G-123)'></script>
<script>
	window.dataLayer = window.dataLayer || [];
	function gtag() { dataLayer.push( arguments ); }
	gtag( 'js', new Date() );
	gtag( 'config', "G-123" );
			</script>
<!-- End Jetpack Google Analytics -->
```
9. Ensure that the browser you are testing with has DNT enabled.
10. Visit the home page of your testing site, view the page source, and confirm that the Google Analytics tracking code is no longer present.