### PR TITLE
VideoPress: remove side effects from package.json file

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-pkg-remove-side-effects
+++ b/projects/packages/videopress/changelog/update-videopress-pkg-remove-side-effects
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: remove sideEffect from package.json

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -48,6 +48,7 @@
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3",
 		"@automattic/jetpack-components": "workspace:* || ^0.18",
 		"@automattic/jetpack-connection": "workspace:* || ^0.18",
+		"@wordpress/components": "19.14.0",
 		"@wordpress/data": "6.12.0",
 		"@wordpress/element": "4.10.0",
 		"@wordpress/date": "4.12.0",

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -40,10 +40,6 @@
 		"webpack": "5.72.1",
 		"webpack-cli": "4.9.1"
 	},
-	"sideEffects": [
-		"*.css",
-		"*.scss"
-	],
 	"engines": {
 		"node": "^16.13.2",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
@@ -52,7 +48,6 @@
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3",
 		"@automattic/jetpack-components": "workspace:* || ^0.18",
 		"@automattic/jetpack-connection": "workspace:* || ^0.18",
-		"@wordpress/components": "19.14.0",
 		"@wordpress/data": "6.12.0",
 		"@wordpress/element": "4.10.0",
 		"@wordpress/date": "4.12.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

For some reason, it breaks the compiling system of the VideoPress package. It is not possible to compile the block editor files. Let's remove it for now, until finding an explanation about why it's happening.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: remove side effects from package.json file

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Clean and build the package:

```cli
jetpack build packages/videopress
```

Confirm that the block-editor files are properly compiled.
