### PR TITLE
E2E tests: always map jetpack when using build artefacts

### DIFF
--- a/.github/files/e2e-tests/map-plugins-for-e2e-env.sh
+++ b/.github/files/e2e-tests/map-plugins-for-e2e-env.sh
@@ -8,7 +8,7 @@ if [[ -z "$PROJECT_PATH" ]]; then
 	exit 1
 fi
 
-tar --xz -xvvf "$BUILD_DIR/jetpack-build/build.tar.xz" -C "$BUILD_DIR"
+tar --xz -xf "$BUILD_DIR/jetpack-build/build.tar.xz" -C "$BUILD_DIR"
 
 SLUG=$(jq -r -e ".ci.pluginSlug" "$PROJECT_PATH/package.json")
 MIRROR=$(jq -r -e ".ci.mirrorName" "$PROJECT_PATH/package.json")
@@ -17,4 +17,8 @@ MIRROR=$(jq -r -e ".ci.mirrorName" "$PROJECT_PATH/package.json")
 	echo "e2e:"
 	echo "  volumeMappings:"
 	echo "    $BUILD_DIR/build/Automattic/$MIRROR: /var/www/html/wp-content/plugins/$SLUG"
-} >> ./tools/docker/jetpack-docker-config.yml
+} > ./tools/docker/jetpack-docker-config.yml
+
+if [[ $SLUG != 'jetpack' ]]; then
+	echo "    $BUILD_DIR/build/Automattic/jetpack-production: /var/www/html/wp-content/plugins/jetpack" >> ./tools/docker/jetpack-docker-config.yml
+fi


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This should fix tests setup for standalone plugins when using build artefacts.
Jetpack also needs to be mapped in Docker volumes when other standalone plugins are tested.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* After merge, check the e2e tests triggered by workflow_run after build workflow completes.

