### PR TITLE
 VideoPress: VideoStatsGroup component

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-video-stats-group-component
+++ b/projects/packages/videopress/changelog/add-videopress-video-stats-group-component
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Add VideoStatsGroup component

--- a/projects/packages/videopress/src/client/admin/components/video-stats-group/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-stats-group/index.tsx
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { Text } from '@automattic/jetpack-components';
+import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
+/**
+ * Internal dependencies
+ */
+import styles from './style.module.scss';
+import { VideoStatsGroupProps } from './types';
+import type React from 'react';
+
+const Stats = ( { label, value = 0 }: { label: string; value: number } ) => {
+	return (
+		<div className={ classnames( styles.column ) }>
+			<Text>{ label }</Text>
+			<Text variant="title-medium" className={ classnames( styles.count ) }>
+				{ value }
+			</Text>
+		</div>
+	);
+};
+
+/**
+ * Video Stats Group component
+ *
+ * @param {VideoStatsGroupProps} props - Component props.
+ * @returns {React.ReactNode} - VideoStatsGroup react component.
+ */
+const VideoStatsGroup = ( {
+	className,
+	videos = 0,
+	plays = 0,
+	playsToday = 0,
+}: VideoStatsGroupProps ) => {
+	return (
+		<div className={ classnames( className, styles.wrapper ) }>
+			<Stats label={ __( 'Videos', 'jetpack-videopress-pkg' ) } value={ videos } />
+			<Stats label={ __( 'Plays', 'jetpack-videopress-pkg' ) } value={ plays } />
+			<Stats label={ __( 'Plays today', 'jetpack-videopress-pkg' ) } value={ playsToday } />
+		</div>
+	);
+};
+
+export default VideoStatsGroup;

--- a/projects/packages/videopress/src/client/admin/components/video-stats-group/stories/VideoStatsGroup.mdx
+++ b/projects/packages/videopress/src/client/admin/components/video-stats-group/stories/VideoStatsGroup.mdx
@@ -1,0 +1,34 @@
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
+import VideoStatsGroup from '../index';
+
+<Meta
+  title="Packages/VideoPress/Video Stats Group"
+  component={VideoStatsGroup}
+/>
+
+# VideoStatsGroup
+Component that shows VideoPress user video stats.
+
+<Canvas withSource="open">
+  <Story id="packages-videopress-video-stats-group--default" />
+</Canvas>
+
+## API
+
+### videos
+
+- type: `number`
+
+The number of uploaded videos.
+
+### plays
+
+- type: `number`
+
+The total number of video plays.
+
+### playsToday
+
+- type: `number`
+
+The total number of video plays of the current day.

--- a/projects/packages/videopress/src/client/admin/components/video-stats-group/stories/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-stats-group/stories/index.tsx
@@ -1,0 +1,22 @@
+import VideoStatsGroup from '..';
+import Doc from './VideoStatsGroup.mdx';
+import type { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+	title: 'Packages/VideoPress/Video Stats Group',
+	component: VideoStatsGroup,
+	parameters: {
+		docs: {
+			page: Doc,
+		},
+	},
+} as ComponentMeta< typeof VideoStatsGroup >;
+
+const Template: ComponentStory< typeof VideoStatsGroup > = args => <VideoStatsGroup { ...args } />;
+
+export const _default = Template.bind( {} );
+_default.args = {
+	videos: 15,
+	plays: 1234,
+	playsToday: 140,
+};

--- a/projects/packages/videopress/src/client/admin/components/video-stats-group/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/video-stats-group/style.module.scss
@@ -1,0 +1,19 @@
+.wrapper {
+	--jp-video-stats-group-wrapper-max-width: 318px;
+
+	display: inline-flex;
+	justify-content: space-between;
+	min-width: var(--jp-video-stats-group-wrapper-max-width);
+	background-color: var( --jp-white );
+	padding: calc( var( --spacing-base ) * 2 ); // 16px;
+	border-radius: calc( var( --jp-border-radius ) * 2 ); // 8px;
+	box-shadow: 0px 4px 40px rgba(0, 0, 0, 0.08);
+
+	.column:not(:last-of-type) {
+		padding-right: calc( var( --spacing-base ) ); // 8px;
+	}
+
+	.count {
+		margin-top: calc( var( --spacing-base ) / 2); // 4px;
+	}
+}

--- a/projects/packages/videopress/src/client/admin/components/video-stats-group/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/video-stats-group/types.ts
@@ -1,0 +1,21 @@
+export type VideoStatsGroupProps = {
+	/**
+	 * Optional classname to apply to the root element.
+	 */
+	className?: string;
+
+	/**
+	 * The number of uploaded videos.
+	 */
+	videos: number;
+
+	/**
+	 * The total number of video plays.
+	 */
+	plays: number;
+
+	/**
+	 * The total number of video plays of the current day.
+	 */
+	playsToday: number;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #25750

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add VideoStatsGroup component

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `cd projects/js-packages/storybook && pnpm run storybook:dev`
* Confirm that the story of `Packages/VideoPress/Video Stats Group` component works as expected

![Screenshot_2022-09-01_16-15-08](https://user-images.githubusercontent.com/8486249/187994518-b2174179-cb2e-496d-ab77-01efeaba1b44.png)