### PR TITLE
Search: Add DB post type breakdown endpoint

### DIFF
--- a/projects/packages/backup/changelog/add-db-post-type-breakdown
+++ b/projects/packages/backup/changelog/add-db-post-type-breakdown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/backup/composer.json
+++ b/projects/packages/backup/composer.json
@@ -11,7 +11,7 @@
 		"automattic/jetpack-config": "^1.10",
 		"automattic/jetpack-connection": "^1.45",
 		"automattic/jetpack-identity-crisis": "^0.8",
-		"automattic/jetpack-my-jetpack": "^2.1",
+		"automattic/jetpack-my-jetpack": "^2.2",
 		"automattic/jetpack-sync": "^1.38",
 		"automattic/jetpack-status": "^1.14"
 	},

--- a/projects/packages/my-jetpack/changelog/add-db-post-type-breakdown
+++ b/projects/packages/my-jetpack/changelog/add-db-post-type-breakdown
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search: add post type breakdown endpoint

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -74,7 +74,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "2.1.x-dev"
+			"dev-trunk": "2.2.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "2.1.2-alpha",
+	"version": "2.2.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -29,7 +29,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '2.1.2-alpha';
+	const PACKAGE_VERSION = '2.2.0-alpha';
 
 	/**
 	 * Initialize My Jetapack

--- a/projects/packages/my-jetpack/src/products/class-search-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-search-stats.php
@@ -102,12 +102,12 @@ class Search_Stats {
 	public static function get_post_type_breakdown_with( $raw_posts_counts, $indexable_post_types, $indexable_status_array ) {
 		$posts_counts = array();
 		foreach ( $raw_posts_counts as $row ) {
-			// ignore if post type is in excluded post types.
-			if ( in_array( $row['post_type'], self::EXCLUDED_POST_TYPES, true ) ) {
-				continue;
-			}
 			// ignore if status is not public.
 			if ( ! in_array( $row['post_status'], $indexable_status_array, true ) ) {
+				continue;
+			}
+			// ignore if post type is in excluded post types.
+			if ( in_array( $row['post_type'], self::EXCLUDED_POST_TYPES, true ) ) {
 				continue;
 			}
 			// ignore if post type is not public and is not explicitly included.

--- a/projects/packages/my-jetpack/src/products/class-search-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-search-stats.php
@@ -14,9 +14,28 @@ use Jetpack_Options;
  * Search stats (e.g. post count, post type breakdown)
  */
 class Search_Stats {
-	const CACHE_EXPIRY             = 5 * MINUTE_IN_SECONDS;
-	const CACHE_GROUP              = 'jetpack_search';
-	const COUNT_ESTIMATE_CACHE_KEY = 'count_estimate';
+	const EXCLUDED_POST_TYPES = array(
+		'elementor_library', // Used by Elementor.
+		'jp_sitemap', // Used by Jetpack.
+		'revision',
+		'vip-legacy-redirect',
+		'scheduled-action',
+		'nbcs_video_lookup',
+		'reply', // bbpress, these get included in the topic
+		'product_variation', // woocommerce, not really public
+		'nav_menu_item',
+		'shop_order', // woocommerce, not really public
+		'redirect_rule', // Used by the Safe Redirect plugin.
+	);
+
+	const DO_NOT_EXCLUDE_POST_TYPES = array(
+		'topic', // bbpress
+		'forum', // bbpress
+	);
+
+	const CACHE_EXPIRY                  = 5 * MINUTE_IN_SECONDS;
+	const CACHE_GROUP                   = 'jetpack_search';
+	const POST_TYPE_BREAKDOWN_CACHE_KEY = 'post_type_break_down';
 
 	/**
 	 * Get stats from the WordPress.com API for the current blog ID.
@@ -43,47 +62,72 @@ class Search_Stats {
 	 * Estimate record counts via a local database query.
 	 */
 	public static function estimate_count() {
-		$cached_value = wp_cache_get( self::COUNT_ESTIMATE_CACHE_KEY, self::CACHE_GROUP );
+		return array_sum( static::get_post_type_breakdown() );
+	}
+
+	/**
+	 * Calculate breakdown of post types for the site.
+	 */
+	public static function get_post_type_breakdown() {
+		$cached_value = wp_cache_get( self::POST_TYPE_BREAKDOWN_CACHE_KEY, self::CACHE_GROUP );
 		if ( false !== $cached_value ) {
 			return $cached_value;
 		}
-
-		global $wpdb;
-		$indexable_statuses     = get_post_stati( array( 'public' => true ) );
-		$unindexable_post_types = array_merge(
-			// Explicitly exclude various post types registered by plugins.
+		$indexable_post_types   = get_post_types(
 			array(
-				'elementor_library', // Used by Elementor.
-				'jp_sitemap', // Used by Jetpack.
-				'product_variation', // Used by Woocommerce.
-				'redirect_rule', // Used by the Safe Redirect plugin.
-				'reply', // Used by bbpress.
-				'scheduled-action', // Used by Woocommerce.
-			),
-			get_post_types(
-				array(
-					'exclude_from_search' => true,
-					'public'              => false,
-				),
-				'names',
-				'or'
+				'public'              => true,
+				'exclude_from_search' => false,
 			)
 		);
-
-		$prep_for_query = function ( $string ) use ( $wpdb ) {
-			// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.QuotedSimplePlaceholder -- This is used to sanitize post type names.
-			return $wpdb->prepare( "'%s'", $string );
-		};
-
-		$statuses_list   = implode( ',', array_map( $prep_for_query, $indexable_statuses ) );
-		$post_types_list = implode( ',', array_map( $prep_for_query, $unindexable_post_types ) );
-
-		$count = (int) $wpdb->get_var(
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- This is properly prepared, but the query is constructed using variables.
-			"SELECT COUNT(ID) FROM {$wpdb->posts} WHERE post_status IN ($statuses_list) AND post_type NOT IN ($post_types_list)"
+		$indexable_status_array = get_post_stati(
+			array(
+				'public'              => true,
+				'exclude_from_search' => false,
+			)
 		);
+		$posts_counts           = static::get_post_type_breakdown_with( $indexable_post_types, $indexable_status_array );
+		wp_cache_set( self::POST_TYPE_BREAKDOWN_CACHE_KEY, $posts_counts, self::CACHE_GROUP, self::CACHE_EXPIRY );
+		return $posts_counts;
+	}
 
-		wp_cache_set( self::COUNT_ESTIMATE_CACHE_KEY, $count, self::CACHE_GROUP, self::CACHE_EXPIRY );
-		return $count;
+	/**
+	 * Calculate breakdown of post types with passed in indexable post types and statuses.
+	 * The function is going to be used from WPCOM as well for consistency.
+	 *
+	 * @param array $indexable_post_types Array of indexable post types.
+	 * @param array $indexable_status_array Array of indexable post statuses.
+	 */
+	public static function get_post_type_breakdown_with( $indexable_post_types, $indexable_status_array ) {
+		global $wpdb;
+
+		$query = "SELECT post_type, post_status, COUNT( * ) AS num_posts
+		FROM {$wpdb->posts}
+		WHERE post_password = ''
+		GROUP BY post_type, post_status";
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$results = $wpdb->get_results( $query, ARRAY_A );
+
+		$posts_counts = array();
+		foreach ( $results as $row ) {
+			// ignore if post type is in excluded post types.
+			if ( in_array( $row['post_type'], self::EXCLUDED_POST_TYPES, true ) ) {
+				continue;
+			}
+			// ignore if status is not public.
+			if ( ! in_array( $row['post_status'], $indexable_status_array, true ) ) {
+				continue;
+			}
+			// ignore if post type is not public and is not explicitly included.
+			if ( ! in_array( $row['post_type'], $indexable_post_types, true ) &&
+				! in_array( $row['post_type'], self::DO_NOT_EXCLUDE_POST_TYPES, true )
+			) {
+				continue;
+			}
+			// add up post type counts of potentially multiple post_status.
+			$posts_counts[ $row['post_type'] ] += intval( $row['num_posts'] );
+		}
+
+		arsort( $posts_counts, SORT_NUMERIC );
+		return $posts_counts;
 	}
 }

--- a/projects/packages/my-jetpack/src/products/class-search-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-search-stats.php
@@ -124,6 +124,9 @@ class Search_Stats {
 				continue;
 			}
 			// add up post type counts of potentially multiple post_status.
+			if ( ! isset( $posts_counts[ $row['post_type'] ] ) ) {
+				$posts_counts[ $row['post_type'] ] = 0;
+			}
 			$posts_counts[ $row['post_type'] ] += intval( $row['num_posts'] );
 		}
 

--- a/projects/packages/my-jetpack/src/products/class-search-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-search-stats.php
@@ -69,7 +69,6 @@ class Search_Stats {
 	 * Calculate breakdown of post types for the site.
 	 */
 	public static function get_post_type_breakdown() {
-
 		$indexable_post_types   = get_post_types(
 			array(
 				'public'              => true,

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -126,11 +126,11 @@ class Search extends Hybrid_Product {
 		$record_count   = intval( Search_Stats::estimate_count() );
 		$search_pricing = static::get_pricing_from_wpcom( $record_count );
 
-		$pricing['estimated_record_count'] = $record_count;
-
 		if ( is_wp_error( $search_pricing ) ) {
 			return $pricing;
 		}
+
+		$pricing['estimated_record_count'] = $record_count;
 
 		return array_merge( $pricing, $search_pricing );
 	}

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -126,6 +126,8 @@ class Search extends Hybrid_Product {
 		$record_count   = intval( Search_Stats::estimate_count() );
 		$search_pricing = static::get_pricing_from_wpcom( $record_count );
 
+		$pricing['estimated_record_count'] = $record_count;
+
 		if ( is_wp_error( $search_pricing ) ) {
 			return $pricing;
 		}

--- a/projects/packages/my-jetpack/tests/php/test-product-search-stats.php
+++ b/projects/packages/my-jetpack/tests/php/test-product-search-stats.php
@@ -1,0 +1,87 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Automattic\Jetpack\My_Jetpack;
+
+use Automattic\Jetpack\My_Jetpack\Products\Search_Stats;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Search_Stats.
+ *
+ * @package automattic/my-jetpack
+ */
+class Test_Search_Stats extends TestCase {
+
+	/**
+	 * Test post type breakdown function.
+	 */
+	public function test_get_post_type_breakdown_with() {
+		$indexable_post_types   = array( 'post', 'page', 'product', 'appointment' );
+		$indexable_status_array = array( 'publish', 'complete' );
+		$raw_posts_counts       = $this->get_raw_post_type_breakdown();
+
+		$this->assertEquals(
+			array(
+				'appointment' => 14,
+				'product'     => 13,
+				'page'        => 12,
+				'post'        => 11,
+				'topic'       => 10,
+			),
+			Search_Stats::get_post_type_breakdown_with( $raw_posts_counts, $indexable_post_types, $indexable_status_array )
+		);
+	}
+
+	/**
+	 * Raw post type breakdown to filter on.
+	 */
+	public function get_raw_post_type_breakdown() {
+		return array(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'num_posts'   => 11,
+			),
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'num_posts'   => 12,
+			),
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'draft',
+				'num_posts'   => 5,
+			),
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'draft',
+				'num_posts'   => 6,
+			),
+			array(
+				'post_type'   => 'product',
+				'post_status' => 'publish',
+				'num_posts'   => 13,
+			),
+			array(
+				'post_type'   => 'appointment',
+				'post_status' => 'complete',
+				'num_posts'   => 14,
+			),
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'private',
+				'num_posts'   => 7,
+			),
+			array(
+				'post_type'   => 'elementor_library',
+				'post_status' => 'publish',
+				'num_posts'   => 9,
+			),
+			array(
+				'post_type'   => 'topic',
+				'post_status' => 'publish',
+				'num_posts'   => 10,
+			),
+		);
+	}
+}

--- a/projects/packages/my-jetpack/tests/php/test-product-search-stats.php
+++ b/projects/packages/my-jetpack/tests/php/test-product-search-stats.php
@@ -82,6 +82,11 @@ class Test_Search_Stats extends TestCase {
 				'post_status' => 'publish',
 				'num_posts'   => 10,
 			),
+			array(
+				'post_type'   => 'topic',
+				'post_status' => 'draft',
+				'num_posts'   => 3,
+			),
 		);
 	}
 }

--- a/projects/packages/search/changelog/add-db-post-type-breakdown
+++ b/projects/packages/search/changelog/add-db-post-type-breakdown
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search: add post type breakdown endpoint

--- a/projects/packages/search/changelog/add-db-post-type-breakdown#2
+++ b/projects/packages/search/changelog/add-db-post-type-breakdown#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -9,7 +9,7 @@
 		"automattic/jetpack-constants": "^1.6",
 		"automattic/jetpack-status": "^1.14",
 		"automattic/jetpack-config": "^1.10",
-		"automattic/jetpack-my-jetpack": "^2.1"
+		"automattic/jetpack-my-jetpack": "^2.2"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.2",

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -132,7 +132,6 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'activate_plan' ),
-				// admin permission is allowed for backward compatibility.
 				'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
 			)
 		);
@@ -142,7 +141,6 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'deactivate_plan' ),
-				// admin permission is allowed for backward compatibility.
 				'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
 			)
 		);

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -157,7 +157,7 @@ class REST_Controller {
 		);
 		register_rest_route(
 			static::$namespace,
-			'/post-type-breakdown',
+			'/search/post-type-breakdown',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_post_type_breakdown' ),

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -155,10 +155,10 @@ class REST_Controller {
 		);
 		register_rest_route(
 			static::$namespace,
-			'/search/post-type-breakdown',
+			'/search/local-stats',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'get_post_type_breakdown' ),
+				'callback'            => array( $this, 'get_local_stats' ),
 				'permission_callback' => array( $this, 'require_valid_blog_token_callback' ),
 			)
 		);
@@ -410,8 +410,11 @@ class REST_Controller {
 	/**
 	 * Return post type breakdown for the site.
 	 */
-	public function get_post_type_breakdown() {
-		return Search_Product_Stats::get_post_type_breakdown();
+	public function get_local_stats() {
+		return array(
+			'post_count'          => Search_Product_Stats::estimate_count(),
+			'post_type_breakdown' => Search_Product_Stats::get_post_type_breakdown(),
+		);
 	}
 
 	/**

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -90,7 +90,7 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'update_settings' ),
-				'permission_callback' => array( $this, 'require_valid_blog_token_or_admin_permission' ),
+				'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
 			)
 		);
 		register_rest_route(
@@ -99,7 +99,7 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_settings' ),
-				'permission_callback' => array( $this, 'require_valid_blog_token_or_admin_permission' ),
+				'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
 			)
 		);
 		register_rest_route(
@@ -133,7 +133,7 @@ class REST_Controller {
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'activate_plan' ),
 				// admin permission is allowed for backward compatibility.
-				'permission_callback' => array( $this, 'require_valid_blog_token_or_admin_permission' ),
+				'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
 			)
 		);
 		register_rest_route(
@@ -143,7 +143,7 @@ class REST_Controller {
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'deactivate_plan' ),
 				// admin permission is allowed for backward compatibility.
-				'permission_callback' => array( $this, 'require_valid_blog_token_or_admin_permission' ),
+				'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
 			)
 		);
 		register_rest_route(
@@ -202,14 +202,6 @@ class REST_Controller {
 		}
 
 		return $this->get_forbidden_error();
-	}
-
-	/**
-	 * Require admin permission or a valid blog token.
-	 * For endpoints that are accessible from both WPCOM and WP-Admin.
-	 */
-	public function require_valid_blog_token_or_admin_permission() {
-		return $this->require_admin_privilege_callback() || $this->require_valid_blog_token_callback();
 	}
 
 	/**

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -161,7 +161,7 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_post_type_breakdown' ),
-				'permission_callback' => 'require_valid_blog_token_callback',
+				'permission_callback' => array( $this, 'require_valid_blog_token_callback' ),
 			)
 		);
 	}

--- a/projects/packages/search/tests/php/test-rest-controller.php
+++ b/projects/packages/search/tests/php/test-rest-controller.php
@@ -358,6 +358,13 @@ class Test_REST_Controller extends Search_Test_Case {
 
 		$response = $this->dispatch_request_signed_with_blog_token( $request );
 		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals(
+			array(
+				'post_count'          => 0,
+				'post_type_breakdown' => array(),
+			),
+			$response->get_data()
+		);
 	}
 
 	/**

--- a/projects/packages/search/tests/php/test-rest-controller.php
+++ b/projects/packages/search/tests/php/test-rest-controller.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\Jetpack\Search;
 
+use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
 use Automattic\Jetpack\Search\Test_Case as Search_Test_Case;
 use WP_REST_Request;
 use WP_REST_Server;
@@ -346,6 +347,100 @@ class Test_REST_Controller extends Search_Test_Case {
 		$request->set_header( 'content-type', 'application/json' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 403, $response->get_status() );
+	}
+
+	/**
+	 * Testing the `GET /jetpack/v4/search/post-type-breakdown` endpoint with blog_token.
+	 */
+	public function test_get_post_type_breakdown() {
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/search/post-type-breakdown' );
+		$request->set_header( 'content-type', 'application/json' );
+
+		$response = $this->dispatch_request_signed_with_blog_token( $request );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * Testing the `GET /jetpack/v4/search/post-type-breakdown` with editor user.
+	 */
+	public function test_get_post_type_breakdown_regular_user() {
+		wp_set_current_user( $this->editor_id );
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/search/post-type-breakdown' );
+		$request->set_header( 'content-type', 'application/json' );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 403, $response->get_status() );
+	}
+
+	/**
+	 * Testing the `GET /jetpack/v4/search/post-type-breakdown` with no auth.
+	 */
+	public function test_get_post_type_breakdown_no_auth() {
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/search/post-type-breakdown' );
+		$request->set_header( 'content-type', 'application/json' );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Signs a request with a blog token before dispatching it.
+	 *
+	 * Ensures that these tests pass through Connection_Rest_Authentication::wp_rest_authenticate,
+	 * because WP_REST_Server::dispatch doesn't call any auth logic (in a real
+	 * request, this would all happen earlier).
+	 *
+	 * @param WP_REST_Request $request The request to sign before dispatching.
+	 * @return WP_REST_Response
+	 */
+	private function dispatch_request_signed_with_blog_token( $request ) {
+		add_filter( 'jetpack_options', array( $this, 'mock_jetpack_site_connection_options' ), 10, 2 );
+
+		$token     = 'new:1:0';
+		$timestamp = (string) time();
+		$nonce     = 'testing123';
+		$body_hash = '';
+
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+
+		$_GET['_for']      = 'jetpack';
+		$_GET['token']     = $token;
+		$_GET['timestamp'] = $timestamp;
+		$_GET['nonce']     = $nonce;
+		$_GET['body-hash'] = $body_hash;
+		// This is intentionally using base64_encode().
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		$_GET['signature'] = base64_encode(
+			hash_hmac(
+				'sha1',
+				implode(
+					"\n",
+					array(
+						$token,
+						$timestamp,
+						$nonce,
+						$body_hash,
+						'POST',
+						'anything.example',
+						'80',
+						'',
+					)
+				) . "\n",
+				'blogtoken',
+				true
+			)
+		);
+
+		$jp_connection_auth = Connection_Rest_Authentication::init();
+		$jp_connection_auth->wp_rest_authenticate( false );
+
+		$response = $this->server->dispatch( $request );
+
+		$jp_connection_auth->reset_saved_auth_state();
+
+		remove_filter( 'jetpack_options', array( $this, 'mock_jetpack_site_connection_options' ) );
+
+		return $response;
 	}
 
 }

--- a/projects/packages/search/tests/php/test-rest-controller.php
+++ b/projects/packages/search/tests/php/test-rest-controller.php
@@ -350,10 +350,10 @@ class Test_REST_Controller extends Search_Test_Case {
 	}
 
 	/**
-	 * Testing the `GET /jetpack/v4/search/post-type-breakdown` endpoint with blog_token.
+	 * Testing the `GET /jetpack/v4/search/local-stats` endpoint with blog_token.
 	 */
 	public function test_get_post_type_breakdown() {
-		$request = new WP_REST_Request( 'GET', '/jetpack/v4/search/post-type-breakdown' );
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/search/local-stats' );
 		$request->set_header( 'content-type', 'application/json' );
 
 		$response = $this->dispatch_request_signed_with_blog_token( $request );
@@ -361,11 +361,11 @@ class Test_REST_Controller extends Search_Test_Case {
 	}
 
 	/**
-	 * Testing the `GET /jetpack/v4/search/post-type-breakdown` with editor user.
+	 * Testing the `GET /jetpack/v4/search/local-stats` with editor user.
 	 */
 	public function test_get_post_type_breakdown_regular_user() {
 		wp_set_current_user( $this->editor_id );
-		$request = new WP_REST_Request( 'GET', '/jetpack/v4/search/post-type-breakdown' );
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/search/local-stats' );
 		$request->set_header( 'content-type', 'application/json' );
 
 		$response = $this->server->dispatch( $request );
@@ -373,10 +373,10 @@ class Test_REST_Controller extends Search_Test_Case {
 	}
 
 	/**
-	 * Testing the `GET /jetpack/v4/search/post-type-breakdown` with no auth.
+	 * Testing the `GET /jetpack/v4/search/local-stats` with no auth.
 	 */
 	public function test_get_post_type_breakdown_no_auth() {
-		$request = new WP_REST_Request( 'GET', '/jetpack/v4/search/post-type-breakdown' );
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/search/local-stats' );
 		$request->set_header( 'content-type', 'application/json' );
 
 		$response = $this->server->dispatch( $request );

--- a/projects/plugins/backup/changelog/add-db-post-type-breakdown
+++ b/projects/plugins/backup/changelog/add-db-post-type-breakdown
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -238,7 +238,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "0d78efcf1a469148255221792a2b910afe90516c"
+                "reference": "4268058efedd9fb715a8d58ce1bb6c9dd5a5b7bb"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -248,7 +248,7 @@
                 "automattic/jetpack-config": "^1.10",
                 "automattic/jetpack-connection": "^1.45",
                 "automattic/jetpack-identity-crisis": "^0.8",
-                "automattic/jetpack-my-jetpack": "^2.1",
+                "automattic/jetpack-my-jetpack": "^2.2",
                 "automattic/jetpack-status": "^1.14",
                 "automattic/jetpack-sync": "^1.38"
             },
@@ -828,7 +828,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "a3793ded9ced8f26345431d777b917db6e2b9373"
+                "reference": "44f6a3765bedab8892264689713153b7f35f65d7"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -854,7 +854,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.1.x-dev"
+                    "dev-trunk": "2.2.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/add-db-post-type-breakdown
+++ b/projects/plugins/boost/changelog/add-db-post-type-breakdown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -20,7 +20,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.10.x-dev",
 		"automattic/jetpack-connection": "1.45.x-dev",
-		"automattic/jetpack-my-jetpack": "2.1.x-dev",
+		"automattic/jetpack-my-jetpack": "2.2.x-dev",
 		"automattic/jetpack-device-detection": "1.4.x-dev",
 		"automattic/jetpack-lazy-images": "2.1.x-dev",
 		"tedivm/jshrink": "1.4.0"

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2b610e738b9e3f4a7501f5ee59beaff5",
+    "content-hash": "7adf0dcadf103cc4d84cc4c2e39f86fe",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -735,7 +735,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "a3793ded9ced8f26345431d777b917db6e2b9373"
+                "reference": "44f6a3765bedab8892264689713153b7f35f65d7"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -761,7 +761,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.1.x-dev"
+                    "dev-trunk": "2.2.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/changelog/add-db-post-type-breakdown
+++ b/projects/plugins/jetpack/changelog/add-db-post-type-breakdown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -31,7 +31,7 @@
 		"automattic/jetpack-lazy-images": "2.1.x-dev",
 		"automattic/jetpack-licensing": "1.7.x-dev",
 		"automattic/jetpack-logo": "1.5.x-dev",
-		"automattic/jetpack-my-jetpack": "2.1.x-dev",
+		"automattic/jetpack-my-jetpack": "2.2.x-dev",
 		"automattic/jetpack-partner": "1.7.x-dev",
 		"automattic/jetpack-plugins-installer": "0.2.x-dev",
 		"automattic/jetpack-post-list": "0.4.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2cff4d00dcc5672173c4012e2f3ef256",
+    "content-hash": "805c1a4c2ffa0cdc768fb6c800ada7d8",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -361,7 +361,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "0d78efcf1a469148255221792a2b910afe90516c"
+                "reference": "4268058efedd9fb715a8d58ce1bb6c9dd5a5b7bb"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -371,7 +371,7 @@
                 "automattic/jetpack-config": "^1.10",
                 "automattic/jetpack-connection": "^1.45",
                 "automattic/jetpack-identity-crisis": "^0.8",
-                "automattic/jetpack-my-jetpack": "^2.1",
+                "automattic/jetpack-my-jetpack": "^2.2",
                 "automattic/jetpack-status": "^1.14",
                 "automattic/jetpack-sync": "^1.38"
             },
@@ -1206,7 +1206,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "a3793ded9ced8f26345431d777b917db6e2b9373"
+                "reference": "44f6a3765bedab8892264689713153b7f35f65d7"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -1232,7 +1232,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.1.x-dev"
+                    "dev-trunk": "2.2.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"
@@ -1750,14 +1750,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "c517a763a5a6c1c876f38c25f9d172ceeee6ca5b"
+                "reference": "6ec32d71a637bb0904941c045bdfc4b9b4d546d6"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
                 "automattic/jetpack-config": "^1.10",
                 "automattic/jetpack-connection": "^1.45",
                 "automattic/jetpack-constants": "^1.6",
-                "automattic/jetpack-my-jetpack": "^2.1",
+                "automattic/jetpack-my-jetpack": "^2.2",
                 "automattic/jetpack-status": "^1.14"
             },
             "require-dev": {

--- a/projects/plugins/protect/changelog/add-db-post-type-breakdown
+++ b/projects/plugins/protect/changelog/add-db-post-type-breakdown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/protect/composer.json
+++ b/projects/plugins/protect/composer.json
@@ -11,7 +11,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.10.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-my-jetpack": "2.1.x-dev",
+		"automattic/jetpack-my-jetpack": "2.2.x-dev",
 		"automattic/jetpack-plugins-installer": "0.2.x-dev",
 		"automattic/jetpack-sync": "1.38.x-dev"
 	},

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6aaea801b8a90b82ef50296dbe305f5e",
+    "content-hash": "473b3f56e652a868f425037845097435",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -745,7 +745,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "a3793ded9ced8f26345431d777b917db6e2b9373"
+                "reference": "44f6a3765bedab8892264689713153b7f35f65d7"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -771,7 +771,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.1.x-dev"
+                    "dev-trunk": "2.2.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/add-db-post-type-breakdown
+++ b/projects/plugins/search/changelog/add-db-post-type-breakdown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -9,7 +9,7 @@
 		"automattic/jetpack-config": "1.10.x-dev",
 		"automattic/jetpack-connection": "1.45.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-my-jetpack": "2.1.x-dev",
+		"automattic/jetpack-my-jetpack": "2.2.x-dev",
 		"automattic/jetpack-search": "0.24.x-dev",
 		"automattic/jetpack-status": "1.14.x-dev",
 		"automattic/jetpack-sync": "1.38.x-dev",

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "68fbfe40eaee3a44f4f559076d7bb031",
+    "content-hash": "f1a46651da5ae14531bdee564c8bcc65",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -745,7 +745,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "a3793ded9ced8f26345431d777b917db6e2b9373"
+                "reference": "44f6a3765bedab8892264689713153b7f35f65d7"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -771,7 +771,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.1.x-dev"
+                    "dev-trunk": "2.2.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"
@@ -1096,14 +1096,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "c517a763a5a6c1c876f38c25f9d172ceeee6ca5b"
+                "reference": "6ec32d71a637bb0904941c045bdfc4b9b4d546d6"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
                 "automattic/jetpack-config": "^1.10",
                 "automattic/jetpack-connection": "^1.45",
                 "automattic/jetpack-constants": "^1.6",
-                "automattic/jetpack-my-jetpack": "^2.1",
+                "automattic/jetpack-my-jetpack": "^2.2",
                 "automattic/jetpack-status": "^1.14"
             },
             "require-dev": {

--- a/projects/plugins/social/changelog/add-db-post-type-breakdown
+++ b/projects/plugins/social/changelog/add-db-post-type-breakdown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -12,7 +12,7 @@
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
 		"automattic/jetpack-publicize": "0.16.x-dev",
 		"automattic/jetpack-connection": "1.45.x-dev",
-		"automattic/jetpack-my-jetpack": "2.1.x-dev",
+		"automattic/jetpack-my-jetpack": "2.2.x-dev",
 		"automattic/jetpack-sync": "1.38.x-dev",
 		"automattic/jetpack-status": "1.14.x-dev",
 		"automattic/jetpack-plans": "0.2.x-dev"

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0fe37b64da788667159e8391b3799358",
+    "content-hash": "59085a2068bb53a3378c4637033aaf27",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -745,7 +745,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "a3793ded9ced8f26345431d777b917db6e2b9373"
+                "reference": "44f6a3765bedab8892264689713153b7f35f65d7"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -771,7 +771,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.1.x-dev"
+                    "dev-trunk": "2.2.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/add-db-post-type-breakdown
+++ b/projects/plugins/starter-plugin/changelog/add-db-post-type-breakdown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/starter-plugin/composer.json
+++ b/projects/plugins/starter-plugin/composer.json
@@ -10,7 +10,7 @@
 		"automattic/jetpack-composer-plugin": "1.1.x-dev",
 		"automattic/jetpack-config": "1.10.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-my-jetpack": "2.1.x-dev",
+		"automattic/jetpack-my-jetpack": "2.2.x-dev",
 		"automattic/jetpack-plugins-installer": "0.2.x-dev",
 		"automattic/jetpack-sync": "1.38.x-dev"
 	},

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3078d528f517ac3b50f0e3cf1448b980",
+    "content-hash": "5add200f74e172ea67871d1a73c1daf1",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -745,7 +745,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "a3793ded9ced8f26345431d777b917db6e2b9373"
+                "reference": "44f6a3765bedab8892264689713153b7f35f65d7"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -771,7 +771,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.1.x-dev"
+                    "dev-trunk": "2.2.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/videopress/changelog/add-db-post-type-breakdown
+++ b/projects/plugins/videopress/changelog/add-db-post-type-breakdown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/videopress/composer.json
+++ b/projects/plugins/videopress/composer.json
@@ -10,7 +10,7 @@
 		"automattic/jetpack-config": "1.10.x-dev",
 		"automattic/jetpack-connection": "1.45.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
-		"automattic/jetpack-my-jetpack": "2.1.x-dev",
+		"automattic/jetpack-my-jetpack": "2.2.x-dev",
 		"automattic/jetpack-sync": "1.38.x-dev",
 		"automattic/jetpack-plugins-installer": "0.2.x-dev",
 		"automattic/jetpack-videopress": "0.4.x-dev"

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a58cc21ca1b540a76bcc2d11d6dee05e",
+    "content-hash": "f531469b5e28a13aaeda46fc3d1396ef",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -745,7 +745,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "a3793ded9ced8f26345431d777b917db6e2b9373"
+                "reference": "44f6a3765bedab8892264689713153b7f35f65d7"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -771,7 +771,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.1.x-dev"
+                    "dev-trunk": "2.2.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/tools/phpcs-excludelist.json
+++ b/tools/phpcs-excludelist.json
@@ -2,7 +2,6 @@
 	"projects/packages/backup/src/class-rest-controller.php",
 	"projects/packages/connection/legacy/class-jetpack-options.php",
 	"projects/packages/connection/src/class-nonce-handler.php",
-	"projects/packages/my-jetpack/src/products/class-search-stats.php",
 	"projects/packages/status/src/class-status.php",
 	"projects/packages/sync/src/class-queue.php",
 	"projects/packages/sync/src/class-replicastore.php",


### PR DESCRIPTION
Fixes #26459 

#### Changes proposed in this Pull Request:
The PR proposes to add a `/jetpack/v4/search/local-stats` endpoint for WPCOM to use for record number estimation. The current solution uses `/wp/v2/search` which is not consistent with all the other places.

The PR adds a method `Automattic\Jetpack\My_Jetpack\Products\Search_Stats::get_post_type_breakdown()` to generate post type breakdown for the site, and also refactors `Automattic\Jetpack\My_Jetpack\Products\Search_Stats::estimate_count()` to use it, just to be consistent with everywhere else.


#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Ensure all PHP tests pass
* Navigate to a site with Search plugin and valid Search subscription
* Open `/wp-admin/admin.php?page=jetpack-search` and inspect network
* Ensure `estimate_record_count` has the indexable number of posts on the site

![image](https://user-images.githubusercontent.com/1425433/192679068-149168e6-8cfc-4f9e-9845-1340fcb01f5d.png)
