### PR TITLE
VideoPress: Fix mobile dashboard layout

### DIFF
--- a/projects/packages/videopress/changelog/update-video-grid-mobile
+++ b/projects/packages/videopress/changelog/update-video-grid-mobile
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: Fix mobile style on dashboard library

--- a/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { Button, Text } from '@automattic/jetpack-components';
-import { __ } from '@wordpress/i18n';
+import { Button, Text, useBreakpointMatch } from '@automattic/jetpack-components';
+import { __, sprintf } from '@wordpress/i18n';
 import { grid, formatListBullets } from '@wordpress/icons';
 import classnames from 'classnames';
 import React, { useState } from 'react';
@@ -64,11 +64,16 @@ const VideoLibraryWrapper = ( {
 } ) => {
 	const { setSearch, search, isFetching } = useVideos();
 	const [ searchQuery, setSearchQuery ] = useState( search );
+	const [ isSm ] = useBreakpointMatch( 'sm' );
 
 	const [ isFilterActive, setIsFilterActive ] = useState( false );
 
-	const singularTotalVideosLabel = __( 'Video', 'jetpack-videopress-pkg' );
-	const pluralTotalVideosLabel = __( 'Videos', 'jetpack-videopress-pkg' );
+	const singularTotalVideosLabel = __( '1 Video', 'jetpack-videopress-pkg' );
+	const pluralTotalVideosLabel = sprintf(
+		/* translators: placeholder is the number of videos */
+		__( '%s Videos', 'jetpack-videopress-pkg' ),
+		totalVideos
+	);
 	const totalVideosLabel = totalVideos === 1 ? singularTotalVideosLabel : pluralTotalVideosLabel;
 
 	return (
@@ -76,14 +81,13 @@ const VideoLibraryWrapper = ( {
 			<Text variant="headline-small" mb={ 1 }>
 				{ title }
 			</Text>
+			{ isSm && <Text className={ styles[ 'total-sm' ] }>{ totalVideosLabel }</Text> }
 			<div className={ styles[ 'total-filter-wrapper' ] }>
-				<Text>
-					{ totalVideos } { totalVideosLabel }
-				</Text>
+				{ ! isSm && <Text>{ totalVideosLabel }</Text> }
 				{ hideFilter ? null : (
 					<div className={ styles[ 'filter-wrapper' ] }>
 						<SearchInput
-							className={ styles[ 'search-input' ] }
+							className={ classnames( styles[ 'search-input' ], { [ styles.small ]: isSm } ) }
 							onSearch={ setSearch }
 							value={ searchQuery }
 							loading={ isFetching }

--- a/projects/packages/videopress/src/client/admin/components/admin-page/styles.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/styles.module.scss
@@ -9,6 +9,10 @@
 		margin-bottom: calc( var(--spacing-base) * 4 );
 	}
 
+	.total-sm {
+		margin-bottom: calc( var(--spacing-base) * 3 );
+	}
+
 	.filter-wrapper {
 		display: flex;
 		align-items: center;
@@ -17,6 +21,10 @@
 
 	.search-input {
 		width: 262px;
+
+		&.small {
+			width: 100%;
+		}
 	}
 
 	.filter-section {

--- a/projects/packages/videopress/src/client/admin/components/video-card/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/video-card/style.module.scss
@@ -84,6 +84,10 @@
 	display: flex;
 	justify-content: space-between;
 
+	&.small {
+		margin-bottom: calc( var( --spacing-base ) * 6 );
+	}
+
 	&:not(.small) {
 		opacity: 0;
 		position: relative;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #26019

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes mobile layout on dashboard library

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With at least one video, go to the dashboard on mobile or simulate mobile on your browser
* Check that the header fits the width correctly

Before | After
----------|-------
![vp-mobile-before](https://user-images.githubusercontent.com/8486249/192847090-9236f122-a4cd-4bfe-9bdb-b39c22d77539.jpg) | ![vp-mobile-after](https://user-images.githubusercontent.com/8486249/192847110-88cf2357-559a-41e7-83d7-1e2c2f4dee30.jpg)
