### PR TITLE
VideoPress: expose and store more video data

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-pick-data-from-jetpack-videopress-field
+++ b/projects/packages/videopress/changelog/update-videopress-pick-data-from-jetpack-videopress-field
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: expose and store more video data

--- a/projects/packages/videopress/src/client/admin/types/index.ts
+++ b/projects/packages/videopress/src/client/admin/types/index.ts
@@ -33,6 +33,12 @@ export type OriginalVideoPressVideo = {
 	 * Video duration, in milliseconds
 	 */
 	duration?: number;
+
+	/**
+	 * Video rating
+	 */
+	rating?: 'G' | 'PG-13' | 'R-17';
+
 	/**
 	 * Plays counter
 	 */
@@ -47,9 +53,22 @@ export type OriginalVideoPressVideo = {
 	isPrivate?: boolean;
 
 	/**
+	 * Whether is possible to download the video, or not.
+	 */
+	allowDownload?: boolean;
+
+	/**
 	 * Video poster image URL
 	 */
 	posterImage?: string;
+
+	/**
+	 * Video privacy setting:
+	 * - 0 `public`: anyone can view the video
+	 * - 1 `private`: only the owner can view the video
+	 * - 2 `site-default`
+	 */
+	privacySetting?: 0 | 1 | 2;
 
 	/**
 	 * Object reflecting poster image data.

--- a/projects/packages/videopress/src/client/state/utils/map-videos.ts
+++ b/projects/packages/videopress/src/client/state/utils/map-videos.ts
@@ -24,13 +24,25 @@ export const mapVideos = ( videos: OriginalVideoPressVideo[] ): VideoPressVideo[
 export const mapVideoFromWPV2MediaEndpoint = (
 	video: OriginalVideoPressVideo
 ): VideoPressVideo => {
-	const { media_details: mediaDetails, id, caption, jetpack_videopress_guid: guid } = video;
+	const {
+		media_details: mediaDetails,
+		id,
+		caption,
+		jetpack_videopress: jetpackVideoPress,
+		jetpack_videopress_guid: guid,
+	} = video;
 
 	const { videopress: videoPressMediaDetails, width, height } = mediaDetails;
 
 	const {
-		title,
+		allow_download: allowDownload,
 		description,
+		privacy_setting: privacySetting,
+		rating,
+		title,
+	} = jetpackVideoPress;
+
+	const {
 		original: url,
 		poster,
 		upload_date: date,
@@ -60,6 +72,9 @@ export const mapVideoFromWPV2MediaEndpoint = (
 		isPrivate,
 		dateFormatted: gmdateI18n( 'F j, Y', date ),
 		posterImage: poster,
+		allowDownload,
+		rating,
+		privacySetting,
 		poster: {
 			src: poster,
 			width,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR reorganizes how to pick some fields from the request-response body and also exposes and stores a few new fields in the state tree.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: expose and store more video data

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to VideoPress dashboard
* Confirm `allowDownload`, rating` and `privacySetting` are defined for each video item. You can use the Redux dev tool


<img width="611" alt="Screen Shot 2022-09-22 at 21 43 15" src="https://user-images.githubusercontent.com/77539/191874218-b152c239-c31d-439e-9d80-8c81c47336eb.png">


