### PR TITLE
E2E tests: pass run_id when downloading build artefacts

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -87,6 +87,7 @@ jobs:
       with:
         workflow: build.yml
         workflow_conclusion: "success"
+        run_id: ${{ github.event.workflow_run.id }}
         path: build-output
 
     - name: Prepare build


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Use build's workflow `run_id` when downloading artefacts. Without it, the last run artefacts are being downloaded, causing e2e tests to use a totally different build than expected.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
1156386383419466-as-1203024369068233

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* After merging, check the `workflow_run` triggered e2e tests job.