### PR TITLE
Backup: Add headline to backup upgrade view

### DIFF
--- a/projects/packages/backup/changelog/add-headline-to-backup-upgrade-view
+++ b/projects/packages/backup/changelog/add-headline-to-backup-upgrade-view
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Title add to connection screen
+
+

--- a/projects/packages/backup/src/js/components/admin-style.scss
+++ b/projects/packages/backup/src/js/components/admin-style.scss
@@ -157,3 +157,15 @@
 	margin: 30px 0;
 }
 
+.jp-connection__connect-screen-layout__left {
+
+	h2 {
+		font-weight: bold;
+		font-size: 36px;
+		margin-top: 32px;
+	}
+
+	h3 {
+		margin-top: 32px;
+	}
+}

--- a/projects/packages/backup/src/js/components/backup-promotion/index.jsx
+++ b/projects/packages/backup/src/js/components/backup-promotion/index.jsx
@@ -1,0 +1,27 @@
+import { __ } from '@wordpress/i18n';
+import React from 'react';
+
+/**
+ * BackupPromotion component definition.
+ *
+ * @returns {React.Component} BackupPromotion component.
+ */
+export default function BackupPromotion() {
+	return (
+		<div className="jp-backup-dashboard-promotion">
+			<h3>
+				{ __(
+					'Save every change and get back online quickly with one‑click restores.',
+					'jetpack-backup-pkg'
+				) }
+			</h3>
+			<ul className="jp-product-promote">
+				<li>{ __( 'Automated real-time backups', 'jetpack-backup-pkg' ) }</li>
+				<li>{ __( 'Easy one-click restores', 'jetpack-backup-pkg' ) }</li>
+				<li>{ __( 'Complete list of all site changes', 'jetpack-backup-pkg' ) }</li>
+				<li>{ __( 'Global server infrastructure', 'jetpack-backup-pkg' ) }</li>
+				<li>{ __( 'Best-in-class support', 'jetpack-backup-pkg' ) }</li>
+			</ul>
+		</div>
+	);
+}

--- a/projects/packages/backup/src/js/hooks/useConnection.js
+++ b/projects/packages/backup/src/js/hooks/useConnection.js
@@ -4,6 +4,7 @@ import { useSelect } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import React from 'react';
+import BackupPromotionBlock from '../components/backup-promotion';
 import { STORE_ID } from '../store';
 
 /**
@@ -41,23 +42,14 @@ export default function useConnection() {
 				priceBefore={ price }
 				pricingIcon="data:image/svg+xml,%3Csvg width='32' height='32' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='m21.092 15.164.019-1.703v-.039c0-1.975-1.803-3.866-4.4-3.866-2.17 0-3.828 1.351-4.274 2.943l-.426 1.524-1.581-.065a2.92 2.92 0 0 0-.12-.002c-1.586 0-2.977 1.344-2.977 3.133 0 1.787 1.388 3.13 2.973 3.133H22.399c1.194 0 2.267-1.016 2.267-2.4 0-1.235-.865-2.19-1.897-2.368l-1.677-.29Zm-10.58-3.204a4.944 4.944 0 0 0-.201-.004c-2.75 0-4.978 2.298-4.978 5.133s2.229 5.133 4.978 5.133h12.088c2.357 0 4.267-1.97 4.267-4.4 0-2.18-1.538-3.99-3.556-4.339v-.06c0-3.24-2.865-5.867-6.4-5.867-2.983 0-5.49 1.871-6.199 4.404Z' fill='%23000'/%3E%3C/svg%3E"
 				pricingTitle={ __( 'Jetpack Backup', 'jetpack-backup-pkg' ) }
-				title={ __(
-					'Save every change and get back online quickly with one‑click restores.',
-					'jetpack-backup-pkg'
-				) }
+				title={ __( 'The best WordPress backup experience', 'jetpack-backup-pkg' ) }
 				apiRoot={ APIRoot }
 				apiNonce={ APINonce }
 				registrationNonce={ registrationNonce }
 				from="jetpack-backup"
 				redirectUri="admin.php?page=jetpack-backup"
 			>
-				<ul>
-					<li>{ __( 'Automated real-time backups', 'jetpack-backup-pkg' ) }</li>
-					<li>{ __( 'Easy one-click restores', 'jetpack-backup-pkg' ) }</li>
-					<li>{ __( 'Complete list of all site changes', 'jetpack-backup-pkg' ) }</li>
-					<li>{ __( 'Global server infrastructure', 'jetpack-backup-pkg' ) }</li>
-					<li>{ __( 'Best-in-class support', 'jetpack-backup-pkg' ) }</li>
-				</ul>
+				<BackupPromotionBlock />
 			</ConnectScreenRequiredPlan>
 		);
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
- Add title to Jetpack Backup connect page
- Add BackupPromotionBlock component
- Additionally, add styling to make the ConnectScreenRequiredPlan look like it should

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a JN site
* Install the Jetpack Backup standalone plugin
* Visit the Admin page of the plugin and confirm that it looks as intended

Before:
<img width="903" alt="Screen Shot 2022-09-29 at 15 06 15" src="https://user-images.githubusercontent.com/16329583/193039377-34aa7944-298c-4347-91b4-c68d18535d1e.png">

After:
<img width="803" alt="Screen Shot 2022-09-29 at 02 07 45" src="https://user-images.githubusercontent.com/16329583/193038968-f0405abb-b052-4eb0-a15f-0af02b8e8666.png">

