### PR TITLE
Tiled Gallery/Carousel: Remove extra char from replacement pattern in carousel gallery block filter hook

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-tiled-gallery-extra-char
+++ b/projects/plugins/jetpack/changelog/fix-tiled-gallery-extra-char
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Remove extra char from replacement pattern in jetpack carousel gallery block filter hook

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -383,7 +383,7 @@ class Jetpack_Carousel {
 		// Add extra attributes to first HTML element (which may have leading whitespace)
 		return preg_replace(
 			'/^(\s*<(div|ul|figure))/',
-			'<$1 ' . $extra_attributes . ' ',
+			'$1 ' . $extra_attributes . ' ',
 			$block_content,
 			1
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixed https://github.com/Automattic/wp-calypso/issues/66865

Introduced in https://github.com/Automattic/jetpack/pull/25441/files#diff-20a0b22f28fd1f2b380b5df535f70d1bd90cca42606e3ff5c7d57fba2ffcbfc2R386
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes extra `<` from replacement pattern

Before
<img width="791" alt="image" src="https://user-images.githubusercontent.com/746152/186253998-4860f011-9b0b-42ff-a6ca-89a54270925d.png">

After

<img width="787" alt="image" src="https://user-images.githubusercontent.com/746152/186254466-f49017ff-3fe9-4c9a-b068-aed64d5ac5ee.png">

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion


#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* _Will use a P2 site as a test site._
* Sandbox this P2 site: pNEWy-fia-p2
* Apply this patch D86416-code
* Visit pNEWy-fia-p2 and confirm you don't see the `<` char over the galleries