### PR TITLE
Changelog prompts: update wording

### DIFF
--- a/projects/packages/changelogger/changelog/update-changelog-message
+++ b/projects/packages/changelogger/changelog/update-changelog-message
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Wording: update changelog prompt sentence
+
+

--- a/projects/packages/changelogger/src/AddCommand.php
+++ b/projects/packages/changelogger/src/AddCommand.php
@@ -181,7 +181,7 @@ EOF
 				$filename = $this->getDefaultFilename( $output );
 			}
 			if ( $isInteractive ) {
-				$question = new Question( "Name your change file <info>[default: $filename]</> > ", $filename );
+				$question = new Question( "Name your changelog file <info>[default: $filename]</> > ", $filename );
 				$question->setValidator( array( $this, 'validateFilename' ) );
 				$filename = $this->getHelper( 'question' )->ask( $input, $output, $question );
 				if ( null === $filename ) { // non-interactive.

--- a/projects/packages/changelogger/src/Application.php
+++ b/projects/packages/changelogger/src/Application.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 class Application extends SymfonyApplication {
 
-	const VERSION = '3.2.0';
+	const VERSION = '3.2.1-alpha';
 
 	/**
 	 * Constructor.

--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -720,7 +720,7 @@ async function promptChangelog( argv, needChangelog ) {
 		{
 			type: 'string',
 			name: 'changelogName',
-			message: 'Name your change file:',
+			message: 'Name your changelog file:',
 			default: gitBranch,
 			validate: input => {
 				const fileExists = doesFilenameExist( input, needChangelog );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:


See https://github.com/Automattic/jetpack/pull/25829#discussion_r955106751

> it automatically prompted me for the changelog while pushing my branch upstream. I was confused by the Name your change file So I switched to the name of the file :)
>
> for me it would have been more intuitive to have Name your changelog file

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

N/A

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

Not much to test here; what do you think of the change?
