### PR TITLE
jetpack: Fix undefined array key access in WPCOM_JSON_API_List_Post_Formats_Endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jpop-issues-7697
+++ b/projects/plugins/jetpack/changelog/fix-jpop-issues-7697
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix an undefined array access.

--- a/projects/plugins/jetpack/changelog/fix-jpop-issues-7697
+++ b/projects/plugins/jetpack/changelog/fix-jpop-issues-7697
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Fix an undefined array access.
+Fix an undefined array key access in `WPCOM_JSON_API_List_Post_Formats_Endpoint`.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -896,7 +896,9 @@ class WPCOM_JSON_API_List_Post_Formats_Endpoint extends WPCOM_JSON_API_Endpoint 
 		$all_formats = get_post_format_strings();
 		$supported   = get_theme_support( 'post-formats' );
 
-		$response          = array();
+		$response          = array(
+			'formats' => array(),
+		);
 		$supported_formats = $response['formats'];
 
 		if ( isset( $supported[0] ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Looks like #22903 got a little confused when fixing
```
$supported_formats = $response['formats'] = array();
```
It de-chained the assignment and fixed the auto-vivification, but lost
the assignment to the 'formats' key in the array.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Fixes Automattic/jpop-issues#7697

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* ?