### PR TITLE
Add refresh podcast button to podcast player

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -91,15 +91,21 @@ class Jetpack_Podcast_Helper {
 	public function get_player_data( $args = array() ) {
 		$guids           = isset( $args['guids'] ) && $args['guids'] ? $args['guids'] : array();
 		$episode_options = isset( $args['episode-options'] ) && $args['episode-options'];
+		$force_refresh   = isset( $args['force-refresh'] ) && $args['force-refresh'];
 
 		// Try loading data from the cache.
 		$transient_key = 'jetpack_podcast_' . md5( $this->feed . implode( ',', $guids ) . "-$episode_options" );
-		$player_data   = get_transient( $transient_key );
+
+		if ( $force_refresh ) {
+			$player_data = false;
+		} else {
+			$player_data = get_transient( $transient_key );
+		}
 
 		// Fetch data if we don't have any cached.
 		if ( false === $player_data || ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ) {
 			// Load feed.
-			$rss = $this->load_feed();
+			$rss = $this->load_feed( $force_refresh );
 
 			if ( is_wp_error( $rss ) ) {
 				return $rss;

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-podcast-player.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-podcast-player.php
@@ -66,6 +66,11 @@ class WPCOM_REST_API_V2_Endpoint_Podcast_Player extends WP_REST_Controller {
 							'type'        => 'boolean',
 							'required'    => 'false',
 						),
+						'force-refresh'   => array(
+							'description' => __( 'Whether we should force a refresh for the podcast.', 'jetpack' ),
+							'type'        => 'boolean',
+							'required'    => 'false',
+						),
 					),
 					'schema'              => array( $this, 'get_public_item_schema' ),
 				),
@@ -114,6 +119,10 @@ class WPCOM_REST_API_V2_Endpoint_Podcast_Player extends WP_REST_Controller {
 
 		if ( isset( $request['episode-options'] ) && $request['episode-options'] ) {
 			$args['episode-options'] = true;
+		}
+
+		if ( isset( $request['force-refresh'] ) && $request['force-refresh'] ) {
+			$args['force-refresh'] = true;
 		}
 
 		$player_data = $helper->get_player_data( $args );

--- a/projects/plugins/jetpack/changelog/try-admin-controls-for-podcast-player
+++ b/projects/plugins/jetpack/changelog/try-admin-controls-for-podcast-player
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Allow editors to refresh a podcast feed from the UI

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/api.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/api.js
@@ -9,7 +9,12 @@ export const fetchTrackQuantity = async () => {
 	return trackQuantity;
 };
 
-export const fetchPodcastFeed = async ( { url, guids = [], fetchEpisodeOptions = false } ) => {
+export const fetchPodcastFeed = async ( {
+	url,
+	guids = [],
+	fetchEpisodeOptions = false,
+	forceRefresh = false,
+} ) => {
 	// First try calling our endpoint for Podcast parsing.
 	let feedData, feedError;
 	try {
@@ -18,6 +23,7 @@ export const fetchPodcastFeed = async ( { url, guids = [], fetchEpisodeOptions =
 				url,
 				guids,
 				[ 'episode-options' ]: fetchEpisodeOptions,
+				[ 'force-refresh' ]: forceRefresh,
 			} ),
 		} );
 	} catch ( err ) {

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/components/admin-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/components/admin-controls.js
@@ -1,0 +1,29 @@
+import { memo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { fetchPodcastFeed } from '../api';
+
+const AdminControls = memo( ( { canUserRefreshPodcast, url } ) => {
+	if ( ! canUserRefreshPodcast || ! url ) {
+		return null;
+	}
+
+	const triggerPodcastRefresh = () => {
+		fetchPodcastFeed( { url, forceRefresh: true } ).then( () => document.location.reload() );
+	};
+
+	return (
+		<div className="jetpack-podcast-player__admin-controls">
+			<span className="jetpack-podcast-player__admin-refresh-message">
+				{ __( "Visitors to your site can't see this option.", 'jetpack' ) }
+			</span>
+			<input
+				type="button"
+				className="jetpack-podcast-player__refresh-podcast-button wp-element-button button"
+				onClick={ triggerPodcastRefresh }
+				value={ __( 'Refresh podcast', 'jetpack' ) }
+			/>
+		</div>
+	);
+} );
+
+export default AdminControls;

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/components/podcast-player.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
 import AudioPlayer from '../../../shared/components/audio-player';
 import { STATE_ERROR, STATE_PAUSED, STORE_ID } from '../../../store/media-source/constants';
 import { getColorsObject } from '../utils';
+import AdminControls from './admin-controls';
 import Header from './header';
 import Playlist from './playlist';
 import withErrorBoundary from './with-error-boundary';
@@ -245,14 +246,15 @@ export class PodcastPlayer extends Component {
 
 	render() {
 		const {
-			playerId,
-			title,
-			link,
-			cover,
-			tracks,
 			attributes,
+			canUserRefreshPodcast,
+			cover,
 			currentTime,
+			link,
+			playerId,
 			playerState,
+			title,
+			tracks,
 		} = this.props;
 		const {
 			itemsToShow,
@@ -268,6 +270,7 @@ export class PodcastPlayer extends Component {
 			showCoverArt,
 			showEpisodeTitle,
 			showEpisodeDescription,
+			url,
 		} = attributes;
 		const { currentTrack } = this.state;
 
@@ -339,6 +342,8 @@ export class PodcastPlayer extends Component {
 						onTimeChange={ this.handleTimeChange }
 						onMetadataLoaded={ this.updateMediaData }
 					/>
+
+					<AdminControls canUserRefreshPodcast={ canUserRefreshPodcast } url={ url } />
 				</Header>
 
 				{ tracksToDisplay.length > 1 && (

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/podcast-player.php
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/podcast-player.php
@@ -151,12 +151,16 @@ function render_player( $player_data, $attributes ) {
 	$instance_id             = wp_unique_id( 'jetpack-podcast-player-block-' . get_the_ID() . '-' );
 	$player_data['playerId'] = $instance_id;
 
+	$can_user_refresh_podcast = ! empty( get_current_user_id() ) && current_user_can( 'edit_post', get_the_ID() );
+
 	// Generate object to be used as props for PodcastPlayer.
 	$player_props = array_merge(
 		// Add all attributes.
 		array( 'attributes' => $attributes ),
 		// Add all player data.
-		$player_data
+		$player_data,
+		// Add flag for whether the current user can refresh the podcast
+		array( 'canUserRefreshPodcast' => $can_user_refresh_podcast )
 	);
 
 	$primary_colors    = get_colors( 'primary', $attributes, 'color' );

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/style.scss
@@ -272,7 +272,7 @@ $jetpack-podcast-player-error: $alert-red;
 	}
 
 	.jetpack-podcast-player__track-description {
-		order: 99; // high number to make it always appear after the audio player
+		order: 99; // high number to make it always appear after the audio player and before the admin controls
 		padding: 0 $gutter-l;
 		margin: 0 0 $gutter-l 0;
 		font-size: $editor-font-size;
@@ -287,6 +287,20 @@ $jetpack-podcast-player-error: $alert-red;
 			-webkit-box-orient: vertical;
 			-webkit-line-clamp: 4;
 			max-height: initial;
+		}
+	}
+
+	.jetpack-podcast-player__admin-controls {
+		align-items: center;
+		column-gap: $gutter-l;
+		display: flex;
+		font-size: $default-font-size;
+		justify-content: space-evenly;
+		order: 100; // ensure this appears after the track description above
+		padding: 0 $gutter-l $gutter-l $gutter-l;
+
+		.jetpack-podcast-player__admin-refresh-message {
+			font-style: italic;
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:

* This PR adds a "Refresh podcast" button to the podcast player for users with edit permissions on the underlying post
* Under the covers this button calls the existing `wpcom/v2/podcast-player` API with a new `force-refresh` flag to allow users with `edit_post` permissions to force a podcast refresh

<img width="796" alt="Screenshot 2022-09-23 at 11 53 04" src="https://user-images.githubusercontent.com/3376401/191936189-cd54a6a5-22cd-42fe-8fdd-368c7424455c.png">

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-hQk-p2 especially this comment: p1HpG7-hQk-p2#comment-57214

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use the Jetpack Beta plugin to get this code applied to your server
* Add a post with a podcast player block to the post
* Visit the public post while logged in
* Verify that you can see the button, and that clicking on the button refreshes the podcast and reloads the page
* Visit the public post while logged out
* Verify that you don't see the button