### PR TITLE
Fix gallery click behaviour when figcaption present

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-gallery-click-behaviour-when-figcaption-present
+++ b/projects/plugins/jetpack/changelog/fix-gallery-click-behaviour-when-figcaption-present
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Ensure Carousel still opens when clicking on a gallery image that has a figcaption with a link inside.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1614,9 +1614,9 @@
 				} else if (
 					parent &&
 					parent.classList.contains( 'wp-block-image' ) &&
-					parent.querySelector( ':scope a' )
+					parent.querySelector( ':scope > a' )
 				) {
-					parentHref = parent.querySelector( ':scope a' ).getAttribute( 'href' );
+					parentHref = parent.querySelector( ':scope > a' ).getAttribute( 'href' );
 				}
 
 				// If the link does not point to the attachment or media file then assume Image has

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1614,9 +1614,9 @@
 				} else if (
 					parent &&
 					parent.classList.contains( 'wp-block-image' ) &&
-					parent.querySelector( 'a' )
+					parent.querySelector( ':scope a' )
 				) {
-					parentHref = parent.querySelector( 'a' ).getAttribute( 'href' );
+					parentHref = parent.querySelector( ':scope a' ).getAttribute( 'href' );
 				}
 
 				// If the link does not point to the attachment or media file then assume Image has


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/65350
Related https://github.com/Automattic/jetpack/pull/25410
Internal discussion/bug report: p8oabR-Vp-p2#comment-6583

#### Changes proposed in this Pull Request:
This PR builds is related to code added in https://github.com/Automattic/jetpack/pull/25410. Specifically, there is an issue whereby the Carousel did not open if you clicked on an image that had a `figcaption` with links inside because the `querySelector()` call was not precise enough and it found the wrong `a` element. 

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test this on a site with Jetpack Beta installed, e.g. an Ephemeral Site.

- Ensure Jetpack Carousel is enabled in Jetpack > Settings
- Create a post that has a gallery with 2+ images and click "Add caption" below one of them, then click the link icon and set a link:
![image](https://user-images.githubusercontent.com/6851384/188424257-b470bc06-c1d1-48c2-b523-1de68da15947.png)
- Preview your post and verify an issue for images with a caption link set. If you click them, then the Carousel should open, but it doesn't if you click the image directly, and it only works if you set the "rounded" image style and click on the area that was rounded off. 
- Next navigate to `/wp-admin/admin.php?page=jetpack-beta&plugin=jetpack`
- Enable this branch
- Refresh the post preview and verify that the Carousel now opens wherever you click on the image. 
- Finally, retest https://github.com/Automattic/jetpack/pull/25410 to verify there are no regressions