### PR TITLE
Social: Improve design of admin page on mobile

### DIFF
--- a/projects/plugins/social/changelog/fix-social-mobile-design
+++ b/projects/plugins/social/changelog/fix-social-mobile-design
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Small UI changes only
+
+

--- a/projects/plugins/social/src/js/components/header/index.js
+++ b/projects/plugins/social/src/js/components/header/index.js
@@ -40,7 +40,7 @@ const Header = () => {
 	} );
 
 	return (
-		<Container horizontalSpacing={ 3 } horizontalGap={ 7 } className={ styles.container }>
+		<Container horizontalSpacing={ 3 } horizontalGap={ 3 } className={ styles.container }>
 			<Col sm={ 4 } md={ 4 } lg={ 5 }>
 				<H3 mt={ 2 }>{ __( 'Write once, post everywhere', 'jetpack-social' ) }</H3>
 				<div className={ styles.actions }>

--- a/projects/plugins/social/src/js/components/stat-cards/index.js
+++ b/projects/plugins/social/src/js/components/stat-cards/index.js
@@ -8,7 +8,9 @@ const StatCard = ( { icon, label, value, link, loading = false } ) => (
 		{ loading ? (
 			<Spinner color="#000" size={ 24 } className={ styles.spinner } />
 		) : (
-			<Text variant="headline-small">{ value }</Text>
+			<Text className={ styles.value } variant="headline-small">
+				{ value }
+			</Text>
 		) }
 	</div>
 );

--- a/projects/plugins/social/src/js/components/stat-cards/styles.module.scss
+++ b/projects/plugins/social/src/js/components/stat-cards/styles.module.scss
@@ -5,6 +5,8 @@
 		margin-left: calc( var( --spacing-base ) * 3 );
 	}
 
+	justify-content: space-evenly;
+
 	@media ( min-width: 600px ) {
 		justify-content: flex-end;
 	}
@@ -17,7 +19,11 @@
 	box-shadow: 0px 0px 40px rgba( 0, 0, 0, 0.08 );
 	border-radius: 4px;
 	padding: calc( var( --spacing-base ) * 3 );
-	max-width: 170px;
+	width: calc( 100% - var( --spacing-base ) * 2 / 2 );
+	
+	@media ( min-width: 600px ) {
+		max-width: 170px;
+	}
 }
 
 .label {
@@ -32,4 +38,8 @@
 .spinner {
 	margin-top: calc( var( --spacing-base ) * 2 );
 	align-self: flex-start;
+}
+
+.value {
+	margin-top: auto;
 }

--- a/projects/plugins/social/src/js/components/stat-cards/styles.module.scss
+++ b/projects/plugins/social/src/js/components/stat-cards/styles.module.scss
@@ -19,7 +19,8 @@
 	box-shadow: 0px 0px 40px rgba( 0, 0, 0, 0.08 );
 	border-radius: 4px;
 	padding: calc( var( --spacing-base ) * 3 );
-	width: calc( 100% - var( --spacing-base ) * 2 / 2 );
+	flex: 0 1 auto;
+	width: 100%;
 	
 	@media ( min-width: 600px ) {
 		max-width: 170px;

--- a/projects/plugins/social/src/js/components/toggle-section/index.js
+++ b/projects/plugins/social/src/js/components/toggle-section/index.js
@@ -1,4 +1,4 @@
-import { Button, Container, Text } from '@automattic/jetpack-components';
+import { Button, Container, Text, useBreakpointMatch } from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -15,6 +15,8 @@ const ToggleSection = () => {
 			connectionsAdminUrl: store.getConnectionsAdminUrl(),
 		};
 	} );
+
+	const [ isSmall ] = useBreakpointMatch( 'sm' );
 
 	return (
 		<Container horizontalSpacing={ 7 } horizontalGap={ 3 }>
@@ -35,6 +37,7 @@ const ToggleSection = () => {
 				</Text>
 				{ connectionsAdminUrl && (
 					<Button
+						fullWidth={ isSmall }
 						className={ styles.button }
 						variant="secondary"
 						isExternalLink={ true }

--- a/projects/plugins/social/src/js/components/toggle-section/styles.module.scss
+++ b/projects/plugins/social/src/js/components/toggle-section/styles.module.scss
@@ -59,8 +59,10 @@
 	margin-top: calc( var( --spacing-base ) * 2 );
 	grid-column: span 2;
 	justify-self: flex-start;
+	width: 100%;
 
 	@media ( min-width: 600px ) {
 		grid-column: 2;
+		width: auto;
 	}
 }

--- a/projects/plugins/social/src/js/components/toggle-section/styles.module.scss
+++ b/projects/plugins/social/src/js/components/toggle-section/styles.module.scss
@@ -59,10 +59,8 @@
 	margin-top: calc( var( --spacing-base ) * 2 );
 	grid-column: span 2;
 	justify-self: flex-start;
-	width: 100%;
 
 	@media ( min-width: 600px ) {
 		grid-column: 2;
-		width: auto;
 	}
 }


### PR DESCRIPTION
This is a small change to fix some UI differences with design (jpldgotrSl8JMHjgUXZLZY-fi-5802%3A39131

### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

#### Made **Manage social media connections** button 100% wide on small screens:

Before            |  After
:-------------------------:|:-------------------------:
<img width="347" alt="CleanShot 2022-08-10 at 12 24 40@2x" src="https://user-images.githubusercontent.com/36671565/183879063-f0d27835-71c5-4c11-bcd3-0c3feadbe0e3.png">  |  <img width="327" alt="CleanShot 2022-08-10 at 12 25 12@2x" src="https://user-images.githubusercontent.com/36671565/183879132-ae78b7c5-ecf0-4453-8cda-9697b7391627.png">

#### Decreased row-gap between Connect button and meter:

Before            |  After
:-------------------------:|:-------------------------:
<img width="486" alt="CleanShot 2022-08-10 at 13 17 05@2x" src="https://user-images.githubusercontent.com/36671565/183888297-38b4716a-b57a-4eb9-be12-1ea1650281e6.png"> |  <img width="489" alt="CleanShot 2022-08-10 at 13 17 29@2x" src="https://user-images.githubusercontent.com/36671565/183888365-20d5a57c-04ef-456c-bffc-9055c3bd125e.png">


#### Set a margin to Card value, so it's allocated at the same height with funny screen sizes:

Before            |  After
:-------------------------:|:-------------------------:
<img width="648" alt="CleanShot 2022-08-10 at 13 20 51@2x" src="https://user-images.githubusercontent.com/36671565/183888931-6e6b9531-6171-4b4e-a652-f9e7624cb964.png">  |  <img width="653" alt="CleanShot 2022-08-10 at 13 21 21@2x" src="https://user-images.githubusercontent.com/36671565/183889000-95f72943-9c3d-4a90-8234-8c53c265e3b4.png">

#### Made cards align to width on small-medium screens, rather than being put to the left:

Before            |  After
:-------------------------:|:-------------------------:
<img width="539" alt="CleanShot 2022-08-10 at 14 43 10@2x" src="https://user-images.githubusercontent.com/36671565/183904321-1ea5b94e-76fa-4e95-89f1-96822e4e0729.png"> | <img width="537" alt="CleanShot 2022-08-10 at 14 43 43@2x" src="https://user-images.githubusercontent.com/36671565/183904452-60cb1af8-68f5-4d28-8014-d4968dd54a1a.png">

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check current design.