### PR TITLE
VideoPress: Search input loading state on dashboard

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-search-input-loading
+++ b/projects/packages/videopress/changelog/update-videopress-search-input-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Link search input load state to videos fetch state on dashboard

--- a/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
@@ -57,7 +57,7 @@ const VideoLibraryWrapper = ( {
 	hideFilter?: boolean;
 	title?: string;
 } ) => {
-	const { setSearch, search } = useVideos();
+	const { setSearch, search, isFetching } = useVideos();
 	const [ searchQuery, setSearchQuery ] = useState( search );
 
 	const [ isFilterActive, setIsFilterActive ] = useState( false );
@@ -81,6 +81,7 @@ const VideoLibraryWrapper = ( {
 							className={ styles[ 'search-input' ] }
 							onSearch={ setSearch }
 							value={ searchQuery }
+							loading={ isFetching }
 							onChange={ setSearchQuery }
 						/>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #26166

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Links `isFetching` state to the search input in the dashboard

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard with at least one uploaded video
* Type a search query and wait for the debounce time (500ms)
* Check that the loading icon appears on the search field

https://user-images.githubusercontent.com/8486249/191985232-6e616838-9459-4e73-a799-27b83c7e5147.mp4