### PR TITLE
Test results to Slack: add support for workflow_run and fix empty blocks

### DIFF
--- a/projects/github-actions/test-results-to-slack/changelog/no-empty-context
+++ b/projects/github-actions/test-results-to-slack/changelog/no-empty-context
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix empty blocks for unsupported events. Add support for workflow_run event.

--- a/projects/github-actions/test-results-to-slack/src/message.js
+++ b/projects/github-actions/test-results-to-slack/src/message.js
@@ -29,27 +29,27 @@ async function createMessage( isFailure ) {
 	);
 	const actorBlock = getTextContextElement( `Actor: ${ actor }` );
 	const lastRunButtonBlock = getButton( 'Last run', getRunUrl( false ) );
+	buttons.push( lastRunButtonBlock );
 
 	if ( eventName === 'pull_request' ) {
 		const { html_url, number, title } = payload.pull_request;
 		target = `for pull request *#${ number }*`;
 		msgId = `pr-${ number }`;
 
-		contextElements.push( getTextContextElement( `Title: ${ title }` ), actorBlock, lastRunBlock );
+		contextElements.push( getTextContextElement( `Title: ${ title }` ), actorBlock );
 
-		buttons.push( lastRunButtonBlock, getButton( `PR #${ number }`, html_url ) );
+		buttons.push( getButton( `PR #${ number }`, html_url ) );
 	}
 
-	if ( eventName === 'push' ) {
+	if ( eventName === 'push' || eventName === 'workflow_run' ) {
 		const { url, id, message } = payload.head_commit;
-		target = `on ${ refType } _*${ refName }*_`;
-		msgId = `commit-${ id }`;
+		target = `on ${ refType } _*${ refName }*_ (${ eventName })`;
+		msgId = `${ eventName }-${ id }`;
 		const truncatedMessage = message.length > 50 ? message.substring( 0, 48 ) + '...' : message;
 
 		contextElements.push(
 			getTextContextElement( `Commit: ${ id.substring( 0, 8 ) } ${ truncatedMessage }` ),
-			actorBlock,
-			lastRunBlock
+			actorBlock
 		);
 
 		buttons.push( lastRunButtonBlock, getButton( `Commit ${ id.substring( 0, 8 ) }`, url ) );
@@ -62,13 +62,12 @@ async function createMessage( isFailure ) {
 		msgId = `sched-${ Date.now() }`;
 		const commitUrl = `${ serverUrl }/${ repository }/commit/${ sha }`;
 
-		contextElements.push(
-			getTextContextElement( `Last commit: ${ sha.substring( 0, 8 ) }` ),
-			lastRunBlock
-		);
+		contextElements.push( getTextContextElement( `Last commit: ${ sha.substring( 0, 8 ) }` ) );
 
 		buttons.push( lastRunButtonBlock, getButton( `Commit ${ sha.substring( 0, 8 ) }`, commitUrl ) );
 	}
+
+	contextElements.push( lastRunBlock );
 
 	const statusIcon = `${ isFailure ? ':x:' : ':white_check_mark:' }`;
 	const statusText = `${ isFailure ? 'failed' : 'passed' }`;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Add explicit support for workflow_run event in Slack notifications action.
* Make sure the context and actions elements lists are never empty. This happened for unknown events, causing notifications to fail.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Notification for PR should work as before.
* After merge, check the tests run for push and workflow_run.
