### PR TITLE
Deploy SVN: Include trunk location at end

### DIFF
--- a/tools/deploy-to-svn.sh
+++ b/tools/deploy-to-svn.sh
@@ -190,3 +190,5 @@ if [[ "$SVNTAG" =~ ^[0-9]+(\.[0-9]+)+$ ]]; then
 else
 	debug "As $TAG appears to be a prerelease version, skipping update of stable tag in readme.txt in SVN tags/$SVNTAG"
 fi
+
+info "Reminder that SVN trunk is at $DIR/trunk"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

When using the FG pages for a new release, you need to cd into the temp dir to svn ci the change to stable, but we only output that at the beginning of the process. We can output it again to make it easier to find.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add build dir to output at end of script.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* When doing a release and deploying to svn, see the output.
* Given the nature of this PR, I'm personally fine if powers that be opt to merge and test for the next weekly or standalone.

