### PR TITLE
Get Site Endpoint: Add difm_lite_site_options to response

### DIFF
--- a/projects/plugins/jetpack/changelog/update-site-endpoint-difm-options
+++ b/projects/plugins/jetpack/changelog/update-site-endpoint-difm-options
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+WordPress.com REST API: Adds difm_lite_site_options key to get site API response.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -180,7 +180,19 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'selected_features',
 		'anchor_podcast',
 		'is_difm_lite_in_progress',
+		'difm_lite_site_options',
 		'site_intent',
+	);
+
+	/**
+	 * List of DIFM Lite options to be displayed
+	 *
+	 * @var array $displayed_difm_lite_site_options
+	 */
+	protected static $displayed_difm_lite_site_options = array(
+		'site_category',
+		'is_website_content_submitted',
+		'selected_page_titles',
 	);
 
 	/**
@@ -763,6 +775,21 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'is_difm_lite_in_progress':
 					$options[ $key ] = $site->is_difm_lite_in_progress();
+					break;
+				case 'difm_lite_site_options':
+					$difm_lite_options          = $site->get_difm_lite_site_options();
+					$visible_options            = self::$displayed_difm_lite_site_options;
+					$filtered_difm_lite_options = new stdClass();
+					if ( $difm_lite_options ) {
+						$filtered_difm_lite_options = array_filter(
+							$difm_lite_options,
+							function ( $key ) use ( $visible_options ) {
+								return in_array( $key, $visible_options, true );
+							},
+							ARRAY_FILTER_USE_KEY
+						);
+					}
+					$options[ $key ] = $filtered_difm_lite_options;
 					break;
 				case 'site_intent':
 					$options[ $key ] = $site->get_site_intent();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/martech#1120

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This change attempts adds `difm_lite_site_options` to the get site endpoint. This was added to WPCOM via D70482-code

#### Other information:

- [ ] Have you written new tests for your changes, if applicable? - NA
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* After checkout out this branch, installing the plugin and connecting to WPCOM, check the response of `https://public-api.wordpress.com/rest/v1.2/sites/<your site id>`
* The options key should contain a child key called `difm_lite_site_options`.
<img width="537" alt="image" src="https://user-images.githubusercontent.com/5436027/192755717-9db4620b-7b9e-4473-a95e-8a75f4fb4b87.png">
