### PR TITLE
Jetpack: Subscriptions - Remove inline styles for post-subscription notice

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subs
+++ b/projects/plugins/jetpack/changelog/fix-subs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Remove inline styles from subscription notification

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -301,7 +301,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 
 			$redirect_fragment = self::get_redirect_fragment();
 			printf(
-				'<div id="%1$s" class="jetpack-sub-notification" style="border: 1px solid%2$s; padding-left: 5px; padding-right: 5px; margin-bottom: 10px;">%3$s</div>',
+				'<div id="%1$s" class="jetpack-sub-notification">%3$s</div>',
 				esc_attr( $redirect_fragment ),
 				esc_attr( $border_color ),
 				wp_kses_post( $message )


### PR DESCRIPTION
Fixes #25330

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes inline styles for post-subscription notice on simple sites

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
1. On your .com sandbox, apply this patch D86412-code
2. Sandbox one of your simple sites
3. Create a post with a subscribe block, publish it, and visit the post and subscribe.
4. Subscribe to the site with your a11n account. 
5. Expect to see a success notice (or an _already subscribed_ one).
6.  Confirm you don't see a border around the message


Before
<img width="731" alt="image" src="https://user-images.githubusercontent.com/746152/186239806-fe21e4e0-66f9-45ca-93a6-c54632c07c43.png">

After

<img width="794" alt="image" src="https://user-images.githubusercontent.com/746152/186239807-765d5541-61f4-4d71-a6d2-be315762ae5f.png">
