### PR TITLE
jetpack: Prepare for de-Fusioning masterbar by removing wpcom checks

### DIFF
--- a/projects/plugins/jetpack/changelog/update-defusion-masterbar-pt-1
+++ b/projects/plugins/jetpack/changelog/update-defusion-masterbar-pt-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+masterbar: Always load CSS from Jetpack, not Fusioned paths, in preparation for de-Fusioning.

--- a/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/class-admin-color-schemes.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/class-admin-color-schemes.php
@@ -59,11 +59,7 @@ class Admin_Color_Schemes {
 	 * @return string
 	 */
 	public function get_admin_color_scheme_url( $color_scheme ) {
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			return plugins_url( 'colors/' . $color_scheme . '/colors.css', __FILE__ );
-		} else {
-			return plugins_url( '_inc/build/masterbar/admin-color-schemes/colors/' . $color_scheme . '/colors.css', JETPACK__PLUGIN_FILE );
-		}
+		return plugins_url( '_inc/build/masterbar/admin-color-schemes/colors/' . $color_scheme . '/colors.css', JETPACK__PLUGIN_FILE );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -247,14 +247,8 @@ abstract class Base_Admin_Menu {
 	 * Enqueues scripts and styles.
 	 */
 	public function enqueue_scripts() {
-		$is_wpcom = defined( 'IS_WPCOM' ) && IS_WPCOM;
-
 		if ( $this->is_rtl() ) {
-			if ( $is_wpcom ) {
-				$css_path = 'rtl/admin-menu-rtl.css';
-			} else {
-				$css_path = 'admin-menu-rtl.css';
-			}
+			$css_path = 'admin-menu-rtl.css';
 		} else {
 			$css_path = 'admin-menu.css';
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Before we can de-Fusion the masterbar PHP code, we need the Jetpack code to load the Jetpack copy of the CSS instead of trying to load from the Fusioned paths.

The Fusioned copy of this code will need to continue loading from the wpcom paths, of course, so the Fusion diff for this PR will not be merged.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1663875860779339-slack-C032DVAHMK3

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this to the Jetpack code on wpcom, then apply [some wpcom diffs that haven't been submitted yet], and make sure the masterbar stuff still works. In particular, change the Dashboard color scheme in [your wordpress.com account settings](https://wordpress.com/me/account) and make sure the corresponding stylesheets are still loaded.