### PR TITLE
Add Newsletter Post Visibility Setting

### DIFF
--- a/projects/plugins/jetpack/changelog/add-newsletter-post-visibility-setting
+++ b/projects/plugins/jetpack/changelog/add-newsletter-post-visibility-setting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+enhancement

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -7,6 +7,7 @@ import {
 } from '@wordpress/block-editor';
 import { TextControl, withFallbackStyles } from '@wordpress/components';
 import { compose, usePrevious } from '@wordpress/compose';
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { useEffect, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import classnames from 'classnames';
@@ -23,6 +24,7 @@ import {
 	DEFAULT_FONTSIZE_VALUE,
 } from './constants';
 import SubscriptionControls from './controls';
+import SubscriptionPostSettings from './settings';
 
 const { getComputedStyle } = window;
 const isGradientAvailable = !! useGradient;
@@ -206,6 +208,9 @@ export function SubscriptionEdit( props ) {
 
 	return (
 		<>
+			<PluginDocumentSettingPanel title={ __( 'Newsletter settings', 'jetpack' ) }>
+				<SubscriptionPostSettings />
+			</PluginDocumentSettingPanel>
 			<InspectorControls>
 				<SubscriptionControls
 					buttonBackgroundColor={ buttonBackgroundColor }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
@@ -3,7 +3,7 @@ import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '
 import { Button, PanelRow, Dropdown, VisuallyHidden } from '@wordpress/components';
 import { compose, useInstanceId } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { PostVisibilityLabel, PostVisibilityCheck } from '@wordpress/editor';
+import { PostVisibilityCheck } from '@wordpress/editor';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -14,21 +14,13 @@ const visibilityOptions = {
 		label: __( 'Public', 'jetpack' ),
 		info: __( 'Visible to everyone', 'jetpack' ),
 	},
-	all_members: {
-		label: __( 'All members', 'jetpack' ),
-		info: __( 'Only visible to your members', 'jetpack' ),
-	},
 	paid_members_only: {
-		label: __( 'Paid-members only', 'jetpack' ),
-		info: __( 'Only members with a premium subscription', 'jetpack' ),
+		label: __( 'Subscribers', 'jetpack' ),
+		info: __( 'Visible to only subscribers', 'jetpack' ),
 	},
-	specific_people: {
-		label: __( 'Specific people', 'jetpack' ),
-		info: __( 'Only people with any of the selected tiers or labels', 'jetpack' ),
-	},
-	usually_nobody: {
-		label: __( 'Usually nobody', 'jetpack' ),
-		info: __( 'Newsletters are off for new posts', 'jetpack' ),
+	nobody: {
+		label: __( 'Private', 'jetpack' ),
+		info: __( 'Visible to only admins and editors', 'jetpack' ),
 	},
 };
 
@@ -42,12 +34,8 @@ function SubscriptionPostSettings( { postMeta, setPostMeta } ) {
 				<PostVisibilityCheck
 					render={ ( { canEdit } ) => (
 						<PanelRow className="edit-post-post-visibility">
-							<span>{ __( 'Visibility', 'jetpack' ) }</span>
-							{ ! canEdit && (
-								<span>
-									<PostVisibilityLabel />
-								</span>
-							) }
+							<span>{ __( 'Audience', 'jetpack' ) }</span>
+							{ ! canEdit && <span>{ visibilityLabel }</span> }
 							{ canEdit && (
 								<Dropdown
 									position="bottom left"
@@ -58,10 +46,9 @@ function SubscriptionPostSettings( { postMeta, setPostMeta } ) {
 											isTertiary
 											onClick={ onToggle }
 											aria-expanded={ isOpen }
-											// translators: %s: Current newsletter post visibility.
 											aria-label={ sprintf(
-												// eslint-disable-next-line @wordpress/i18n-translator-comments
-												__( 'Select visibility: %s', 'jetpack' ),
+												// translators: %s: Current newsletter post visibility.
+												__( 'Select auudience: %s', 'jetpack' ),
 												visibilityLabel
 											) }
 										>
@@ -94,12 +81,12 @@ function PostVisibility( { visibility, setPostMeta, onClose } ) {
 	return (
 		<div className="editor-post-visibility">
 			<InspectorPopoverHeader
-				title={ __( 'Visibility', 'jetpack' ) }
+				title={ __( 'Audience', 'jetpack' ) }
 				help={ __( 'Control how this newsletter is viewed.', 'jetpack' ) }
 				onClose={ onClose }
 			/>
 			<fieldset className="editor-post-visibility__fieldset">
-				<VisuallyHidden as="legend">{ __( 'Visibility', 'jetpack' ) } </VisuallyHidden>
+				<VisuallyHidden as="legend">{ __( 'Audience', 'jetpack' ) } </VisuallyHidden>
 				{ Object.keys( visibilityOptions ).map( key => (
 					<PostVisibilityChoice
 						instanceId={ instanceId }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
@@ -3,12 +3,10 @@ import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '
 import { Button, PanelRow, Dropdown, VisuallyHidden } from '@wordpress/components';
 import { compose, useInstanceId } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
+import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { PostVisibilityCheck } from '@wordpress/editor';
 import { __, sprintf } from '@wordpress/i18n';
 
-/**
- * Visibility options for Newsletter settings
- */
 const visibilityOptions = {
 	public: {
 		label: __( 'Public', 'jetpack' ),
@@ -24,110 +22,104 @@ const visibilityOptions = {
 	},
 };
 
-function SubscriptionPostSettings( { postMeta, setPostMeta } ) {
+function NewsletterSettings( { postMeta, setPostMeta } ) {
 	const visibilityKey = postMeta._newsletter_visibility ?? 'public';
 	const visibilityLabel = visibilityOptions[ visibilityKey ]?.label ?? 'Public';
 
 	return (
 		<>
 			<PanelRow>
-				<PostVisibilityCheck
-					render={ ( { canEdit } ) => (
-						<PanelRow className="edit-post-post-visibility">
-							<span>{ __( 'Audience', 'jetpack' ) }</span>
-							{ ! canEdit && <span>{ visibilityLabel }</span> }
-							{ canEdit && (
-								<Dropdown
-									position="bottom left"
-									contentClassName="edit-post-post-visibility__dialog"
-									focusOnMount
-									renderToggle={ ( { isOpen, onToggle } ) => (
-										<Button
-											isTertiary
-											onClick={ onToggle }
-											aria-expanded={ isOpen }
-											aria-label={ sprintf(
-												// translators: %s: Current newsletter post visibility.
-												__( 'Select auudience: %s', 'jetpack' ),
-												visibilityLabel
-											) }
-										>
-											{ visibilityLabel }
-										</Button>
-									) }
-									renderContent={ ( { onClose } ) => (
-										<PostVisibility
-											onClose={ onClose }
-											visibility={ visibilityKey }
-											setPostMeta={ setPostMeta }
-										/>
-									) }
-								/>
-							) }
-						</PanelRow>
-					) }
+				<NewsletterAudience
+					setPostMeta={ setPostMeta }
+					visibilityKey={ visibilityKey }
+					visibilityLabel={ visibilityLabel }
 				/>
 			</PanelRow>
+
+			<PluginPrePublishPanel title={ __( 'Newsletter settings', 'jetpack' ) }>
+				<NewsletterAudience
+					setPostMeta={ setPostMeta }
+					visibilityKey={ visibilityKey }
+					visibilityLabel={ visibilityLabel }
+				/>
+			</PluginPrePublishPanel>
 		</>
 	);
 }
 
-function PostVisibility( { visibility, setPostMeta, onClose } ) {
-	const instanceId = useInstanceId( PostVisibility );
-	const hanldeOnClick = event => {
-		setPostMeta( { _newsletter_visibility: event?.target?.value } );
-	};
+function NewsletterAudience( { visibilityLabel, visibilityKey, setPostMeta } ) {
+	const instanceId = useInstanceId( NewsletterAudience );
 
 	return (
-		<div className="editor-post-visibility">
-			<InspectorPopoverHeader
-				title={ __( 'Audience', 'jetpack' ) }
-				help={ __( 'Control how this newsletter is viewed.', 'jetpack' ) }
-				onClose={ onClose }
-			/>
-			<fieldset className="editor-post-visibility__fieldset">
-				<VisuallyHidden as="legend">{ __( 'Audience', 'jetpack' ) } </VisuallyHidden>
-				{ Object.keys( visibilityOptions ).map( key => (
-					<PostVisibilityChoice
-						instanceId={ instanceId }
-						key={ key }
-						value={ key }
-						label={ visibilityOptions[ key ].label }
-						info={ visibilityOptions[ key ].info }
-						checked={ key === visibility }
-						onChange={ hanldeOnClick }
-					/>
-				) ) }
-			</fieldset>
-		</div>
-	);
-}
-
-function PostVisibilityChoice( { instanceId, value, label, info, ...props } ) {
-	return (
-		<div className="editor-post-visibility__choice">
-			<input
-				type="radio"
-				name={ `editor-post-visibility__setting-${ instanceId }` }
-				value={ value }
-				id={ `editor-post-${ value }-${ instanceId }` }
-				aria-describedby={ `editor-post-${ value }-${ instanceId }-description` }
-				className="editor-post-visibility__radio"
-				{ ...props }
-			/>
-			<label
-				htmlFor={ `editor-post-${ value }-${ instanceId }` }
-				className="editor-post-visibility__label"
-			>
-				{ label }
-			</label>
-			<p
-				id={ `editor-post-${ value }-${ instanceId }-description` }
-				className="editor-post-visibility__info"
-			>
-				{ info }
-			</p>
-		</div>
+		<PostVisibilityCheck
+			render={ ( { canEdit } ) => (
+				<PanelRow className="edit-post-post-visibility">
+					<span>{ __( 'Audience', 'jetpack' ) }</span>
+					{ ! canEdit && <span>{ visibilityLabel }</span> }
+					{ canEdit && (
+						<Dropdown
+							position="bottom left"
+							contentClassName="edit-post-post-visibility__dialog"
+							focusOnMount
+							renderToggle={ ( { isOpen, onToggle } ) => (
+								<Button
+									isTertiary
+									onClick={ onToggle }
+									aria-expanded={ isOpen }
+									aria-label={ sprintf(
+										// translators: %s: Current newsletter post visibility.
+										__( 'Select audience: %s', 'jetpack' ),
+										visibilityLabel
+									) }
+								>
+									{ visibilityLabel }
+								</Button>
+							) }
+							renderContent={ ( { onClose } ) => (
+								<div className="editor-post-visibility">
+									<InspectorPopoverHeader
+										title={ __( 'Audience', 'jetpack' ) }
+										help={ __( 'Control how this newsletter is viewed.', 'jetpack' ) }
+										onClose={ onClose }
+									/>
+									<fieldset className="editor-post-visibility__fieldset">
+										<VisuallyHidden as="legend">{ __( 'Audience', 'jetpack' ) } </VisuallyHidden>
+										{ Object.keys( visibilityOptions ).map( key => (
+											<div className="editor-post-visibility__choice">
+												<input
+													type="radio"
+													checked={ key === visibilityKey }
+													name={ `editor-post-visibility__setting-${ instanceId }` }
+													value={ key }
+													id={ `editor-post-${ key }-${ instanceId }` }
+													aria-describedby={ `editor-post-${ key }-${ instanceId }-description` }
+													className="editor-post-visibility__radio"
+													onChange={ event =>
+														setPostMeta( { _newsletter_visibility: event?.target?.value } )
+													}
+												/>
+												<label
+													htmlFor={ `editor-post-${ key }-${ instanceId }` }
+													className="editor-post-visibility__label"
+												>
+													{ visibilityOptions[ key ].label }
+												</label>
+												<p
+													id={ `editor-post-${ key }-${ instanceId }-description` }
+													className="editor-post-visibility__info"
+												>
+													{ visibilityOptions[ key ].info }
+												</p>
+											</div>
+										) ) }
+									</fieldset>
+								</div>
+							) }
+						/>
+					) }
+				</PanelRow>
+			) }
+		/>
 	);
 }
 
@@ -140,4 +132,4 @@ export default compose( [
 			dispatch( 'core/editor' ).editPost( { meta: newMeta } );
 		},
 	} ) ),
-] )( SubscriptionPostSettings );
+] )( NewsletterSettings );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
@@ -1,8 +1,8 @@
 // eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
 import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '@wordpress/block-editor';
 import { Button, PanelRow, Dropdown, VisuallyHidden } from '@wordpress/components';
-import { compose, useInstanceId } from '@wordpress/compose';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { useInstanceId } from '@wordpress/compose';
+import { useEntityProp } from '@wordpress/core-data';
 import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { PostVisibilityCheck } from '@wordpress/editor';
 import { __, sprintf } from '@wordpress/i18n';
@@ -22,7 +22,8 @@ const visibilityOptions = {
 	},
 };
 
-function NewsletterSettings( { postMeta, setPostMeta } ) {
+export default function NewsletterSettings() {
+	const [ postMeta, setPostMeta ] = useEntityProp( 'postType', 'post', 'meta' );
 	const visibilityKey = postMeta._newsletter_visibility ?? 'public';
 	const visibilityLabel = visibilityOptions[ visibilityKey ]?.label ?? 'Public';
 
@@ -85,7 +86,7 @@ function NewsletterAudience( { visibilityLabel, visibilityKey, setPostMeta } ) {
 									<fieldset className="editor-post-visibility__fieldset">
 										<VisuallyHidden as="legend">{ __( 'Audience', 'jetpack' ) } </VisuallyHidden>
 										{ Object.keys( visibilityOptions ).map( key => (
-											<div className="editor-post-visibility__choice">
+											<div className="editor-post-visibility__choice" key={ key }>
 												<input
 													type="radio"
 													checked={ key === visibilityKey }
@@ -122,14 +123,3 @@ function NewsletterAudience( { visibilityLabel, visibilityKey, setPostMeta } ) {
 		/>
 	);
 }
-
-export default compose( [
-	withSelect( select => ( {
-		postMeta: select( 'core/editor' ).getEditedPostAttribute( 'meta' ),
-	} ) ),
-	withDispatch( dispatch => ( {
-		setPostMeta( newMeta ) {
-			dispatch( 'core/editor' ).editPost( { meta: newMeta } );
-		},
-	} ) ),
-] )( NewsletterSettings );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
@@ -1,0 +1,156 @@
+// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
+import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '@wordpress/block-editor';
+import { Button, PanelRow, Dropdown, VisuallyHidden } from '@wordpress/components';
+import { compose, useInstanceId } from '@wordpress/compose';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { PostVisibilityLabel, PostVisibilityCheck } from '@wordpress/editor';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Visibility options for Newsletter settings
+ */
+const visibilityOptions = {
+	public: {
+		label: __( 'Public', 'jetpack' ),
+		info: __( 'Visible to everyone', 'jetpack' ),
+	},
+	all_members: {
+		label: __( 'All members', 'jetpack' ),
+		info: __( 'Only visible to your members', 'jetpack' ),
+	},
+	paid_members_only: {
+		label: __( 'Paid-members only', 'jetpack' ),
+		info: __( 'Only members with a premium subscription', 'jetpack' ),
+	},
+	specific_people: {
+		label: __( 'Specific people', 'jetpack' ),
+		info: __( 'Only people with any of the selected tiers or labels', 'jetpack' ),
+	},
+	usually_nobody: {
+		label: __( 'Usually nobody', 'jetpack' ),
+		info: __( 'Newsletters are off for new posts', 'jetpack' ),
+	},
+};
+
+function SubscriptionPostSettings( { postMeta, setPostMeta } ) {
+	const visibilityKey = postMeta._newsletter_visibility ?? 'public';
+	const visibilityLabel = visibilityOptions[ visibilityKey ]?.label ?? 'Public';
+
+	return (
+		<>
+			<PanelRow>
+				<PostVisibilityCheck
+					render={ ( { canEdit } ) => (
+						<PanelRow className="edit-post-post-visibility">
+							<span>{ __( 'Visibility', 'jetpack' ) }</span>
+							{ ! canEdit && (
+								<span>
+									<PostVisibilityLabel />
+								</span>
+							) }
+							{ canEdit && (
+								<Dropdown
+									position="bottom left"
+									contentClassName="edit-post-post-visibility__dialog"
+									focusOnMount
+									renderToggle={ ( { isOpen, onToggle } ) => (
+										<Button
+											isTertiary
+											onClick={ onToggle }
+											aria-expanded={ isOpen }
+											// translators: %s: Current newsletter post visibility.
+											aria-label={ sprintf(
+												// eslint-disable-next-line @wordpress/i18n-translator-comments
+												__( 'Select visibility: %s', 'jetpack' ),
+												visibilityLabel
+											) }
+										>
+											{ visibilityLabel }
+										</Button>
+									) }
+									renderContent={ ( { onClose } ) => (
+										<PostVisibility
+											onClose={ onClose }
+											visibility={ visibilityKey }
+											setPostMeta={ setPostMeta }
+										/>
+									) }
+								/>
+							) }
+						</PanelRow>
+					) }
+				/>
+			</PanelRow>
+		</>
+	);
+}
+
+function PostVisibility( { visibility, setPostMeta, onClose } ) {
+	const instanceId = useInstanceId( PostVisibility );
+	const hanldeOnClick = event => {
+		setPostMeta( { _newsletter_visibility: event?.target?.value } );
+	};
+
+	return (
+		<div className="editor-post-visibility">
+			<InspectorPopoverHeader
+				title={ __( 'Visibility', 'jetpack' ) }
+				help={ __( 'Control how this newsletter is viewed.', 'jetpack' ) }
+				onClose={ onClose }
+			/>
+			<fieldset className="editor-post-visibility__fieldset">
+				<VisuallyHidden as="legend">{ __( 'Visibility', 'jetpack' ) } </VisuallyHidden>
+				{ Object.keys( visibilityOptions ).map( key => (
+					<PostVisibilityChoice
+						instanceId={ instanceId }
+						key={ key }
+						value={ key }
+						label={ visibilityOptions[ key ].label }
+						info={ visibilityOptions[ key ].info }
+						checked={ key === visibility }
+						onChange={ hanldeOnClick }
+					/>
+				) ) }
+			</fieldset>
+		</div>
+	);
+}
+
+function PostVisibilityChoice( { instanceId, value, label, info, ...props } ) {
+	return (
+		<div className="editor-post-visibility__choice">
+			<input
+				type="radio"
+				name={ `editor-post-visibility__setting-${ instanceId }` }
+				value={ value }
+				id={ `editor-post-${ value }-${ instanceId }` }
+				aria-describedby={ `editor-post-${ value }-${ instanceId }-description` }
+				className="editor-post-visibility__radio"
+				{ ...props }
+			/>
+			<label
+				htmlFor={ `editor-post-${ value }-${ instanceId }` }
+				className="editor-post-visibility__label"
+			>
+				{ label }
+			</label>
+			<p
+				id={ `editor-post-${ value }-${ instanceId }-description` }
+				className="editor-post-visibility__info"
+			>
+				{ info }
+			</p>
+		</div>
+	);
+}
+
+export default compose( [
+	withSelect( select => ( {
+		postMeta: select( 'core/editor' ).getEditedPostAttribute( 'meta' ),
+	} ) ),
+	withDispatch( dispatch => ( {
+		setPostMeta( newMeta ) {
+			dispatch( 'core/editor' ).editPost( { meta: newMeta } );
+		},
+	} ) ),
+] )( SubscriptionPostSettings );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -39,6 +39,19 @@ function register_block() {
 			)
 		);
 	}
+
+	register_post_meta(
+		'post',
+		'_newsletter_visibility',
+		array(
+			'show_in_rest'  => true,
+			'single'        => true,
+			'type'          => 'string',
+			'auth_callback' => function () {
+				return wp_get_current_user()->has_cap( 'edit_posts' );
+			},
+		)
+	);
 }
 add_action( 'init', __NAMESPACE__ . '\register_block', 9 );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add a newsletter setting UI to the post sidebar to allow users of the Subscribe block to change the newsletter visibility setting easily

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p58i-d5j-p2. 

This was done as a part of a meetup project

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup Jetpack
* Go to a post
* Click on "Post" in the sidebar
* Notice a new setting is available called "Newsletter setting"
* Click on the "Newsletter setting", change the visibility setting and saved the post
* Refresh the page and notice the newsletter post setting is persisted.