### PR TITLE
VideoPress: check title and description before propagating to block attributes

### DIFF
--- a/projects/plugins/jetpack/changelog/update-videopress-better-sync-data-handling
+++ b/projects/plugins/jetpack/changelog/update-videopress-better-sync-data-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+VideoPress: check title and description before to propagate to block attributes

--- a/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/video-chapters/edit.js
@@ -26,10 +26,19 @@ const withVideoChaptersEdit = createHigherOrderComponent( BlockEdit => props => 
 			return;
 		}
 
-		const freshAttributes = {
-			title: videoItem?.title,
-			description: videoItem?.description,
-		};
+		const freshAttributes = {};
+
+		if ( videoItem?.title ) {
+			freshAttributes.title = videoItem.title;
+		}
+
+		if ( videoItem?.description ) {
+			freshAttributes.description = videoItem.description;
+		}
+
+		if ( ! Object.keys( freshAttributes ).length ) {
+			return;
+		}
 
 		setAttributes( freshAttributes );
 		forceInitialState( freshAttributes );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR enhances the process that keep-in-sync the VideoPress data of the video with the block attributes.

When the block mounts, the app print the title and/or description of the block immediately according to its attributes. However, at the same time, it performs a sync request to keep in sync the data with the VideoPress service.
When the data gets, it updates the local attributes.


Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: check title and description before propagating to block attributes

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Block editor
* Add a VideoPress block
* Edit title and description
* Save
* Hard Refresh
* Before this PR, check the sidebar sometimes shows empty values for title and description kist for a moment.
* After this PR, confirm the title and/or description are printed once the block mounts, and update their values only when there are different compared with what the response provides

