### PR TITLE
Instant Search: User-friendly error messaging

### DIFF
--- a/projects/packages/search/changelog/update-proper-error-messages
+++ b/projects/packages/search/changelog/update-proper-error-messages
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Instant Search: user friendly error messaging

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -69,7 +69,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.18.x-dev"
+			"dev-trunk": "0.19.x-dev"
 		},
 		"version-constants": {
 			"::VERSION": "src/class-package.php"

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.18.1-alpha",
+	"version": "0.19.0-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.18.1-alpha';
+	const VERSION = '0.19.0-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/instant-search/components/search-results.jsx
+++ b/projects/packages/search/src/instant-search/components/search-results.jsx
@@ -141,12 +141,7 @@ class SearchResults extends Component {
 					<Notice type="warning">{ getErrorMessage( this.props.response.error ) }</Notice>
 				) }
 				{ hasResults && ! this.props.hasError && this.props.response._isOffline && (
-					<Notice type="warning">
-						{ __(
-							"It looks like you're offline. Please reconnect to load the latest results.",
-							'jetpack-search-pkg'
-						) }
-					</Notice>
+					<Notice type="warning">{ getErrorMessage( { message: 'offline' } ) }</Notice>
 				) }
 				{ hasResults && ! this.props.hasError && (
 					<ol

--- a/projects/packages/search/src/instant-search/components/search-results.jsx
+++ b/projects/packages/search/src/instant-search/components/search-results.jsx
@@ -2,6 +2,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import React, { Component, Fragment } from 'react';
 import { getConstrastingColor } from '../lib/colors';
 import { MULTISITE_NO_GROUP_VALUE, OVERLAY_FOCUS_ANCHOR_ID } from '../lib/constants';
+import { getErrorMessage } from '../lib/errors';
 import { getAvailableStaticFilters } from '../lib/filters';
 import Gridicon from './gridicon';
 import Notice from './notice';
@@ -137,12 +138,7 @@ class SearchResults extends Component {
 					</p>
 				) }
 				{ this.props.hasError && (
-					<Notice type="warning">
-						{ __(
-							"It looks like you're offline. Please reconnect for results.",
-							'jetpack-search-pkg'
-						) }
-					</Notice>
+					<Notice type="warning">{ getErrorMessage( this.props.response.error ) }</Notice>
 				) }
 				{ hasResults && ! this.props.hasError && this.props.response._isOffline && (
 					<Notice type="warning">

--- a/projects/packages/search/src/instant-search/lib/api.js
+++ b/projects/packages/search/src/instant-search/lib/api.js
@@ -435,9 +435,9 @@ export function search( options, requestId ) {
 	} )
 		.then( response => {
 			if ( response.status !== 200 ) {
-				return Promise.reject(
-					`Unexpected response from API with status code ${ response.status }.`
-				);
+				return response.json().then( json => {
+					throw new Error( json.error );
+				} );
 			}
 			return response;
 		} )

--- a/projects/packages/search/src/instant-search/lib/errors.js
+++ b/projects/packages/search/src/instant-search/lib/errors.js
@@ -16,7 +16,7 @@ export function getErrorMessage( error ) {
 			return sprintf(
 				// translators: %s: Error code.
 				__(
-					"Jetpack Search has encountered an error (reason: '%s'). Please contact the site administrator if the issue persists.",
+					'Jetpack Search has encountered an error. Please contact the site administrator if the issue persists. [%s]',
 					'jetpack-search-pkg'
 				),
 				error.message
@@ -32,7 +32,7 @@ export function getErrorMessage( error ) {
 			return sprintf(
 				// translators: %s: Error code.
 				__(
-					"Jetpack Search is currently unavailable (reason: '%s'). Please try again later.",
+					'Jetpack Search is currently unavailable. Please try again later. [%s]',
 					'jetpack-search-pkg'
 				),
 				error?.message ?? 'unknown'

--- a/projects/packages/search/src/instant-search/lib/errors.js
+++ b/projects/packages/search/src/instant-search/lib/errors.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
  * @returns {*}	an error message
  */
 export function getErrorMessage( error ) {
-	switch ( error.message ) {
+	switch ( error?.message ) {
 		case 'service_unavailable':
 			return __(
 				'Jetpack Search is currently unavailable. Please try again later.',

--- a/projects/packages/search/src/instant-search/lib/errors.js
+++ b/projects/packages/search/src/instant-search/lib/errors.js
@@ -1,0 +1,38 @@
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Returns an error message based on the error code.
+ *
+ * @param {Error} error - Error object
+ * @returns {*}	an error message
+ */
+export function getErrorMessage( error ) {
+	switch ( error.message ) {
+		case 'service_unavailable':
+			return __(
+				'Jetpack Search is currently unavailable. Please try again later.',
+				'jetpack-search-pkg'
+			);
+		case 'unknown_blog':
+		case 'unauthorized':
+			return __( 'You are not authorized to perform search on the website.', 'jetpack-search-pkg' );
+		case 'bad_request':
+			return __(
+				'One or more parameters are not accepted by the server. Please contact the website administrator.',
+				'jetpack-search-pkg'
+			);
+		case 'payload_too_large':
+			return __(
+				'The search request is too large. Please contact the website administrator.',
+				'jetpack-search-pkg'
+			);
+		case 'not_supported':
+			return __(
+				'The website does not have a valid Jetpack Search subscription. Please contact the website administrator.',
+				'jetpack-search-pkg'
+			);
+
+		default:
+			return __( 'An unknown error occurred. Please try again later.', 'jetpack-search-pkg' );
+	}
+}

--- a/projects/packages/search/src/instant-search/lib/errors.js
+++ b/projects/packages/search/src/instant-search/lib/errors.js
@@ -15,7 +15,7 @@ export function getErrorMessage( error ) {
 			);
 		case 'unknown_blog':
 		case 'unauthorized':
-			return __( 'You are not authorized to perform search on the website.', 'jetpack-search-pkg' );
+			return __( 'You are not authorized to search on the website.', 'jetpack-search-pkg' );
 		case 'bad_request':
 			return __(
 				'One or more parameters are not accepted by the server. Please contact the website administrator.',

--- a/projects/packages/search/src/instant-search/lib/errors.js
+++ b/projects/packages/search/src/instant-search/lib/errors.js
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Returns an error message based on the error code.
@@ -8,31 +8,34 @@ import { __ } from '@wordpress/i18n';
  */
 export function getErrorMessage( error ) {
 	switch ( error?.message ) {
-		case 'service_unavailable':
-			return __(
-				'Jetpack Search is currently unavailable. Please try again later.',
-				'jetpack-search-pkg'
-			);
 		case 'unknown_blog':
 		case 'unauthorized':
-			return __( 'You are not authorized to search on the website.', 'jetpack-search-pkg' );
 		case 'bad_request':
-			return __(
-				'One or more parameters are not accepted by the server. Please contact the website administrator.',
-				'jetpack-search-pkg'
-			);
 		case 'payload_too_large':
-			return __(
-				'The search request is too large. Please contact the website administrator.',
-				'jetpack-search-pkg'
-			);
 		case 'not_supported':
+			return sprintf(
+				// translators: %s: Error code.
+				__(
+					"Jetpack Search has encountered an error (reason: '%s'). Please contact the site administrator if the issue persists.",
+					'jetpack-search-pkg'
+				),
+				error.message
+			);
+		case 'offline':
 			return __(
-				'The website does not have a valid Jetpack Search subscription. Please contact the website administrator.',
+				"It looks like you're offline. Please reconnect to load the latest results.",
 				'jetpack-search-pkg'
 			);
 
+		case 'service_unavailable':
 		default:
-			return __( 'An unknown error occurred. Please try again later.', 'jetpack-search-pkg' );
+			return sprintf(
+				// translators: %s: Error code.
+				__(
+					"Jetpack Search is currently unavailable (reason: '%s'). Please try again later.",
+					'jetpack-search-pkg'
+				),
+				error?.message ?? 'unknown'
+			);
 	}
 }

--- a/projects/packages/search/src/instant-search/lib/errors.js
+++ b/projects/packages/search/src/instant-search/lib/errors.js
@@ -8,31 +8,32 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 export function getErrorMessage( error ) {
 	switch ( error?.message ) {
-		case 'unknown_blog':
-		case 'unauthorized':
-		case 'bad_request':
-		case 'payload_too_large':
-		case 'not_supported':
+		case 'service_unavailable':
 			return sprintf(
 				// translators: %s: Error code.
 				__(
-					'Jetpack Search has encountered an error. Please contact the site administrator if the issue persists. [%s]',
+					'Jetpack Search is currently unavailable. Please try again later. [%s]',
 					'jetpack-search-pkg'
 				),
-				error.message
+				error?.message
 			);
+
 		case 'offline':
 			return __(
 				"It looks like you're offline. Please reconnect to load the latest results.",
 				'jetpack-search-pkg'
 			);
 
-		case 'service_unavailable':
+		case 'unknown_blog':
+		case 'unauthorized':
+		case 'bad_request':
+		case 'payload_too_large':
+		case 'not_supported':
 		default:
 			return sprintf(
 				// translators: %s: Error code.
 				__(
-					'Jetpack Search is currently unavailable. Please try again later. [%s]',
+					'Jetpack Search has encountered an error. Please contact the site administrator if the issue persists. [%s]',
 					'jetpack-search-pkg'
 				),
 				error?.message ?? 'unknown'

--- a/projects/packages/search/src/instant-search/store/effects.js
+++ b/projects/packages/search/src/instant-search/store/effects.js
@@ -41,7 +41,7 @@ function makeSearchAPIRequest( action, store ) {
 		} )
 		.catch( error => {
 			// eslint-disable-next-line no-console
-			console.error( 'Jetpack Search encountered an error:', error );
+			console.error( 'Jetpack Search ', error );
 			store.dispatch( recordFailedSearchRequest( error ) );
 		} );
 }

--- a/projects/packages/search/src/instant-search/store/reducer/api.js
+++ b/projects/packages/search/src/instant-search/store/reducer/api.js
@@ -90,6 +90,10 @@ export function response( state = {}, action ) {
 
 			return newState;
 		}
+		case 'RECORD_FAILED_SEARCH_REQUEST': {
+			state.error = action.error;
+			return state;
+		}
 	}
 
 	return state;

--- a/projects/plugins/jetpack/changelog/update-proper-error-messages
+++ b/projects/plugins/jetpack/changelog/update-proper-error-messages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -37,7 +37,7 @@
 		"automattic/jetpack-publicize": "0.11.x-dev",
 		"automattic/jetpack-redirect": "1.7.x-dev",
 		"automattic/jetpack-roles": "1.4.x-dev",
-		"automattic/jetpack-search": "0.18.x-dev",
+		"automattic/jetpack-search": "0.19.x-dev",
 		"automattic/jetpack-status": "1.14.x-dev",
 		"automattic/jetpack-sync": "1.37.x-dev",
 		"automattic/jetpack-videopress": "0.1.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c45e64ee74ab0fcedafa57a31bf52d40",
+    "content-hash": "62f23563f988c7656934e4dbab390431",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1638,7 +1638,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "bbe4c7a4e31b05439b0f93b35caff7e3886b7544"
+                "reference": "dce2ca66e301a94854e5eabb3e5b5fd57a512650"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -1662,7 +1662,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.18.x-dev"
+                    "dev-trunk": "0.19.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"

--- a/projects/plugins/search/changelog/update-proper-error-messages
+++ b/projects/plugins/search/changelog/update-proper-error-messages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -9,7 +9,7 @@
 		"automattic/jetpack-config": "1.9.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
 		"automattic/jetpack-my-jetpack": "2.0.x-dev",
-		"automattic/jetpack-search": "0.18.x-dev",
+		"automattic/jetpack-search": "0.19.x-dev",
 		"automattic/jetpack-status": "^1.14",
 		"automattic/jetpack-sync": "1.37.x-dev"
 	},

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9053fc18317417904824cb25f6269fe3",
+    "content-hash": "e68f2bf5e040956a4ba69434065a5cff",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -903,7 +903,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "bbe4c7a4e31b05439b0f93b35caff7e3886b7544"
+                "reference": "dce2ca66e301a94854e5eabb3e5b5fd57a512650"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -927,7 +927,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.18.x-dev"
+                    "dev-trunk": "0.19.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"


### PR DESCRIPTION
Fixes #25380

#### Changes proposed in this Pull Request:
The PR replaces the old `It looks like you're offline. Please reconnect for results.` message with more accurate and user-friendly error messages. The PR is meant to work with `D85612-code`☑️, but could be tested and merged separately. <strike>Error codes that have messages mapped are as following.</strike> All errors are all shown user friendly and with error code returned from API for us to better diagnose issues.

- bad_request - 400
- payload_too_large - 413
- service_unavailable - 503 - basically when ES returns us error
- unauthorized - 403 - user doesn't have access
- not_supported - 403 - site needs search plan
-  unknown_blog - 404


#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Open a website with Jetpack Search subscription and Instant Search enabled
* Sandbox `public-api.wordpress.com`
* Add `return new WP_Error( 'unauthorized', 'Yep the request is naughty', 400 );` as the first line of function `callback` in `public.api/rest/wpcom-json-endpoints/class.wpcom-json-api-search-site-v1-3-endpoint.php`
* Perform a search
* Ensure proper errors are displayed

For example if you change the error code to `not_supported`, the following error would be displayed:

<img width="918" alt="image" src="https://user-images.githubusercontent.com/1425433/184260024-cb78d8d2-c9d4-4019-a0b2-5781261f0b8e.png">


