### PR TITLE
Publicize: update paths for de-fusioning #25221

### DIFF
--- a/projects/plugins/jetpack/changelog/update-publicize-wpcom-filepaths
+++ b/projects/plugins/jetpack/changelog/update-publicize-wpcom-filepaths
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Publicize: update wpcom filepaths for defusioning #25221
+
+

--- a/projects/plugins/jetpack/modules/publicize.php
+++ b/projects/plugins/jetpack/modules/publicize.php
@@ -79,8 +79,8 @@ class Jetpack_Publicize {
 			);
 		} else {
 			global $publicize;
-			require_once dirname( __DIR__ ) . '/mu-plugins/keyring/keyring.php';
-			require_once __DIR__ . '/publicize/publicize-wpcom.php';
+			require_once WP_CONTENT_DIR . '/mu-plugins/keyring/keyring.php';
+			require_once WP_CONTENT_DIR . '/admin-plugins/publicize/publicize-wpcom.php';
 			$publicize    = new Publicize();
 			$publicize_ui = new Automattic\Jetpack\Publicize\Publicize_UI();
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Update wpcom specific file path requires, prerequisite for #25221

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

n/a

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

Proofread. Will be tested as part of #25221 on wpcom before deploy.

