### PR TITLE
Build: only try to comment on PRs created by a12s

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Check if a WordPress.com test reminder comment is needed.
         id: check-test-reminder-comment
         uses: actions/github-script@v6
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
         with:
           result-encoding: string
           script: |
@@ -112,7 +112,7 @@ jobs:
       - name: Update reminder with testing instructions
         id: update-reminder-comment
         uses: actions/github-script@v6
-        if: ${{ github.event_name == 'pull_request' && steps.check-test-reminder-comment.outputs.result != 0 }}
+        if: ${{ github.event_name == 'pull_request' && steps.check-test-reminder-comment.outputs.result != 0 && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
         env:
           BRANCH_NAME: ${{ github.head_ref }}
           COMMENT_ID: ${{ steps.check-test-reminder-comment.outputs.result }}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Non-a12s (or rather folks using a fork of the repo instead of the upstream automattic/jetpack) will not have the necessary permissions to post comments on pull_request events, so let's not try to do that.

Here is an example:
- #25741
- https://github.com/Automattic/jetpack/runs/7967924473?check_suite_focus=true

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

- N/A

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

Once this is merged and #25741 is rebased against the latest trunk, the Build workflow should pass on that PR.
