### PR TITLE
Instant Search: only show animation to users who have not chosen reduced motion

### DIFF
--- a/projects/packages/search/changelog/add-search-css-reduced-motion
+++ b/projects/packages/search/changelog/add-search-css-reduced-motion
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Instant Search: Only show animation to users who have not chosen reduced motion
+Instant Search: only show animation to users who have not chosen reduced motion

--- a/projects/packages/search/changelog/add-search-css-reduced-motion
+++ b/projects/packages/search/changelog/add-search-css-reduced-motion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Instant Search: Only show animation to users who have not chosen reduced motion

--- a/projects/packages/search/src/instant-search/components/overlay.scss
+++ b/projects/packages/search/src/instant-search/components/overlay.scss
@@ -22,8 +22,6 @@ $overlay-horizontal-padding-lg: 3em;
 	overflow-x: hidden;
 	overflow-y: auto;
 
-	transition: opacity 0.1s ease-in;
-
 	z-index: 9999999999999;
 
 	// Override font for Argent theme.
@@ -68,3 +66,9 @@ $overlay-horizontal-padding-lg: 3em;
     }
 }
 
+// Only show animation to users who have not chosen reduced motion
+@media (prefers-reduced-motion: no-preference) {
+	.jetpack-instant-search__overlay {
+		transition: opacity 0.1s ease-in;
+	}
+}

--- a/projects/packages/search/src/instant-search/components/search-box.scss
+++ b/projects/packages/search/src/instant-search/components/search-box.scss
@@ -66,7 +66,6 @@ input.jetpack-instant-search__box-input.search-field {
 	height: 60px;
 	line-height: 1;
 	margin: 0 0.25em 0 0;
-	transition: 0.1s linear all;
 	width: 60px;
 	word-wrap: normal;
 
@@ -84,7 +83,6 @@ input.jetpack-instant-search__box-input.search-field {
 .jetpack-instant-search__box input[type='search'].jetpack-instant-search__box-input {
 	width: 100%;
 	height: 52px;
-	transition: color 0.15s ease-in-out, border-color 0.25s ease-in-out;
 	outline-style: none;
 	border: none;
 	box-shadow: none;
@@ -110,5 +108,16 @@ input.jetpack-instant-search__box-input.search-field {
 	&::-ms-clear,
 	&::-ms-reveal {
 		display: none;
+	}
+}
+
+// Only show animation to users who have not chosen reduced motion
+@media (prefers-reduced-motion: no-preference) {
+	.jetpack-instant-search__box input[type='button'] {
+		transition: 0.1s linear all;
+	}
+
+	.jetpack-instant-search__box input[type='search'].jetpack-instant-search__box-input {
+		transition: color 0.15s ease-in-out, border-color 0.25s ease-in-out;
 	}
 }

--- a/projects/packages/search/src/instant-search/components/search-results.scss
+++ b/projects/packages/search/src/instant-search/components/search-results.scss
@@ -68,7 +68,6 @@ $modal-max-width-lg: 95%;
 	margin: 0;
 	padding: 8px;
 	text-decoration: none;
-	transition: background-color 0.25s ease-in-out;
 
 	.jetpack-instant-search__overlay--no-sidebar & {
 		visibility: hidden;
@@ -82,6 +81,7 @@ $modal-max-width-lg: 95%;
 	@include break( '>l' ) {
 		display: none;
 	}
+
 	#{$customberg-container-selector } & {
 		@include break( '>l' ) {
 			display: flex;
@@ -273,4 +273,11 @@ button.jetpack-instant-search__overlay-close {
 	margin: 50px;
 	display: block;
 	flex: none;
+}
+
+// Only show animation to users who have not chosen reduced motion
+@media (prefers-reduced-motion: no-preference) {
+	.jetpack-instant-search__search-results-filter-button {
+		transition: background-color 0.25s ease-in-out;
+	}
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack/issues/25348.

#### Changes proposed in this Pull Request:
We currently use `transition` in a few spots for animation (including when opening the overlay). This PR removes `transition` by default and then adds it back if the user has not specified a reduced motion preference in their accessibility settings.

Reference: https://www.joshwcomeau.com/react/prefers-reduced-motion/

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Set up a test site with Instant Search.

Confirm that, on the front end of the site, there is animation when opening the search overlay. You can verify this in the CSS inspector in your browser.

Now in your system accessibility settings, choose 'Reduce motion'.

<img width="780" alt="Screen Shot 2022-08-10 at 16 27 33" src="https://user-images.githubusercontent.com/17325/183816699-3407fb01-4d53-4fc8-a183-f1a62dbaeed1.png">

Confirm that, after refreshing the page on the front end of the site, there is *no* animation when opening the search overlay.