### PR TITLE
Update/upgrade banner in columns

### DIFF
--- a/projects/plugins/jetpack/changelog/update-upgrade-banner-in-columns
+++ b/projects/plugins/jetpack/changelog/update-upgrade-banner-in-columns
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Fix display of upgrade nudge when a premium block is displayed in a narrow column
+
+

--- a/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/editor.scss
+++ b/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/editor.scss
@@ -7,16 +7,14 @@ $icon-background-color: #fff;
 
 // Upgrade Banner.
 .jetpack-upgrade-plan-banner {
-	$banner-height: 48px;
-
 	.jetpack-upgrade-plan-banner__wrapper {
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
 		font-size: 14px;
-		height: $banner-height;
+		height: auto;
 		background: black;
-		padding: 0 20px;
+		padding: 10px 20px;
 		border-radius: 2px;
 		box-shadow: 0 0 1px inset $studio-white;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Other approaches have been discussed on #25102

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
A nudge to upgrade plan is displayed for Premium Blocks, however on
constrained widths, such as when displayed inside a column block, this
nudge is not displayed correctly. The nudge becomes hard to read and is
obscured by the toolbar menu.

The toolbar is displayed in relation to the block element, this change
attempts to capitalise on that by setting the style of the block element
in javascript to leave enough space for the upgrade nudge. It does not
work because this is calculated too late - after the toolbar rendering
code has ran.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

