### PR TITLE
My Jetpack: Integrate connection error React component

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -6,6 +6,7 @@ import {
 	Col,
 	Text,
 } from '@automattic/jetpack-components';
+import { useConnectionErrorNotice, ConnectionError } from '@automattic/jetpack-connection';
 import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, warning, info } from '@wordpress/icons';
@@ -45,6 +46,7 @@ const GlobalNotice = ( { message, options, clean } ) => {
 export default function MyJetpackScreen() {
 	useConnectionWatcher();
 	const { message, options, clean } = useGlobalNotice();
+	const { hasConnectionError } = useConnectionErrorNotice();
 
 	const { recordEvent } = useAnalytics();
 
@@ -73,6 +75,11 @@ export default function MyJetpackScreen() {
 							{ __( 'Manage your Jetpack products', 'jetpack-my-jetpack' ) }
 						</Text>
 					</Col>
+					{ hasConnectionError && (
+						<Col>
+							<ConnectionError />
+						</Col>
+					) }
 					{ message && (
 						<Col>
 							<GlobalNotice message={ message } options={ options } clean={ clean } />

--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-connection-errors
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-connection-errors
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Integrate the new connection error message React component into My Jetpack.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Integrate the `ConnectionErrorNotice` React component into My Jetpack. This is part of a bigger project (1202697549597858-as) to provide consistent failed connection error reporting and an interface to reconnect (1202697549597858-as-1202697549597864) to all plugins and projects in the monorepo.

The changes will affect the following:
* My Jetpack

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
* p9dueE-5w8-p2

#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:
1. Run `jetpack build packages/my-jetpack`.
1. Enable the "Jetpack Debug Tools" plugin.
1. Go to Jetpack Debug > Jetpack Debug.
1. Enable "Broken token Utilities" and click "Save".
1. Go to Jetpack > My Jetpack.
1. Confirm that no errors display below the "Manage your Jetpack products" heading.
1. Go to Jetpack Debug > Broken Token
1. Click the "Set invalid blog token" button and the "Set invalid user tokens" button.
1. Go to Jetpack > My Jetpack.
1. You should see an error message as shown in the below screenshot:
![jetpack-connection-error-example-2](https://user-images.githubusercontent.com/56307/193135578-6989a244-5c24-4ed0-94a6-9b3e706a3925.png)
1. Click on "Restore Connection".
1. The "Reconnecting Jetpack" message appears with the animating wait image.
1. The "Reconnecting Jetpack" connection disappears.
1. You are taken to the Jetpack connection page.