### PR TITLE
Adds filter to monorepo path

### DIFF
--- a/tools/docker/mu-plugins/01-monorepo.php
+++ b/tools/docker/mu-plugins/01-monorepo.php
@@ -39,7 +39,7 @@ class Monorepo {
 	 * Class constructor.
 	 */
 	public function __construct() {
-		$this->monorepo = '/usr/local/src/jetpack-monorepo/';
+		$this->monorepo = apply_filters( 'jetpack_monorepo_path', '/usr/local/src/jetpack-monorepo/' );
 		$this->plugins  = $this->monorepo . 'projects/plugins/';
 		$this->packages = $this->monorepo . 'projects/packages/';
 	}

--- a/tools/docker/mu-plugins/01-monorepo.php
+++ b/tools/docker/mu-plugins/01-monorepo.php
@@ -39,6 +39,13 @@ class Monorepo {
 	 * Class constructor.
 	 */
 	public function __construct() {
+		/**
+		 * Filter the monorepo path for development environments.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param string $path Monorepo file path.
+		 */
 		$this->monorepo = apply_filters( 'jetpack_monorepo_path', '/usr/local/src/jetpack-monorepo/' );
 		$this->plugins  = $this->monorepo . 'projects/plugins/';
 		$this->packages = $this->monorepo . 'projects/packages/';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Adds a filter to monorepo path to make it easier to run a development version of Jetpack outside of Docker.

#### Other information:

- n/a Have you written new tests for your changes, if applicable?
- n/a Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

n/a

#### Does this pull request change what data or activity we track or use?

no

#### Testing instructions:

Add a filter callback to `jetpack_monorepo_path`, e.g.

```php
add_filter( 'jetpack_monorepo_path', function( $path ) {
	return '/my/monorepo/path';
} );
```

