### PR TITLE
Backup: Fix antipattern where components are returned from functions called renderXXXX() instead of just being components

### DIFF
--- a/projects/packages/backup/changelog/fix-render-pattern-backup
+++ b/projects/packages/backup/changelog/fix-render-pattern-backup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Replace antippatern where components are returned from non-functionl components called renderSomething

--- a/projects/packages/backup/src/js/components/Admin.js
+++ b/projects/packages/backup/src/js/components/Admin.js
@@ -423,7 +423,7 @@ const LoadedState = ( {
 	capabilitiesError,
 	capabilities,
 } ) => {
-	const [ connectionStatus, renderConnectScreen ] = useConnection();
+	const [ connectionStatus, BackupConnectionScreen ] = useConnection();
 
 	if (
 		! connectionLoaded ||
@@ -437,7 +437,7 @@ const LoadedState = ( {
 		return (
 			<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 				<Col lg={ 12 } md={ 8 } sm={ 4 }>
-					{ renderConnectScreen() }
+					<BackupConnectionScreen />
 				</Col>
 			</Container>
 		);

--- a/projects/packages/backup/src/js/components/Backups.js
+++ b/projects/packages/backup/src/js/components/Backups.js
@@ -35,7 +35,6 @@ const Backups = () => {
 		warnings: false,
 	} );
 	const domain = useSelect( select => select( STORE_ID ).getCalypsoSlug(), [] );
-	const siteTitle = useSelect( select => select( STORE_ID ).getSiteTitle(), [] );
 
 	const BACKUP_STATE = {
 		LOADING: 0,
@@ -121,65 +120,6 @@ const Backups = () => {
 	const trackRecentRestorePointClick = useCallback( () => {
 		tracks.recordEvent( 'jetpack_backup_view_recent_restore_points_click', { site: domain } );
 	}, [ tracks, domain ] );
-
-	const renderInProgressBackup = ( showProgressBar = true ) => {
-		return (
-			<div className="jp-row">
-				<div className="lg-col-span-5 md-col-span-8 sm-col-span-4">
-					{ showProgressBar && (
-						<div className="backup__progress">
-							<div className="backup__progress-info">
-								<p>
-									{ sprintf(
-										/* translators: placeholder is the Site Title */
-										__( 'Backing up %s', 'jetpack-backup-pkg' ),
-										siteTitle
-									) }
-								</p>
-								<p className="backup__progress-info-percentage">{ progress }%</p>
-							</div>
-							<div className="backup__progress-bar">
-								<div
-									className="backup__progress-bar-actual"
-									style={ { width: progress + '%' } }
-								></div>
-							</div>
-						</div>
-					) }
-					<h1>{ __( 'Your first cloud backup will be ready soon', 'jetpack-backup-pkg' ) }</h1>
-					<p>
-						{ __(
-							'The first backup usually takes a few minutes, so it will become available soon.',
-							'jetpack-backup-pkg'
-						) }
-					</p>
-					<p>
-						{ createInterpolateElement(
-							__(
-								'In the meanwhile, you can start getting familiar with your <a>backup management on Jetpack.com</a>.',
-								'jetpack-backup-pkg'
-							),
-							{
-								a: (
-									<a
-										href={ getRedirectUrl( 'jetpack-backup', { site: domain } ) }
-										target="_blank"
-										rel="noreferrer"
-									/>
-								),
-							}
-						) }
-					</p>
-				</div>
-				<div className="lg-col-span-1 md-col-span-4 sm-col-span-0"></div>
-				<div className="backup__animation lg-col-span-6 md-col-span-2 sm-col-span-2">
-					<img className="backup__animation-el-1" src={ BackupAnim1 } alt="" />
-					<img className="backup__animation-el-2" src={ BackupAnim2 } alt="" />
-					<img className="backup__animation-el-3" src={ BackupAnim3 } alt="" />
-				</div>
-			</div>
-		);
-	};
 
 	const formatDateString = dateString => {
 		const todayString = __( 'Today', 'jetpack-backup-pkg' );
@@ -322,11 +262,75 @@ const Backups = () => {
 	return (
 		<div className="jp-wrap jp-content">
 			{ BACKUP_STATE.LOADING === backupState && renderLoading() }
-			{ BACKUP_STATE.NO_BACKUPS === backupState && renderInProgressBackup() }
-			{ BACKUP_STATE.NO_BACKUPS_RETRY === backupState && renderInProgressBackup( false ) }
-			{ BACKUP_STATE.IN_PROGRESS === backupState && renderInProgressBackup() }
+			{ BACKUP_STATE.NO_BACKUPS === backupState && <InProgressBackup progress={ progress } /> }
+			{ BACKUP_STATE.NO_BACKUPS_RETRY === backupState && (
+				<InProgressBackup progress={ progress } showProgressBar={ false } />
+			) }
+			{ BACKUP_STATE.IN_PROGRESS === backupState && <InProgressBackup progress={ progress } /> }
 			{ BACKUP_STATE.COMPLETE === backupState && renderCompleteBackup() }
 			{ BACKUP_STATE.NO_GOOD_BACKUPS === backupState && renderNoGoodBackups() }
+		</div>
+	);
+};
+
+const InProgressBackup = ( { progress, showProgressBar = true } ) => {
+	const domain = useSelect( select => select( STORE_ID ).getCalypsoSlug(), [] );
+	const siteTitle = useSelect( select => select( STORE_ID ).getSiteTitle(), [] );
+
+	return (
+		<div className="jp-row">
+			<div className="lg-col-span-5 md-col-span-8 sm-col-span-4">
+				{ showProgressBar && (
+					<div className="backup__progress">
+						<div className="backup__progress-info">
+							<p>
+								{ sprintf(
+									/* translators: placeholder is the Site Title */
+									__( 'Backing up %s', 'jetpack-backup-pkg' ),
+									siteTitle
+								) }
+							</p>
+							<p className="backup__progress-info-percentage">{ progress }%</p>
+						</div>
+						<div className="backup__progress-bar">
+							<div
+								className="backup__progress-bar-actual"
+								style={ { width: progress + '%' } }
+							></div>
+						</div>
+					</div>
+				) }
+				<h1>{ __( 'Your first cloud backup will be ready soon', 'jetpack-backup-pkg' ) }</h1>
+				<p>
+					{ __(
+						'The first backup usually takes a few minutes, so it will become available soon.',
+						'jetpack-backup-pkg'
+					) }
+				</p>
+				<p>
+					{ createInterpolateElement(
+						__(
+							'In the meanwhile, you can start getting familiar with your <a>backup management on Jetpack.com</a>.',
+							'jetpack-backup-pkg'
+						),
+						{
+							a: (
+								<a
+									href={ getRedirectUrl( 'jetpack-backup', { site: domain } ) }
+									target="_blank"
+									rel="noreferrer"
+								/>
+							),
+						}
+					) }
+				</p>
+			</div>
+			<div className="lg-col-span-1 md-col-span-4 sm-col-span-0"></div>
+			<div className="backup__animation lg-col-span-6 md-col-span-2 sm-col-span-2">
+				<img className="backup__animation-el-1" src={ BackupAnim1 } alt="" />
+				<img className="backup__animation-el-2" src={ BackupAnim2 } alt="" />
+				<img className="backup__animation-el-3" src={ BackupAnim3 } alt="" />
+			</div>
 		</div>
 	);
 };

--- a/projects/packages/backup/src/js/components/Backups.js
+++ b/projects/packages/backup/src/js/components/Backups.js
@@ -32,7 +32,6 @@ const Backups = () => {
 		themes: 0,
 		warnings: false,
 	} );
-	const domain = useSelect( select => select( STORE_ID ).getCalypsoSlug(), [] );
 
 	const BACKUP_STATE = {
 		LOADING: 0,
@@ -111,37 +110,6 @@ const Backups = () => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ trackProgress ] );
 
-	const renderNoGoodBackups = () => {
-		return (
-			<div className="jp-row">
-				<div className="lg-col-span-5 md-col-span-4 sm-col-span-4">
-					<img src={ CloudAlertIcon } alt="" />
-					<h1>{ __( "We're having trouble backing up your site", 'jetpack-backup-pkg' ) }</h1>
-					<p>
-						{ createInterpolateElement(
-							__(
-								' <a>Get in touch with us</a> to get your site backups going again.',
-								'jetpack-backup-pkg'
-							),
-							{
-								a: (
-									<a
-										//TODO: we may want to add a specific redirect for Backup plugin related issues
-										href={ getRedirectUrl( 'jetpack-contact-support', { site: domain } ) }
-										target="_blank"
-										rel="noreferrer"
-									/>
-								),
-							}
-						) }
-					</p>
-				</div>
-				<div className="lg-col-span-1 md-col-span-4 sm-col-span-0"></div>
-				<div className="lg-col-span-6 md-col-span-2 sm-col-span-2"></div>
-			</div>
-		);
-	};
-
 	return (
 		<div className="jp-wrap jp-content">
 			{ BACKUP_STATE.LOADING === backupState && <Loading /> }
@@ -153,7 +121,39 @@ const Backups = () => {
 			{ BACKUP_STATE.COMPLETE === backupState && (
 				<CompleteBackup latestTime={ latestTime } stats={ stats } />
 			) }
-			{ BACKUP_STATE.NO_GOOD_BACKUPS === backupState && renderNoGoodBackups() }
+			{ BACKUP_STATE.NO_GOOD_BACKUPS === backupState && <NoGoodBackups /> }
+		</div>
+	);
+};
+
+const NoGoodBackups = () => {
+	const domain = useSelect( select => select( STORE_ID ).getCalypsoSlug(), [] );
+	return (
+		<div className="jp-row">
+			<div className="lg-col-span-5 md-col-span-4 sm-col-span-4">
+				<img src={ CloudAlertIcon } alt="" />
+				<h1>{ __( "We're having trouble backing up your site", 'jetpack-backup-pkg' ) }</h1>
+				<p>
+					{ createInterpolateElement(
+						__(
+							' <a>Get in touch with us</a> to get your site backups going again.',
+							'jetpack-backup-pkg'
+						),
+						{
+							a: (
+								<a
+									//TODO: we may want to add a specific redirect for Backup plugin related issues
+									href={ getRedirectUrl( 'jetpack-contact-support', { site: domain } ) }
+									target="_blank"
+									rel="noreferrer"
+								/>
+							),
+						}
+					) }
+				</p>
+			</div>
+			<div className="lg-col-span-1 md-col-span-4 sm-col-span-0"></div>
+			<div className="lg-col-span-6 md-col-span-2 sm-col-span-2"></div>
 		</div>
 	);
 };

--- a/projects/packages/backup/src/js/components/Backups.js
+++ b/projects/packages/backup/src/js/components/Backups.js
@@ -255,13 +255,9 @@ const Backups = () => {
 		);
 	};
 
-	const renderLoading = () => {
-		return <div className="jp-row"></div>;
-	};
-
 	return (
 		<div className="jp-wrap jp-content">
-			{ BACKUP_STATE.LOADING === backupState && renderLoading() }
+			{ BACKUP_STATE.LOADING === backupState && <Loading /> }
 			{ BACKUP_STATE.NO_BACKUPS === backupState && <InProgressBackup progress={ progress } /> }
 			{ BACKUP_STATE.NO_BACKUPS_RETRY === backupState && (
 				<InProgressBackup progress={ progress } showProgressBar={ false } />
@@ -271,6 +267,10 @@ const Backups = () => {
 			{ BACKUP_STATE.NO_GOOD_BACKUPS === backupState && renderNoGoodBackups() }
 		</div>
 	);
+};
+
+const Loading = () => {
+	return <div className="jp-row"></div>;
 };
 
 const InProgressBackup = ( { progress, showProgressBar = true } ) => {

--- a/projects/packages/backup/src/js/hooks/useConnection.js
+++ b/projects/packages/backup/src/js/hooks/useConnection.js
@@ -7,9 +7,9 @@ import React from 'react';
 import { STORE_ID } from '../store';
 
 /**
- * Expose the `connectionStatus` state object and `renderConnectScreen()` to show a component used for connection.
+ * Expose the `connectionStatus` state object and `BackupConnectionScreen` to show a component used for connection.
  *
- * @returns {Array} connectionStatus, renderConnectScreen
+ * @returns {Array} connectionStatus, BackupConnectionScreen
  */
 export default function useConnection() {
 	const APINonce = useSelect( select => select( STORE_ID ).getAPINonce(), [] );
@@ -33,7 +33,7 @@ export default function useConnection() {
 		} );
 	}, [] );
 
-	const renderConnectScreen = () => {
+	const BackupConnectionScreen = () => {
 		return (
 			<ConnectScreenRequiredPlan
 				buttonLabel={ __( 'Get Jetpack Backup', 'jetpack-backup-pkg' ) }
@@ -62,5 +62,5 @@ export default function useConnection() {
 		);
 	};
 
-	return [ connectionStatus, renderConnectScreen ];
+	return [ connectionStatus, BackupConnectionScreen ];
 }


### PR DESCRIPTION
Fixes unnecessary re-renders and lack of visibility in React Dev tools

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates `renderInProgressBackup` to be a component `InProgressBackup`.
* Updates `renderLoading` to be a component `Loading`.
* Updates `renderCompleteBackup` to be a component `CompleteBackup`.
* Updates `renderNoGoodBackup` to be a component `NoGoodBackup`.
* Refactors renderConnectScreen to be a component `BackupConnectionScreen`.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
None

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

**Note: The final diff looks weird as GitHub tries to match some lines in weird ways. It's better to look at each commit to understand what's being done.**

1. Launch a [JN site with Backup standalone and this branch](https://jurassic.ninja/create/?jetpack-beta&branches.jetpack-backup=fix/render-pattern-backup&wp-debug-log)
2. Keep the JS console open and expect to see no warning for the following steps
3. Connect, expect to see the in progress status
4. Wait until backup is complete. Expect to see information about the backup.

