### PR TITLE
Search plugin: always show search submenu when search plugin installed

### DIFF
--- a/projects/plugins/search/changelog/update-show-search-submenu-when-search-plugin-installed
+++ b/projects/plugins/search/changelog/update-show-search-submenu-when-search-plugin-installed
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Search: always show Search submenu when Search plugin is installed

--- a/projects/plugins/search/compatibility/jetpack.php
+++ b/projects/plugins/search/compatibility/jetpack.php
@@ -7,22 +7,11 @@
 
 namespace Automattic\Jetpack\Search_Plugin\Compatibility\Jetpack;
 
-use Jetpack;
-
 /**
  * Override the condition to show Search submenu when Jetpack plugin exists.
  */
 function should_show_jetpack_search_submenu() {
-	if ( ! current_user_can( 'manage_options' ) ) {
-		return false;
-	}
-
-	// If site is in Offline Mode or not connected yet.
-	if ( ! Jetpack::is_active_and_not_offline_mode() ) {
-		return false;
-	}
-
-	return true;
+	return current_user_can( 'manage_options' );
 }
 
 // Search package uses priority 10 to override Search submenu visibility for Jetpack.

--- a/projects/plugins/search/compatibility/jetpack.php
+++ b/projects/plugins/search/compatibility/jetpack.php
@@ -7,13 +7,7 @@
 
 namespace Automattic\Jetpack\Search_Plugin\Compatibility\Jetpack;
 
-/**
- * Override the condition to show Search submenu when Jetpack plugin exists.
- */
-function should_show_jetpack_search_submenu() {
-	return current_user_can( 'manage_options' );
-}
-
 // Search package uses priority 10 to override Search submenu visibility for Jetpack.
+// The captibility check is already done in `add_submenu_page()`, so we just return `true` from here.
 // https://github.com/Automattic/jetpack/blob/8594fe4d22863b251383c2550ca5f8d000d45b89/projects/packages/search/compatibility/jetpack.php#L29.
-add_filter( 'jetpack_search_should_add_search_submenu', __NAMESPACE__ . '\should_show_jetpack_search_submenu', 20 );
+add_filter( 'jetpack_search_should_add_search_submenu', '__return_true', 20 );

--- a/projects/plugins/search/src/class-jetpack-search-plugin.php
+++ b/projects/plugins/search/src/class-jetpack-search-plugin.php
@@ -109,7 +109,6 @@ class Jetpack_Search_Plugin {
 			}
 		}
 
-		// Redirect to the Search Dashboard only when Jetpack plugin is not activated.
 		if (
 			JETPACK_SEARCH_PLUGIN__FILE_RELATIVE_PATH === $plugin &&
 			\Automattic\Jetpack\Plugins_Installer::is_current_request_activating_plugin_from_plugins_screen( JETPACK_SEARCH_PLUGIN__FILE_RELATIVE_PATH )

--- a/projects/plugins/search/src/class-jetpack-search-plugin.php
+++ b/projects/plugins/search/src/class-jetpack-search-plugin.php
@@ -112,7 +112,6 @@ class Jetpack_Search_Plugin {
 		// Redirect to the Search Dashboard only when Jetpack plugin is not activated.
 		if (
 			JETPACK_SEARCH_PLUGIN__FILE_RELATIVE_PATH === $plugin &&
-			! class_exists( 'Jetpack' ) &&
 			\Automattic\Jetpack\Plugins_Installer::is_current_request_activating_plugin_from_plugins_screen( JETPACK_SEARCH_PLUGIN__FILE_RELATIVE_PATH )
 		) {
 			wp_safe_redirect( esc_url( admin_url( 'admin.php?page=jetpack-search' ) ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:


We currently [hide Jetpack Search menu when Jetpack Search and Jetpack plugins are both installed and site is not connected](https://github.com/Automattic/jetpack/blob/6814ab33222f1a2d89acd77a194eccb77226b1c7/projects/plugins/search/compatibility/jetpack.php#L20). We hoped to make the submenu of Jetpack clearer and let Jetpack handle the connection process. However this leads to several problems,

- When user choose to install Search plugin, they would expect to see the Search submenu. But they wouldn’t be able to find it if the site is not connected.
- We have some logic to [redirect](https://github.com/Automattic/jetpack/pull/25340)/[link](https://github.com/Automattic/jetpack/pull/25718) user to Search Dashboard, so if Search submenu is hidden, these could be broken.
- We also want the exposure of Search product to users when the plugin is installed. There’s no good reason to hide it. We are doing this to align with the experience of other standalone plugins as well.

The PR changes the behavior to always show the Search submenu if Search plugin is installed and reverted the check of Jetpack class because we'll have the page ready when the plugin is activated.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
pcNPJE-15r-p2

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Create fresh JN a site with Jetpack and Jetpack Search plugins
- Ensure Search submenu is shown under Jetpack menu regardless of whether the site is connected or not

<img width="146" alt="image" src="https://user-images.githubusercontent.com/1425433/186046336-861f468c-5a97-4263-a6fb-d7569f6d5ce3.png">
