### PR TITLE
VideoPress: save title and description in block attributes

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-vp-chapters-save-title-and-description
+++ b/projects/plugins/jetpack/changelog/update-jetpack-vp-chapters-save-title-and-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack: store videopress title and descriptio in the block attributes

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -21,6 +21,7 @@ import deprecatedV3 from './deprecated/v3';
 import deprecatedV4 from './deprecated/v4';
 import withVideoPressEdit from './edit';
 import withVideoPressSave from './save';
+import addVideoPressVideoChaptersSupport from './video-chapters';
 import withVideoChaptersEdit from './video-chapters/edit';
 import videoPressBlockExampleImage from './videopress-block-example-image.jpg';
 import './editor.scss';
@@ -386,4 +387,10 @@ const addVideoPressSupport = ( settings, name ) => {
  * @see packages/block-editor/src/hooks/align.js
  */
 addFilter( 'blocks.registerBlockType', 'jetpack/videopress', addVideoPressSupport, 5 );
+addFilter(
+	'blocks.registerBlockType',
+	'videopress/add-wp-chapters-support',
+	addVideoPressVideoChaptersSupport
+);
+
 addFilter( 'editor.BlockEdit', 'videopress/with-video-chapters-edit', withVideoChaptersEdit );

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -387,6 +387,7 @@ const addVideoPressSupport = ( settings, name ) => {
  * @see packages/block-editor/src/hooks/align.js
  */
 addFilter( 'blocks.registerBlockType', 'jetpack/videopress', addVideoPressSupport, 5 );
+
 addFilter(
 	'blocks.registerBlockType',
 	'videopress/add-wp-chapters-support',

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/components/details-control/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/components/details-control/index.js
@@ -7,15 +7,13 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import useBlockAttributes from '../../hooks/use-block-attributes';
-import useVideoItem from '../../hooks/use-video-item';
 
 const VIDEOPRESS_VIDEO_CHAPTERS_FEATURE = 'videopress/video-chapters';
 const isVideoChaptersEnabled = !! window?.Jetpack_Editor_Initial_State?.available_blocks[
 	VIDEOPRESS_VIDEO_CHAPTERS_FEATURE
 ];
 
-export default function DetailsControl( { id } ) {
-	const [ isRequestingVideoItem ] = useVideoItem( id );
+export default function DetailsControl( { isRequestingVideoItem } ) {
 	const { attributes, setAttributes } = useBlockAttributes();
 
 	if ( ! isVideoChaptersEnabled ) {

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/components/details-control/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/components/details-control/index.js
@@ -3,6 +3,10 @@
  */
 import { PanelBody, TextareaControl, TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import useBlockAttributes from '../../hooks/use-block-attributes';
 import useVideoItem from '../../hooks/use-video-item';
 
 const VIDEOPRESS_VIDEO_CHAPTERS_FEATURE = 'videopress/video-chapters';
@@ -11,25 +15,28 @@ const isVideoChaptersEnabled = !! window?.Jetpack_Editor_Initial_State?.availabl
 ];
 
 export default function DetailsControl( { id } ) {
-	const [ videoItem, isRequestingVideoItem ] = useVideoItem( id );
+	const [ isRequestingVideoItem ] = useVideoItem( id );
+	const { attributes, setAttributes } = useBlockAttributes();
 
 	if ( ! isVideoChaptersEnabled ) {
 		return null;
 	}
 
-	const onTitleChangeHandler = () => {
-		// @todo
+	const { title, description } = attributes;
+
+	const onTitleChangeHandler = newTitle => {
+		setAttributes( { title: newTitle } );
 	};
 
-	const onDescriptionChangeHandler = () => {
-		// @todo
+	const onDescriptionChangeHandler = newDescription => {
+		setAttributes( { description: newDescription } );
 	};
 
 	return (
 		<PanelBody title={ __( 'Details', 'jetpack' ) }>
 			<TextControl
 				label={ __( 'Title', 'jetpack' ) }
-				value={ videoItem?.title }
+				value={ title }
 				placeholder={ __( 'Video title', 'jetpack' ) }
 				onChange={ onTitleChangeHandler }
 				disabled={ isRequestingVideoItem }
@@ -37,7 +44,7 @@ export default function DetailsControl( { id } ) {
 
 			<TextareaControl
 				label={ __( 'Description', 'jetpack' ) }
-				value={ videoItem?.description }
+				value={ description }
 				placeholder={ __( 'Video description', 'jetpack' ) }
 				onChange={ onDescriptionChangeHandler }
 				disabled={ isRequestingVideoItem }

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/edit.js
@@ -7,9 +7,12 @@ import { createHigherOrderComponent } from '@wordpress/compose';
  * Internal dependencies
  */
 import DetailsControl from './components/details-control';
+import useVideoItem from './hooks/use-video-item';
 import { isVideoChaptersEnabled } from '.';
 
 const withVideoChaptersEdit = createHigherOrderComponent( BlockEdit => props => {
+	const [ isRequestingVideoItem ] = useVideoItem( props?.attributes?.id );
+
 	if ( ! isVideoChaptersEnabled ) {
 		return <BlockEdit { ...props } />;
 	}
@@ -21,7 +24,7 @@ const withVideoChaptersEdit = createHigherOrderComponent( BlockEdit => props => 
 	return (
 		<>
 			<InspectorControls>
-				<DetailsControl id={ props?.attributes?.id } />
+				<DetailsControl isRequestingVideoItem={ isRequestingVideoItem } />
 			</InspectorControls>
 
 			<BlockEdit { ...props } />

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/edit.js
@@ -3,6 +3,7 @@
  */
 import { InspectorControls } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
@@ -11,7 +12,23 @@ import useVideoItem from './hooks/use-video-item';
 import { isVideoChaptersEnabled } from '.';
 
 const withVideoChaptersEdit = createHigherOrderComponent( BlockEdit => props => {
-	const [ isRequestingVideoItem ] = useVideoItem( props?.attributes?.id );
+	const [ videoItem, isRequestingVideoItem ] = useVideoItem( props?.attributes?.id );
+	const { setAttributes } = props;
+
+	/*
+	 * Propagate title and description from the video item
+	 * to the block attributes.
+	 */
+	useEffect( () => {
+		if ( ! videoItem ) {
+			return;
+		}
+
+		setAttributes( {
+			title: videoItem?.title,
+			description: videoItem?.description,
+		} );
+	}, [ videoItem, setAttributes ] );
 
 	if ( ! isVideoChaptersEnabled ) {
 		return <BlockEdit { ...props } />;

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/hooks/use-block-attributes/Readme.md
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/hooks/use-block-attributes/Readme.md
@@ -1,0 +1,22 @@
+# useBlockAttributes
+
+React custom hook to handle block attributes.
+
+```jsx
+import { TextControl } from '@wordpress/components';
+import useBlockAttributes from './use-block-attributes';
+
+export default function BlockTitleControl() {
+	const { attributes, setAttributes } = useBlockAttributes();
+
+	const { title } = attributes;
+
+	return (
+		<TextControl
+			label="title"
+			value={ title }
+			onChange={ newTitle => setAttributes( { title: newTitle } ) }
+		/>
+	);
+}
+```

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/hooks/use-block-attributes/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/hooks/use-block-attributes/index.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useSelect, useDispatch } from '@wordpress/data';
+
+export default function useBlockAttributes() {
+	const { clientId, attributes } = useSelect( select => {
+		const _clientId = select( blockEditorStore ).getSelectedBlockClientId();
+
+		return {
+			clientId: _clientId,
+			attributes: select( 'core/block-editor' ).getBlockAttributes( _clientId ),
+		};
+	} );
+
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	const setAttributes = newAttributes => updateBlockAttributes( clientId, newAttributes );
+
+	return { clientId, attributes, setAttributes };
+}

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/index.js
@@ -3,3 +3,26 @@ const VIDEOPRESS_VIDEO_CHAPTERS_FEATURE = 'videopress/video-chapters';
 export const isVideoChaptersEnabled = !! window?.Jetpack_Editor_Initial_State?.available_blocks[
 	VIDEOPRESS_VIDEO_CHAPTERS_FEATURE
 ];
+
+export default function addVideoPressVideoChaptersSupport( settings, name ) {
+	if ( isVideoChaptersEnabled ) {
+		return settings;
+	}
+
+	if ( name !== 'core/video' ) {
+		return settings;
+	}
+
+	return {
+		...settings,
+		attributes: {
+			...settings.attributes,
+			title: {
+				type: 'string',
+			},
+			description: {
+				type: 'string',
+			},
+		},
+	};
+}

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/index.js
@@ -5,7 +5,7 @@ export const isVideoChaptersEnabled = !! window?.Jetpack_Editor_Initial_State?.a
 ];
 
 export default function addVideoPressVideoChaptersSupport( settings, name ) {
-	if ( isVideoChaptersEnabled ) {
+	if ( ! isVideoChaptersEnabled ) {
 		return settings;
 	}
 
@@ -13,16 +13,18 @@ export default function addVideoPressVideoChaptersSupport( settings, name ) {
 		return settings;
 	}
 
+	const videoChaptersAttributes = {
+		...settings.attributes,
+		title: {
+			type: 'string',
+		},
+		description: {
+			type: 'string',
+		},
+	};
+
 	return {
 		...settings,
-		attributes: {
-			...settings.attributes,
-			title: {
-				type: 'string',
-			},
-			description: {
-				type: 'string',
-			},
-		},
+		attributes: videoChaptersAttributes,
 	};
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

~# Depends on https://github.com/Automattic/jetpack/pull/26182~

This PR stores the `title` and `description` data of the VideoPress video in the block attributes. We use attributes to deal with the UI changes, and also a method to catch the data provided by the REST API.


Fixes https://github.com/Automattic/jetpack/issues/26200

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: save title and description in block attributes

#### Other information:

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with a site with VideoPress enabled
* Upload a video
* Edit the title and description via wp-admin Library or Calypso
* Got to block the editor
* Create a video block with the same video
* Confirm the changes are properly populated 
* save the post
* hard refresh
* Confirm the title and description files are shown immediately (before it waits for the request-response) 

wp-admin | block editor | components inspector
------|------|------
<img width="385" alt="image" src="https://user-images.githubusercontent.com/77539/190403580-9b8aadb7-7425-4518-b835-51762a6a5958.png"> | <img width="400" alt="image" src="https://user-images.githubusercontent.com/77539/190403630-34498881-616b-4041-8019-bc66056b02a1.png"> | <img width="800" alt="image" src="https://user-images.githubusercontent.com/77539/190403706-7e21ba41-eeaa-40f3-91f6-a83191f3cf7f.png">
