### PR TITLE
VideoPress: Adjust description textarea size on load

### DIFF
--- a/projects/plugins/jetpack/changelog/update-details-control-description-field
+++ b/projects/plugins/jetpack/changelog/update-details-control-description-field
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+VideoPress: Expand description textarea to accomodate text on block load

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/components/details-control/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/components/details-control/index.js
@@ -15,10 +15,21 @@ const isVideoChaptersEnabled = !! window?.Jetpack_Editor_Initial_State?.availabl
 	VIDEOPRESS_VIDEO_CHAPTERS_FEATURE
 ];
 
+const CHARACTERS_PER_LINE = 31;
+
 export default function DetailsControl( { isRequestingVideoItem } ) {
 	const { attributes, setAttributes } = useBlockAttributes();
 	const { title, description } = attributes;
 	const isBeta = isBetaExtension( VIDEOPRESS_VIDEO_CHAPTERS_FEATURE );
+
+	// Expands the description textarea to accommodate the description
+	const rows = description
+		.split( '\n' )
+		.map( line => Math.ceil( line.length / CHARACTERS_PER_LINE ) || 1 )
+		.reduce( ( sum, current ) => sum + current, 0 );
+	const maxRows = 20;
+	const minRows = 4;
+	const descriptionControlRows = Math.min( maxRows, Math.max( rows, minRows ) );
 
 	if ( ! isVideoChaptersEnabled ) {
 		return null;
@@ -48,6 +59,7 @@ export default function DetailsControl( { isRequestingVideoItem } ) {
 				placeholder={ __( 'Video description', 'jetpack' ) }
 				onChange={ setDescriptionAttribute }
 				disabled={ isRequestingVideoItem }
+				rows={ descriptionControlRows }
 			/>
 		</PanelBody>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/components/details-control/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/components/details-control/index.js
@@ -27,7 +27,7 @@ export default function DetailsControl( { isRequestingVideoItem } ) {
 		.split( '\n' )
 		.map( line => Math.ceil( line.length / CHARACTERS_PER_LINE ) || 1 )
 		.reduce( ( sum, current ) => sum + current, 0 );
-	const maxRows = 20;
+	const maxRows = 12;
 	const minRows = 4;
 	const descriptionControlRows = Math.min( maxRows, Math.max( rows, minRows ) );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #26245

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Computes the necessary number of rows to accommodate the description text on load

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to block editor
* Edit a videopress block
* Change the description
* Save the post
* Hard refresh
* Confirm the description field enlarges to the size of the description up to 12 rows

![Screenshot_2022-09-16_18-47-30](https://user-images.githubusercontent.com/8486249/190802447-c1de81a0-6f9c-4376-b968-20e69fc0aa74.png)
