### PR TITLE
Jetpack: Update "Convert to Audio" post-publish panel to show Jetpack Icon and use secondary variant button

### DIFF
--- a/projects/plugins/jetpack/changelog/update-audio-post-publis-panel
+++ b/projects/plugins/jetpack/changelog/update-audio-post-publis-panel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Show Jetpack icon in post publish panel for audio

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/editor.js
@@ -55,10 +55,8 @@ const ConvertToAudio = () => {
 		<PluginPostPublishPanel
 			className="anchor-post-publish-outbound-link"
 			icon={ <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" /> }
+			title={ __( 'Convert to audio', 'jetpack' ) }
 		>
-			<p className="post-publish-panel__postpublish-subheader">
-				<strong>{ __( 'Convert to audio', 'jetpack' ) }</strong>
-			</p>
 			<p>
 				{ __(
 					'Seamlessly turn this post into a podcast episode with Anchor - and let readers listen to your post.',

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/editor.js
@@ -56,6 +56,7 @@ const ConvertToAudio = () => {
 			className="anchor-post-publish-outbound-link"
 			icon={ <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" /> }
 			title={ __( 'Convert to audio', 'jetpack' ) }
+			initialOpen={ true }
 		>
 			<PanelRow>
 				<p>

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/editor.js
@@ -1,3 +1,4 @@
+import { JetpackLogo } from '@automattic/jetpack-components';
 import { Button } from '@wordpress/components';
 import { dispatch } from '@wordpress/data';
 import { PluginPostPublishPanel } from '@wordpress/edit-post';
@@ -51,7 +52,10 @@ const ConvertToAudio = () => {
 		[]
 	);
 	return (
-		<PluginPostPublishPanel className="anchor-post-publish-outbound-link">
+		<PluginPostPublishPanel
+			className="anchor-post-publish-outbound-link"
+			icon={ <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" /> }
+		>
 			<p className="post-publish-panel__postpublish-subheader">
 				<strong>{ __( 'Convert to audio', 'jetpack' ) }</strong>
 			</p>

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/editor.js
@@ -72,7 +72,7 @@ const ConvertToAudio = () => {
 				onClick={ handleClick }
 				onKeyDown={ handleClick }
 			>
-				<Button variant="primary" href="https://anchor.fm/wordpressdotcom" target="_top">
+				<Button variant="secondary" href="https://anchor.fm/wordpressdotcom" target="_top">
 					{ __( 'Create a podcast episode', 'jetpack' ) }{ ' ' }
 					<Icon icon={ external } className="anchor-post-publish-outbound-link__external_icon" />
 				</Button>

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/editor.js
@@ -1,5 +1,5 @@
 import { JetpackLogo } from '@automattic/jetpack-components';
-import { Button } from '@wordpress/components';
+import { Button, PanelRow } from '@wordpress/components';
 import { dispatch } from '@wordpress/data';
 import { PluginPostPublishPanel } from '@wordpress/edit-post';
 import { __ } from '@wordpress/i18n';
@@ -57,12 +57,14 @@ const ConvertToAudio = () => {
 			icon={ <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" /> }
 			title={ __( 'Convert to audio', 'jetpack' ) }
 		>
-			<p>
-				{ __(
-					'Seamlessly turn this post into a podcast episode with Anchor - and let readers listen to your post.',
-					'jetpack'
-				) }
-			</p>
+			<PanelRow>
+				<p>
+					{ __(
+						'Seamlessly turn this post into a podcast episode with Anchor - and let readers listen to your post.',
+						'jetpack'
+					) }
+				</p>
+			</PanelRow>
 			<div
 				role="link"
 				className="post-publish-panel__postpublish-buttons"


### PR DESCRIPTION
Part of https://github.com/Automattic/jetpack/issues/26048
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds Jetpack logo to post-publish Audio Panel
* Sets it to be open by default
* Updates button in the panel to `secondary` variant
* Adds use of `<PanelRow />` component




#### Jetpack After

<img width="287" alt="Screen Shot 2022-09-16 at 11 22 56" src="https://user-images.githubusercontent.com/746152/190662752-76914826-02eb-46a7-9326-e8fb9c151901.png">


#### Jetpack Before

<img width="286" alt="image" src="https://user-images.githubusercontent.com/746152/190663290-bae61bfa-1f9b-48dc-9aa3-e9eece39fdc9.png">


#### wpcom After
<img width="288" alt="image" src="https://user-images.githubusercontent.com/746152/190667188-11fc2e18-f6e5-45d5-bb06-cca7159c69f3.png">

#### wpcom Before

<img width="297" alt="image" src="https://user-images.githubusercontent.com/746152/190663806-7e81e8d6-d33f-4734-9d42-36b05f73352c.png">

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
p1HpG7-hDK-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

* On a connected site
* Start writing a post
* Hit "Publish" , confirm with another click on Publish. and stop . Confirm in the right sidebar that you see the Jetpack logo   in the Convert to audio panel and that the button now shows its secondary variant.

