### PR TITLE
Search: Fix compliance with show_powered_by option

### DIFF
--- a/projects/packages/search/changelog/fix-search-powered-by-setting-compliance
+++ b/projects/packages/search/changelog/fix-search-powered-by-setting-compliance
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: It's a fix for a regression introduced in a PR merged minutes ago. I'm following up and the changelog can safely assume the regression was never introduced when we release this'
+
+

--- a/projects/packages/search/src/class-helper.php
+++ b/projects/packages/search/src/class-helper.php
@@ -852,7 +852,7 @@ class Helper {
 				'highlightColor'    => get_option( $prefix . 'highlight_color', '#FFC' ),
 				'overlayTrigger'    => get_option( $prefix . 'overlay_trigger', Options::DEFAULT_OVERLAY_TRIGGER ),
 				'resultFormat'      => get_option( $prefix . 'result_format', Options::RESULT_FORMAT_MINIMAL ),
-				'showPoweredBy'     => $show_powered_by,
+				'showPoweredBy'     => $show_powered_by || ( get_option( $prefix . 'show_powered_by', '1' ) === '1' ),
 
 				// These options require kicking off a new search.
 				'defaultSort'       => get_option( $prefix . 'default_sort', 'relevance' ),


### PR DESCRIPTION
A follow-up to #26320

Addresses second observation in https://github.com/Automattic/jetpack/pull/26320#pullrequestreview-1116104516.

Makes the Colophon respect the existing `colophon` option. #26320 introduced a regression and it currently ignores whatever the user has configured in Customberg/Customizer and purely depends on the `free_tier` query value.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Continues leveraging the `show_powered_by` option.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

https://github.com/Automattic/jetpack/pull/26320#pullrequestreview-1116104516

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Navigate to site page adding to the url the params `/?s=&free_tier=0`
* Make sure the colophon respects the setting in Customberg/Customizer
* Navigate to site page adding to the url the params `/?s=&free_tier=1`
* Make sure the colophon appears in spite of the setting in Customberg/Customizer
