### PR TITLE
Disconnect Dialog: Fix the prop types to prevent the React warnings

### DIFF
--- a/projects/js-packages/connection/changelog/fix-disconnect-prop-errors
+++ b/projects/js-packages/connection/changelog/fix-disconnect-prop-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Disconnect Dialog: Fixed the prop types to avoid warnings from React

--- a/projects/js-packages/connection/components/disconnect-card/index.jsx
+++ b/projects/js-packages/connection/components/disconnect-card/index.jsx
@@ -34,7 +34,7 @@ DisconnectCard.propTypes = {
 	/** Optional value/ statistic to show. */
 	value: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ),
 	/** Description to go with the stat value. */
-	description: PropTypes.number,
+	description: PropTypes.string,
 };
 
 export default DisconnectCard;

--- a/projects/js-packages/connection/components/disconnect-dialog/steps/step-disconnect.jsx
+++ b/projects/js-packages/connection/components/disconnect-dialog/steps/step-disconnect.jsx
@@ -175,7 +175,7 @@ StepDisconnect.propTypes = {
 	/** An error that occurred during a request to disconnect. */
 	disconnectError: PropTypes.bool,
 	/** A component to be rendered as part of this step */
-	disconnectStepComponent: PropTypes.elementType,
+	disconnectStepComponent: PropTypes.element,
 	/** Plugins that are using the Jetpack connection. */
 	connectedPlugins: PropTypes.array,
 	/** The slug of the plugin that is initiating the disconnection. */

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-benefits/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-benefits/index.jsx
@@ -37,8 +37,13 @@ const JetpackBenefits = props => {
 						</p>
 					</div>
 					<div className="jp-connection__disconnect-card__group">
-						{ siteBenefits.map( ( { value, description, title } ) => (
-							<DisconnectCard title={ title } value={ value } description={ description } />
+						{ siteBenefits.map( ( { value, description, title }, index ) => (
+							<DisconnectCard
+								title={ title }
+								value={ value }
+								description={ description }
+								key={ index }
+							/>
 						) ) }
 					</div>
 				</React.Fragment>

--- a/projects/plugins/jetpack/changelog/fix-disconnect-prop-errors
+++ b/projects/plugins/jetpack/changelog/fix-disconnect-prop-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Disconnect Dialog: Fixed the prop types to avoid warnings from React


### PR DESCRIPTION
The disconnect dialog was causing some warnings to be thrown up in the browser dev console, when trying to disconnect Jetpack.

#### Changes proposed in this Pull Request:

This change adjusts the prop types, and adds a key to the list in JetpackBenefits, in order to prevent the warnings.

Fixes #

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
p1663834510339849-slack-CDLH4C1UZ

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Go to /wp-admin/plugins.php
* Activate and connect Jetpack
* Click to deactive Jetpack.
* The disconnect dialog will be displayed
* Without this PR you'll see a number of warnings in the dev console
* With this PR the warnings should not be shown.