### PR TITLE
Media Library: Add check for iframe before attempting to remove it on modal close

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-add-check-for-iframe-before-accessing-it-vp-modal-close
+++ b/projects/plugins/jetpack/changelog/fix-add-check-for-iframe-before-accessing-it-vp-modal-close
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixes a js error when closing a non-VideoPress video modal in the Media Library.

--- a/projects/plugins/jetpack/modules/videopress/editor-media-view.php
+++ b/projects/plugins/jetpack/modules/videopress/editor-media-view.php
@@ -234,7 +234,10 @@ function videopress_override_media_templates() {
 				escape: function () {
 					BaseMediaModal.prototype.escape.apply( this );
 					var playerIframe = document.getElementsByClassName( "videopress-iframe" )[0];
-					playerIframe.parentElement.removeChild( playerIframe );
+					if ( playerIframe && playerIframe.parentElement ) {
+						playerIframe.parentElement.removeChild( playerIframe );
+					}
+
 				}
 			} );
 		})( wp.media );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #25833 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* adds a check that the iframe variable is set before attempting to use it.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
nope
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Media Library
* open a non-VideoPress attachment (ex an image)
* close the modal
* check the browser console. There should NOT be an error similar to `playerIframe is undefined`
* open a VideoPress attachment and then press Play, ensure the video is not muted
* close the modal. The video should stop player (you shouldn't hear audio anymore)

