### PR TITLE
Subscribe block: Fix input and submit button coupling for Safari when split style is selected

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-safari-default-margin-for-buttons-subscription-submit
+++ b/projects/plugins/jetpack/changelog/fix-safari-default-margin-for-buttons-subscription-submit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix Subscribe block input and submit button coupling for Safari when split style is selected

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -918,6 +918,7 @@ function jetpack_do_subscription_form( $instance ) {
 	if ( isset( $instance['button_on_newline'] ) && 'true' === $instance['button_on_newline'] ) {
 		$submit_button_styles .= 'margin-top: ' . $button_spacing . 'px; ';
 	} else {
+		$submit_button_styles .= 'margin: 0px; '; // Reset Safari's 2px default margin for buttons affecting input and button union
 		$submit_button_styles .= 'margin-left: ' . $button_spacing . 'px; ';
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Resets default margin of 2px from subscription submit button

After

<img width="1347" alt="image" src="https://user-images.githubusercontent.com/746152/186422571-c3529c19-bd56-4f68-889c-5e0ddf49c8fc.png">


Before

<img width="1343" alt="image" src="https://user-images.githubusercontent.com/746152/186422485-48cde0fd-746f-4f5a-93aa-43d79442047a.png">

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

pNEWy-fia-p2#comment-54846

#### Does this pull request change what data or activity we track or use?

no

#### Testing instructions:

* Apply the patch and sandbox lettredemo.wordpress.com
* Visit the site's home and confirm you dont' see the issue shown in the screenshots