### PR TITLE
jetpack: Register `pcast.pocketcasts.net` oembed provider with WP 6.1

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-pocketcasts-test
+++ b/projects/plugins/jetpack/changelog/fix-pocketcasts-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Register `pcast.pocketcasts.net` for oEmbed even with WordPress 6.1, they only register `pca.st`.

--- a/projects/plugins/jetpack/modules/shortcodes/others.php
+++ b/projects/plugins/jetpack/modules/shortcodes/others.php
@@ -25,5 +25,6 @@ wp_oembed_add_provider( '#https?://(www\.)?loom\.com/share/.*#i', 'https://www.l
 global $wp_version;
 if ( version_compare( $wp_version, '6.1-alpha-53744', '<' ) ) {
 	wp_oembed_add_provider( '#https?://pca\.st/.+#i', 'https://pca.st/oembed.json', true );
-	wp_oembed_add_provider( '#https?://pcast\.pocketcasts\.net/.+#i', 'https://pcast.pocketcasts.net/oembed.json', true );
 }
+// WordPress core only registers pca.st, not pcast.pocketcasts.net.
+wp_oembed_add_provider( '#https?://pcast\.pocketcasts\.net/.+#i', 'https://pcast.pocketcasts.net/oembed.json', true );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
In #25696 someone added registration for `pca.st` and `pcast.pocketcasts.net`, conditional on the WordPress core version as WP core is adding `pca.st` in 6.1.

But WP core is not adding `pcast.pocketcasts.net` in 6.1, so we still need to register that one.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Do the "PHP 8.0 trunk" tests pass now?