### PR TITLE
Search:  Refactor renderHeader and renderFooter to be components

### DIFF
--- a/projects/packages/search/changelog/fox-anti-pattern-search-6
+++ b/projects/packages/search/changelog/fox-anti-pattern-search-6
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix antipattern, no user facing changes
+
+

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -69,20 +69,6 @@ export default function DashboardPage( { isLoading = false } ) {
 	const handleLocalNoticeDismissClick = useDispatch( STORE_ID ).removeNotice;
 	const notices = useSelect( select => select( STORE_ID ).getNotices(), [] );
 
-	const renderHeader = () => {
-		return (
-			<div className="jp-search-dashboard-header jp-search-dashboard-wrap">
-				<div className="jp-search-dashboard-row">
-					<div className="lg-col-span-12 md-col-span-8 sm-col-span-4">
-						<div className="jp-search-dashboard-header__logo-container">
-							<JetpackLogo className="jp-search-dashboard-header__masthead" />
-						</div>
-					</div>
-				</div>
-			</div>
-		);
-	};
-
 	const renderMockedSearchInterface = () => {
 		return (
 			<div className="jp-search-dashboard-top jp-search-dashboard-wrap">
@@ -152,7 +138,7 @@ export default function DashboardPage( { isLoading = false } ) {
 			{ isPageLoading && <Loading /> }
 			{ ! isPageLoading && (
 				<div className="jp-search-dashboard-page">
-					{ renderHeader() }
+					<Header />
 					{ renderMockedSearchInterface() }
 					<RecordMeter
 						postCount={ postCount }
@@ -172,3 +158,17 @@ export default function DashboardPage( { isLoading = false } ) {
 		</>
 	);
 }
+
+const Header = () => {
+	return (
+		<div className="jp-search-dashboard-header jp-search-dashboard-wrap">
+			<div className="jp-search-dashboard-row">
+				<div className="lg-col-span-12 md-col-span-8 sm-col-span-4">
+					<div className="jp-search-dashboard-header__logo-container">
+						<JetpackLogo className="jp-search-dashboard-header__masthead" />
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -35,7 +35,6 @@ export default function DashboardPage( { isLoading = false } ) {
 	);
 
 	const siteAdminUrl = useSelect( select => select( STORE_ID ).getSiteAdminUrl() );
-	const AUTOMATTIC_WEBSITE = 'https://automattic.com/';
 
 	const updateOptions = useDispatch( STORE_ID ).updateJetpackSettings;
 	const isInstantSearchPromotionActive = useSelect( select =>
@@ -119,20 +118,6 @@ export default function DashboardPage( { isLoading = false } ) {
 		);
 	};
 
-	const renderFooter = () => {
-		return (
-			<div className="jp-search-dashboard-footer jp-search-dashboard-wrap">
-				<div className="jp-search-dashboard-row">
-					<JetpackFooter
-						a8cLogoHref={ AUTOMATTIC_WEBSITE }
-						moduleName={ __( 'Jetpack Search', 'jetpack-search-pkg' ) }
-						className="lg-col-span-12 md-col-span-8 sm-col-span-4"
-					/>
-				</div>
-			</div>
-		);
-	};
-
 	return (
 		<>
 			{ isPageLoading && <Loading /> }
@@ -148,7 +133,7 @@ export default function DashboardPage( { isLoading = false } ) {
 						postTypes={ postTypes }
 					/>
 					{ renderModuleControl() }
-					{ renderFooter() }
+					<Footer />
 					<NoticesList
 						notices={ notices }
 						handleLocalNoticeDismissClick={ handleLocalNoticeDismissClick }
@@ -158,6 +143,21 @@ export default function DashboardPage( { isLoading = false } ) {
 		</>
 	);
 }
+
+const Footer = () => {
+	const AUTOMATTIC_WEBSITE = 'https://automattic.com/';
+	return (
+		<div className="jp-search-dashboard-footer jp-search-dashboard-wrap">
+			<div className="jp-search-dashboard-row">
+				<JetpackFooter
+					a8cLogoHref={ AUTOMATTIC_WEBSITE }
+					moduleName={ __( 'Jetpack Search', 'jetpack-search-pkg' ) }
+					className="lg-col-span-12 md-col-span-8 sm-col-span-4"
+				/>
+			</div>
+		</div>
+	);
+};
 
 const Header = () => {
 	return (


### PR DESCRIPTION
Change renderHeader and renderFooter to be components to fix unnecessary re-renders and lack of visibility in React Dev tools.


- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
#### Testing instructions:
1- Launch a JN site with Search standalone and this branch
2- Keep the JS console open and expect to see no warning for the following steps
3- Connect and navigate the page. Expect to see no crashing page

