### PR TITLE
Search: Fix flicking connection page during site/user connection

### DIFF
--- a/projects/packages/search/changelog/fix-flicky-connection-page
+++ b/projects/packages/search/changelog/fix-flicky-connection-page
@@ -1,4 +1,4 @@
-Significance: patch
+Significance: minor
 Type: changed
 
-Search: show connection page is user is not connected
+Search: revert "Search should not require user connection"

--- a/projects/packages/search/changelog/fix-flicky-connection-page
+++ b/projects/packages/search/changelog/fix-flicky-connection-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search: show connection page is user is not connected

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -69,7 +69,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.20.x-dev"
+			"dev-trunk": "0.21.x-dev"
 		},
 		"version-constants": {
 			"::VERSION": "src/class-package.php"

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.20.1-alpha",
+	"version": "0.21.0-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.20.1-alpha';
+	const VERSION = '0.21.0-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/dashboard/components/dashboard/wrapped-dashboard.jsx
+++ b/projects/packages/search/src/dashboard/components/dashboard/wrapped-dashboard.jsx
@@ -14,7 +14,7 @@ import { STORE_ID } from 'store';
  * @returns {React.Component} WrappedDashboard component.
  */
 export default function WrappedDashboard() {
-	const { isSiteConnected } = useConnection();
+	const { isFullyConnected } = useConnection();
 
 	const initializeAnalytics = () => {
 		const tracksUser = syncSelect( STORE_ID ).getWpcomUser();
@@ -40,8 +40,8 @@ export default function WrappedDashboard() {
 
 	return (
 		<>
-			{ ! isSiteConnected && <SearchConnectionPage /> }
-			{ isSiteConnected && <AfterConnectionPage /> }
+			{ ! isFullyConnected && <SearchConnectionPage /> }
+			{ isFullyConnected && <AfterConnectionPage /> }
 		</>
 	);
 }

--- a/projects/plugins/jetpack/changelog/fix-flicky-connection-page
+++ b/projects/plugins/jetpack/changelog/fix-flicky-connection-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -38,7 +38,7 @@
 		"automattic/jetpack-publicize": "0.12.x-dev",
 		"automattic/jetpack-redirect": "1.7.x-dev",
 		"automattic/jetpack-roles": "1.4.x-dev",
-		"automattic/jetpack-search": "0.20.x-dev",
+		"automattic/jetpack-search": "0.21.x-dev",
 		"automattic/jetpack-status": "1.14.x-dev",
 		"automattic/jetpack-sync": "1.38.x-dev",
 		"automattic/jetpack-videopress": "0.2.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7e1811841c453fe76ac1256ca79ee91e",
+    "content-hash": "ccc2fb9f9616fe0cee8a2ecdd4b84930",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1697,7 +1697,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "7d472724155ea5c6f92f9beda34beb4560823dd9"
+                "reference": "5d150cbcbd4cee1342c12ea3687e2fd0a818181d"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -1721,7 +1721,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.20.x-dev"
+                    "dev-trunk": "0.21.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"

--- a/projects/plugins/search/changelog/fix-flicky-connection-page
+++ b/projects/plugins/search/changelog/fix-flicky-connection-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -10,7 +10,7 @@
 		"automattic/jetpack-connection": "1.43.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
 		"automattic/jetpack-my-jetpack": "2.0.x-dev",
-		"automattic/jetpack-search": "0.20.x-dev",
+		"automattic/jetpack-search": "0.21.x-dev",
 		"automattic/jetpack-status": "^1.14",
 		"automattic/jetpack-sync": "1.38.x-dev",
 		"automattic/jetpack-plugins-installer": "0.2.x-dev"

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7aaba54981744973c4a119a3e7f23294",
+    "content-hash": "f08bc4a437de9dafee3d2b86657419f6",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1075,7 +1075,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "7d472724155ea5c6f92f9beda34beb4560823dd9"
+                "reference": "5d150cbcbd4cee1342c12ea3687e2fd0a818181d"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -1099,7 +1099,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.20.x-dev"
+                    "dev-trunk": "0.21.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"


### PR DESCRIPTION
#### Changes proposed in this Pull Request
In #24477, we removed the requirement for a user connection, it worked. However, it resulted in a flicking screen switching during the connection process. The PR reverted the change to skip connection page when site is connected, meaning if user is not fully connected, then he'll still see the connection page.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- [Create a fresh JN site with only Search plugin](https://jurassic.ninja/create/?jetpack-beta&branches.jetpack-search=fix/flicky-connection-page&nojetpack)
- Open `/wp-admin/admin.php?page=jetpack-search`
- Click `Log in to get started`
- Ensure the upsell page or the dashboard don't show up before it redirects user to WordPress.com authentication page; NOT like the following (the site has a plan, otherwise upsell page would popup instead):


https://user-images.githubusercontent.com/1425433/186287041-81d4b804-9b11-4968-aef7-763561edf06d.mp4





