### PR TITLE
Search: change renderConnectionFooter to be a component

### DIFF
--- a/projects/packages/search/changelog/fix-anti-pattern-search-5
+++ b/projects/packages/search/changelog/fix-anti-pattern-search-5
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix antipattern, no user-facing change
+
+

--- a/projects/packages/search/src/dashboard/components/pages/connection-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/connection-page.jsx
@@ -27,32 +27,6 @@ export default function ConnectionPage( { isLoading = false } ) {
 		[ isLoading ]
 	);
 
-	const renderConnectionFooter = () => {
-		return (
-			<div className="jp-search-dashboard-connection-footer">
-				<p className="jp-search-dashboard-connection-footer__text">
-					{ __(
-						'Special introductory pricing, all renewals are at full price. 14 day money back guarantee.',
-						'jetpack-search-pkg'
-					) }
-				</p>
-				<p className="jp-search-dashboard-connection-footer__text">
-					*{ ' ' }
-					{ __(
-						'Pricing will automatically adjust based on the number of records in your search index.',
-						'jetpack-search-pkg'
-					) }{ ' ' }
-					<a
-						href={ getRedirectUrl( 'search-product-pricing' ) }
-						className="jp-search-dashboard-connection-footer__link"
-					>
-						{ __( 'Learn more', 'jetpack-search-pkg' ) }
-					</a>
-				</p>
-			</div>
-		);
-	};
-
 	return (
 		<>
 			{ isPageLoading && <Loading /> }
@@ -65,7 +39,7 @@ export default function ConnectionPage( { isLoading = false } ) {
 								<SearchConnectionScreen />
 							</Col>
 							<Col lg={ 12 } md={ 8 } sm={ 4 }>
-								{ renderConnectionFooter() }
+								{ <ConnectionFooter /> }
 							</Col>
 						</Container>
 					</AdminSectionHero>
@@ -74,6 +48,32 @@ export default function ConnectionPage( { isLoading = false } ) {
 		</>
 	);
 }
+
+const ConnectionFooter = () => {
+	return (
+		<div className="jp-search-dashboard-connection-footer">
+			<p className="jp-search-dashboard-connection-footer__text">
+				{ __(
+					'Special introductory pricing, all renewals are at full price. 14 day money back guarantee.',
+					'jetpack-search-pkg'
+				) }
+			</p>
+			<p className="jp-search-dashboard-connection-footer__text">
+				*{ ' ' }
+				{ __(
+					'Pricing will automatically adjust based on the number of records in your search index.',
+					'jetpack-search-pkg'
+				) }{ ' ' }
+				<a
+					href={ getRedirectUrl( 'search-product-pricing' ) }
+					className="jp-search-dashboard-connection-footer__link"
+				>
+					{ __( 'Learn more', 'jetpack-search-pkg' ) }
+				</a>
+			</p>
+		</div>
+	);
+};
 
 const SearchConnectionScreen = () => {
 	const APINonce = useSelect( select => select( STORE_ID ).getAPINonce(), [] );


### PR DESCRIPTION
Change renderConnectionFooter to be a component to fix unnecessary re-renders and lack of visibility in React Dev tools.


- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
#### Testing instructions:
1- Launch a JN site with Search standalone and this branch
2- Keep the JS console open and expect to see no warning for the following steps
3- Connect and navigate the page. Expect to see no crashing page

