### PR TITLE
Jetpack: Fix requiring missing utility-functions.php file

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-include-utility-functions-videopress
+++ b/projects/plugins/jetpack/changelog/fix-include-utility-functions-videopress
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Remove inclusion modules/videopress/utility-functions.php from Jetpack shortcodes module

--- a/projects/plugins/jetpack/modules/shortcodes/videopress.php
+++ b/projects/plugins/jetpack/modules/shortcodes/videopress.php
@@ -15,7 +15,6 @@ if ( ! Jetpack::is_module_active( 'videopress' ) ) {
 		'dns-prefetch'
 	);
 
-	include_once JETPACK__PLUGIN_DIR . 'modules/videopress/utility-functions.php';
 	include_once JETPACK__PLUGIN_DIR . 'modules/videopress/shortcode.php';
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes the following PHP Warning:

```
PHP Warning: include_once(/wordpress/plugins/jetpack/11.3-a.5/modules/videopress/utility-functions.php):
failed to open stream: No such file or directory in /wordpress/plugins/jetpack/11.3-a.5/modules/shortcodes/videopress.php on line 18”
```

The `utility-functions.php` doesn't exist anymore in the Jetpack plugin. It's provided by [the VideoPress package.](https://github.com/Automattic/jetpack/blob/f0ff539b8fc1e10e180f53044fec404076e20202/projects/packages/videopress/src/class-initializer.php#L44)

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Make sure the Videopress module **is inactive**.
* Visit the Jetpack dashboard and confirm you don't get the error mentioned above  in the debug log


