### PR TITLE
VideoPress: fix printing the upload video date

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-fix-upload-date-value
+++ b/projects/packages/videopress/changelog/update-videopress-fix-upload-date-value
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: fix printing the upload video date

--- a/projects/packages/videopress/src/client/admin/components/video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-details/index.tsx
@@ -1,10 +1,19 @@
+/**
+ * External dependencies
+ */
 import { Text } from '@automattic/jetpack-components';
+import { gmdateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
 import ClipboardButtonInput from '../clipboard-button-input';
 import styles from './style.module.scss';
 import { VideoDetailsProps } from './types';
 
 const VideoDetails = ( { filename, src, uploadDate }: VideoDetailsProps ) => {
+	const formattedDate = uploadDate?.length ? gmdateI18n( 'F j, Y', uploadDate ) : false;
+
 	return (
 		<div className={ styles.details }>
 			<div className={ styles[ 'detail-row' ] }>
@@ -19,7 +28,7 @@ const VideoDetails = ( { filename, src, uploadDate }: VideoDetailsProps ) => {
 
 			<div>
 				<Text variant="body-small">{ __( 'Upload date', 'jetpack-videopress-pkg' ) }</Text>
-				<Text variant="body">{ uploadDate }</Text>
+				<Text variant="body">{ formattedDate }</Text>
 			</div>
 		</div>
 	);

--- a/projects/packages/videopress/src/client/admin/types/index.ts
+++ b/projects/packages/videopress/src/client/admin/types/index.ts
@@ -24,11 +24,8 @@ export type OriginalVideoPressVideo = {
 	/**
 	 * Video uploaded date in UTC
 	 */
-	date: number;
-	/**
-	 * Video uploaded date formatted
-	 */
-	dateFormatted: string;
+	uploadDate: number;
+
 	/**
 	 * Video duration, in milliseconds
 	 */
@@ -84,10 +81,6 @@ export type VideoPressVideo = Omit< OriginalVideoPressVideo, 'videoTitle' > & {
 	 * VideoPress GUID
 	 */
 	guid?: string;
-	/**
-	 * Video upload date
-	 */
-	uploadDate: string;
 };
 
 export type LocalVideo = {

--- a/projects/packages/videopress/src/client/state/utils/map-videos.ts
+++ b/projects/packages/videopress/src/client/state/utils/map-videos.ts
@@ -1,8 +1,4 @@
 /**
- * External dependencies
- */
-import { gmdateI18n } from '@wordpress/date';
-/**
  * Internal dependencies
  */
 import { OriginalVideoPressVideo, VideoPressVideo } from '../types';
@@ -16,7 +12,7 @@ export const mapVideo = ( video: OriginalVideoPressVideo ): VideoPressVideo => {
 	};
 };
 
-// priobably @deprecated since it was used when hitting the admin-ajax endpoint
+// Probably @deprecated since it was used when hitting the admin-ajax endpoint
 export const mapVideos = ( videos: OriginalVideoPressVideo[] ): VideoPressVideo[] => {
 	return videos.map( mapVideo );
 };
@@ -33,7 +29,7 @@ export const mapVideoFromWPV2MediaEndpoint = (
 		description,
 		original: url,
 		poster,
-		upload_date: date,
+		upload_date: uploadDate,
 		duration,
 		is_private: isPrivate,
 		file_url_base: fileURLBase,
@@ -55,10 +51,9 @@ export const mapVideoFromWPV2MediaEndpoint = (
 		description,
 		caption,
 		url,
-		date,
+		uploadDate,
 		duration,
 		isPrivate,
-		dateFormatted: gmdateI18n( 'F j, Y', date ),
 		posterImage: poster,
 		poster: {
 			src: poster,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes the issue when printing the upload date of the video. For this, it stores only the date (not the formatted value) and applies the format at the component level.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: fix printing the upload video date


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to VideoPress dashboard
* Edit video by clicking on the Edit Details button

before | after
------|------
<img width="517" alt="Screen Shot 2022-09-21 at 18 06 35" src="https://user-images.githubusercontent.com/77539/191610564-164c796c-c870-4ac0-afca-28baa148e1f8.png"> | <img width="527" alt="Screen Shot 2022-09-21 at 18 03 14" src="https://user-images.githubusercontent.com/77539/191609915-0e1e07d0-4703-4c39-8aee-1aae20b09a56.png">
