### PR TITLE
Editor Extensions: Brand Jetpack features in pre-publish flows

### DIFF
--- a/projects/plugins/jetpack/changelog/update-brand-jetpack-features-in-publish-flows
+++ b/projects/plugins/jetpack/changelog/update-brand-jetpack-features-in-publish-flows
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Editor Extensions: Brand Jetpack features in publish flows

--- a/projects/plugins/jetpack/extensions/blocks/seo/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/seo/index.js
@@ -1,3 +1,4 @@
+import { JetpackIcon } from '@automattic/jetpack-components';
 import { PanelBody } from '@wordpress/components';
 import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { Fragment } from '@wordpress/element';
@@ -25,6 +26,7 @@ export const settings = {
 						{ __( 'SEO Description', 'jetpack' ) }
 					</span>
 				}
+				icon={ <JetpackIcon /> }
 			>
 				<SeoPanel />
 			</PluginPrePublishPanel>

--- a/projects/plugins/jetpack/extensions/blocks/social-previews/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/social-previews/index.js
@@ -1,3 +1,4 @@
+import { JetpackIcon } from '@automattic/jetpack-components';
 import { SocialPreviewsModal, SocialPreviewsPanel } from '@automattic/jetpack-publicize-components';
 import { PanelBody } from '@wordpress/components';
 import { PluginPrePublishPanel } from '@wordpress/edit-post';
@@ -23,7 +24,7 @@ export const SocialPreviews = function SocialPreviews() {
 					<SocialPreviewsPanel openModal={ () => setIsOpened( true ) } />
 				</PanelBody>
 			</JetpackPluginSidebar>
-			<PluginPrePublishPanel title={ __( 'Social Previews', 'jetpack' ) }>
+			<PluginPrePublishPanel title={ __( 'Social Previews', 'jetpack' ) } icon={ <JetpackIcon /> }>
 				<SocialPreviewsPanel openModal={ () => setIsOpened( true ) } />
 			</PluginPrePublishPanel>
 		</>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -1,4 +1,4 @@
-import { numberFormat } from '@automattic/jetpack-components';
+import { JetpackIcon, numberFormat } from '@automattic/jetpack-components';
 import { isComingSoon, isPrivateSite } from '@automattic/jetpack-shared-extension-utils';
 import { useSelect } from '@wordpress/data';
 import { PluginPrePublishPanel, PluginPostPublishPanel } from '@wordpress/edit-post';
@@ -38,6 +38,7 @@ export default function SubscribePanels() {
 				className="jetpack-subscribe-pre-publish-panel"
 				initialOpen
 				title={ __( 'Subscribers', 'jetpack' ) }
+				icon={ <JetpackIcon /> }
 			>
 				<InspectorNotice>
 					{ createInterpolateElement(

--- a/projects/plugins/jetpack/extensions/plugins/publicize/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/index.js
@@ -8,6 +8,7 @@
  * displays the Publicize UI there.
  */
 
+import { JetpackIcon } from '@automattic/jetpack-components';
 import { TwitterThreadListener } from '@automattic/jetpack-publicize-components';
 import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { PostTypeSupportCheck } from '@wordpress/editor';
@@ -36,6 +37,7 @@ export const settings = {
 						{ __( 'Share this post', 'jetpack' ) }
 					</span>
 				}
+				icon={ <JetpackIcon /> }
 			>
 				<PublicizePanel prePublish={ true } />
 			</PluginPrePublishPanel>

--- a/projects/plugins/social/changelog/update-brand-jetpack-features-in-publish-flows
+++ b/projects/plugins/social/changelog/update-brand-jetpack-features-in-publish-flows
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Use Jetpack logo in Jetpack Social pre-publish screen for Publicize and Social Preview features

--- a/projects/plugins/social/src/js/editor.js
+++ b/projects/plugins/social/src/js/editor.js
@@ -1,4 +1,4 @@
-import { SocialIcon } from '@automattic/jetpack-components';
+import { JetpackIcon, SocialIcon } from '@automattic/jetpack-components';
 import { SocialPreviewsModal, SocialPreviewsPanel } from '@automattic/jetpack-publicize-components';
 import { PanelBody } from '@wordpress/components';
 import { dispatch } from '@wordpress/data';
@@ -54,11 +54,19 @@ const JetpackSocialSidebar = () => {
 				</PanelBody>
 			</PluginSidebar>
 
-			<PluginPrePublishPanel initialOpen title={ __( 'Share this post', 'jetpack-social' ) }>
+			<PluginPrePublishPanel
+				initialOpen
+				title={ __( 'Share this post', 'jetpack-social' ) }
+				icon={ <JetpackIcon /> }
+			>
 				<PublicizePanel prePublish={ true } />
 			</PluginPrePublishPanel>
 
-			<PluginPrePublishPanel initialOpen title={ __( 'Social Previews', 'jetpack-social' ) }>
+			<PluginPrePublishPanel
+				initialOpen
+				title={ __( 'Social Previews', 'jetpack-social' ) }
+				icon={ <JetpackIcon /> }
+			>
 				<SocialPreviewsPanel openModal={ openModal } />
 			</PluginPrePublishPanel>
 		</PostTypeSupportCheck>


### PR DESCRIPTION
Part of https://github.com/Automattic/jetpack/issues/26048

Introduces Jetpack branding on pre-publish panels


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds Jetpack logo to pre-publish Social Previews Panel
* Adds Jetpack logo to pre-publish SEO Descrption Panel
* Adds Jetpack logo to pre-publish Subscribers Panel
* Adds Jetpack logo to pre-publish _Share this Post_ Panel


### Pre-publish
![image](https://user-images.githubusercontent.com/746152/188519280-a45b7ee1-e25f-424f-bf1b-85fb4eeff207.png)


#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
p1HpG7-hDK-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

* On a connected site
* Enable Subscriptions
* Enable SEO tools
* Enable Social tools
* Start writing a post
* Hit "Publish" and stop before the next confirmation button. Confirm in the right sidebar that you see the Jetpack logo on each of the following: sections:
  * Social Previews Panel
  * SEO Description Panel
  * Subscribers Panel
  * Share this Post Panel