### PR TITLE
Search: fix footer link in footer of Search Dashboard

### DIFF
--- a/projects/packages/search/changelog/fix-search-dashboard-footer-link
+++ b/projects/packages/search/changelog/fix-search-dashboard-footer-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: fixed Automattic link in footer when Jetpack plugin does not exist

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -35,7 +35,7 @@ export default function DashboardPage( { isLoading = false } ) {
 	);
 
 	const siteAdminUrl = useSelect( select => select( STORE_ID ).getSiteAdminUrl() );
-	const aboutPageUrl = siteAdminUrl + 'admin.php?page=jetpack_about';
+	const AUTOMATTIC_WEBSITE = 'https://automattic.com/';
 
 	const updateOptions = useDispatch( STORE_ID ).updateJetpackSettings;
 	const isInstantSearchPromotionActive = useSelect( select =>
@@ -138,7 +138,7 @@ export default function DashboardPage( { isLoading = false } ) {
 			<div className="jp-search-dashboard-footer jp-search-dashboard-wrap">
 				<div className="jp-search-dashboard-row">
 					<JetpackFooter
-						a8cLogoHref={ aboutPageUrl }
+						a8cLogoHref={ AUTOMATTIC_WEBSITE }
 						moduleName={ __( 'Jetpack Search', 'jetpack-search-pkg' ) }
 						className="lg-col-span-12 md-col-span-8 sm-col-span-4"
 					/>

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page.jsx
@@ -16,6 +16,8 @@ import getProductCheckoutUrl from 'utils/get-product-checkout-url';
 
 import './upsell-page.scss';
 
+const AUTOMATTIC_WEBSITE = 'https://automattic.com/';
+
 /**
  * defines UpsellPage.
  *
@@ -64,7 +66,7 @@ export default function UpsellPage( { isLoading = false } ) {
 						withHeader={ true }
 						withFooter={ true }
 						moduleName={ __( 'Jetpack Search', 'jetpack-search-pkg' ) }
-						a8cLogoHref="https://www.jetpack.com"
+						a8cLogoHref={ AUTOMATTIC_WEBSITE }
 					>
 						<AdminSectionHero>
 							<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The link of  `AN AUTOMATTIC AIRLINE` in the footer is linked to Jeptack plugin page on site, which is broken when Jetpack plugin doesn't exist. The PR proposes to change the link to Automattic official website `https://automattic.com`.

<img width="838" alt="image" src="https://user-images.githubusercontent.com/1425433/188521105-6beb1aa7-27bb-49c1-badd-f38745d8a9d5.png">


#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Go to a site with Jetpack Search subscription
* Open `/wp-admin/admin.php?page=jetpack-search`
* Ensure the link of  `AN AUTOMATTIC AIRLINE` in the footer is linked to`https://automattic.com`

