### PR TITLE
Search: Fix preventing clicks on the colophon from closing the overlay.

### DIFF
--- a/projects/packages/search/changelog/fix-colophone-click-handler-targetting
+++ b/projects/packages/search/changelog/fix-colophone-click-handler-targetting
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixes a regression from a PR merged minutes ago. No need for changelog entry
+
+

--- a/projects/packages/search/src/customberg/components/app-wrapper/styles.scss
+++ b/projects/packages/search/src/customberg/components/app-wrapper/styles.scss
@@ -20,7 +20,7 @@
 		// Needs to have equal z-index to .interface-interface-skeleton__sidebar.
 		z-index: 90;
 
-		.jetpack-instant-search__search-wrapper {
+		.jetpack-instant-search__search-results-wrapper {
 			max-width: initial;
 		}
 

--- a/projects/packages/search/src/instant-search/components/overlay.jsx
+++ b/projects/packages/search/src/instant-search/components/overlay.jsx
@@ -47,7 +47,7 @@ const Overlay = props => {
 
 		const closeWithOutsideClick = event => {
 			const resultsContainer = document.getElementsByClassName(
-				'jetpack-instant-search__search-results'
+				'jetpack-instant-search__search-results-wrapper'
 			)[ 0 ];
 			if (
 				event.target?.isConnected && // Ensure that the click target is still connected to DOM.

--- a/projects/packages/search/src/instant-search/components/search-results.jsx
+++ b/projects/packages/search/src/instant-search/components/search-results.jsx
@@ -214,7 +214,7 @@ class SearchResults extends Component {
 	render() {
 		return (
 			<div
-				className={ classNames( 'jetpack-instant-search__search-wrapper', {
+				className={ classNames( 'jetpack-instant-search__search-results-wrapper', {
 					'has-colophon': this.props.showPoweredBy,
 				} ) }
 			>

--- a/projects/packages/search/src/instant-search/components/search-results.scss
+++ b/projects/packages/search/src/instant-search/components/search-results.scss
@@ -4,7 +4,7 @@ $modal-max-width: 1080px;
 $modal-max-width-lg: 95%;
 $colophon-height: 40px;
 
-.jetpack-instant-search__search-wrapper {
+.jetpack-instant-search__search-results-wrapper {
 	position: relative;
 	max-width: $modal-max-width;
 	height: 100%;


### PR DESCRIPTION
Prevent clicks on the colophon from closing the overlay. 

#26320 introduced an update on class names which ended up incorrectly targeting the overlay in [this file](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/search/src/instant-search/components/overlay.jsx#L50)

Fixes #26334

Addresses first observation in https://github.com/Automattic/jetpack/pull/26320#pullrequestreview-1116104516.

Makes the Colophon respect the existing `colophon` option. #26320 introduced a regression and it currently ignores whatever the user has configured in Customberg/Customizer and purely depends on the `free_tier` query value.


#### Changes proposed in this Pull Request:

* Updates class name `jetpack-instant-search__search-wrapper` to `jetpack-instant-search__search-results-wrapper` as suggested by @jsnmoon 
* Addressed targetting on click handler to match the class `jetpack-instant-search__search-results-wrapper`

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

https://github.com/Automattic/jetpack/pull/26320#pullrequestreview-1116104516.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

* Navigate to site page adding to the url the params `/?s=&free_tier=1`
* Make sure the colophon opens the link properly to a new tab and the search overlay does not get closed.

