### PR TITLE
Backup Plugin: enable autotag, autorelease, and autosvn actions

### DIFF
--- a/projects/plugins/backup/changelog/update-jp-backup-plugin-enable-autosvn
+++ b/projects/plugins/backup/changelog/update-jp-backup-plugin-enable-autosvn
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Enable autotag, autorelease, and autosvn actions in the composer.json extras.
+
+

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -39,8 +39,11 @@
 	},
 	"extra": {
 		"mirror-repo": "Automattic/jetpack-backup-plugin",
+		"autorelease": true,
+		"autotagger": true,
 		"release-branch-prefix": "backup",
-		"wp-plugin-slug": "jetpack-backup"
+		"wp-plugin-slug": "jetpack-backup",
+		"wp-svn-autopublish": true
 	},
 	"changelogger": {
 		"versioning": "wordpress"

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -40,7 +40,9 @@
 	"extra": {
 		"mirror-repo": "Automattic/jetpack-backup-plugin",
 		"autorelease": true,
-		"autotagger": true,
+		"autotagger": {
+			"v": false
+		},
 		"release-branch-prefix": "backup",
 		"wp-plugin-slug": "jetpack-backup",
 		"wp-svn-autopublish": true

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7ffa23ebf7f3ab1436cd81c88917a7c9",
+    "content-hash": "b6636195524607b95d410140046eb9c8",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Enable autorelease, autotagger, and wp-svn-autopublish for the plugin.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Proofread.
