### PR TITLE
Jetpack: remove buttons from the QRPostCode modal

### DIFF
--- a/projects/plugins/jetpack/changelog/update-qrcode-remove-dialog-buttons
+++ b/projects/plugins/jetpack/changelog/update-qrcode-remove-dialog-buttons
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack: remove buttons from the QRPostCode modal

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/components/qr-post.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/components/qr-post.js
@@ -6,7 +6,6 @@ import { useRef, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { JetpackLogo } from '../../../shared/icons.js';
 import useSiteLogo from '../hooks/use-site-logo.js';
-import { handleDownloadQRCode } from '../utils/handle-download-qr-code.js';
 
 /**
  * React component that renders a QR code for the post,
@@ -61,7 +60,6 @@ export function QRPost() {
 
 export function QRPostButton() {
 	const qrCodeRef = useRef();
-	const slug = useSelect( select => select( editorStore ).getEditedPostSlug(), [] );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const switchModal = () => setIsModalOpen( v => ! v );
 	const closeModal = () => setIsModalOpen( false );
@@ -80,16 +78,6 @@ export function QRPostButton() {
 				>
 					<div className="qr-post-modal__qr-code" ref={ qrCodeRef }>
 						<QRPost />
-					</div>
-
-					<div className="qr-post-modal__actions_buttons">
-						<Button isSecondary onClick={ () => handleDownloadQRCode( slug, qrCodeRef ) }>
-							{ __( 'Download', 'jetpack' ) }
-						</Button>
-
-						<Button isSecondary onClick={ closeModal }>
-							{ __( 'Close', 'jetpack' ) }
-						</Button>
 					</div>
 				</Modal>
 			) }

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/editor.scss
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/editor.scss
@@ -24,13 +24,3 @@
 .qr-post-jetpack-logo {
 	display: none;
 }
-
-.qr-post-modal__actions_buttons {
-	display: flex;
-	justify-content: right;
-	margin: 10px auto;
-	max-width: 300px;
-	.components-button {
-		margin-left: 5px;
-	}
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The `Download` and `Close` buttons are redundant in the QRPostCode modal. This PR removes them.

<img width="644" alt="image" src="https://user-images.githubusercontent.com/77539/187451724-cdda578c-3936-4cec-aa84-f9345b14fa34.png">

Fixes https://github.com/Automattic/jetpack/issues/25920

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack: remove buttons from the QRPostCode modal

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to block editor
* Create/edit a post
* Open the Jetpack sidebar
* Get the QR code by clicking on the `Get QR code` button
* Confirm both `Download` and `Cancel` button are gone.

before | after
------|------
<img width="400" alt="image" src="https://user-images.githubusercontent.com/77539/187452765-092d7279-4fd3-426b-a3aa-1f9fab58cc1a.png"> | <img width="418" alt="image" src="https://user-images.githubusercontent.com/77539/187451633-065bc6e9-f857-46dd-b50d-595229a1c2ba.png">
