### PR TITLE
E2E tests: add support for workflow_run in tests matrix

### DIFF
--- a/.github/files/e2e-tests/create-e2e-projects-matrix.sh
+++ b/.github/files/e2e-tests/create-e2e-projects-matrix.sh
@@ -6,7 +6,7 @@ PROJECTS=('{"project":"Jetpack connection","path":"projects/plugins/jetpack/test
 PROJECTS_MATRIX=()
 RUN_NAME=''
 
-if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_EVENT_NAME" == "push" ]]; then
+if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
 	CHANGED_PROJECTS="$(.github/files/list-changed-projects.sh)"
 
 	for PROJECT in "${PROJECTS[@]}"; do
@@ -27,18 +27,23 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_EVENT_NAME" == "push" ]
 			done
 		fi
 	done
-else
+elif [[ "$GITHUB_EVENT_NAME" == "push" || "$GITHUB_EVENT_NAME" == "workflow_run" ]]; then
+	echo "GITHUB_EVENT_NAME is \"$GITHUB_EVENT_NAME\", returning all projects."
+	PROJECTS_MATRIX=("${PROJECTS[*]}")
+elif [[ "$GITHUB_EVENT_NAME" == "schedule" ]]; then
 	# gutenberg scheduled run
-	if [ "$CRON" == "0 */12 * * *" ]; then
-		PROJECTS_MATRIX+=('{"project":"Jetpack with Gutenberg","path":"projects/plugins/jetpack/tests/e2e","testArgs":["blocks","--retries=2"]}')
-		RUN_NAME='gutenberg'
-	fi
+  	if [ "$CRON" == "0 */12 * * *" ]; then
+  		PROJECTS_MATRIX+=('{"project":"Jetpack with Gutenberg","path":"projects/plugins/jetpack/tests/e2e","testArgs":["blocks","--retries=2"]}')
+  		RUN_NAME='gutenberg'
+  	fi
 
-	# atomic scheduled run
-	if [ "$CRON" == "30 */4 * * *" ]; then
-		PROJECTS_MATRIX+=('{"project":"Jetpack on Atomic","path":"projects/plugins/jetpack/tests/e2e","testArgs":["blocks", "--grep-invert", "wordads", "--retries=2"]}')
-		RUN_NAME='atomic'
-	fi
+  	# atomic scheduled run
+  	if [ "$CRON" == "30 */4 * * *" ]; then
+  		PROJECTS_MATRIX+=('{"project":"Jetpack on Atomic","path":"projects/plugins/jetpack/tests/e2e","testArgs":["blocks", "--grep-invert", "wordads", "--retries=2"]}')
+  		RUN_NAME='atomic'
+  	fi
+else
+	echo "Unsupported GITHUB_EVENT_NAME \"$GITHUB_EVENT_NAME\""
 fi
 
 jq -n -c --arg runName "$RUN_NAME" --argjson projects "$(jq -s -c -r '.' <<<"${PROJECTS_MATRIX[@]}")" '{ "run": $runName, "matrix": $projects }'


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

#26278 added `workflow_run` as trigger for e2e tests, but `create-e2e-projects-matrix.sh` script ignored this trigger.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Running `GITHUB_EVENT_NAME=workflow_run .github/files/e2e-tests/create-e2e-projects-matrix.sh` should return all defined projects.
* Tests for pull_request should run fine, as before.
* To check test runs after merge

