### PR TITLE
VideoPress: check whether the description is defined before splitting it up

### DIFF
--- a/projects/plugins/jetpack/changelog/update-videopress-fix-computing-desc-lines-bug
+++ b/projects/plugins/jetpack/changelog/update-videopress-fix-computing-desc-lines-bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: check whether the description is defined before to split it up

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/components/details-control/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/components/details-control/index.js
@@ -23,12 +23,15 @@ export default function DetailsControl( { isRequestingVideoItem } ) {
 	const isBeta = isBetaExtension( VIDEOPRESS_VIDEO_CHAPTERS_FEATURE );
 
 	// Expands the description textarea to accommodate the description
-	const rows = description
-		.split( '\n' )
-		.map( line => Math.ceil( line.length / CHARACTERS_PER_LINE ) || 1 )
-		.reduce( ( sum, current ) => sum + current, 0 );
-	const maxRows = 12;
 	const minRows = 4;
+	const maxRows = 12;
+	const rows = description?.length
+		? description
+				.split( '\n' )
+				.map( line => Math.ceil( line.length / CHARACTERS_PER_LINE ) || 1 )
+				.reduce( ( sum, current ) => sum + current, 0 )
+		: minRows;
+
 	const descriptionControlRows = Math.min( maxRows, Math.max( rows, minRows ) );
 
 	if ( ! isVideoChaptersEnabled ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes an issue when the app tries to compute the textarea lines od the description field.

Fixes https://github.com/Automattic/jetpack/issues/26282

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: check whether the description is defined before splitting it up

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to block editor
* edit/create a VideoPress block instance
* Open the sidebar
* Confirm the bug described on [this issue](https://github.com/Automattic/jetpack/issues/26282) is fixed 


