### PR TITLE
ConnectionErrorNotice: use Button component 

### DIFF
--- a/projects/js-packages/connection/changelog/modify-connection-error-notice-button
+++ b/projects/js-packages/connection/changelog/modify-connection-error-notice-button
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Changed a tag with Button component in ConnectionErrorNotice
+
+

--- a/projects/js-packages/connection/components/connection-error-notice/index.jsx
+++ b/projects/js-packages/connection/components/connection-error-notice/index.jsx
@@ -22,7 +22,7 @@ const ConnectErrorNotice = () => {
 				<Notice status={ 'error' } isDismissible={ false } className={ styles.notice }>
 					<Icon icon={ warning } />
 					<div className={ styles.message }>{ errors[ 0 ].error_message }</div>
-					<Button variant="external-link" weight="bold" className={ styles.link }>
+					<Button variant="link" className={ styles.link } href="#">
 						{ __( 'Restore Connection', 'jetpack' ) }
 					</Button>
 				</Notice>

--- a/projects/js-packages/connection/components/connection-error-notice/index.jsx
+++ b/projects/js-packages/connection/components/connection-error-notice/index.jsx
@@ -1,3 +1,4 @@
+import { Button } from '@automattic/jetpack-components';
 import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, warning } from '@wordpress/icons';
@@ -21,7 +22,9 @@ const ConnectErrorNotice = () => {
 				<Notice status={ 'error' } isDismissible={ false } className={ styles.notice }>
 					<Icon icon={ warning } />
 					<div className={ styles.message }>{ errors[ 0 ].error_message }</div>
-					<a className={ styles.link }>{ __( 'Restore Connection', 'jetpack' ) }</a>
+					<Button variant="external-link" weight="bold" className={ styles.link }>
+						{ __( 'Restore Connection', 'jetpack' ) }
+					</Button>
 				</Notice>
 			);
 		}

--- a/projects/js-packages/connection/components/connection-error-notice/styles.module.scss
+++ b/projects/js-packages/connection/components/connection-error-notice/styles.module.scss
@@ -39,13 +39,13 @@
 	svg {
 		flex-shrink: 0;
 	}
+
+	.link {
+		margin-left: auto;
+	}
 }
 
 .message {
 	margin-left: 8px;
 }
 
-.link {
-	margin-left: auto;
-	text-decoration: underline;
-}

--- a/projects/js-packages/connection/components/connection-error-notice/styles.module.scss
+++ b/projects/js-packages/connection/components/connection-error-notice/styles.module.scss
@@ -47,6 +47,5 @@
 
 .link {
 	margin-left: auto;
-	padding-left: var( --spacing-base );
 	text-decoration: underline;
 }

--- a/projects/js-packages/connection/components/connection-error-notice/styles.module.scss
+++ b/projects/js-packages/connection/components/connection-error-notice/styles.module.scss
@@ -47,8 +47,6 @@
 
 .link {
 	margin-left: auto;
-	padding-left: 8px;
+	padding-left: var( --spacing-base );
 	text-decoration: underline;
-	color: var( --jp-black );
-	font-weight:700;
 }

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.20.0",
+	"version": "0.20.1-alpha",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26293

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Modify component ConnectionErrorNotice so it uses the Button component instead of the <a> HTML tag.
* Remove CSS definitions for color and weight and use the ones defined by the component instead

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1663676919306359-slack-C02TQF5VAJD

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the steps in [this PR](https://github.com/Automattic/jetpack/pull/26259)
* Make the component visible by [adding it again here](https://github.com/Automattic/jetpack/pull/26259/commits/7b546aeb3b37c7a683c42517e1ab57e42b965fd7)
* Confirm that the message is styled as expected:
* 
![Screen Shot 2022-09-20 at 17 29 00](https://user-images.githubusercontent.com/16329583/191303372-07ba1845-8cba-44b0-b697-7d4b28e00896.png)


