### PR TITLE
Search: Factor out OldPricingComponent and NewPricingComponent out of UpsellPage component

### DIFF
--- a/projects/packages/search/changelog/udpate-upsell_page-render-pattern
+++ b/projects/packages/search/changelog/udpate-upsell_page-render-pattern
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Just a refactor
+
+

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page.jsx
@@ -68,87 +68,6 @@ export default function UpsellPage( { isLoading = false } ) {
 		'jetpack-search-pkg'
 	);
 
-	// For new pricing table
-	const siteDomain = useSelect( select => select( STORE_ID ).getCalypsoSlug(), [] );
-	const newPricingArgs = {
-		title: 'The best WordPress search experience',
-		items: [
-			{
-				name: 'Number of records',
-				tooltipInfo: (
-					<>
-						Records are all posts, pages, custom post types and other types of content indexed by
-						Jetpack Search.
-					</>
-				),
-			},
-			{
-				name: 'Monthly requests',
-				tooltipInfo: (
-					<>A search request is when someone visiting your site searches for something.</>
-				),
-			},
-			{
-				name: 'Unbranded search',
-				tooltipInfo: <>Paid customers can remove branding from the search tool.</>,
-			},
-			{
-				name: 'Priority support',
-				tooltipInfo: (
-					<>
-						Paid customers get dedicated email support from our world-class Happiness Engineers to
-						help with any issue.
-						<br />
-						<br />
-						All other questions are handled by our team as quickly as we are able to through the
-						WordPress support forum.
-					</>
-				),
-			},
-			{
-				name: 'Instant search and indexing',
-				tooltipInfo: (
-					<>
-						Instant search and filtering without reloading the page.
-						<br />
-						<br />
-						Real-time indexing, so your search index will update within minutes of changes to your
-						site.
-					</>
-				),
-			},
-			{
-				name: 'Powerful filtering',
-				tooltipInfo: (
-					<>
-						Filtered and faceted searches by tags, categories, dates, custom taxonomies, and post
-						types.
-					</>
-				),
-			},
-			{
-				name: 'Supports 38 languages',
-				tooltipInfo: (
-					<>
-						Language support for English, Spanish, French, Portuguese, Hindi, Japanese, among
-						others.{ ' ' }
-						<a href="#" rel="external noopener noreferrer nofollow" target="_blank">
-							See all supported languanges
-						</a>
-					</>
-				),
-			},
-			{
-				name: 'Spelling correction',
-				tooltipInfo: (
-					<>
-						Quick and accurate spelling correction for when your site visitors mistype their search.
-					</>
-				),
-			},
-		],
-	};
-
 	const oldPricingComponent = (
 		<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 			<Col lg={ 6 } md={ 6 } sm={ 4 }>
@@ -172,7 +91,32 @@ export default function UpsellPage( { isLoading = false } ) {
 		</Container>
 	);
 
-	const newPricingComponent = (
+	return (
+		<>
+			{ isPageLoading && <Loading /> }
+			{ ! isPageLoading && (
+				<div className="jp-search-dashboard-upsell-page">
+					<AdminPage
+						moduleName={ __( 'Jetpack Search', 'jetpack-search-pkg' ) }
+						a8cLogoHref={ AUTOMATTIC_WEBSITE }
+					>
+						<AdminSectionHero>
+							{ isNewPricing ? (
+								<NewPricingComponent sendToCart={ sendToCart } />
+							) : (
+								oldPricingComponent()
+							) }
+						</AdminSectionHero>
+					</AdminPage>
+				</div>
+			) }
+		</>
+	);
+}
+
+const NewPricingComponent = ( { sendToCart } ) => {
+	const siteDomain = useSelect( select => select( STORE_ID ).getCalypsoSlug(), [] );
+	return (
 		<Container horizontalSpacing={ 8 }>
 			<Col lg={ 12 } md={ 12 } sm={ 12 }>
 				<ThemeProvider>
@@ -268,22 +212,81 @@ export default function UpsellPage( { isLoading = false } ) {
 			</Col>
 		</Container>
 	);
+};
 
-	return (
-		<>
-			{ isPageLoading && <Loading /> }
-			{ ! isPageLoading && (
-				<div className="jp-search-dashboard-upsell-page">
-					<AdminPage
-						moduleName={ __( 'Jetpack Search', 'jetpack-search-pkg' ) }
-						a8cLogoHref={ AUTOMATTIC_WEBSITE }
-					>
-						<AdminSectionHero>
-							{ isNewPricing ? newPricingComponent : oldPricingComponent }
-						</AdminSectionHero>
-					</AdminPage>
-				</div>
-			) }
-		</>
-	);
-}
+// For new pricing table
+const newPricingArgs = {
+	title: 'The best WordPress search experience',
+	items: [
+		{
+			name: 'Number of records',
+			tooltipInfo: (
+				<>
+					Records are all posts, pages, custom post types and other types of content indexed by
+					Jetpack Search.
+				</>
+			),
+		},
+		{
+			name: 'Monthly requests',
+			tooltipInfo: <>A search request is when someone visiting your site searches for something.</>,
+		},
+		{
+			name: 'Unbranded search',
+			tooltipInfo: <>Paid customers can remove branding from the search tool.</>,
+		},
+		{
+			name: 'Priority support',
+			tooltipInfo: (
+				<>
+					Paid customers get dedicated email support from our world-class Happiness Engineers to
+					help with any issue.
+					<br />
+					<br />
+					All other questions are handled by our team as quickly as we are able to through the
+					WordPress support forum.
+				</>
+			),
+		},
+		{
+			name: 'Instant search and indexing',
+			tooltipInfo: (
+				<>
+					Instant search and filtering without reloading the page.
+					<br />
+					<br />
+					Real-time indexing, so your search index will update within minutes of changes to your
+					site.
+				</>
+			),
+		},
+		{
+			name: 'Powerful filtering',
+			tooltipInfo: (
+				<>
+					Filtered and faceted searches by tags, categories, dates, custom taxonomies, and post
+					types.
+				</>
+			),
+		},
+		{
+			name: 'Supports 38 languages',
+			tooltipInfo: (
+				<>
+					Language support for English, Spanish, French, Portuguese, Hindi, Japanese, among others.{ ' ' }
+					<a href="#" rel="external noopener noreferrer nofollow" target="_blank">
+						See all supported languanges
+					</a>
+				</>
+			),
+		},
+		{
+			name: 'Spelling correction',
+			tooltipInfo: (
+				<>
+					Quick and accurate spelling correction for when your site visitors mistype their search.
+				</>
+			),
+		},
+	],
+};

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page.jsx
@@ -58,6 +58,30 @@ export default function UpsellPage( { isLoading = false } ) {
 		} );
 	}, [ domain, adminUrl, isFullyConnected ] );
 
+	return (
+		<>
+			{ isPageLoading && <Loading /> }
+			{ ! isPageLoading && (
+				<div className="jp-search-dashboard-upsell-page">
+					<AdminPage
+						moduleName={ __( 'Jetpack Search', 'jetpack-search-pkg' ) }
+						a8cLogoHref={ AUTOMATTIC_WEBSITE }
+					>
+						<AdminSectionHero>
+							{ isNewPricing ? (
+								<NewPricingComponent sendToCart={ sendToCart } />
+							) : (
+								<OldPricingComponent sendToCart={ sendToCart } />
+							) }
+						</AdminSectionHero>
+					</AdminPage>
+				</div>
+			) }
+		</>
+	);
+}
+
+const OldPricingComponent = ( { sendToCart } ) => {
 	// For old pricing card
 	const priceBefore = useSelect( select => select( STORE_ID ).getPriceBefore() / 12, [] );
 	const priceAfter = useSelect( select => select( STORE_ID ).getPriceAfter() / 12, [] );
@@ -68,7 +92,7 @@ export default function UpsellPage( { isLoading = false } ) {
 		'jetpack-search-pkg'
 	);
 
-	const oldPricingComponent = (
+	return (
 		<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 			<Col lg={ 6 } md={ 6 } sm={ 4 }>
 				<h1>{ __( 'The best WordPress search experience', 'jetpack-search-pkg' ) }</h1>
@@ -90,29 +114,7 @@ export default function UpsellPage( { isLoading = false } ) {
 			</Col>
 		</Container>
 	);
-
-	return (
-		<>
-			{ isPageLoading && <Loading /> }
-			{ ! isPageLoading && (
-				<div className="jp-search-dashboard-upsell-page">
-					<AdminPage
-						moduleName={ __( 'Jetpack Search', 'jetpack-search-pkg' ) }
-						a8cLogoHref={ AUTOMATTIC_WEBSITE }
-					>
-						<AdminSectionHero>
-							{ isNewPricing ? (
-								<NewPricingComponent sendToCart={ sendToCart } />
-							) : (
-								oldPricingComponent()
-							) }
-						</AdminSectionHero>
-					</AdminPage>
-				</div>
-			) }
-		</>
-	);
-}
+};
 
 const NewPricingComponent = ( { sendToCart } ) => {
 	const siteDomain = useSelect( select => select( STORE_ID ).getCalypsoSlug(), [] );


### PR DESCRIPTION

Follow-up to #26408 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Moves NewPricingComponent  and NewPricingComponent definition outside UpsellPage.
* Moves newPricingArgs out of UpsellPage body

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
No

#### Does this pull request change what data or activity we track or use?
No
#### Testing instructions:

* Go to a connected site with Jetpack Search without a plan.
* Navigate to  `/wp-admin/admin.php?page=jetpack-search`
* Confirm  you see the current upsell page with current pricing card
* Navigate to url `/wp-admin/admin.php?page=jetpack-search&new_pricing_202208=1`
* Confirm there is a brand new upsell page
