### PR TITLE
E2E tests: fix tests matrix for push and workflow_run

### DIFF
--- a/.github/files/e2e-tests/create-e2e-projects-matrix.sh
+++ b/.github/files/e2e-tests/create-e2e-projects-matrix.sh
@@ -28,7 +28,6 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
 		fi
 	done
 elif [[ "$GITHUB_EVENT_NAME" == "push" || "$GITHUB_EVENT_NAME" == "workflow_run" ]]; then
-	echo "GITHUB_EVENT_NAME is \"$GITHUB_EVENT_NAME\", returning all projects."
 	PROJECTS_MATRIX=("${PROJECTS[*]}")
 elif [[ "$GITHUB_EVENT_NAME" == "schedule" ]]; then
 	# gutenberg scheduled run


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

With #26347 I left a debug statement in the create matrix script, breaking the output for e2e tests.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Check e2e tests run after merge.

