### PR TITLE
Fix SearchInput behavior on VideoPress dashboard

### DIFF
--- a/projects/packages/videopress/changelog/update-search-on-input-clear
+++ b/projects/packages/videopress/changelog/update-search-on-input-clear
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fix SearchInput clear and initial typing behavior on dashboard

--- a/projects/packages/videopress/src/client/admin/components/input/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/input/index.tsx
@@ -148,6 +148,7 @@ export const SearchInput = ( {
 
 	const clearInput = useCallback( () => {
 		componentProps.onChange?.( '' );
+		onSearch( '' );
 	}, [ componentProps.onChange ] );
 
 	return (

--- a/projects/packages/videopress/src/client/admin/hooks/use-videos/index.js
+++ b/projects/packages/videopress/src/client/admin/hooks/use-videos/index.js
@@ -16,6 +16,7 @@ export default function useVideos() {
 	return {
 		// Data
 		items: useSelect( select => select( STORE_ID ).getVideos(), [] ),
+		search: '',
 		...useSelect( select => select( STORE_ID ).getVideosQuery() || {} ),
 		...useSelect( select => select( STORE_ID ).getPagination(), [] ),
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #26359
Closes #26328

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a default value for the search query parameter
* Calls `onSearch` when the user clicks the clear icon on the search input

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Search on clear:
* Open the storybook: `cd projects/js-packages/storybook && pnpm run storybook:dev`
* Packages > VideoPress > Input > Search
* Type anything and then click on the clear (`X`) icon
* Check that an `onSearch` action with an empty string is logged on the `Actions` tab

Warning fix:
* At the VideoPress dashboard with at least one video, type something in the search input
* Check that there is no warning

Note: If a search finds no videos, the search input disappears. This is a known bug to be tracked in this issue: https://github.com/Automattic/jetpack/issues/26360

![Screenshot_2022-09-22_15-59-19](https://user-images.githubusercontent.com/8486249/191829700-8bd731a8-c018-47b8-bec0-68ddbe377747.png)
