### PR TITLE
Jetpack Social: Don't show the usage metre if someone has a paid plan 

### DIFF
--- a/projects/plugins/social/changelog/add-limits-for-paid-users
+++ b/projects/plugins/social/changelog/add-limits-for-paid-users
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added check to not show the share metre if someone has a paid plan.

--- a/projects/plugins/social/src/js/components/header/index.js
+++ b/projects/plugins/social/src/js/components/header/index.js
@@ -22,6 +22,7 @@ const Header = () => {
 		sharesCount,
 		postsCount,
 		isShareLimitEnabled,
+		hasPaidPlan,
 	} = useSelect( select => {
 		const store = select( STORE_ID );
 		return {
@@ -31,6 +32,7 @@ const Header = () => {
 			sharesCount: select( STORE_ID ).getSharesCount(),
 			postsCount: select( STORE_ID ).getPostsCount(),
 			isShareLimitEnabled: select( STORE_ID ).isShareLimitEnabled(),
+			hasPaidPlan: select( STORE_ID ).hasPaidPlan(),
 		};
 	} );
 
@@ -61,7 +63,7 @@ const Header = () => {
 					</div>
 				</Col>
 				<Col sm={ 4 } md={ 4 } lg={ { start: 7, end: 12 } }>
-					{ isShareLimitEnabled ? (
+					{ isShareLimitEnabled && ! hasPaidPlan ? (
 						<ShareCounter value={ sharesCount } max={ 30 } />
 					) : (
 						<StatCards


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* If someone has a paid plan and has the blog sticker enabled, they should not be seeing the usage metre. Instead, they should be seeing this screen. 
<img width="1466" alt="Screenshot 2022-09-21 at 2 35 49 PM" src="https://user-images.githubusercontent.com/6594561/191463608-f6b475f7-0f83-4ed8-99af-f595c2c82fd2.png">


#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1663750556634349-slack-C02JJ910CNL
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Without the blog sticker, you should not see the usage metre
* With the blog sticker and without a paid plan, you should see the usage metre
* With the blog sticker and with a paid plan, you should not see the usage metre