### PR TITLE
Search: Fix anti-pattern where filterOption is returned from a function instead of being component

### DIFF
--- a/projects/packages/search/changelog/fix-anti-pattern-search-1
+++ b/projects/packages/search/changelog/fix-anti-pattern-search-1
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix antipattern with no user-facing change
+
+

--- a/projects/packages/search/src/dashboard/components/mocked-search/mocked-instant-search.jsx
+++ b/projects/packages/search/src/dashboard/components/mocked-search/mocked-instant-search.jsx
@@ -10,15 +10,6 @@ import './mocked-instant-search.scss';
  * @returns {React.Component}	Mocked Search instant dialog component.
  */
 export default function MockedInstantSearch() {
-	const renderFilterOption = ( val, key ) => (
-		<div className="jp-mocked-instant-search__search-filter" key={ key }>
-			<label>
-				<input type="checkbox" disabled="disabled" />{ ' ' }
-				<TextRowPlaceHolder style={ { width: '30%' } } />
-			</label>
-		</div>
-	);
-
 	const renderSearchResult = ( val, key ) => (
 		<div className="jp-mocked-instant-search__search-result" key={ key }>
 			<TextRowPlaceHolder
@@ -75,10 +66,20 @@ export default function MockedInstantSearch() {
 						{ __( 'Filter options', 'jetpack-search-pkg' ) }
 					</div>
 					<div className="jp-mocked-instant-search__search-filter-list">
-						{ Array.apply( null, Array( 2 ) ).map( renderFilterOption ) }
+						<MockedFilterOption />
+						<MockedFilterOption />
 					</div>
 				</div>
 			</div>
 		</div>
 	);
 }
+
+const MockedFilterOption = () => (
+	<div className="jp-mocked-instant-search__search-filter">
+		<label>
+			<input type="checkbox" disabled="disabled" />{ ' ' }
+			<TextRowPlaceHolder style={ { width: '30%' } } />
+		</label>
+	</div>
+);


### PR DESCRIPTION
Change renderFilterOption to be a component to fix unnecessary re-renders and lack of visibility in React Dev tools.


- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
#### Testing instructions:
1- Launch a JN site with Search standalone and this branch
2- Keep the JS console open and expect to see no warning for the following steps
3- Connect and navigate the page. Expect to see no crashing page

