### PR TITLE
Masterbar: Apply Calypso 'Add new site' styles to wp-admin

### DIFF
--- a/projects/plugins/jetpack/changelog/update-masterbar-add-new-site-styles
+++ b/projects/plugins/jetpack/changelog/update-masterbar-add-new-site-styles
@@ -1,4 +1,4 @@
 Significance: patch
 Type: compat
 
-Applies Calypso 'Add new site' styles to wp-admin
+Applies Calypso 'Add new site' styles to wp-admin

--- a/projects/plugins/jetpack/changelog/update-masterbar-add-new-site-styles
+++ b/projects/plugins/jetpack/changelog/update-masterbar-add-new-site-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Applies Calypso 'Add new site' styles to wp-admin

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -528,3 +528,53 @@
 .screen-switcher__button:focus > strong, .screen-switcher__button:hover > strong, a.screen-switcher__button:focus > strong, a.screen-switcher__button:hover > strong {
 	color:var(--wp-admin-theme-color)
 }
+
+/** Add new site button **/
+#adminmenu {
+	display: flex;
+	flex-direction: column;
+}
+#adminmenu .menu-top[class*="/start?ref=calypso-sidebar"] {
+	order: 99999;
+}
+
+body:not(.folded) #adminmenu .menu-top[class*="/start?ref=calypso-sidebar"] {
+	padding: 8px;
+}
+
+body:not(.folded) #adminmenu .menu-top[class*="/start?ref=calypso-sidebar"] a {
+	background: transparent;
+	border-color: var(--transparent-button-text-color, currentcolor);
+	display: flex;
+	justify-content: center;
+	margin-top: auto;
+	background: transparent;
+	border-style: solid;
+	border-width: 1px;
+	cursor: pointer;
+	margin: 0;
+	outline: 0;
+	overflow: hidden;
+	text-align: center;
+	text-overflow: ellipsis;
+	text-decoration: none;
+	vertical-align: top;
+	box-sizing: border-box;
+	font-size: 14px;
+	line-height: 22px;
+	border-radius: 2px;
+	padding: 8px 14px;
+	appearance: none;
+}
+
+body:not(.folded) #adminmenu .menu-top[class*="/start?ref=calypso-sidebar"] a:hover {
+	box-shadow: none;
+}
+
+body:not(.folded) #adminmenu .menu-top[class*="/start?ref=calypso-sidebar"] a .wp-menu-name {
+	padding: 0;
+}
+
+body:not(.folded) #adminmenu .menu-top[class*="/start?ref=calypso-sidebar"] a .wp-menu-image {
+	display: none;
+}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -540,6 +540,7 @@
 
 body:not(.folded) #adminmenu .menu-top[class*="/start?ref=calypso-sidebar"] {
 	padding: 8px;
+	width: auto;
 }
 
 body:not(.folded) #adminmenu .menu-top[class*="/start?ref=calypso-sidebar"] a {

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -186,7 +186,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			return;
 		}
 
-		$this->add_admin_menu_separator();
 		add_menu_page( __( 'Add New Site', 'jetpack' ), __( 'Add New Site', 'jetpack' ), 'read', 'https://wordpress.com/start?ref=calypso-sidebar', null, 'dashicons-plus-alt' );
 	}
 


### PR DESCRIPTION
Fixes 897-gh-Automattic/dotcom-forge

## Proposed changes

Applies Calypso's 'Add new site' button styles to wp-admin:

<img width="798" alt="image" src="https://user-images.githubusercontent.com/36432/191133855-0f21cb49-c9d7-4753-a6bb-903e980bd22e.png">

Note: The button doesn't sit all of the way on the bottom (like it does in Calypso) because `#adminmenuwrap` uses `position: fixed;` to make the sidebar sticky. Given core's admin CSS is a total mess, I don't think it's worth going beyond what I've proposed in this PR.

## Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

## Jetpack product discussion

N/A.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

1. Create a new free WordPress.com site with a new WordPress.com user.
2. Apply the patch to your sandbox.
3. Sandbox the new WordPress.com site.
4. Navigate to `<sitename>.wordpress.com/wp-admin/` and observe the 'Add new site' styling in a few browsers.
5. Add some free credits to the WordPress.com user.
6. Upgrade the WordPress.com site to a Business plan.
7. Activate hosting features for the WordPress.com site.
8. Install [Jetpack beta plugin](https://jetpack.com/download-jetpack-beta/) and switch to this branch: `update/masterbar-add-new-site-styles`
9. Navigate to `<sitename>.wpcomstaging.com/wp-admin/` and observe the 'Add new site' styling in a few browsers.