### PR TITLE
WPSC: enable autotag, autorelease, and autosvn actions

### DIFF
--- a/projects/plugins/super-cache/changelog/add-wpsc-auto-svn
+++ b/projects/plugins/super-cache/changelog/add-wpsc-auto-svn
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Enable autotag, autorelease, and autosvn actions in the composer.json extras.
+
+

--- a/projects/plugins/super-cache/composer.json
+++ b/projects/plugins/super-cache/composer.json
@@ -38,12 +38,15 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"extra": {
-		"mirror-repo": "Automattic/wp-super-cache",
+		"autorelease": true,
+		"autotagger": true,
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/wp-super-cache/compare/v${old}...v${new}",
 			"versioning": "wordpress"
 		},
+		"mirror-repo": "Automattic/wp-super-cache",
 		"release-branch-prefix": "super-cache",
-		"wp-plugin-slug": "wp-super-cache"
+		"wp-plugin-slug": "wp-super-cache",
+		"wp-svn-autopublish": true
 	}
 }

--- a/projects/plugins/super-cache/composer.lock
+++ b/projects/plugins/super-cache/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "921ae63fd643ecd40b5f01a50a821539",
+    "content-hash": "f6035d4a328d62f36add145422b9d63e",
     "packages": [],
     "packages-dev": [
         {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Enable autorelease, autotagger, and wp-svn-autopublish for the plugin. Secrets already configured for mirror-repo.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

Internal: p1661276085689299-slack-C01U2KGS2PQ

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

Proofread.