### PR TITLE
Repo gardening: disable Slack link and media previews in messages

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-disable-link-unfurling
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-disable-link-unfurling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: disable Slack link and media previews in messages that are already custom-formatted.

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -188,6 +188,8 @@ function formatSlackMessage( payload, channel, message ) {
 		],
 		text: `${ message } -- <${ html_url }|${ title }>`, // Fallback text for display in notifications.
 		mrkdwn: true, // Formatting of the fallback text.
+		unfurl_links: false,
+		unfurl_media: false,
 	};
 }
 

--- a/projects/github-actions/repo-gardening/src/tasks/reply-to-customers-reminder/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/reply-to-customers-reminder/index.js
@@ -118,6 +118,8 @@ function formatSlackMessage( payload, channel, message ) {
 		],
 		text: `${ message } -- <${ html_url }|${ title }>`, // Fallback text for display in notifications.
 		mrkdwn: true, // Formatting of the fallback text.
+		unfurl_links: false,
+		unfurl_media: false,
 	};
 }
 

--- a/projects/github-actions/repo-gardening/src/utils/send-slack-message.js
+++ b/projects/github-actions/repo-gardening/src/utils/send-slack-message.js
@@ -66,6 +66,8 @@ async function sendSlackMessage( message, channel, token, payload, customMessage
 			],
 			text: `${ message } -- <${ html_url }|${ title }>`, // Fallback text for display in notifications.
 			mrkdwn: true, // Formatting of the fallback text.
+			unfurl_links: false,
+			unfurl_media: false,
 		};
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Those messages already have their own custom formatting, they do not need an additional link preview.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

* p1661534636418599-slack-C03G2H51WJX

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

This cannot really be tested before it's merged, but you can take a look at those 2 messages, generated from a fork:

- p1661838365798109-slack-CN2FSK7L4
- p1661838218207949-slack-CN2FSK7L4