### PR TITLE
CI: Pass --no-frozen-lockfile to pnpm in "Lock files are up to date" check

### DIFF
--- a/.github/files/check-lock-files.sh
+++ b/.github/files/check-lock-files.sh
@@ -26,7 +26,7 @@ done
 for FILE in $(git -c core.quotepath=off ls-files 'pnpm-lock.yaml' '**/pnpm-lock.yaml'); do
 	cd $(dirname "$FILE")
 	echo "::group::$FILE - pnpm install"
-	pnpm install
+	pnpm install --no-frozen-lockfile
 	echo "::endgroup::"
 	if ! git diff --exit-code pnpm-lock.yaml; then
 		echo "---" # Bracket message containing newlines for better visibility in GH's logs.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Pnpm sets `--frozen-lockfile` by default in CI environments, which we
specifically don't want for this check as it ignores certain optional
updates.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/25661#discussion_r948834581

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make a PR that adds a project with a `package.json` that has no dependencies, and do not update `pnpm-lock.yaml`. CI should now complain that pnpm-lock needs updating where it wouldn't before.