### PR TITLE
Debug Helper: Concatinate akismet suspicious link URL to prevent plugin being identified as a threat

### DIFF
--- a/projects/plugins/debug-helper/changelog/fix-debug-helper-suspicious-link-concat
+++ b/projects/plugins/debug-helper/changelog/fix-debug-helper-suspicious-link-concat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevented the threat tester from being identified as a threat due to containing the Akismet suspicious link URL.

--- a/projects/plugins/debug-helper/modules/class-scan-helper.php
+++ b/projects/plugins/debug-helper/modules/class-scan-helper.php
@@ -205,7 +205,7 @@ class Scan_Helper {
 	 * @return string|WP_Error Success message on success, WP_Error object on failure.
 	 */
 	private function generate_suspicious_link_threat() {
-		if ( ! $this->write_file( $this->threats['suspicious_link'], "<?php\n \$url = 'https://example.com/akismet-guaranteed-spam/'; \n" ) ) {
+		if ( ! $this->write_file( $this->threats['suspicious_link'], "<?php\n \$url = 'https://example.com" . "/akismet-guaranteed-spam/'; \n" ) ) {
 			return new WP_Error( 'could-not-write', "Unable to write threat file {$this->threats['suspicious_link']}" );
 		}
 

--- a/projects/plugins/debug-helper/modules/class-scan-helper.php
+++ b/projects/plugins/debug-helper/modules/class-scan-helper.php
@@ -205,6 +205,7 @@ class Scan_Helper {
 	 * @return string|WP_Error Success message on success, WP_Error object on failure.
 	 */
 	private function generate_suspicious_link_threat() {
+		// phpcs:disable Generic.Strings.UnnecessaryStringConcat.Found
 		if ( ! $this->write_file( $this->threats['suspicious_link'], "<?php\n \$url = 'https://example.com" . "/akismet-guaranteed-spam/'; \n" ) ) {
 			return new WP_Error( 'could-not-write', "Unable to write threat file {$this->threats['suspicious_link']}" );
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR splits up the Akismet suspicious link URL, to prevent the debug helper plugin from being identified as a threat itself, since it contains the suspicious URL. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Splits the Akismet suspicious link URL string into two concatenated strings.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1663075060346939-slack-C029WFNV69M

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install the Debug Helper plugin
* Run a scan
* Validate that the suspicious link threat is not identified