### PR TITLE
Components: Remove translations from Pricing Table ternary to prevent build issue

### DIFF
--- a/projects/js-packages/components/changelog/fix-pricing-table-string-build
+++ b/projects/js-packages/components/changelog/fix-pricing-table-string-build
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed bug preventing Pricing Table from building properly.

--- a/projects/js-packages/components/components/pricing-table/index.tsx
+++ b/projects/js-packages/components/components/pricing-table/index.tsx
@@ -30,7 +30,9 @@ export const PricingTableItem: React.FC< PricingTableItemProps > = ( {
 	const [ isLg ] = useBreakpointMatch( 'lg' );
 	const items = useContext( PricingTableContext );
 	const rowLabel = items[ index ];
-	let defaultLabel = isIncluded ? __( 'Included', 'jetpack' ) : __( 'Not included', 'jetpack' );
+	const includedLabel = __( 'Included', 'jetpack' );
+	const notIncludedLabel = __( 'Not included', 'jetpack' );
+	let defaultLabel = isIncluded ? includedLabel : notIncludedLabel;
 	defaultLabel = isLg ? defaultLabel : rowLabel;
 
 	if ( ! isLg && ! isIncluded ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Fixes the following error:

```
msgid argument is not a string literal: __(t?"Included":"Not included","jetpack")

Optimization seems to have broken the following translation strings:
- "Included"
- "Not included"
```

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use the component in a JS file.
* For example, using the Social plugin, open [the main admin page](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/social/src/js/index.js) and use the component.
```
import {
	PricingTable,
	PricingTableColumn,
	PricingTableHeader,
	PricingTableItem,
} from '@automattic/jetpack-components';
```
```
<PricingTable title="Title" items={ [ 'item 1' ] }>
	<PricingTableColumn>
		<PricingTableHeader>1</PricingTableHeader>
		<PricingTableItem isIncluded={ true } />
	</PricingTableColumn>
	<PricingTableColumn>
		<PricingTableHeader>2</PricingTableHeader>
		<PricingTableItem isIncluded={ false } />
	</PricingTableColumn>
</PricingTable>
```
* Run `jetpack build plugins/social --p --verbose` to run a production build.
* Without this PR, the build will fail, and with this PR the build should run.

