### PR TITLE
Paid blocks: Prevent upgrade banner from being rendered if the block container is missing

### DIFF
--- a/projects/plugins/jetpack/changelog/update-paid-blocks-handle-selector-miss
+++ b/projects/plugins/jetpack/changelog/update-paid-blocks-handle-selector-miss
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: [WP.com only] Bugfix to handle situations where the block container where we want to render a paid block upgrade banner is missing
+
+

--- a/projects/plugins/jetpack/class.jetpack-plan.php
+++ b/projects/plugins/jetpack/class.jetpack-plan.php
@@ -335,8 +335,6 @@ class Jetpack_Plan {
 			return wpcom_site_has_feature( $feature );
 		}
 
-		return false;
-
 		// Search product bypasses plan feature check.
 		if ( 'search' === $feature && (bool) get_option( 'has_jetpack_search_product' ) ) {
 			return true;

--- a/projects/plugins/jetpack/class.jetpack-plan.php
+++ b/projects/plugins/jetpack/class.jetpack-plan.php
@@ -335,6 +335,8 @@ class Jetpack_Plan {
 			return wpcom_site_has_feature( $feature );
 		}
 
+		return false;
+
 		// Search product bypasses plan feature check.
 		if ( 'search' === $feature && (bool) get_option( 'has_jetpack_search_product' ) ) {
 			return true;

--- a/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
@@ -71,13 +71,18 @@ export default createHigherOrderComponent(
 		}, [ setAttributes, hasParentBanner ] );
 
 		useEffect( () => {
+			const block = document.querySelector( `[data-block="${ clientId }"]` );
+			if ( ! block ) {
+				return;
+			}
+
 			let upgradeBannerContainer = document.querySelector(
 				`[data-block="${ clientId }"] > .jetpack-block-upgrade-banner-container`
 			);
 			if ( ! upgradeBannerContainer ) {
 				upgradeBannerContainer = document.createElement( 'div' );
 				upgradeBannerContainer.classList.add( 'jetpack-block-upgrade-banner-container' );
-				document.querySelector( `[data-block="${ clientId }"]` ).prepend( upgradeBannerContainer );
+				block.prepend( upgradeBannerContainer );
 			}
 
 			render(
@@ -105,6 +110,16 @@ export default createHigherOrderComponent(
 
 		return (
 			<PaidBlockProvider onBannerVisibilityChange={ setIsVisible } hasParentBanner>
+				<UpgradePlanBanner
+					className={ `is-${ name.replace( /\//, '-' ) }-paid-block` }
+					title={ null }
+					align={ attributes?.align }
+					visible={ isBannerVisible }
+					description={ usableBlocksProps?.description }
+					requiredPlan={ requiredPlan }
+					context={ bannerContext }
+					onRedirect={ () => trackUpgradeClickEvent( trackEventData ) }
+				/>
 				<BlockEdit { ...props } />
 			</PaidBlockProvider>
 		);

--- a/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
@@ -110,16 +110,6 @@ export default createHigherOrderComponent(
 
 		return (
 			<PaidBlockProvider onBannerVisibilityChange={ setIsVisible } hasParentBanner>
-				<UpgradePlanBanner
-					className={ `is-${ name.replace( /\//, '-' ) }-paid-block` }
-					title={ null }
-					align={ attributes?.align }
-					visible={ isBannerVisible }
-					description={ usableBlocksProps?.description }
-					requiredPlan={ requiredPlan }
-					context={ bannerContext }
-					onRedirect={ () => trackUpgradeClickEvent( trackEventData ) }
-				/>
 				<BlockEdit { ...props } />
 			</PaidBlockProvider>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This fixes a regression introduced by #25812 which has been reported in p1661919557108639-slack-C02A76B714Z. It seems that there might be cases where the block container where we want to render a paid block upgrade banner could be missing (e.g. when previewing a pattern), producing a failure that prevents the block from being correctly rendered. We now check whether the block container exists in the DOM before proceeding with the display of the upgrade banner.

Before | After
--- | ---
<img width="333" alt="Screen Shot 2022-08-31 at 11 05 57" src="https://user-images.githubusercontent.com/1233880/187641931-9a13b2c7-f658-4db1-9beb-984148834aff.png"> | <img width="335" alt="Screen Shot 2022-08-31 at 11 05 32" src="https://user-images.githubusercontent.com/1233880/187641954-0774b796-11bb-42e3-b814-fa116efa624f.png">


#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
- Apply the diff created by Fusion to a WP.com sandbox
- Sandbox this demo site: `lynxdemo.wordpress.com`
  - You might also need to sandbox the static domains (`s0.wp.com`,  etc).
- Edit any page of the demo site (e.g. `/wp-admin/post.php?post=40&action=edit`)
- Open the block inserter
- Click on the "Patterns" tab
- Make sure the patterns are previewed correctly