### PR TITLE
Add JITMs to Jetpack Backup

### DIFF
--- a/projects/packages/backup/changelog/add-jitms-jetpack-backup
+++ b/projects/packages/backup/changelog/add-jitms-jetpack-backup
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add support for JITMs to Backup plugin

--- a/projects/packages/backup/composer.json
+++ b/projects/packages/backup/composer.json
@@ -73,7 +73,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-backup/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "1.7.x-dev"
+			"dev-trunk": "1.8.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.7.3';
+	const PACKAGE_VERSION = '1.8.0-alpha';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/backup/src/js/components/Admin.js
+++ b/projects/packages/backup/src/js/components/Admin.js
@@ -74,6 +74,11 @@ const Admin = () => {
 			<div id="jetpack-backup-admin-container" className="jp-content">
 				<div className="content">
 					<AdminSectionHero>
+						<Container horizontalSpacing={ 0 }>
+							<Col>
+								<div id="jp-admin-notices" className="jetpack-backup-jitm-card" />
+							</Col>
+						</Container>
 						<LoadedState
 							connectionLoaded={ connectionLoaded }
 							connectionStatus={ connectionStatus }

--- a/projects/packages/backup/src/js/components/admin-style.scss
+++ b/projects/packages/backup/src/js/components/admin-style.scss
@@ -143,6 +143,12 @@
 	}
 }
 
+.jetpack-backup-jitm-card {
+		.jitm-card {
+			margin-right: 0;
+		}
+	}
+
 .jp-dashboard-footer {
 	padding: 40px 0;
 }

--- a/projects/plugins/backup/changelog/add-add-jitm-to-jetpack-backup
+++ b/projects/plugins/backup/changelog/add-add-jitm-to-jetpack-backup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"automattic/jetpack-autoloader": "2.11.x-dev",
-		"automattic/jetpack-backup": "1.7.x-dev",
+		"automattic/jetpack-backup": "1.8.x-dev",
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-plugins-installer": "^0.2"
 	},

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f9211fe90318f9f43f0cd0047e2d5e96",
+    "content-hash": "7ffa23ebf7f3ab1436cd81c88917a7c9",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -235,7 +235,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "e650c1f636a2df2d09d6e0a8de2a8fd39c461e3c"
+                "reference": "8518710b9f5c174709234c283d46cc1dd7886277"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -267,7 +267,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-backup/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.7.x-dev"
+                    "dev-trunk": "1.8.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/add-add-jitm-to-jetpack-backup
+++ b/projects/plugins/jetpack/changelog/add-add-jitm-to-jetpack-backup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -15,7 +15,7 @@
 		"automattic/jetpack-abtest": "1.10.x-dev",
 		"automattic/jetpack-assets": "1.17.x-dev",
 		"automattic/jetpack-autoloader": "2.11.x-dev",
-		"automattic/jetpack-backup": "1.7.x-dev",
+		"automattic/jetpack-backup": "1.8.x-dev",
 		"automattic/jetpack-blocks": "1.4.x-dev",
 		"automattic/jetpack-compat": "1.7.x-dev",
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5ac4d89d394a655d571f6afe87ec0506",
+    "content-hash": "38c07fdc8762d8b6cd2167d24ff47d55",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -290,7 +290,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "e650c1f636a2df2d09d6e0a8de2a8fd39c461e3c"
+                "reference": "8518710b9f5c174709234c283d46cc1dd7886277"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -322,7 +322,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-backup/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.7.x-dev"
+                    "dev-trunk": "1.8.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This PR adds support for JITMs to the Jetpack Backup plugin.

#### Jetpack product discussion
p1HpG7-hAU-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
- Connect to your sandbox with D73609-code to get the JITM. 
- Update the path to match the Jetpack Backup plugin ( `->message_path( '/wp:(jetpack_page_jetpack-backup):admin_notices/' )` )
- Visit the Jetpack Backup admin page and confirm that the JITM is displayed as expected.
- Visit the Jetpack Backup admin page without the JITM enabled to ensure no side effects of adding the empty container/col

<img width="1193" alt="Screen Shot 2022-08-31 at 02 49 03" src="https://user-images.githubusercontent.com/16329583/187570405-93464edf-17c3-409d-9209-df6b186e0af6.png">
<img width="959" alt="Screen Shot 2022-08-31 at 02 51 59" src="https://user-images.githubusercontent.com/16329583/187570409-d85a2561-b0e2-4286-a079-d06227d777f7.png">


