### PR TITLE
autorelease: Fix "v" handling for tags

### DIFF
--- a/.github/files/gh-autorelease/files/autorelease.sh
+++ b/.github/files/gh-autorelease/files/autorelease.sh
@@ -14,7 +14,6 @@ if [[ ! "$GITHUB_REF" =~ ^refs/tags/v?[0-9]+(\.[0-9]+)+$ ]]; then
 	exit 1
 fi
 TAG="${GITHUB_REF#refs/tags/}"
-TAG="${TAG#v}"
 echo "Creating release for $TAG"
 
 ## Determine slug and title format.
@@ -35,7 +34,7 @@ if [[ "$TITLEFMT" != *"%s"* ]]; then
 	echo '::error::Missing or invalid `.extra.autorelease.titlefmt`'
 	exit 1
 fi
-printf -v TITLE "$TITLEFMT" "$TAG"
+printf -v TITLE "$TITLEFMT" "${TAG#v}"
 echo "Creating release \"$TITLE\""
 
 ## Create the archive artifact.
@@ -68,7 +67,7 @@ SCRIPT="
 ENTRY=$(sed -n -E -e "$SCRIPT" CHANGELOG.md)
 if [[ -z "$ENTRY" ]]; then
 	echo '::endgroup::'
-	echo "::error::Failed to find section for $TAG in CHANGELOG.md"
+	echo "::error::Failed to find section for ${TAG#v} in CHANGELOG.md"
 	exit 1
 fi
 
@@ -100,7 +99,7 @@ curl -v -L \
 	--header 'content-type: application/json' \
 	--header 'accept: application/vnd.github.v3+json' \
 	--url "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases" \
-	--data "$(jq -n --arg tag "v$TAG" --arg sha "$GITHUB_SHA" --arg title "$TITLE" --arg body "$ENTRY" '{ tag_name: $tag, target_commitish: $sha, name: $title, body: $body}')" \
+	--data "$(jq -n --arg tag "$TAG" --arg sha "$GITHUB_SHA" --arg title "$TITLE" --arg body "$ENTRY" '{ tag_name: $tag, target_commitish: $sha, name: $title, body: $body}')" \
 	2>&1 > code.txt
 cat out.json
 echo


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
When we create the release, we need to use the same format as the original tag. If we always prepend "v" then GH will create a new copy of the tag under that name.

The most straightforward thing to do seemed to be to make `TAG` always be the original tag, and strip the leading "v" in the cases where we wanted it stripped.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1662660452269539-slack-C01U2KGS2PQ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Copy this action and file into a repo somewhere, then push a tag with and without "v". The corresponding releases should match.