### PR TITLE
Publicize: Remove broken Publicize_UI code

### DIFF
--- a/projects/packages/publicize/changelog/fix-remove-publicize-ui-code
+++ b/projects/packages/publicize/changelog/fix-remove-publicize-ui-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Removed errant code change.

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.13.0",
+	"version": "0.13.1-alpha",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/publicize/src/class-publicize-ui.php
+++ b/projects/packages/publicize/src/class-publicize-ui.php
@@ -253,31 +253,6 @@ jQuery( function($) {
 		return false;
 	} );
 
-	$('#publicize-form').click( function(event) {
-		var target = $(event.target);
-
-		if (!target.is('input') || target.is(':disabled')) {
-			return;
-		}
-
-		// If a connection is checked and disabled, it's already been Publicized to, and we don't want to change it.
-		var enabledConnections = $('#publicize-form').find('input[type="checkbox"]:checked:not(:disabled)');
-		var outOfConnections   = enabledConnections.length >= 1;
-
-		var inputs = $('#publicize-form').find('input[type="checkbox"]').each(function() {
-			// Don't do anything for the current target.
-			if ( this.id === target.attr('id') ) {
-				return true;
-			}
-
-			// If it's checked, don't change anything.
-			if ( this.checked ) {
-				return true;
-			}
-
-			$(this).prop('disabled', outOfConnections);
-		} );
-	})
 
 	$('#publicize-form-hide').click( function() {
 		var newList = $.map( $('#publicize-form').slideUp( 'fast' ).find( ':checked' ), function( el ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


#### Changes proposed in this Pull Request:
This PR removes some code that breaks Publicize in the classic editor.

#### Other information:

- [X] Have you written new tests for your changes, if applicable?
- [X] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate Jetpack or Jetpack Social on your testing site.
* Ensure you have at least two Jetpack Social connections.
* Make sure the Classic Editor plugin is active.
* Make a new post and open the Jetpack Social settings in the sidebar.
* With this PR, you should be able to check both connections without any issue.
* Without this PR, after checking a connection the other one will be disabled.

