### PR TITLE
Backup plugin: hide Cloud links to disconnected users

### DIFF
--- a/projects/packages/backup/changelog/fix-hide-cloud-links-disconnected-users
+++ b/projects/packages/backup/changelog/fix-hide-cloud-links-disconnected-users
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: removed non working links
+
+

--- a/projects/packages/backup/src/js/components/Admin.js
+++ b/projects/packages/backup/src/js/components/Admin.js
@@ -105,6 +105,7 @@ const Admin = () => {
 
 // Renders additional segments under the jp-hero area condition on having a backup plan
 const BackupSegments = ( hasBackupPlan, connectionLoaded ) => {
+	const [ connectionStatus ] = useConnection();
 	const { tracks } = useAnalytics();
 	const domain = useSelect( select => select( STORE_ID ).getCalypsoSlug(), [] );
 
@@ -148,7 +149,7 @@ const BackupSegments = ( hasBackupPlan, connectionLoaded ) => {
 						'jetpack-backup-pkg'
 					) }
 				</p>
-				{ hasBackupPlan && (
+				{ hasBackupPlan && connectionStatus.isUserConnected && (
 					<p>
 						<ExternalLink
 							href={ getRedirectUrl( 'jetpack-backup', { site: domain } ) }
@@ -168,7 +169,7 @@ const BackupSegments = ( hasBackupPlan, connectionLoaded ) => {
 						'jetpack-backup-pkg'
 					) }
 				</p>
-				{ hasBackupPlan && (
+				{ hasBackupPlan && connectionStatus.isUserConnected && (
 					<p>
 						<ExternalLink
 							href={ getRedirectUrl( 'backup-plugin-activity-log', { site: domain } ) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26277

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Whenever the site has a Backup plan and is connected to Jetpack but the user visiting the plugin's admin page is not connected to Jetpack( secondary admin ), don't show the links to Jetpack Cloud. 

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a JN site with the Jetpack Backup plugin
* Add a plan with backup capabilities to the site
* Confirm that the Admin page of the plugin shows the links ( check screenshot )
* Create a second WordPress admin account for the site and login to the site from an incognito window
* Confirm that the links are not visible for this account since it is not connected to Jetpack


Expected Admin page for connected user:
<img width="1000" alt="Screen Shot 2022-09-21 at 21 14 27" src="https://user-images.githubusercontent.com/16329583/191591695-6d47ad77-8f90-4b78-8846-50e4781ca05e.png">

Expected Admin page for non-connected user on connected site:
<img width="1004" alt="Screen Shot 2022-09-21 at 21 15 28" src="https://user-images.githubusercontent.com/16329583/191591806-8a17fcf1-a0d8-41d5-8753-e44cdcd4f27c.png">
