### PR TITLE
Stats: don't show links in dashboard widget when module inactive

### DIFF
--- a/projects/plugins/jetpack/changelog/update-stats-widget-inactive
+++ b/projects/plugins/jetpack/changelog/update-stats-widget-inactive
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Dashboard Widget: do not show the Stats configuration links when the feature is inactive

--- a/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
@@ -141,24 +141,29 @@ class Jetpack_Stats_Dashboard_Widget {
 			<?php
 				$jetpack_logo = new Jetpack_Logo();
 				echo $jetpack_logo->get_jp_emblem( true );// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			?>
-			<span>
-				<?php
-				if ( current_user_can( 'jetpack_manage_modules' ) ) :
-					$i18n_headers = jetpack_get_module_i18n( 'stats' );
-					?>
-			<a href="<?php echo esc_url( admin_url( 'admin.php?page=jetpack#/settings?term=' . rawurlencode( $i18n_headers['name'] ) ) ); ?>"
-				>
-					<?php
-					esc_html_e( 'Configure stats', 'jetpack' );
-					?>
-			</a>
-			|
-					<?php
-					endif;
+
+			if ( Jetpack::is_module_active( 'stats' ) ) :
 				?>
-			<a href="<?php echo esc_url( Redirect::get_url( 'jetpack-support-wordpress-com-stats' ) ); ?>" target="_blank"><?php esc_html_e( 'Learn more', 'jetpack' ); ?></a>
-			</span>
+				<span>
+					<?php
+					if ( current_user_can( 'jetpack_manage_modules' ) ) :
+						$i18n_headers = jetpack_get_module_i18n( 'stats' );
+						?>
+				<a href="<?php echo esc_url( admin_url( 'admin.php?page=jetpack#/settings?term=' . rawurlencode( $i18n_headers['name'] ) ) ); ?>"
+					>
+						<?php
+						esc_html_e( 'Configure stats', 'jetpack' );
+						?>
+				</a>
+				|
+						<?php
+						endif;
+					?>
+				<a href="<?php echo esc_url( Redirect::get_url( 'jetpack-support-wordpress-com-stats' ) ); ?>" target="_blank"><?php esc_html_e( 'Learn more', 'jetpack' ); ?></a>
+				</span>
+				<?php
+			endif;
+			?>
 
 		</div>
 		</footer>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The Jetpack Stats dashboard widget, while named that way, is used for more than just stats. When the stats module is inactive, we still register the widget and use it to display other types of stats: Akismet and Protect.

In those situations, the stats config links are not that useful and should be removed.

**Before**

<img width="617" alt="Screen Shot 2022-08-16 at 15 51 32" src="https://user-images.githubusercontent.com/426388/184898113-8d29c0c3-6bd6-44f7-9cbf-fc2dbee1be59.png">

**After**

<img width="621" alt="Screen Shot 2022-08-16 at 15 51 02" src="https://user-images.githubusercontent.com/426388/184898135-b463d5f4-3fe3-4d11-8908-b625d378a340.png">

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start with an existing site, with some stats data as well as Protect data (the 2 modules must be active).
* Go to `wp-admin` and note the Jetpack dashboard widget with the link to stats settings.
* Go to `wp-admin/admin.php?page=jetpack_modules&module_tag=Site%20Stats` and deactivate stats.
* The stats link should disappear from the dashboard widget.
