### PR TITLE
Hide WPCOM notifications button when 3rd party cookies are blocked

### DIFF
--- a/projects/plugins/jetpack/changelog/update-disable-wpcom-notes-when-no-3pc
+++ b/projects/plugins/jetpack/changelog/update-disable-wpcom-notes-when-no-3pc
@@ -1,4 +1,4 @@
 Significance: patch
-Type: bugfix
+Type: compat
 
-Hide WPCOM notifications button when 3rd party cookies are blocked
+Notifications: do not attempt to display the Notifications panel when 3rd-party cookies are disabled in the browser.

--- a/projects/plugins/jetpack/changelog/update-disable-wpcom-notes-when-no-3pc
+++ b/projects/plugins/jetpack/changelog/update-disable-wpcom-notes-when-no-3pc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Hide WPCOM notifications button when 3rd party cookies are blocked

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -195,6 +195,8 @@ class Jetpack_Notifications {
 			}
 		}
 
+		$third_party_cookie_check_iframe = '<iframe src="https://widgets.wp.com/3rd-party-cookie-check/index.html" style="display:none"></iframe>';
+
 		$classes = 'wpnt-loading wpn-read';
 		$wp_admin_bar->add_menu(
 			array(
@@ -203,7 +205,7 @@ class Jetpack_Notifications {
 					<span class="noticon noticon-notification"></span>
 					</span>',
 				'meta'   => array(
-					'html'  => '<div id="wpnt-notes-panel2" class="intrinsic-ignore" style="display:none" lang="' . esc_attr( $wpcom_locale ) . '" dir="' . ( is_rtl() ? 'rtl' : 'ltr' ) . '"><div class="wpnt-notes-panel-header"><span class="wpnt-notes-header">' . __( 'Notifications', 'jetpack' ) . '</span><span class="wpnt-notes-panel-link"></span></div></div>',
+					'html'  => '<div id="wpnt-notes-panel2" class="intrinsic-ignore" style="display:none" lang="' . esc_attr( $wpcom_locale ) . '" dir="' . ( is_rtl() ? 'rtl' : 'ltr' ) . '"><div class="wpnt-notes-panel-header"><span class="wpnt-notes-header">' . __( 'Notifications', 'jetpack' ) . '</span><span class="wpnt-notes-panel-link"></span></div></div>' . $third_party_cookie_check_iframe,
 					'class' => 'menupop',
 				),
 				'parent' => 'top-secondary',
@@ -227,6 +229,21 @@ class Jetpack_Notifications {
 	var wpNotesLinkAccountsURL = '<?php echo esc_url( $link_accounts_url ); ?>';
 <?php endif; ?>
 /* ]]> */
+	window.addEventListener('message', function ( event ) {
+		// Confirm that the message is from the right origin.
+		if ('https://widgets.wp.com' !== event.origin) {
+			return;
+		}
+		// Check whether 3rd Party Cookies are blocked
+		var has3PCBlocked = 'WPCOM:3PC:blocked' === event.data;
+
+		var tagerElement = document.getElementById('wp-admin-bar-notes');
+
+		if ( has3PCBlocked && tagerElement ) {
+			// Hide the notification button/icon
+			tagerElement.style.display = 'none';
+		}
+	}, false );
 </script>
 		<?php
 	}


### PR DESCRIPTION
This PR hides wp.com notifications button in admin bar when third-party cookies are blocked.

Fixes #24832, Completes 1164141197617539-as-1202693674383091/f

#### Changes proposed in this Pull Request:
* It adds a hidden widget (`widgets.wp.com`) in an iframe just beside the notifications button
* It adds an event listener to subscribe to the message events from the iframe informing whether cookies are blocked
* It then hides the notification button if cookies are blocked

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
p1HpG7-gS4-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply D85866-code to your sandbox
* Ensure that `widgets.wp.com` points to your sandbox in the host file
* Ensure that [this link](https://widgets.wp.com/3rd-party-cookie-check/index.html) loads in your browser to confirm host file changes
* Create a JN site using Jetpack Live Branches below or open [this link](https://jurassic.ninja/create?jetpack-beta&branches.jetpack=update/hide-wpcom-notes-when-no-3pc&wp-debug-log)
* Connect Jetpack
* In your browser settings enable All or Third-party cookies, e.g. in Chrome enter this in the address bar `chrome://settings/cookies` to goto cookies related settings
* Goto wp-admin of your JN site
* Confirm that you see the WPCOM notifications button in the admin bar
* Click on the button
* Confirm that the notifications load correctly
* Now in your browser settings, Block third-party cookies.
* Reload wp-admin of the JN site
* Confirm that WPCOM notifications button is no longer visible


| 3rd party cookies ALLOWED | 3rd party cookies BLOCKED |
| - | - |
| <img width="426" alt="Screenshot 2022-08-12 at 12 56 30 PM" src="https://user-images.githubusercontent.com/18226415/184306054-45b6ef40-9f61-489b-96d5-ac81f03b5895.png"> | <img width="351" alt="Screenshot 2022-08-12 at 12 57 03 PM" src="https://user-images.githubusercontent.com/18226415/184306107-5e811087-2f04-4b83-afcf-62c8d8567ea1.png"> |

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1202693674383091