### PR TITLE
Publicize and Sync: Fix the tests.

### DIFF
--- a/projects/plugins/jetpack/changelog/try-fix-publicize-connections-field-tests
+++ b/projects/plugins/jetpack/changelog/try-fix-publicize-connections-field-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Publicize Connections Post Field: Fix the tests

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-fields/test-post-fields-publicize-connections.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-fields/test-post-fields-publicize-connections.php
@@ -184,14 +184,14 @@ class Test_WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WP_Test_Je
 	 * Set up.
 	 */
 	public function set_up() {
+		parent::set_up();
+
 		$this->draft_id = $this->factory->post->create(
 			array(
 				'post_status' => 'draft',
 				'post_author' => self::$user_id,
 			)
 		);
-
-		parent::set_up();
 
 		$this->setup_fields();
 

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full-immediately.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full-immediately.php
@@ -383,7 +383,7 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 		global $wpdb;
 
 		$suppress      = $wpdb->suppress_errors();
-		$other_blog_id = wpmu_create_blog( 'foo.com', '', 'My Blog', $this->user_id );
+		$other_blog_id = wpmu_create_blog( 'foo.com', '', 'My Blog', null );
 		$wpdb->suppress_errors( $suppress );
 
 		// let's create some users on the other blog


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

It seems that something has changed, and it's highlighting a potential problem with calling `setup` after using the `factory`. This PR swaps that around to see if it fixes the tests in CI.

Edited (by @coder-karen) to add that this PR now also includes a change to a Sync test to help ensure all tests (currently) pass so this PR can be merged.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
p1662548337184269-slack-C03QNBQKG73

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
TBC