### PR TITLE
VideoPress: fix updating the store when editing video data

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-fix-updating-store
+++ b/projects/packages/videopress/changelog/update-videopress-fix-updating-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: fix updating the store when editing video data

--- a/projects/packages/videopress/src/client/state/reducers.js
+++ b/projects/packages/videopress/src/client/state/reducers.js
@@ -79,8 +79,19 @@ const videos = ( state = {}, action ) => {
 		case SET_VIDEO: {
 			const { video } = action;
 			const { items = [] } = state;
-			if ( ! items.find( item => item.ID === video.ID ) ) {
+
+			if ( ! items.length ) {
+				// Add video when no items
 				items.push( video );
+			} else {
+				const videoIndex = items.findIndex( item => item.id === video.id );
+				if ( videoIndex === -1 ) {
+					// Add video when not found
+					items.push( video );
+				} else {
+					// Update video when found
+					items[ videoIndex ] = video;
+				}
 			}
 
 			return {

--- a/projects/packages/videopress/src/client/state/reducers.js
+++ b/projects/packages/videopress/src/client/state/reducers.js
@@ -79,19 +79,14 @@ const videos = ( state = {}, action ) => {
 		case SET_VIDEO: {
 			const { video } = action;
 			const { items = [] } = state;
+			const videoIndex = items.findIndex( item => item.id === video.id );
 
-			if ( ! items.length ) {
-				// Add video when no items
+			if ( videoIndex === -1 ) {
+				// Add video when not found
 				items.push( video );
 			} else {
-				const videoIndex = items.findIndex( item => item.id === video.id );
-				if ( videoIndex === -1 ) {
-					// Add video when not found
-					items.push( video );
-				} else {
-					// Update video when found
-					items[ videoIndex ] = video;
-				}
+				// Update video when found
+				items[ videoIndex ] = video;
 			}
 
 			return {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes the issue when editing video data.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: fix updating the store when editing video data

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load a single video page: `http://localhost/wp-admin/admin.php?page=jetpack-videopress#/video/<id>/edit`
* Confirm the data loads after the app requests the data
* Change data (title, desc, ...)
* Save
* Confirm the data is immediately updated in the dashboard


https://user-images.githubusercontent.com/77539/191771819-393a2e27-e144-484f-930a-836211650112.mov
