### PR TITLE
WAF: disable on Atomic platform

### DIFF
--- a/projects/plugins/jetpack/changelog/resolve-atomic-waf
+++ b/projects/plugins/jetpack/changelog/resolve-atomic-waf
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Atomic: always disable WAF

--- a/projects/plugins/jetpack/load-jetpack.php
+++ b/projects/plugins/jetpack/load-jetpack.php
@@ -90,4 +90,21 @@ add_filter( 'is_jetpack_site', '__return_true' );
 
 require_once JETPACK__PLUGIN_DIR . '3rd-party/3rd-party.php';
 
+// WAF should never be available on the Atomic platform.
+
+if ( ( new Automattic\Jetpack\Status\Host() )->is_atomic_platform() ) {
+	add_filter(
+		'jetpack_get_available_modules',
+		function ( $modules ) {
+			unset( $modules['waf'] );
+
+			return $modules;
+		}
+	);
+
+	if ( ! defined( 'DISABLE_JETPACK_WAF' ) ) {
+		define( 'DISABLE_JETPACK_WAF', true );
+	}
+}
+
 Jetpack::init();

--- a/projects/plugins/jetpack/modules/waf.php
+++ b/projects/plugins/jetpack/modules/waf.php
@@ -22,17 +22,6 @@ if ( defined( 'DISABLE_JETPACK_WAF' ) && DISABLE_JETPACK_WAF ) {
 	return;
 }
 
-if ( ( new Automattic\Jetpack\Status\Host() )->is_atomic_platform() ) {
-	add_filter(
-		'jetpack_get_available_modules',
-		function ( $modules ) {
-			unset( $modules['waf'] );
-
-			return $modules;
-		}
-	);
-}
-
 /**
  * Triggers when the Jetpack plugin is updated
  */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The WAF should never be available on Atomic.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* The previous check only ran when the module was active, meaning that the option to enable it would display. We want to not show the option either.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1663876136995039-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start an Atomic Ephemeral site with Jetpack Beta.
* Connect and visit Jetpack->Settings
* Under Security, see the option to activate the Firewall Protection.
* Under Jetpack Beta, activate this branch `resolve/atomic-waf`.
* Return to Jetpack->Settings->Security
* See no option to engage the firewall.