### PR TITLE
E2E tests: do not include Jetpack update test group for workflow_run event

### DIFF
--- a/.github/files/e2e-tests/create-e2e-projects-matrix.sh
+++ b/.github/files/e2e-tests/create-e2e-projects-matrix.sh
@@ -2,7 +2,13 @@
 
 set -eo pipefail
 
-PROJECTS=('{"project":"Jetpack connection","path":"projects/plugins/jetpack/tests/e2e","testArgs":["specs/connection","--retries=2"]}' '{"project":"Jetpack pre-connection","path":"projects/plugins/jetpack/tests/e2e","testArgs":["specs/pre-connection","--retries=2"]}' '{"project":"Jetpack post-connection","path":"projects/plugins/jetpack/tests/e2e","testArgs":["specs/post-connection","--retries=2"]}' '{"project":"Jetpack sync","path":"projects/plugins/jetpack/tests/e2e","testArgs":["specs/sync","--retries=2"]}' '{"project":"Jetpack blocks","path":"projects/plugins/jetpack/tests/e2e","testArgs":["specs/blocks","--retries=2"]}' '{"project":"Jetpack update","path":"projects/plugins/jetpack/tests/e2e","testArgs":["plugin-update","--retries=2"]}' '{"project":"Boost","path":"projects/plugins/boost/tests/e2e","testArgs":[]}' '{"project":"Search","path":"projects/plugins/search/tests/e2e","testArgs":[]}' '{"project":"VideoPress","path":"projects/plugins/videopress/tests/e2e","testArgs":[]}')
+PROJECTS=('{"project":"Jetpack connection","path":"projects/plugins/jetpack/tests/e2e","testArgs":["specs/connection","--retries=2"]}' '{"project":"Jetpack pre-connection","path":"projects/plugins/jetpack/tests/e2e","testArgs":["specs/pre-connection","--retries=2"]}' '{"project":"Jetpack post-connection","path":"projects/plugins/jetpack/tests/e2e","testArgs":["specs/post-connection","--retries=2"]}' '{"project":"Jetpack sync","path":"projects/plugins/jetpack/tests/e2e","testArgs":["specs/sync","--retries=2"]}' '{"project":"Jetpack blocks","path":"projects/plugins/jetpack/tests/e2e","testArgs":["specs/blocks","--retries=2"]}' '{"project":"Boost","path":"projects/plugins/boost/tests/e2e","testArgs":[]}' '{"project":"Search","path":"projects/plugins/search/tests/e2e","testArgs":[]}' '{"project":"VideoPress","path":"projects/plugins/videopress/tests/e2e","testArgs":[]}')
+
+## Update test only works with local build and workflow_run uses CI built artefacts
+if [[ "$GITHUB_EVENT_NAME" != "workflow_run" ]]; then
+	PROJECTS+=('{"project":"Jetpack update","path":"projects/plugins/jetpack/tests/e2e","testArgs":["plugin-update","--retries=2"]}')
+fi
+
 PROJECTS_MATRIX=()
 RUN_NAME=''
 

--- a/tools/e2e-commons/bin/e2e-env.sh
+++ b/tools/e2e-commons/bin/e2e-env.sh
@@ -54,6 +54,8 @@ gb_setup() {
 }
 
 configure_wp_env() {
+	$BASE_CMD wp plugin status
+
 	$BASE_CMD wp plugin activate jetpack
 	$BASE_CMD wp plugin activate e2e-plan-data-interceptor
 	$BASE_CMD wp plugin activate e2e-waf-data-interceptor
@@ -69,6 +71,8 @@ configure_wp_env() {
 	$BASE_CMD wp jetpack module deactivate sso
 	$BASE_CMD wp theme activate twentytwentyone
 
+	echo
+	$BASE_CMD wp plugin status
 	echo
 	echo "WordPress is ready!"
 	echo


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

Only run the update test for events other than `workflow_run`
Jetpack update e2e test needs a local build to work and when running in CI on `workflow_run` event we're not building, but using the build workflow artefacts.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Check the e2e tests run for `workflow_run` after merge.

