### PR TITLE
Instant Search: use classname rather than ID for styling sort select

### DIFF
--- a/projects/packages/search/changelog/fix-sort-id-to-class
+++ b/projects/packages/search/changelog/fix-sort-id-to-class
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Instant Search: use classname rather than ID for styling sort select

--- a/projects/packages/search/src/instant-search/components/search-app.scss
+++ b/projects/packages/search/src/instant-search/components/search-app.scss
@@ -168,7 +168,7 @@ body.enable-search-modal .cover-modal.show-modal.search-modal.active {
 		color: $studio-gray-80;
 	}
 
-	#jetpack-instant-search__search-sort-select {
+	.jetpack-instant-search__search-sort-select {
 		background: $color-dark-modal-background;
 		border-color: $color-dark-layout-borders;
 		color: $color-dark-text;

--- a/projects/packages/search/src/instant-search/components/search-sort.jsx
+++ b/projects/packages/search/src/instant-search/components/search-sort.jsx
@@ -35,6 +35,7 @@ export default class SearchSort extends Component {
 						{ __( 'Sort:', 'jetpack-search-pkg' ) }
 					</label>
 					<select
+						className="jetpack-instant-search__search-sort-select"
 						id="jetpack-instant-search__search-sort-select"
 						onBlur={ this.handleSelectChange }
 						onChange={ this.handleSelectChange }

--- a/projects/packages/search/src/instant-search/components/search-sort.scss
+++ b/projects/packages/search/src/instant-search/components/search-sort.scss
@@ -35,7 +35,7 @@
 	}
 }
 
-#jetpack-instant-search__search-sort-select {
+.jetpack-instant-search__search-sort-select {
 	font-size: 1em;
 
 	padding: 0.25em;


### PR DESCRIPTION
The Calypso CSS standards (which we use on Instant Search) say:

```
Avoid # selectors for style purposes. Their specificity becomes troublesome to manage fairly quickly.
```

https://github.com/Automattic/wp-calypso/blob/trunk/docs/coding-guidelines/css.md

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Replace ID with class for styling `.jetpack-instant-search__search-sort-select`.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
On a test site with Instant Search, load results with the `product` result format:

/?s=&sort=newest&result_format=product

... and check that the sort dropdown is styled correctly.

<img width="254" alt="Screen Shot 2022-08-15 at 15 31 43" src="https://user-images.githubusercontent.com/17325/184572656-7ae62320-819c-4fb5-9ee8-12b410e41eff.png">

Try both light and dark modes.



