### PR TITLE
Search: port search 1.2.0 changelog to trunk

### DIFF
--- a/projects/plugins/search/CHANGELOG.md
+++ b/projects/plugins/search/CHANGELOG.md
@@ -66,6 +66,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release.
 
 [1.1.0-beta]: https://github.com/Automattic/jetpack-search-plugin/compare/1.0.0...1.1.0-beta
-[1.2.0-beta]: https://github.com/Automattic/jetpack-search-plugin/compare/v1.1.0...v1.2.0-beta
-[1.2.0]: https://github.com/Automattic/jetpack-search-plugin/compare/v1.1.0...v1.2.0
+[1.2.0-beta]: https://github.com/Automattic/jetpack-search-plugin/compare/1.1.0...1.2.0-beta
+[1.2.0]: https://github.com/Automattic/jetpack-search-plugin/compare/1.2.0-beta...1.2.0
 [1.1.0]: https://github.com/Automattic/jetpack-search-plugin/compare/1.1.0-beta...1.1.0

--- a/projects/plugins/search/CHANGELOG.md
+++ b/projects/plugins/search/CHANGELOG.md
@@ -5,18 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.0-beta] - 2022-08-25
+## [1.2.0] - 2022-09-05
 ### Added
-- Adds links to Search plugin line on plugins page [#25718]
-- My Jetpack includes JITMs [#22452]
-- Search: start v1.2.0-alpha release [#25320]
+- Instant Search: add author filtering support.
+- Instant Search: add descriptions to post type icons for accessibility purposes.
+- Instant Search: add focus border to search input field.
+- Instant Search: always use submit overlay trigger if user prefers reduced motion.
+- Instant Search: only show animation to users who have not chosen reduced motion.
+- Instant Search: user friendly error messaging.
+- My Jetpack: include JITMs.
+- Record Meter: adds info link to docs.
+- Search: add links to Search plugin line on plugins page.
 
 ### Changed
-- Activation: only redirect when activating from the Plugins page in the browser [#25715]
-- E2E tests: bump dependencies [#25725]
-- Search: always show Search submenu when Search plugin is installed [#25774]
-- Search: changed default overlay trigger to form submission [#25093]
+- Instant Search: updates dark mode active link color for increased contrast.
+- Search: always show Search submenu when Search plugin is installed.
+- Search: changed default overlay trigger to form submission.
+- Search: changed to only require site level connection.
+- Search: only redirect when activating from the Plugins page in the browser.
+- Search: revert "Search should not require user connection".
 - Updated package dependencies.
+
+### Removed
+- Search: remove 'results' overlay trigger.
+
+### Fixed
+- Dashboard: updated Instant Search description to match changes in default overlay trigger.
+- Instant Search: add focus styles for easier keyboard navigation.
+- Instant Search: constrain tab loop to overlay when visible.
+- Instant Search: fix button styling in Twenty Twenty One theme.
+- Instant Search: fix the display order on mobile to match the tab order.
+- Instant Search: make "Clear filters" button accessible.
+- Instant Search: remove redundant links from search results.
+- Instant Search: use classname rather than ID for styling sort select.
+- Search Widget: keep widget preview with settings.
 
 ## [1.1.0] - 2022-08-02
 ### Added
@@ -45,4 +67,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [1.1.0-beta]: https://github.com/Automattic/jetpack-search-plugin/compare/1.0.0...1.1.0-beta
 [1.2.0-beta]: https://github.com/Automattic/jetpack-search-plugin/compare/v1.1.0...v1.2.0-beta
+[1.2.0]: https://github.com/Automattic/jetpack-search-plugin/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/Automattic/jetpack-search-plugin/compare/1.1.0-beta...1.1.0

--- a/projects/plugins/search/changelog/update-port-search-1.2.0-changelog
+++ b/projects/plugins/search/changelog/update-port-search-1.2.0-changelog
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Ported back 1.2.0 release changelog

--- a/projects/plugins/search/readme.txt
+++ b/projects/plugins/search/readme.txt
@@ -4,7 +4,7 @@ Tags: search, jetpack
 Requires at least: 5.9
 Requires PHP: 5.6
 Tested up to: 6.0
-Stable tag: 1.1.0
+Stable tag: 1.2.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -111,18 +111,40 @@ You can purchase a Search subscription directly through this plugin or via the [
 5. Manage all of your Jetpack products, including Search, in a single place.
 
 == Changelog ==
-### 1.2.0-beta - 2022-08-25
+### 1.2.0 - 2022-09-05
 #### Added
-- Adds links to Search plugin line on plugins page
-- My Jetpack includes JITMs
-- Search: start v1.2.0-alpha release
+- Instant Search: add author filtering support.
+- Instant Search: add descriptions to post type icons for accessibility purposes.
+- Instant Search: add focus border to search input field.
+- Instant Search: always use submit overlay trigger if user prefers reduced motion.
+- Instant Search: only show animation to users who have not chosen reduced motion.
+- Instant Search: user friendly error messaging.
+- My Jetpack: include JITMs.
+- Record Meter: adds info link to docs.
+- Search: add links to Search plugin line on plugins page.
 
 #### Changed
-- Activation: only redirect when activating from the Plugins page in the browser
-- E2E tests: bump dependencies
-- Search: always show Search submenu when Search plugin is installed
-- Search: changed default overlay trigger to form submission
+- Instant Search: updates dark mode active link color for increased contrast.
+- Search: always show Search submenu when Search plugin is installed.
+- Search: changed default overlay trigger to form submission.
+- Search: changed to only require site level connection.
+- Search: only redirect when activating from the Plugins page in the browser.
+- Search: revert "Search should not require user connection".
 - Updated package dependencies.
+
+#### Removed
+- Search: remove 'results' overlay trigger.
+
+#### Fixed
+- Dashboard: updated Instant Search description to match changes in default overlay trigger.
+- Instant Search: add focus styles for easier keyboard navigation.
+- Instant Search: constrain tab loop to overlay when visible.
+- Instant Search: fix button styling in Twenty Twenty One theme.
+- Instant Search: fix the display order on mobile to match the tab order.
+- Instant Search: make "Clear filters" button accessible.
+- Instant Search: remove redundant links from search results.
+- Instant Search: use classname rather than ID for styling sort select.
+- Search Widget: keep widget preview with settings.
 
 == Testimonials ==
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Port back search plugin 1.2.0 changelog as instructed in FG, including the update of stable tag to 1.2.0.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Ensure the changelog looks okay