### PR TITLE
Search: add search dashboard page even when the submenu is hidden

### DIFF
--- a/projects/packages/search/changelog/update-add-search-dashboard-page-anyway
+++ b/projects/packages/search/changelog/update-add-search-dashboard-page-anyway
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search: add Search Dashboard page even when submenu is hidden

--- a/projects/packages/search/src/dashboard/class-dashboard.php
+++ b/projects/packages/search/src/dashboard/class-dashboard.php
@@ -93,23 +93,32 @@ class Dashboard {
 	 * The page to be added to submenu
 	 */
 	public function add_wp_admin_submenu() {
-		if ( ! $this->should_add_search_submenu() ) {
-			return;
-		}
-
 		// Jetpack of version <= 10.5 would register `jetpack-search` submenu with its built-in search module.
 		$this->remove_search_submenu_if_exists();
 
-		$page_suffix = Admin_Menu::add_menu(
-			__( 'Search Settings', 'jetpack-search-pkg' ),
-			_x( 'Search', 'product name shown in menu', 'jetpack-search-pkg' ),
-			'manage_options',
-			'jetpack-search',
-			array( $this, 'render' ),
-			100
-		);
-
-		add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );
+		$page_suffix = '';
+		if ( $this->should_add_search_submenu() ) {
+			$page_suffix = Admin_Menu::add_menu(
+				__( 'Search Settings', 'jetpack-search-pkg' ),
+				_x( 'Search', 'product name shown in menu', 'jetpack-search-pkg' ),
+				'manage_options',
+				'jetpack-search',
+				array( $this, 'render' ),
+				100
+			);
+		} else {
+			$page_suffix = add_submenu_page(
+				null,
+				__( 'Search Settings', 'jetpack-search-pkg' ),
+				_x( 'Search', 'product name shown in menu', 'jetpack-search-pkg' ),
+				'manage_options',
+				'jetpack-search',
+				array( $this, 'render' )
+			);
+		}
+		if ( $page_suffix ) {
+			add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );
+		}
 	}
 
 	/**

--- a/projects/packages/search/src/dashboard/class-dashboard.php
+++ b/projects/packages/search/src/dashboard/class-dashboard.php
@@ -108,6 +108,7 @@ class Dashboard {
 			);
 		} else {
 			$page_suffix = add_submenu_page(
+				// The page is added without a submenu item.
 				null,
 				__( 'Search Settings', 'jetpack-search-pkg' ),
 				_x( 'Search', 'product name shown in menu', 'jetpack-search-pkg' ),

--- a/projects/packages/search/src/dashboard/class-dashboard.php
+++ b/projects/packages/search/src/dashboard/class-dashboard.php
@@ -96,6 +96,7 @@ class Dashboard {
 		// Jetpack of version <= 10.5 would register `jetpack-search` submenu with its built-in search module.
 		$this->remove_search_submenu_if_exists();
 
+		// We are considering another approach.
 		$page_suffix = '';
 		if ( $this->should_add_search_submenu() ) {
 			$page_suffix = Admin_Menu::add_menu(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
We have the Search submenu added [only under certain circumstance](https://github.com/Automattic/jetpack/blob/7f10325a9cfa7a45dbc987e7074d081e52e3e8b0/projects/packages/search/src/dashboard/class-dashboard.php#L96), but there are places (e.g. #25340, #25718) that link/redirect to the dashboard anyway, which would error out when the submenu is not added. The PR proposes to add the page anyway to eliminate errors like that.

- When the submenu is added, it's just fine
- When the submenu is not added, we only add the page

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Create a fresh JN site with Search and Jetpack plugin by visiting [link](https://jurassic.ninja/create/?jetpack-beta&branches.jetpack-search=update/add-search-dashboard-page-anyway) 
* Open `/wp-admin/`
* Ensure Search submenu is not registered
* Open `/wp-admin/admin.php?page=jetpack-search`
* Ensure connection page is displayed correctly

