### PR TITLE
Moved the tweetstorm permission check.

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-tweetstorm-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-tweetstorm-helper.php
@@ -210,6 +210,45 @@ class Jetpack_Tweetstorm_Helper {
 	private static $urls = array();
 
 	/**
+	 * Checks if a given request is allowed to gather tweets.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return true|WP_Error True if the request has access to gather tweets from a thread, WP_Error object otherwise.
+	 */
+	public function permissions_check( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$blog_id = get_current_blog_id();
+
+		/*
+		 * User hitting the endpoint hosted on their Jetpack site, from their Jetpack site,
+		 * or hitting the endpoint hosted on WPCOM, from their WPCOM site.
+		 */
+		if ( current_user_can_for_blog( $blog_id, 'edit_posts' ) ) {
+			return true;
+		}
+
+		// Jetpack hitting the endpoint hosted on WPCOM, from a Jetpack site with a blog token.
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			if ( is_jetpack_site( $blog_id ) ) {
+				if ( ! class_exists( 'WPCOM_REST_API_V2_Endpoint_Jetpack_Auth' ) ) {
+					require_once dirname( __DIR__ ) . '/rest-api-plugins/endpoints/jetpack-auth.php';
+				}
+
+				$jp_auth_endpoint = new WPCOM_REST_API_V2_Endpoint_Jetpack_Auth();
+				if ( true === $jp_auth_endpoint->is_jetpack_authorized_for_site() ) {
+					return true;
+				}
+			}
+		}
+
+		return new WP_Error(
+			'rest_forbidden',
+			__( 'Sorry, you are not allowed to use tweetstorm endpoints on this site.', 'jetpack' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
+	}
+
+	/**
 	 * Gather the Tweetstorm.
 	 *
 	 * @param  string $url The tweet URL to gather from.
@@ -1590,7 +1629,10 @@ class Jetpack_Tweetstorm_Helper {
 
 		$requests = array_map(
 			function ( $url ) use ( $validator ) {
-				if ( $validator->isValidURL( $url ) ) {
+				if (
+					false !== wp_http_validate_url( $url )
+					&& $validator->isValidURL( $url )
+				) {
 					return array(
 						'url' => $url,
 					);

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-tweetstorm-gather.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-tweetstorm-gather.php
@@ -56,47 +56,8 @@ class WPCOM_REST_API_V2_Endpoint_Tweetstorm_Gather extends WP_REST_Controller {
 				'private_site_security_settings' => array(
 					'allow_blog_token_access' => true,
 				),
-				'permission_callback'            => array( $this, 'tweetstorm_permissions_check' ),
+				'permission_callback'            => array( 'Jetpack_Tweetstorm_Helper', 'permissions_check' ),
 			)
-		);
-	}
-
-	/**
-	 * Checks if a given request is allowed to gather tweets.
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 *
-	 * @return true|WP_Error True if the request has access to gather tweets from a thread, WP_Error object otherwise.
-	 */
-	public function tweetstorm_permissions_check( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$blog_id = get_current_blog_id();
-
-		/*
-		 * User hitting the endpoint hosted on their Jetpack site, from their Jetpack site,
-		 * or hitting the endpoint hosted on WPCOM, from their WPCOM site.
-		 */
-		if ( current_user_can_for_blog( $blog_id, 'edit_posts' ) ) {
-			return true;
-		}
-
-		// Jetpack hitting the endpoint hosted on WPCOM, from a Jetpack site with a blog token.
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			if ( is_jetpack_site( $blog_id ) ) {
-				if ( ! class_exists( 'WPCOM_REST_API_V2_Endpoint_Jetpack_Auth' ) ) {
-					require_once __DIR__ . '/jetpack-auth.php';
-				}
-
-				$jp_auth_endpoint = new WPCOM_REST_API_V2_Endpoint_Jetpack_Auth();
-				if ( true === $jp_auth_endpoint->is_jetpack_authorized_for_site() ) {
-					return true;
-				}
-			}
-		}
-
-		return new WP_Error(
-			'rest_forbidden',
-			__( 'Sorry, you are not allowed to gather tweets on this site.', 'jetpack' ),
-			array( 'status' => rest_authorization_required_code() )
 		);
 	}
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-tweetstorm-parse.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-tweetstorm-parse.php
@@ -44,7 +44,7 @@ class WPCOM_REST_API_V2_Endpoint_Tweetstorm_Parse extends WP_REST_Controller {
 				'methods'                               => WP_REST_Server::EDITABLE,
 				'callback'                              => array( $this, 'parse_tweetstorm' ),
 				'allow_blog_token_when_site_is_private' => true,
-				'permission_callback'                   => '__return_true',
+				'permission_callback'                   => array( 'Jetpack_Tweetstorm_Helper', 'permissions_check' ),
 			)
 		);
 
@@ -62,7 +62,7 @@ class WPCOM_REST_API_V2_Endpoint_Tweetstorm_Parse extends WP_REST_Controller {
 				'methods'                               => WP_REST_Server::EDITABLE,
 				'callback'                              => array( $this, 'generate_cards' ),
 				'allow_blog_token_when_site_is_private' => true,
-				'permission_callback'                   => '__return_true',
+				'permission_callback'                   => array( 'Jetpack_Tweetstorm_Helper', 'permissions_check' ),
 			)
 		);
 	}

--- a/projects/plugins/jetpack/changelog/move-tweetstorm-permission-check
+++ b/projects/plugins/jetpack/changelog/move-tweetstorm-permission-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Moved the permission check for the Tweetstorm endpoint into a helper class.


### PR DESCRIPTION
This change moves the permission callback of the Tweetstorm endpoints into a helper file. This allows us to make sure the different endpoints use the same permission callback without duplicating code.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Moved the permission check to the helper file.
* Amended the messaging.
* Renamed the permisison check.
* Added URL validation.

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Make sure the Twitter threads are still expandable in new posts.