### PR TITLE
OG tags: avoid PHP warning when og:description is not set

### DIFF
--- a/projects/plugins/social/changelog/fix-warning-og-tags
+++ b/projects/plugins/social/changelog/fix-warning-og-tags
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid PHP warnings when OG description is not set.

--- a/projects/plugins/social/src/class-meta-tags.php
+++ b/projects/plugins/social/src/class-meta-tags.php
@@ -230,6 +230,10 @@ class Meta_Tags {
 			);
 		}
 
+		// Trim the description if it's still too long, and add an ellipsis.
+		$description_length = 197;
+		$description        = mb_strimwidth( $description, 0, $description_length, '…' );
+
 		return $description;
 	}
 
@@ -259,23 +263,20 @@ class Meta_Tags {
 
 		$tags['og:url'] = get_permalink( $data->ID );
 		if ( ! post_password_required( $data ) ) {
+			$excerpt = '';
+
 			/*
 			 * If the post author set an excerpt, use that.
 			 * Otherwise, pick the post content that comes before the More tag if there is one.
 			 * Do not use the post content if it contains premium content.
 			 */
 			if ( ! empty( $data->post_excerpt ) ) {
-				$tags['og:description'] = $this->get_description( $data->post_excerpt );
+				$excerpt = $data->post_excerpt;
 			} elseif ( ! has_block( 'premium-content/container', $data->post_content ) ) {
-				$excerpt                = explode( '<!--more-->', $data->post_content )[0];
-				$tags['og:description'] = $this->get_description( $excerpt );
+				$excerpt = explode( '<!--more-->', $data->post_content )[0];
 			}
 
-			// Shorten the description if it's too long.
-			$description_length = 197;
-			if ( ! empty( $tags['og:description'] ) ) {
-				$tags['og:description'] = strlen( $tags['og:description'] ) > $description_length ? mb_substr( $tags['og:description'], 0, $description_length ) . '…' : $tags['og:description'];
-			}
+			$tags['og:description'] = $this->get_description( $excerpt );
 		}
 
 		$image = $this->get_featured_image();

--- a/projects/plugins/social/src/class-meta-tags.php
+++ b/projects/plugins/social/src/class-meta-tags.php
@@ -270,9 +270,12 @@ class Meta_Tags {
 				$excerpt                = explode( '<!--more-->', $data->post_content )[0];
 				$tags['og:description'] = $this->get_description( $excerpt );
 			}
+
 			// Shorten the description if it's too long.
-			$description_length     = 197;
-			$tags['og:description'] = strlen( $tags['og:description'] ) > $description_length ? mb_substr( $tags['og:description'], 0, $description_length ) . '…' : $tags['og:description'];
+			$description_length = 197;
+			if ( ! empty( $tags['og:description'] ) ) {
+				$tags['og:description'] = strlen( $tags['og:description'] ) > $description_length ? mb_substr( $tags['og:description'], 0, $description_length ) . '…' : $tags['og:description'];
+			}
 		}
 
 		$image = $this->get_featured_image();

--- a/projects/plugins/social/tests/php/test-class-meta-tags.php
+++ b/projects/plugins/social/tests/php/test-class-meta-tags.php
@@ -208,41 +208,49 @@ class Meta_Tags_Test extends BaseTestCase {
 	 */
 	public function get_description_data_provider() {
 		return array(
-			'empty'                  => array(
+			'empty'                                       => array(
 				'',
 				'Visit the post for more.',
 			),
-			'no_entities'            => array(
+			'null'                                        => array(
+				null,
+				'Visit the post for more.',
+			),
+			'no_entities'                                 => array(
 				"OpenGraph's test",
 				'OpenGraph&#8217;s test',
 			),
-			'too_many_words'         => array(
+			'too_many_words'                              => array(
 				'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam consectetur quam eget finibus consectetur. Donec sollicitudin finibus massa, ut cursus elit. Mauris dictum quam eu ullamcorper feugiat. Proin id ante purus. Aliquam lorem libero, tempus id dictum non, feugiat vel eros. Sed sed viverra libero. Praesent eu lacinia felis, et tempus turpis. Proin bibendum, ligula. These last sentence should be removed.',
-				'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam consectetur quam eget finibus consectetur. Donec sollicitudin finibus massa, ut cursus elit. Mauris dictum quam eu ullamcorper feugiat. Proin id ante purus. Aliquam lorem libero, tempus id dictum non, feugiat vel eros. Sed sed viverra libero. Praesent eu lacinia felis, et tempus turpis. Proin bibendum, ligula.&hellip;',
+				'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam consectetur quam eget finibus consectetur. Donec sollicitudin finibus massa, ut cursus elit. Mauris dictum quam eu ullamcorper feugia…',
 			),
-			'no_tags'                => array(
+			'no_tags'                                     => array(
 				'A post description<script>alert("hello");</script>',
 				'A post description',
 			),
-			'no_shortcodes'          => array(
+			'no_shortcodes'                               => array(
 				'[foo test="true"]A post description',
 				'A post description',
 			),
-			'no_links'               => array(
+			'no_links'                                    => array(
 				'A post description https://jetpack.com',
 				'A post description',
 			),
-			'no_html'                => array(
+			'no_html'                                     => array(
 				'<strong>A post description</strong>',
 				'A post description',
 			),
-			'image_then_text'        => array(
+			'image_then_text'                             => array(
 				'<img src="https://example.org/jetpack-icon.jpg" />A post description',
 				'A post description',
 			),
-			'linked_image_then_text' => array(
+			'linked_image_then_text'                      => array(
 				'<a href="https://jetpack.com"><img src="https://example.org/jetpack-icon.jpg" /></a>A post description',
 				'A post description',
+			),
+			'removed_tags_dont_count_for_character_limit' => array(
+				'<img src="https://example.org/jetpack-icon.jpg" />This string is exactly 197 characters long if you ignore the HTML tags, which should be removed by the function—after which we start enforcing the limit. Just making sure it works the way it should',
+				'This string is exactly 197 characters long if you ignore the HTML tags, which should be removed by the function—after which we start enforcing the limit. Just making sure it works the way it should',
 			),
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

In some scenarios (no post excerpt, post with a Premium block), you may have no og:description, thus causing a warning.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

N/A

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

- Start on a WoA site using Jetpack, where you've inserted a Premium Content block into one of your posts.
- Activate the Social plugin.
- Visit that post, and see the PHP warning in your logs.
- Apply this branch; it should help.
