### PR TITLE
VideoPress: iterate over VideoThumbnailEdit component

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-iterate-over-video-thumbnail-edit-cmp
+++ b/projects/packages/videopress/changelog/update-videopress-iterate-over-video-thumbnail-edit-cmp
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: iterate over VideoThumbnailEdit component

--- a/projects/packages/videopress/src/client/admin/components/video-details-card/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-details-card/index.tsx
@@ -77,6 +77,7 @@ export const VideoThumbnailDropdown: React.FC< VideoThumbnailDropdownProps > = (
  */
 export const VideoThumbnail: React.FC< VideoThumbnailProps > = ( {
 	thumbnail,
+	duration,
 	onUseDefaultThumbnail,
 	onSelectFromVideo,
 	onUploadImage,
@@ -93,6 +94,16 @@ export const VideoThumbnail: React.FC< VideoThumbnailProps > = ( {
 					onUploadImage={ onUploadImage }
 				/>
 			) }
+			{ duration && (
+				<div className={ styles[ 'video-thumbnail-duration' ] }>
+					<Text variant="body-small" component="div">
+						{ duration >= 3600 * 1000
+							? gmdateI18n( 'H:i:s', duration )
+							: gmdateI18n( 'i:s', duration ) }
+					</Text>
+				</div>
+			) }
+
 			<img src={ thumbnail } alt={ __( 'Video thumbnail', 'jetpack-videopress-pkg' ) } />
 		</div>
 	);
@@ -131,6 +142,7 @@ const VideoDetailsCard: React.FC<
 	filename,
 	src,
 	uploadDate,
+	duration,
 
 	thumbnail,
 	onUseDefaultThumbnail,
@@ -146,6 +158,7 @@ const VideoDetailsCard: React.FC<
 				onSelectFromVideo={ onSelectFromVideo }
 				onUploadImage={ onUploadImage }
 				editable={ editable }
+				duration={ duration }
 			/>
 
 			<VideoDetails filename={ filename } src={ src } uploadDate={ uploadDate } />

--- a/projects/packages/videopress/src/client/admin/components/video-details-card/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-details-card/index.tsx
@@ -78,10 +78,10 @@ export const VideoThumbnailDropdown: React.FC< VideoThumbnailDropdownProps > = (
 export const VideoThumbnail: React.FC< VideoThumbnailProps > = ( {
 	thumbnail,
 	duration,
+	editable,
 	onUseDefaultThumbnail,
 	onSelectFromVideo,
 	onUploadImage,
-	editable,
 } ) => {
 	const [ isSmall ] = useBreakpointMatch( 'sm' );
 

--- a/projects/packages/videopress/src/client/admin/components/video-details-card/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-details-card/index.tsx
@@ -12,16 +12,70 @@ import classnames from 'classnames';
  */
 import ClipboardButtonInput from '../clipboard-button-input';
 import styles from './style.module.scss';
-import { VideoDetailsProps, VideoThumbnailEditProps } from './types';
+import { VideoDetailsProps, VideoThumbnailProps, VideoThumbnailDropdownProps } from './types';
 import type React from 'react';
+
+const VideoThumbnailDropdown: React.FC< VideoThumbnailDropdownProps > = ( {
+	onUseDefaultThumbnail,
+	onSelectFromVideo,
+	onUploadImage,
+} ) => {
+	return (
+		<div className={ styles[ 'videi-thumbnail-edit' ] }>
+			<Dropdown
+				position="bottom left"
+				renderToggle={ ( { isOpen, onToggle } ) => (
+					<Button
+						variant="secondary"
+						className={ styles[ 'thumbnail__edit-button' ] }
+						icon={ edit }
+						onClick={ onToggle }
+						aria-expanded={ isOpen }
+					/>
+				) }
+				renderContent={ () => (
+					<>
+						<Button
+							weight="regular"
+							fullWidth
+							variant="tertiary"
+							icon={ image }
+							onClick={ onUseDefaultThumbnail }
+						>
+							{ __( 'Use default thumbnail', 'jetpack-videopress-pkg' ) }
+						</Button>
+						<Button
+							weight="regular"
+							fullWidth
+							variant="tertiary"
+							icon={ media }
+							onClick={ onSelectFromVideo }
+						>
+							{ __( 'Select from video', 'jetpack-videopress-pkg' ) }
+						</Button>
+						<Button
+							weight="regular"
+							fullWidth
+							variant="tertiary"
+							icon={ cloud }
+							onClick={ onUploadImage }
+						>
+							{ __( 'Upload image', 'jetpack-videopress-pkg' ) }
+						</Button>
+					</>
+				) }
+			/>
+		</div>
+	);
+};
 
 /**
  * React component to display video thumbnail.
  *
- * @param {VideoThumbnailEditProps} props - Component props.
- * @returns {React.ReactNode} - VideoThumbnailEdit react component.
+ * @param {VideoThumbnailProps} props - Component props.
+ * @returns {React.ReactNode} - VideoThumbnail react component.
  */
-export const VideoThumbnailEdit: React.FC< VideoThumbnailEditProps > = ( {
+export const VideoThumbnail: React.FC< VideoThumbnailProps > = ( {
 	thumbnail,
 	onUseDefaultThumbnail,
 	onSelectFromVideo,
@@ -31,51 +85,11 @@ export const VideoThumbnailEdit: React.FC< VideoThumbnailEditProps > = ( {
 
 	return (
 		<div className={ classnames( styles.thumbnail, { [ styles[ 'is-small' ] ]: isSmall } ) }>
-			<div className={ styles[ 'video-details-card__edit-button-container' ] }>
-				<Dropdown
-					position="bottom left"
-					renderToggle={ ( { isOpen, onToggle } ) => (
-						<Button
-							variant="secondary"
-							className={ styles[ 'thumbnail__edit-button' ] }
-							icon={ edit }
-							onClick={ onToggle }
-							aria-expanded={ isOpen }
-						/>
-					) }
-					renderContent={ () => (
-						<>
-							<Button
-								weight="regular"
-								fullWidth
-								variant="tertiary"
-								icon={ image }
-								onClick={ onUseDefaultThumbnail }
-							>
-								{ __( 'Use default thumbnail', 'jetpack-videopress-pkg' ) }
-							</Button>
-							<Button
-								weight="regular"
-								fullWidth
-								variant="tertiary"
-								icon={ media }
-								onClick={ onSelectFromVideo }
-							>
-								{ __( 'Select from video', 'jetpack-videopress-pkg' ) }
-							</Button>
-							<Button
-								weight="regular"
-								fullWidth
-								variant="tertiary"
-								icon={ cloud }
-								onClick={ onUploadImage }
-							>
-								{ __( 'Upload image', 'jetpack-videopress-pkg' ) }
-							</Button>
-						</>
-					) }
-				/>
-			</div>
+			<VideoThumbnailDropdown
+				onUseDefaultThumbnail={ onUseDefaultThumbnail }
+				onSelectFromVideo={ onSelectFromVideo }
+				onUploadImage={ onUploadImage }
+			/>
 			<img src={ thumbnail } alt={ __( 'Video thumbnail', 'jetpack-videopress-pkg' ) } />
 		</div>
 	);
@@ -105,10 +119,12 @@ export const VideoDetails: React.FC< VideoDetailsProps > = ( { filename, src, up
 /**
  * Video Details Card component
  *
- * @param {VideoThumbnailEditProps} props - Component props.
+ * @param {VideoThumbnailProps} props - Component props.
  * @returns {React.ReactNode} - VideoDetailsCard react component.
  */
-const VideoDetailsCard: React.FC< VideoDetailsProps & VideoThumbnailEditProps > = ( {
+const VideoDetailsCard: React.FC<
+	VideoDetailsProps & VideoThumbnailProps & VideoThumbnailDropdownProps
+> = ( {
 	filename,
 	src,
 	uploadDate,
@@ -120,7 +136,7 @@ const VideoDetailsCard: React.FC< VideoDetailsProps & VideoThumbnailEditProps > 
 } ) => {
 	return (
 		<div className={ styles.wrapper }>
-			<VideoThumbnailEdit
+			<VideoThumbnail
 				thumbnail={ thumbnail }
 				onUseDefaultThumbnail={ onUseDefaultThumbnail }
 				onSelectFromVideo={ onSelectFromVideo }

--- a/projects/packages/videopress/src/client/admin/components/video-details-card/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-details-card/index.tsx
@@ -80,16 +80,19 @@ export const VideoThumbnail: React.FC< VideoThumbnailProps > = ( {
 	onUseDefaultThumbnail,
 	onSelectFromVideo,
 	onUploadImage,
+	editable,
 } ) => {
 	const [ isSmall ] = useBreakpointMatch( 'sm' );
 
 	return (
 		<div className={ classnames( styles.thumbnail, { [ styles[ 'is-small' ] ]: isSmall } ) }>
-			<VideoThumbnailDropdown
-				onUseDefaultThumbnail={ onUseDefaultThumbnail }
-				onSelectFromVideo={ onSelectFromVideo }
-				onUploadImage={ onUploadImage }
-			/>
+			{ editable && (
+				<VideoThumbnailDropdown
+					onUseDefaultThumbnail={ onUseDefaultThumbnail }
+					onSelectFromVideo={ onSelectFromVideo }
+					onUploadImage={ onUploadImage }
+				/>
+			) }
 			<img src={ thumbnail } alt={ __( 'Video thumbnail', 'jetpack-videopress-pkg' ) } />
 		</div>
 	);
@@ -133,6 +136,7 @@ const VideoDetailsCard: React.FC<
 	onUseDefaultThumbnail,
 	onSelectFromVideo,
 	onUploadImage,
+	editable,
 } ) => {
 	return (
 		<div className={ styles.wrapper }>
@@ -141,6 +145,7 @@ const VideoDetailsCard: React.FC<
 				onUseDefaultThumbnail={ onUseDefaultThumbnail }
 				onSelectFromVideo={ onSelectFromVideo }
 				onUploadImage={ onUploadImage }
+				editable={ editable }
 			/>
 
 			<VideoDetails filename={ filename } src={ src } uploadDate={ uploadDate } />

--- a/projects/packages/videopress/src/client/admin/components/video-details-card/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-details-card/index.tsx
@@ -15,13 +15,13 @@ import styles from './style.module.scss';
 import { VideoDetailsProps, VideoThumbnailProps, VideoThumbnailDropdownProps } from './types';
 import type React from 'react';
 
-const VideoThumbnailDropdown: React.FC< VideoThumbnailDropdownProps > = ( {
+export const VideoThumbnailDropdown: React.FC< VideoThumbnailDropdownProps > = ( {
 	onUseDefaultThumbnail,
 	onSelectFromVideo,
 	onUploadImage,
 } ) => {
 	return (
-		<div className={ styles[ 'videi-thumbnail-edit' ] }>
+		<div className={ styles[ 'video-thumbnail-edit' ] }>
 			<Dropdown
 				position="bottom left"
 				renderToggle={ ( { isOpen, onToggle } ) => (

--- a/projects/packages/videopress/src/client/admin/components/video-details-card/stories/VideoDetailsCard.mdx
+++ b/projects/packages/videopress/src/client/admin/components/video-details-card/stories/VideoDetailsCard.mdx
@@ -15,6 +15,10 @@ It is composed of two simpler components: VideoThumbnail and VideoDetails compon
 
 -------
 
+# VideoThumbnailDropdown
+
+<Story id="packages-videopress-video-details-card--video-dropdown" />
+
 # VideoThumbnail
 
 <Story id="packages-videopress-video-details-card--video-thumbnail" />

--- a/projects/packages/videopress/src/client/admin/components/video-details-card/stories/VideoDetailsCard.mdx
+++ b/projects/packages/videopress/src/client/admin/components/video-details-card/stories/VideoDetailsCard.mdx
@@ -9,15 +9,15 @@ import VideoDetailsCard from '../index';
 # VideoDetailsCard
 
 React component that shows a card with details about the given video. It is possible to change it via the edit button.
-It is composed of two simpler components: VideoThumbnailEdit and VideoDetails components.
+It is composed of two simpler components: VideoThumbnail and VideoDetails components.
 
 <Story id="packages-videopress-video-details-card--default" />
 
 -------
 
-# VideoThumbnailEdit
+# VideoThumbnail
 
-<Story id="packages-videopress-video-details-card--video-thumbnail-edit" />
+<Story id="packages-videopress-video-details-card--video-thumbnail" />
 
 # VideoDetails
 

--- a/projects/packages/videopress/src/client/admin/components/video-details-card/stories/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-details-card/stories/index.tsx
@@ -38,6 +38,7 @@ _default.args = {
 	onSelectFromVideo: action( 'onSelectFromVideo' ),
 	onUploadImage: action( 'onUploadImage' ),
 	editable: true,
+	duration: ( 4 * 60 + 20 ) * 1000, // 4 minutes and 20 seconds
 };
 
 const VideoDetailsTemplate: ComponentStory< typeof VideoDetailsComponent > = VideoDetailsComponent;

--- a/projects/packages/videopress/src/client/admin/components/video-details-card/stories/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-details-card/stories/index.tsx
@@ -6,7 +6,7 @@ import { action } from '@storybook/addon-actions';
  * Internal dependencies
  */
 import VideoDetailsCard, {
-	VideoThumbnailEdit as VideoThumbnailEditComponent,
+	VideoThumbnail as VideoThumbnailComponent,
 	VideoDetails as VideoDetailsComponent,
 } from '..';
 import Doc from './VideoDetailsCard.mdx';
@@ -46,12 +46,12 @@ VideoDetails.args = {
 	src: 'https://videos.files.wordpress.com/fx123456B/video-thumbnail.mov',
 };
 
-const VideoThumbnailEditTemplate: ComponentStory<
-	typeof VideoThumbnailEditComponent
-> = VideoThumbnailEditComponent;
+const VideoThumbnailTemplate: ComponentStory<
+	typeof VideoThumbnailComponent
+> = VideoThumbnailComponent;
 
-export const VideoThumbnailEdit = VideoThumbnailEditTemplate.bind( {} );
-VideoThumbnailEdit.args = {
+export const VideoThumbnail = VideoThumbnailTemplate.bind( {} );
+VideoThumbnail.args = {
 	thumbnail,
 	onUseDefaultThumbnail: action( 'onUseDefaultThumbnail' ),
 	onSelectFromVideo: action( 'onSelectFromVideo' ),

--- a/projects/packages/videopress/src/client/admin/components/video-details-card/stories/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-details-card/stories/index.tsx
@@ -6,8 +6,9 @@ import { action } from '@storybook/addon-actions';
  * Internal dependencies
  */
 import VideoDetailsCard, {
-	VideoThumbnail as VideoThumbnailComponent,
 	VideoDetails as VideoDetailsComponent,
+	VideoThumbnail as VideoThumbnailComponent,
+	VideoThumbnailDropdown as VideoThumbnailDropdownComponent,
 } from '..';
 import Doc from './VideoDetailsCard.mdx';
 import thumbnail from './video-thumbnail.png';
@@ -53,6 +54,17 @@ const VideoThumbnailTemplate: ComponentStory<
 export const VideoThumbnail = VideoThumbnailTemplate.bind( {} );
 VideoThumbnail.args = {
 	thumbnail,
+	onUseDefaultThumbnail: action( 'onUseDefaultThumbnail' ),
+	onSelectFromVideo: action( 'onSelectFromVideo' ),
+	onUploadImage: action( 'onUploadImage' ),
+};
+
+const VideoThumbnailDropdownTemplate: ComponentStory<
+	typeof VideoThumbnailDropdownComponent
+> = VideoThumbnailDropdownComponent;
+
+export const VideoDropdown = VideoThumbnailDropdownTemplate.bind( {} );
+VideoDropdown.args = {
 	onUseDefaultThumbnail: action( 'onUseDefaultThumbnail' ),
 	onSelectFromVideo: action( 'onSelectFromVideo' ),
 	onUploadImage: action( 'onUploadImage' ),

--- a/projects/packages/videopress/src/client/admin/components/video-details-card/stories/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-details-card/stories/index.tsx
@@ -37,6 +37,7 @@ _default.args = {
 	onUseDefaultThumbnail: action( 'onUseDefaultThumbnail' ),
 	onSelectFromVideo: action( 'onSelectFromVideo' ),
 	onUploadImage: action( 'onUploadImage' ),
+	editable: true,
 };
 
 const VideoDetailsTemplate: ComponentStory< typeof VideoDetailsComponent > = VideoDetailsComponent;
@@ -57,6 +58,7 @@ VideoThumbnail.args = {
 	onUseDefaultThumbnail: action( 'onUseDefaultThumbnail' ),
 	onSelectFromVideo: action( 'onSelectFromVideo' ),
 	onUploadImage: action( 'onUploadImage' ),
+	editable: true,
 };
 
 const VideoThumbnailDropdownTemplate: ComponentStory<

--- a/projects/packages/videopress/src/client/admin/components/video-details-card/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/video-details-card/style.module.scss
@@ -19,14 +19,6 @@
 	> img {
 		width: 100%;
 	}
-
-	button.thumbnail__edit-button:global(.components-button) {
-		padding: var( --spacing-base );
-
-		> svg {
-			margin: 0;
-		}
-	}
 	
 	&:not( .is-small ) {
 		> img {
@@ -35,10 +27,18 @@
 	}
 }
 
-.videi-thumbnail-edit {
+.video-thumbnail-edit {
 	position: absolute;
 	top: var( --spacing-base );
 	right: var( --spacing-base );
+
+	button.thumbnail__edit-button:global(.components-button) {
+		padding: var( --spacing-base );
+
+		> svg {
+			margin: 0;
+		}
+	}
 }
 
 .details {

--- a/projects/packages/videopress/src/client/admin/components/video-details-card/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/video-details-card/style.module.scss
@@ -35,7 +35,7 @@
 	}
 }
 
-.video-details-card__edit-button-container {
+.videi-thumbnail-edit {
 	position: absolute;
 	top: var( --spacing-base );
 	right: var( --spacing-base );

--- a/projects/packages/videopress/src/client/admin/components/video-details-card/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/video-details-card/style.module.scss
@@ -45,7 +45,7 @@
 }
 
 .video-thumbnail-edit {
-	button.thumbnail__edit-button:global(.components-button) {
+        .thumbnail__edit-button:global(.components-button) {
 		padding: var( --spacing-base );
 
 		> svg {

--- a/projects/packages/videopress/src/client/admin/components/video-details-card/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/video-details-card/style.module.scss
@@ -26,6 +26,17 @@
 		right: var( --spacing-base );
 	}
 	
+	.video-thumbnail-duration {
+		position: absolute;
+		bottom: var( --spacing-base );
+		right: var( --spacing-base );
+		padding-left: var( --spacing-base );
+		padding-right: var( --spacing-base );
+		border-radius: var( --jp-border-radius );
+		color: var( --jp-white );
+		background-color: rgba( 44, 51, 56, 0.9 ); // (--jp-gray-80) Todo: figure how to apply opacity with HEXA colors
+	}
+
 	&:not( .is-small ) {
 		> img {
 			border-radius: var( --jp-border-radius );

--- a/projects/packages/videopress/src/client/admin/components/video-details-card/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/video-details-card/style.module.scss
@@ -19,6 +19,12 @@
 	> img {
 		width: 100%;
 	}
+
+	.video-thumbnail-edit {
+		position: absolute;
+		top: var( --spacing-base );
+		right: var( --spacing-base );
+	}
 	
 	&:not( .is-small ) {
 		> img {
@@ -28,10 +34,6 @@
 }
 
 .video-thumbnail-edit {
-	position: absolute;
-	top: var( --spacing-base );
-	right: var( --spacing-base );
-
 	button.thumbnail__edit-button:global(.components-button) {
 		padding: var( --spacing-base );
 

--- a/projects/packages/videopress/src/client/admin/components/video-details-card/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/video-details-card/types.ts
@@ -44,6 +44,11 @@ export type VideoDetailsProps = {
 	uploadDate: string;
 
 	/**
+	 * Video duration. Number, in milliseconds.
+	 */
+	duration?: number;
+
+	/**
 	 * Whether is possible to edit the thumbnail
 	 */
 	editable: true;

--- a/projects/packages/videopress/src/client/admin/components/video-details-card/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/video-details-card/types.ts
@@ -3,6 +3,16 @@ export type VideoThumbnailProps = {
 	 * Video thumbnial image
 	 */
 	thumbnail: string;
+
+	/**
+	 * Video duration. Number, in milliseconds.
+	 */
+	duration?: number;
+
+	/**
+	 * Whether is possible to edit the thumbnail
+	 */
+	editable: true;
 };
 
 export type VideoThumbnailDropdownProps = {
@@ -24,11 +34,6 @@ export type VideoThumbnailDropdownProps = {
 
 export type VideoDetailsProps = {
 	/**
-	 * Optional classname to apply to the root element.
-	 */
-	className?: string;
-
-	/**
 	 * Video filename.
 	 */
 	filename: string;
@@ -42,14 +47,4 @@ export type VideoDetailsProps = {
 	 * Video uploaded date
 	 */
 	uploadDate: string;
-
-	/**
-	 * Video duration. Number, in milliseconds.
-	 */
-	duration?: number;
-
-	/**
-	 * Whether is possible to edit the thumbnail
-	 */
-	editable: true;
 };

--- a/projects/packages/videopress/src/client/admin/components/video-details-card/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/video-details-card/types.ts
@@ -42,4 +42,9 @@ export type VideoDetailsProps = {
 	 * Video uploaded date
 	 */
 	uploadDate: string;
+
+	/**
+	 * Whether is possible to edit the thumbnail
+	 */
+	editable: true;
 };

--- a/projects/packages/videopress/src/client/admin/components/video-details-card/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/video-details-card/types.ts
@@ -1,9 +1,11 @@
-export type VideoThumbnailEditProps = {
+export type VideoThumbnailProps = {
 	/**
 	 * Video thumbnial image
 	 */
 	thumbnail: string;
+};
 
+export type VideoThumbnailDropdownProps = {
 	/**
 	 * Callback to be invoked when clicking on the `Use default thumbnail` dropdown menu option.
 	 */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR iterates over the VideoThumbnailEdit component to make the thumbnail components reusable in other contexts.

VideoDetailCard | VideoGrid
------|------
<img width="411" alt="image" src="https://user-images.githubusercontent.com/77539/187714069-1aa6ee65-6ea6-4a6a-8b11-09611af84c7e.png"> | <img width="444" alt="image" src="https://user-images.githubusercontent.com/77539/187714134-52b5428d-3c82-4dc4-8e98-f9be3fcfaf91.png">

Also, it adds the direction property.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update/videopress iterate over video thumbnail edit cmp

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with storybook
* VideoDetailsCard: http://localhost:50240/?path=/story/packages-videopress-video-details-card--default
* Confirm you see the duration label
* Show the Addons
* Play with `editable` and `duration` properties


https://user-images.githubusercontent.com/77539/187714872-47d56168-ca7a-41ed-889d-a5f1524b4b54.mov



