### PR TITLE
Boost: Add footer link in plugin dashboard

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/sections/Footer.svelte
+++ b/projects/plugins/boost/app/assets/src/js/sections/Footer.svelte
@@ -10,6 +10,8 @@
 		{__( 'Jetpack Boost', 'jetpack-boost' )}
 	</div>
 	<div class="jb-signature--automattic">
-		<AutomatticLogo />
+		<a href="https://automattic.com" aria-label={__( 'An Automattic Airline', 'jetpack-boost' )}>
+			<AutomatticLogo />
+		</a>
 	</div>
 </footer>

--- a/projects/plugins/boost/changelog/fix-boost-dashboard-footer-link
+++ b/projects/plugins/boost/changelog/fix-boost-dashboard-footer-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Boost: Add Automattic link to footer airline image


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #26050

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds dashboard footer link to Automattic's website on Boost plugin

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With Jetpack Boost plugin installed, go to the dashboard: `/wp-admin/admin.php?page=jetpack-boost`
* Check that the `AN AUTOMATTIC AIRLINE` text in the footer links to `https://automattic.com`

![Screenshot_2022-09-08_11-31-21](https://user-images.githubusercontent.com/8486249/189149449-76048cce-50d4-4af9-ae47-d57278265aa7.png)
