### PR TITLE
Protect: Formalize status, extension, and threat data with model classes

### DIFF
--- a/projects/plugins/debug-helper/changelog/add-protect-model-classes
+++ b/projects/plugins/debug-helper/changelog/add-protect-model-classes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed sample vulnerability output type.

--- a/projects/plugins/debug-helper/modules/class-protect-helper.php
+++ b/projects/plugins/debug-helper/modules/class-protect-helper.php
@@ -303,7 +303,7 @@ class Protect_Helper {
 		);
 		for ( $i = 1; $i <= $how_many; $i++ ) {
 			$id     = $current_index < count( $ids ) ? $ids[ $current_index ] : $this->get_random_id();
-			$vuls[] = array(
+			$vuls[] = (object) array(
 				'id'          => $id,
 				'title'       => 'Sample Vulnerability number ' . $i . ' with a long title',
 				'description' => 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Phasellus hendrerit. 

--- a/projects/plugins/protect/changelog/add-protect-model-classes
+++ b/projects/plugins/protect/changelog/add-protect-model-classes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added data model classes for the status report and its related threats and extension data.

--- a/projects/plugins/protect/src/class-status.php
+++ b/projects/plugins/protect/src/class-status.php
@@ -426,13 +426,8 @@ class Status {
 
 		if ( isset( $core_check->version ) && $core_check->version === $wp_version ) {
 			if ( is_array( $core_check->vulnerabilities ) ) {
-				$core->checked         = true;
-				$core->vulnerabilities = array_map(
-					function ( $vulnerability ) {
-						return new Threat_Model( $vulnerability );
-					},
-					$core_check->vulnerabilities
-				);
+				$core->checked = true;
+				$core->set_vulnerabilities( $core_check->vulnerabilities );
 			}
 		}
 

--- a/projects/plugins/protect/src/class-status.php
+++ b/projects/plugins/protect/src/class-status.php
@@ -57,14 +57,14 @@ class Status {
 	/**
 	 * Memoization for the current status
 	 *
-	 * @var null|array
+	 * @var null|Status_Model
 	 */
 	public static $status = null;
 
 	/**
 	 * Gets the current status of the Jetpack Protect checks
 	 *
-	 * @return array
+	 * @return Status_Model
 	 */
 	public static function get_status() {
 		if ( self::$status !== null ) {
@@ -78,13 +78,15 @@ class Status {
 		}
 
 		if ( is_wp_error( $status ) ) {
-			$status = array(
-				'error'         => true,
-				'error_code'    => $status->get_error_code(),
-				'error_message' => $status->get_error_message(),
+			$status = new Status_Model(
+				array(
+					'error'         => true,
+					'error_code'    => $status->get_error_code(),
+					'error_message' => $status->get_error_message(),
+				)
 			);
 		} else {
-			$status = self::normalize_report_data( $status );
+			$status = self::load_data_from_protect_report( $status );
 		}
 
 		self::$status = $status;
@@ -294,33 +296,45 @@ class Status {
 	}
 
 	/**
-	 * Prepare the report data for the UI
+	 * Normalize data from the Protect Report data source.
 	 *
-	 * @param string $report_data The report status report response.
-	 * @return object The normalized report data.
+	 * @param object $report_data Data from the Protect Report.
+	 * @return Status_Model
 	 */
-	private static function normalize_report_data( $report_data ) {
-		$installed_plugins    = Plugins_Installer::get_plugins();
-		$last_report_plugins  = isset( $report_data->plugins ) ? $report_data->plugins : new \stdClass();
-		$report_data->plugins = self::merge_installed_and_checked_lists( $installed_plugins, $last_report_plugins, array( 'type' => 'plugin' ) );
+	private static function load_data_from_protect_report( $report_data ) {
+		$status = new Status_Model();
 
-		$installed_themes    = Sync_Functions::get_themes();
-		$last_report_themes  = isset( $report_data->themes ) ? $report_data->themes : new \stdClass();
-		$report_data->themes = self::merge_installed_and_checked_lists( $installed_themes, $last_report_themes, array( 'type' => 'theme' ) );
+		// map report data properties directly into the Status_Model
+		$status->status                      = isset( $report_data->status ) ? $report_data->status : null;
+		$status->last_checked                = isset( $report_data->last_checked ) ? $report_data->last_checked : null;
+		$status->num_vulnerabilities         = isset( $report_data->num_vulnerabilities ) ? $report_data->num_vulnerabilities : null;
+		$status->num_themes_vulnerabilities  = isset( $report_data->num_themes_vulnerabilities ) ? $report_data->num_themes_vulnerabilities : null;
+		$status->num_plugins_vulnerabilities = isset( $report_data->num_plugins_vulnerabilities ) ? $report_data->num_plugins_vulnerabilities : null;
 
-		$report_data->core = self::normalize_core_information( isset( $report_data->core ) ? $report_data->core : new \stdClass() );
+		// merge plugins from report with all installed plugins before mapping into the Status_Model
+		$installed_plugins   = Plugins_Installer::get_plugins();
+		$last_report_plugins = isset( $report_data->plugins ) ? $report_data->plugins : new \stdClass();
+		$status->plugins     = self::merge_installed_and_checked_lists( $installed_plugins, $last_report_plugins, array( 'type' => 'plugins' ) );
 
-		$all_items       = array_merge( $report_data->plugins, $report_data->themes, array( $report_data->core ) );
-		$unchecked_items = array_filter(
+		// merge themes from report with all installed plugins before mapping into the Status_Model
+		$installed_themes   = Sync_Functions::get_themes();
+		$last_report_themes = isset( $report_data->themes ) ? $report_data->themes : new \stdClass();
+		$status->themes     = self::merge_installed_and_checked_lists( $installed_themes, $last_report_themes, array( 'type' => 'themes' ) );
+
+		// normalize WordPress core report data and map into Status_Model
+		$status->core = self::normalize_core_information( isset( $report_data->core ) ? $report_data->core : new \stdClass() );
+
+		// check if any installed items (themes, plugins, or core) have not been checked in the report
+		$all_items                   = array_merge( $status->plugins, $status->themes, array( $report_data->core ) );
+		$unchecked_items             = array_filter(
 			$all_items,
 			function ( $item ) {
 				return ! isset( $item->checked ) || ! $item->checked;
 			}
 		);
-		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-		$report_data->hasUncheckedItems = ! empty( $unchecked_items );
+		$status->has_unchecked_items = ! empty( $unchecked_items );
 
-		return $report_data;
+		return $status;
 	}
 
 	/**
@@ -333,20 +347,10 @@ class Status {
 	 */
 	private static function merge_installed_and_checked_lists( $installed, $checked, $append ) {
 		$new_list = array();
-		foreach ( $installed as $slug => $item ) {
-			if ( isset( $checked->{ $slug } ) && $checked->{ $slug }->version === $installed[ $slug ]['Version'] ) {
-				$new_list[] = (object) array_merge(
-					array(
-						'name'            => $installed[ $slug ]['Name'],
-						'version'         => $checked->{ $slug }->version,
-						'slug'            => $slug,
-						'vulnerabilities' => $checked->{ $slug }->vulnerabilities,
-						'checked'         => true,
-					),
-					$append
-				);
-			} else {
-				$new_list[] = (object) array_merge(
+		foreach ( array_keys( $installed ) as $slug ) {
+
+			$extension = new Extension_Model(
+				array_merge(
 					array(
 						'name'            => $installed[ $slug ]['Name'],
 						'version'         => $installed[ $slug ]['Version'],
@@ -355,8 +359,28 @@ class Status {
 						'checked'         => false,
 					),
 					$append
-				);
+				)
+			);
+
+			if ( isset( $checked->{ $slug } ) && $checked->{ $slug }->version === $installed[ $slug ]['Version'] ) {
+				$extension->version = $checked->{ $slug }->version;
+				$extension->checked = true;
+				if ( is_array( $checked->{ $slug }->vulnerabilities ) ) {
+					foreach ( $checked->{ $slug }->vulnerabilities as $vulnerability ) {
+						$extension->vulnerabilities[] = new Threat_Model(
+							array(
+								'id'          => $vulnerability->id,
+								'title'       => $vulnerability->title,
+								'fixed_in'    => $vulnerability->fixed_in,
+								'description' => isset( $vulnerability->description ) ? $vulnerability->description : null,
+							)
+						);
+					}
+				}
 			}
+
+			$new_list[] = $extension;
+
 		}
 		usort(
 			$new_list,
@@ -391,18 +415,27 @@ class Status {
 	private static function normalize_core_information( $core_check ) {
 		global $wp_version;
 
-		$core = new \stdClass();
+		$core = new Extension_Model(
+			array(
+				'type'    => 'core',
+				'name'    => 'WordPress',
+				'version' => $wp_version,
+				'checked' => false,
+			)
+		);
+
 		if ( isset( $core_check->version ) && $core_check->version === $wp_version ) {
-			$core       = $core_check;
-			$core->name = 'WordPress';
-			$core->type = 'core';
-		} else {
-			$core->version         = $wp_version;
-			$core->vulnerabilities = array();
-			$core->checked         = false;
-			$core->name            = 'WordPress';
-			$core->type            = 'core';
+			if ( is_array( $core_check->vulnerabilities ) ) {
+				$core->checked         = true;
+				$core->vulnerabilities = array_map(
+					function ( $vulnerability ) {
+						return new Threat_Model( $vulnerability );
+					},
+					$core_check->vulnerabilities
+				);
+			}
 		}
+
 		return $core;
 	}
 

--- a/projects/plugins/protect/src/class-status.php
+++ b/projects/plugins/protect/src/class-status.php
@@ -325,7 +325,7 @@ class Status {
 		$status->core = self::normalize_core_information( isset( $report_data->core ) ? $report_data->core : new \stdClass() );
 
 		// check if any installed items (themes, plugins, or core) have not been checked in the report
-		$all_items                   = array_merge( $status->plugins, $status->themes, array( $report_data->core ) );
+		$all_items                   = array_merge( $status->plugins, $status->themes, array( $status->core ) );
 		$unchecked_items             = array_filter(
 			$all_items,
 			function ( $item ) {

--- a/projects/plugins/protect/src/models/class-extension-model.php
+++ b/projects/plugins/protect/src/models/class-extension-model.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Model class for extensions.
+ *
+ * @package automattic/jetpack-protect-plugin
+ */
+
+namespace Automattic\Jetpack\Protect;
+
+/**
+ * Model class for extension data.
+ */
+class Extension_Model {
+
+	/**
+	 * The extension name.
+	 *
+	 * @var string
+	 */
+	public $name;
+
+	/**
+	 * The extension slug.
+	 *
+	 * @var string
+	 */
+	public $slug;
+
+	/**
+	 * The extension version.
+	 *
+	 * @var string
+	 */
+	public $version;
+
+	/**
+	 * A collection of vulnerabilities related to this version of the extension.
+	 *
+	 * @var array<Threat_Model>
+	 */
+	public $vulnerabilities = array();
+
+	/**
+	 * Whether the extension has been checked for vulnerabilities.
+	 *
+	 * @var bool
+	 */
+	public $checked;
+
+	/**
+	 * The type of extension ("plugins", "themes", or "core").
+	 *
+	 * @var string
+	 */
+	public $type;
+
+	/**
+	 * Extension Model Constructor
+	 *
+	 * @param array|object $extension Extension data to load into the model instance.
+	 */
+	public function __construct( $extension = array() ) {
+		if ( is_object( $extension ) ) {
+			$extension = (array) $extension;
+		}
+
+		foreach ( $extension as $property => $value ) {
+			if ( property_exists( $this, $property ) ) {
+				// use the property's setter method when possible
+				if ( method_exists( $this, "set_$property" ) ) {
+					$this->{ "set_$property" }( $value );
+					continue;
+				}
+
+				// otherwise, map the value directly into the class property
+				$this->$property = $value;
+			}
+		}
+	}
+
+	/**
+	 * Set Vulnerabilities
+	 *
+	 * @param array<Threat_Model|array|object> $vulnerabilities An array of vulnerability data to add to the extension.
+	 */
+	private function set_vulnerabilities( $vulnerabilities ) {
+		if ( ! is_array( $vulnerabilities ) ) {
+			$this->vulnerabilities = array();
+			return;
+		}
+
+		// convert each provided vulnerability item into an instance of Threat_Model
+		$vulnerabilities = array_map(
+			function ( $vulnerability ) {
+				if ( is_a( $vulnerability, 'Threat_Model' ) ) {
+					return $vulnerability;
+				}
+
+				if ( is_object( $vulnerability ) ) {
+					$vulnerability = (array) $vulnerability;
+				}
+
+				return new Threat_Model( $vulnerability );
+			},
+			$vulnerabilities
+		);
+
+		$this->vulnerabilities = $vulnerabilities;
+	}
+
+}

--- a/projects/plugins/protect/src/models/class-extension-model.php
+++ b/projects/plugins/protect/src/models/class-extension-model.php
@@ -83,7 +83,7 @@ class Extension_Model {
 	 *
 	 * @param array<Threat_Model|array|object> $vulnerabilities An array of vulnerability data to add to the extension.
 	 */
-	private function set_vulnerabilities( $vulnerabilities ) {
+	public function set_vulnerabilities( $vulnerabilities ) {
 		if ( ! is_array( $vulnerabilities ) ) {
 			$this->vulnerabilities = array();
 			return;

--- a/projects/plugins/protect/src/models/class-status-model.php
+++ b/projects/plugins/protect/src/models/class-status-model.php
@@ -56,16 +56,23 @@ class Status_Model {
 	/**
 	 * Status themes.
 	 *
-	 * @var array
+	 * @var array<Extension_Model>
 	 */
 	public $themes = array();
 
 	/**
 	 * Status plugins.
 	 *
-	 * @var array
+	 * @var array<Extension_Model>
 	 */
 	public $plugins = array();
+
+	/**
+	 * Whether the site includes items that have not been checked.
+	 *
+	 * @var boolean
+	 */
+	public $has_unchecked_items;
 
 	/**
 	 * Whether there was an error loading the status.
@@ -87,13 +94,6 @@ class Status_Model {
 	 * @var string
 	 */
 	public $error_message;
-
-	/**
-	 * Whether the site includes items that have not been checked.
-	 *
-	 * @var boolean
-	 */
-	public $has_unchecked_items;
 
 	/**
 	 * Status constructor.

--- a/projects/plugins/protect/src/models/class-status-model.php
+++ b/projects/plugins/protect/src/models/class-status-model.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Model class for Protect status report data.
+ *
+ * @package automattic/jetpack-protect-plugin
+ */
+
+namespace Automattic\Jetpack\Protect;
+
+/**
+ * Model class for the Protect status report data.
+ */
+class Status_Model {
+	/**
+	 * The date and time when the status was generated.
+	 *
+	 * @var string
+	 */
+	public $last_checked;
+
+	/**
+	 * The number of vulnerabilities.
+	 *
+	 * @var int
+	 */
+	public $num_vulnerabilities;
+
+	/**
+	 * The number of plugin vulnerabilities.
+	 *
+	 * @var int
+	 */
+	public $num_plugins_vulnerabilities;
+
+	/**
+	 * The number of theme vulnerabilities.
+	 *
+	 * @var int
+	 */
+	public $num_themes_vulnerabilities;
+
+	/**
+	 * The current report status.
+	 *
+	 * @var string
+	 */
+	public $status;
+
+	/**
+	 * WordPress core status.
+	 *
+	 * @var object
+	 */
+	public $core;
+
+	/**
+	 * Status themes.
+	 *
+	 * @var array
+	 */
+	public $themes = array();
+
+	/**
+	 * Status plugins.
+	 *
+	 * @var array
+	 */
+	public $plugins = array();
+
+	/**
+	 * Whether there was an error loading the status.
+	 *
+	 * @var bool
+	 */
+	public $error = false;
+
+	/**
+	 * The error code thrown when loading the status.
+	 *
+	 * @var string
+	 */
+	public $error_code;
+
+	/**
+	 * The error message thrown when loading the status.
+	 *
+	 * @var string
+	 */
+	public $error_message;
+
+	/**
+	 * Whether the site includes items that have not been checked.
+	 *
+	 * @var boolean
+	 */
+	public $has_unchecked_items;
+
+	/**
+	 * Status constructor.
+	 *
+	 * @param array $status The status data to load into the class instance.
+	 */
+	public function __construct( $status = array() ) {
+		// set status defaults
+		$this->core = new \stdClass();
+
+		foreach ( $status as $property => $value ) {
+			if ( property_exists( $this, $property ) ) {
+				$this->$property = $value;
+			}
+		}
+	}
+
+}

--- a/projects/plugins/protect/src/models/class-threat-model.php
+++ b/projects/plugins/protect/src/models/class-threat-model.php
@@ -62,18 +62,11 @@ class Threat_Model {
 	public $severity;
 
 	/**
-	 * Whether the threat is fixable.
+	 * Information about the auto-fix available for this threat. False when not auto-fixable.
 	 *
-	 * @var bool
+	 * @var false|object
 	 */
 	public $fixable;
-
-	/**
-	 * Information about the auto-fix available for this threat.
-	 *
-	 * @var object
-	 */
-	public $fixer;
 
 	/**
 	 * The current status of the threat.

--- a/projects/plugins/protect/src/models/class-threat-model.php
+++ b/projects/plugins/protect/src/models/class-threat-model.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Model class for threat data.
+ *
+ * @package automattic/jetpack-protect-plugin
+ */
+
+namespace Automattic\Jetpack\Protect;
+
+/**
+ * Model class for threat data.
+ */
+class Threat_Model {
+
+	/**
+	 * Threat ID.
+	 *
+	 * @var string
+	 */
+	public $id;
+
+	/**
+	 * Threat Signature.
+	 *
+	 * @var string
+	 */
+	public $signature;
+
+	/**
+	 * Threat Title.
+	 *
+	 * @var string
+	 */
+	public $title;
+
+	/**
+	 * Threat Description.
+	 *
+	 * @var string
+	 */
+	public $description;
+
+	/**
+	 * The data the threat was first detected.
+	 *
+	 * @var string
+	 */
+	public $first_detected;
+
+	/**
+	 * The version the threat is fixed in.
+	 *
+	 * @var string
+	 */
+	public $fixed_in;
+
+	/**
+	 * The severity of the threat between 1-5.
+	 *
+	 * @var int
+	 */
+	public $severity;
+
+	/**
+	 * Whether the threat is fixable.
+	 *
+	 * @var bool
+	 */
+	public $fixable;
+
+	/**
+	 * Information about the auto-fix available for this threat.
+	 *
+	 * @var object
+	 */
+	public $fixer;
+
+	/**
+	 * The current status of the threat.
+	 *
+	 * @var string
+	 */
+	public $status;
+
+	/**
+	 * The filename of the threat.
+	 *
+	 * @var string
+	 */
+	public $filename;
+
+	/**
+	 * The context of the threat.
+	 *
+	 * @var object
+	 */
+	public $context;
+
+	/**
+	 * The vulnerable extension related to the threat.
+	 *
+	 * @var Extension_Model
+	 */
+	public $extension;
+
+	/**
+	 * Threat Constructor
+	 *
+	 * @param array|object $threat Threat data to load into the class instance.
+	 */
+	public function __construct( $threat ) {
+		if ( is_object( $threat ) ) {
+			$threat = (array) $threat;
+		}
+
+		foreach ( $threat as $property => $value ) {
+			if ( property_exists( $this, $property ) ) {
+				$this->$property = $value;
+			}
+		}
+	}
+
+}

--- a/projects/plugins/protect/src/models/class-threat-model.php
+++ b/projects/plugins/protect/src/models/class-threat-model.php
@@ -97,13 +97,6 @@ class Threat_Model {
 	public $context;
 
 	/**
-	 * The vulnerable extension related to the threat.
-	 *
-	 * @var Extension_Model
-	 */
-	public $extension;
-
-	/**
 	 * Threat Constructor
 	 *
 	 * @param array|object $threat Threat data to load into the class instance.

--- a/projects/plugins/protect/tests/php/models/test-extension-model.php
+++ b/projects/plugins/protect/tests/php/models/test-extension-model.php
@@ -1,0 +1,75 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Automattic\Jetpack\Protect;
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Tests for the Extension_Model class.
+ *
+ * @package automattic/jetpack-protect
+ */
+class Test_Extension_Model extends BaseTestCase {
+
+	/**
+	 * Set up before each test
+	 *
+	 * @before
+	 */
+	protected function set_up() {
+		parent::setUp();
+	}
+
+	/**
+	 * Get a sample vulnerability
+	 *
+	 * @param int|string $id The sample vulnerability's unique identifier.
+	 * @return array
+	 */
+	private static function get_sample_vulnerability( $id = 0 ) {
+		return array(
+			'id'          => "test-threat-$id",
+			'signature'   => 'Test.Threat',
+			'title'       => "Test Threat $id",
+			'description' => 'This is a test threat.',
+		);
+	}
+
+	/**
+	 * Tests for extension model's __construct() method.
+	 */
+	public function test_extension_model_construct() {
+		$test_data = array(
+			'name'            => 'Test Extension',
+			'slug'            => 'test-extension',
+			'version'         => '1.0.0',
+			'vulnerabilities' => array(
+				self::get_sample_vulnerability( 0 ),
+				self::get_sample_vulnerability( 1 ),
+				self::get_sample_vulnerability( 2 ),
+			),
+			'checked'         => true,
+			'type'            => 'plugins',
+		);
+
+		// Initialize multiple instances of Extension_Model to test varying initial params
+		$test_extensions = array(
+			new Extension_Model( $test_data ),
+			new Extension_Model( (object) $test_data ),
+		);
+
+		foreach ( $test_extensions as $extension ) {
+			foreach ( $extension->vulnerabilities as $loop_index => $vulnerability ) {
+				// Validate the threat data is converted into Threat_Models
+				$this->assertSame( get_class( $vulnerability ), 'Automattic\Jetpack\Protect\Threat_Model' );
+
+				// Validate the threat data is set properly
+				foreach ( self::get_sample_vulnerability( $loop_index ) as $key => $value ) {
+					$this->assertSame( $value, $vulnerability->{ $key } );
+				}
+			}
+		}
+
+	}
+
+}

--- a/projects/plugins/protect/tests/php/models/test-threat-model.php
+++ b/projects/plugins/protect/tests/php/models/test-threat-model.php
@@ -1,0 +1,75 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Automattic\Jetpack\Protect;
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Tests for the Threat_Model class.
+ *
+ * @package automattic/jetpack-protect
+ */
+class Test_Threat_Model extends BaseTestCase {
+
+	/**
+	 * Set up before each test
+	 *
+	 * @before
+	 */
+	protected function set_up() {
+		parent::setUp();
+	}
+
+	/**
+	 * Get a sample vulnerability
+	 *
+	 * @param int|string $id The sample vulnerability's unique identifier.
+	 * @return array
+	 */
+	private static function get_sample_vulnerability( $id = 0 ) {
+		return array(
+			'id'          => "test-threat-$id",
+			'signature'   => 'Test.Threat',
+			'title'       => "Test Threat $id",
+			'description' => 'This is a test threat.',
+		);
+	}
+
+	/**
+	 * Tests for threat model's __construct() method.
+	 */
+	public function test_threat_model_construct() {
+		$test_data = array(
+			'id'             => 'abc-123-abc-123',
+			'signature'      => 'Test.Threat',
+			'title'          => 'Test Threat',
+			'description'    => 'This is a test threat.',
+			'first_detected' => '2022-01-01T00:00:00.000Z',
+			'fixed_in'       => '1.0.1',
+			'severity'       => 4,
+			'fixable'        => (object) array(
+				'fixer'            => 'update',
+				'target'           => '1.0.1',
+				'extension_status' => 'active',
+			),
+			'status'         => 'current',
+			'filename'       => '/srv/htdocs/wp-content/uploads/threat.jpg.php',
+			'context'        => (object) array(),
+		);
+
+		// Initialize multiple instances of Threat_Model to test varying initial params
+		$test_threats = array(
+			new Threat_Model( $test_data ),
+			new Threat_Model( (object) $test_data ),
+		);
+
+		foreach ( $test_threats as $threat ) {
+			// Validate the threat data is set properly
+			foreach ( $test_data as $key => $value ) {
+				$this->assertSame( $value, $threat->{ $key } );
+			}
+		}
+
+	}
+
+}

--- a/projects/plugins/protect/tests/php/test-status.php
+++ b/projects/plugins/protect/tests/php/test-status.php
@@ -40,7 +40,7 @@ class Test_Status extends BaseTestCase {
 			'version'         => '1.0.2',
 			'name'            => 'Sample Theme',
 			'checked'         => true,
-			'type'            => 'theme',
+			'type'            => 'themes',
 			'vulnerabilities' => array(),
 			'slug'            => "theme-$id",
 		);
@@ -62,7 +62,7 @@ class Test_Status extends BaseTestCase {
 			'version'         => '1.0.2',
 			'name'            => 'Sample Plugin',
 			'checked'         => true,
-			'type'            => 'plugin',
+			'type'            => 'plugins',
 			'vulnerabilities' => array(),
 			'slug'            => "plugin-$id",
 		);
@@ -114,8 +114,10 @@ class Test_Status extends BaseTestCase {
 	 * @return object
 	 */
 	public function get_sample_empty_response() {
-		return (object) array(
-			'last_checked' => '',
+		return new Status_Model(
+			array(
+				'last_checked' => '',
+			)
 		);
 	}
 
@@ -148,21 +150,23 @@ class Test_Status extends BaseTestCase {
 	 * @return object
 	 */
 	public function get_sample_status() {
-		return (object) array(
-			'plugins'                     => array(
-				$this->get_sample_plugin( '1' ),
-				$this->get_sample_plugin( '2', false ),
-			),
-			'themes'                      => array(
-				$this->get_sample_theme( '1' ),
-			),
-			'core'                        => $this->get_sample_core(),
-			'wordpress'                   => $this->get_sample_core(),
-			'last_checked'                => '2003-03-03 03:03:03',
-			'num_vulnerabilities'         => 3,
-			'num_themes_vulnerabilities'  => 1,
-			'num_plugins_vulnerabilities' => 1,
-			'hasUncheckedItems'           => false,
+		return new Status_Model(
+			array(
+				'plugins'                     => array(
+					new Extension_Model( $this->get_sample_plugin( '1' ) ),
+					new Extension_Model( $this->get_sample_plugin( '2', false ) ),
+				),
+				'themes'                      => array(
+					new Extension_Model( $this->get_sample_theme( '1' ) ),
+				),
+				'core'                        => new Extension_Model( $this->get_sample_core() ),
+				'wordpress'                   => $this->get_sample_core(),
+				'last_checked'                => '2003-03-03 03:03:03',
+				'num_vulnerabilities'         => 3,
+				'num_themes_vulnerabilities'  => 1,
+				'num_plugins_vulnerabilities' => 1,
+				'has_unchecked_items'         => false,
+			)
 		);
 	}
 
@@ -264,7 +268,7 @@ class Test_Status extends BaseTestCase {
 		remove_filter( 'all_plugins', array( $this, 'return_sample_plugins' ) );
 		remove_filter( 'jetpack_sync_get_themes_callable', array( $this, 'return_sample_themes' ) );
 
-		$this->assertSame( 'site_not_connected', $status['error_code'] );
+		$this->assertSame( 'site_not_connected', $status->error_code );
 
 		// Make sure this was not cached
 		$this->assertFalse( Status::get_from_options() );
@@ -311,9 +315,9 @@ class Test_Status extends BaseTestCase {
 		$this->mock_connection();
 
 		$expected = array(
-			$this->get_sample_vul(),
-			$this->get_sample_vul(),
-			$this->get_sample_vul(),
+			new Threat_Model( $this->get_sample_vul() ),
+			new Threat_Model( $this->get_sample_vul() ),
+			new Threat_Model( $this->get_sample_vul() ),
 		);
 
 		add_filter( 'pre_http_request', array( $this, 'return_sample_response' ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


The intention of this pull request is to add defined structure to how we store and interact with Protect report data, primarily by adding new model classes:

* `Status_Model`: the entire status report as a whole.
* `Extension_Model`: plugin, theme, or core data.
* `Threat_Model`: generic model for plugin, theme, and core threats and vulnerabilities, 

This is a preparatory step taken prior to introducing the Scan API as an alternate data source.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds new `/models` directory with definitions for `Status_Model`, `Extension_Model`, and `Threat_Model`.
* Integrates new model classes into the loading and implementation of Protect Report data, primarily in `class-status.php`. The generic `normalize_report_data()` method is replaced with a data-source specific `load_data_from_protect_report()` method, which is quite similar but more specific in how each property is mapped into the new `Status_Model` class.
* Updates existing tests to expect model instances to be returned in the status.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

1201069996155224-as-1202717789119448/f

pbuNQi-3pv-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run through the full Jetpack Protect installation process on a fresh site with Jetpack Protect, ensuring that the following is validated without regression:
  * Waiting for initial results screen
  * Display of site with no vulnerabilities
  * Display of theme, plugin, and core vulnerabilities
  * Display of results from API and cache