### PR TITLE
VideoPress: Add endpoint for returning today's video stats

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-stats-endpoint
+++ b/projects/packages/videopress/changelog/add-videopress-stats-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: add videos stats endpoint.

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -119,6 +119,7 @@ class Initializer {
 		Jwt_Token_Bridge::init();
 		Uploader_Rest_Endpoints::init();
 		VideoPress_Rest_Api_V1_Token::init();
+		VideoPress_Rest_Api_V1_Stats::init();
 		XMLRPC::init();
 		self::register_oembed_providers();
 		if ( self::should_initialize_admin_ui() ) {

--- a/projects/packages/videopress/src/class-stats.php
+++ b/projects/packages/videopress/src/class-stats.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Provides data stats about videos inside VideoPress
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+use Automattic\Jetpack\Connection\Client;
+use WP_Error;
+
+/**
+ * Provides data stats about videos inside VideoPress
+ */
+class Stats {
+
+	/**
+	 * Returns the counter of today's plays for all videos.
+	 *
+	 * @return int|WP_Error the total of plays for today, or WP_Error on failure.
+	 */
+	public static function get_today_plays() {
+		$error = new WP_Error(
+			'videopress_stats_error',
+			__( "Could not fetch today's stats from the service", 'jetpack-videopress-pkg' )
+		);
+
+		$blog_id = VideoPressToken::blog_id();
+
+		$path = sprintf(
+			'sites/%d/stats/video-plays',
+			$blog_id
+		);
+
+		$response = Client::wpcom_json_api_request_as_blog( $path, '1.1', array(), null, 'rest' );
+
+		if ( is_wp_error( $response ) ) {
+			return $error;
+		}
+
+		$response_code = wp_remote_retrieve_response_code( $response );
+		if ( 200 !== $response_code ) {
+			return $error;
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		$data = json_decode( $body, true );
+
+		if ( ! $data || ! isset( $data['days'] ) || count( $data['days'] ) === 0 ) {
+			return $error;
+		}
+
+		/*
+		 * The only result here is today's stats
+		 */
+		$today_stats = array_pop( $data['days'] );
+
+		return $today_stats['total_plays'];
+	}
+}

--- a/projects/packages/videopress/src/class-videopress-rest-api-v1-stats.php
+++ b/projects/packages/videopress/src/class-videopress-rest-api-v1-stats.php
@@ -47,7 +47,7 @@ class VideoPress_Rest_Api_V1_Stats {
 	 * @return boolean
 	 */
 	public static function permissions_callback() {
-		return true; // TODO: decide on the best access level
+		return current_user_can( 'read' ); // TODO: confirm this
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-videopress-rest-api-v1-stats.php
+++ b/projects/packages/videopress/src/class-videopress-rest-api-v1-stats.php
@@ -92,7 +92,7 @@ class VideoPress_Rest_Api_V1_Stats {
 			$blog_id
 		);
 
-		$response = Client::wpcom_json_api_request_as_user( $path, '1.1', array(), null, 'rest' );
+		$response = Client::wpcom_json_api_request_as_blog( $path, '1.1', array(), null, 'rest' );
 
 		if ( is_wp_error( $response ) ) {
 			return $error;

--- a/projects/packages/videopress/src/class-videopress-rest-api-v1-stats.php
+++ b/projects/packages/videopress/src/class-videopress-rest-api-v1-stats.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * VideoPress Stats Endpoints
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+use WP_REST_Response;
+
+/**
+ * VideoPress stats rest api class
+ */
+class VideoPress_Rest_Api_V1_Stats {
+	/**
+	 * Initializes the endpoints
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'rest_api_init', array( static::class, 'register_rest_endpoints' ) );
+	}
+
+	/**
+	 * Register the REST API routes.
+	 *
+	 * @return void
+	 */
+	public static function register_rest_endpoints() {
+		register_rest_route(
+			'videopress/v1',
+			'stats',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => static::class . '::get_stats',
+				'permission_callback' => static::class . '::permissions_callback',
+			)
+		);
+	}
+
+	/**
+	 * Checks wether the user have permissions to see stats
+	 *
+	 * @return boolean
+	 */
+	public static function permissions_callback() {
+		return true; // TODO: decide on the best access level
+	}
+
+	/**
+	 * Endpoint for getting the general VideoPress stats for the site.
+	 *
+	 * Returns the plays for all the videos, for today and since the beggining of times.
+	 *
+	 * @return WP_Rest_Response - The response object.
+	 */
+	public static function get_stats() {
+		try {
+			$status = 200;
+			$data   = array(
+				'plays' => array(
+					'today' => 10,
+					'all'   => 123456,
+				),
+			);
+		} catch ( \Exception $e ) {
+			// TODO: Improve status code.
+			$status = 500;
+			$data   = array(
+				'error' => $e->getMessage(),
+			);
+		}
+
+		return rest_ensure_response(
+			new WP_REST_Response( $data, $status )
+		);
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Relates to #26479.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Register `videopress/v1/stats` endpoint to return general video stats
* Return the counter of plays for today, using the information provided by the WPCOM REST API
* The plan was to add a counter for all-time plays, but we still need to sort out how to request it, so it's not included here

Pending issues:

* which capability the user needs to have to see this data?
* how to make this work inside WPCOM / make sure the class got loaded (similar to #26406)

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use a site with VideoPress installed
* Do a `GET` request to `yoursite.com/wp-json/videopress/v1/stats`, for example:

```
curl -X GET -u "user:pass" http://yoursite.com/wp-json/videopress/v1/stats | jq
```

* The expected response is similar to this:

```
{
    "plays": {
        "today": 1
    }
}
```

* It's useful to have some media available on the site with usage information, so make sure you uploaded at least one video, put it on a post and do at least one play on it