### PR TITLE
WPSC: fix readme changelog header marker

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-wpsc-readme-changelog-marker
+++ b/projects/plugins/super-cache/changelog/fix-wpsc-readme-changelog-marker
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix readme changelog header
+
+

--- a/projects/plugins/super-cache/readme.txt
+++ b/projects/plugins/super-cache/readme.txt
@@ -267,7 +267,7 @@ Your theme is probably responsive which means it resizes the page to suit whatev
 * [WordPress Mobile Pack](https://wordpress.org/plugins/wordpress-mobile-pack/) (can't have "Don't cache pages for known users." enabled)
 
 
-## Changelog ##
+== Changelog ==
 
 ### 1.7.9 ###
 * Fix nonces used by "Delete Cache" button and remove JS from it on the frontend admin bar.

--- a/projects/plugins/super-cache/readme.txt
+++ b/projects/plugins/super-cache/readme.txt
@@ -272,3 +272,7 @@ Your theme is probably responsive which means it resizes the page to suit whatev
 ### 1.7.9 ###
 * Fix nonces used by "Delete Cache" button and remove JS from it on the frontend admin bar.
 * Define the constant WPSCDISABLEDELETEBUTTON to disable the "Delete Cache" button in the admin bar.
+
+--------
+
+[See the previous changelogs here](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/super-cache/CHANGELOG.md#changelog)


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

When running `jetpack release plugins/<plugin> readme`, it requires the
`== Changelog ==` header to replace correctly.

Also adds link to the changelog file for looking at prior releases.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

n/a

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

Proofread.
