### PR TITLE
Sync: Add additional Gutenberg theme_supports

### DIFF
--- a/projects/packages/sync/changelog/add-gutenberg-theme-supports
+++ b/projects/packages/sync/changelog/add-gutenberg-theme-supports
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Gutenberg Support: add additional theme_supports items to our synced allowlist.

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -796,6 +796,7 @@ class Defaults {
 	 */
 	public static $default_theme_support_whitelist = array(
 		'align-wide',
+		'appearance-tools', // In Gutenberg.
 		'automatic-feed-links',
 		'block-templates',
 		'block-template-parts', // WP 6.1. Added via https://core.trac.wordpress.org/changeset/54176
@@ -804,6 +805,8 @@ class Defaults {
 		'custom-logo',
 		'customize-selective-refresh-widgets',
 		'dark-editor-style',
+		'default-color-palette', // In Gutenberg.
+		'default-gradient-presets', // In Gutenberg.
 		'disable-custom-colors',
 		'disable-custom-font-sizes',
 		'disable-custom-gradients',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

As a follow up to https://github.com/Automattic/jetpack/pull/26236 and https://github.com/Automattic/jetpack/pull/26220, I went through Gutenberg adding other theme_support features that are used there. They may or may not end up in Core, but there's little harm to adding them here.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds `apperance-tools`, `default-color-palette`, and `default-gradient-presets` to the `$default_theme_Support_whitelist`.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
no

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Additional theme_support items, already covered under existing policy.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* None for this specific additional. You could spin up a site, add theme_support values for the new items to your theme, then check to see if we're aware of it on WP.com. But, the mech is well-utilized.

