### PR TITLE
Search: Fix no search results in customizer

### DIFF
--- a/projects/packages/search/changelog/fix-no-search-results-in-customizer
+++ b/projects/packages/search/changelog/fix-no-search-results-in-customizer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixes the issue where search results are not loaded in customizer

--- a/projects/packages/search/src/instant-search/components/search-app.jsx
+++ b/projects/packages/search/src/instant-search/components/search-app.jsx
@@ -79,7 +79,7 @@ class SearchApp extends Component {
 	}
 
 	componentDidMount() {
-		// The condition can only occur in the Customberg preview context.
+		// This condition can only occur within Customberg or the Customizer.
 		if (
 			( this.props.initialShowResults && this.props.initialIsVisible ) ||
 			this.props.isInCustomizer

--- a/projects/packages/search/src/instant-search/components/search-app.jsx
+++ b/projects/packages/search/src/instant-search/components/search-app.jsx
@@ -80,7 +80,10 @@ class SearchApp extends Component {
 
 	componentDidMount() {
 		// The condition can only occur in the Customberg preview context.
-		if ( this.props.initialShowResults && this.props.initialIsVisible ) {
+		if (
+			( this.props.initialShowResults && this.props.initialIsVisible ) ||
+			this.props.isInCustomizer
+		) {
 			this.getResults();
 		}
 		if ( this.props.hasActiveQuery ) {


### PR DESCRIPTION
Fixes #25000

#### Changes proposed in this Pull Request:
The PR proposes to load search results for customizer when `isInCustomizer` is true for component `SearchApp`, so that user could preview the overlay properly.


#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Create a JN site by click [here](https://jurassic.ninja/create/?jetpack-beta&branches.jetpack-search=fix/no-search-results-in-customizer&nojetpack)
- Open cutomizer ( `/wp-admin/customize.php?return=%2Fwp-admin%2Fwidgets.php` ) and click Jetpack Search section

<img width="467" alt="image" src="https://user-images.githubusercontent.com/1425433/190028811-1299b7c5-195d-43b5-ba01-b132ff812963.png">

- Ensure the search results is loaded

<img width="935" alt="image" src="https://user-images.githubusercontent.com/1425433/190028919-2c69de4b-3406-48b7-9e89-cc16814de8e5.png">
