### PR TITLE
VideoPress: Update the "Edit video" toolbar button icon with "Replace" text to match core block

### DIFF
--- a/projects/plugins/jetpack/changelog/update-videopress-replace-replace-icon-with-text
+++ b/projects/plugins/jetpack/changelog/update-videopress-replace-replace-icon-with-text
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Change the toolbar text for the "Edit video" button on the VideoPress block to "Replace" to match core video block.
+Changed the toolbar text for the "Edit video" button on the VideoPress block to "Replace" to match the core video block's toolbar.

--- a/projects/plugins/jetpack/changelog/update-videopress-replace-replace-icon-with-text
+++ b/projects/plugins/jetpack/changelog/update-videopress-replace-replace-icon-with-text
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Change the toolbar text for the "Edit video" button on the VideoPress block to "Replace" to match core video block.

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
@@ -30,7 +30,7 @@ import { useSelect, withDispatch, withSelect } from '@wordpress/data';
 import { Component, createRef, Fragment } from '@wordpress/element';
 import { escapeHTML } from '@wordpress/escape-html';
 import { __, _x, sprintf } from '@wordpress/i18n';
-import { Icon, pencil } from '@wordpress/icons';
+import { Icon } from '@wordpress/icons';
 import classnames from 'classnames';
 import { get, indexOf } from 'lodash';
 import { useEffect } from 'react';
@@ -494,9 +494,8 @@ const VideoPressEdit = CoreVideoEdit =>
 						<ToolbarGroup>
 							<ToolbarButton
 								className="components-icon-button components-toolbar__control"
-								label={ __( 'Edit video', 'jetpack' ) }
+								text={ __( 'Replace', 'jetpack' ) }
 								onClick={ this.switchToEditing }
-								icon={ <Icon icon={ pencil } /> }
 							/>
 						</ToolbarGroup>
 					</BlockControls>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes # 1348-gh-Automattic/greenhouse

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates the label for the "Edit video" pencil toolbar button on the `/video` block to the text "Replace" to better match the core video block and `/image` block.

**Before**
<img width="494" alt="Screen Shot 2022-09-28 at 11 59 39 AM" src="https://user-images.githubusercontent.com/4081020/192830477-9fc3dc30-17bf-49c4-a245-de6eca97ebad.png">

**After**
<img width="674" alt="Screen Shot 2022-09-28 at 11 51 52 AM" src="https://user-images.githubusercontent.com/4081020/192830467-c79aa722-4097-4a0a-a05b-b1dc1902dc2a.png">

**Core Video block** (just for comparison - no changes)
<img width="697" alt="Screen Shot 2022-09-28 at 11 58 28 AM" src="https://user-images.githubusercontent.com/4081020/192830474-52dd37ce-b2bf-456f-9aca-844d302248e8.png">

**Core Image Block** (just for comparison - no changes)
<img width="691" alt="Screen Shot 2022-09-28 at 11 51 47 AM" src="https://user-images.githubusercontent.com/4081020/192830464-39d6e0ab-3417-4689-9cef-5463f335fa53.png">





#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
nope

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* apply patch
* on a Jetpack site with VideoPress enabled, edit or create a new post
* add a `/video` block, and upload or select an existing video
* Click on the video block to view the toolbar
* You should see the text `Replace` in place of the original "pencil" icon
* Click the button to ensure it continues to work as expected

cc @Automattic/jetpack-agora incase this has any implications for the new VideoPress block you are working on. I couldn't find a toolbar definition in the new edit block.