### PR TITLE
VideoPress: Map new caption field on admin video details

### DIFF
--- a/projects/packages/videopress/changelog/fix-map-new-caption-field-on-videopress-videos
+++ b/projects/packages/videopress/changelog/fix-map-new-caption-field-on-videopress-videos
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Set the right mapping for the caption field, relying on the new jetpack_videopress.caption raw information.

--- a/projects/packages/videopress/src/client/state/utils/map-videos.ts
+++ b/projects/packages/videopress/src/client/state/utils/map-videos.ts
@@ -23,7 +23,6 @@ export const mapVideoFromWPV2MediaEndpoint = (
 	const {
 		media_details: mediaDetails,
 		id,
-		caption,
 		jetpack_videopress: jetpackVideoPress,
 		jetpack_videopress_guid: guid,
 	} = video;
@@ -36,6 +35,7 @@ export const mapVideoFromWPV2MediaEndpoint = (
 		privacy_setting: privacySetting,
 		rating,
 		title,
+		caption,
 	} = jetpackVideoPress;
 
 	const {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26341.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Changes the mapping for the store `caption` field, from the root `caption` to the new  (#26409) `jetpack_videopress.caption` raw value field

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test on a connected site with VideoPress upgrade
* Upload one video using `Media > Add New` option
* Go to `https://wordpress.com/media/yoursite.com` to edit the video details, setting a caption value for the video:

![videopress-caption-field-on-wpcom-edit-media-page](https://user-images.githubusercontent.com/6760046/192302950-b1492ae5-0278-4e74-9e1c-d84c194ed1a8.png)

* On your test site, go to `Jetpack > VideoPress` to open your VideoPress library
* Click the `Edit video details` button for your video:

![videopress-library-edit-details-button](https://user-images.githubusercontent.com/6760046/192302281-821e66f9-992d-44b8-9361-25c681ed5eb0.png)

* Check the value of the `Caption` field:

![videopress-admin-details-with-caption](https://user-images.githubusercontent.com/6760046/192302335-c8ae73f8-d9c5-42ed-b840-5fbb774f9a63.png)

* The value there should be same as you set on WPCOM
* **Known issue:** if we change the value of the field and click on "Save changes", the change is not actually saved. I'll fill an issue to investigate and fix it.
