### PR TITLE
Actions: auto-release GitHub actions

### DIFF
--- a/projects/github-actions/pr-is-up-to-date/changelog/update-actions-autorelease
+++ b/projects/github-actions/pr-is-up-to-date/changelog/update-actions-autorelease
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Tooling: enable automatic GitHub releases when a new version of the action is tagged, so the new version can be made available in the GitHub Actions marketplace.

--- a/projects/github-actions/pr-is-up-to-date/composer.json
+++ b/projects/github-actions/pr-is-up-to-date/composer.json
@@ -23,6 +23,7 @@
 		"autotagger": {
 			"major": true
 		},
+		"autorelease": true,
 		"mirror-repo": "Automattic/action-pr-is-up-to-date",
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/action-pr-is-up-to-date/compare/v${old}...v${new}"

--- a/projects/github-actions/push-to-mirrors/changelog/update-actions-autorelease
+++ b/projects/github-actions/push-to-mirrors/changelog/update-actions-autorelease
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Tooling: enable automatic GitHub releases when a new version of the action is tagged, so the new version can be made available in the GitHub Actions marketplace.

--- a/projects/github-actions/push-to-mirrors/composer.json
+++ b/projects/github-actions/push-to-mirrors/composer.json
@@ -20,6 +20,7 @@
 		"autotagger": {
 			"major": true
 		},
+		"autorelease": true,
 		"mirror-repo": "Automattic/action-push-to-mirrors",
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/action-push-to-mirrors/compare/v${old}...v${new}"

--- a/projects/github-actions/repo-gardening/changelog/update-actions-autorelease
+++ b/projects/github-actions/repo-gardening/changelog/update-actions-autorelease
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Tooling: enable automatic GitHub releases when a new version of the action is tagged, so the new version can be made available in the GitHub Actions marketplace.

--- a/projects/github-actions/repo-gardening/composer.json
+++ b/projects/github-actions/repo-gardening/composer.json
@@ -25,6 +25,7 @@
 		"autotagger": {
 			"major": true
 		},
+		"autorelease": true,
 		"mirror-repo": "Automattic/action-repo-gardening",
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/action-repo-gardening/compare/v${old}...v${new}"

--- a/projects/github-actions/required-review/changelog/update-actions-autorelease
+++ b/projects/github-actions/required-review/changelog/update-actions-autorelease
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Tooling: enable automatic GitHub releases when a new version of the action is tagged, so the new version can be made available in the GitHub Actions marketplace.

--- a/projects/github-actions/required-review/composer.json
+++ b/projects/github-actions/required-review/composer.json
@@ -25,6 +25,7 @@
 		"autotagger": {
 			"major": true
 		},
+		"autorelease": true,
 		"mirror-repo": "Automattic/action-required-review",
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/action-required-review/compare/v${old}...v${new}"

--- a/projects/github-actions/test-results-to-slack/changelog/update-actions-autorelease
+++ b/projects/github-actions/test-results-to-slack/changelog/update-actions-autorelease
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Tooling: enable automatic GitHub releases when a new version of the action is tagged, so the new version can be made available in the GitHub Actions marketplace.

--- a/projects/github-actions/test-results-to-slack/composer.json
+++ b/projects/github-actions/test-results-to-slack/composer.json
@@ -26,6 +26,7 @@
 		"autotagger": {
 			"major": true
 		},
+		"autorelease": true,
 		"mirror-repo": "Automattic/action-test-results-to-slack",
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/action-test-results-to-slack/compare/v${old}...v${new}"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Most of our GitHub actions (except one at the moment, automattic/test-results-to-slack) are made available via the GitHub Actions marketplace. Here is an example:

- https://github.com/marketplace/actions/required-review

This Marketplace, however, only lists versions that have a matching GitHub release. This is why the page above lists v2.2.2 as the latest version, even though we've seen released v3.0.0.

Let's consequently enable auto-releasing for those actions, so the new releases are made available in the marketplace as well, without needing any manual work from us.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

* 1156386383419466-as-1202839314841476

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

I don't believe we can easily test this before to merge and release a new version.
