### PR TITLE
E2E tests: update selectors for pricing page (broken connection tests)

### DIFF
--- a/tools/e2e-commons/pages/wpcom/pick-a-plan.js
+++ b/tools/e2e-commons/pages/wpcom/pick-a-plan.js
@@ -1,17 +1,11 @@
 import WpPage from '../wp-page.js';
-import logger from '../../logger.cjs';
 
 export default class PickAPlanPage extends WpPage {
 	constructor( page ) {
 		super( page, {
-			expectedSelectors: [ 'div[data-e2e-product-slug="jetpack_complete"]' ],
+			expectedSelectors: [ 'div.jetpack-product-store' ],
 			explicitWaitMS: 40000,
 		} );
-	}
-
-	async waitForPage() {
-		await super.waitForPage();
-		await this.waitForElementToBeHidden( '.display-price__price-placeholder' );
 	}
 
 	async select( product = 'free' ) {
@@ -25,10 +19,7 @@ export default class PickAPlanPage extends WpPage {
 	}
 
 	async selectFreePlan() {
-		const freePlanButton = '[data-e2e-product-slug="free"] a';
-		const href = await this.page.getAttribute( freePlanButton, 'href' );
-		logger.debug( `Free plan button href: ${ href }` );
-		await this.waitForTimeout( 500 );
+		const freePlanButton = '.jetpack-product-store__jetpack-free a';
 		return await this.click( freePlanButton );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

There is a new pricing page in place and the old selectors are no longer valid, breaking connection tests.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
p1664260931070299-slack-C03QNBQKG73

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* All e2e tests should pass