### PR TITLE
Jetpack: Hide BETA label and styles when hovering after a delay of 0.5 sec

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-remove-beta-labeling-when-hovering
+++ b/projects/plugins/jetpack/changelog/update-jetpack-remove-beta-labeling-when-hovering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: Hide BETA label and styles when hovering after a delay of 0.5 sec

--- a/projects/plugins/jetpack/extensions/index.scss
+++ b/projects/plugins/jetpack/extensions/index.scss
@@ -3,6 +3,7 @@
 .is-beta-extension {
 	position: relative;
 	box-shadow: 0 0 3px var( --jp-green-30 );
+	transition: 0.5s box-shadow linear;
 
 	&::before {
 		content: 'BETA';
@@ -18,10 +19,17 @@
 		border-radius: 4px;
 		font-weight: 600;
 		z-index: 10000;
+		transition: visibility 0.5s, opacity 0.5s linear;
+		visibility: visible;
+		opacity: 1;
 	}
 
 	&:focus,
 	&:hover {
-		box-shadow: 0 0 10px solid var( --jp-green-30 );
+		box-shadow: none;
+		&::before {
+			opacity: 0;
+			visibility: hidden;
+		}
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR removes the BETA label and its styles for beta blocks when hovering after 0.5 seconds to be as less intrusive as possible.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack: Hide BETA label and styles when hovering after a delay of 0.5 sec

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply these changes
* Go to block editor
* Add a beta block (typing beta, for instance
* Confirm the styles, and the BETA label disappears when hovering over the block in the editor canvas.

https://user-images.githubusercontent.com/77539/187541715-0c1ff10d-69c9-4f19-a075-a0efd772c68f.mov
