### PR TITLE
Jetpack: fix a typo when picking the videopress info description field

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-videopress-metada-fix-description-prop-bug
+++ b/projects/plugins/jetpack/changelog/update-jetpack-videopress-metada-fix-description-prop-bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack: fix a typo when picking the videopress info description field

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-edit-attachment.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-edit-attachment.php
@@ -186,7 +186,7 @@ class VideoPress_Edit_Attachment {
 
 		$fields['post_excerpt']['label'] = _x( 'Description', 'A header for the short description display', 'jetpack' );
 		$fields['post_excerpt']['input'] = 'textarea';
-		$fields['post_excerpt']['value'] = ! empty( $info->description ) ? $info->descrption : '';
+		$fields['post_excerpt']['value'] = ! empty( $info->description ) ? $info->description : '';
 
 		$fields['is_videopress_attachment'] = array(
 			'input' => 'hidden',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack: fix a typo when picking the videopress info description field

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Confirm visually the typo and it fixes

