### PR TITLE
Defensive Coding: Do not pass invalid types to strpos

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-atomic-php-warnings
+++ b/projects/plugins/jetpack/changelog/fix-atomic-php-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Compat: wp_startswith should only pass to strpos if string is passed.

--- a/projects/plugins/jetpack/functions.compat.php
+++ b/projects/plugins/jetpack/functions.compat.php
@@ -91,7 +91,7 @@ if ( ! function_exists( 'wp_startswith' ) ) :
 	 * @return bool
 	 */
 	function wp_startswith( $haystack, $needle ) {
-		if ( ! $haystack || ! $needle ) {
+		if ( ! $haystack || ! $needle || ! is_scalar( $haystack ) || ! is_scalar( $needle ) ) {
 			return false;
 		}
 
@@ -114,7 +114,7 @@ if ( ! function_exists( 'wp_endswith' ) ) :
 	 * @return bool
 	 */
 	function wp_endswith( $haystack, $needle ) {
-		if ( ! $haystack || ! $needle ) {
+		if ( ! $haystack || ! $needle || ! is_scalar( $haystack ) || ! is_scalar( $needle ) ) {
 			return false;
 		}
 
@@ -138,7 +138,7 @@ if ( ! function_exists( 'wp_in' ) ) :
 	 * @return bool
 	 */
 	function wp_in( $needle, $haystack ) {
-		if ( ! $haystack || ! $needle ) {
+		if ( ! $haystack || ! $needle || ! is_scalar( $haystack ) || ! is_scalar( $needle ) ) {
 			return false;
 		}
 

--- a/projects/plugins/jetpack/functions.compat.php
+++ b/projects/plugins/jetpack/functions.compat.php
@@ -109,11 +109,22 @@ if ( ! function_exists( 'wp_endswith' ) ) :
 	/**
 	 * Check whether a string ends with a specific substring.
 	 *
-	 * @param var    $haystack String we are filtering.
+	 * @param string $haystack String we are filtering.
 	 * @param string $needle The substring we are looking for.
 	 * @return bool
 	 */
 	function wp_endswith( $haystack, $needle ) {
+		if ( ! $haystack || ! $needle ) {
+			return false;
+		}
+
+		$haystack = (string) $haystack;
+		$needle   = (string) $needle;
+
+		if ( function_exists( 'str_ends_with' ) ) { // remove when PHP 8.0 is the minimum supported.
+			return str_ends_with( $haystack, $needle );
+
+		}
 		return $needle === substr( $haystack, -strlen( $needle ) );
 	}
 endif;
@@ -123,10 +134,21 @@ if ( ! function_exists( 'wp_in' ) ) :
 	 * Checks whether a string contains a specific substring.
 	 *
 	 * @param string $needle The substring we are looking for.
-	 * @param var    $haystack String we are filtering.
+	 * @param string $haystack String we are filtering.
 	 * @return bool
 	 */
 	function wp_in( $needle, $haystack ) {
+		if ( ! $haystack || ! $needle ) {
+			return false;
+		}
+
+		$haystack = (string) $haystack;
+		$needle   = (string) $needle;
+
+		if ( function_exists( 'str_contains' ) ) { // remove when PHP 8.0 is the minimum supported.
+			return str_contains( $haystack, $needle );
+		}
+
 		return false !== strpos( $haystack, $needle );
 	}
 endif;

--- a/projects/plugins/jetpack/functions.compat.php
+++ b/projects/plugins/jetpack/functions.compat.php
@@ -91,8 +91,15 @@ if ( ! function_exists( 'wp_startswith' ) ) :
 	 * @return bool
 	 */
 	function wp_startswith( $haystack, $needle ) {
-		if ( ! $haystack || ! is_string( $haystack ) ) {
+		if ( ! $haystack || ! $needle ) {
 			return false;
+		}
+
+		$haystack = (string) $haystack;
+		$needle   = (string) $needle;
+
+		if ( function_exists( 'str_starts_with' ) ) { // remove when PHP 8.0 is the minimum supported.
+			return str_starts_with( $haystack, $needle );
 		}
 		return 0 === strpos( $haystack, $needle );
 	}

--- a/projects/plugins/jetpack/functions.compat.php
+++ b/projects/plugins/jetpack/functions.compat.php
@@ -86,11 +86,14 @@ if ( ! function_exists( 'wp_startswith' ) ) :
 	/**
 	 * Check whether a string starts with a specific substring.
 	 *
-	 * @param var    $haystack String we are filtering.
+	 * @param string $haystack String we are filtering.
 	 * @param string $needle The substring we are looking for.
 	 * @return bool
 	 */
 	function wp_startswith( $haystack, $needle ) {
+		if ( ! $haystack || ! is_string( $haystack ) ) {
+			return false;
+		}
 		return 0 === strpos( $haystack, $needle );
 	}
 endif;

--- a/projects/plugins/jetpack/functions.compat.php
+++ b/projects/plugins/jetpack/functions.compat.php
@@ -99,7 +99,7 @@ if ( ! function_exists( 'wp_startswith' ) ) :
 		$needle   = (string) $needle;
 
 		if ( function_exists( 'str_starts_with' ) ) { // remove when PHP 8.0 is the minimum supported.
-			return str_starts_with( $haystack, $needle );
+			return str_starts_with( $haystack, $needle ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions
 		}
 		return 0 === strpos( $haystack, $needle );
 	}
@@ -122,7 +122,7 @@ if ( ! function_exists( 'wp_endswith' ) ) :
 		$needle   = (string) $needle;
 
 		if ( function_exists( 'str_ends_with' ) ) { // remove when PHP 8.0 is the minimum supported.
-			return str_ends_with( $haystack, $needle );
+			return str_ends_with( $haystack, $needle ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions
 
 		}
 		return $needle === substr( $haystack, -strlen( $needle ) );
@@ -146,7 +146,7 @@ if ( ! function_exists( 'wp_in' ) ) :
 		$needle   = (string) $needle;
 
 		if ( function_exists( 'str_contains' ) ) { // remove when PHP 8.0 is the minimum supported.
-			return str_contains( $haystack, $needle );
+			return str_contains( $haystack, $needle ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions
 		}
 
 		return false !== strpos( $haystack, $needle );

--- a/projects/plugins/jetpack/phpunit.xml.dist
+++ b/projects/plugins/jetpack/phpunit.xml.dist
@@ -126,6 +126,9 @@
 		<testsuite name="csstidy">
 			<directory prefix="test" suffix=".php">tests/php/modules/csstidy</directory>
 		</testsuite>
+		<testsuite name="compatfunctions">
+			<file>tests/php/test_functions.compat.php</file>
+		</testsuite>
 	</testsuites>
 	<groups>
 		<exclude>

--- a/projects/plugins/jetpack/tests/php/test_functions.compat.php
+++ b/projects/plugins/jetpack/tests/php/test_functions.compat.php
@@ -24,6 +24,7 @@ class WP_Test_Jetpack_Compat_Functions extends WP_UnitTestCase {
 			array( 'Random String', 'random', false ), // case-sensitive.
 			array( 'Random String', 'string', false ), // Nope.
 			array( null, 'string', false ),
+			array( array( 'random' ), 'string', false ),
 		);
 	}
 
@@ -41,6 +42,7 @@ class WP_Test_Jetpack_Compat_Functions extends WP_UnitTestCase {
 			array( 'Random String', 'string', false ), // case-sensitive.
 			array( 'Random String', 'Random', false ), // Nope.
 			array( null, 'string', false ),
+			array( array( 'random' ), 'string', false ),
 		);
 	}
 
@@ -59,6 +61,7 @@ class WP_Test_Jetpack_Compat_Functions extends WP_UnitTestCase {
 			array( 'Random String', 'str', false ), // case-sensitive.
 			array( 'Random String', 'Bananas', false ), // Nope.
 			array( null, 'string', false ),
+			array( array( 'random' ), 'string', false ),
 		);
 	}
 }

--- a/projects/plugins/jetpack/tests/php/test_functions.compat.php
+++ b/projects/plugins/jetpack/tests/php/test_functions.compat.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Test the compat file.
+ *
+ * @package Automattic/jetpack
+ */
+
+/**
+ * Testing class.
+ */
+class WP_Test_Jetpack_Compat_Functions extends WP_UnitTestCase {
+
+	/**
+	 * @dataProvider provider_wp_startswith
+	 */
+	public function test_wp_startswith( $haystack, $needle, $expected ) {
+		$this->assertEquals( $expected, wp_startswith( $haystack, $needle ) );
+	}
+
+	public function provider_wp_startswith() {
+		return array(
+			array( 'Random String', 'Random', true ), // Regular usage.
+			array( '12345', 12345, true ), // Passing an int as the needle is deprecated, but previously supported.
+			array( 'Random String', 'random', false ), // case-sensitive.
+			array( 'Random String', 'string', false ), // Nope.
+		);
+	}
+}

--- a/projects/plugins/jetpack/tests/php/test_functions.compat.php
+++ b/projects/plugins/jetpack/tests/php/test_functions.compat.php
@@ -20,9 +20,45 @@ class WP_Test_Jetpack_Compat_Functions extends WP_UnitTestCase {
 	public function provider_wp_startswith() {
 		return array(
 			array( 'Random String', 'Random', true ), // Regular usage.
-			array( '12345', 12345, true ), // Passing an int as the needle is deprecated, but previously supported.
+			array( '12345', 123, true ), // Passing an int as the needle is deprecated, but previously supported.
 			array( 'Random String', 'random', false ), // case-sensitive.
 			array( 'Random String', 'string', false ), // Nope.
+			array( null, 'string', false ),
+		);
+	}
+
+	/**
+	 * @dataProvider provider_wp_endswith
+	 */
+	public function test_wp_endswith( $haystack, $needle, $expected ) {
+		$this->assertEquals( $expected, wp_endswith( $haystack, $needle ) );
+	}
+
+	public function provider_wp_endswith() {
+		return array(
+			array( 'Random String', 'String', true ), // Regular usage.
+			array( '12345', 45, true ), // Passing an int as the needle is deprecated, but previously supported.
+			array( 'Random String', 'string', false ), // case-sensitive.
+			array( 'Random String', 'Random', false ), // Nope.
+			array( null, 'string', false ),
+		);
+	}
+
+	/**
+	 * @dataProvider provider_wp_in
+	 */
+	public function test_wp_in( $haystack, $needle, $expected ) {
+		$this->assertEquals( $expected, wp_in( $needle, $haystack ) );
+	}
+
+	public function provider_wp_in() {
+		// Notice this is in the $haystack, $needle format, even though this function is $needle, $haystack.
+		return array(
+			array( 'Random String', 'dom', true ), // Regular usage.
+			array( '12345', 23, true ), // Passing an int as the needle is deprecated, but previously supported.
+			array( 'Random String', 'str', false ), // case-sensitive.
+			array( 'Random String', 'Bananas', false ), // Nope.
+			array( null, 'string', false ),
 		);
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes `PHP Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /wordpress/plugins/jetpack/11.3-a.7/functions.compat.php on line 94` as seen in Atomic logs.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* strpos expects a string.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `wp_startswith( null, 'anything' );` before and after patch.
* Run `wp_startswith( array('something'), 'anything');` before and after patch.

