### PR TITLE
Subscriptions: Display readers number with bold font

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscriptions-make-readers-num-bold
+++ b/projects/plugins/jetpack/changelog/update-subscriptions-make-readers-num-bold
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subscriptions: Display readers number in subscriptions panel bold instead of underlined

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.scss
@@ -5,7 +5,7 @@
 	}
 
 	.jetpack-subscribe-reader-count {
-		text-decoration: underline;
+		font-weight: bold;
 		white-space: nowrap; // Prevent reader counts from being broken into separate lines.
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/68382

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* display readers number, in subscription panel, with bold font instead of underline. See screenshots of before and after for more context. 

Before:
![Screen Shot 2022-09-28 at 13 02 49](https://user-images.githubusercontent.com/2019970/192795033-67053251-5708-4a98-98bd-c4334215d8b4.png)

After:
![Screen Shot 2022-09-28 at 14 52 55](https://user-images.githubusercontent.com/2019970/192795098-80ab5e9b-df6d-490b-a4b4-90b6ec75d6e6.png)


#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pbAok1-3fI-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Ensure to have jetpack subscriptions enabled on your site, and that you have at least one subscriber. 
![Screen Shot 2022-09-28 at 16 04 14](https://user-images.githubusercontent.com/2019970/192800552-3bc101a1-83ce-42f9-a0d2-72cdc1a364d0.png)
* Go to new post editor
* Write some content
* Click on **Publish**
* Pre-publish sidebar should open up with **Subscribers** panel at the bottom. Ensure that the number of subscriptions displays with bold font instead of underlined
