### PR TITLE
Fix value for SelectControl in block visibility 

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-block-visibility-action-select-value
+++ b/projects/plugins/jetpack/changelog/fix-block-visibility-action-select-value
@@ -1,5 +1,5 @@
 Significance: patch
 Type: bugfix
-Comment: Widget visibility: - fixes issue where customizer wasn't properly showing the set visibility settings.
+Comment: Widget visibility: fixes issue where customizer wasn't properly showing the set visibility settings.
 
 

--- a/projects/plugins/jetpack/changelog/fix-block-visibility-action-select-value
+++ b/projects/plugins/jetpack/changelog/fix-block-visibility-action-select-value
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Minor
+
+

--- a/projects/plugins/jetpack/changelog/fix-block-visibility-action-select-value
+++ b/projects/plugins/jetpack/changelog/fix-block-visibility-action-select-value
@@ -1,5 +1,5 @@
 Significance: patch
 Type: bugfix
-Comment: Minor
+Widget visibility: Fixes issue where customizer wasn't properly showing the set visibility settings.
 
 

--- a/projects/plugins/jetpack/changelog/fix-block-visibility-action-select-value
+++ b/projects/plugins/jetpack/changelog/fix-block-visibility-action-select-value
@@ -1,5 +1,5 @@
 Significance: patch
 Type: bugfix
-Widget visibility: Fixes issue where customizer wasn't properly showing the set visibility settings.
+Comment: Widget visibility: - fixes issue where customizer wasn't properly showing the set visibility settings.
 
 

--- a/projects/plugins/jetpack/modules/widget-visibility/editor/index.jsx
+++ b/projects/plugins/jetpack/modules/widget-visibility/editor/index.jsx
@@ -363,7 +363,7 @@ const visibilityAdvancedControls = createHigherOrderComponent(
 						className="widget-vis__show-hide"
 						label={ __( 'Action', 'jetpack' ) }
 						hideLabelFromVision
-						value={ attributes.action }
+						value={ attributes.conditions.action }
 						options={ [
 							{ label: __( 'Show this block', 'jetpack' ), value: 'show' },
 							{ label: __( 'Hide this block', 'jetpack' ), value: 'hide' },


### PR DESCRIPTION
Fixes issue discussed in this comment https://github.com/Automattic/jetpack/issues/21519#issuecomment-1252067141

#### Changes proposed in this Pull Request:
Changes the variable used for the value attribute of the SelectControl used within the block visibility plugin to choose whether rules are Show or Hide conditions. The value was expecting an "action" attribute when the "action" variable is actually within the "conditions" attribute.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] 
#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

* With a theme active that has a sidebar (such as Twenty Twenty) go to Appearance > Widgets
* Select a parent block in the sidebar that has Visibility options available
* Add a condition using "Show this block" in the Visibility drop down
* Save and refresh, checking the settings remain
* Change the dropdown to "HIde this block", save and refresh
* Observe that before this PR the dropdown returns back to "Show this block" and afterwards it updates as expected. 

