### PR TITLE
VideoPress: remove workaround for package initialization

### DIFF
--- a/projects/packages/videopress/changelog/update-remove-init-workaround
+++ b/projects/packages/videopress/changelog/update-remove-init-workaround
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -27,17 +27,6 @@ class Initializer {
 	 * @return void
 	 */
 	public static function init() {
-		add_action( 'plugins_loaded', array( __CLASS__, 'do_init' ), 90 ); // do the actual initialization after Config ensured options from all consumers.
-	}
-
-	/**
-	 * Actually initializes the package, after all calls to Config::ensure have been processed
-	 *
-	 * Do not call this method directly.
-	 *
-	 * @return void
-	 */
-	public static function do_init() {
 		if ( ! did_action( 'videopress_init' ) ) {
 
 			self::unconditional_initialization();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes a workaround in the package initialization that was needed before https://github.com/Automattic/jetpack/pull/25710

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/25710

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate VideoPress plugin and make sure the Jetpack > VideoPress menu item is added
* Activate Jetpack and confirm the menu item is still there
* Deactivate VideoPress and confirm the menu item is gone

