### PR TITLE
Search: Add new pricing 2022 feature lock

### DIFF
--- a/projects/packages/search/changelog/add-pricing-2022-feature-lock
+++ b/projects/packages/search/changelog/add-pricing-2022-feature-lock
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search: added free_tier and new_pricing_202208 to gate new pricing features

--- a/projects/packages/search/src/class-helper.php
+++ b/projects/packages/search/src/class-helper.php
@@ -963,7 +963,8 @@ class Helper {
 	 * Returns true if the new_pricing_202210 is set to not empty in URL for testing purpose.
 	 */
 	public static function is_forced_new_pricing_202208() {
+		$referrer = wp_get_referer();
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		return isset( $_GET['new_pricing_202208'] ) && $_GET['new_pricing_202208'];
+		return ( isset( $_GET['new_pricing_202208'] ) && $_GET['new_pricing_202208'] ) || $referrer && strpos( $referrer, 'new_pricing_202208=1' ) !== false;
 	}
 }

--- a/projects/packages/search/src/class-helper.php
+++ b/projects/packages/search/src/class-helper.php
@@ -24,6 +24,11 @@ class Helper {
 	const FILTER_WIDGET_BASE = 'jetpack-search-filters';
 
 	/**
+	 * TODO: remove the lock once the functionalities are finished.
+	 */
+	const NEW_PRICING_202208_READY = false;
+
+	/**
 	 * Create a URL for the current search that doesn't include the "paged" parameter.
 	 *
 	 * @since 5.8.0
@@ -966,5 +971,12 @@ class Helper {
 		$referrer = wp_get_referer();
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 		return ( isset( $_GET['new_pricing_202208'] ) && $_GET['new_pricing_202208'] ) || $referrer && strpos( $referrer, 'new_pricing_202208=1' ) !== false;
+	}
+
+	/**
+	 * Return true if the new pricing is finished and ready to be used in production.
+	 */
+	public static function is_new_pricing_202208_ready() {
+		return self::NEW_PRICING_202208_READY;
 	}
 }

--- a/projects/packages/search/src/class-helper.php
+++ b/projects/packages/search/src/class-helper.php
@@ -867,6 +867,7 @@ class Helper {
 			'postTypes'             => $post_type_labels,
 			'webpackPublicPath'     => plugins_url( '/build/instant-search/', __DIR__ ),
 			'isPhotonEnabled'       => ( $is_wpcom || $is_jetpack_photon_enabled ) && ! $is_private_site,
+			'isFreeTier'            => ( new Plan() )->is_free_tier(),
 
 			// config values related to private site support.
 			'apiRoot'               => esc_url_raw( rest_url() ),
@@ -948,5 +949,21 @@ class Helper {
 
 		// Returns cache site ID.
 		return \Jetpack_Options::get_option( 'id' );
+	}
+
+	/**
+	 * Returns true if the free_tier is set to not empty in URL, which is used for testing purpose.
+	 */
+	public static function is_forced_free_tier() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		return isset( $_GET['free_tier'] ) && $_GET['free_tier'];
+	}
+
+	/**
+	 * Returns true if the new_pricing_202210 is set to not empty in URL for testing purpose.
+	 */
+	public static function is_forced_new_pricing_202208() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		return isset( $_GET['new_pricing_202208'] ) && $_GET['new_pricing_202208'];
 	}
 }

--- a/projects/packages/search/src/class-plan.php
+++ b/projects/packages/search/src/class-plan.php
@@ -19,6 +19,9 @@ class Plan {
 	const JETPACK_SEARCH_PLAN_INFO_OPTION_KEY  = 'jetpack_search_plan_info';
 	const JETPACK_SEARCH_EVER_SUPPORTED_SEARCH = 'jetpack_search_ever_supported_search';
 
+	// The pricing update starting from August 2022.
+	const JETPACK_SEARCH_NEW_PRICING_VERSION = '202208';
+
 	/**
 	 * Whether we have hooked the actions.
 	 *
@@ -111,6 +114,14 @@ class Plan {
 	 */
 	public function ever_supported_search() {
 		return (bool) get_option( self::JETPACK_SEARCH_EVER_SUPPORTED_SEARCH ) || $this->supports_search();
+	}
+
+	/**
+	 * Returns true if the site is on free plan.
+	 */
+	public function is_free_tier() {
+		$plan_info = $this->get_plan_info();
+		return Helper::is_forced_free_tier() || ( isset( $plan_info['is_free_tier'] ) && $plan_info['is_free_tier'] );
 	}
 
 	/**

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -378,6 +378,11 @@ class REST_Controller {
 	 */
 	public function product_pricing() {
 		$tier_pricing = Search_Product::get_pricing_for_ui();
+		// We don't want to show the half finished new pricing, even when it's set to open from the API.
+		if ( ! Helper::is_new_pricing_202208_ready() ) {
+			unset( $tier_pricing['pricing_version'] );
+		}
+		// Unless we are testing.
 		if ( Helper::is_forced_new_pricing_202208() ) {
 			$tier_pricing['pricing_version'] = Plan::JETPACK_SEARCH_NEW_PRICING_VERSION;
 		}

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -378,6 +378,9 @@ class REST_Controller {
 	 */
 	public function product_pricing() {
 		$tier_pricing = Search_Product::get_pricing_for_ui();
+		if ( Helper::is_forced_new_pricing_202208() ) {
+			$tier_pricing['pricing_version'] = Plan::JETPACK_SEARCH_NEW_PRICING_VERSION;
+		}
 		return rest_ensure_response( $tier_pricing );
 	}
 

--- a/projects/packages/search/src/dashboard/store/selectors/search-pricing.js
+++ b/projects/packages/search/src/dashboard/store/selectors/search-pricing.js
@@ -3,7 +3,7 @@ const searchPricingSelectors = {
 	getPriceBefore: state => state.searchPricing.full_price ?? 0,
 	getPriceAfter: state => state.searchPricing.discount_price ?? 0,
 	getPriceCurrencyCode: state => state.searchPricing.currency_code ?? 'USD',
-	isNewPricing202208: state => state.searchPricing.pricing_version === '202208',
+	isNewPricing202208: state => state.searchPricing.pricing_version >= '202208',
 };
 
 export default searchPricingSelectors;

--- a/projects/packages/search/src/dashboard/store/selectors/search-pricing.js
+++ b/projects/packages/search/src/dashboard/store/selectors/search-pricing.js
@@ -3,6 +3,7 @@ const searchPricingSelectors = {
 	getPriceBefore: state => state.searchPricing.full_price ?? 0,
 	getPriceAfter: state => state.searchPricing.discount_price ?? 0,
 	getPriceCurrencyCode: state => state.searchPricing.currency_code ?? 'USD',
+	isNewPricing202208: state => state.searchPricing.pricing_version === '202208',
 };
 
 export default searchPricingSelectors;


### PR DESCRIPTION
Fixes #25909 

#### Changes proposed in this Pull Request:
The PR introduces a lock for the new pricing, named `pricing_version` in the pricing object. And provides a URL parameter to force it on `new_pricing_202208=1` in URL. The feature relies on WPCOM pricing endpoint to tell whether the new pricing is active by setting key `pricing_version` with value `202208`, which will be implemented soon.

The PR also introduced a state for Instant Search named `isFreeTier`, which would be true, if site is on free tier. And provides a URL parameter to force it on `free_tier=1` in URL. The feature relies on WPCOM plan  endpoint to tell whether the the site is on free tier by setting key `is_free_tier` to `true`, which will be implemented soon.

We also added `Helper::NEW_PRICING_202208_READY` to guard the unfinished feature, because we don't want the half done dashboard to show for users even the new pricing is set to active.

Any changes to Dashboard and Instant Search regarding the new pricing project should leverage these states to determine whether to activate functionalities or components.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Create a site with Jetpack Search active
- Open a frontend page
- Append `free_tier=1` in URL
- Open console, enter `JetpackInstantSearchOptions`
- Ensure the value of `isFreeTier` is set to `true`

- Open Search dashboard
- Open dev tools
- Append `new_pricing_202208=1` in URL
- Inspect API response of `/wp-json/jetpack/v4/search/pricing`
- Ensure the value of `pricing_version` is set to `202208`