### PR TITLE
VideoPress: request data in the single video page when it doesn't exist

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-pull-single-video-when-isnt-fulfilled
+++ b/projects/packages/videopress/changelog/update-videopress-pull-single-video-when-isnt-fulfilled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: resolve addVideo() selector

--- a/projects/packages/videopress/src/client/state/reducers.js
+++ b/projects/packages/videopress/src/client/state/reducers.js
@@ -78,13 +78,10 @@ const videos = ( state = {}, action ) => {
 
 		case SET_VIDEO: {
 			const { video } = action;
-
-			const items = state.items.map( item => {
-				if ( item.id === video.id ) {
-					return video;
-				}
-				return item;
-			} );
+			const { items = [] } = state;
+			if ( ! items.find( item => item.ID === video.ID ) ) {
+				items.push( video );
+			}
 
 			return {
 				...state,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

~Branched off from https://github.com/Automattic/jetpack/pull/26326~

This PR adds the `getVideo()` resolver to request the video data when it is not defined in the state tree.

Fixes https://github.com/Automattic/jetpack/issues/26323

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: request data in the single video page when it doesn't exist

#### Other information:

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard
* Ensure you have a few VP videos, more than six (the total of videos shown in the initial rendering)
* in the dashboard, the videos should be visualized
* Click on the Edit details button
* Confirm the app does not perform a request
* Confirm the Details page shows the video data
* Go back to the dashboard
* change the page by clicking on the Pagination
* Click on the Edit details button of a card of the new page
* Confirm the app does not perform a new request
* Confirm the Details page shows the video data
* Hard refresh

Before
The single video page doesn't show the data

https://user-images.githubusercontent.com/77539/191602746-eb626e6d-28bc-4ce2-adf2-33d89b6db168.mov

After
* Confirm the page shows the video data
* Confirm the app performs a new request to the media

https://user-images.githubusercontent.com/77539/191602644-a57dd32d-8076-4802-933d-16eba735bdd0.mov
