### PR TITLE
Paid blocks: Hide upgrade banner for nested paid blocks

### DIFF
--- a/projects/plugins/jetpack/changelog/update-hide-paid-block-upgrade-banner-on-child-blocks
+++ b/projects/plugins/jetpack/changelog/update-hide-paid-block-upgrade-banner-on-child-blocks
@@ -1,0 +1,3 @@
+Significance: patch
+Type: enhancement
+Comment: Minor update for WP.com sites that hides the upgrade banner of paid blocks if they are nested inside another paid block

--- a/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/components.js
+++ b/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/components.js
@@ -10,20 +10,14 @@ export const PaidBlockContext = createContext();
  * Paid Block Provider
  *
  * @param {object}  props - Provider properties.
- * @param {Function}  props.onBannerVisibilityChange - Callback to set banner visibility.
- * @param {Function} props.onChildBannerVisibilityChange - Callback to set child banner visibility.
+ * @param {Function} props.onBannerVisibilityChange - Callback to set banner visibility.
  * @param {boolean} props.hasParentBanner - True if a parent of this block has a banner, which may or may not be visible.
  * @param {boolean} props.children - Provider Children.
  * @returns {*} Provider component.
  */
-export const PaidBlockProvider = ( {
-	onBannerVisibilityChange,
-	onChildBannerVisibilityChange,
-	hasParentBanner,
-	children,
-} ) => (
+export const PaidBlockProvider = ( { onBannerVisibilityChange, hasParentBanner, children } ) => (
 	<PaidBlockContext.Provider
-		value={ { onBannerVisibilityChange, onChildBannerVisibilityChange, hasParentBanner } }
+		value={ { onBannerVisibilityChange, hasParentBanner } }
 		children={ children }
 	/>
 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Minor enhancement that hides the upgrade banner of paid blocks (only visible on WP.com sites) if they are nested inside another paid block, and ensures that the the one of the parent block is the only one visible.

Before | After
--- | ---
<img width="647" alt="Screen Shot 2022-08-25 at 12 53 48" src="https://user-images.githubusercontent.com/1233880/186646749-bd54585f-7ca4-4d48-8388-c8f6764e26ea.png"> | <img width="641" alt="Screen Shot 2022-08-25 at 12 54 31" src="https://user-images.githubusercontent.com/1233880/186646761-78d15edf-08b3-4cdb-8f26-dd1d4b891483.png">


#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
N/A.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- Apply the diff created by Fusion to your WP.com sandbox.
- Sandbox a WP.com site.
- Go to https://wordpress.com/post.
- Select a Free site.
- Insert a paid block that contains another inner paid block. Some examples:
  - Payment buttons (requires D84922-code).
  - WhatApp button.
  - Premium content with a video in the subscriber content.
- Make sure that the upgrade nudger of the parent block is the only one that is visible.

