### PR TITLE
Blazepress: Add advertising menu on Atomic

### DIFF
--- a/projects/plugins/jetpack/changelog/blazepress-add-advertising-menu-atomic
+++ b/projects/plugins/jetpack/changelog/blazepress-add-advertising-menu-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Added Advertising menu entry for Atomic sites gated behind a filter that will be toggled from wpcomsh

--- a/projects/plugins/jetpack/changelog/blazepress-add-advertising-menu-atomic
+++ b/projects/plugins/jetpack/changelog/blazepress-add-advertising-menu-atomic
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Added Advertising menu entry for Atomic sites gated behind a filter that will be toggled from wpcomsh
+WordPress.com toolbar: allow enabling an "Advertising" menu item via a new filter.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -365,8 +365,17 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		// performance settings already have a link to Page Optimize settings page.
 		$this->hide_submenu_page( 'options-general.php', 'page-optimize' );
 
-		// Add Avertising menu item.
-		if ( apply_filters( 'dsp_promote_posts_enabled', false, get_current_user_id() ) ) {
+		/**
+		 * Wether to show the Advertising menu under the main Tools menu.
+		 *
+		 * @module masterbar
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool $menu_enabled Wether the menu entry is shown.
+		 * @param int  $user_id      The Advertising menu will be shown/hidden for this user.
+		 */
+		if ( apply_filters( 'jetpack_dsp_promote_posts_enabled', false, get_current_user_id() ) ) {
 			add_submenu_page( 'tools.php', esc_attr__( 'Advertising', 'jetpack' ), __( 'Advertising', 'jetpack' ), 'manage_options', 'https://wordpress.com/advertising/' . $this->domain, null, 1 );
 		}
 	}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -364,6 +364,11 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		// would conflict with our own Settings > Performance that links to Calypso, so we hide it it since the Calypso
 		// performance settings already have a link to Page Optimize settings page.
 		$this->hide_submenu_page( 'options-general.php', 'page-optimize' );
+
+		// Add Avertising menu item.
+		if ( apply_filters( 'dsp_promote_posts_enabled', false, get_current_user_id() ) ) {
+			add_submenu_page( 'tools.php', esc_attr__( 'Advertising', 'jetpack' ), __( 'Advertising', 'jetpack' ), 'manage_options', 'https://wordpress.com/advertising/' . $this->domain, null, 1 );
+		}
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This diff adds an Advertising menu under Tools if the `dsp_promote_posts_enabled` filter is enabled. This filter will be toggled later from wpcomsh. 

#### Jetpack product discussion

- pMyNb-5wG-p2
- 1083-gh-wpcomsh
- https://github.com/Automattic/wp-calypso/pull/67056
- pMyNb-5CW-p2

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

No visible changes, the change is behind a default false filter. It relies on 2 changes that are not merged yet: https://github.com/Automattic/wp-calypso/pull/67056 and 1083-gh-wpcomsh