### PR TITLE
[plugin]Backup: add watch command to backup plugin

### DIFF
--- a/projects/plugins/backup/changelog/add-watch-to-backup-plugin
+++ b/projects/plugins/backup/changelog/add-watch-to-backup-plugin
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Added watch
+
+

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -18,7 +18,9 @@
 			"src/"
 		]
 	},
-	"scripts": {},
+	"scripts": {
++               "watch": "echo 'This script is actually watching the Jetpack Backup package, not the plugin' && jetpack watch packages/backup"
++       },
 	"repositories": [
 		{
 			"type": "path",

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -19,8 +19,8 @@
 		]
 	},
 	"scripts": {
-+               "watch": "echo 'This script is actually watching the Jetpack Backup package, not the plugin' && jetpack watch packages/backup"
-+       },
+		"watch": "echo 'This script is actually watching the Jetpack Backup package, not the plugin' && jetpack watch packages/backup"
+	},
 	"repositories": [
 		{
 			"type": "path",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26132 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add watch command, `jetpack watch plugins/backup`.  
It runs the same scripts to watch packages/backup.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?


#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply patch
* Open the command line in the jetpack directory and run `jetpack watch plugins/backup`
* Confirm that it works

