### PR TITLE
VideoPress: expose package version to the client

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-pick-and-expose-pkg-version-to-the-client
+++ b/projects/packages/videopress/changelog/update-videopress-pick-and-expose-pkg-version-to-the-client
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: create and expose videoPressInitialState global var to the client

--- a/projects/packages/videopress/src/class-admin-ui.php
+++ b/projects/packages/videopress/src/class-admin-ui.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\VideoPress;
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
+use Automattic\Jetpack\VideoPress\Initializer as VideoPress_Initializer;
 
 /**
  * Initialized the VideoPress package
@@ -103,6 +104,15 @@ class Admin_UI {
 		// Initial JS state including JP Connection data.
 		wp_add_inline_script( self::JETPACK_VIDEOPRESS_PKG_NAMESPACE, Connection_Initial_State::render(), 'before' );
 		wp_add_inline_script( self::JETPACK_VIDEOPRESS_PKG_NAMESPACE, self::render_initial_state(), 'before' );
+
+		// Initial VideoPress date_add
+		wp_localize_script(
+			self::JETPACK_VIDEOPRESS_PKG_NAMESPACE,
+			'videoPressInitialState',
+			array(
+				'version' => VideoPress_Initializer::get_version(),
+			)
+		);
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -45,6 +45,31 @@ class Initializer {
 	}
 
 	/**
+	 * Return the package version,
+	 * based on the version of the package's json file.
+	 *
+	 * @return string
+	 */
+	public static function get_version() {
+		$pkg_file        = __DIR__ . '/../package.json';
+		$pkg_file_exists = file_exists( $pkg_file );
+		if ( ! $pkg_file_exists ) {
+			return;
+		}
+
+		$package_data = json_decode(
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			file_get_contents( $pkg_file )
+		);
+
+		if ( ! isset( $package_data->version ) ) {
+			return;
+		}
+
+		return $package_data->version;
+	}
+
+	/**
 	 * Update the initialization options
 	 *
 	 * This method is called by the Config class


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

~This PR creates and exposes the `videoPressInitialState` global to the client. It's an object that contains the package version.~

This PR exposes the package version into the global initial state.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*  VideoPress: create and expose the global videoPressInitialState var to the client

VideoPress: create and expose videoPressInitialState global var to the client

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Active VideoPress standalone plugin
* In the plugin admin page, open the dev console
* Confirm the global object is defined
* Confirm it shows the current version of the package.

<img width="781" alt="image" src="https://user-images.githubusercontent.com/77539/188512343-98efeba7-2006-4cf0-a00b-47b9c5037b9c.png">



