### PR TITLE
VideoPress: Add default end time for VTT file generation function

### DIFF
--- a/projects/plugins/jetpack/changelog/update-default-long-end-time-chapter-vtt
+++ b/projects/plugins/jetpack/changelog/update-default-long-end-time-chapter-vtt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+VideoPress: Add default end time for vtt file generation function

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/utils/generate-chapters-file.ts
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/utils/generate-chapters-file.ts
@@ -27,7 +27,10 @@ function millisecondsToClockTime( milliseconds: number ) {
  * @param {number} videoDuration - The video duration, in milliseconds
  * @returns {string}             - WebVTT text content
  */
-function generateChaptersFileContent( description: string, videoDuration: number ): string | null {
+function generateChaptersFileContent(
+	description: string,
+	videoDuration = 359999000 // 99:59:59
+): string | null {
 	const chapters = extractVideoChapters( description );
 	if ( chapters.length === 0 ) {
 		return null;

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/utils/test/generate-chapters-file.ts
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/utils/test/generate-chapters-file.ts
@@ -1,13 +1,15 @@
 import { generateChaptersFileContent } from '../generate-chapters-file';
 
 describe( 'generateChaptersFileContent', () => {
-	it( 'generates WebVTT file contents', () => {
-		const description = `
+	describe( 'with video duration', () => {
+		it( 'generates WebVTT file contents', () => {
+			const description = `
 0:00 Chapter 1
 1:42 Chapter 2 - Reloaded
 4:44 Chapter 3 - Revolutions
 `;
-		const expectedResult = `WEBVTT
+			const videoDuration = 300000; // 5 minutes
+			const expectedResult = `WEBVTT
 
 1
 00:00:00.000 --> 00:01:42.000
@@ -21,7 +23,34 @@ Chapter 2 - Reloaded
 00:04:44.001 --> 00:05:00.000
 Chapter 3 - Revolutions
 `;
-		const result = generateChaptersFileContent( description, 300000 );
-		expect( result ).toBe( expectedResult );
+			const result = generateChaptersFileContent( description, videoDuration );
+			expect( result ).toBe( expectedResult );
+		} );
+	} );
+
+	describe( 'without video duration', () => {
+		it( 'generates WebVTT file contents with long end time', () => {
+			const description = `
+0:00 Chapter 1
+1:42 Chapter 2 - Reloaded
+4:44 Chapter 3 - Revolutions
+`;
+			const expectedResult = `WEBVTT
+
+1
+00:00:00.000 --> 00:01:42.000
+Chapter 1
+
+2
+00:01:42.001 --> 00:04:44.000
+Chapter 2 - Reloaded
+
+3
+00:04:44.001 --> 99:59:59.000
+Chapter 3 - Revolutions
+`;
+			const result = generateChaptersFileContent( description );
+			expect( result ).toBe( expectedResult );
+		} );
 	} );
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #26258

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a default end time of `99:59:59` for the last chapter when generating a chapters webVTT file without knowing the video duration

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `jetpack test plugins/jetpack js`
* Check that the `extensions/blocks/videopress/video-chapters/utils/test/generate-chapters-file.ts` test passes

Alternatively

* Add a `video` block in the block editor
* Upload a file
* On the sidebar, add chapters as shown [here](https://github.com/Automattic/jetpack/pull/26260)
* Check that the last chapter works

![Screenshot_2022-09-16_17-43-04](https://user-images.githubusercontent.com/8486249/190729523-8b8e28f9-d7bc-48d3-9ea4-1afe89ab8001.png)
