### PR TITLE
Super Cache: add missing plugin slug to composer file

### DIFF
--- a/projects/plugins/super-cache/changelog/add-super-cache-plugin-slug
+++ b/projects/plugins/super-cache/changelog/add-super-cache-plugin-slug
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Janitorial: add missing plugin slug to composer file.
+
+

--- a/projects/plugins/super-cache/composer.json
+++ b/projects/plugins/super-cache/composer.json
@@ -42,6 +42,7 @@
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/wp-super-cache/compare/v${old}...v${new}"
 		},
-		"release-branch-prefix": "super-cache"
+		"release-branch-prefix": "super-cache",
+		"wp-plugin-slug": "wp-super-cache"
 	}
 }

--- a/projects/plugins/super-cache/composer.lock
+++ b/projects/plugins/super-cache/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9dd1dd57fb4ab7865de4b84d95dfae8c",
+    "content-hash": "77d33507620dd0c6c35bfacbc47a4f52",
     "packages": [],
     "packages-dev": [
         {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Add the custom plugin slug to the composer file, to support the matching slug on WordPress.org.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Not much to test on this one; this will be tested when a plugin update is eventually released.
