### PR TITLE
Search: Move JetpackColophon and enforce display on the free tier

### DIFF
--- a/projects/packages/search/changelog/update-pricing-tier-move-colophon
+++ b/projects/packages/search/changelog/update-pricing-tier-move-colophon
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Move JetpackColophon to bottom of SearchResults

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -70,7 +70,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.22.x-dev"
+			"dev-trunk": "0.23.x-dev"
 		},
 		"version-constants": {
 			"::VERSION": "src/class-package.php"

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.22.2",
+	"version": "0.23.0-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-helper.php
+++ b/projects/packages/search/src/class-helper.php
@@ -839,6 +839,11 @@ class Helper {
 		$is_private_site           = '-1' === get_option( 'blog_public' );
 		$is_jetpack_photon_enabled = method_exists( 'Jetpack', 'is_module_active' ) && Jetpack::is_module_active( 'photon' );
 
+		// @todo Determine $show_powered_by by real pricing tier
+		// $show_powered_by = get_option( $prefix . 'show_powered_by', '1' ) === '1';
+		//phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$show_powered_by = isset( $_GET['free_tier'] ) && $_GET['free_tier'] === '1';
+
 		$options = array(
 			'overlayOptions'        => array(
 				'colorTheme'        => get_option( $prefix . 'color_theme', 'light' ),
@@ -847,7 +852,7 @@ class Helper {
 				'highlightColor'    => get_option( $prefix . 'highlight_color', '#FFC' ),
 				'overlayTrigger'    => get_option( $prefix . 'overlay_trigger', Options::DEFAULT_OVERLAY_TRIGGER ),
 				'resultFormat'      => get_option( $prefix . 'result_format', Options::RESULT_FORMAT_MINIMAL ),
-				'showPoweredBy'     => get_option( $prefix . 'show_powered_by', '1' ) === '1',
+				'showPoweredBy'     => $show_powered_by,
 
 				// These options require kicking off a new search.
 				'defaultSort'       => get_option( $prefix . 'default_sort', 'relevance' ),

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.22.2';
+	const VERSION = '0.23.0-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/customberg/components/app-wrapper/styles.scss
+++ b/projects/packages/search/src/customberg/components/app-wrapper/styles.scss
@@ -20,7 +20,7 @@
 		// Needs to have equal z-index to .interface-interface-skeleton__sidebar.
 		z-index: 90;
 
-		.jetpack-instant-search__search-results {
+		.jetpack-instant-search__search-wrapper {
 			max-width: initial;
 		}
 

--- a/projects/packages/search/src/instant-search/components/jetpack-colophon.jsx
+++ b/projects/packages/search/src/instant-search/components/jetpack-colophon.jsx
@@ -45,8 +45,8 @@ const JetpackColophon = props => {
 	const locale_prefix = typeof props.locale === 'string' ? props.locale.split( '-', 1 )[ 0 ] : null;
 	const url =
 		locale_prefix && locale_prefix !== 'en'
-			? 'https://' + locale_prefix + '.jetpack.com/search?utm_source=poweredby'
-			: 'https://jetpack.com/search?utm_source=poweredby';
+			? 'https://' + locale_prefix + '.jetpack.com/support/search?utm_source=poweredby'
+			: 'https://jetpack.com/support/search/?utm_source=poweredby';
 	return (
 		<div className="jetpack-instant-search__jetpack-colophon">
 			<a
@@ -57,7 +57,7 @@ const JetpackColophon = props => {
 			>
 				{ svg }
 				<span className="jetpack-instant-search__jetpack-colophon-text">
-					{ __( 'Search powered by Jetpack', 'jetpack-search-pkg' ) }
+					{ __( 'Search powered by Jetpack Search', 'jetpack-search-pkg' ) }
 				</span>
 			</a>
 		</div>

--- a/projects/packages/search/src/instant-search/components/jetpack-colophon.scss
+++ b/projects/packages/search/src/instant-search/components/jetpack-colophon.scss
@@ -20,8 +20,9 @@
 }
 
 .jetpack-instant-search__jetpack-colophon-text {
-	color: $color-text-light;
+	color: $studio-gray-80;
 	font-size: 0.7em;
-	font-weight: 400;
-	padding-left: 6px;
+	font-weight: 500;
+	padding-left: 12px;
+	line-height: 16px;
 }

--- a/projects/packages/search/src/instant-search/components/overlay.scss
+++ b/projects/packages/search/src/instant-search/components/overlay.scss
@@ -42,7 +42,12 @@ $overlay-horizontal-padding-lg: 3em;
 		padding: $overlay-vertical-padding-lg $overlay-horizontal-padding-lg;
 	}
 
-	h1, h2, h3, h4, h5, h6 {
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6 {
 		@include remove-header-styling();
 	}
 
@@ -61,13 +66,13 @@ $overlay-horizontal-padding-lg: 3em;
 
 // Ensure the hidden overlay doesn't add whitespace to printed pages
 @media print {
-    .jetpack-instant-search__overlay.is-hidden {
-        display: none;
-    }
+	.jetpack-instant-search__overlay.is-hidden {
+		display: none;
+	}
 }
 
 // Only show animation to users who have not chosen reduced motion
-@media (prefers-reduced-motion: no-preference) {
+@media ( prefers-reduced-motion: no-preference ) {
 	.jetpack-instant-search__overlay {
 		transition: opacity 0.1s ease-in;
 	}

--- a/projects/packages/search/src/instant-search/components/scroll-button.jsx
+++ b/projects/packages/search/src/instant-search/components/scroll-button.jsx
@@ -4,22 +4,27 @@ import { __ } from '@wordpress/i18n';
 // eslint-disable-next-line lodash/import-scope
 import debounce from 'lodash/debounce';
 import React, { Component } from 'react';
-import { OVERLAY_CLASS_NAME } from '../lib/constants';
+import { SEARCH_RESULTS_CLASS_NAME, SEARCH_RESULTS_LOAD_MORE_OFFSET } from '../lib/constants';
 import './scroll-button.scss';
 
 class ScrollButton extends Component {
-	overlayElement = document.getElementsByClassName( OVERLAY_CLASS_NAME )[ 0 ];
+	scrollElement = document.getElementsByClassName( SEARCH_RESULTS_CLASS_NAME )[ 0 ];
 	componentDidMount() {
-		this.overlayElement.addEventListener( 'scroll', this.checkScroll );
+		this.scrollElement.addEventListener( 'scroll', this.checkScroll );
 	}
 	componentDidUnmount() {
-		this.overlayElement.removeEventListener( 'scroll', this.checkScroll );
+		this.scrollElement.removeEventListener( 'scroll', this.checkScroll );
 	}
 
 	checkScroll = debounce( () => {
+		const visibleHeightToLoadMore =
+			this.scrollElement.clientHeight +
+			this.scrollElement.scrollTop +
+			SEARCH_RESULTS_LOAD_MORE_OFFSET;
+
 		if (
 			this.props.enableLoadOnScroll &&
-			window.innerHeight + this.overlayElement.scrollTop >= this.overlayElement.scrollHeight
+			visibleHeightToLoadMore >= this.scrollElement.scrollHeight
 		) {
 			this.props.onLoadNextPage();
 		}

--- a/projects/packages/search/src/instant-search/components/search-app.scss
+++ b/projects/packages/search/src/instant-search/components/search-app.scss
@@ -80,6 +80,11 @@ body.enable-search-modal .cover-modal.show-modal.search-modal.active {
 		color: $color-dark-text-lighter;
 	}
 
+	.jetpack-instant-search__jetpack-colophon {
+		border-color: $color-dark-layout-borders;
+		background-color: $color-dark-modal-background;
+	}
+
 	.jetpack-instant-search__box,
 	button.jetpack-instant-search__overlay-close {
 		border-color: $color-dark-layout-borders;

--- a/projects/packages/search/src/instant-search/components/search-results.jsx
+++ b/projects/packages/search/src/instant-search/components/search-results.jsx
@@ -1,4 +1,5 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
+import classNames from 'classnames';
 import React, { Component, Fragment } from 'react';
 import { getConstrastingColor } from '../lib/colors';
 import { MULTISITE_NO_GROUP_VALUE, OVERLAY_FOCUS_ANCHOR_ID } from '../lib/constants';
@@ -212,7 +213,11 @@ class SearchResults extends Component {
 
 	render() {
 		return (
-			<div className="jetpack-instant-search__search-wrapper">
+			<div
+				className={ classNames( 'jetpack-instant-search__search-wrapper', {
+					'has-colophon': this.props.showPoweredBy,
+				} ) }
+			>
 				<div
 					aria-hidden={ this.props.isLoading === true }
 					className="jetpack-instant-search__search-results"

--- a/projects/packages/search/src/instant-search/components/search-results.jsx
+++ b/projects/packages/search/src/instant-search/components/search-results.jsx
@@ -5,6 +5,7 @@ import { MULTISITE_NO_GROUP_VALUE, OVERLAY_FOCUS_ANCHOR_ID } from '../lib/consta
 import { getErrorMessage } from '../lib/errors';
 import { getAvailableStaticFilters } from '../lib/filters';
 import Gridicon from './gridicon';
+import JetpackColophon from './jetpack-colophon';
 import Notice from './notice';
 import ScrollButton from './scroll-button';
 import SearchControls from './search-controls';
@@ -191,7 +192,6 @@ class SearchResults extends Component {
 				locale={ this.props.locale }
 				postTypes={ this.props.postTypes }
 				response={ this.props.response }
-				showPoweredBy={ this.props.showPoweredBy }
 				widgets={ this.props.widgets }
 				widgetOutsideOverlay={ this.props.widgetOutsideOverlay }
 			/>
@@ -212,83 +212,87 @@ class SearchResults extends Component {
 
 	render() {
 		return (
-			<div
-				aria-hidden={ this.props.isLoading === true }
-				className="jetpack-instant-search__search-results"
-			>
-				<div className="jetpack-instant-search__search-results-controls" role="form">
-					<SearchForm
-						aria-controls="jetpack-instant-search__search-results-content"
-						className="jetpack-instant-search__search-results-search-form"
-						isVisible={ this.props.isVisible }
-						onChangeSearch={ this.props.onChangeSearch }
-						searchQuery={ this.props.searchQuery }
-					/>
-					<button
-						className="jetpack-instant-search__overlay-close"
-						onClick={ this.closeOverlay }
-						onKeyPress={ this.onKeyPressHandler }
-						tabIndex="0"
-						aria-label={ __( 'Close search results', 'jetpack-search-pkg' ) }
+			<div className="jetpack-instant-search__search-wrapper">
+				<div
+					aria-hidden={ this.props.isLoading === true }
+					className="jetpack-instant-search__search-results"
+				>
+					<div className="jetpack-instant-search__search-results-controls" role="form">
+						<SearchForm
+							aria-controls="jetpack-instant-search__search-results-content"
+							className="jetpack-instant-search__search-results-search-form"
+							isVisible={ this.props.isVisible }
+							onChangeSearch={ this.props.onChangeSearch }
+							searchQuery={ this.props.searchQuery }
+						/>
+						<button
+							className="jetpack-instant-search__overlay-close"
+							onClick={ this.closeOverlay }
+							onKeyPress={ this.onKeyPressHandler }
+							tabIndex="0"
+							aria-label={ __( 'Close search results', 'jetpack-search-pkg' ) }
+						>
+							<Gridicon icon="cross" size="24" aria-hidden="true" focusable="false" />
+						</button>
+					</div>
+
+					<SearchControls
+						enableSort={ this.props.enableSort }
+						onChangeSort={ this.props.onChangeSort }
+						resultFormat={ this.props.resultFormat }
+						sort={ this.props.sort }
 					>
-						<Gridicon icon="cross" size="24" aria-hidden="true" focusable="false" />
+						{ ( this.hasFilterOptions() || this.props.hasNonSearchWidgets ) && (
+							<div
+								role="button"
+								onClick={ this.toggleMobileSecondary }
+								onKeyDown={ this.toggleMobileSecondary }
+								tabIndex="0"
+								className="jetpack-instant-search__search-results-filter-button"
+							>
+								{ __( 'Filters', 'jetpack-search-pkg' ) }
+								<Gridicon
+									icon="chevron-down"
+									size={ 16 }
+									alt={ __( 'Show search filters', 'jetpack-search-pkg' ) }
+									aria-hidden="true"
+								/>
+								<span className="screen-reader-text assistive-text">
+									{ this.state.shouldShowMobileSecondary
+										? __( 'Hide filters', 'jetpack-search-pkg' )
+										: __( 'Show filters', 'jetpack-search-pkg' ) }
+								</span>
+							</div>
+						) }
+					</SearchControls>
+
+					<div
+						aria-live="polite"
+						className="jetpack-instant-search__search-results-content"
+						id="jetpack-instant-search__search-results-content"
+					>
+						<div className="jetpack-instant-search__search-results-primary">
+							{ this.renderPrimarySection() }
+						</div>
+						<div
+							className={ [
+								'jetpack-instant-search__search-results-secondary',
+								`${
+									this.state.shouldShowMobileSecondary
+										? 'jetpack-instant-search__search-results-secondary--show-as-modal'
+										: ''
+								} `,
+							].join( ' ' ) }
+						>
+							{ this.renderSecondarySection() }
+						</div>
+					</div>
+					<button id={ OVERLAY_FOCUS_ANCHOR_ID } onClick={ this.closeOverlay }>
+						Close Search
 					</button>
 				</div>
 
-				<SearchControls
-					enableSort={ this.props.enableSort }
-					onChangeSort={ this.props.onChangeSort }
-					resultFormat={ this.props.resultFormat }
-					sort={ this.props.sort }
-				>
-					{ ( this.hasFilterOptions() || this.props.hasNonSearchWidgets ) && (
-						<div
-							role="button"
-							onClick={ this.toggleMobileSecondary }
-							onKeyDown={ this.toggleMobileSecondary }
-							tabIndex="0"
-							className="jetpack-instant-search__search-results-filter-button"
-						>
-							{ __( 'Filters', 'jetpack-search-pkg' ) }
-							<Gridicon
-								icon="chevron-down"
-								size={ 16 }
-								alt={ __( 'Show search filters', 'jetpack-search-pkg' ) }
-								aria-hidden="true"
-							/>
-							<span className="screen-reader-text assistive-text">
-								{ this.state.shouldShowMobileSecondary
-									? __( 'Hide filters', 'jetpack-search-pkg' )
-									: __( 'Show filters', 'jetpack-search-pkg' ) }
-							</span>
-						</div>
-					) }
-				</SearchControls>
-
-				<div
-					aria-live="polite"
-					className="jetpack-instant-search__search-results-content"
-					id="jetpack-instant-search__search-results-content"
-				>
-					<div className="jetpack-instant-search__search-results-primary">
-						{ this.renderPrimarySection() }
-					</div>
-					<div
-						className={ [
-							'jetpack-instant-search__search-results-secondary',
-							`${
-								this.state.shouldShowMobileSecondary
-									? 'jetpack-instant-search__search-results-secondary--show-as-modal'
-									: ''
-							} `,
-						].join( ' ' ) }
-					>
-						{ this.renderSecondarySection() }
-					</div>
-				</div>
-				<button id={ OVERLAY_FOCUS_ANCHOR_ID } onClick={ this.closeOverlay }>
-					Close Search
-				</button>
+				{ this.props.showPoweredBy && <JetpackColophon locale={ this.props.locale } /> }
 			</div>
 		);
 	}

--- a/projects/packages/search/src/instant-search/components/search-results.scss
+++ b/projects/packages/search/src/instant-search/components/search-results.scss
@@ -3,21 +3,42 @@
 $modal-max-width: 1080px;
 $modal-max-width-lg: 95%;
 
-.jetpack-instant-search__search-results {
-	background: $color-modal-background;
-	border-radius: 3px;
-	min-height: 100%;
-	margin: 0 auto;
+.jetpack-instant-search__search-wrapper {
+	position: relative;
 	max-width: $modal-max-width;
+	height: 100%;
+	margin: 0 auto;
+	padding-bottom: 40px;
+	border-radius: 4px;
+	overflow: hidden;
+
+	@include break-large-up() {
+		max-width: $modal-max-width-lg;
+	}
+}
+
+.jetpack-instant-search__jetpack-colophon {
+	position: absolute;
+	bottom: 0;
+	display: flex;
+	justify-content: center;
+	height: 40px;
+	width: 100%;
+	margin: 0;
+	background-color: $studio-white;
+	border-top: 1px solid $color-layout-borders;
+}
+
+.jetpack-instant-search__search-results {
+	overflow-y: auto;
+	height: 100%;
+	background: $color-modal-background;
+	min-height: 100%;
 	position: relative;
 	z-index: 10;
 
 	@include break-small-down() {
 		border-radius: 0;
-	}
-
-	@include break-large-up() {
-		max-width: $modal-max-width-lg;
 	}
 
 	mark {
@@ -159,14 +180,6 @@ $modal-max-width-lg: 95%;
 
 			@include break( '<s' ) {
 				max-height: 80vh;
-			}
-
-			.jetpack-instant-search__jetpack-colophon {
-				margin-bottom: 1em;
-			}
-
-			.jetpack-instant-search__jetpack-colophon-text {
-				font-size: 0.8em;
 			}
 
 			.jetpack-instant-search__overlay--no-sidebar & {

--- a/projects/packages/search/src/instant-search/components/search-results.scss
+++ b/projects/packages/search/src/instant-search/components/search-results.scss
@@ -2,18 +2,22 @@
 
 $modal-max-width: 1080px;
 $modal-max-width-lg: 95%;
+$colophon-height: 40px;
 
 .jetpack-instant-search__search-wrapper {
 	position: relative;
 	max-width: $modal-max-width;
 	height: 100%;
 	margin: 0 auto;
-	padding-bottom: 40px;
 	border-radius: 4px;
 	overflow: hidden;
 
 	@include break-large-up() {
 		max-width: $modal-max-width-lg;
+	}
+
+	&.has-colophon {
+		padding-bottom: $colophon-height;
 	}
 }
 
@@ -22,7 +26,7 @@ $modal-max-width-lg: 95%;
 	bottom: 0;
 	display: flex;
 	justify-content: center;
-	height: 40px;
+	height: $colophon-height;
 	width: 100%;
 	margin: 0;
 	background-color: $studio-white;

--- a/projects/packages/search/src/instant-search/components/sidebar.jsx
+++ b/projects/packages/search/src/instant-search/components/sidebar.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { createPortal } from 'react-dom';
-import JetpackColophon from './jetpack-colophon';
 import SearchFilters from './search-filters';
 import WidgetAreaContainer from './widget-area-container';
 
@@ -44,7 +43,6 @@ const Sidebar = props => {
 					document.getElementById( `${ widget.widget_id }-wrapper` )
 				);
 			} ) }
-			{ props.showPoweredBy && <JetpackColophon locale={ props.locale } /> }
 		</div>
 	);
 };

--- a/projects/packages/search/src/instant-search/lib/constants.js
+++ b/projects/packages/search/src/instant-search/lib/constants.js
@@ -4,6 +4,8 @@ export const MULTISITE_NO_GROUP_VALUE = '__NO_GROUP__';
 
 export const SERVER_OBJECT_NAME = 'JetpackInstantSearchOptions';
 export const OVERLAY_CLASS_NAME = 'jetpack-instant-search__overlay';
+export const SEARCH_RESULTS_CLASS_NAME = 'jetpack-instant-search__search-results';
+export const SEARCH_RESULTS_LOAD_MORE_OFFSET = 70;
 export const OVERLAY_SEARCH_BOX_INPUT_CLASS_NAME = 'jetpack-instant-search__box-input';
 export const OVERLAY_FOCUS_ANCHOR_ID = 'jetpack-instant-search__overlay-focus-anchor';
 export const SORT_DIRECTION_ASC = 'ASC';

--- a/projects/plugins/jetpack/changelog/update-pricing-tier-move-colophon
+++ b/projects/plugins/jetpack/changelog/update-pricing-tier-move-colophon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -39,7 +39,7 @@
 		"automattic/jetpack-publicize": "0.15.x-dev",
 		"automattic/jetpack-redirect": "1.7.x-dev",
 		"automattic/jetpack-roles": "1.4.x-dev",
-		"automattic/jetpack-search": "0.22.x-dev",
+		"automattic/jetpack-search": "0.23.x-dev",
 		"automattic/jetpack-status": "1.14.x-dev",
 		"automattic/jetpack-sync": "1.38.x-dev",
 		"automattic/jetpack-videopress": "0.4.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eca8e90560aff85e9bf2846314b35580",
+    "content-hash": "f3a838f863cfe59a84e608e832a65b46",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1804,7 +1804,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "fa32ecefba3c18b8f2926e6582b27e7f259e7378"
+                "reference": "6607908833b83eef517673bdff4b69d5458c6e0a"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -1828,7 +1828,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.22.x-dev"
+                    "dev-trunk": "0.23.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"

--- a/projects/plugins/search/changelog/update-pricing-tier-move-colophon
+++ b/projects/plugins/search/changelog/update-pricing-tier-move-colophon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -10,7 +10,7 @@
 		"automattic/jetpack-connection": "1.45.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
 		"automattic/jetpack-my-jetpack": "2.1.x-dev",
-		"automattic/jetpack-search": "0.22.x-dev",
+		"automattic/jetpack-search": "0.23.x-dev",
 		"automattic/jetpack-status": "1.14.x-dev",
 		"automattic/jetpack-sync": "1.38.x-dev",
 		"automattic/jetpack-plugins-installer": "0.2.x-dev"

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "09d6fe39a1faf9b14429bb2a81b347d0",
+    "content-hash": "85810c299d618f4a78c09416d37bcd79",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1096,7 +1096,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "fa32ecefba3c18b8f2926e6582b27e7f259e7378"
+                "reference": "6607908833b83eef517673bdff4b69d5458c6e0a"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -1120,7 +1120,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.22.x-dev"
+                    "dev-trunk": "0.23.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #25906 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Make SearchResults scrollable inside `.jetpack-instant-search__search-wrapper`
* Move JetpackColophon from Sidebar to bottom of SearchResults
* Use URL flag `free_tier=1` to show JetpackColophon temporarily

> Note: I was trying to refactor the whole SearchResults to a fixed frame with only the result list scrollable. However, users would suffer from a small monitor to see fewer results. Thus, I add the search wrapper to put the colophon at the bottom and leave the whole SearchResults scrollable.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-hEH-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Navigate site url with params `/?s=&free_tier=0`
* Ensure there is **no** Jetpack colophon displaying regardless of whether the `Show "Powered by Jetpack"` in the Customizer is set or not.
<img width="951" alt="截圖 2022-09-21 下午11 38 04" src="https://user-images.githubusercontent.com/6869813/191548732-1930cac6-c56e-4056-8957-1f6483ed402f.png">

* Navigate site url with params `/?s=&free_tier=1`
* Ensure there is Jetpack colophon displaying regardless of whether the `Show "Powered by Jetpack"` in the Customizer is set or not.
<img width="935" alt="截圖 2022-09-21 下午11 39 54" src="https://user-images.githubusercontent.com/6869813/191549103-1c5b9e9e-a1d6-4590-abd9-98d096c6c42d.png">

* Scroll result list on the search overlay
* Ensure the Jetpack colophon would be fixed at the same position
<img width="948" alt="截圖 2022-09-21 下午11 40 03" src="https://user-images.githubusercontent.com/6869813/191549323-a35b1607-5d22-45d1-920a-a23245bac44d.png">

* Click text on the Jetpack colophon
* You should be navigated to [Jetpack Search support page](https://jetpack.com/support/search/) within a new tab