### PR TITLE
VideoPress: Fix filters layout on mobile

### DIFF
--- a/projects/packages/videopress/changelog/update-video-library-filters-mobile
+++ b/projects/packages/videopress/changelog/update-video-library-filters-mobile
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: Fix filters mobile layout on dashboard library

--- a/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
@@ -64,7 +64,7 @@ const VideoLibraryWrapper = ( {
 } ) => {
 	const { setSearch, search, isFetching } = useVideos();
 	const [ searchQuery, setSearchQuery ] = useState( search );
-	const [ isSm ] = useBreakpointMatch( 'sm' );
+	const [ isLg ] = useBreakpointMatch( 'lg' );
 
 	const [ isFilterActive, setIsFilterActive ] = useState( false );
 
@@ -81,13 +81,13 @@ const VideoLibraryWrapper = ( {
 			<Text variant="headline-small" mb={ 1 }>
 				{ title }
 			</Text>
-			{ isSm && <Text className={ styles[ 'total-sm' ] }>{ totalVideosLabel }</Text> }
+			{ ! isLg && <Text className={ styles[ 'total-sm' ] }>{ totalVideosLabel }</Text> }
 			<div className={ styles[ 'total-filter-wrapper' ] }>
-				{ ! isSm && <Text>{ totalVideosLabel }</Text> }
+				{ isLg && <Text>{ totalVideosLabel }</Text> }
 				{ hideFilter ? null : (
 					<div className={ styles[ 'filter-wrapper' ] }>
 						<SearchInput
-							className={ classnames( styles[ 'search-input' ], { [ styles.small ]: isSm } ) }
+							className={ classnames( styles[ 'search-input' ], { [ styles.small ]: ! isLg } ) }
 							onSearch={ setSearch }
 							value={ searchQuery }
 							loading={ isFetching }

--- a/projects/packages/videopress/src/client/admin/components/admin-page/styles.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/styles.module.scss
@@ -17,6 +17,8 @@
 		display: flex;
 		align-items: center;
 		gap: var(--spacing-base);
+		flex-grow: 1;
+		justify-content: end;
 	}
 
 	.search-input {
@@ -24,6 +26,7 @@
 
 		&.small {
 			width: 100%;
+			max-width: 262px;
 		}
 	}
 

--- a/projects/packages/videopress/src/client/admin/components/video-filter/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-filter/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Button, Col, Container, Text } from '@automattic/jetpack-components';
+import { Button, Col, Container, Text, useBreakpointMatch } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 /**
@@ -47,27 +47,21 @@ export const CheckboxCheckmark = ( props: { label?: string; for: string } ): JSX
 };
 
 export const FilterSection = ( props ): JSX.Element => {
+	const [ isSm ] = useBreakpointMatch( 'sm' );
+
 	return (
 		<div className={ classnames( styles[ 'filters-section' ], props.className ) }>
-			<Container horizontalSpacing={ 4 } horizontalGap={ 1 }>
+			<Container horizontalSpacing={ isSm ? 2 : 4 } horizontalGap={ 2 }>
 				<Col sm={ 4 } md={ 4 } lg={ 4 }>
-					<Text variant="body-small" weight="bold">
+					<Text variant="body-extra-small-bold" weight="bold">
 						{ __( 'Uploader', 'jetpack-videopress-pkg' ) }
 					</Text>
 				</Col>
+
 				<Col sm={ 4 } md={ 4 } lg={ 4 }>
-					<Text variant="body-small" weight="bold">
+					<Text variant="body-extra-small-bold" weight="bold">
 						{ __( 'Privacy', 'jetpack-videopress-pkg' ) }
 					</Text>
-				</Col>
-				<Col sm={ 4 } md={ 4 } lg={ 4 }>
-					<Text variant="body-small" weight="bold">
-						{ __( 'Rating', 'jetpack-videopress-pkg' ) }
-					</Text>
-				</Col>
-
-				<Col sm={ 4 } md={ 4 } lg={ 4 } />
-				<Col sm={ 4 } md={ 4 } lg={ 4 }>
 					<CheckboxCheckmark
 						for="filter-public"
 						label={ __( 'Public', 'jetpack-videopress-pkg' ) }
@@ -79,6 +73,9 @@ export const FilterSection = ( props ): JSX.Element => {
 				</Col>
 
 				<Col sm={ 4 } md={ 4 } lg={ 4 }>
+					<Text variant="body-extra-small-bold" weight="bold">
+						{ __( 'Rating', 'jetpack-videopress-pkg' ) }
+					</Text>
 					<CheckboxCheckmark for="filter-g" label={ __( 'G', 'jetpack-videopress-pkg' ) } />
 					<CheckboxCheckmark for="filter-pg-13" label={ __( 'PG-13', 'jetpack-videopress-pkg' ) } />
 					<CheckboxCheckmark for="filter-r" label={ __( 'R', 'jetpack-videopress-pkg' ) } />

--- a/projects/packages/videopress/src/client/admin/components/video-filter/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/video-filter/style.module.scss
@@ -1,4 +1,6 @@
 .filter-button {
+	flex-shrink: 0;
+
 	&.is-active {
 		> svg {
 			fill: var( --jp-white );

--- a/projects/packages/videopress/src/client/admin/components/video-filter/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/video-filter/style.module.scss
@@ -22,7 +22,7 @@
 	cursor: pointer;
 	height: 20px;
 	line-height: 20px;
-	margin-bottom: var( --spacing-base );
+	margin-top: var( --spacing-base );
 
 	.checkbox[type="checkbox"] {
 		border: 1px solid var( --jp-green-40 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #26167

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixed filters section layout on mobile and tablet

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* WIth at least one uploaded video, go to the VideoPress dashboard on mobile (or simulate mobile on your browser)
* Tap/click the `Filters` button
* Check that the layout is correct now

Before | After
----------|--------
![vp-filters-mobile-before](https://user-images.githubusercontent.com/8486249/192873208-4d917c0e-810c-45a3-bfc8-dedb581f85ab.jpg) |  ![vp-filters-mobile-after](https://user-images.githubusercontent.com/8486249/192873224-93504e6f-d2c4-417d-b459-66bb16de852a.jpg)

Desktop | Tablet
------------|--------
![Screenshot_2022-09-28_16-38-47](https://user-images.githubusercontent.com/8486249/192873472-6b1523ad-c673-45a9-99e6-11440db9d66c.png) | ![Screenshot_2022-09-28_16-39-04](https://user-images.githubusercontent.com/8486249/192873544-45bcc5e8-fcd2-4922-b32d-56585572a6ef.png)
