### PR TITLE
CSSTidy: adding margin-block as valid CSS properties

### DIFF
--- a/projects/plugins/jetpack/modules/custom-css/csstidy/data.inc.php
+++ b/projects/plugins/jetpack/modules/custom-css/csstidy/data.inc.php
@@ -108,6 +108,9 @@ $GLOBALS['csstidy']['unit_values'] = array(
 	'margin-right',
 	'margin-bottom',
 	'margin-left',
+	'margin-block',
+	'margin-block-start',
+	'margin-block-end',
 	'max-height',
 	'max-width',
 	'min-height',
@@ -330,6 +333,7 @@ $GLOBALS['csstidy']['shorthands']['border-color']       = array( 'border-top-col
 $GLOBALS['csstidy']['shorthands']['border-style']       = array( 'border-top-style', 'border-right-style', 'border-bottom-style', 'border-left-style' );
 $GLOBALS['csstidy']['shorthands']['border-width']       = array( 'border-top-width', 'border-right-width', 'border-bottom-width', 'border-left-width' );
 $GLOBALS['csstidy']['shorthands']['margin']             = array( 'margin-top', 'margin-right', 'margin-bottom', 'margin-left' );
+$GLOBALS['csstidy']['shorthands']['margin-block']       = array( 'margin-block-start', 'margin-block-end' );
 $GLOBALS['csstidy']['shorthands']['padding']            = array( 'padding-top', 'padding-right', 'padding-bottom', 'padding-left' );
 $GLOBALS['csstidy']['shorthands']['-moz-border-radius'] = 0;
 
@@ -529,6 +533,16 @@ $GLOBALS['csstidy']['all_properties']['margin-bottom']               = 'CSS1.0,C
 $GLOBALS['csstidy']['all_properties']['margin-left']                 = 'CSS1.0,CSS2.0,CSS2.1,CSS3.0';
 $GLOBALS['csstidy']['all_properties']['margin-right']                = 'CSS1.0,CSS2.0,CSS2.1,CSS3.0';
 $GLOBALS['csstidy']['all_properties']['margin-top']                  = 'CSS1.0,CSS2.0,CSS2.1,CSS3.0';
+
+/*
+ * Part of the W3C Working Draft:
+ * https://www.w3.org/TR/css-logical-1/#margin-properties
+ */
+$GLOBALS['csstidy']['all_properties']['margin-block']                = 'CSS1.0,CSS2.0,CSS2.1,CSS3.0';
+$GLOBALS['csstidy']['all_properties']['margin-block-start']          = 'CSS1.0,CSS2.0,CSS2.1,CSS3.0';
+$GLOBALS['csstidy']['all_properties']['margin-block-end']            = 'CSS1.0,CSS2.0,CSS2.1,CSS3.0';
+/* */
+
 $GLOBALS['csstidy']['all_properties']['marker-offset']               = 'CSS3.0';
 $GLOBALS['csstidy']['all_properties']['marks']                       = 'CSS2.0,CSS3.0';
 $GLOBALS['csstidy']['all_properties']['marquee-direction']           = 'CSS3.0';


### PR DESCRIPTION
:information_source: This commit was generated from D86305-code.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

**Fixes:**
:bug: Numerous layouts are or can be broken or looking not as intended because of unwanted margins added or not removed by global styles.

#### Changes proposed in this Pull Request:

:information_source: Why? Gutenberg is rendering diferent global styles in dotCom than in the dotOrg version.
:information_source:  What is different? The dotCom version lack some CSS related to the flex layouts.
:information_source:  Why is different? Because Gutenberg is adding certain CSS for the layout that includes margin-block-start and margin-block-end. This CSS works well in Gutenberg dotOrg but it is stripped away by the CSS validation rules used in WPCOM. These CSS properties are removed by CSSTidy from the rendered CSS because they are not part of CSS3 specification but a W3C Working draft.

:warning:  This problem is affecting the layout of all block themes on dotCom, including the default theme Twenty Twenty Two.

You can compare the global styles rendered by WPCOM Gutenberg vs WPORG Gutenberg and you will be able to see that this CSS is missing:

![image](https://user-images.githubusercontent.com/1310626/186020135-be78e22e-0b78-4f9f-8433-a798ca2f6fef.png)


#### Other information:

There is another revision trying to remove CSStidy opened 10 months ago but it wasn't merged yet: D70703-code

This would be a little patch that would allow us to fix the broken layouts until we arrive at a better solution for CSSTidy.

WPCOM fix link: D86305-code

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Please see the testing instruction on: D86305-code