### PR TITLE
Releases: Enable autotag, autorelease and autopublish on all standalone plugins

### DIFF
--- a/projects/plugins/boost/changelog/update-auto-publish-standalones
+++ b/projects/plugins/boost/changelog/update-auto-publish-standalones
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Adds ability to autotag, autorelease and autopublish releases

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -85,13 +85,17 @@
 		}
 	],
 	"extra": {
-		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-boost-production",
+		"autorelease": true,
+		"autotagger": {
+			"v": false
+		},
 		"release-branch-prefix": "boost",
 		"version-constants": {
 			"JETPACK_BOOST_VERSION": "jetpack-boost.php"
 		},
 		"wp-plugin-slug": "jetpack-boost",
+		"wp-svn-autopublish": true,
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-boost-production/compare/v${old}...v${new}"
 		}

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "37b54812293049a817fbbb19f82d093f",
+    "content-hash": "652542c89ee67b1ff0811df549397d90",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/protect/changelog/update-auto-publish-standalones
+++ b/projects/plugins/protect/changelog/update-auto-publish-standalones
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Adds ability to autotag, autorelease and autopublish releases

--- a/projects/plugins/protect/composer.json
+++ b/projects/plugins/protect/composer.json
@@ -60,8 +60,13 @@
 	"prefer-stable": true,
 	"extra": {
 		"mirror-repo": "Automattic/jetpack-protect-plugin",
+		"autorelease": true,
+		"autotagger": {
+			"v": false
+		},
 		"release-branch-prefix": "protect",
 		"wp-plugin-slug": "jetpack-protect",
+		"wp-svn-autopublish": true,
 		"version-constants": {
 			"JETPACK_PROTECT_VERSION": "jetpack-protect.php"
 		}

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "79bcc205c66b68ea93fff5214e815729",
+    "content-hash": "6ae6ba1328aeadd4e0985de73a170179",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/search/changelog/update-auto-publish-standalones
+++ b/projects/plugins/search/changelog/update-auto-publish-standalones
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Adds ability to autotag, autorelease and autopublish releases

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -50,12 +50,16 @@
 	"prefer-stable": true,
 	"extra": {
 		"mirror-repo": "Automattic/jetpack-search-plugin",
+		"autorelease": true,
+		"autotagger": {
+			"v": false
+		},
 		"release-branch-prefix": "search",
 		"wp-plugin-slug": "jetpack-search",
+		"wp-svn-autopublish": true,
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-search-plugin/compare/v${old}...v${new}"
 		},
-		"autotagger": true,
 		"version-constants": {
 			"JETPACK_SEARCH_PLUGIN__VERSION": "jetpack-search.php"
 		}

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "21d4affb84628fbcba887193a5c5381b",
+    "content-hash": "f6bf79f57c732537134f46483f7202ba",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/social/changelog/update-auto-publish-standalones
+++ b/projects/plugins/social/changelog/update-auto-publish-standalones
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Adds ability to autotag, autorelease and autopublish releases

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -63,7 +63,9 @@
 	"prefer-stable": true,
 	"extra": {
 		"autorelease": true,
-		"autotagger": true,
+		"autotagger": {
+			"v": false
+		},
 		"mirror-repo": "Automattic/jetpack-social-plugin",
 		"release-branch-prefix": "social",
 		"wp-plugin-slug": "jetpack-social",

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9dd0c53d7746f992814ec589b7b0f417",
+    "content-hash": "3fd568aad7dec014c7bda9b120da51bc",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/videopress/changelog/update-auto-publish-standalones
+++ b/projects/plugins/videopress/changelog/update-auto-publish-standalones
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Adds ability to autotag, autorelease and autopublish releases

--- a/projects/plugins/videopress/composer.json
+++ b/projects/plugins/videopress/composer.json
@@ -39,9 +39,12 @@
 	"prefer-stable": true,
 	"extra": {
 		"mirror-repo": "Automattic/jetpack-videopress-plugin",
+		"autorelease": true,
+		"autotagger": true,
 		"release-branch-prefix": "videopress",
 		"beta-plugin-slug": "jetpack-videopress",
-		"wp-plugin-slug": "jetpack-videopress"
+		"wp-plugin-slug": "jetpack-videopress",
+		"wp-svn-autopublish": true
 	},
 	"config": {
 		"allow-plugins": {

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fcf1f4833613825ffb7bc9b3f1144182",
+    "content-hash": "ff0961f2805c39881ee96bddfd297df7",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Adds autotag/release/publish on all standalones, following the existing convention with not prepending `v` tag except for VideoPress, which seems to be the only plugin that does.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Nothing to test until the next release.

