### PR TITLE
Update Calendly block customization link

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-calendly-block-customization-link
+++ b/projects/plugins/jetpack/changelog/fix-calendly-block-customization-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Update the embed options link for Calendly block as the current link is broken

--- a/projects/plugins/jetpack/extensions/blocks/calendly/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/controls.js
@@ -58,8 +58,8 @@ export const CalendlyInspectorControls = props => {
 			</PanelBody>
 			{ url && (
 				<Notice className={ `${ defaultClassName }-color-notice` } isDismissible={ false }>
-					<ExternalLink href="https://help.calendly.com/hc/en-us/community/posts/360033166114-Embed-Widget-Color-Customization-Available-Now-">
-						{ __( 'Follow these instructions to change the colors in this block.', 'jetpack' ) }
+					<ExternalLink href="https://help.calendly.com/hc/en-us/articles/223147027-Embed-options-overview">
+						{ __( 'Explore more customization options from Calendly.', 'jetpack' ) }
 					</ExternalLink>
 				</Notice>
 			) }

--- a/projects/plugins/jetpack/extensions/blocks/calendly/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/controls.js
@@ -1,3 +1,4 @@
+import { isAtomicSite, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import { BlockControls, InspectorControls } from '@wordpress/block-editor';
 import {
 	Button,
@@ -31,6 +32,15 @@ export const CalendlyInspectorControls = props => {
 		setEmbedCode,
 	} = props;
 
+	let externalDocLink = null;
+
+	if ( url ) {
+		externalDocLink =
+			isAtomicSite() || isSimpleSite()
+				? 'https://wordpress.com/support/wordpress-editor/blocks/calendly-block/#customize-the-calendly-block'
+				: 'https://jetpack.com/support/jetpack-blocks/calendly-block/#customizing-a-calendly-block';
+	}
+
 	return (
 		<>
 			<PanelBody PanelBody title={ __( 'Calendar settings', 'jetpack' ) } initialOpen={ false }>
@@ -56,10 +66,10 @@ export const CalendlyInspectorControls = props => {
 					onChange={ () => setAttributes( { hideEventTypeDetails: ! hideEventTypeDetails } ) }
 				/>
 			</PanelBody>
-			{ url && (
+			{ externalDocLink && (
 				<Notice className={ `${ defaultClassName }-color-notice` } isDismissible={ false }>
-					<ExternalLink href="https://help.calendly.com/hc/en-us/articles/223147027-Embed-options-overview">
-						{ __( 'Explore more customization options from Calendly.', 'jetpack' ) }
+					<ExternalLink href={ externalDocLink }>
+						{ __( 'Explore more customization options.', 'jetpack' ) }
 					</ExternalLink>
 				</Notice>
 			) }

--- a/projects/plugins/jetpack/extensions/blocks/calendly/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/test/controls.js
@@ -144,14 +144,14 @@ describe( 'CalendlyInspectorControls', () => {
 		const user = userEvent.setup();
 		await renderExpandedSettings( user, defaultProps );
 
-		const colorHelpUrl =
-			'https://help.calendly.com/hc/en-us/community/posts/360033166114-Embed-Widget-Color-Customization-Available-Now-';
+		const customizationHelpUrl =
+			'https://jetpack.com/support/jetpack-blocks/calendly-block/#customizing-a-calendly-block';
 		const noticeClass = `${ defaultProps.defaultClassName }-color-notice`;
-		const linkText = 'Follow these instructions to change the colors in this block.';
+		const linkText = 'Explore more customization options.';
 		const link = screen.getByText( linkText );
 
 		expect( link ).toBeInTheDocument();
-		expect( link ).toHaveAttribute( 'href', colorHelpUrl );
+		expect( link ).toHaveAttribute( 'href', customizationHelpUrl );
 		// eslint-disable-next-line testing-library/no-node-access
 		expect( link.closest( '.components-notice' ) ).toHaveClass( noticeClass );
 	} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/wp-calypso#65757

#### Changes proposed in this Pull Request:

* This PR updates the wording for the "extra customization" link we show for the Calendly block once it has a valid URL. Instead of pointing at a broken link from Calendly, we now refer to the customisation section of the WordPress.com or Jetpack.com documentation for the Calendly block.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
No major discussion here -- the previous link was broken, and I worked with the docs team to get the Jetpack block documentations updated so we could link to those docs.

#### Does this pull request change what data or activity we track or use?

No change in data usage or activity tracking.

#### Testing instructions:

* This change will need testing in three environments as part of this PR:
  1. A standalone site running Jetpack,
  2. A WordPress.com Atomic site, and
  3. A WordPress.com Simple site
* For the Atomic and standalone sites, ensure that you have the Jetpack Beta plugin installed, and are running the code from this branch, `update/calendly-customization-link`
* For each of the site types above:
  - Go to _Posts_ -> _Add New_ in the left nav
  - Add a new Calendly block to your new post
  - Enter a valid Calendly URL and click on the "Embed" button
  - Ensure that the block settings toolbar is visible, and ensure that you see a link in the _Style_ section that has the text `Explore more customization options.` with an external link icon
  - If you are on a WordPress.com site (either Simple or Atomic), verify that the link takes you to the WordPress.com documentation for the Calendly block at https://wordpress.com/support/wordpress-editor/blocks/calendly-block/#customize-the-calendly-block.
 - If you are on a standalone Jetpack site, verify that the link takes you to the Jetpack.com documentation for the Calendly block at https://jetpack.com/support/jetpack-blocks/calendly-block/#customizing-a-calendly-block.

#### Screenshot

<img width="282" alt="Screenshot 2022-08-11 at 20 16 51" src="https://user-images.githubusercontent.com/3376401/184210669-187e782b-2b66-4424-9464-e897a43ee517.png">