### PR TITLE
Publicize: Ensure the Publicize code is loaded, not only an active module

### DIFF
--- a/projects/plugins/jetpack/changelog/resolve-corner-case-publicize
+++ b/projects/plugins/jetpack/changelog/resolve-corner-case-publicize
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Resolves a corner-case fatal
+
+

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -708,7 +708,7 @@ class Jetpack_Gutenberg {
 			'siteLocale'       => str_replace( '_', '-', get_locale() ),
 		);
 
-		if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || did_action( 'jetpack_module_loaded_publicize' ) ) {
+		if ( Jetpack::is_module_active( 'publicize' ) && function_exists( 'publicize_init' ) ) {
 			$publicize               = publicize_init();
 			$initial_state['social'] = array(
 				'sharesData'  => $publicize->get_publicize_shares_info( $blog_id ),

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -708,7 +708,7 @@ class Jetpack_Gutenberg {
 			'siteLocale'       => str_replace( '_', '-', get_locale() ),
 		);
 
-		if ( Jetpack::is_module_active( 'publicize' ) ) {
+		if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || did_action( 'jetpack_module_loaded_publicize' ) ) {
 			$publicize               = publicize_init();
 			$initial_state['social'] = array(
 				'sharesData'  => $publicize->get_publicize_shares_info( $blog_id ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes a fatal introduced via #26420

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* updated checks

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
Internal: p1664282377516619-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Connect a site using Jetpack the plugin. Ensure the Publicize module is active (should be by default).
* Disconnect the site, but leave Jetpack installed and activated.
* Install a standalone that does not use the user connection (e.g. Boost or Protect) OR click to connect Jetpack but abort before auth your user.
* Go to the Block Editor.

Before this PR, it'll fatal with an undeclared function name.
After, it should load as normal.