### PR TITLE
VideoPress package: Avoid conflict with old versions of Jetpack plugin

### DIFF
--- a/projects/packages/videopress/changelog/update-avoid-declaration-conflict
+++ b/projects/packages/videopress/changelog/update-avoid-declaration-conflict
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid conflict with old versions of Jetpack plugin

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -75,7 +75,9 @@ class Initializer {
 	 * @return void
 	 */
 	private static function unconditional_initialization() {
-		require_once __DIR__ . '/utility-functions.php';
+		if ( self::should_include_utilities() ) {
+			require_once __DIR__ . '/utility-functions.php';
+		}
 
 		// Set up package version hook.
 		add_filter( 'jetpack_package_versions', __NAMESPACE__ . '\Package_Version::send_package_version_to_tracker' );
@@ -85,6 +87,22 @@ class Initializer {
 		if ( is_admin() ) {
 			AJAX::init();
 		}
+	}
+
+	/**
+	 * This avoids conflicts when running VideoPress plugin with older versions of the Jetpack plugin
+	 *
+	 * On version 11.3-a.7 utility functions include were removed from the plugin and it is safe to include it from the package
+	 *
+	 * @return boolean
+	 */
+	private static function should_include_utilities() {
+		if ( ! class_exists( 'Jetpack' ) || ! defined( 'JETPACK__VERSION' ) ) {
+			return true;
+		}
+
+		return version_compare( JETPACK__VERSION, '11.3-a.7', '>=' );
+
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #25686

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Avoid conflict between the package ad old versions of Jetpack plugin

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
NA

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Launch a new JN site
* Use VideoPress plugin on this branch
* set Jetpack plugin on latests stable (11.2)
* test the usage of VideoPress
* set Jetpack plugin to any version after 11.2-a.7 and confirm it works fine
* test other versions
* Note: version 11.2-a.5 is known to be broken

