### PR TITLE
Test results to Slack: fix missing commit url for workflow_run event

### DIFF
--- a/projects/github-actions/test-results-to-slack/changelog/fix-url-for-workflow_run
+++ b/projects/github-actions/test-results-to-slack/changelog/fix-url-for-workflow_run
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed missing commit url for workflow_run event

--- a/projects/github-actions/test-results-to-slack/src/message.js
+++ b/projects/github-actions/test-results-to-slack/src/message.js
@@ -41,9 +41,9 @@ async function createMessage( isFailure ) {
 		buttons.push( getButton( `PR #${ number }`, html_url ) );
 	}
 
-	if ( eventName === 'push' || eventName === 'workflow_run' ) {
+	if ( eventName === 'push' ) {
 		const { url, id, message } = payload.head_commit;
-		target = `on ${ refType } _*${ refName }*_ (${ eventName })`;
+		target = `on ${ refType } _*${ refName }*_`;
 		msgId = `${ eventName }-${ id }`;
 		const truncatedMessage = message.length > 50 ? message.substring( 0, 48 ) + '...' : message;
 
@@ -53,6 +53,20 @@ async function createMessage( isFailure ) {
 		);
 
 		buttons.push( lastRunButtonBlock, getButton( `Commit ${ id.substring( 0, 8 ) }`, url ) );
+	}
+
+	if ( eventName === 'workflow_run' ) {
+		const { id, message } = payload.workflow_run.head_commit;
+		target = `on ${ refType } _*${ refName }*_ (${ eventName })`;
+		msgId = `${ eventName }-${ id }`;
+		const truncatedMessage = message.length > 50 ? message.substring( 0, 48 ) + '...' : message;
+
+		contextElements.push(
+			getTextContextElement( `Commit: ${ id.substring( 0, 8 ) } ${ truncatedMessage }` ),
+			actorBlock
+		);
+
+		buttons.push( lastRunButtonBlock );
 	}
 
 	if ( eventName === 'schedule' ) {

--- a/projects/github-actions/test-results-to-slack/tests/message.test.js
+++ b/projects/github-actions/test-results-to-slack/tests/message.test.js
@@ -9,9 +9,9 @@ describe( 'Message content', () => {
 
 	test.each`
 		eventName           | isFailure  | suiteName         | expected
-		${ 'push' }         | ${ false } | ${ undefined }    | ${ { text: `:white_check_mark:	Tests passed on ${ refType } _*${ refName }*_ (push)` } }
-		${ 'push' }         | ${ true }  | ${ undefined }    | ${ { text: `:x:	Tests failed on ${ refType } _*${ refName }*_ (push)` } }
-		${ 'push' }         | ${ true }  | ${ 'suite name' } | ${ { text: `:x:	_*suite name*_ tests failed on ${ refType } _*${ refName }*_ (push)` } }
+		${ 'push' }         | ${ false } | ${ undefined }    | ${ { text: `:white_check_mark:	Tests passed on ${ refType } _*${ refName }*_` } }
+		${ 'push' }         | ${ true }  | ${ undefined }    | ${ { text: `:x:	Tests failed on ${ refType } _*${ refName }*_` } }
+		${ 'push' }         | ${ true }  | ${ 'suite name' } | ${ { text: `:x:	_*suite name*_ tests failed on ${ refType } _*${ refName }*_` } }
 		${ 'workflow_run' } | ${ false } | ${ undefined }    | ${ { text: `:white_check_mark:	Tests passed on ${ refType } _*${ refName }*_ (workflow_run)` } }
 		${ 'workflow_run' } | ${ true }  | ${ undefined }    | ${ { text: `:x:	Tests failed on ${ refType } _*${ refName }*_ (workflow_run)` } }
 		${ 'workflow_run' } | ${ true }  | ${ 'suite name' } | ${ { text: `:x:	_*suite name*_ tests failed on ${ refType } _*${ refName }*_ (workflow_run)` } }
@@ -34,6 +34,7 @@ describe( 'Message content', () => {
 				payload: {
 					head_commit: { id: '123', message: 'Some commit message' },
 					pull_request: { number: prNumber },
+					workflow_run: { head_commit: { id: '123', message: 'Some commit message' } },
 				},
 				sha,
 				eventName,
@@ -124,6 +125,7 @@ describe( 'Message content', () => {
 			payload: {
 				head_commit: { id: '123', message: 'Some commit message' },
 				pull_request: { number: prNumber },
+				workflow_run: { head_commit: { id: '123', message: 'Some commit message' } },
 			},
 			sha,
 			eventName,


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

GitHub context has not `head_commit.url` property for `workflow_run` events and Slack notification is failing trying to use that.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Check Slack notifications for workflow_run test run after this gets merged.

