### PR TITLE
VideoPress: Fix video counter on VideoPress library page

### DIFF
--- a/projects/packages/videopress/changelog/fix-show-total-video-count-on-videopress-library
+++ b/projects/packages/videopress/changelog/fix-show-total-video-count-on-videopress-library
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Set the right source for the total of videos counter on the VideoPress library page.

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -29,8 +29,9 @@ const Admin = () => {
 	const { isUserConnected, isRegistered } = connectionStatus;
 	const showConnectionCard = ! isRegistered || ! isUserConnected;
 
-	const { items: videos } = useVideos();
+	const { items: videos, total: totalVideoCount } = useVideos();
 	const localVideos = [];
+	const localTotalVideoCount = 0;
 	const hasVideos = videos && videos.length > 0;
 	const hasLocalVideos = localVideos && localVideos.length > 0;
 	const addNewLabel = __( 'Add new video', 'jetpack-videopress-pkg' );
@@ -70,7 +71,7 @@ const Admin = () => {
 						<Container horizontalSpacing={ 6 } horizontalGap={ 10 }>
 							{ hasVideos ? (
 								<Col sm={ 4 } md={ 6 } lg={ 12 }>
-									<VideoPressLibrary videos={ videos } />
+									<VideoPressLibrary videos={ videos } totalVideos={ totalVideoCount } />
 								</Col>
 							) : (
 								<Col sm={ 4 } md={ 6 } lg={ 12 } className={ styles[ 'first-video-wrapper' ] }>
@@ -85,7 +86,7 @@ const Admin = () => {
 							) }
 							{ hasLocalVideos && (
 								<Col sm={ 4 } md={ 6 } lg={ 12 }>
-									<LocalLibrary videos={ localVideos } />
+									<LocalLibrary videos={ localVideos } totalVideos={ localTotalVideoCount } />
 								</Col>
 							) }
 						</Container>

--- a/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
@@ -139,10 +139,10 @@ export const VideoPressLibrary = ( { videos, totalVideos }: VideoLibraryProps ) 
 	);
 };
 
-export const LocalLibrary = ( { videos }: VideoLibraryProps ) => {
+export const LocalLibrary = ( { videos, totalVideos }: VideoLibraryProps ) => {
 	return (
 		<VideoLibraryWrapper
-			totalVideos={ videos?.length }
+			totalVideos={ totalVideos }
 			hideFilter
 			title={ __( 'Local videos', 'jetpack-videopress-pkg' ) }
 		>

--- a/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
@@ -62,13 +62,19 @@ const VideoLibraryWrapper = ( {
 
 	const [ isFilterActive, setIsFilterActive ] = useState( false );
 
+	const singularTotalVideosLabel = __( 'Video', 'jetpack-videopress-pkg' );
+	const pluralTotalVideosLabel = __( 'Videos', 'jetpack-videopress-pkg' );
+	const totalVideosLabel = totalVideos === 1 ? singularTotalVideosLabel : pluralTotalVideosLabel;
+
 	return (
 		<div className={ styles[ 'library-wrapper' ] }>
 			<Text variant="headline-small" mb={ 1 }>
 				{ title }
 			</Text>
 			<div className={ styles[ 'total-filter-wrapper' ] }>
-				<Text>{ totalVideos } Video</Text>
+				<Text>
+					{ totalVideos } { totalVideosLabel }
+				</Text>
 				{ hideFilter ? null : (
 					<div className={ styles[ 'filter-wrapper' ] }>
 						<SearchInput

--- a/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
@@ -44,7 +44,6 @@ const ConnectedPagination: React.FC< PaginationProps > = props => {
 
 const VideoLibraryWrapper = ( {
 	children,
-	videosOnPage = 0,
 	totalVideos = 0,
 	libraryType = LibraryType.List,
 	onChangeType,
@@ -53,7 +52,6 @@ const VideoLibraryWrapper = ( {
 }: {
 	children: React.ReactNode;
 	libraryType?: LibraryType;
-	videosOnPage?: number;
 	totalVideos?: number;
 	onChangeType?: () => void;
 	hideFilter?: boolean;
@@ -70,9 +68,7 @@ const VideoLibraryWrapper = ( {
 				{ title }
 			</Text>
 			<div className={ styles[ 'total-filter-wrapper' ] }>
-				<Text>
-					{ videosOnPage } of { totalVideos } Video
-				</Text>
+				<Text>{ totalVideos } Video</Text>
 				{ hideFilter ? null : (
 					<div className={ styles[ 'filter-wrapper' ] }>
 						<SearchInput
@@ -125,7 +121,6 @@ export const VideoPressLibrary = ( { videos, totalVideos }: VideoLibraryProps ) 
 	return (
 		<VideoLibraryWrapper
 			totalVideos={ totalVideos }
-			videosOnPage={ videos?.length }
 			onChangeType={ toggleType }
 			libraryType={ libraryType }
 			title={ __( 'Your VideoPress library', 'jetpack-videopress-pkg' ) }

--- a/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
@@ -108,7 +108,7 @@ const VideoLibraryWrapper = ( {
 	);
 };
 
-export const VideoPressLibrary = ( { videos }: VideoLibraryProps ) => {
+export const VideoPressLibrary = ( { videos, totalVideos }: VideoLibraryProps ) => {
 	const navigate = useNavigate();
 	const [ libraryType, setLibraryType ] = useState< LibraryType >( LibraryType.Grid );
 
@@ -124,7 +124,8 @@ export const VideoPressLibrary = ( { videos }: VideoLibraryProps ) => {
 
 	return (
 		<VideoLibraryWrapper
-			totalVideos={ videos?.length }
+			totalVideos={ totalVideos }
+			videosOnPage={ videos?.length }
 			onChangeType={ toggleType }
 			libraryType={ libraryType }
 			title={ __( 'Your VideoPress library', 'jetpack-videopress-pkg' ) }

--- a/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
@@ -44,6 +44,7 @@ const ConnectedPagination: React.FC< PaginationProps > = props => {
 
 const VideoLibraryWrapper = ( {
 	children,
+	videosOnPage = 0,
 	totalVideos = 0,
 	libraryType = LibraryType.List,
 	onChangeType,
@@ -52,6 +53,7 @@ const VideoLibraryWrapper = ( {
 }: {
 	children: React.ReactNode;
 	libraryType?: LibraryType;
+	videosOnPage?: number;
 	totalVideos?: number;
 	onChangeType?: () => void;
 	hideFilter?: boolean;
@@ -68,7 +70,9 @@ const VideoLibraryWrapper = ( {
 				{ title }
 			</Text>
 			<div className={ styles[ 'total-filter-wrapper' ] }>
-				<Text>{ totalVideos } Video</Text>
+				<Text>
+					{ videosOnPage } of { totalVideos } Video
+				</Text>
 				{ hideFilter ? null : (
 					<div className={ styles[ 'filter-wrapper' ] }>
 						<SearchInput

--- a/projects/packages/videopress/src/client/admin/components/admin-page/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/types.ts
@@ -12,7 +12,10 @@ declare global {
 	}
 }
 
-export type VideoLibraryProps = { videos: Array< VideoPressVideo > };
+export type VideoLibraryProps = {
+	videos: Array< VideoPressVideo >;
+	totalVideos?: number;
+};
 
 export interface ConnectionStore {
 	getConnectionStatus: () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26346.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Change the VideoPressLibrary and LocalLibrary component to expect a `totalVideos` prop
* Use the information returned by `useVideos()` to set this prop on when rendering the components
* Set proper plural and internationalization for the counter words

Visual changes:

* **Before the fix:** the counter would show the number of videos on the current page

![Counter on VideoPress Library, page 1](https://user-images.githubusercontent.com/6760046/191841713-fedd2abf-7218-4054-bfde-7b312f6f2a9a.png)

![Counter on VideoPress Library, page 2](https://user-images.githubusercontent.com/6760046/191841774-dc8503e4-c0a9-4122-b443-a9050cddefdd.png)

* **After the fix:** The counter will always show the total of videos from the library, regardless of the page; singular ("Video") and plural ("Videos") are properly handled, as well as internationalization

![Counter on VideoPress Library with proper singular label](https://user-images.githubusercontent.com/6760046/191843296-239e76a7-9220-4820-9c45-16c96081dd2d.png)

![Counter on VideoPress Library, page 1, showing the total of videos](https://user-images.githubusercontent.com/6760046/191843311-423d693b-6c39-4ca7-8223-be6c7abcfccc.png)

![Counter on VideoPress Library, page 2, still showing the total of videos](https://user-images.githubusercontent.com/6760046/191843304-0b456af0-75a2-4a17-8f5e-ea60d81f3243.png)

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Based on the designs from p1HpG7-gQf-p2.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use a connected site with the VideoPress plugin installed and an active VideoPress upgrade
* If you don't have any videos, add one through `Media > Add New`
* Go to `Jetpack > VideoPress` to open the VideoPress library
* The counter will show the total of videos from your library
* If you have less than 6 videos on the library, add a few more using `Media > Add New` so you get more than one page on the listing
* Go to `Jetpack > VideoPress` to open the VideoPress library again
* The counter will show always the total of videos from your library, always the same number regardless of the page