### PR TITLE
 VideoPress: sync video `description` value

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-sync-video-description-value
+++ b/projects/packages/videopress/changelog/update-videopress-sync-video-description-value
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: sync video `description` value

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
@@ -179,6 +179,17 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 					);
 				}
 
+				if ( isset( $json_params['description'] ) ) {
+					$meta['videopress']['description'] = sanitize_text_field( $json_params['description'] );
+					$should_update_meta                = true;
+					wp_update_post(
+						array(
+							'ID'           => $post_id,
+							'post_content' => $json_params['description'],
+						)
+					);
+				}
+
 				if ( isset( $json_params['allow_download'] ) ) {
 					$allow_download = (bool) $json_params['allow_download'];
 					if ( ! isset( $meta['videopress']['allow_download'] ) || $meta['videopress']['allow_download'] !== $allow_download ) {

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
@@ -180,7 +180,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 				}
 
 				if ( isset( $json_params['description'] ) ) {
-					$meta['videopress']['description'] = sanitize_text_field( $json_params['description'] );
+					$meta['videopress']['description'] = sanitize_textarea_field( $json_params['description'] );
 					$should_update_meta                = true;
 					wp_update_post(
 						array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Currently, we are updating videopress meta data hitting the `/wpcom/v2/videopress/meta` endpoint. For instance, when updating the rating:

<img width="581" alt="image" src="https://user-images.githubusercontent.com/77539/190414318-7516383a-1b97-434b-af0a-a8ec0edc35fd.png">

we need to be able to do the same but with the video description. This PR tries to tackle it.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*  VideoPress: sync video `description` value

#### Other information:

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Block editor
* Create/edit a VideoPress block
* Ppen the block sidebar
* Edit `title` and `description`...

