### PR TITLE
Jetpack: Remove JetpackIcon from InspectorNotice component

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-jetpack-logo-from-inspector-notice
+++ b/projects/plugins/jetpack/changelog/remove-jetpack-logo-from-inspector-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Remove JetpackIcon from InspectorNotice component

--- a/projects/plugins/jetpack/extensions/shared/components/inspector-notice/index.jsx
+++ b/projects/plugins/jetpack/extensions/shared/components/inspector-notice/index.jsx
@@ -1,12 +1,9 @@
-import { JetpackLogo } from '@automattic/jetpack-components';
-
 import './style.scss';
 
 export default function InspectorNotice( { children } ) {
 	return (
 		<div className="jetpack-inspector-notice">
 			<span>{ children }</span>
-			<JetpackLogo height={ 16 } logoColor="#1a1a1a" showText={ false } />
 		</div>
 	);
 }


### PR DESCRIPTION
Part of #26048

We are now showing the Jetpack logo in all pre-publish panels. We don't need to be redundant inside the notice.

There's no usage of this component other than on Subscribe block related controls and we now show the Jetpack icon in the panel headers (See https://github.com/Automattic/jetpack/pulls?q=is%3Apr+author%3Aoskosk+is%3Aclosed).


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes rendering of a Jetpack icon in notices. 

#### After

<img width="280" alt="image" src="https://user-images.githubusercontent.com/746152/188976338-c58708f6-e7a3-4060-a184-cdea524c2bae.png">
<img width="284" alt="image" src="https://user-images.githubusercontent.com/746152/188978789-017ef88c-c2e1-465e-9835-ae29896a1838.png">



#### before

<img width="282" alt="image" src="https://user-images.githubusercontent.com/746152/188975817-bfc20ad0-ba41-492e-a6dc-9e9d4e60de4f.png">
<img width="273" alt="image" src="https://user-images.githubusercontent.com/746152/188979083-8ab3d9a3-e078-46c4-aaae-dc23a4ed58f8.png">


#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

p1HpG7-hDK-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

* On a connected site
* Enable Subscriptions
* Make sure you have at least one subscriber. Add a subscribe form to a post, publish it, visit the post and subscribe yourself via email. (you'll have to confirm the mail you get). 
* Start drafting a new post. Whatever title or content.
* Hit "Publish" **and stop before hitting the next Publish button**. Confirm you no longer see the Jetpack logo in the notice

  * Subscribers Panel
