### PR TITLE
Add/create site button admin menu

### DIFF
--- a/projects/plugins/jetpack/changelog/add-create-site-button-admin-menu
+++ b/projects/plugins/jetpack/changelog/add-create-site-button-admin-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Admin Menu: show add new site at the bottom for all users on simiple and atomic sites

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -181,11 +181,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	 * Adds a link to the menu to create a new site.
 	 */
 	public function add_new_site_link() {
-		$site_count = get_user_option( 'wpcom_site_count' );
-		if ( $site_count && $site_count > 1 ) {
-			return;
-		}
-
 		$this->add_admin_menu_separator();
 		add_menu_page( __( 'Add New Site', 'jetpack' ), __( 'Add New Site', 'jetpack' ), 'read', 'https://wordpress.com/start?ref=calypso-sidebar', null, 'dashicons-plus-alt' );
 	}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -132,10 +132,6 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	 * Adds a link to the menu to create a new site.
 	 */
 	public function add_new_site_link() {
-		if ( $this->get_current_user_blog_count() > 1 ) {
-			return;
-		}
-
 		$this->add_admin_menu_separator();
 		add_menu_page( __( 'Add New Site', 'jetpack' ), __( 'Add New Site', 'jetpack' ), 'read', 'https://wordpress.com/start?ref=calypso-sidebar', null, 'dashicons-plus-alt' );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

- Closes https://github.com/Automattic/wp-calypso/issues/67323

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

- Show always add new site button for all users.
- Show this button at the bottom of the admin menu on atomic and simple sites.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Atomic Sites**
- Install jetpack beta and chose this branch: ``

**Simple Sites**
- Sandbox a site with the diff

**Observe the button**

After applying one of the testing instructions described above:

* Go to '/wp-admin' on a simple or atomic site
* Observe the "Add New Site" is in the left Sidebar and it appears at the bottom.
* Check also on mobile devices

