### PR TITLE
Search: change conditions inside the same filter group to be unioned

### DIFF
--- a/projects/packages/search/changelog/update-change-filter-query-logic
+++ b/projects/packages/search/changelog/update-change-filter-query-logic
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Search: change conditions inside the same filter group to be unioned

--- a/projects/packages/search/src/instant-search/lib/api.js
+++ b/projects/packages/search/src/instant-search/lib/api.js
@@ -190,7 +190,7 @@ function buildFilterObject( filterQuery, adminQueryFilter, excludedPostTypes ) {
 		.filter( key => isLengthyArray( filterQuery[ key ] ) )
 		.forEach( key => {
 			// Filter conditions in the same group are OR-ed together.
-			const group_condition = { bool: { should: [] } };
+			const group_condition = { bool: { should: [], minimum_should_match: 1 } };
 			filterQuery[ key ].forEach( item => {
 				if ( filterKeyToEsFilter.has( key ) ) {
 					group_condition.bool.should.push( filterKeyToEsFilter.get( key )( item ) );

--- a/projects/plugins/search/changelog/update-change-filter-query-logic
+++ b/projects/plugins/search/changelog/update-change-filter-query-logic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Search E2E: change search request interception to cope with filtering changes

--- a/projects/plugins/search/tests/e2e/helpers/search-helper.js
+++ b/projects/plugins/search/tests/e2e/helpers/search-helper.js
@@ -88,8 +88,8 @@ export async function searchAPIRoute( page ) {
 		}
 
 		// deal with filtering: only works with one category and one tag by filtering the results array
-		const category = params.get( 'filter[bool][must][0][term][category.slug]' );
-		const tag = params.get( 'filter[bool][must][0][term][tag.slug]' );
+		const category = params.get( 'filter[bool][must][0][bool][should][0][term][category.slug]' );
+		const tag = params.get( 'filter[bool][must][1][bool][should][0][term][tag.slug]' );
 
 		if ( category ) {
 			body.results = body.results.filter( v => v?.categories?.includes( category ) );

--- a/projects/plugins/search/tests/e2e/helpers/search-helper.js
+++ b/projects/plugins/search/tests/e2e/helpers/search-helper.js
@@ -89,7 +89,7 @@ export async function searchAPIRoute( page ) {
 
 		// deal with filtering: only works with one category and one tag by filtering the results array
 		const category = params.get( 'filter[bool][must][0][bool][should][0][term][category.slug]' );
-		const tag = params.get( 'filter[bool][must][1][bool][should][0][term][tag.slug]' );
+		const tag = params.get( 'filter[bool][must][0][bool][should][0][term][tag.slug]' );
 
 		if ( category ) {
 			body.results = body.results.filter( v => v?.categories?.includes( category ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The previous logic was to get an intersection of all conditions regardless of whether the conditions are from the same filter (say category) or not. The PR proposes to change the operators among the conditions in the same group to be OR and keep the operators among groups to be AND. For example, the following filters would be interpreted as 

`( category='Classic' OR category='Post Formats') AND (tags='image' OR tags='Post Formats') AND (year=2010)`.

![image](https://user-images.githubusercontent.com/1425433/185257831-231ab094-7ce7-430e-9b1e-8755cbd20cda.png)


#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
pcNPJE-14g#comment-1524-p2

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Go to a site with Instant Search enabled and several filters configured
* Click two categories in the same group
* Ensure the total results increased rather than decreased previously



