### PR TITLE
Fix/wp super cache contents align

### DIFF
--- a/projects/plugins/super-cache/changelog/survey-fix
+++ b/projects/plugins/super-cache/changelog/survey-fix
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Fixed the display issue with the survey link

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -995,9 +995,9 @@ table.wpsc-settings-table {
 		$call_out_box = "0px";
 		$showing_2022_survey = get_option('wpsc_2022-survey', true);
 		//to handle the way the yellow box is output in the UI in a table cell.
-		if($showing_2022_survey){
-			$call_out_box = "-90px";
-		}
+	if ( $showing_2022_survey && $curr_tab !== 'contents' ) {
+		$call_out_box = '-90px';
+	}
 	?>
 	
 	<script>


### PR DESCRIPTION
Small hot fix for the survey spilling over on the "contents" tab

#### Other information:
No new tests needed

#### Jetpack product discussion
No discussion needed here

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
- Open WP Super Cache settings
- Go to the "Contents" tab
- In trunk the survey notice would spill over the yellow box
- In this branch it does not spill over the box

