### PR TITLE
JS Components: Add indeterminate progress bar

### DIFF
--- a/projects/js-packages/components/changelog/add-indeterminate-progress-bar
+++ b/projects/js-packages/components/changelog/add-indeterminate-progress-bar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added indeterminate progress bar

--- a/projects/js-packages/components/components/indeterminate-progress-bar/index.tsx
+++ b/projects/js-packages/components/components/indeterminate-progress-bar/index.tsx
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+/**
+ * Internal dependencies
+ */
+import styles from './style.module.scss';
+import { IndeterminateProgressBarProps } from './types';
+import type React from 'react';
+
+/**
+ * Progress Bar component
+ *
+ * @param {IndeterminateProgressBarProps} props - Component props.
+ * @returns {React.ReactNode} - IndeterminateProgressBar react component.
+ */
+const IndeterminateProgressBar: React.FC< IndeterminateProgressBarProps > = ( { className } ) => {
+	return <div className={ classnames( className, styles.wrapper ) } />;
+};
+
+export default IndeterminateProgressBar;

--- a/projects/js-packages/components/components/indeterminate-progress-bar/index.tsx
+++ b/projects/js-packages/components/components/indeterminate-progress-bar/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 /**
  * Internal dependencies
@@ -10,13 +11,18 @@ import { IndeterminateProgressBarProps } from './types';
 import type React from 'react';
 
 /**
- * Progress Bar component
+ * Indeterminate Progress Bar component
  *
  * @param {IndeterminateProgressBarProps} props - Component props.
  * @returns {React.ReactNode} - IndeterminateProgressBar react component.
  */
 const IndeterminateProgressBar: React.FC< IndeterminateProgressBarProps > = ( { className } ) => {
-	return <div className={ classnames( className, styles.wrapper ) } />;
+	return (
+		<div
+			className={ classnames( className, styles[ 'indeterminate-progress-bar' ] ) }
+			aria-label={ __( 'Indeterminate Progress Bar', 'jetpack' ) }
+		/>
+	);
 };
 
 export default IndeterminateProgressBar;

--- a/projects/js-packages/components/components/indeterminate-progress-bar/stories/index.tsx
+++ b/projects/js-packages/components/components/indeterminate-progress-bar/stories/index.tsx
@@ -1,0 +1,14 @@
+import IndeterminateProgressBar from '..';
+import type { ComponentStory, ComponentMeta } from '@storybook/react';
+
+export default {
+	title: 'JS Packages/Components/Indeterminate Progress Bar',
+	component: IndeterminateProgressBar,
+} as ComponentMeta< typeof IndeterminateProgressBar >;
+
+const Template: ComponentStory< typeof IndeterminateProgressBar > = args => {
+	return <IndeterminateProgressBar { ...args } />;
+};
+
+export const _default = Template.bind( {} );
+_default.args = {};

--- a/projects/js-packages/components/components/indeterminate-progress-bar/style.module.scss
+++ b/projects/js-packages/components/components/indeterminate-progress-bar/style.module.scss
@@ -2,6 +2,7 @@
 	--jp-indeterminate-progress-bar__light-color: #d6d6d6;
 	--jp-indeterminate-progress-bar__dark-color: var(--jp-gray);
 }
+
 .indeterminate-progress-bar {
 	width: 100%;
 	height: 24px;

--- a/projects/js-packages/components/components/indeterminate-progress-bar/style.module.scss
+++ b/projects/js-packages/components/components/indeterminate-progress-bar/style.module.scss
@@ -1,0 +1,27 @@
+@keyframes indeterminate_progress_bar__animation {
+	0% {
+		background-position: 96px 0;
+	}
+}
+
+.wrapper {
+	--jp-indeterminate-progress-bar__light-color: #D0D0D0;
+	--jp-indeterminate-progress-bar__dark-color: #DCDCDE;
+	width: 100%;
+	height: 24px;
+	background-color: transparent;
+	border-radius: calc(var(--spacing-base) * 3);
+
+	pointer-events: none;
+	animation: indeterminate_progress_bar__animation 2000ms infinite linear;
+	background-size: 48px 100%;
+	background-image: linear-gradient(
+		-45deg,
+		var(--jp-indeterminate-progress-bar__light-color) 33%,
+		var(--jp-indeterminate-progress-bar__dark-color) 33%,
+		var(--jp-indeterminate-progress-bar__dark-color) 67%,
+		var(--jp-indeterminate-progress-bar__light-color) 67%
+	);
+	display: inline-block;
+
+}

--- a/projects/js-packages/components/components/indeterminate-progress-bar/style.module.scss
+++ b/projects/js-packages/components/components/indeterminate-progress-bar/style.module.scss
@@ -1,5 +1,5 @@
 :root {
-	--jp-indeterminate-progress-bar__light-color: #d6d6d6;
+	--jp-indeterminate-progress-bar__light-color: #d9d9d9;
 	--jp-indeterminate-progress-bar__dark-color: var(--jp-gray);
 }
 
@@ -16,14 +16,14 @@
 		var(--jp-indeterminate-progress-bar__light-color) 33%,
 		var(--jp-indeterminate-progress-bar__dark-color) 33%,
 		var(--jp-indeterminate-progress-bar__dark-color) 67%,
-		var(--jp-indeterminate-progress-bar__light-color) 67%
+		var(--jp-indeterminate-progress-bar__light-color) 67%,
 	);
 	display: inline-block;
 }
 
 @keyframes indeterminate_progress_bar__animation {
 	0% {
-		background-position: 96px 0;
+		background-position: 48px 0;
 	}
 }
 

--- a/projects/js-packages/components/components/indeterminate-progress-bar/style.module.scss
+++ b/projects/js-packages/components/components/indeterminate-progress-bar/style.module.scss
@@ -16,14 +16,14 @@
 		var(--jp-indeterminate-progress-bar__light-color) 33%,
 		var(--jp-indeterminate-progress-bar__dark-color) 33%,
 		var(--jp-indeterminate-progress-bar__dark-color) 67%,
-		var(--jp-indeterminate-progress-bar__light-color) 67%,
+		var(--jp-indeterminate-progress-bar__light-color) 67%
 	);
 	display: inline-block;
 }
 
 @keyframes indeterminate_progress_bar__animation {
 	0% {
-		background-position: 48px 0;
+		background-position: 96px 0;
 	}
 }
 

--- a/projects/js-packages/components/components/indeterminate-progress-bar/style.module.scss
+++ b/projects/js-packages/components/components/indeterminate-progress-bar/style.module.scss
@@ -4,7 +4,7 @@
 	}
 }
 
-.wrapper {
+.indeterminate-progress-bar {
 	--jp-indeterminate-progress-bar__light-color: #D0D0D0;
 	--jp-indeterminate-progress-bar__dark-color: #DCDCDE;
 	width: 100%;
@@ -13,7 +13,6 @@
 	border-radius: calc(var(--spacing-base) * 3);
 
 	pointer-events: none;
-	animation: indeterminate_progress_bar__animation 2000ms infinite linear;
 	background-size: 48px 100%;
 	background-image: linear-gradient(
 		-45deg,
@@ -23,5 +22,10 @@
 		var(--jp-indeterminate-progress-bar__light-color) 67%
 	);
 	display: inline-block;
+}
 
+@media (prefers-reduced-motion: no-preference) {
+	.indeterminate-progress-bar {
+	animation: indeterminate_progress_bar__animation 2000ms infinite linear;
+	}
 }

--- a/projects/js-packages/components/components/indeterminate-progress-bar/style.module.scss
+++ b/projects/js-packages/components/components/indeterminate-progress-bar/style.module.scss
@@ -1,12 +1,8 @@
-@keyframes indeterminate_progress_bar__animation {
-	0% {
-		background-position: 96px 0;
-	}
+:root {
+	--jp-indeterminate-progress-bar__light-color: #d6d6d6;
+	--jp-indeterminate-progress-bar__dark-color: var(--jp-gray);
 }
-
 .indeterminate-progress-bar {
-	--jp-indeterminate-progress-bar__light-color: #D0D0D0;
-	--jp-indeterminate-progress-bar__dark-color: #DCDCDE;
 	width: 100%;
 	height: 24px;
 	background-color: transparent;
@@ -24,8 +20,14 @@
 	display: inline-block;
 }
 
+@keyframes indeterminate_progress_bar__animation {
+	0% {
+		background-position: 96px 0;
+	}
+}
+
 @media (prefers-reduced-motion: no-preference) {
 	.indeterminate-progress-bar {
-	animation: indeterminate_progress_bar__animation 2000ms infinite linear;
+		animation: indeterminate_progress_bar__animation 2000ms infinite linear;
 	}
 }

--- a/projects/js-packages/components/components/indeterminate-progress-bar/style.module.scss
+++ b/projects/js-packages/components/components/indeterminate-progress-bar/style.module.scss
@@ -1,5 +1,5 @@
 :root {
-	--jp-indeterminate-progress-bar__light-color: #d9d9d9;
+	--jp-indeterminate-progress-bar__light-color: #d0d0d0;
 	--jp-indeterminate-progress-bar__dark-color: var(--jp-gray);
 }
 

--- a/projects/js-packages/components/components/indeterminate-progress-bar/types.ts
+++ b/projects/js-packages/components/components/indeterminate-progress-bar/types.ts
@@ -1,0 +1,16 @@
+export type IndeterminateProgressBarProps = {
+	/**
+	 * Optional classname to apply to the root element.
+	 */
+	className?: string;
+
+	/**
+	 * Light color for the bar.
+	 */
+	lightColor?: string;
+
+	/**
+	 * Dark color for the bar.
+	 */
+	darkColor?: string;
+};

--- a/projects/js-packages/components/components/indeterminate-progress-bar/types.ts
+++ b/projects/js-packages/components/components/indeterminate-progress-bar/types.ts
@@ -3,14 +3,4 @@ export type IndeterminateProgressBarProps = {
 	 * Optional classname to apply to the root element.
 	 */
 	className?: string;
-
-	/**
-	 * Light color for the bar.
-	 */
-	lightColor?: string;
-
-	/**
-	 * Dark color for the bar.
-	 */
-	darkColor?: string;
 };

--- a/projects/js-packages/components/index.ts
+++ b/projects/js-packages/components/index.ts
@@ -51,4 +51,5 @@ export { default as DonutMeter } from './components/donut-meter';
 export { default as RecordMeterBar } from './components/record-meter-bar';
 export { default as ContextualUpgradeTrigger } from './components/contextual-upgrade-trigger';
 export { default as Alert } from './components/alert';
+export { default as IndeterminateProgressBar } from './components/indeterminate-progress-bar';
 export { getUserLocale, cleanLocale } from './lib/locale';


### PR DESCRIPTION
Fixes #26055 

#### Changes proposed in this Pull Request:
The PR adds a indeterminate progress bar to JS Components. It's illustrated how it's filled below: 

![linear-fill](https://user-images.githubusercontent.com/1425433/192371261-37ed37dd-5373-4bf5-9b4c-3ca07caea661.jpeg)

The animation is done by changing the background position.

Note: the original pair of colors don't look sharp enough, so I changed the light color from `#D9D9D9` to `#D0D0D0`. Feedback appreciated.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
`p1HpG7-hrJ#comment-56575-p2`

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Run storybook `cd projects/js-packages/storybook && npm run storybook:dev`
* Navigate to `http://localhost:50240/?path=/story/js-packages-components-indeterminate-progress-bar--default`
* Ensure it looks okay



![progress-bar](https://user-images.githubusercontent.com/1425433/191890658-6d24d895-1e57-4b1e-a3de-9dd6f232cecf.gif)


