### PR TITLE
Filter local theme-provided fonts from the Google Font Provider

### DIFF
--- a/projects/plugins/jetpack/modules/google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts.php
@@ -71,18 +71,18 @@ function jetpack_add_google_fonts_provider() {
 	// Note: Ideally wp_webfonts()->get_registered_webfonts() would include the local webfonts registered via theme.json
 	// This does not (currently) seem to be the case, either because they aren't registered yet or they aren't reported
 	// in that collection.
-	$theme_webfonts = wp_get_global_settings( array( 'typography', 'fontFamilies', 'theme' ) );
-	$theme_webfont_families = [];
-	$unregistered_google_fonts = [];
+	$theme_webfonts            = wp_get_global_settings( array( 'typography', 'fontFamilies', 'theme' ) );
+	$theme_webfont_families    = array();
+	$unregistered_google_fonts = array();
 
-	foreach( $theme_webfonts  as $theme_font ) {
+	foreach ( $theme_webfonts  as $theme_font ) {
 		if ( $theme_font[ 'fontFace' ] ) {
 			$theme_webfont_families[] = $theme_font['fontFace'][0]['fontFamily'];
 		}
 	}
 
-	foreach( JETPACK_GOOGLE_FONTS_LIST as $font_family ) {
-		if ( ! in_array( $font_family, $theme_webfont_families ) ) {
+	foreach ( JETPACK_GOOGLE_FONTS_LIST as $font_family ) {
+		if ( ! in_array( $font_family, $theme_webfont_families, true ) ) {
 			$unregistered_google_fonts[] = $font_family;
 		}
 	}
@@ -96,7 +96,7 @@ function jetpack_add_google_fonts_provider() {
 	 *
 	 * @param array $fonts_to_register Array of Google Font names to register.
 	 */
-	$fonts_to_register = apply_filters( 'jetpack_google_fonts_list', JETPACK_GOOGLE_FONTS_LIST );
+	$fonts_to_register = apply_filters( 'jetpack_google_fonts_list', $unregistered_google_fonts );
 
 	foreach ( $fonts_to_register as $font_family ) {
 		wp_register_webfonts(

--- a/projects/plugins/jetpack/modules/google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts.php
@@ -68,6 +68,25 @@ function jetpack_add_google_fonts_provider() {
 
 	wp_register_webfont_provider( 'jetpack-google-fonts', '\Automattic\Jetpack\Fonts\Google_Fonts_Provider' );
 
+	// Note: Ideally wp_webfonts()->get_registered_webfonts() would include the local webfonts registered via theme.json
+	// This does not (currently) seem to be the case, either because they aren't registered yet or they aren't reported
+	// in that collection.
+	$theme_webfonts = wp_get_global_settings( array( 'typography', 'fontFamilies', 'theme' ) );
+	$theme_webfont_families = [];
+	$unregistered_google_fonts = [];
+
+	foreach( $theme_webfonts  as $theme_font ) {
+		if ( $theme_font[ 'fontFace' ] ) {
+			$theme_webfont_families[] = $theme_font['fontFace'][0]['fontFamily'];
+		}
+	}
+
+	foreach( JETPACK_GOOGLE_FONTS_LIST as $font_family ) {
+		if ( ! in_array( $font_family, $theme_webfont_families ) ) {
+			$unregistered_google_fonts[] = $font_family;
+		}
+	}
+
 	/**
 	 * Curated list of Google Fonts.
 	 *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #25987 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Gets a list of fonts provided by the theme via theme.json
* Filters list of fonts to provide to not include fonts already provided by the theme

#### Other information:

Ideally this change would use `wp_webfonts()->get_registered_webfonts()` to determine the webfonts supplied by theme.json.  However that doesn't seem to include those fonts so `wp_get_global_settings()` was used instead.

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate the theme `Pendant` (which includes opinionated 'Literata' font)
* Load any page and observe where the fonts are loaded from (they should now be loaded from the theme rather than from the Google Font CDN).

