### PR TITLE
E2E tests: Only send Slack notifications for failures

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -124,7 +124,7 @@ jobs:
         pnpm run test:run "${TEST_ARGS[@]}"
 
     - name: Send Slack notification
-      if: ${{ ! cancelled() }}
+      if: ${{ ! failure() }}
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
         SUITE: ${{ matrix.project }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -124,7 +124,7 @@ jobs:
         pnpm run test:run "${TEST_ARGS[@]}"
 
     - name: Send Slack notification
-      if: ${{ ! failure() }}
+      if: ${{ failure() }}
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
         SUITE: ${{ matrix.project }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -170,7 +170,7 @@ jobs:
   slack-notification:
     name: "Slack notification"
     runs-on: ubuntu-latest
-    if: ${{ ! cancelled() }}
+    if: ${{ ! cancelled() }} # need to run on failure and also on success, so it can send notifications when tests passed on re-runs
     needs: [e2e-tests]
 
     steps:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -124,7 +124,7 @@ jobs:
         pnpm run test:run "${TEST_ARGS[@]}"
 
     - name: Send Slack notification
-      if: ${{ failure() }}
+      if: ${{ failure() && ! cancelled() }}
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
         SUITE: ${{ matrix.project }}

--- a/projects/github-actions/test-results-to-slack/changelog/e2e-only-send-slack-notif-on-failure
+++ b/projects/github-actions/test-results-to-slack/changelog/e2e-only-send-slack-notif-on-failure
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Only send notifications for failures

--- a/projects/github-actions/test-results-to-slack/src/index.js
+++ b/projects/github-actions/test-results-to-slack/src/index.js
@@ -33,6 +33,11 @@ const { isWorkflowFailed, getNotificationText } = require( './utils' );
 		return;
 	}
 	const isFailure = await isWorkflowFailed( ghToken );
+
+	if ( ! isFailure ) {
+		return;
+	}
+
 	icon_emoji = isFailure ? ':red_circle:' : ':green_circle:';
 
 	const text = await getNotificationText( isFailure );

--- a/projects/github-actions/test-results-to-slack/src/index.js
+++ b/projects/github-actions/test-results-to-slack/src/index.js
@@ -35,6 +35,7 @@ const { isWorkflowFailed, getNotificationText } = require( './utils' );
 	const isFailure = await isWorkflowFailed( ghToken );
 
 	if ( ! isFailure ) {
+		// this is only temporary. In the future: it will send notification for success if the previous run was failed.
 		return;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Update condition for which we send Slack notifications for e2e tests, to only send on failure.
This updates both the current notification system and the new in development GitHub action.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
p1660210457349239/1660209027.446999-slack-C03QNBQKG73

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* CI happy. If e2e tests are successful (as they should be) no Slack notification is sent to either channel.