### PR TITLE
Jetpack Social:  Disable sharing if sharing limits have been reached. 

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1444,7 +1444,7 @@ importers:
       '@automattic/jetpack-connection': workspace:* || ^0.20
       '@automattic/jetpack-licensing': workspace:* || ^0.5
       '@automattic/jetpack-partner-coupon': workspace:* || ^0.2
-      '@automattic/jetpack-publicize-components': workspace:* || ^0.6
+      '@automattic/jetpack-publicize-components': workspace:* || ^0.7
       '@automattic/jetpack-shared-extension-utils': workspace:* || ^0.6
       '@automattic/jetpack-webpack-config': workspace:* || ^1.3
       '@automattic/popup-monitor': 1.0.2
@@ -1746,7 +1746,7 @@ importers:
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
       '@automattic/jetpack-components': workspace:* || ^0.21
       '@automattic/jetpack-connection': workspace:* || ^0.20
-      '@automattic/jetpack-publicize-components': workspace:* || ^0.6
+      '@automattic/jetpack-publicize-components': workspace:* || ^0.7
       '@automattic/jetpack-webpack-config': workspace:* || ^1.3
       '@babel/core': 7.18.13
       '@babel/preset-env': 7.18.10

--- a/projects/js-packages/publicize-components/changelog/fix-sharing-limits
+++ b/projects/js-packages/publicize-components/changelog/fix-sharing-limits
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Fixed toggle being shown incorrectly if someone has hit sharing limits. 

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.6.1-alpha",
+	"version": "0.7.0-alpha",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/src/components/form/index.js
+++ b/projects/js-packages/publicize-components/src/components/form/index.js
@@ -43,12 +43,14 @@ export default function PublicizeForm( {
 	} = useSocialMediaConnections();
 	const { message, updateMessage, maxLength } = useSocialMediaMessage();
 
+	const isShareLimitEnabled = numberOfSharesRemaining !== null;
+	const outOfConnections =
+		isShareLimitEnabled && numberOfSharesRemaining <= enabledConnections.length;
+	const hasZeroShares = isShareLimitEnabled && 0 === numberOfSharesRemaining;
+
 	const isDisabled = () =>
 		! isRePublicizeFeatureEnabled && connections.every( connection => ! connection.toggleable );
 	const Wrapper = isPublicizeDisabledBySitePlan ? Disabled : Fragment;
-
-	const outOfConnections =
-		numberOfSharesRemaining !== null && numberOfSharesRemaining <= enabledConnections.length;
 
 	return (
 		<Wrapper>
@@ -88,10 +90,11 @@ export default function PublicizeForm( {
 								( { display_name, enabled, id, service_name, toggleable, profile_picture } ) => (
 									<PublicizeConnection
 										disabled={
+											hasZeroShares ||
 											( isRePublicizeFeatureEnabled ? ! isPublicizeEnabled : ! toggleable ) ||
 											( ! enabled && toggleable && outOfConnections )
 										}
-										enabled={ enabled && ! isPublicizeDisabledBySitePlan }
+										enabled={ ! hasZeroShares && enabled && ! isPublicizeDisabledBySitePlan }
 										key={ id }
 										id={ id }
 										label={ display_name }
@@ -112,7 +115,7 @@ export default function PublicizeForm( {
 
 					{ isPublicizeEnabled && connections.some( connection => connection.enabled ) && (
 						<MessageBoxControl
-							disabled={ isDisabled() }
+							disabled={ isDisabled() || hasZeroShares }
 							maxLength={ maxLength }
 							onChange={ updateMessage }
 							message={ message }

--- a/projects/plugins/jetpack/changelog/fix-sharing-limits
+++ b/projects/plugins/jetpack/changelog/fix-sharing-limits
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -54,7 +54,7 @@
 		"@automattic/jetpack-connection": "workspace:* || ^0.20",
 		"@automattic/jetpack-licensing": "workspace:* || ^0.5",
 		"@automattic/jetpack-partner-coupon": "workspace:* || ^0.2",
-		"@automattic/jetpack-publicize-components": "workspace:* || ^0.6",
+		"@automattic/jetpack-publicize-components": "workspace:* || ^0.7",
 		"@automattic/jetpack-shared-extension-utils": "workspace:* || ^0.6",
 		"@automattic/popup-monitor": "1.0.2",
 		"@automattic/request-external-access": "1.0.0",

--- a/projects/plugins/social/changelog/fix-sharing-limits
+++ b/projects/plugins/social/changelog/fix-sharing-limits
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Fixed toggle being shown incorrectly if someone has hit sharing limits. 

--- a/projects/plugins/social/package.json
+++ b/projects/plugins/social/package.json
@@ -29,7 +29,7 @@
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3",
 		"@automattic/jetpack-components": "workspace:* || ^0.21",
 		"@automattic/jetpack-connection": "workspace:* || ^0.20",
-		"@automattic/jetpack-publicize-components": "workspace:* || ^0.6",
+		"@automattic/jetpack-publicize-components": "workspace:* || ^0.7",
 		"@wordpress/data": "7.0.0",
 		"@wordpress/date": "4.16.0",
 		"@wordpress/element": "4.14.0",

--- a/projects/plugins/social/src/js/components/publicize-panel/index.jsx
+++ b/projects/plugins/social/src/js/components/publicize-panel/index.jsx
@@ -38,6 +38,9 @@ const PublicizePanel = ( { prePublish } ) => {
 		};
 	} );
 
+	const zeroSharesLeft =
+		isShareLimitEnabled && ! hasPaidPlan && 0 === numberOfSharesRemaining ? true : false;
+
 	// Refresh connections when the post is just published.
 	usePostJustPublished(
 		function () {
@@ -74,8 +77,8 @@ const PublicizePanel = ( { prePublish } ) => {
 									  )
 							}
 							onChange={ togglePublicizeFeature }
-							checked={ isPublicizeEnabled }
-							disabled={ ! hasConnections }
+							checked={ isPublicizeEnabled && ! zeroSharesLeft }
+							disabled={ ! hasConnections || zeroSharesLeft }
 						/>
 					</PanelRow>
 				) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Without this PR, sharing buttons were enabled even if zero shares were remaining. 
Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Disabled the sharing buttons if the number of sharing remaining is zero. 

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1663923166964819/1663916666.178489-slack-C02JJ910CNL

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


- Without this PR, the connections can be toggled and their default state was on **when the shares left were zero**. With this fix in place, connections can't be toggle and their default value will be off. Also the button next to "Share when publishing" was toggled on earlier when shares left is zero. With this PR applied it will be toggled off. 

- Test that without the blog sticker, sharing continues to work fine even if you're over the plan limits. 

- Test that you're able to share when the number of shares left is greater than zero, but less than the number of connections you want to share to 

- With the blog sticker on and a paid plan, you should be able to share.


- Test on Jetpack that there is no change in existing behaviour and you're able to share freely with or without the blog sticker

Before

<img width="339" alt="Screenshot 2022-09-23 at 3 33 57 PM" src="https://user-images.githubusercontent.com/6594561/191937901-3c1bd752-5069-4bf6-a30a-e0e370719e10.png">

After 

<img width="375" alt="Screenshot 2022-09-23 at 3 32 54 PM" src="https://user-images.githubusercontent.com/6594561/191937726-37f77736-7498-43dc-8086-e2f87cc1efa7.png">
