### PR TITLE
Jetpack: Deprecate `jetpack_require_lib`

### DIFF
--- a/projects/plugins/jetpack/changelog/deprecate-jetpack_require_lib
+++ b/projects/plugins/jetpack/changelog/deprecate-jetpack_require_lib
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Deprecated `jetpack_require_lib` and `jetpack_require_lib_dir`. No `_deprecated_function` calls yet, that will come after we've removed internal uses.

--- a/projects/plugins/jetpack/load-jetpack.php
+++ b/projects/plugins/jetpack/load-jetpack.php
@@ -10,6 +10,7 @@
  * in require_lib().
  *
  * @since 4.0.2
+ * @deprecated since $$next-version$$ Use `JETPACK__PLUGIN_DIR . '_inc/lib/'` instead.
  *
  * @return string Location of Jetpack library directory.
  *

--- a/projects/plugins/jetpack/require-lib.php
+++ b/projects/plugins/jetpack/require-lib.php
@@ -8,6 +8,8 @@
 /**
  * Function for loading library files.
  *
+ * @deprecated since $$next-version$$ Load libraries directly (from `JETPACK__PLUGIN_DIR . '_inc/lib/'`) instead.
+ *
  * @param string $slug Library slug.
  * @return void
  */
@@ -24,6 +26,7 @@ function jetpack_require_lib( $slug ) {
 	 * Filter the location of the library directory.
 	 *
 	 * @since 2.5.0
+	 * @deprecated since $$next-version$$
 	 *
 	 * @param string $lib_dir Path to the library directory.
 	 */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The `jetpack_require_lib` function exists for compatibility with the way
Jetpack code is shared with WordPress.com Simple sites (i.e. Fusion).

We're now changing the way that the code sharing works in a way that
means this function will no longer be needed and would need extra logic
to make work in a backwards- and forwards-compatible manner. Instead
we're going to replace all uses of the function with direct requiring of
the relevant files, then remove it.

Note this PR does not remove uses (that needs to be done as part of the
de-Fusioning of each feature), and so does not add `_deprecated_function`
and `apply_filters_deprecated` calls yet. That will come once we've
removed all uses in Jetpack (and WordPress.com). Then we'll wait a few
Jetpack releases after that before removing the function entirely.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-5EZ-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Nothing to test, this is just adding doc comments.