### PR TITLE
Search: Fix warning message position in instant search

### DIFF
--- a/projects/packages/search/changelog/fix-search-25434-message-position
+++ b/projects/packages/search/changelog/fix-search-25434-message-position
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Updating warning message for JP Search by adding

--- a/projects/packages/search/changelog/fix-search-25434-message-position
+++ b/projects/packages/search/changelog/fix-search-25434-message-position
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Updating warning message for JP Search by adding new container to fix its position.
+Fix error message styling in Instant Search overlay.

--- a/projects/packages/search/changelog/fix-search-25434-message-position
+++ b/projects/packages/search/changelog/fix-search-25434-message-position
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Updating warning message for JP Search by adding
+Updating warning message for JP Search by adding new container to fix its position.

--- a/projects/packages/search/src/instant-search/components/notice.jsx
+++ b/projects/packages/search/src/instant-search/components/notice.jsx
@@ -10,7 +10,7 @@ const Notice = ( { type, children } ) => {
 	return (
 		<div className="jetpack-instant-search__notice jetpack-instant-search__notice--warning">
 			<Gridicon icon="info" size={ 20 } />
-			{ children }
+			<div>{ children }</div>
 		</div>
 	);
 };

--- a/projects/packages/search/src/instant-search/components/notice.scss
+++ b/projects/packages/search/src/instant-search/components/notice.scss
@@ -4,6 +4,7 @@
 	padding: 0.75em;
 	margin: 1em 0;
 	font-size: 14px;
+	display: flex;
 
 	&.jetpack-instant-search__notice--warning {
 		background-color: $studio-yellow-5;
@@ -12,7 +13,8 @@
 
 	.gridicon {
 		vertical-align: middle;
-		margin-top: -5px;
+		margin-top: 1px;
 		margin-right: 0.5em;
+		flex-shrink: 0;
 	}
 }

--- a/projects/packages/search/src/instant-search/components/test/__snapshots__/notice.test.js.snap
+++ b/projects/packages/search/src/instant-search/components/test/__snapshots__/notice.test.js.snap
@@ -21,6 +21,7 @@ exports[`returns a notice if the type is warning: <Notice> output 1`] = `
         />
       </g>
     </svg>
+    <div />
   </div>
 </DocumentFragment>
 `;


### PR DESCRIPTION
Fixes #25434 

#### Changes proposed in this Pull Request:
* update `display` of message container to `flex`
* wrapping warning message in a div to position an icon and the message next to each other
* update the icon's margin to centre it with the first line of text 
* add `flex-shrink` for the icon to maintain its size

#### Other information:

- ~~Have you written new tests for your changes, if applicable?~~
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* Create JN instance here https://jurassic.ninja/create/?jetpack-beta&branches.jetpack-search=fix/search/25434-message-position
* Go to your JN wp-admin and connect Jetpack
* Purchase JP Search subscription using your credits in Store Admin
* View your JN page (not the administration area)
* At the bottom of the page you will see a search input (if you purchased JP Search) eg:
![Screenshot 2022-09-22 at 1 56 47 PM](https://user-images.githubusercontent.com/112354940/191641602-8c6653bc-794d-4caf-ba71-17e9f04462c4.png)
* Enter a keyword, for example, `test` and wait for an instant search overlay to show up
* Keeping your JN page and search overlay opened, go to your Store Admin and revoke your JP Search subscription
* Without closing your search overlay type a new search keyword e.g. `test2`
* You should see a warning message that has been updated in this PR

After:
<img width="776" alt="Screenshot 2022-09-22 at 11 34 10 AM" src="https://user-images.githubusercontent.com/112354940/191642886-4396240c-f970-4cde-b813-45bde95f1d16.png">

Before:
<img width="756" alt="Screenshot 2022-09-22 at 2 10 45 PM" src="https://user-images.githubusercontent.com/112354940/191643114-3d466a6b-f904-498d-af0b-9745396793e6.png">


