### PR TITLE
Paid blocks: Stop exposing cover block controls to inner blocks

### DIFF
--- a/projects/plugins/jetpack/changelog/update-paid-blocks-toolbar-cover
+++ b/projects/plugins/jetpack/changelog/update-paid-blocks-toolbar-cover
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Minor WP.com-only bugfix that prevents the cover block controls from being exposed to the inner blocks
+
+

--- a/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/index.js
+++ b/projects/plugins/jetpack/extensions/extended-blocks/paid-blocks/index.js
@@ -38,11 +38,15 @@ const jetpackPaidBlock = ( settings, name ) => {
 			};
 		}
 
-		// Ensure that the toolbar of the inner blocks doesn't overlap the upgrade banner.
-		settings.supports = {
-			...settings.supports,
-			__experimentalExposeControlsToChildren: true,
-		};
+		// Ensure that the toolbar of the inner blocks doesn't overlap the upgrade banner by displaying the controls
+		// of the inner blocks in the parent block toolbar (which is always placed above the upgrade banner).
+		// The cover block is excluded from this behavior because the toolbars of its inner blocks do not interfere.
+		if ( name !== 'core/cover' ) {
+			settings.supports = {
+				...settings.supports,
+				__experimentalExposeControlsToChildren: true,
+			};
+		}
 	}
 
 	return settings;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/67929

#### Changes proposed in this Pull Request:

Excludes the cover block from the behavior introduced by https://github.com/Automattic/jetpack/pull/25812 that forces all paid blocks to share their toolbar with their inner blocks.

Before | After
--- | ---
<img width="400" alt="Screen Shot 2022-09-16 at 1 45 57 PM" src="https://user-images.githubusercontent.com/28742426/190701220-eba064ca-2687-46a4-bf5f-e04e8c8ba49a.png"> | <img width="400" alt="Screen Shot 2022-09-16 at 1 47 55 PM" src="https://user-images.githubusercontent.com/28742426/190701346-ff1b41f4-a63e-4b57-b89e-45557aa6c4fa.png">


#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
- Apply the diff created by Fusion to your WP.com sandbox
- Sandbox a simple site with a Free plan
- Go to https://wordpress.com/post
- Select the sandboxed site
- Insert a cover block
- Add some blocks inside the cover block
- Select the inner blocks
- Make sure the toolbar is placed just above the inner block (and it doesn't use the cover block toolbar)
