### PR TITLE
Repo gardening: add default value for issue body when empty

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/fix-repo-gardening-body-default
+++ b/projects/github-actions/repo-gardening/changelog/fix-repo-gardening-body-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Gather Support References: avoid throwing an error when an issue has no content.

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -54,7 +54,10 @@ async function getIssueReferences( octokit, owner, repo, number, issueComments )
 		repo,
 		issue_number: +number,
 	} );
-	ticketReferences.push( ...body.matchAll( referencesRegexP ) );
+
+	if ( body ) {
+		ticketReferences.push( ...body.matchAll( referencesRegexP ) );
+	}
 
 	debug( `gather-support-references: Getting references from comments.` );
 	issueComments.map( comment => {


### PR DESCRIPTION
Fixes #26006

#### Changes proposed in this Pull Request:

When an issue has no content at all, avoid errors.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

This cannot be tested before it is merged, but was tested in this forked repo:
https://github.com/jeherve/jetpack/actions/runs/2978514263