### PR TITLE
Test results to Slack: fix notification for schedule event

### DIFF
--- a/projects/github-actions/test-results-to-slack/changelog/fix-slack-notif-for-schedule
+++ b/projects/github-actions/test-results-to-slack/changelog/fix-slack-notif-for-schedule
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed notifications for event of type schedule

--- a/projects/github-actions/test-results-to-slack/src/github.js
+++ b/projects/github-actions/test-results-to-slack/src/github.js
@@ -9,15 +9,15 @@ const extras = require( './extra-context' );
 async function isWorkflowFailed( token ) {
 	// eslint-disable-next-line new-cap
 	const octokit = new github.getOctokit( token );
-	const {
-		payload: { repository },
-		runId,
-	} = github.context;
+
+	const { runId } = github.context;
+	const { repository } = extras;
+	const repo = repository.split( '/' );
 
 	// Get the list of jobs for the current workflow run
 	const response = await octokit.rest.actions.listJobsForWorkflowRun( {
-		owner: repository.owner.login,
-		repo: repository.name,
+		owner: repo[ 0 ],
+		repo: repo[ 1 ],
 		run_id: runId,
 	} );
 

--- a/projects/github-actions/test-results-to-slack/tests/content.test.js
+++ b/projects/github-actions/test-results-to-slack/tests/content.test.js
@@ -1,9 +1,9 @@
-const { mockGitHubContext, setInputData } = require( './test-utils' );
+const { mockGitHubContext, mockContextExtras } = require( './test-utils' );
 
 const sha = '12345abcd';
 const refName = 'trunk';
 const refType = 'branch';
-const repo = 'foo/bar';
+const repository = 'foo/bar';
 const commitId = '123';
 const commitURL = `https://github.com/commit/${ commitId }`;
 const prNumber = '123';
@@ -12,14 +12,11 @@ const prTitle = 'Pull request title';
 const runId = '123456789';
 const actor = 'octocat';
 const triggeringActor = 'another-octocat';
-
-beforeAll( () => {
-	setInputData( { repo } );
-} );
+const runAttempt = '1';
 
 describe( 'Notification text', () => {
 	test.each`
-		event               | isFailure  | expected
+		eventName           | isFailure  | expected
 		${ 'push' }         | ${ false } | ${ { text: `Tests passed on ${ refType } *${ refName }*` } }
 		${ 'push' }         | ${ true }  | ${ { text: `Tests failed on ${ refType } *${ refName }*` } }
 		${ 'schedule' }     | ${ false } | ${ { text: `Tests passed for scheduled run on ${ refType } *${ refName }*` } }
@@ -29,23 +26,19 @@ describe( 'Notification text', () => {
 		${ 'unsupported' }  | ${ true }  | ${ { text: `Tests failed for ${ sha }` } }
 	`(
 		`Message text is correct for $event event and workflow failed=$isFailure`,
-		async ( { event, isFailure, expected } ) => {
+		async ( { eventName, isFailure, expected } ) => {
 			// Mock GitHub context
-			await mockGitHubContext( {
+			mockGitHubContext( {
 				payload: {
 					head_commit: { url: commitURL, id: '123' },
 					pull_request: { html_url: prUrl, number: prNumber, title: prTitle },
 				},
 				sha,
-				eventName: event,
+				eventName,
 				runId,
 				actor,
 			} );
-			process.env.GITHUB_RUN_ATTEMPT = '1';
-			process.env.GITHUB_REF_TYPE = refType;
-			process.env.GITHUB_REF_NAME = refName;
-			process.env.GITHUB_REPOSITORY = repo;
-			process.env.GITHUB_TRIGGERING_ACTOR = triggeringActor;
+			mockContextExtras( { repository, refType, refName, triggeringActor, runAttempt } );
 
 			const { getNotificationData } = require( '../src/github' );
 			const actual = await getNotificationData( isFailure );

--- a/projects/github-actions/test-results-to-slack/tests/extra-context.test.js
+++ b/projects/github-actions/test-results-to-slack/tests/extra-context.test.js
@@ -1,3 +1,5 @@
+const { mockContextExtras } = require( './test-utils' );
+
 describe( 'Extra context', () => {
 	const runAttempt = '3';
 	const refType = 'branch';
@@ -5,11 +7,7 @@ describe( 'Extra context', () => {
 	const repository = 'foo/bar';
 	const triggeringActor = 'octocat';
 
-	process.env.GITHUB_RUN_ATTEMPT = runAttempt;
-	process.env.GITHUB_REF_TYPE = refType;
-	process.env.GITHUB_REF_NAME = refName;
-	process.env.GITHUB_REPOSITORY = repository;
-	process.env.GITHUB_TRIGGERING_ACTOR = triggeringActor;
+	mockContextExtras( { repository, refType, refName, triggeringActor, runAttempt } );
 
 	test( 'Environment variables are exposed in extra context', async () => {
 		const extras = require( '../src/extra-context' );

--- a/projects/github-actions/test-results-to-slack/tests/test-utils.js
+++ b/projects/github-actions/test-results-to-slack/tests/test-utils.js
@@ -1,7 +1,7 @@
 const github = require( '@actions/github' );
 
 /**
- * Mocks the GitHub context
+ * Mocks the GitHub context exposed by `@actions/github`
  *
  * @param {object} value - context object
  */
@@ -17,23 +17,53 @@ function mockGitHubContext( value ) {
  * @param {object} options - options object
  */
 function setInputData( options ) {
+	const { ghToken, slackToken, slackChannel, slackUsername, slackIconEmoji } = options;
+
+	if ( ghToken ) {
+		process.env.INPUT_GITHUB_TOKEN = ghToken;
+	}
+
+	if ( slackToken ) {
+		process.env.INPUT_SLACK_TOKEN = slackToken;
+	}
+
+	if ( slackChannel ) {
+		process.env.INPUT_SLACK_CHANNEL = slackChannel;
+	}
+
+	if ( slackUsername ) {
+		process.env.INPUT_SLACK_USERNAME = slackUsername;
+	}
+
+	if ( slackIconEmoji ) {
+		process.env.INPUT_SLACK_ICON_EMOJI = slackIconEmoji;
+	}
+}
+
+/**
+ * The context exposed by `@actions/github` is missing some properties that we need.
+ * This function sets those env variables that we use to fill the missing properties.
+ *
+ * @param {object} options - options object
+ */
+function mockContextExtras( options ) {
 	const {
-		ghToken = 'token',
-		slackToken = 'token',
-		slackChannel = '123ABC',
-		slackUsername = 'Reporter',
-		slackIconEmoji = ':bot:',
-		repo = 'foo/bar',
+		runAttempt = '1',
+		refType = 'branch',
+		refName = 'trunk',
+		repository = 'foo/bar',
+		triggeringActor = 'the-other-octocat',
 	} = options;
-	process.env.INPUT_GITHUB_TOKEN = ghToken;
-	process.env.INPUT_SLACK_TOKEN = slackToken;
-	process.env.INPUT_SLACK_CHANNEL = slackChannel;
-	process.env.INPUT_SLACK_USERNAME = slackUsername;
-	process.env.INPUT_SLACK_ICON_EMOJI = slackIconEmoji;
-	process.env.GITHUB_REPOSITORY = repo;
+
+	process.env.GITHUB_RUN_ATTEMPT = runAttempt;
+	process.env.GITHUB_REF_TYPE = refType;
+	process.env.GITHUB_REF_NAME = refName;
+	process.env.GITHUB_REPOSITORY = repository;
+	process.env.GITHUB_TRIGGERING_ACTOR = triggeringActor;
 }
 
 module.exports = {
 	mockGitHubContext,
 	setInputData,
+	mockContextExtras,
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The repository information used to call GitHub API to get workflow conclusion was missing in the `schedule` event payload, making the call to fail and thus the notification.
This PR changes the source of the data and gets the repository information from the root of the context, where it should be available for all events.

I also cleaned up the tests a bit.


#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
pd5faL-aI-p2

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- All tests should pass.
- Hard to test e2e, until it gets merged, and a scheduled run runs.