### PR TITLE
Subscribe block: Leverage placeholder attribute when rendering the shortcode in wpcom

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribe-block-placeholder-wpcom
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-block-placeholder-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Leverage placeholder attribute when rendering the shortcode in wpcom

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -400,7 +400,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 							? esc_attr( $email_field_styles )
 							: 'width: 95%; padding: 1px 10px'
 						),
-						esc_attr__( 'Enter your email address', 'jetpack' ),
+						( empty( $subscribe_placeholder ) ? esc_attr__( 'Enter your email address', 'jetpack' ) : esc_attr( $subscribe_placeholder ) ),
 						esc_attr( $email_field_id )
 					);
 					?>


### PR DESCRIPTION
Fixes 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

For an input like this

<img width="998" alt="image" src="https://user-images.githubusercontent.com/746152/187430560-44a334e2-6493-438b-8960-bc1f6f102d63.png">


After

<img width="699" alt="image" src="https://user-images.githubusercontent.com/746152/187430377-181c023c-9383-4bc8-83a8-59bd6021774e.png">

Before 
<img width="703" alt="image" src="https://user-images.githubusercontent.com/746152/187430489-2ad7e378-2d29-46c7-a6ec-281a63774fcd.png">

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Apply the patch on .com sandboxing a simple site. `arc patch D86836`
* Create a page with a subscribe form. 
* From the Code Editor, tamper with the block markup and add `{"subscribePlaceholder":"New placeholder"}`
* Switch out of Code editor and expect to see an _Attempt recovery_ message. Click the butotn
* Save the post.
* Visit the frontend and expect to see the placeholder updated