### PR TITLE
ci: Set up test env with built version of WordPress

### DIFF
--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -31,22 +31,25 @@ echo "::endgroup::"
 echo "::group::Preparing WordPress from \"$WP_BRANCH\" branch";
 case "$WP_BRANCH" in
 	trunk)
-		git clone --depth=1 --branch trunk git://develop.git.wordpress.org/ /tmp/wordpress-trunk
+		TAG=trunk
 		;;
 	latest)
-		LATEST=$(php ./tools/get-wp-version.php)
-		git clone --depth=1 --branch "$LATEST" git://develop.git.wordpress.org/ /tmp/wordpress-latest
+		TAG=$(php ./tools/get-wp-version.php)
 		;;
 	previous)
 		# We hard-code the version here because there's a time near WP releases where
 		# we've dropped the old 'previous' but WP hasn't actually released the new 'latest'
-		git clone --depth=1 --branch 5.9 git://develop.git.wordpress.org/ /tmp/wordpress-previous
+		TAG=5.9
 		;;
 	*)
 		echo "Unrecognized value for WP_BRANCH: $WP_BRANCH" >&2
 		exit 1
 		;;
 esac
+git clone --depth=1 --branch "$TAG" git://develop.git.wordpress.org/ "/tmp/wordpress-$WP_BRANCH"
+# We need a built version of WordPress to test against, so download that into the src directory instead of what's in wordpress-develop.
+rm -rf "/tmp/wordpress-$WP_BRANCH/src"
+git clone --depth=1 --branch "$TAG" git://core.git.wordpress.org/ "/tmp/wordpress-$WP_BRANCH/src"
 echo "::endgroup::"
 
 # Don't symlink, it breaks when copied later.

--- a/projects/plugins/jetpack/changelog/fix-tests-against-wp-trunk
+++ b/projects/plugins/jetpack/changelog/fix-tests-against-wp-trunk
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Mock update API response in sync test.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
WordPress core recently made a change that breaks testing unless WordPress has been built, and put in a special case only for _their_ unit tests.

The most future-proof option seems likely to be to download a built version of WordPress (from the "core" repo) to test against, replacing the unbuilt code from the "develop" repo. But we still need the test base classes and bootstrapping code from the "develop" repo too.

Rejected alternatives:
* Build the develop repo. They require different software versions, not worth messing with.
* Work around the immediate issue. There will probably be others down the road. Since the documented way to integration-test plugins involves fetching from the "core" repo, that's probably all they'll support.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1663943601852509-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?
* Is the "PHP 8.0 trunk" check passing again?