### PR TITLE
VideoPress: hit wp/v2/media to request videos data

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-replace-admin-ajax-by-wp-v2-media-endpoint
+++ b/projects/packages/videopress/changelog/update-videopress-replace-admin-ajax-by-wp-v2-media-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: hit wp/v2/media to request videos data

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.4.0",
+	"version": "0.4.1-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.4.0';
+	const PACKAGE_VERSION = '0.4.1-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/client/admin/components/video-grid/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-grid/index.tsx
@@ -46,7 +46,7 @@ const VideoGrid = ( { videos, count = 6, onVideoDetailsClick }: VideoGridProps )
 							<VideoCard
 								id={ video.id }
 								title={ video.title }
-								thumbnail={ video?.posterImage }
+								thumbnail={ video?.posterImage } // TODO: we should use thumbnail when the API is ready https://github.com/Automattic/jetpack/issues/26319
 								duration={ video.duration }
 								uploadDate={ video.uploadDate }
 								plays={ video.plays }

--- a/projects/packages/videopress/src/client/admin/types/index.ts
+++ b/projects/packages/videopress/src/client/admin/types/index.ts
@@ -22,10 +22,6 @@ export type OriginalVideoPressVideo = {
 	 */
 	filename: string;
 	/**
-	 * Video poster image URL
-	 */
-	posterImage?: string;
-	/**
 	 * Video uploaded date in UTC
 	 */
 	date: number;
@@ -49,10 +45,16 @@ export type OriginalVideoPressVideo = {
 	 * Whether the video is private, or not.
 	 */
 	isPrivate?: boolean;
+
+	/**
+	 * Video poster image URL
+	 */
+	posterImage?: string;
+
 	/**
 	 * Object reflecting poster image data.
 	 */
-	image?: {
+	poster?: {
 		/**
 		 * Video poster image URL
 		 */
@@ -66,6 +68,11 @@ export type OriginalVideoPressVideo = {
 		 */
 		height: number;
 	};
+
+	/**
+	 * Video thumbnail image URL
+	 */
+	thumbnail?: string;
 };
 
 export type VideoPressVideo = Omit< OriginalVideoPressVideo, 'videoTitle' > & {

--- a/projects/packages/videopress/src/client/admin/types/index.ts
+++ b/projects/packages/videopress/src/client/admin/types/index.ts
@@ -74,6 +74,10 @@ export type VideoPressVideo = Omit< OriginalVideoPressVideo, 'videoTitle' > & {
 	 */
 	title: string;
 	/**
+	 * VideoPress GUID
+	 */
+	guid?: string;
+	/**
 	 * Video upload date
 	 */
 	uploadDate: string;

--- a/projects/packages/videopress/src/client/state/README.md
+++ b/projects/packages/videopress/src/client/state/README.md
@@ -13,7 +13,7 @@ export default function VideoList() {
 	const videos = useSelect( select => select( 'videopress/media' ).getVideos( {
 		itemsPerPage: 10,
 		orderBy: 'date',
-		order: 'DESC',
+		order: 'desc',
 	} ), [] );
 
 	return (

--- a/projects/packages/videopress/src/client/state/constants.js
+++ b/projects/packages/videopress/src/client/state/constants.js
@@ -2,10 +2,11 @@
  * STORE
  */
 export const STORE_ID = 'videopress/media';
+
 /*
  * API
  */
-export const REST_API_SITE_PURCHASES_ENDPOINT = '/wp-admin/admin-ajax.php';
+export const WP_ADMIN_AJAX_API_URL = '/wp-admin/admin-ajax.php';
 
 /*
  * Actions

--- a/projects/packages/videopress/src/client/state/constants.js
+++ b/projects/packages/videopress/src/client/state/constants.js
@@ -7,6 +7,7 @@ export const STORE_ID = 'videopress/media';
  * API
  */
 export const WP_ADMIN_AJAX_API_URL = '/wp-admin/admin-ajax.php';
+export const WP_REST_API_MEDIA_ENDPOINT = '/wp/v2/media';
 
 /*
  * Actions

--- a/projects/packages/videopress/src/client/state/reducers.js
+++ b/projects/packages/videopress/src/client/state/reducers.js
@@ -20,8 +20,8 @@ import {
  */
 export function getDefaultQuery() {
 	return {
+		order: 'desc',
 		orderBy: 'date',
-		order: 'DESC',
 		itemsPerPage: 6,
 		page: 1,
 		type: 'video/videopress',

--- a/projects/packages/videopress/src/client/state/resolvers.js
+++ b/projects/packages/videopress/src/client/state/resolvers.js
@@ -34,6 +34,10 @@ const getVideos = {
 			mime_type: 'video/videopress',
 		};
 
+		if ( typeof query.search === 'string' && query.search.length > 0 ) {
+			wpv2MediaQuery.search = query.search;
+		}
+
 		dispatch.setIsFetchingVideos( true );
 
 		try {

--- a/projects/packages/videopress/src/client/state/resolvers.js
+++ b/projects/packages/videopress/src/client/state/resolvers.js
@@ -1,16 +1,18 @@
 /**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+/**
  * Internal dependencies
  */
-import { WP_ADMIN_AJAX_API_URL, SET_VIDEOS_QUERY } from './constants';
+import { SET_VIDEOS_QUERY, WP_REST_API_MEDIA_ENDPOINT } from './constants';
 import { getDefaultQuery } from './reducers';
 
 const getVideos = {
 	fulfill: () => async ( { dispatch, select } ) => {
-		const payload = new FormData();
-		payload.set( 'action', 'query-attachments' );
-		payload.set( 'post_id', 0 );
-
 		let query = select.getVideosQuery();
+
 		/*
 		 * If there is no query:
 		 * - set the default query (dispatch)
@@ -21,31 +23,25 @@ const getVideos = {
 			dispatch.setVideosQuery( query );
 		}
 
-		payload.set( 'query[orderby]', query.orderBy );
-		payload.set( 'query[order]', query.order );
-		payload.set( 'query[posts_per_page]', query.itemsPerPage );
-		payload.set( 'query[paged]', query.page );
-		payload.set( 'query[post_mime_type]', query.type );
-
-		if ( typeof query.search === 'string' && query.search.length > 0 ) {
-			payload.set( 'query[s]', query.search );
-		}
+		// Map query to the format expected by the API.
+		const wpv2MediaQuery = {
+			order: query.order,
+			orderby: query.orderBy,
+			page: query.page,
+			per_page: query.itemsPerPage,
+			media_type: 'video',
+			mime_type: 'video/videopress',
+		};
 
 		dispatch.setIsFetchingVideos( true );
 
 		try {
-			const response = await fetch( WP_ADMIN_AJAX_API_URL, {
-				method: 'POST',
-				body: payload,
+			const videosList = await apiFetch( {
+				path: addQueryArgs( WP_REST_API_MEDIA_ENDPOINT, wpv2MediaQuery ),
 			} );
 
-			const body = await response.json();
-			if ( ! body.success ) {
-				return dispatch.setFetchVideosError( body.data );
-			}
-
-			dispatch.setVideos( body.data );
-			return body.data;
+			dispatch.setVideos( videosList );
+			return videosList;
 		} catch ( error ) {
 			dispatch.setFetchVideosError( error );
 		}

--- a/projects/packages/videopress/src/client/state/resolvers.js
+++ b/projects/packages/videopress/src/client/state/resolvers.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { REST_API_SITE_PURCHASES_ENDPOINT, SET_VIDEOS_QUERY } from './constants';
+import { WP_ADMIN_AJAX_API_URL, SET_VIDEOS_QUERY } from './constants';
 import { getDefaultQuery } from './reducers';
 
 const getVideos = {
@@ -34,7 +34,7 @@ const getVideos = {
 		dispatch.setIsFetchingVideos( true );
 
 		try {
-			const response = await fetch( REST_API_SITE_PURCHASES_ENDPOINT, {
+			const response = await fetch( WP_ADMIN_AJAX_API_URL, {
 				method: 'POST',
 				body: payload,
 			} );

--- a/projects/packages/videopress/src/client/state/resolvers.js
+++ b/projects/packages/videopress/src/client/state/resolvers.js
@@ -8,6 +8,7 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import { SET_VIDEOS_QUERY, WP_REST_API_MEDIA_ENDPOINT } from './constants';
 import { getDefaultQuery } from './reducers';
+import { mapVideosFromWPV2MediaEndpoint } from './utils/map-videos';
 
 const getVideos = {
 	fulfill: () => async ( { dispatch, select } ) => {
@@ -40,7 +41,7 @@ const getVideos = {
 				path: addQueryArgs( WP_REST_API_MEDIA_ENDPOINT, wpv2MediaQuery ),
 			} );
 
-			dispatch.setVideos( videosList );
+			dispatch.setVideos( mapVideosFromWPV2MediaEndpoint( videosList ) );
 			return videosList;
 		} catch ( error ) {
 			dispatch.setFetchVideosError( error );

--- a/projects/packages/videopress/src/client/state/selectors.js
+++ b/projects/packages/videopress/src/client/state/selectors.js
@@ -1,7 +1,5 @@
-import { mapVideos } from './utils/map-videos';
-
 export const getVideos = state => {
-	return mapVideos( state?.videos?.items || [] );
+	return state?.videos?.items || [];
 };
 
 export const getVideosQuery = state => {

--- a/projects/packages/videopress/src/client/state/utils/map-videos.ts
+++ b/projects/packages/videopress/src/client/state/utils/map-videos.ts
@@ -23,7 +23,7 @@ export const mapVideos = ( videos: OriginalVideoPressVideo[] ): VideoPressVideo[
 export const mapVideoFromWPV2MediaEndpoint = (
 	video: OriginalVideoPressVideo
 ): VideoPressVideo => {
-	const { media_details: mediaDetails, id, caption } = video;
+	const { media_details: mediaDetails, id, caption, jetpack_videopress_guid: guid } = video;
 
 	const { videopress: videoPressMediaDetails, width, height } = mediaDetails;
 
@@ -46,6 +46,7 @@ export const mapVideoFromWPV2MediaEndpoint = (
 
 	return {
 		id,
+		guid,
 		title,
 		description,
 		caption,

--- a/projects/packages/videopress/src/client/state/utils/map-videos.ts
+++ b/projects/packages/videopress/src/client/state/utils/map-videos.ts
@@ -16,6 +16,7 @@ export const mapVideo = ( video: OriginalVideoPressVideo ): VideoPressVideo => {
 	};
 };
 
+// priobably @deprecated since it was used when hitting the admin-ajax endpoint
 export const mapVideos = ( videos: OriginalVideoPressVideo[] ): VideoPressVideo[] => {
 	return videos.map( mapVideo );
 };
@@ -41,8 +42,11 @@ export const mapVideoFromWPV2MediaEndpoint = (
 
 	const { dvd } = files;
 
-	// Pick poster image from dvd file type.
-	const dvdImage = `${ fileURLBase.https }${ dvd.original_img }`;
+	/*
+	 * Define thumbnail picking the image from DVD file type
+	 * Issue: https://github.com/Automattic/jetpack/issues/26319
+	 */
+	const thumbnail = `${ fileURLBase.https }${ dvd.original_img }`;
 
 	return {
 		id,
@@ -51,16 +55,17 @@ export const mapVideoFromWPV2MediaEndpoint = (
 		description,
 		caption,
 		url,
-		posterImage: poster,
 		date,
 		duration,
 		isPrivate,
 		dateFormatted: gmdateI18n( 'F j, Y', date ),
-		image: {
-			src: dvdImage,
+		posterImage: poster,
+		poster: {
+			src: poster,
 			width,
 			height,
 		},
+		thumbnail,
 	};
 };
 

--- a/projects/packages/videopress/src/client/state/utils/map-videos.ts
+++ b/projects/packages/videopress/src/client/state/utils/map-videos.ts
@@ -1,3 +1,10 @@
+/**
+ * External dependencies
+ */
+import { gmdateI18n } from '@wordpress/date';
+/**
+ * Internal dependencies
+ */
 import { OriginalVideoPressVideo, VideoPressVideo } from '../types';
 
 export const mapVideo = ( video: OriginalVideoPressVideo ): VideoPressVideo => {
@@ -11,4 +18,53 @@ export const mapVideo = ( video: OriginalVideoPressVideo ): VideoPressVideo => {
 
 export const mapVideos = ( videos: OriginalVideoPressVideo[] ): VideoPressVideo[] => {
 	return videos.map( mapVideo );
+};
+
+export const mapVideoFromWPV2MediaEndpoint = (
+	video: OriginalVideoPressVideo
+): VideoPressVideo => {
+	const { media_details: mediaDetails, id, caption } = video;
+
+	const { videopress: videoPressMediaDetails, width, height } = mediaDetails;
+
+	const {
+		title,
+		description,
+		original: url,
+		poster,
+		upload_date: date,
+		duration,
+		is_private: isPrivate,
+		file_url_base: fileURLBase,
+		files,
+	} = videoPressMediaDetails;
+
+	const { dvd } = files;
+
+	// Pick poster image from dvd file type.
+	const dvdImage = `${ fileURLBase.https }${ dvd.original_img }`;
+
+	return {
+		id,
+		title,
+		description,
+		caption,
+		url,
+		posterImage: poster,
+		date,
+		duration,
+		isPrivate,
+		dateFormatted: gmdateI18n( 'F j, Y', date ),
+		image: {
+			src: dvdImage,
+			width,
+			height,
+		},
+	};
+};
+
+export const mapVideosFromWPV2MediaEndpoint = (
+	videos: OriginalVideoPressVideo[]
+): VideoPressVideo => {
+	return videos.map( mapVideoFromWPV2MediaEndpoint );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

On this PR

* Replace the admin-ajax endpoint with the wp/v2/media endpoint
* Adjust the wp/v2/media request response body to fit with what the app expects about the video data shape

The `/wp/v2/media` endpoint provides almost all data that we need to implement the UI. Some of these data are located in the `jetpack_videopress` and `jetpack_videopress_guid` fields, but also in the `media_details` field.

This PR adds the `mapVideosFromWPV2MediaEndpoint()` helper to organize the data based on what the response body provides, and pass them through to the components.
Also, this action happens just before sending the data to the store.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress:  replace the admin-ajax endpoint with the wp/v2/media endpoint to request videos data

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with a site with some VP vides
* Go to VP dashboard
* Confirm you see the videos in the library
* There are some data exposed and processed that you should confirm you see: `duration`, `url`, `date`, `dateFormatted`. Disclaimer: `Caption` is not properly addressed. 
* Confirm the post image is lighter than the current one, since it picks the `dvd` version of it.

<img width="904" alt="Screen Shot 2022-09-21 at 10 30 53" src="https://user-images.githubusercontent.com/77539/191521780-c4ccca4b-aa71-490c-be35-607995658fc6.png">
<img width="519" alt="Screen Shot 2022-09-21 at 10 30 31" src="https://user-images.githubusercontent.com/77539/191521785-862dca78-cf29-45fe-aaa9-9e04df21b6b3.png">


* additionally, you can take a look at the store to see the data structure

<img width="693" alt="image" src="https://user-images.githubusercontent.com/77539/191522201-d03c58ce-f129-4361-b6a8-1113f0c95145.png">

