### PR TITLE
VideoPress: expose title and description in jetpack_videopress endpoint response body

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-populate-details-endpoint-field
+++ b/projects/packages/videopress/changelog/update-videopress-populate-details-endpoint-field
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: expose title and description in jetpack_videopress endpoint response body

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
@@ -120,7 +120,10 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Data {
 	 */
 	public function get_videopress_data( $attachment_id, $blog_id ) {
 		$info = video_get_info_by_blogpostid( $blog_id, $attachment_id );
+
 		return array(
+			'title'           => $info->title,
+			'description'     => $info->description,
 			'guid'            => $info->guid,
 			'rating'          => $info->rating,
 			'allow_download'  =>

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
@@ -120,10 +120,18 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Data {
 	 */
 	public function get_videopress_data( $attachment_id, $blog_id ) {
 		$info = video_get_info_by_blogpostid( $blog_id, $attachment_id );
+		$info = video_get_info_by_blogpostid( $blog_id, $attachment_id );
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$title       = video_get_title( $blog_id, $attachment_id );
+			$description = video_get_description( $blog_id, $attachment_id );
+		} else {
+			$title       = $info->title;
+			$description = $info->description;
+		}
 
 		return array(
-			'title'           => $info->title,
-			'description'     => $info->description,
+			'title'           => $title,
+			'description'     => $description,
 			'guid'            => $info->guid,
 			'rating'          => $info->rating,
 			'allow_download'  =>

--- a/projects/packages/videopress/src/utility-functions.php
+++ b/projects/packages/videopress/src/utility-functions.php
@@ -485,6 +485,8 @@ function video_get_info_by_blogpostid( $blog_id, $post_id ) {
 	$video_info->guid            = null;
 	$video_info->finish_date_gmt = '0000-00-00 00:00:00';
 	$video_info->rating          = null;
+	$video_info->description     = $post->post_content;
+	$video_info->title           = $post->post_title;
 
 	if ( is_wp_error( $post ) ) {
 		return $video_info;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The `/wp/vw/media` endpoint is the endpoint that we will use to deal with VP video data. Currently, the `jetpack_videopress` exposes a couple of fields. This PR adds `title` and `description` together to them.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: expose title and description in jetpack_videopress endpoint response body

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with a site with VP. 
* Upload a video
* Pick the attachment id
* hit the `/wp/v2/media/{ id }` endpoint
* confirm you see the `title` and `description` in the `jetpack_videopress` field

<img width="514" alt="Screen Shot 2022-09-14 at 20 42 39" src="https://user-images.githubusercontent.com/77539/190281550-47b1c56e-dd11-4e0e-91a9-dc06bbf63da5.png">
