### PR TITLE
Dashboard: fix a propType warning for <DashAkismet>

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/akismet.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/akismet.jsx
@@ -26,7 +26,8 @@ class DashAkismet extends Component {
 		trackUpgradeButtonView: PropTypes.func,
 
 		// Connected props
-		akismetData: PropTypes.oneOfType( [ PropTypes.string, PropTypes.object ] ).isRequired,
+		akismetData: PropTypes.oneOfType( [ PropTypes.string, PropTypes.object, PropTypes.number ] )
+			.isRequired,
 		isOfflineMode: PropTypes.bool.isRequired,
 		upgradeUrl: PropTypes.string.isRequired,
 		hasConnectedOwner: PropTypes.bool.isRequired,

--- a/projects/plugins/jetpack/changelog/2022-08-09-20-42-16-586706
+++ b/projects/plugins/jetpack/changelog/2022-08-09-20-42-16-586706
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix propType warning for DashAkismet
+
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Cleaning up some console noise by fixing a propType warning for `<DashAkismet>` used on the JP Dashboard. Prop `akismetData` may return an integer when fetched.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

n/a

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

Not much to test here, just cleaning up a console warning.