### PR TITLE
Search: Fix anti-pattern where SearchResult is returned from a function instead of being a component

### DIFF
--- a/projects/packages/search/changelog/fix-anti-pattern-search-2
+++ b/projects/packages/search/changelog/fix-anti-pattern-search-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix antipattern with no user facing changes
+
+

--- a/projects/packages/search/src/dashboard/components/mocked-search/mocked-instant-search.jsx
+++ b/projects/packages/search/src/dashboard/components/mocked-search/mocked-instant-search.jsx
@@ -10,21 +10,6 @@ import './mocked-instant-search.scss';
  * @returns {React.Component}	Mocked Search instant dialog component.
  */
 export default function MockedInstantSearch() {
-	const renderSearchResult = ( val, key ) => (
-		<div className="jp-mocked-instant-search__search-result" key={ key }>
-			<TextRowPlaceHolder
-				style={ {
-					height: '2.5em',
-					width: '50%',
-					maxWidth: '200px',
-					margin: '0.1em 0.1em 1em 0.1em',
-				} }
-			/>
-			<TextRowPlaceHolder style={ { height: '1em', width: '90%', margin: '0.1em' } } />
-			<TextRowPlaceHolder style={ { height: '1em', width: '70%', margin: '0.1em' } } />
-		</div>
-	);
-
 	return (
 		<div className="jp-mocked-instant-search" aria-hidden="true">
 			<div className="jp-mocked-instant-search__search-controls">
@@ -58,7 +43,9 @@ export default function MockedInstantSearch() {
 						</div>
 					</div>
 					<div className="jp-mocked-instant-search__search-results-content">
-						{ Array.apply( null, Array( 3 ) ).map( renderSearchResult ) }
+						<MockedSearchResult />
+						<MockedSearchResult />
+						<MockedSearchResult />
 					</div>
 				</div>
 				<div className="jp-mocked-instant-search__search-results-secondary">
@@ -81,5 +68,20 @@ const MockedFilterOption = () => (
 			<input type="checkbox" disabled="disabled" />{ ' ' }
 			<TextRowPlaceHolder style={ { width: '30%' } } />
 		</label>
+	</div>
+);
+
+const MockedSearchResult = () => (
+	<div className="jp-mocked-instant-search__search-result">
+		<TextRowPlaceHolder
+			style={ {
+				height: '2.5em',
+				width: '50%',
+				maxWidth: '200px',
+				margin: '0.1em 0.1em 1em 0.1em',
+			} }
+		/>
+		<TextRowPlaceHolder style={ { height: '1em', width: '90%', margin: '0.1em' } } />
+		<TextRowPlaceHolder style={ { height: '1em', width: '70%', margin: '0.1em' } } />
 	</div>
 );


### PR DESCRIPTION
Change renderSearchResult function to be a component (MockedSearchResult)  to fix unnecessary re-renders and lack of visibility in React Dev tools.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1- Launch a JN site with Search standalone and this branch
2- Keep the JS console open and expect to see no warning for the following steps
3- Connect and navigate the page. Expect to see no crashing page

