### PR TITLE
Sync class-wpcom-admin-menu.php

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-wpcom-menu
+++ b/projects/plugins/jetpack/changelog/fix-wpcom-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+sync class-wpcom-admin-menu file

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -345,6 +345,9 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	public function add_options_menu() {
 		parent::add_options_menu();
 
+		if ( apply_filters( 'dsp_promote_posts_enabled', false, get_current_user_id() ) ) {
+			add_submenu_page( 'tools.php', esc_attr__( 'Advertising', 'jetpack' ), __( 'Advertising', 'jetpack' ), 'manage_options', 'https://wordpress.com/advertising/' . $this->domain, null, 1 );
+		}
 		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 10 );
 	}
 


### PR DESCRIPTION
I've added this changes to this file: `wpcom/wp-content/mu-plugins/masterbar/admin-menu/class-wpcom-admin-menu.php` on WPCOM and this PR is to get it in Sync.

The changes to the files where done in this 2 diffs:  D86138-code D86236-code

#### Testing instructions:
No visible changes, this changes WPCOM menu.

#### Does this pull request change what data or activity we track or use?
no