### PR TITLE
Modifies the subscribe block by adding 'Add new plan' button.

### DIFF
--- a/projects/plugins/jetpack/changelog/superstack-add-new-plan-to-subscribe-block
+++ b/projects/plugins/jetpack/changelog/superstack-add-new-plan-to-subscribe-block
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: Small change that doesn't affect much.
+
+

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
@@ -26,7 +26,6 @@ import {
 	DEFAULT_SPACING_VALUE,
 	DEFAULT_FONTSIZE_VALUE,
 } from './constants';
-
 import { PaidPlanPanel } from './paid-plan';
 
 export default function SubscriptionControls( {
@@ -55,7 +54,7 @@ export default function SubscriptionControls( {
 } ) {
 	return (
 		<>
-			<PaidPlanPanel/>
+			<PaidPlanPanel />
 			{ subscriberCount > 1 && (
 				<InspectorNotice>
 					{ createInterpolateElement(

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
@@ -27,6 +27,8 @@ import {
 	DEFAULT_FONTSIZE_VALUE,
 } from './constants';
 
+import { PaidPlanPanel } from './paid-plan';
+
 export default function SubscriptionControls( {
 	buttonBackgroundColor,
 	borderColor,
@@ -53,6 +55,7 @@ export default function SubscriptionControls( {
 } ) {
 	return (
 		<>
+			<PaidPlanPanel/>
 			{ subscriberCount > 1 && (
 				<InspectorNotice>
 					{ createInterpolateElement(

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -1,11 +1,12 @@
 import {
+	BlockControls,
 	InspectorControls,
 	RichText,
 	withColors,
 	withFontSizes,
 	__experimentalUseGradient as useGradient, // eslint-disable-line wpcalypso/no-unsafe-wp-apis
 } from '@wordpress/block-editor';
-import { TextControl, withFallbackStyles } from '@wordpress/components';
+import { TextControl, Toolbar, ToolbarButton, withFallbackStyles } from '@wordpress/components';
 import { compose, usePrevious } from '@wordpress/compose';
 import { useEffect, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
@@ -23,6 +24,7 @@ import {
 	DEFAULT_FONTSIZE_VALUE,
 } from './constants';
 import SubscriptionControls from './controls';
+import { getPaidPlanLink } from './utils';
 
 const { getComputedStyle } = window;
 const isGradientAvailable = !! useGradient;
@@ -204,6 +206,8 @@ export function SubscriptionEdit( props ) {
 		setBorderColor( buttonBackgroundColor.color );
 	}, [ buttonBackgroundColor, previousButtonBackgroundColor, borderColor, setBorderColor ] );
 
+	const addPaidPlanButtonText = __( 'Add paid plan', 'jetpack' );
+
 	return (
 		<>
 			<InspectorControls>
@@ -232,6 +236,11 @@ export function SubscriptionEdit( props ) {
 					successMessage={ successMessage }
 				/>
 			</InspectorControls>
+			<BlockControls>
+				<Toolbar>
+					<ToolbarButton href={ getPaidPlanLink() } target="_blank">{ addPaidPlanButtonText }</ToolbarButton>
+				</Toolbar>
+			</BlockControls>
 
 			<div className={ getBlockClassName() }>
 				<div className="wp-block-jetpack-subscriptions__form" role="form">

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -238,7 +238,9 @@ export function SubscriptionEdit( props ) {
 			</InspectorControls>
 			<BlockControls>
 				<Toolbar>
-					<ToolbarButton href={ getPaidPlanLink() } target="_blank">{ addPaidPlanButtonText }</ToolbarButton>
+					<ToolbarButton href={ getPaidPlanLink() } target="_blank">
+						{ addPaidPlanButtonText }
+					</ToolbarButton>
 				</Toolbar>
 			</BlockControls>
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/paid-plan.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/paid-plan.js
@@ -1,0 +1,24 @@
+import { PanelBody, PanelRow, Button } from "@wordpress/components";
+import { __, sprintf } from '@wordpress/i18n';
+
+import { getPaidPlanLink } from "./utils";
+
+export function PaidPlanPanel(){
+	const title = __( 'Paid Newsletter', 'jetpack' );
+	const text = __( 'Create plans for the readers to pay for the content', 'jetpack' );
+	return (
+		<>
+			<PanelBody title={ title } opened={ true }>
+				<PanelRow>
+					{ text }
+				</PanelRow>
+				<PanelRow>
+					<Button variant="primary" href={ getPaidPlanLink() } target="_blank">{ __( 'Add paid plan', 'jetpack' ) }</Button>
+				</PanelRow>
+				{/* <PanelRow>
+					Secure Payments are set up. <a href="">Configure</a>
+				</PanelRow> */}
+			</PanelBody>
+		</>
+	);
+};

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/paid-plan.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/paid-plan.js
@@ -1,24 +1,20 @@
-import { PanelBody, PanelRow, Button } from "@wordpress/components";
-import { __, sprintf } from '@wordpress/i18n';
+import { PanelBody, PanelRow, Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { getPaidPlanLink } from './utils';
 
-import { getPaidPlanLink } from "./utils";
-
-export function PaidPlanPanel(){
+export function PaidPlanPanel() {
 	const title = __( 'Paid Newsletter', 'jetpack' );
 	const text = __( 'Create plans for the readers to pay for the content', 'jetpack' );
 	return (
 		<>
 			<PanelBody title={ title } opened={ true }>
+				<PanelRow>{ text }</PanelRow>
 				<PanelRow>
-					{ text }
+					<Button variant="primary" href={ getPaidPlanLink() } target="_blank">
+						{ __( 'Add paid plan', 'jetpack' ) }
+					</Button>
 				</PanelRow>
-				<PanelRow>
-					<Button variant="primary" href={ getPaidPlanLink() } target="_blank">{ __( 'Add paid plan', 'jetpack' ) }</Button>
-				</PanelRow>
-				{/* <PanelRow>
-					Secure Payments are set up. <a href="">Configure</a>
-				</PanelRow> */}
 			</PanelBody>
 		</>
 	);
-};
+}

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/utils.js
@@ -16,3 +16,8 @@ export const encodeValueForShortcodeAttribute = value => {
 		.replace( /\u00a0/g, '&nbsp;' )
 		.replace( /\u200b/g, '&#x200b;' );
 };
+
+export const getPaidPlanLink = () => {
+	const siteSlug = location.hostname;
+	return 'https://wordpress.com/earn/payments-plans/' + siteSlug + '#add-new-payment-plan';
+}

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/utils.js
@@ -20,4 +20,4 @@ export const encodeValueForShortcodeAttribute = value => {
 export const getPaidPlanLink = () => {
 	const siteSlug = location.hostname;
 	return 'https://wordpress.com/earn/payments-plans/' + siteSlug + '#add-new-payment-plan';
-}
+};


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds 'add new plan' to subscribe block for paid newsletters.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
p58i-d5j-p2

#### Does this pull request change what data or activity we track or use?
🤷‍♂️

<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create or edit a new post.
2. Add the subscribe block
3. See that the 'Add new plan' button is added to the block controls & the inspectorControls/sidebar.