### PR TITLE
RNA: Add StatCard component

### DIFF
--- a/projects/js-packages/components/changelog/add-rna-stat-card
+++ b/projects/js-packages/components/changelog/add-rna-stat-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+JS Components: Add StatCard component

--- a/projects/js-packages/components/components/stat-card/index.tsx
+++ b/projects/js-packages/components/components/stat-card/index.tsx
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
+import numberFormat from '../number-format';
 import Text from '../text';
 import styles from './style.module.scss';
 import { StatCardProps } from './types';
@@ -18,13 +19,14 @@ import type React from 'react';
  */
 const StatCard = ( { className, icon, label, value, variant = 'square' }: StatCardProps ) => {
 	const valueTextVariant = variant === 'square' ? 'headline-small' : 'title-medium-semi-bold';
+	const formattedValue = numberFormat( value );
 
 	return (
 		<div className={ classnames( className, styles.wrapper, styles[ variant ] ) }>
 			<div className={ classnames( styles.icon ) }>{ icon }</div>
 			<div className={ classnames( styles.info ) }>
 				<Text className={ styles.label }>{ label }</Text>
-				<Text variant={ valueTextVariant }>{ value }</Text>
+				<Text variant={ valueTextVariant }>{ formattedValue }</Text>
 			</div>
 		</div>
 	);

--- a/projects/js-packages/components/components/stat-card/index.tsx
+++ b/projects/js-packages/components/components/stat-card/index.tsx
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+/**
+ * Internal dependencies
+ */
+import Text from '../text';
+import styles from './style.module.scss';
+import { StatCardProps } from './types';
+import type React from 'react';
+
+/**
+ * StatCard component
+ *
+ * @param {StatCardProps} props - Component props.
+ * @returns {React.ReactNode} - StatCard react component.
+ */
+const StatCard = ( { className, icon, label, value, variant = 'square' }: StatCardProps ) => {
+	const valueTextVariant = variant === 'square' ? 'headline-small' : 'title-medium-semi-bold';
+
+	return (
+		<div className={ classnames( className, styles.wrapper, styles[ variant ] ) }>
+			<div className={ classnames( styles.icon ) }>{ icon }</div>
+			<div className={ classnames( styles.info ) }>
+				<Text className={ styles.label }>{ label }</Text>
+				<Text variant={ valueTextVariant }>{ value }</Text>
+			</div>
+		</div>
+	);
+};
+
+export default StatCard;

--- a/projects/js-packages/components/components/stat-card/stories/StatCard.mdx
+++ b/projects/js-packages/components/components/stat-card/stories/StatCard.mdx
@@ -1,0 +1,37 @@
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
+import StatCard from '../index';
+
+<Meta
+  title="JS Packages/Components/Stat Card"
+  component={StatCard}
+/>
+
+# StatCard
+
+Component that shows a stat value.
+
+## API
+
+### icon
+
+- type: `JSX.Element`
+
+### label
+
+- type: `string`
+
+### value
+
+- type: `number`
+
+### variant
+
+- type: `string`
+- default: `"square"`
+
+It accepts 2 values: `square` and `horizontal`.
+
+<Canvas withSource="open">
+  <Story id="js-packages-components-stat-card--default" />
+  <Story id="js-packages-components-stat-card--horizontal" />
+</Canvas>

--- a/projects/js-packages/components/components/stat-card/stories/index.tsx
+++ b/projects/js-packages/components/components/stat-card/stories/index.tsx
@@ -1,0 +1,30 @@
+import { Icon, postList } from '@wordpress/icons';
+import StatCard from '..';
+import Doc from './StatCard.mdx';
+import type { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+	title: 'JS Packages/Components/Stat Card',
+	component: StatCard,
+	parameters: {
+		docs: {
+			page: Doc,
+		},
+	},
+} as ComponentMeta< typeof StatCard >;
+
+const defaultArgs = {
+	icon: <Icon icon={ postList } color="green" />,
+	label: 'Posted this month',
+	value: 1806,
+};
+
+const Template: ComponentStory< typeof StatCard > = args => {
+	return <StatCard { ...args } />;
+};
+
+export const _default = Template.bind( {} );
+_default.args = defaultArgs;
+
+export const Horizontal = Template.bind( {} );
+Horizontal.args = { ...defaultArgs, variant: 'horizontal' };

--- a/projects/js-packages/components/components/stat-card/style.module.scss
+++ b/projects/js-packages/components/components/stat-card/style.module.scss
@@ -1,0 +1,43 @@
+.wrapper {
+	background-color: var( --jp-white );
+	box-shadow: 0px 4px 40px rgba(0, 0, 0, 0.08);
+	border-radius: calc( var( --jp-border-radius ) * 2 ); // 8px;
+	display: flex;
+
+	&.horizontal {
+		align-items: center;
+		padding: calc( var( --spacing-base ) * 2 ); // 16px;
+		width: 358px;
+
+		.info {
+			display: flex;
+			align-items: center;
+			width: 100%;
+		}
+
+		.label {
+			margin: 0 calc( var( --spacing-base ) * 2	); // 16px;
+			flex-grow: 1;
+		}
+	}
+	
+	&.square {
+		--square-stat-vertical-spacing: calc( var( --spacing-base ) * 2	); // 16px;
+		--square-stat-horizontal-spacing: calc( var( --spacing-base ) * 3	); // 24px;
+		flex-direction: column;
+		justify-content: space-between;
+		height: 168px;
+		width: 168px;
+		padding: var( --square-stat-vertical-spacing ) var( --square-stat-horizontal-spacing );
+
+		.label {
+			margin-bottom: calc( var( --spacing-base ) / 2	); // 4px;
+		}
+	}
+
+	.icon {
+		display: flex;
+		color: var( --jp-green-40 );
+		fill: var( --jp-green-40 );
+	}
+}

--- a/projects/js-packages/components/components/stat-card/types.ts
+++ b/projects/js-packages/components/components/stat-card/types.ts
@@ -1,0 +1,28 @@
+export type StatCardProps = {
+	/**
+	 * Custom className to be inserted.
+	 */
+	className?: string;
+
+	/**
+	 * The stat card icon.
+	 */
+	icon: JSX.Element;
+
+	/**
+	 * The stat label.
+	 */
+	label: string;
+
+	/**
+	 * The stat value.
+	 */
+	value: number;
+
+	/**
+	 * The component variant.
+	 *
+	 * @default 'square'
+	 */
+	variant?: 'square' | 'horizontal';
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #26020

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add a `StatCard` component with variants for desktop and mobile sizes

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the storybook: `cd projects/js-packages/storybook && pnpm run storybook:dev`
* Check `JS Packages/Components/StatCard` component

![Screenshot_2022-09-05_11-45-51](https://user-images.githubusercontent.com/8486249/188474704-70d878a3-2517-4a3e-8e3c-21b9cb90bfe9.png)
