### PR TITLE
VideoPress Pkg: Avoiding re-register the VideoPress video

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-avoid-registering-block-twice
+++ b/projects/packages/videopress/changelog/update-videopress-avoid-registering-block-twice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress Pkg: Avoiding re-register the VideoPress video

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -236,6 +236,10 @@ class Initializer {
 	 * @return void
 	 */
 	public static function register_videopress_block() {
+		if ( \WP_Block_Type_Registry::get_instance()->is_registered( 'jetpack/videopress' ) ) {
+        	return;
+        }
+
 		register_block_type( __DIR__ . '/client/block-editor/blocks/videopress/' );
 	}
 }

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -237,8 +237,8 @@ class Initializer {
 	 */
 	public static function register_videopress_block() {
 		if ( \WP_Block_Type_Registry::get_instance()->is_registered( 'jetpack/videopress' ) ) {
-        	return;
-        }
+			return;
+		}
 
 		register_block_type( __DIR__ . '/client/block-editor/blocks/videopress/' );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR checks whether the VideoPress block has already been registered before to do it. This scenario is possible to recreate by enabling Jetpack and VideoPress plugins at the same time, on the same site.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress Pkg: Avoiding re-register the VideoPress video

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate Jetpack and VideoPress plugins in the same site
* Go to the block editor
* Take a look at the backend logs
```
jetpack docker tail
```

* confirmed you don't see the following PHP Notice:

```
PHP Notice:  Function WP_Block_Type_Registry::register was called <strong>incorrectly</strong>. Block type "jetpack/videopress" is already registered. Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 5.0.0.) in /var/www/html/wp-includes/functions.php on line 5831
```

