### PR TITLE
Search: increase search pricing/plan timeouts to 5 seconds

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-search-pricing-timeouts
+++ b/projects/packages/my-jetpack/changelog/fix-search-pricing-timeouts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: increased search plan/pricing API timeouts to 5s

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -160,10 +160,10 @@ class Search extends Hybrid_Product {
 
 		$response = wp_remote_get(
 			sprintf( Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' ) . '/wpcom/v2/jetpack-search/pricing?record_count=%1$d&locale=%2$s', $record_count, get_user_locale() ),
-			array( 'timeout' => 2 )
+			array( 'timeout' => 5 )
 		);
 
-		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			return new WP_Error( 'search_pricing_fetch_failed' );
 		}
 
@@ -191,12 +191,12 @@ class Search extends Hybrid_Product {
 		$response = Client::wpcom_json_api_request_as_blog(
 			'/sites/' . $blog_id . '/jetpack-search/plan',
 			'2',
-			array( 'timeout' => 2 ),
+			array( 'timeout' => 5 ),
 			null,
 			'wpcom'
 		);
 
-		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			return new WP_Error( 'search_state_fetch_failed' );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<img width="300" alt="image" src="https://user-images.githubusercontent.com/1425433/186055318-3a839969-3112-4552-936d-635d8d6222bd.png">

The search pricing and plan API occasionally needs more than 2 seconds to return (happens often on JN sites), so the PR proposes to change timeouts to 5 seconds to avoid timeout errors. 

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- [Create a fresh JN site with only Search plugin](https://jurassic.ninja/create/?jetpack-beta&branches.jetpack-search=fix/search-pricing-timeouts&nojetpack)
- Open `/wp-admin/admin.php?page=jetpack-search`
- Ensure the Search pricing is displayed

<img width="300" alt="image" src="https://user-images.githubusercontent.com/1425433/186055421-f2c33214-3aea-46c4-b17b-9ae4a6659766.png">

