### PR TITLE
Dashboard: fix <DashScan> child key warning

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/scan.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/scan.jsx
@@ -55,7 +55,7 @@ const renderCard = props => (
 		overrideContent={ props.overrideContent }
 	>
 		{ isArray( props.content ) ? (
-			props.content
+			props.content.map( ( el, i ) => <React.Fragment key={ i }>{ el }</React.Fragment> )
 		) : (
 			<p className="jp-dash-item__description">{ props.content }</p>
 		) }

--- a/projects/plugins/jetpack/changelog/update-dashscan-use-child-keys
+++ b/projects/plugins/jetpack/changelog/update-dashscan-use-child-keys
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: DashScan Component: fix child key warning
+
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Cleaning up some console noise by fixing a `Warning: Each child in a list should have a unique "key" prop.` from the `<DashScan>` component used on the JP Dashboard.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

n/a

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

- Before patching, while viewing the JP Dashboard verify you see the warning in web console: `Warning: Each child in a list should have a unique "key" prop. Check the render method of 'DashScan'`
- After patching/building, open the same page and make sure the warning is no more.
- Make sure the design remains the same.
