### PR TITLE
VideoPress: Add "watch" jetpack CLI command to plugins/videopress

### DIFF
--- a/projects/plugins/videopress/changelog/add-cli-watch-command-to-videopress-plugin
+++ b/projects/plugins/videopress/changelog/add-cli-watch-command-to-videopress-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Included `watch` script on composer file to run the packages/videopress watch command.

--- a/projects/plugins/videopress/composer.json
+++ b/projects/plugins/videopress/composer.json
@@ -26,6 +26,7 @@
 		]
 	},
 	"scripts": {
+		"watch": "echo 'This script is actually watching the Jetpack VideoPress package' && jetpack watch packages/videopress",
 		"post-install-cmd": "WorDBless\\Composer\\InstallDropin::copy",
 		"post-update-cmd": "WorDBless\\Composer\\InstallDropin::copy"
 	},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26325.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Changed `composer.json` file from `plugins/videopress` to include `watch` script
* The new script will run the `watch` command from the `packages/videopress`

By doing so, when we run `jetpack watch plugins/videopress`, we are actually getting the same results of `jetpack watch packages/videopress`.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On your jetpack directory, run `jetpack watch plugins/videopress`
* The command should not fail
* You should see the same results of running `jetpack watch packages/videopress`, as following:

![videopress-watch-cli](https://user-images.githubusercontent.com/6760046/191594182-cac12306-5fcc-4e66-a657-5a320f1286a3.png)

*Note the reference to the `packages/videopress` directory.*