### PR TITLE
VideoPress: fix error on undefined preview image

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-error-on-undefined-preview-image
+++ b/projects/packages/videopress/changelog/fix-videopress-error-on-undefined-preview-image
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: small fix to variable assignement
+
+

--- a/projects/packages/videopress/src/client/state/utils/map-videos.ts
+++ b/projects/packages/videopress/src/client/state/utils/map-videos.ts
@@ -46,7 +46,8 @@ export const mapVideoFromWPV2MediaEndpoint = (
 	 * Define thumbnail picking the image from DVD file type
 	 * Issue: https://github.com/Automattic/jetpack/issues/26319
 	 */
-	const thumbnail = `${ fileURLBase.https }${ dvd.original_img }`;
+
+	const thumbnail = dvd?.original_img ? `${ fileURLBase.https }${ dvd.original_img }` : undefined;
 
 	return {
 		id,

--- a/projects/packages/videopress/src/client/state/utils/map-videos.ts
+++ b/projects/packages/videopress/src/client/state/utils/map-videos.ts
@@ -46,7 +46,6 @@ export const mapVideoFromWPV2MediaEndpoint = (
 	 * Define thumbnail picking the image from DVD file type
 	 * Issue: https://github.com/Automattic/jetpack/issues/26319
 	 */
-
 	const thumbnail = dvd?.original_img ? `${ fileURLBase.https }${ dvd.original_img }` : undefined;
 
 	return {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26343 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Whenever a new video is uploaded to VideoPress and the VP dashboard is visited right after, we get the error
`Cannot read properties of undefined (reading 'original_img')`.
This is because we are trying to fetch the preview image, that is not yet defined.

Error screenshot:
![Image](https://user-images.githubusercontent.com/16329583/191736752-ce182acb-cc72-4e17-a99c-6a4b98762086.png)

This PR adds a check to confirm that the value exists before using it. 

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1663843423636939-slack-C02TQF5VAJD

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1- Create a site with a paid VideoPress plan and the standalone plugin active
2- Go to Media -> Library , and upload a video
3- Visit the VideoPress dashboard and check the console for errors


