### PR TITLE
Check request body error type before creating wp error

### DIFF
--- a/projects/packages/connection/changelog/fix-4779
+++ b/projects/packages/connection/changelog/fix-4779
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Check request body error type before creating wp error

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -710,7 +710,7 @@ class Error_Handler {
 		}
 
 		$body = json_decode( $body_raw, true );
-		if ( empty( $body['error'] ) ) {
+		if ( empty( $body['error'] ) || ( ! is_string( $body['error'] ) && ! is_int( $body['error'] ) ) ) {
 			return;
 		}
 

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.45.1';
+	const PACKAGE_VERSION = '1.45.2-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 


### PR DESCRIPTION
Stripe formats its error messages as an array but the Jetpack request is looking for errors as strings.  WCPay already checks whether the response is an error and throws an API_Exception so this PR only ignores errors that are not strings so we don't have any critical errors in `WP_Error`. 

Fixes https://github.com/Automattic/woocommerce-payments/issues/4779#issuecomment-1251972023

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Check request body error type and ignore non-string error before creating `WP_Error`

#### Testing instructions:
To reproduce this error, you'll need:
- PHP 8.0+ (since invalid offsets are a warning in PHP 7.4 but an [error in PHP 8.0](https://www.php.net/manual/en/migration80.incompatible.php))
- Install Jetpack 11.3+ on your site
- Create a subscription product with a free trial
- Complete checkout with the test card number `4000000000000002` (generic decline)

<img width="674" alt="Screen Shot 2022-09-19 at 3 57 21 PM" src="https://user-images.githubusercontent.com/56378160/191394825-06f3eda9-8f00-42a7-bf83-e7990cc5f03e.png">

If check out this PR, shouldn't see this error.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->