### PR TITLE
VideoPress: Support `endAdornment` at `Input`

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-input-adornment
+++ b/projects/packages/videopress/changelog/update-videopress-input-adornment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: Support endAdornment in Input

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.3.1",
+	"version": "0.3.2-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.3.1';
+	const PACKAGE_VERSION = '0.3.2-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/client/admin/components/input/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/input/index.tsx
@@ -20,6 +20,7 @@ const InputWrapper = ( {
 	disabled = false,
 	loading = false,
 	icon = null,
+	endAdornment = null,
 	onChange,
 	onEnter,
 	size = 'small',
@@ -42,10 +43,6 @@ const InputWrapper = ( {
 		},
 		[ onEnter ]
 	);
-
-	const clearInput = useCallback( () => {
-		onChange( '' );
-	}, [ onChange ] );
 
 	const baseProps = {
 		className: classnames( styles.input, {
@@ -71,23 +68,17 @@ const InputWrapper = ( {
 				<textarea { ...inputProps } { ...baseProps } />
 			) : (
 				<>
-					{ loading ? (
-						<div className={ classnames( styles[ 'icon-wrapper' ], styles.loader ) }>
-							<Spinner />
+					{ loading || icon ? (
+						<div
+							className={ classnames( styles[ 'icon-wrapper' ], {
+								[ styles.loader ]: loading,
+							} ) }
+						>
+							{ loading ? <Spinner /> : icon }
 						</div>
-					) : (
-						<div className={ classnames( styles[ 'icon-wrapper' ] ) }>{ icon }</div>
-					) }
+					) : null }
 					<input { ...inputProps } { ...baseProps } value={ inputProps.value } />
-					{ inputProps.value !== '' && (
-						<div className={ classnames( styles[ 'icon-wrapper' ] ) }>
-							<Icon
-								icon={ closeSmall }
-								onClick={ clearInput }
-								className={ classnames( styles[ 'clear-icon' ] ) }
-							/>
-						</div>
-					) }
+					{ endAdornment }
 				</>
 			) }
 		</div>
@@ -155,6 +146,10 @@ export const SearchInput = ( {
 		[ componentProps.onChange ]
 	);
 
+	const clearInput = useCallback( () => {
+		componentProps.onChange?.( '' );
+	}, [ componentProps.onChange ] );
+
 	return (
 		<Input
 			{ ...componentProps }
@@ -163,6 +158,19 @@ export const SearchInput = ( {
 			type="text"
 			onEnter={ onEnterHandler }
 			onChange={ onChangeHandler }
+			endAdornment={
+				<>
+					{ componentProps.value !== '' && (
+						<div className={ classnames( styles[ 'icon-wrapper' ] ) }>
+							<Icon
+								icon={ closeSmall }
+								onClick={ clearInput }
+								className={ classnames( styles[ 'clear-icon' ] ) }
+							/>
+						</div>
+					) }
+				</>
+			}
 		/>
 	);
 };

--- a/projects/packages/videopress/src/client/admin/components/input/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/input/index.tsx
@@ -160,7 +160,7 @@ export const SearchInput = ( {
 			onChange={ onChangeHandler }
 			endAdornment={
 				<>
-					{ componentProps.value !== '' && (
+					{ Boolean( componentProps.value ) && (
 						<div className={ classnames( styles[ 'icon-wrapper' ] ) }>
 							<Icon
 								icon={ closeSmall }

--- a/projects/packages/videopress/src/client/admin/components/input/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/input/types.ts
@@ -22,6 +22,11 @@ type InputBaseProps = {
 	loading?: boolean;
 
 	/**
+	 * Append an adornment at the end of the input.
+	 */
+	endAdornment?: React.ReactNode;
+
+	/**
 	 * Callback to be invoked when the input value changes.
 	 */
 	onChange?: ( value: string ) => unknown;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Open support for `endAdornment` prop at `Input`, and move specific `SearchInput` endAdornment for its own place.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Support `endAdornment` prop in `Input`.
* Doesn't render `icon-wrapper` if it isn't loading or has `icon`.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start `Storybook`
* Goes to `VideoPress/Components/Input`.
* Interact with default and search stories.
* It should works properly

