### PR TITLE
Social Logos: remove iswpcom check for defusioning

### DIFF
--- a/projects/plugins/jetpack/_inc/social-logos.php
+++ b/projects/plugins/jetpack/_inc/social-logos.php
@@ -8,17 +8,8 @@
  * @package automattic/jetpack
  */
 
-/*
- * Those references to the social logos location can be updated
- * in other environments such as WordPress.com.
- */
-if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-	define( 'JETPACK_SOCIAL_LOGOS_URL', '/wp-content/mu-plugins/social-logos/' );
-	define( 'JETPACK_SOCIAL_LOGOS_DIR', ABSPATH . JETPACK_SOCIAL_LOGOS_URL );
-} else {
-	define( 'JETPACK_SOCIAL_LOGOS_URL', plugin_dir_url( __FILE__ ) . 'social-logos/' );
-	define( 'JETPACK_SOCIAL_LOGOS_DIR', plugin_dir_path( __FILE__ ) . 'social-logos/' );
-}
+define( 'JETPACK_SOCIAL_LOGOS_URL', plugin_dir_url( __FILE__ ) . 'social-logos/' );
+define( 'JETPACK_SOCIAL_LOGOS_DIR', plugin_dir_path( __FILE__ ) . 'social-logos/' );
 
 /**
  * Globally registers the 'social-logos' style and font.

--- a/projects/plugins/jetpack/changelog/update-social-logos-remove-iswpcom-check
+++ b/projects/plugins/jetpack/changelog/update-social-logos-remove-iswpcom-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Jetpack Defusion: remove iswpcom check for social-logos since all files are in sync
+
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

As part of #25233 , remove the iswpcom check since the `/social-logos/` directory is fully synced as-is.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
Internal: p1663348368256779-slack-C032DVAHMK3

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

There should be no functional changes here since `/social-logos/` is currently fusioned/synced.