### PR TITLE
VideoPress: fix library titles

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-fix-galleriy-titles
+++ b/projects/packages/videopress/changelog/update-videopress-fix-galleriy-titles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: fix library titles

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -56,9 +56,9 @@ const Admin = () => {
 						<Container horizontalSpacing={ 6 } horizontalGap={ 3 }>
 							<Col sm={ 4 } md={ 4 } lg={ 8 }>
 								<Text variant="headline-small" mb={ 3 }>
-									High quality, ad-free video
+									{ __( 'High quality, ad-free video', 'jetpack-videopress-pkg' ) }
 								</Text>
-								<Button>Add new video</Button>
+								<Button>{ __( 'Add new video', 'jetpack-videopress-pkg' ) }</Button>
 							</Col>
 						</Container>
 					</AdminSectionHero>

--- a/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
@@ -120,7 +120,7 @@ export const LocalLibrary = ( { videos }: VideoLibraryProps ) => {
 		<VideoLibraryWrapper
 			totalVideos={ videos?.length }
 			hideFilter
-			title={ __( 'Local library', 'jetpack-videopress-pkg' ) }
+			title={ __( 'Local videos', 'jetpack-videopress-pkg' ) }
 		>
 			<VideoList hidePrivacy hideDuration hidePlays hideEditButton videos={ videos } />
 		</VideoLibraryWrapper>

--- a/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
@@ -1,7 +1,14 @@
+/**
+ * External dependencies
+ */
 import { Button, Text } from '@automattic/jetpack-components';
 import { Rect, SVG } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { grid, formatListBullets } from '@wordpress/icons';
 import React, { useState } from 'react';
+/**
+ * Internal dependencies
+ */
 import useVideos from '../../hooks/use-videos';
 import { SearchInput } from '../input';
 import Pagination from '../pagination';
@@ -9,6 +16,9 @@ import { PaginationProps } from '../pagination/types';
 import VideoGrid from '../video-grid';
 import VideoList from '../video-list';
 import styles from './styles.module.scss';
+/**
+ * Types
+ */
 import { VideoLibraryProps } from './types';
 
 const LibraryType = {
@@ -37,19 +47,21 @@ const VideoLibraryWrapper = ( {
 	libraryType = LibraryType.List,
 	onChangeType,
 	hideFilter = false,
+	title,
 }: {
 	children: React.ReactNode;
 	libraryType?: LibraryType;
 	totalVideos?: number;
 	onChangeType?: () => void;
 	hideFilter?: boolean;
+	title?: string;
 } ) => {
 	const { setSearch } = useVideos();
 
 	return (
 		<div className={ styles[ 'library-wrapper' ] }>
 			<Text variant="headline-small" mb={ 1 }>
-				Your VideoPress library
+				{ title }
 			</Text>
 			<div className={ styles[ 'total-filter-wrapper' ] }>
 				<Text>{ totalVideos } Video</Text>
@@ -57,7 +69,7 @@ const VideoLibraryWrapper = ( {
 					<div className={ styles[ 'filter-wrapper' ] }>
 						<SearchInput onSearch={ setSearch } />
 						<Button variant="secondary" icon={ filterIcon } weight="regular">
-							Filters
+							{ __( 'Filters', 'jetpack-videopress-pkg' ) }
 						</Button>
 						<Button
 							variant="tertiary"
@@ -92,6 +104,7 @@ export const VideoPressLibrary = ( { videos }: VideoLibraryProps ) => {
 			totalVideos={ videos?.length }
 			onChangeType={ toggleType }
 			libraryType={ libraryType }
+			title={ __( 'Your VideoPress library', 'jetpack-videopress-pkg' ) }
 		>
 			{ libraryType === LibraryType.Grid ? (
 				<VideoGrid videos={ videos } />
@@ -104,7 +117,11 @@ export const VideoPressLibrary = ( { videos }: VideoLibraryProps ) => {
 
 export const LocalLibrary = ( { videos }: VideoLibraryProps ) => {
 	return (
-		<VideoLibraryWrapper totalVideos={ videos?.length } hideFilter>
+		<VideoLibraryWrapper
+			totalVideos={ videos?.length }
+			hideFilter
+			title={ __( 'Local library', 'jetpack-videopress-pkg' ) }
+		>
 			<VideoList hidePrivacy hideDuration hidePlays hideEditButton videos={ videos } />
 		</VideoLibraryWrapper>
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR sets properly the library titles. Also, it applies i18n to some strings.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: fix library titles

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard
* Confirm the library titles look ok

<img width="959" alt="Screen Shot 2022-09-09 at 12 14 41" src="https://user-images.githubusercontent.com/77539/189384076-08b1ba24-406a-4f32-b7d2-5be9c17eb9e5.png">

