### PR TITLE
Fix/autoloader guard allows same plugin in mu plugins

### DIFF
--- a/projects/packages/autoloader/changelog/fix-autoloader-guard-allows-same-plugin-in-mu-plugins
+++ b/projects/packages/autoloader/changelog/fix-autoloader-guard-allows-same-plugin-in-mu-plugins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Allow same plugin version in mu-plugins

--- a/projects/packages/autoloader/src/class-latest-autoloader-guard.php
+++ b/projects/packages/autoloader/src/class-latest-autoloader-guard.php
@@ -52,6 +52,9 @@ class Latest_Autoloader_Guard {
 	 * @return bool True if we should stop initialization, otherwise false.
 	 */
 	public function should_stop_init( $current_plugin, $plugins, $was_included_by_autoloader ) {
+		if ( ! function_exists( 'get_plugin_data' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
 		global $jetpack_autoloader_latest_version;
 
 		// We need to reset the autoloader when the plugins change because
@@ -68,7 +71,11 @@ class Latest_Autoloader_Guard {
 		}
 
 		$latest_plugin = $this->autoloader_locator->find_latest_autoloader( $plugins, $jetpack_autoloader_latest_version );
-		if ( isset( $latest_plugin ) && $latest_plugin !== $current_plugin ) {
+
+		$current_plugin_data = $current_plugin ? get_plugin_data( $current_plugin . '/' . basename( $current_plugin ) . '.php' ) : null;
+		$latest_plugin_data  = $latest_plugin ? get_plugin_data( $latest_plugin . '/' . basename( $latest_plugin ) . '.php' ) : null;
+
+		if ( isset( $latest_plugin ) && $current_plugin_data !== $latest_plugin_data ) {
 			require $this->autoloader_locator->get_autoloader_path( $latest_plugin );
 			return true;
 		}

--- a/projects/packages/autoloader/tests/php/lib/functions-wordpress.php
+++ b/projects/packages/autoloader/tests/php/lib/functions-wordpress.php
@@ -389,6 +389,27 @@ if ( ! function_exists( 'add_action' ) ) {
 	}
 }
 
+if ( ! function_exists( 'get_plugin_data' ) ) {
+
+	/**
+	 * A drop-in replacement for a WordPress core function.
+	 *
+	 * @param string $plugin_file Absolute path to the main plugin file.
+	 * @return array {
+	 *     Plugin data. Values will be empty if not supplied by the plugin.
+	 *
+	 *     @type string $Name        Name of the plugin. Should be unique.
+	 *     @type string $Version     Plugin version.
+	 * }
+	 */
+	function get_plugin_data( $plugin_file ) {
+		return array(
+			'Name'    => basename( $plugin_file ),
+			'Version' => str_contains( $plugin_file, 'mu-plugins' ) ? 'mu-plugin' : 'plugin',
+		);
+	}
+}
+
 /**
  * A function to clean up all of the test data added by the test suite.
  */

--- a/projects/packages/autoloader/tests/php/lib/functions-wordpress.php
+++ b/projects/packages/autoloader/tests/php/lib/functions-wordpress.php
@@ -405,7 +405,7 @@ if ( ! function_exists( 'get_plugin_data' ) ) {
 	function get_plugin_data( $plugin_file ) {
 		return array(
 			'Name'    => basename( $plugin_file ),
-			'Version' => str_contains( $plugin_file, 'mu-plugins' ) ? 'mu-plugin' : 'plugin',
+			'Version' => strpos( $plugin_file, 'mu-plugins' ) !== false ? 'mu-plugin' : 'plugin',
 		);
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Changed check in autoloader guard to consider the comparison between current and latest plugin to be done using plugin data instead of the plugin path. 
p1660675242364729-slack-CDD9LQRSN
3543-gh-Automattic/vip-go-mu-plugins
#### Other information:
- [  ] Have you written new tests for your changes, if applicable? 
- [ X ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->


#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install the same version of a plugin that uses Jetpack autoloader (e.g. Jetpack) inside mu-plugins (This can be done by copying the plugin folder into the mu-plugins folder and using a proxy PHP loader file as indicated [here](https://wordpress.org/support/article/must-use-plugins/#Caveats) )
* Make sure the plugin is in active plugins.
* Try to navigate to the WP application. 
* Prior to the changes, a Fatal `Cannot declare class ...` should appear. After the changes Fatal should not be present and application should be able to load normally.