### PR TITLE
Debug Helper: remove pre-defined prefix in the REST API tool

### DIFF
--- a/projects/plugins/debug-helper/changelog/update-rest-api-tester-prefix
+++ b/projects/plugins/debug-helper/changelog/update-rest-api-tester-prefix
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Remove pre-defined prefix in the REST API tool.

--- a/projects/plugins/debug-helper/modules/class-rest-api-tester.php
+++ b/projects/plugins/debug-helper/modules/class-rest-api-tester.php
@@ -93,7 +93,7 @@ class REST_API_Tester {
 				<div class="api-tester-block">
 					<label for="api-tester-url">REST Route:</label>
 					<div class="api-tester-field">
-						<span class="rest-route-prefix">/jetpack/v4/</span>
+						<span class="rest-route-prefix">/</span>
 						<input type="text" name="url" class="input-url" id="api-tester-url">
 					</div>
 				</div>

--- a/projects/plugins/debug-helper/modules/inc/css/rest-api-tester.css
+++ b/projects/plugins/debug-helper/modules/inc/css/rest-api-tester.css
@@ -34,7 +34,7 @@ Slyling up the REST API Tester
 .jetpack-debug-api-tester .api-tester-block .input-url {
 	width: 400px;
 	height: 35px;
-	padding-left: 95px;
+	padding-left: 23px;
 	font-size: 15px;
 }
 

--- a/projects/plugins/debug-helper/modules/inc/js/rest-api-tester.js
+++ b/projects/plugins/debug-helper/modules/inc/js/rest-api-tester.js
@@ -55,7 +55,7 @@ class Jetpack_Debug_REST_API_Tester {
 		let body = null;
 
 		const request = new XMLHttpRequest();
-		request.open( method, `${ window.wpApiSettings.root }jetpack/v4/${ this.urlElement.value }` );
+		request.open( method, `${ window.wpApiSettings.root }${ this.urlElement.value }` );
 
 		request.setRequestHeader( 'X-WP-Nonce', window.wpApiSettings.nonce );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Remove the predefined prefix in the URL field to allow sending requests to any REST endpoints.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Go to "Jetpack Debug -> REST API Tester" (you might need to activate it first).
2. Send a GET request to `jetpack/v4/connection`, the response code/headers/body should show up.