### PR TITLE
VideoPress plugin: only redirect from plugins page activation

### DIFF
--- a/projects/plugins/videopress/changelog/update-videopress-activation
+++ b/projects/plugins/videopress/changelog/update-videopress-activation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Activation: only redirect when activating from the Plugins page in the browser

--- a/projects/plugins/videopress/composer.json
+++ b/projects/plugins/videopress/composer.json
@@ -12,6 +12,7 @@
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
 		"automattic/jetpack-my-jetpack": "2.0.x-dev",
 		"automattic/jetpack-sync": "1.38.x-dev",
+		"automattic/jetpack-plugins-installer": "0.2.x-dev",
 		"automattic/jetpack-videopress": "0.2.x-dev"
 	},
 	"require-dev": {

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dfca2391da9110a4f9a1ca7fe07d35be",
+    "content-hash": "799e7137d54856d84d6fa2f1fe821a04",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -4234,6 +4234,7 @@
         "automattic/jetpack-identity-crisis": 20,
         "automattic/jetpack-my-jetpack": 20,
         "automattic/jetpack-sync": 20,
+        "automattic/jetpack-plugins-installer": 20,
         "automattic/jetpack-videopress": 20
     },
     "prefer-stable": true,

--- a/projects/plugins/videopress/jetpack-videopress.php
+++ b/projects/plugins/videopress/jetpack-videopress.php
@@ -95,7 +95,10 @@ add_action( 'activated_plugin', 'jetpack_videopress_activation' );
  * @param string $plugin Path to the plugin file relative to the plugins directory.
  */
 function jetpack_videopress_activation( $plugin ) {
-	if ( JETPACK_VIDEOPRESS_ROOT_FILE_RELATIVE_PATH === $plugin ) {
+	if (
+		JETPACK_VIDEOPRESS_ROOT_FILE_RELATIVE_PATH === $plugin &&
+		\Automattic\Jetpack\Plugins_Installer::is_current_request_activating_plugin_from_plugins_screen( JETPACK_VIDEOPRESS_ROOT_FILE_RELATIVE_PATH )
+	) {
 		wp_safe_redirect( esc_url( admin_url( 'admin.php?page=jetpack-videopress' ) ) );
 		exit;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Plugin activation: Only redirect when activating from Plugins page in the browser
* Remove some Boost references

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-5CL-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate from the CLI and make sure there are no errors `wp plugin activate videopress`
* Activate it from the Plugins page in the admin and make sure you are redirected to the VideoPress plugin page after activation

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202813985335444