### PR TITLE
Search: start new release cycle for v1.3.0-alpha

### DIFF
--- a/projects/plugins/search/changelog/add-new-search-release-cycle-1-3-0-alpha
+++ b/projects/plugins/search/changelog/add-new-search-release-cycle-1-3-0-alpha
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search: start v1.3.0-alpha release cycle

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -62,7 +62,7 @@
 	},
 	"config": {
 		"sort-packages": true,
-		"autoloader-suffix": "b462338fb66be23595d68a93345c9e3d_jetpack_searchⓥ1_2_0_beta",
+		"autoloader-suffix": "b462338fb66be23595d68a93345c9e3d_jetpack_searchⓥ1_3_0_alpha",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true,

--- a/projects/plugins/search/jetpack-search.php
+++ b/projects/plugins/search/jetpack-search.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Search
  * Plugin URI: https://jetpack.com/search/
  * Description: A cloud-powered replacement for WordPress' search.
- * Version: 1.2.0-beta
+ * Version: 1.3.0-alpha
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later
@@ -26,7 +26,7 @@ define( 'JETPACK_SEARCH_PLUGIN__DIR', plugin_dir_path( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__FILE', __FILE__ );
 define( 'JETPACK_SEARCH_PLUGIN__FILE_RELATIVE_PATH', plugin_basename( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__SLUG', 'jetpack-search' );
-define( 'JETPACK_SEARCH_PLUGIN__VERSION', '1.2.0-beta' );
+define( 'JETPACK_SEARCH_PLUGIN__VERSION', '1.3.0-alpha' );
 
 defined( 'JETPACK_CLIENT__AUTH_LOCATION' ) || define( 'JETPACK_CLIENT__AUTH_LOCATION', 'header' );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Start a new release cycle for the Search plugin.

Part of the process described in PCYsg-z6w-p2.

Previous: #25320

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Manual check of new versions.