### PR TITLE
JS Package Licensing: Record events related to license activations

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -889,10 +889,17 @@ importers:
     specifiers:
       '@automattic/format-currency': 1.0.1
       '@automattic/jetpack-analytics': workspace:* || ^0.1
+<<<<<<< HEAD
       '@automattic/jetpack-api': workspace:* || ^0.14
       '@automattic/jetpack-components': workspace:* || ^0.22
       '@automattic/jetpack-connection': workspace:* || ^0.22
       '@automattic/jetpack-licensing': workspace:* || ^0.5
+=======
+      '@automattic/jetpack-api': workspace:* || ^0.13
+      '@automattic/jetpack-components': workspace:* || ^0.18
+      '@automattic/jetpack-connection': workspace:* || ^0.18
+      '@automattic/jetpack-licensing': workspace:* || ^0.6
+>>>>>>> e035e9f0a9 (Update dependencies)
       '@automattic/jetpack-webpack-config': workspace:* || ^1.3
       '@babel/core': 7.19.3
       '@babel/preset-env': 7.19.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -364,6 +364,7 @@ importers:
 
   projects/js-packages/licensing:
     specifiers:
+      '@automattic/jetpack-analytics': workspace:* || ^0.1
       '@automattic/jetpack-api': workspace:* || ^0.14
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
       '@automattic/jetpack-components': workspace:* || ^0.22
@@ -383,6 +384,7 @@ importers:
       react-dom: 17.0.2
       react-test-renderer: 17.0.2
     dependencies:
+      '@automattic/jetpack-analytics': link:../analytics
       '@automattic/jetpack-api': link:../api
       '@automattic/jetpack-components': link:../components
       '@wordpress/components': 21.1.0_7zkbjz6d46tpcbbta4lk5n6n6i

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -889,17 +889,10 @@ importers:
     specifiers:
       '@automattic/format-currency': 1.0.1
       '@automattic/jetpack-analytics': workspace:* || ^0.1
-<<<<<<< HEAD
       '@automattic/jetpack-api': workspace:* || ^0.14
       '@automattic/jetpack-components': workspace:* || ^0.22
       '@automattic/jetpack-connection': workspace:* || ^0.22
-      '@automattic/jetpack-licensing': workspace:* || ^0.5
-=======
-      '@automattic/jetpack-api': workspace:* || ^0.13
-      '@automattic/jetpack-components': workspace:* || ^0.18
-      '@automattic/jetpack-connection': workspace:* || ^0.18
       '@automattic/jetpack-licensing': workspace:* || ^0.6
->>>>>>> e035e9f0a9 (Update dependencies)
       '@automattic/jetpack-webpack-config': workspace:* || ^1.3
       '@babel/core': 7.19.3
       '@babel/preset-env': 7.19.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1427,7 +1427,7 @@ importers:
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
       '@automattic/jetpack-components': workspace:* || ^0.22
       '@automattic/jetpack-connection': workspace:* || ^0.22
-      '@automattic/jetpack-licensing': workspace:* || ^0.5
+      '@automattic/jetpack-licensing': workspace:* || ^0.6
       '@automattic/jetpack-partner-coupon': workspace:* || ^0.2
       '@automattic/jetpack-publicize-components': workspace:* || ^0.7
       '@automattic/jetpack-shared-extension-utils': workspace:* || ^0.6

--- a/projects/js-packages/licensing/changelog/add-licensing-package-analytics
+++ b/projects/js-packages/licensing/changelog/add-licensing-package-analytics
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Analytics: record license activation events

--- a/projects/js-packages/licensing/components/activation-screen-controls/index.jsx
+++ b/projects/js-packages/licensing/components/activation-screen-controls/index.jsx
@@ -1,10 +1,11 @@
+import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { JetpackLogo, Spinner } from '@automattic/jetpack-components';
 import { Button, TextControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, warning } from '@wordpress/icons';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import './style.scss';
 
@@ -24,6 +25,10 @@ const ActivationScreenControls = props => {
 	const { activateLicense, isActivating, license, licenseError, onLicenseChange } = props;
 
 	const hasLicenseError = licenseError !== null && licenseError !== undefined;
+
+	useEffect( () => {
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_wpa_license_key_activation_view' );
+	}, [] );
 
 	return (
 		<div className="jp-license-activation-screen-controls">

--- a/projects/js-packages/licensing/components/activation-screen/index.jsx
+++ b/projects/js-packages/licensing/components/activation-screen/index.jsx
@@ -1,3 +1,4 @@
+import jetpackAnalytics from '@automattic/jetpack-analytics';
 import restApi from '@automattic/jetpack-api';
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
@@ -75,6 +76,9 @@ const ActivationScreen = props => {
 
 		setLicenseError( null );
 		setIsSaving( true );
+
+		jetpackAnalytics.tracks.recordJetpackClick( { target: 'license_activation_button' } );
+
 		// returning our promise chain makes testing a bit easier ( see ./test/components.jsx - "should render an error from API" )
 		return restApi
 			.attachLicenses( [ license ] )
@@ -82,9 +86,11 @@ const ActivationScreen = props => {
 				const activatedProductId = parseAttachLicensesResult( result );
 				setActivatedProduct( activatedProductId );
 				onActivationSuccess( activatedProductId );
+				jetpackAnalytics.tracks.recordEvent( 'jetpack_wpa_license_activation_success' );
 			} )
 			.catch( error => {
 				setLicenseError( error.message );
+				jetpackAnalytics.tracks.recordEvent( 'jetpack_wpa_license_activation_error' );
 			} )
 			.finally( () => {
 				setIsSaving( false );

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.6.0",
+	"version": "0.6.0-alpha",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.5.15",
+	"version": "0.6.0",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -20,6 +20,7 @@
 		"test-coverage": "pnpm run test --coverageDirectory=\"$COVERAGE_DIR\" --coverage --coverageReporters=clover"
 	},
 	"dependencies": {
+		"@automattic/jetpack-analytics": "workspace:* || ^0.1",
 		"@automattic/jetpack-api": "workspace:* || ^0.14",
 		"@automattic/jetpack-components": "workspace:* || ^0.22",
 		"@wordpress/components": "21.1.0",

--- a/projects/packages/my-jetpack/changelog/add-licensing-package-analytics
+++ b/projects/packages/my-jetpack/changelog/add-licensing-package-analytics
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -27,7 +27,7 @@
 		"@automattic/jetpack-api": "workspace:* || ^0.14",
 		"@automattic/jetpack-components": "workspace:* || ^0.22",
 		"@automattic/jetpack-connection": "workspace:* || ^0.22",
-		"@automattic/jetpack-licensing": "workspace:* || ^0.5",
+		"@automattic/jetpack-licensing": "workspace:* || ^0.6",
 		"@wordpress/api-fetch": "6.15.0",
 		"@wordpress/components": "21.1.0",
 		"@wordpress/data": "7.2.0",

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "2.2.0",
+	"version": "2.2.1-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -29,7 +29,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '2.2.0';
+	const PACKAGE_VERSION = '2.2.1-alpha';
 
 	/**
 	 * Initialize My Jetapack

--- a/projects/plugins/jetpack/changelog/add-licensing-package-analytics
+++ b/projects/plugins/jetpack/changelog/add-licensing-package-analytics
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update js-packages/licensing dependency version

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -52,7 +52,7 @@
 		"@automattic/jetpack-api": "workspace:* || ^0.14",
 		"@automattic/jetpack-components": "workspace:* || ^0.22",
 		"@automattic/jetpack-connection": "workspace:* || ^0.22",
-		"@automattic/jetpack-licensing": "workspace:* || ^0.5",
+		"@automattic/jetpack-licensing": "workspace:* || ^0.6",
 		"@automattic/jetpack-partner-coupon": "workspace:* || ^0.2",
 		"@automattic/jetpack-publicize-components": "workspace:* || ^0.7",
 		"@automattic/jetpack-shared-extension-utils": "workspace:* || ^0.6",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes 1164141197617539-as-1202857845845246

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add the `@automattic/jetpack-analytics` dependency to `js-packages/licensing` to record events associated with license activations.
* Update the` @automattic/jetpack-licensing` dependency to include these changes in the Jetpack plugin.
* Record when the user visits the license activation page.
* Record when the user submits a license key.
* Record the result of a license activation attempt.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
The result of a discussion over Slack was captured in 1164141197617539-as-1202857845845246. 

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
As mentioned in the description, we will track the following events:
* When the user visits the license activation page.
* When the user submits a license key.
* The result of a license activation attempt.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your Jetpack installation using Jetpack Beta or a similar medium.
* Connect your WP Admin user to WordPress.com via the Jetpack Connection.
* Open the Network tab to see the network traffic.
* Enter `jetpack_wpa_` in the search bar to see only the traffic we care about.
* Visit `https://your-jetpack-site/wp-admin/admin.php?page=jetpack#/license/activation`.
* Make sure we record an event called `jetpack_wpa_license_key_activation_view`.
* Enter any text into the License Key input box (not a real license key), and submit it.
* Make sure we record an event called `jetpack_wpa_click` with target equal to `license_activation_button`.
* After the attempt fails, make sure we record an event called `jetpack_wpa_license_activation_error`.
* Open a new tab, visit https://cloud.jetpack.com/pricing, purchase a Jetpack license, and copy the license key to your clipboard.
* Go back to the other tab (`https://your-jetpack-site/wp-admin/admin.php?page=jetpack#/license/activation`).
* Paste the real license key you just purchased.
* Make sure we record an event called `jetpack_wpa_click` with target equal to `license_activation_button`.
* After the attempt succeeds, make sure we record an event called `jetpack_wpa_license_activation_success`.