### PR TITLE
Search: Refactor renderModuleControl to just render a component

### DIFF
--- a/projects/packages/search/changelog/fix-anti-pattern-search-8
+++ b/projects/packages/search/changelog/fix-anti-pattern-search-8
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix anti-pattern, no user-facing changes
+
+

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -68,28 +68,6 @@ export default function DashboardPage( { isLoading = false } ) {
 	const handleLocalNoticeDismissClick = useDispatch( STORE_ID ).removeNotice;
 	const notices = useSelect( select => select( STORE_ID ).getNotices(), [] );
 
-	const renderModuleControl = () => {
-		return (
-			<div className="jp-search-dashboard-bottom">
-				<ModuleControl
-					siteAdminUrl={ siteAdminUrl }
-					updateOptions={ updateOptions }
-					domain={ domain }
-					isInstantSearchPromotionActive={ isInstantSearchPromotionActive }
-					upgradeBillPeriod={ upgradeBillPeriod }
-					supportsOnlyClassicSearch={ supportsOnlyClassicSearch }
-					supportsSearch={ supportsSearch }
-					supportsInstantSearch={ supportsInstantSearch }
-					isModuleEnabled={ isModuleEnabled }
-					isInstantSearchEnabled={ isInstantSearchEnabled }
-					isSavingEitherOption={ isSavingEitherOption }
-					isTogglingModule={ isTogglingModule }
-					isTogglingInstantSearch={ isTogglingInstantSearch }
-				/>
-			</div>
-		);
-	};
-
 	return (
 		<>
 			{ isPageLoading && <Loading /> }
@@ -107,7 +85,23 @@ export default function DashboardPage( { isLoading = false } ) {
 						lastIndexedDate={ lastIndexedDate }
 						postTypes={ postTypes }
 					/>
-					{ renderModuleControl() }
+					<div className="jp-search-dashboard-bottom">
+						<ModuleControl
+							siteAdminUrl={ siteAdminUrl }
+							updateOptions={ updateOptions }
+							domain={ domain }
+							isInstantSearchPromotionActive={ isInstantSearchPromotionActive }
+							upgradeBillPeriod={ upgradeBillPeriod }
+							supportsOnlyClassicSearch={ supportsOnlyClassicSearch }
+							supportsSearch={ supportsSearch }
+							supportsInstantSearch={ supportsInstantSearch }
+							isModuleEnabled={ isModuleEnabled }
+							isInstantSearchEnabled={ isInstantSearchEnabled }
+							isSavingEitherOption={ isSavingEitherOption }
+							isTogglingModule={ isTogglingModule }
+							isTogglingInstantSearch={ isTogglingInstantSearch }
+						/>
+					</div>
 					<Footer />
 					<NoticesList
 						notices={ notices }


### PR DESCRIPTION
Change renderModuleControl to be only a component to fix unnecessary re-renders and lack of visibility in React Dev tools.


- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
#### Testing instructions:
1- Launch a JN site with Search standalone and this branch
2- Keep the JS console open and expect to see no warning for the following steps
3- Connect and navigate the page. Expect to see no crashing page

