### PR TITLE
ci: Use `...` diff in list-changed-projects.sh

### DIFF
--- a/.github/files/list-changed-projects.sh
+++ b/.github/files/list-changed-projects.sh
@@ -19,7 +19,7 @@ ARGS=( --add-dependents )
 
 if [[ "${GITHUB_EVENT_NAME:?}" == "pull_request" ]]; then
 	[[ -f "${GITHUB_EVENT_PATH:?}" ]] || die "GITHUB_EVENT_PATH file $GITHUB_EVENT_PATH does not exist"
-	DIFF="$(jq -r '"\( .pull_request.base.sha )..\( .pull_request.head.sha )"' "$GITHUB_EVENT_PATH")"
+	DIFF="$(jq -r '"\( .pull_request.base.sha )...\( .pull_request.head.sha )"' "$GITHUB_EVENT_PATH")"
 	debug "GITHUB_EVENT_NAME is pull_request, checking diff from $DIFF"
 	ARGS+=( --verbose "--git-changed=$DIFF" )
 elif [[ "${GITHUB_EVENT_NAME:?}" == "push" ]]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The base ref passed from GitHub is the tip of the target branch, not the
merge-base with the current PR. `git diff base..head` will wind up
showing a diff that reverses any changes between the merge-base and the
passed base; the behavior we want is `git diff base...head`.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Compare the Actions output [before](https://github.com/Automattic/jetpack/runs/8073954766?check_suite_focus=true#step:6:13) and [after](https://github.com/Automattic/jetpack/runs/8073988437?check_suite_focus=true#step:6:13) this change. On the "before" side is sees files not actually changed in this PR.