### PR TITLE
Connection: Add ConnectionErrorNotice integration to the Jetpack plugin

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -6,6 +6,7 @@ import {
 	Col,
 	Text,
 } from '@automattic/jetpack-components';
+import { ConnectionErrorNotice } from '@automattic/jetpack-connection';
 import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, warning, info } from '@wordpress/icons';
@@ -72,6 +73,9 @@ export default function MyJetpackScreen() {
 						<Text variant="headline-small">
 							{ __( 'Manage your Jetpack products', 'jetpack-my-jetpack' ) }
 						</Text>
+					</Col>
+					<Col>
+						<ConnectionErrorNotice />
 					</Col>
 					{ message && (
 						<Col>

--- a/projects/packages/my-jetpack/changelog/add-jetpack-display-connect-error-notice
+++ b/projects/packages/my-jetpack/changelog/add-jetpack-display-connect-error-notice
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Display error connection notices in the Jetpack plugin.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Add the new verified connection error notices to the back-end pages of the Jetpack plugin. This is part of a bigger project (1202697549597858-as) to provide consistent failed connection error reporting and an interface to reconnect (1202697549597858-as-1202697549597864). 

The changes will affect the following:
* Jetpack
* Connection

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
* p9dueE-5w8-p2

#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:
* Run `jetpack build packages/my-jetpack`.
* Enable the "Jetpack Debug Tools" plugin.
* Go to Jetpack Debug > Jetpack Debug.
* Enable "Broken token Utilities" and click "Save".
* Go to Jetpack Debug > Connection Errors
* Under "Create fake errors", select "With the blog token", select "Verified", and click the "Create error" button.
* Go to Jetpack > My Jetpack.
* You should see an error message as shown in the below screenshot:
![jetpack-connection-error-example](https://user-images.githubusercontent.com/56307/190708871-b9c573e3-0e90-451c-8fc0-7de2ebcd8d2e.png)