### PR TITLE
Backup: Update logic for showing header/footer on connection screen

### DIFF
--- a/projects/packages/backup/changelog/fix-cannot-update-a-component-backup
+++ b/projects/packages/backup/changelog/fix-cannot-update-a-component-backup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Do not show header footer on connection screen

--- a/projects/packages/backup/src/js/components/Admin.js
+++ b/projects/packages/backup/src/js/components/Admin.js
@@ -26,9 +26,10 @@ const Admin = () => {
 	const [ capabilities, setCapabilities ] = useState( null );
 	const [ capabilitiesError, setCapabilitiesError ] = useState( null );
 	const [ capabilitiesLoaded, setCapabilitiesLoaded ] = useState( false );
-	const [ showHeaderFooter, setShowHeaderFooter ] = useState( true );
 	const { tracks } = useAnalytics();
 	const connectionLoaded = 0 < Object.keys( connectionStatus ).length;
+	const isFullyConnected =
+		connectionLoaded && connectionStatus.hasConnectedOwner && connectionStatus.isRegistered;
 
 	useEffect( () => {
 		tracks.recordEvent( 'jetpack_backup_admin_page_view' );
@@ -56,18 +57,14 @@ const Admin = () => {
 		);
 	}, [ connectionLoaded, connectionStatus ] );
 
-	const isFullyConnected = () => {
-		return connectionLoaded && connectionStatus.hasConnectedOwner && connectionStatus.isRegistered;
-	};
-
 	const hasBackupPlan = () => {
 		return Array.isArray( capabilities ) && capabilities.includes( 'backup' );
 	};
 
 	return (
 		<AdminPage
-			withHeader={ false }
-			withFooter={ false }
+			showHeader={ isFullyConnected }
+			showFooter={ isFullyConnected }
 			moduleName={ __( 'Jetpack Backup', 'jetpack-backup-pkg' ) }
 		>
 			<div id="jetpack-backup-admin-container" className="jp-content">
@@ -81,16 +78,15 @@ const Admin = () => {
 						<LoadedState
 							connectionLoaded={ connectionLoaded }
 							connectionStatus={ connectionStatus }
-							showHeaderFooter={ showHeaderFooter }
-							setShowHeaderFooter={ setShowHeaderFooter }
 							capabilitiesLoaded={ capabilitiesLoaded }
 							hasBackupPlan={ hasBackupPlan() }
 							capabilitiesError={ capabilitiesError }
 							capabilities={ capabilities }
+							isFullyConnected={ isFullyConnected }
 						/>
 					</AdminSectionHero>
 					<AdminSection>
-						{ isFullyConnected() && (
+						{ isFullyConnected && (
 							<BackupSegments
 								hasBackupPlan={ hasBackupPlan() }
 								connectionLoaded={ connectionLoaded }
@@ -415,25 +411,15 @@ const NoBackupCapabilities = () => {
 };
 
 const LoadedState = ( {
-	connectionLoaded,
-	showHeaderFooter,
-	setShowHeaderFooter,
 	capabilitiesLoaded,
 	hasBackupPlan,
 	capabilitiesError,
 	capabilities,
+	isFullyConnected,
 } ) => {
-	const [ connectionStatus, BackupConnectionScreen ] = useConnection();
+	const [ , BackupConnectionScreen ] = useConnection();
 
-	if (
-		! connectionLoaded ||
-		! connectionStatus.hasConnectedOwner ||
-		! connectionStatus.isRegistered
-	) {
-		if ( showHeaderFooter ) {
-			setShowHeaderFooter( false );
-		}
-
+	if ( ! isFullyConnected ) {
 		return (
 			<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 				<Col lg={ 12 } md={ 8 } sm={ 4 }>
@@ -441,11 +427,6 @@ const LoadedState = ( {
 				</Col>
 			</Container>
 		);
-	}
-
-	// Show header and footer on all screens except ConnectScreen
-	if ( ! showHeaderFooter ) {
-		setShowHeaderFooter( true );
 	}
 
 	if ( ! capabilitiesLoaded ) {
@@ -461,7 +442,6 @@ const LoadedState = ( {
 			</Container>
 		);
 	}
-
 	// Render an error state, this shouldn't occurr since we've passed userConnected checks
 	if ( capabilitiesError === 'is_unlinked' ) {
 		return (

--- a/projects/packages/backup/src/js/components/Admin.js
+++ b/projects/packages/backup/src/js/components/Admin.js
@@ -57,9 +57,7 @@ const Admin = () => {
 		);
 	}, [ connectionLoaded, connectionStatus ] );
 
-	const hasBackupPlan = () => {
-		return Array.isArray( capabilities ) && capabilities.includes( 'backup' );
-	};
+	const hasBackupPlan = Array.isArray( capabilities ) && capabilities.includes( 'backup' );
 
 	return (
 		<AdminPage
@@ -79,7 +77,7 @@ const Admin = () => {
 							connectionLoaded={ connectionLoaded }
 							connectionStatus={ connectionStatus }
 							capabilitiesLoaded={ capabilitiesLoaded }
-							hasBackupPlan={ hasBackupPlan() }
+							hasBackupPlan={ hasBackupPlan }
 							capabilitiesError={ capabilitiesError }
 							capabilities={ capabilities }
 							isFullyConnected={ isFullyConnected }
@@ -88,7 +86,7 @@ const Admin = () => {
 					<AdminSection>
 						{ isFullyConnected && (
 							<BackupSegments
-								hasBackupPlan={ hasBackupPlan() }
+								hasBackupPlan={ hasBackupPlan }
 								connectionLoaded={ connectionLoaded }
 							/>
 						) }


### PR DESCRIPTION

Fixes a rendering bug where a child component was trying to update parent's state on render.

Also the logic for showing or hiding footer/header was not working

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes unnecessary state var.
* Update isFullyConnected to be a var instead of function
* Update hasBackupPlan to be a var instead of function

#### After

<img width="1679" alt="image" src="https://user-images.githubusercontent.com/746152/192141689-3b2d2e8f-4caa-49da-946c-266e722efb4d.png">

#### Before
![image](https://user-images.githubusercontent.com/746152/192141776-7416ec7d-fe14-492f-bd49-5fccd6a09bcd.png)


#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
* On a disconnected site, visit the Backup page with the console open
* Confirm you don't see header or footer and that no React warning is shown in the console

