### PR TITLE
Jetpack: Refactor SEO Description panel to reuse title and icon props on Pre-Publish and Jetpack Plugin Sidebar

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-plugin-sidebar-seo-description-icon
+++ b/projects/plugins/jetpack/changelog/update-jetpack-plugin-sidebar-seo-description-icon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Refactor SEO Description panel to share the same code for title and icon on both Pre-Publish panel and Jetpack Plugin Sidebar panel.

--- a/projects/plugins/jetpack/extensions/blocks/seo/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/seo/index.js
@@ -11,28 +11,32 @@ import './editor.scss';
 export const name = 'seo';
 
 export const settings = {
-	render: () => (
-		<Fragment>
-			<JetpackPluginSidebar>
-				<PanelBody
-					title={ __( 'SEO Description', 'jetpack' ) }
-					icon={ <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" /> }
+	render: function JetpackSEODescriptionPanel() {
+		const panelProps = {
+			title: __( 'SEO Description', 'jetpack' ),
+			icon: <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" />,
+		};
+
+		return (
+			<Fragment>
+				<JetpackPluginSidebar>
+					<PanelBody { ...panelProps }>
+						<SeoPanel />
+					</PanelBody>
+				</JetpackPluginSidebar>
+				<PluginPrePublishPanel
+					initialOpen
+					id="seo-title"
+					title={
+						<span id="seo-defaults" key="seo-title-span">
+							{ panelProps.title }
+						</span>
+					}
+					icon={ panelProps.icon }
 				>
 					<SeoPanel />
-				</PanelBody>
-			</JetpackPluginSidebar>
-			<PluginPrePublishPanel
-				initialOpen
-				id="seo-title"
-				title={
-					<span id="seo-defaults" key="seo-title-span">
-						{ __( 'SEO Description', 'jetpack' ) }
-					</span>
-				}
-				icon={ <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" /> }
-			>
-				<SeoPanel />
-			</PluginPrePublishPanel>
-		</Fragment>
-	),
+				</PluginPrePublishPanel>
+			</Fragment>
+		);
+	},
 };

--- a/projects/plugins/jetpack/extensions/blocks/seo/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/seo/index.js
@@ -14,7 +14,10 @@ export const settings = {
 	render: () => (
 		<Fragment>
 			<JetpackPluginSidebar>
-				<PanelBody title={ __( 'SEO Description', 'jetpack' ) }>
+				<PanelBody
+					title={ __( 'SEO Description', 'jetpack' ) }
+					icon={ <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" /> }
+				>
 					<SeoPanel />
 				</PanelBody>
 			</JetpackPluginSidebar>

--- a/projects/plugins/jetpack/extensions/blocks/seo/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/seo/index.js
@@ -12,28 +12,25 @@ export const name = 'seo';
 
 export const settings = {
 	render: function JetpackSEODescriptionPanel() {
-		const panelProps = {
+		const generalPanelProps = {
 			title: __( 'SEO Description', 'jetpack' ),
 			icon: <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" />,
+		};
+
+		const prePublishPanelProps = {
+			...generalPanelProps,
+			initialOpen: true,
+			id: 'seo-title',
 		};
 
 		return (
 			<Fragment>
 				<JetpackPluginSidebar>
-					<PanelBody { ...panelProps }>
+					<PanelBody { ...generalPanelProps }>
 						<SeoPanel />
 					</PanelBody>
 				</JetpackPluginSidebar>
-				<PluginPrePublishPanel
-					initialOpen
-					id="seo-title"
-					title={
-						<span id="seo-defaults" key="seo-title-span">
-							{ panelProps.title }
-						</span>
-					}
-					icon={ panelProps.icon }
-				>
+				<PluginPrePublishPanel { ...prePublishPanelProps }>
 					<SeoPanel />
 				</PluginPrePublishPanel>
 			</Fragment>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26271.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds Jetpack icon on the Jetpack Plugin Sidebar SEO Description panel
* Refactors the code so the title and the icon for both Pre-Publish and Jetpack Plugin Sidebar comes from the same source

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Related to p1HpG7-hDK-p2.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure your local development environment is a Jetpack connected site and that you can access it publicly (using [Jurassic Tube](https://github.com/Automattic/jetpack/blob/trunk/docs/quick-start.md#setting-up-jurassic-tube), for example)
* Build the Jetpack plugin again using `jetpack build plugins/jetpack`
* Go to Jetpack > Settings and enable the "Customize your SEO settings" toggle
* Go to Posts > Add New and add some title to start writing a new post
* Click the Publish button once, so the Pre-Publish panel will show up on the right side of the screen
* **You should see a "SEO Description" block with the Jetpack icon right after the title, like this:**

![jJetpack icon on SEO Description Pre-Publish panel](https://user-images.githubusercontent.com/6760046/191116803-c5dc7b3f-261e-4f0a-a55b-81c87c68d96f.png)

* Publish the post by clicking the Publish button again
* Reload the page
* Click the Jetpack icon at the top, near the Update button:

![jetpack-menu-on-top](https://user-images.githubusercontent.com/6760046/191117552-79ba3fe4-de23-472a-8a3b-bda69c70aa07.png)

* The Jetpack Plugin Sidebar will open
* **You should see a "SEO Description" block with the Jetpack icon right after the title, the same as the first one, like this:**

![jetpack-icon-on-seo-description-jetpack-sidebar](https://user-images.githubusercontent.com/6760046/191117716-c8c4ab21-1b7d-41fd-995c-93f8f9970c52.png)
