### PR TITLE
Sync: add support for block-template-parts

### DIFF
--- a/projects/packages/sync/changelog/add-block-template-parts
+++ b/projects/packages/sync/changelog/add-block-template-parts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Default Theme Support: Add support for new feature added in WP 6.1

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -798,6 +798,7 @@ class Defaults {
 		'align-wide',
 		'automatic-feed-links',
 		'block-templates',
+		'block-template-parts', // WP 6.1. Added via https://core.trac.wordpress.org/changeset/54176
 		'custom-background',
 		'custom-header',
 		'custom-logo',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Core added a new theme_supports, block-template-parts, in https://core.trac.wordpress.org/changeset/54176

Sync needs to sync this too.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds `block-template-parts` to the default_theme_supports_whitelist

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check WP trunk / PHP 8.0 CI test result

