### PR TITLE
Custom CSS: change wording for custom content width option

### DIFF
--- a/projects/plugins/jetpack/changelog/update-custom-css-content-width-wording
+++ b/projects/plugins/jetpack/changelog/update-custom-css-content-width-wording
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Custom CSS: change wording for content width option.
+
+

--- a/projects/plugins/jetpack/modules/custom-css/custom-css-4.7.php
+++ b/projects/plugins/jetpack/modules/custom-css/custom-css-4.7.php
@@ -369,11 +369,11 @@ class Jetpack_Custom_CSS_Enhancements {
 		wp_enqueue_style( 'jetpack-customizer-css' );
 		wp_enqueue_script( 'jetpack-customizer-css' );
 
-		$content_help = __( 'Set a different content width for full size images.', 'jetpack' );
+		$content_help = __( 'Set a different media width for full size images.', 'jetpack' );
 		if ( ! empty( $GLOBALS['content_width'] ) ) {
 			$content_help .= sprintf(
 				// translators: the theme name and then the default width.
-				_n( ' The default content width for the <strong>%1$s</strong> theme is %2$d pixel.', ' The default content width for the <strong>%1$s</strong> theme is %2$d pixels.', (int) $GLOBALS['content_width'], 'jetpack' ),
+				_n( ' The default media width for the <strong>%1$s</strong> theme is %2$d pixel.', ' The default media width for the <strong>%1$s</strong> theme is %2$d pixels.', (int) $GLOBALS['content_width'], 'jetpack' ),
 				wp_get_theme()->Name,
 				(int) $GLOBALS['content_width']
 			);


### PR DESCRIPTION
Fixes #25864

#### Changes proposed in this Pull Request:

Jetpack's Custom CSS includes an option to overwrite the content width value set by a theme. While this option is less and less valuable in a FSE world where more and more themes do not offer easy access to the customizer and its Custom CSS panel, we can still improve that wording to avoid confusion, since this value will mostly impact the maximum width of the media included in posts and pages.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

N/A

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

* Start with a site with an older theme, not a block theme
* Enable the custom CSS module in Jetpack > Settings
* Go to Appearance > Edit CSS
* Check the option at the bottom of the page.
