### PR TITLE
VideoPress: keep in-sync video item data

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-vp-save-video-data
+++ b/projects/plugins/jetpack/changelog/update-jetpack-vp-save-video-data
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+VideoPress: save title and description when post saves

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -22,7 +22,6 @@ import deprecatedV4 from './deprecated/v4';
 import withVideoPressEdit from './edit';
 import withVideoPressSave from './save';
 import addVideoPressVideoChaptersSupport from './video-chapters';
-import withVideoChaptersEdit from './video-chapters/edit';
 import videoPressBlockExampleImage from './videopress-block-example-image.jpg';
 import './editor.scss';
 
@@ -393,5 +392,3 @@ addFilter(
 	'videopress/add-wp-chapters-support',
 	addVideoPressVideoChaptersSupport
 );
-
-addFilter( 'editor.BlockEdit', 'videopress/with-video-chapters-edit', withVideoChaptersEdit );

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/components/details-control/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/components/details-control/index.js
@@ -15,18 +15,17 @@ const isVideoChaptersEnabled = !! window?.Jetpack_Editor_Initial_State?.availabl
 
 export default function DetailsControl( { isRequestingVideoItem } ) {
 	const { attributes, setAttributes } = useBlockAttributes();
+	const { title, description } = attributes;
 
 	if ( ! isVideoChaptersEnabled ) {
 		return null;
 	}
 
-	const { title, description } = attributes;
-
-	const onTitleChangeHandler = newTitle => {
+	const setTitleAttribute = newTitle => {
 		setAttributes( { title: newTitle } );
 	};
 
-	const onDescriptionChangeHandler = newDescription => {
+	const setDescriptionAttribute = newDescription => {
 		setAttributes( { description: newDescription } );
 	};
 
@@ -36,7 +35,7 @@ export default function DetailsControl( { isRequestingVideoItem } ) {
 				label={ __( 'Title', 'jetpack' ) }
 				value={ title }
 				placeholder={ __( 'Video title', 'jetpack' ) }
-				onChange={ onTitleChangeHandler }
+				onChange={ setTitleAttribute }
 				disabled={ isRequestingVideoItem }
 			/>
 
@@ -44,7 +43,7 @@ export default function DetailsControl( { isRequestingVideoItem } ) {
 				label={ __( 'Description', 'jetpack' ) }
 				value={ description }
 				placeholder={ __( 'Video description', 'jetpack' ) }
-				onChange={ onDescriptionChangeHandler }
+				onChange={ setDescriptionAttribute }
 				disabled={ isRequestingVideoItem }
 			/>
 		</PanelBody>

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/edit.js
@@ -9,26 +9,31 @@ import { useEffect } from '@wordpress/element';
  */
 import DetailsControl from './components/details-control';
 import useVideoItem from './hooks/use-video-item';
+import { useSyncMedia } from './hooks/use-video-item-update';
 import { isVideoChaptersEnabled } from '.';
 
 const withVideoChaptersEdit = createHigherOrderComponent( BlockEdit => props => {
-	const [ videoItem, isRequestingVideoItem ] = useVideoItem( props?.attributes?.id );
-	const { setAttributes } = props;
+	const { attributes, setAttributes } = props;
+	const [ videoItem, isRequestingVideoItem ] = useVideoItem( attributes?.id );
+	const [ updateDataToSync ] = useSyncMedia( attributes );
 
 	/*
-	 * Propagate title and description from the video item
-	 * to the block attributes.
+	 * Propagate title and description from
+	 * the video item (metadata) to the block attributes.
 	 */
 	useEffect( () => {
 		if ( ! videoItem ) {
 			return;
 		}
 
-		setAttributes( {
+		const freshAttributes = {
 			title: videoItem?.title,
 			description: videoItem?.description,
-		} );
-	}, [ videoItem, setAttributes ] );
+		};
+
+		setAttributes( freshAttributes );
+		updateDataToSync( freshAttributes );
+	}, [ videoItem, setAttributes, updateDataToSync ] );
 
 	if ( ! isVideoChaptersEnabled ) {
 		return <BlockEdit { ...props } />;

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/edit.js
@@ -15,7 +15,7 @@ import { isVideoChaptersEnabled } from '.';
 const withVideoChaptersEdit = createHigherOrderComponent( BlockEdit => props => {
 	const { attributes, setAttributes } = props;
 	const [ videoItem, isRequestingVideoItem ] = useVideoItem( attributes?.id );
-	const [ updateDataToSync ] = useSyncMedia( attributes );
+	const [ forceInitialState ] = useSyncMedia( attributes );
 
 	/*
 	 * Propagate title and description from
@@ -32,8 +32,8 @@ const withVideoChaptersEdit = createHigherOrderComponent( BlockEdit => props => 
 		};
 
 		setAttributes( freshAttributes );
-		updateDataToSync( freshAttributes );
-	}, [ videoItem, setAttributes, updateDataToSync ] );
+		forceInitialState( freshAttributes );
+	}, [ videoItem, setAttributes, forceInitialState ] );
 
 	if ( ! isVideoChaptersEnabled ) {
 		return <BlockEdit { ...props } />;

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/hooks/use-block-attributes/Readme.md
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/hooks/use-block-attributes/Readme.md
@@ -6,7 +6,7 @@ React custom hook to handle block attributes.
 import { TextControl } from '@wordpress/components';
 import useBlockAttributes from './use-block-attributes';
 
-export default function BlockTitleControl() {
+function BlockTitleControl() {
 	const { attributes, setAttributes } = useBlockAttributes();
 
 	const { title } = attributes;

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/hooks/use-block-attributes/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/hooks/use-block-attributes/index.js
@@ -10,7 +10,9 @@ export default function useBlockAttributes() {
 
 		return {
 			clientId: _clientId,
-			attributes: select( 'core/block-editor' ).getBlockAttributes( _clientId ),
+			attributes: _clientId
+				? select( 'core/block-editor' ).getBlockAttributes( _clientId )
+				: undefined,
 		};
 	} );
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/hooks/use-video-item-update/Readme.md
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/hooks/use-video-item-update/Readme.md
@@ -1,0 +1,70 @@
+# useMediaItemUpdate
+
+React custom hook to update the video metadata
+
+```jsx
+import { useMediaItemUpdate } from './use-video-item-update';
+
+function VideoItem( { id }) {
+
+	const updateMedia = useMediaItemUpdate( id );
+
+	return (
+		<TextControl
+			label="title"
+			value={ title }
+			onChange={ newTitle => updateMedia( { title: newTitle } ) }
+		/>
+	);
+}
+```
+
+# useSyncMedia
+
+React custom hook to keep block attributes in-sync with the video item metadata.
+The hook will keep the initial state of the attributes to keep in-sync, 
+and will update them at the same time the post saves.
+
+```jsx
+import { useSyncMedia } from './use-video-item-update';
+
+export default function VideoItemComponent( { attributes, setAttributes } ) {
+	useSyncMedia( attributes );
+
+	return (
+		<TextControl
+			label="title"
+			value={ attributes.title }
+			onChange={ newTitle => setAttributes( { title: newTitle } ) }
+		/>
+	);
+}
+```
+
+## Forcing initial state
+
+In case you need to force the initial state, the hook returns a handler for it:
+
+```jsx
+import { useSyncMedia } from './use-video-item-update';
+
+export default function VideoItemComponent( { attributes, setAttributes } ) {
+	const [ forceInitialState ] = useSyncMedia( attributes );
+
+	useEffect( () => {
+		if ( dataChanged ) {
+			return;
+		}
+
+		forceInitialState( dataChanged );
+	}, [ dataChanged, forceInitialState ]
+
+	return (
+		<TextControl
+			label="title"
+			value={ attributes.title }
+			onChange={ newTitle => setAttributes( { title: newTitle } ) }
+		/>
+	);
+}
+```

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/hooks/use-video-item-update/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/hooks/use-video-item-update/index.js
@@ -33,7 +33,7 @@ export function useSyncMedia( { id, title, description } ) {
 
 	const [ initialState, setState ] = useState();
 
-	const updateData = useCallback( data => {
+	const updateInitialState = useCallback( data => {
 		setState( current => ( { ...current, ...data } ) );
 	}, [] );
 
@@ -68,7 +68,7 @@ export function useSyncMedia( { id, title, description } ) {
 			return;
 		}
 
-		updateMedia( dataToUpdate );
+		updateMedia( dataToUpdate ).then( () => updateInitialState( { title, description } ) );
 	}, [
 		id,
 		isSaving,
@@ -78,7 +78,8 @@ export function useSyncMedia( { id, title, description } ) {
 		initialState?.description,
 		description,
 		updateMedia,
+		updateInitialState,
 	] );
 
-	return [ updateData ];
+	return [ updateInitialState ];
 }

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/hooks/use-video-item-update/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/hooks/use-video-item-update/index.js
@@ -2,16 +2,17 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { usePrevious } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
+import { useEffect, useState, useCallback } from '@wordpress/element';
 
 export default function useMediaItemUpdate( id ) {
 	const updateMediaItem = data => {
 		return new Promise( ( resolve, reject ) => {
-			const apiData = { id, ...data };
-
 			apiFetch( {
 				path: '/wpcom/v2/videopress/meta',
 				method: 'POST',
-				data: apiData,
+				data: { id, ...data },
 			} )
 				.then( result => {
 					if ( 200 !== result?.data ) {
@@ -24,4 +25,60 @@ export default function useMediaItemUpdate( id ) {
 	};
 
 	return updateMediaItem;
+}
+
+export function useSyncMedia( { id, title, description } ) {
+	const isSaving = useSelect( select => select( 'core/editor' ).isSavingPost(), [] );
+	const wasSaving = usePrevious( isSaving );
+
+	const [ initialState, setState ] = useState();
+
+	const updateData = useCallback( data => {
+		setState( current => ( { ...current, ...data } ) );
+	}, [] );
+
+	// Populate initial state when mounted
+	useEffect( () => {
+		setState( { title, description } );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	const updateMedia = useMediaItemUpdate( id );
+
+	useEffect( () => {
+		if ( ! isSaving || wasSaving ) {
+			return;
+		}
+
+		if ( ! id ) {
+			return;
+		}
+
+		const dataToUpdate = {};
+
+		if ( initialState?.title !== title ) {
+			dataToUpdate.title = title;
+		}
+
+		if ( initialState?.description !== description ) {
+			dataToUpdate.description = description;
+		}
+
+		if ( ! Object.keys( dataToUpdate ).length ) {
+			return;
+		}
+
+		updateMedia( dataToUpdate );
+	}, [
+		id,
+		isSaving,
+		wasSaving,
+		title,
+		initialState?.title,
+		initialState?.description,
+		description,
+		updateMedia,
+	] );
+
+	return [ updateData ];
 }

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/hooks/use-video-item-update/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/hooks/use-video-item-update/index.js
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+export default function useMediaItemUpdate( id ) {
+	const updateMediaItem = data => {
+		return new Promise( ( resolve, reject ) => {
+			const apiData = { id, ...data };
+
+			apiFetch( {
+				path: '/wpcom/v2/videopress/meta',
+				method: 'POST',
+				data: apiData,
+			} )
+				.then( result => {
+					if ( 200 !== result?.data ) {
+						return reject( result );
+					}
+					resolve( result );
+				} )
+				.catch( reject );
+		} );
+	};
+
+	return updateMediaItem;
+}

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/index.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import withVideoChaptersEdit from './edit';
+
 const VIDEOPRESS_VIDEO_CHAPTERS_FEATURE = 'videopress/video-chapters';
 
 export const isVideoChaptersEnabled = !! window?.Jetpack_Editor_Initial_State?.available_blocks[
@@ -26,5 +31,6 @@ export default function addVideoPressVideoChaptersSupport( settings, name ) {
 	return {
 		...settings,
 		attributes: videoChaptersAttributes,
+		edit: withVideoChaptersEdit( settings.edit ),
 	};
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR keeps in-sync the `title` and `description` attributes with the video metadata. To do this, the app detects when one of these values changes. If so, they will be updated (hitting the meta endpoint) only when the post saves.

Fixes https://github.com/Automattic/jetpack/issues/26199

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: keep in-sync video item data

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to block editor
* Create/edit a VideoPress instance
* Open the sidebar 
* Change `description` and/or `title` attributes
* Save the post
* Confirm the data is updated correctly, for instance, comparing with the wp-admin library page or Calypso.

**DISCLAIMER**: there is an issue when sanitizing the description file. It's going to be handled with one https://github.com/Automattic/jetpack/pull/26242

https://user-images.githubusercontent.com/77539/190485325-3d3a4e34-29d8-4403-a096-61f29852cab2.mov

