### PR TITLE
Search: Refactor renderMockedSearchInterface to be a component

### DIFF
--- a/projects/packages/search/changelog/fix-anti-pattern-search-7
+++ b/projects/packages/search/changelog/fix-anti-pattern-search-7
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix antipattern, no user-facing changes
+
+

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -68,34 +68,6 @@ export default function DashboardPage( { isLoading = false } ) {
 	const handleLocalNoticeDismissClick = useDispatch( STORE_ID ).removeNotice;
 	const notices = useSelect( select => select( STORE_ID ).getNotices(), [] );
 
-	const renderMockedSearchInterface = () => {
-		return (
-			<div className="jp-search-dashboard-top jp-search-dashboard-wrap">
-				<div className="jp-search-dashboard-row">
-					<div className="jp-search-dashboard-top__title lg-col-span-6 md-col-span-7 sm-col-span-4">
-						<h1>
-							{ __(
-								"Help your visitors find exactly what they're looking for, fast",
-								'jetpack-search-pkg'
-							) }
-						</h1>
-					</div>
-					<div className=" lg-col-span-6 md-col-span-1 sm-col-span-0"></div>
-				</div>
-				<div className="jp-search-dashboard-row" aria-hidden="true">
-					<div className="lg-col-span-1 md-col-span-1 sm-col-span-0"></div>
-					<div className="jp-search-dashboard-top__mocked-search-interface lg-col-span-10 md-col-span-6 sm-col-span-4">
-						<MockedSearch
-							supportsInstantSearch={ supportsInstantSearch }
-							supportsOnlyClassicSearch={ supportsOnlyClassicSearch }
-						/>
-					</div>
-					<div className="lg-col-span-1 md-col-span-1 sm-col-span-0"></div>
-				</div>
-			</div>
-		);
-	};
-
 	const renderModuleControl = () => {
 		return (
 			<div className="jp-search-dashboard-bottom">
@@ -124,7 +96,10 @@ export default function DashboardPage( { isLoading = false } ) {
 			{ ! isPageLoading && (
 				<div className="jp-search-dashboard-page">
 					<Header />
-					{ renderMockedSearchInterface() }
+					<MockedSearchInterface
+						supportsInstantSearch={ supportsInstantSearch }
+						supportsOnlyClassicSearch={ supportsOnlyClassicSearch }
+					/>
 					<RecordMeter
 						postCount={ postCount }
 						postTypeBreakdown={ postTypeBreakdown }
@@ -143,6 +118,34 @@ export default function DashboardPage( { isLoading = false } ) {
 		</>
 	);
 }
+
+const MockedSearchInterface = ( { supportsInstantSearch, supportsOnlyClassicSearch } ) => {
+	return (
+		<div className="jp-search-dashboard-top jp-search-dashboard-wrap">
+			<div className="jp-search-dashboard-row">
+				<div className="jp-search-dashboard-top__title lg-col-span-6 md-col-span-7 sm-col-span-4">
+					<h1>
+						{ __(
+							"Help your visitors find exactly what they're looking for, fast",
+							'jetpack-search-pkg'
+						) }
+					</h1>
+				</div>
+				<div className=" lg-col-span-6 md-col-span-1 sm-col-span-0"></div>
+			</div>
+			<div className="jp-search-dashboard-row" aria-hidden="true">
+				<div className="lg-col-span-1 md-col-span-1 sm-col-span-0"></div>
+				<div className="jp-search-dashboard-top__mocked-search-interface lg-col-span-10 md-col-span-6 sm-col-span-4">
+					<MockedSearch
+						supportsInstantSearch={ supportsInstantSearch }
+						supportsOnlyClassicSearch={ supportsOnlyClassicSearch }
+					/>
+				</div>
+				<div className="lg-col-span-1 md-col-span-1 sm-col-span-0"></div>
+			</div>
+		</div>
+	);
+};
 
 const Footer = () => {
 	const AUTOMATTIC_WEBSITE = 'https://automattic.com/';


### PR DESCRIPTION
Change renderMockedSearchInterface to be a component to fix unnecessary re-renders and lack of visibility in React Dev tools.


- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
#### Testing instructions:
1- Launch a JN site with Search standalone and this branch
2- Keep the JS console open and expect to see no warning for the following steps
3- Connect and navigate the page. Expect to see no crashing page

