### PR TITLE
Avoid using $_SERVER['QUERY_STRING'] as it is not guaranteed in all environments.

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-super-cache-params-parsing
+++ b/projects/plugins/super-cache/changelog/fix-super-cache-params-parsing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid use of QUERY_STRING value, as it is not available in all hosting environments

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -3438,7 +3438,8 @@ function wpsc_is_get_query() {
 	static $is_get_query = null;
 
 	if ( null === $is_get_query ) {
-		$is_get_query = ! empty( $_SERVER['QUERY_STRING'] );
+		$request_uri  = wpsc_parse_partial_url( $_SERVER['REQUEST_URI'] );
+		$is_get_query = $request_uri && ! empty( $request_uri['query'] );
 	}
 
 	return $is_get_query;


### PR DESCRIPTION
Use the new `wpsc_parse_partial_url` method to check for GET params instead of relying on `QUERY_STRING`, which [may not be set in all environments](https://www.php.net/manual/en/reserved.variables.server.php#120980).

Props to @pyronaur for spotting this issue.

#### Changes proposed in this Pull Request:
* Revert changes to checking for GET parameters from #26247, and use `wpsc_parse_partial_url` instead.

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Clear your cache
* `curl 'http://your-site//?s=123'`
* Load your homepage, and ensure it doesn't serve stale search results.

