### PR TITLE
Social: Fix Jetpack Social permissions check

### DIFF
--- a/projects/packages/publicize/changelog/fix-fix-publicize-rest-permissions-check
+++ b/projects/packages/publicize/changelog/fix-fix-publicize-rest-permissions-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed wrong permissions check for contributors

--- a/projects/packages/publicize/src/class-connections-post-field.php
+++ b/projects/packages/publicize/src/class-connections-post-field.php
@@ -218,7 +218,7 @@ class Connections_Post_Field {
 
 		$permission_check = $this->permission_check( empty( $post->ID ) ? 0 : $post->ID );
 		if ( is_wp_error( $permission_check ) ) {
-			return $permission_check;
+			return empty( $request_connections ) ? $post : $permission_check;
 		}
 		// memoize.
 		$this->get_meta_to_update( $request_connections, isset( $post->ID ) ? $post->ID : 0 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/26023

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Check if we're actually trying to update connections. If not, just return the `$post` parameter rather than the failed permissions check.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
p1662143133231429-slack-C02JJ910CNL

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Log in as a contributor and save a draft from the block editor.
* With this PR checked out, it should save normally.
* Without this PR it should show you a Jetpack Social-related error message instead.