### PR TITLE
Instant Search: Update styles to reduce usage of "!important".

### DIFF
--- a/projects/packages/search/changelog/overlay-add-focus-styles
+++ b/projects/packages/search/changelog/overlay-add-focus-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Instant Search: Add focus styles for easier keyboard navigation. (a11y)

--- a/projects/packages/search/changelog/overlay-replace-important-styles
+++ b/projects/packages/search/changelog/overlay-replace-important-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Instant Search: Update CSS styles to removes uses of "!important" where possible.

--- a/projects/packages/search/src/instant-search/components/scroll-button.scss
+++ b/projects/packages/search/src/instant-search/components/scroll-button.scss
@@ -7,5 +7,11 @@
 	box-shadow: none;
 	// !important is temporarily needed to override :not() selectors in certain themes like Twenty Twenty One
 	font-size: 13px !important;
-	padding: 0;
+	padding: 0 6px;
+
+	&:focus {
+		outline: 1px auto Highlight;
+		outline: 1px auto -webkit-focus-ring-color !important;
+		outline-offset: inherit;
+	}
 }

--- a/projects/packages/search/src/instant-search/components/scroll-button.scss
+++ b/projects/packages/search/src/instant-search/components/scroll-button.scss
@@ -1,12 +1,10 @@
 @import '../lib/styles/_helper.scss';
 
 .jetpack-instant-search__scroll-button {
-	@include inherit-parent-colors-important();
+	// @include inherit-parent-colors-important();
 	outline: 0;
 	border: 0;
 	box-shadow: none;
-	// !important is temporarily needed to override :not() selectors in certain themes like Twenty Twenty One
-	font-size: 13px !important;
 	padding: 0 6px;
 
 	&:focus {
@@ -14,4 +12,15 @@
 		outline: 1px auto -webkit-focus-ring-color !important;
 		outline-offset: inherit;
 	}
+}
+
+.jetpack-instant-search__search-results
+	.jetpack-instant-search__search-results-pagination
+	button.jetpack-instant-search__scroll-button {
+	// Extra specificity to override overly agressive theme styles.
+	// Without this, we need to use "!important" to get our default styling.
+	background-color: inherit;
+	color: #646970;
+	font-size: inherit;
+	font-weight: inherit;
 }

--- a/projects/packages/search/src/instant-search/components/search-filters.scss
+++ b/projects/packages/search/src/instant-search/components/search-filters.scss
@@ -19,8 +19,8 @@
 }
 
 .jetpack-instant-search__clear-filters-link {
-	@include inherit-parent-colors-important();
-	@include inherit-parent-font-size-important();
+	// @include inherit-parent-colors-important();
+	// @include inherit-parent-font-size-important();
 	border: none;
 	cursor: pointer;
 	position: absolute;
@@ -35,6 +35,17 @@
 		outline: 1px auto -webkit-focus-ring-color !important;
 		outline-offset: inherit;
 	}
+}
+
+.jetpack-instant-search__sidebar
+	.jetpack-instant-search__search-filters
+	button.jetpack-instant-search__clear-filters-link {
+	// Extra specificity to override overly agressive theme styles.
+	// Without this, we need to use "!important" to get our default styling.
+	background-color: inherit;
+	color: #646970;
+	font-size: inherit;
+	font-weight: inherit;
 }
 
 .jetpack-instant-search__search-filter-sub-heading {

--- a/projects/packages/search/src/instant-search/components/search-filters.scss
+++ b/projects/packages/search/src/instant-search/components/search-filters.scss
@@ -26,9 +26,15 @@
 	position: absolute;
 	margin: 0;
 	line-height: 1.3;
-	padding: 0;
+	padding: 0 4px;
 	right: 0;
 	top: 0;
+
+	&:focus {
+		outline: 1px auto Highlight;
+		outline: 1px auto -webkit-focus-ring-color !important;
+		outline-offset: inherit;
+	}
 }
 
 .jetpack-instant-search__search-filter-sub-heading {
@@ -63,6 +69,10 @@
 		&::after,
 		&::before {
 			display: none !important; // always hide custom selected checkbox styling.
+		}
+		&:focus {
+			outline: 1px auto Highlight;
+			outline: 1px auto -webkit-focus-ring-color !important;
 		}
 	}
 

--- a/projects/packages/search/src/instant-search/components/search-results.scss
+++ b/projects/packages/search/src/instant-search/components/search-results.scss
@@ -36,6 +36,7 @@ $modal-max-width-lg: 95%;
 		font-weight: 400;
 		margin-right: 4px;
 		margin-bottom: 4px;
+		padding: 4px 6px;
 		width: 1px;
 		overflow: hidden;
 		clip: rect( 1px, 1px, 1px, 1px );
@@ -44,6 +45,9 @@ $modal-max-width-lg: 95%;
 			clip: auto !important;
 			clip-path: none;
 			width: auto;
+			outline: 1px auto Highlight;
+			outline: 1px auto -webkit-focus-ring-color !important;
+			outline-offset: inherit;
 		}
 	}
 }
@@ -253,6 +257,7 @@ button.jetpack-instant-search__overlay-close {
 	&:focus {
 		outline: 1px auto Highlight;
 		outline: 1px auto -webkit-focus-ring-color !important; /* this won't work without !important */
+		outline-offset: inherit;
 	}
 
 	svg.gridicon {
@@ -276,7 +281,7 @@ button.jetpack-instant-search__overlay-close {
 }
 
 // Only show animation to users who have not chosen reduced motion
-@media (prefers-reduced-motion: no-preference) {
+@media ( prefers-reduced-motion: no-preference ) {
 	.jetpack-instant-search__search-results-filter-button {
 		transition: background-color 0.25s ease-in-out;
 	}

--- a/projects/packages/search/src/instant-search/components/search-sort.scss
+++ b/projects/packages/search/src/instant-search/components/search-sort.scss
@@ -56,8 +56,8 @@
 
 .jetpack-instant-search__search-sort-option {
 	@include remove-button-styling();
-	@include inherit-parent-colors-important();
-	@include inherit-parent-font-size-important();
+	// @include inherit-parent-colors-important();
+	// @include inherit-parent-font-size-important();
 	cursor: pointer;
 	padding: 0 2px 0 2px;
 
@@ -66,10 +66,20 @@
 		outline: 1px auto -webkit-focus-ring-color !important;
 		outline-offset: inherit;
 	}
+}
+
+.jetpack-instant-search__search-form-controls
+	.jetpack-instant-search__search-sort
+	button.jetpack-instant-search__search-sort-option {
+	// Extra specificity to override overly agressive theme styles.
+	// Without this, we need to use "!important" to get our default styling.
+	background-color: inherit;
+	color: #646970;
+	font-size: inherit;
+	font-weight: inherit;
 
 	&.is-selected {
-		// !important is temporarily needed to override :not() selectors in certain themes like Twenty Twenty One
-		color: $color-link-alt !important;
+		color: $color-link-alt;
 		font-weight: 600;
 		text-decoration: none;
 	}

--- a/projects/packages/search/src/instant-search/components/search-sort.scss
+++ b/projects/packages/search/src/instant-search/components/search-sort.scss
@@ -61,6 +61,12 @@
 	cursor: pointer;
 	padding: 0 2px 0 2px;
 
+	&:focus {
+		outline: 1px auto Highlight;
+		outline: 1px auto -webkit-focus-ring-color !important;
+		outline-offset: inherit;
+	}
+
 	&.is-selected {
 		// !important is temporarily needed to override :not() selectors in certain themes like Twenty Twenty One
 		color: $color-link-alt !important;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Introduces some more specific CSS rules for the various styled buttons in the Overlay. Separated out and limited to those styles (font/color attributes) that are currently dependant on `!important` directives. Necessary to prevent aggressive theme styles from bleeding into the Overlay.

With this technique, it would still be possible for site owners to override the styles as needed.

Also updates the font weights to match what we had initially before the Twenty Twenty One issues surfaced.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Visit a site with a Jetpack Search plan.
2. Make sure the Twenty Twenty One theme is active. It has the aggressive theme styles we are trying to address.
3. Open the Overlay by appending `?s=&category=uncategorized` to your site address.
4. Confirm the Sort Options buttons look correct.
5. Confirm the "Clear filters" button looks correct.
6. Clear the filters and confirm the "Load more" button looks correct.

You can toggle the light/dark themes from `/wp-admin/admin.php?page=jetpack-search-configure`.
