### PR TITLE
Components: fix the position of TOS component of the Pricing Table component

### DIFF
--- a/projects/js-packages/components/changelog/update-component-product-table-tos-tweak-position
+++ b/projects/js-packages/components/changelog/update-component-product-table-tos-tweak-position
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Components: fix the positio of TOS component of the PricingTable cmp

--- a/projects/js-packages/components/components/pricing-table/index.tsx
+++ b/projects/js-packages/components/components/pricing-table/index.tsx
@@ -163,11 +163,11 @@ const PricingTable: React.FC< PricingTableProps > = ( { title, items, children }
 						) ) }
 					{ children }
 				</div>
-				<div className={ styles[ 'tos-container' ] }>
-					<Text className={ styles.tos } variant="body-small">
-						{ ToS }
-					</Text>
-				</div>
+			</div>
+			<div className={ styles[ 'tos-container' ] }>
+				<Text className={ styles.tos } variant="body-small">
+					{ ToS }
+				</Text>
 			</div>
 		</PricingTableContext.Provider>
 	);

--- a/projects/js-packages/components/components/pricing-table/styles.module.scss
+++ b/projects/js-packages/components/components/pricing-table/styles.module.scss
@@ -148,10 +148,8 @@
 }
 
 .tos-container {
-	.is-viewport-large & {
-		display: grid;
-		grid-template-columns: repeat( var( --columns ), 1fr );
-		grid-auto-flow: column;
-		column-gap: var( --gap );
-	}
+	display: flex;
+	align-items: right;
+	justify-content: right;
+	margin: 0 calc( var( --spacing-base ) * 4 );
 }

--- a/projects/packages/videopress/changelog/update-component-product-table-tos-tweak-position
+++ b/projects/packages/videopress/changelog/update-component-product-table-tos-tweak-position
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Components: fix the positio of TOS component of the PricingTable cmp


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Components: fix the position of TOS component of the Pricing Table component

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use storybook
* Test the PricingTable component
* Pay attention to the TOS section, changing the viewport width

<img width="975" alt="image" src="https://user-images.githubusercontent.com/77539/192820420-11d0dd7e-f6af-409c-b9cc-69fc88cbd206.png">


before | after
-------|-----
<img width="1004" alt="Screen Shot 2022-09-28 at 12 25 43" src="https://user-images.githubusercontent.com/77539/192820247-c65582c6-518a-45e1-998e-2bcdddbc2404.png"> | <img width="1011" alt="Screen Shot 2022-09-28 at 12 25 17" src="https://user-images.githubusercontent.com/77539/192820266-e4046d02-3073-4a1e-a4de-090d0cb1dba2.png">




