### PR TITLE
VideoPress: Add beta style to DetailsControl sidebar component in video block

### DIFF
--- a/projects/plugins/jetpack/changelog/add-videopress-beta-style-details-control
+++ b/projects/plugins/jetpack/changelog/add-videopress-beta-style-details-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+VideoPress: Add beta style to DetailsControl component

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/components/details-control/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/components/details-control/index.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { isBetaExtension } from '../../../../../editor';
 import useBlockAttributes from '../../hooks/use-block-attributes';
 import './index.scss';
 
@@ -17,6 +18,7 @@ const isVideoChaptersEnabled = !! window?.Jetpack_Editor_Initial_State?.availabl
 export default function DetailsControl( { isRequestingVideoItem } ) {
 	const { attributes, setAttributes } = useBlockAttributes();
 	const { title, description } = attributes;
+	const isBeta = isBetaExtension( VIDEOPRESS_VIDEO_CHAPTERS_FEATURE );
 
 	if ( ! isVideoChaptersEnabled ) {
 		return null;
@@ -31,7 +33,7 @@ export default function DetailsControl( { isRequestingVideoItem } ) {
 	};
 
 	return (
-		<PanelBody title={ __( 'Details', 'jetpack' ) } className="is-beta">
+		<PanelBody title={ __( 'Details', 'jetpack' ) } className={ isBeta ? 'is-beta' : '' }>
 			<TextControl
 				label={ __( 'Title', 'jetpack' ) }
 				value={ title }

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/components/details-control/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/components/details-control/index.js
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import useBlockAttributes from '../../hooks/use-block-attributes';
+import './index.scss';
 
 const VIDEOPRESS_VIDEO_CHAPTERS_FEATURE = 'videopress/video-chapters';
 const isVideoChaptersEnabled = !! window?.Jetpack_Editor_Initial_State?.available_blocks[
@@ -30,7 +31,7 @@ export default function DetailsControl( { isRequestingVideoItem } ) {
 	};
 
 	return (
-		<PanelBody title={ __( 'Details', 'jetpack' ) }>
+		<PanelBody title={ __( 'Details', 'jetpack' ) } className="is-beta">
 			<TextControl
 				label={ __( 'Title', 'jetpack' ) }
 				value={ title }

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/components/details-control/index.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/components/details-control/index.scss
@@ -1,0 +1,39 @@
+@import '@automattic/jetpack-base-styles/style';
+
+.is-beta {
+	transition: 0.5s box-shadow linear;
+	position: relative;
+
+	&.is-opened {
+		box-shadow: inset 0 0 3px var( --jp-green-30 );
+	}
+
+	&::before {
+		content: 'BETA';
+		position: absolute;
+		top: 12px;
+		right: 56px;
+		height: 24px;
+		line-height: 24px;
+		font-size: 11px;
+		padding: 0 5px;
+		background-color: var( --jp-green-30 );
+		color: var( --jp-white );
+		border-radius: var( --jp-border-radius );
+		font-weight: 600;
+		z-index: 10000;
+		transition: visibility 0.5s, opacity 0.5s linear;
+		visibility: visible;
+		opacity: 1;
+	}
+
+	&:focus,
+	&:hover {
+		box-shadow: none;
+
+		&::before {
+			opacity: 0;
+			visibility: hidden;
+		}
+	}
+}

--- a/projects/plugins/jetpack/extensions/editor.js
+++ b/projects/plugins/jetpack/extensions/editor.js
@@ -70,7 +70,7 @@ apiFetch.use( ( options, next ) => {
  * @param {string} name - Block name
  * @returns {boolean}     Whether the extension is a beta extension
  */
-function isBetaExtension( name ) {
+export function isBetaExtension( name ) {
 	if ( ! extensionList ) {
 		return;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #26198

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds `beta` style to the `DetailsControl` sidebar component of the `video` block

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* [Enable beta extensions](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/jetpack/extensions/README.md)
* On the block editor (new/edit post), add a `video` block and upload a video
* Select the block and check the `Block` sidebar tab
* It should be as the screenshot shows

open | closed | hover
-------|-----------|--------
![Screenshot_2022-09-16_14-30-55](https://user-images.githubusercontent.com/8486249/190699090-cf7fcd67-0e79-4b5f-aeeb-cfdeb977bf4b.png) | ![Screenshot_2022-09-16_14-31-07](https://user-images.githubusercontent.com/8486249/190699087-25375a33-8abc-4cd7-aa0f-f408f2b2e968.png) | ![Screenshot_2022-09-16_14-31-21](https://user-images.githubusercontent.com/8486249/190699083-3207b99b-d51d-4e7f-b083-ece1d873e718.png)
