### PR TITLE
Search: Allow non-owner admins to see search dashboard

### DIFF
--- a/projects/packages/search/changelog/fix-dashboard-not-shown-for-non-owners
+++ b/projects/packages/search/changelog/fix-dashboard-not-shown-for-non-owners
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: Allow non-owner admins to see search dashboard

--- a/projects/packages/search/src/dashboard/hooks/use-connection.jsx
+++ b/projects/packages/search/src/dashboard/hooks/use-connection.jsx
@@ -16,7 +16,7 @@ export default function useConnection() {
 
 	const isFullyConnected =
 		( Object.keys( connectionStatus ).length &&
-			connectionStatus.isUserConnected &&
+			connectionStatus.hasConnectedOwner &&
 			connectionStatus.isRegistered ) ||
 		isWpcom;
 


### PR DESCRIPTION
Fixes #26094 

#### Changes proposed in this Pull Request:
The `connectionStatus.isUserConnected` state from the connection package means whether the current user is connected. And we should use `connectionStatus.hasConnectedOwner` to see if a site is connected to a user.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Launch a JN site with Jetpack Search on it
- Connect and purchase a plan
- Create a secondary administrator
- Sign in as a this other administrator
- Visit the Jetpack Search page
- Ensure you could see the search dashboard

<img width="986" alt="image" src="https://user-images.githubusercontent.com/1425433/189010673-953109ad-89c7-47f9-91f6-419a473e8223.png">
