### PR TITLE
Docs: Adding block deprecation information

### DIFF
--- a/projects/plugins/jetpack/changelog/update-docs-blocks-deprecation
+++ b/projects/plugins/jetpack/changelog/update-docs-blocks-deprecation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Doc update: add information about block deprecation.

--- a/projects/plugins/jetpack/extensions/README.md
+++ b/projects/plugins/jetpack/extensions/README.md
@@ -281,7 +281,7 @@ Blocks can be registered but not available:
 
 When updating block markup or attributes, you will want to avoid block validation errors showing to all current users of the previous version of the block.
 
-In Jetpack the scenario that has been used historically is to create a deprecation. This [developer.wordpress.org](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-deprecation/) guide explains block deprecation in more detail. An example of block deprecation can be seen with the [Tiled Gallery block here](https://github.com/Automattic/jetpack/tree/7d97ced29dbbf6bd5c7a5d85bb5d752d9245f1c7/projects/plugins/jetpack/extensions/blocks/tiled-gallery) (see`index.js` in both the `deprecated` folder and the root `tiled-gallery` folder to see the `default` import and export in use).
+In Jetpack the scenario that has been used historically is to create a deprecation. [This developer.wordpress.org guide](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-deprecation/) explains block deprecation in more detail. An example of block deprecation within Jetpack can be seen from [this `deprecated` directory within the Tiled Gallery block](https://github.com/Automattic/jetpack/tree/7d97ced29dbbf6bd5c7a5d85bb5d752d9245f1c7/projects/plugins/jetpack/extensions/blocks/tiled-gallery) (see`index.js` in both the `deprecated` folder and the root `tiled-gallery` folder to see the `default` import and export in use).
 
 ## Good to know when developing Gutenberg extensions
 

--- a/projects/plugins/jetpack/extensions/README.md
+++ b/projects/plugins/jetpack/extensions/README.md
@@ -277,6 +277,12 @@ Blocks can be registered but not available:
 - Registered: The block appears in the block inserter
 - Available: The block is included in the user's current plan and renders in the front end of the site
 
+## Block upgrade and deprecation paths
+
+When updating block markup or attributes, you will want to avoid block validation errors showing to all current users of the previous version of the block.
+
+In Jetpack the scenario that has been used historically is to create a deprecation. This [developer.wordpress.org](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-deprecation/) guide explains block deprecation in more detail. An example of block deprecation can be seen with the [Tiled Gallery block here](https://github.com/Automattic/jetpack/tree/7d97ced29dbbf6bd5c7a5d85bb5d752d9245f1c7/projects/plugins/jetpack/extensions/blocks/tiled-gallery) (see`index.js` in both the `deprecated` folder and the root `tiled-gallery` folder to see the `default` import and export in use).
+
 ## Good to know when developing Gutenberg extensions
 
 ### The Build


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* This PR adds some additional information to the extensions readme to cover scenarios where block deprecation would be used, such as upgrading a block's markup or attributes.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

p1661146310307909/1660922638.697689-slack-C01U2KGS2PQ

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Proof-read - does the location of the item within the readme seem obvious for example.