### PR TITLE
i18n-check-webpack-plugin: Document another problematic pattern

### DIFF
--- a/projects/js-packages/i18n-check-webpack-plugin/README.md
+++ b/projects/js-packages/i18n-check-webpack-plugin/README.md
@@ -148,6 +148,26 @@ if ( value === 'foo' ) {
 }
 ```
 
+This can also happen if you use different translator comments for the same string in multiple places, whether in the same file or different files.
+```js
+export const usedFunction = v => {
+	return sprintf(
+		/* translators: A thing */
+		__( 'Thing: %s', 'domain' ),
+		v
+	);
+};
+
+export const unusedFunction = v => {
+	return sprintf(
+		/* translators: A munged thing */
+		__( 'Thing: %s', 'domain' ),
+		munge( v )
+	);
+};
+```
+In that case a good fix would be to use identical translator comments for all instances of the string. Or, if the comments need to be different, that's a good sign you should be using `_x()` with differing contexts too.
+
 ## Caveats
 
 Certain situations cannot be detected by the plugin:

--- a/projects/js-packages/i18n-check-webpack-plugin/changelog/add-i18n-check-another-example
+++ b/projects/js-packages/i18n-check-webpack-plugin/changelog/add-i18n-check-another-example
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add documentation of another problematic pattern (same string with different translator comments).

--- a/projects/js-packages/i18n-check-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-check-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-check-webpack-plugin",
-	"version": "1.0.17",
+	"version": "1.0.18-alpha",
 	"description": "A Webpack plugin to check that WordPress i18n hasn't been mangled by Webpack optimizations.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/i18n-check-webpack-plugin/#readme",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
If the same string is used with different translator comments in
different places, and one of those branches is pruned, the check will
flag it. This seems worth mentioning in the documentation as a
problematic code pattern.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/25297#issuecomment-1216903278

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Does the new text look right and make sense?