### PR TITLE
Update/deprecate jetpack plan for waf,status,jetpack

### DIFF
--- a/projects/packages/plans/changelog/update-deprecate-jetpack-plan-waf-status-jetpack
+++ b/projects/packages/plans/changelog/update-deprecate-jetpack-plan-waf-status-jetpack
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+Deprecated Jetpack_Plan class to Current_Plan

--- a/projects/packages/status/changelog/update-deprecate-jetpack-plan-waf-status-jetpack
+++ b/projects/packages/status/changelog/update-deprecate-jetpack-plan-waf-status-jetpack
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+Deprecated Jetpack_Plan class to Current_Plan

--- a/projects/packages/status/composer.json
+++ b/projects/packages/status/composer.json
@@ -4,7 +4,8 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-constants": "^1.6"
+		"automattic/jetpack-constants": "^1.6",
+		"automattic/jetpack-plans": "0.2.x-dev"
 	},
 	"require-dev": {
 		"brain/monkey": "2.6.1",

--- a/projects/packages/status/src/class-modules.php
+++ b/projects/packages/status/src/class-modules.php
@@ -436,7 +436,7 @@ class Modules {
 				}
 			}
 
-			if ( class_exists( 'Jetpack_Plan' ) && ! \Jetpack_Plan::supports( $module ) ) {
+			if ( class_exists( 'Current_Plan' ) && ! Current_Plan::supports( $module ) ) {
 				return false;
 			}
 

--- a/projects/packages/waf/changelog/update-deprecate-jetpack-plan-waf-status-jetpack
+++ b/projects/packages/waf/changelog/update-deprecate-jetpack-plan-waf-status-jetpack
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+Deprecated Jetpack_Plan class to Current_Plan

--- a/projects/packages/waf/composer.json
+++ b/projects/packages/waf/composer.json
@@ -4,7 +4,8 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"wikimedia/aho-corasick": "^1.0"
+		"wikimedia/aho-corasick": "^1.0",
+		"automattic/jetpack-plans": "0.2.x-dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.0.3",

--- a/projects/packages/waf/src/class-waf-endpoints.php
+++ b/projects/packages/waf/src/class-waf-endpoints.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Waf;
 
 use Automattic\Jetpack\Connection\REST_Connector;
+use Automattic\Jetpack\Current_Plan;
 use WP_Error;
 use WP_REST_Server;
 
@@ -32,7 +33,7 @@ class Waf_Endpoints {
 	 */
 	private static function has_rules_access() {
 		// any site with Jetpack Scan can download new WAF rules
-		return \Jetpack_Plan::supports( 'scan' );
+		return Current_Plan::supports( 'scan' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-deprecate-jetpack-plan-waf-status-jetpack
+++ b/projects/plugins/jetpack/changelog/update-deprecate-jetpack-plan-waf-status-jetpack
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Deprecated Jetpack_Plan to Current_Plan class

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
+use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Partner_Coupon as Jetpack_Partner_Coupon;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
@@ -78,7 +79,7 @@ class Jetpack_Admin {
 
 		if ( class_exists( 'Akismet_Admin' ) ) {
 			// If the site has Jetpack Anti-Spam, change the Akismet menu label accordingly.
-			$site_products      = Jetpack_Plan::get_products();
+			$site_products      = Current_Plan::get_products();
 			$anti_spam_products = array( 'jetpack_anti_spam_monthly', 'jetpack_anti_spam' );
 			if ( ! empty( array_intersect( $anti_spam_products, array_column( $site_products, 'product_slug' ) ) ) ) {
 				// Prevent Akismet from adding a menu item.
@@ -412,7 +413,7 @@ class Jetpack_Admin {
 			return false;
 		}
 
-		return Jetpack_Plan::supports( $module['module'] );
+		return Current_Plan::supports( $module['module'] );
 
 	}
 
@@ -479,7 +480,7 @@ class Jetpack_Admin {
 		/*
 		 * Plan restrictions.
 		 */
-		if ( ! Jetpack_Plan::supports( $module['module'] ) ) {
+		if ( ! Current_Plan::supports( $module['module'] ) ) {
 			return __( 'Not supported by current plan', 'jetpack' );
 		}
 

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -10,6 +10,7 @@ use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 
@@ -1114,7 +1115,7 @@ class Jetpack_Gutenberg {
 	public static function set_availability_for_plan( $slug ) {
 		$slug = self::remove_extension_prefix( $slug );
 
-		if ( Jetpack_Plan::supports( $slug ) ) {
+		if ( Current_Plan::supports( $slug ) ) {
 			self::set_extension_available( $slug );
 			return;
 		}
@@ -1142,7 +1143,7 @@ class Jetpack_Gutenberg {
 			}
 		} else {
 			// Jetpack sites.
-			$plan = Jetpack_Plan::get_minimum_plan_for_feature( $slug );
+			$plan = Current_Plan::get_minimum_plan_for_feature( $slug );
 		}
 
 		self::set_extension_unavailable(

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -752,7 +752,7 @@ class Jetpack {
 		);
 
 		// Update the site's Jetpack plan and products from API on heartbeats.
-		add_action( 'jetpack_heartbeat', array( 'Jetpack_Plan', 'refresh_from_wpcom' ) );
+		add_action( 'jetpack_heartbeat', array( 'Current_Plan', 'refresh_from_wpcom' ) );
 
 		/**
 		 * This is the hack to concatenate all css files into one.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -33,6 +33,7 @@
 		"automattic/jetpack-logo": "1.5.x-dev",
 		"automattic/jetpack-my-jetpack": "2.0.x-dev",
 		"automattic/jetpack-partner": "1.7.x-dev",
+		"automattic/jetpack-plans": "0.2.x-dev",
 		"automattic/jetpack-plugins-installer": "0.2.x-dev",
 		"automattic/jetpack-publicize": "0.11.x-dev",
 		"automattic/jetpack-redirect": "1.7.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "96a80b1b8f6f6b702b0b4cc0fdad6cbc",
+    "content-hash": "758249f1202cad638ed38635e051aa3c",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1718,10 +1718,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "1c747edbd6e497fd58eb51ddab48d836b61a5298"
+                "reference": "8ae93ae68b4488e5247d7edc93483d5b58d9612e"
             },
             "require": {
-                "automattic/jetpack-constants": "^1.6"
+                "automattic/jetpack-constants": "^1.6",
+                "automattic/jetpack-plans": "0.2.x-dev"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -1900,9 +1901,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/waf",
-                "reference": "76a37f2b5b89b3702a05cf7c31746107d606c313"
+                "reference": "0a3b548c2812091a19e307d1ea92a73d7b50bdf7"
             },
             "require": {
+                "automattic/jetpack-plans": "0.2.x-dev",
                 "wikimedia/aho-corasick": "^1.0"
             },
             "require-dev": {
@@ -5185,6 +5187,7 @@
         "automattic/jetpack-logo": 20,
         "automattic/jetpack-my-jetpack": 20,
         "automattic/jetpack-partner": 20,
+        "automattic/jetpack-plans": 20,
         "automattic/jetpack-plugins-installer": 20,
         "automattic/jetpack-publicize": 20,
         "automattic/jetpack-redirect": 20,


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Changed `Jetpack_Plans` class to `Current_Plan` class for packages and plugins
* This change has changes for multiple plugins

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

1202726932197503-as-1202726932197515
pdWQjU-4i-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Current_Plan occurrences should find the class and call the method.

#### Jetpack admin-page and Gutenberg

Put this into the top of constructor in class.jetpack-admin.php: (So it is not only running with Akismet)
```
$site_products = Current_Plan::get_products();
error_log(json_encode($site_products));
```
In the Current_Plan class put this into the get_products method: `error_log(wp_debug_backtrace_summary());`

In the logs you should see the function called, and the stack trace should start from the admin page

Into class.jetpack-admin.php. It should go to the Current_Plan class, check stack.

For Gutenberg add the debug backtrace function to the supports function in the Current_Plan class. Adding a new post on the site thus opening Gutenberg should trigger the function

#### waf package

Going to the Jetpack Firewall's settings should trigger the Current_Plan's support function. Use techniques above to check stack.

#### status package

Activating a module should go to the Current_Plan class's support function. Use techniques above to check stack.

These should work as before without error, testing with and without paid plan