### PR TITLE
Repo Gardening: do not send Slack reminders for closed issues

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/fix-repo-gardening-no-reminders-closed-issues
+++ b/projects/github-actions/repo-gardening/changelog/fix-repo-gardening-no-reminders-closed-issues
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Gather Support References: avoid sending reminders for closed issues.

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -224,6 +224,14 @@ async function checkForEscalation( issueReferences, commentBody, escalationNote,
 		return true;
 	}
 
+	// When the issue is already closed, do not send any Slack reminder.
+	if ( payload.issue.state === 'closed' ) {
+		debug(
+			`gather-support-references: Issue ${ payload.issue.number } is closed, no need to escalate.`
+		);
+		return false;
+	}
+
 	debug(
 		`gather-support-references: Issue #${ payload.issue.number } has now gathered more than 10 tickets. It's time to escalate it.`
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

When an issue is closed, even if it's already gathered a lot of tickets, we do not need to escalate it anymore, so let's not send any Slack message.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

* p1660323987770139/1660320265.911789-slack-C03G2H51WJX

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* It cannot really be tested here before we merge, but here is an issue that triggered no Slack reminder:

- https://github.com/jeherve/jetpack/issues/43#issuecomment-1213355928
- https://github.com/jeherve/jetpack/runs/7810991972?check_suite_focus=true

<img width="782" alt="Screen Shot 2022-08-12 at 19 37 46" src="https://user-images.githubusercontent.com/426388/184413430-0f065ff1-ef89-46de-82a4-fc9701d75962.png">
