### PR TITLE
Update site type answer text

### DIFF
--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/site-type/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/site-type/index.jsx
@@ -58,7 +58,7 @@ const SiteTypeQuestionComponent = props => {
 				/>
 				<CheckboxAnswer
 					answerKey={ 'site-type-personal' }
-					title={ __( 'This is my personal site', 'jetpack' ) }
+					title={ __( 'This is a personal site', 'jetpack' ) }
 					info={ __(
 						'You built this site yourself, nice work! Personal sites include things like blogs, resume sites, wedding sites, and hobby sites.',
 						'jetpack'

--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/site-type/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/site-type/test/component.js
@@ -95,7 +95,7 @@ describe( 'Recommendations – Site Type', () => {
 			initialState: buildInitialState(),
 		} );
 
-		const personalCheckbox = screen.getByLabelText( 'This is my a personal site' );
+		const personalCheckbox = screen.getByLabelText( 'This is a personal site' );
 		expect( personalCheckbox.checked ).toBe( false );
 
 		await user.click( personalCheckbox );

--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/site-type/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/site-type/test/component.js
@@ -72,7 +72,7 @@ describe( 'Recommendations – Site Type', () => {
 		expect( screen.getByText( 'Tell us more about Test Site?' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'I build or manage this site for a client' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'This is an e-commerce site' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'This is my personal site' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'This is a personal site' ) ).toBeInTheDocument();
 	} );
 
 	it( 'shows questions with the right default initial state', () => {
@@ -81,7 +81,7 @@ describe( 'Recommendations – Site Type', () => {
 		} );
 		expect( screen.getByLabelText( 'I build or manage this site for a client' ) ).toBeChecked();
 		expect( screen.getByLabelText( 'This is an e-commerce site' ) ).toBeChecked();
-		expect( screen.getByLabelText( 'This is my personal site' ) ).not.toBeChecked();
+		expect( screen.getByLabelText( 'This is a personal site' ) ).not.toBeChecked();
 	} );
 
 	it( 'updates the state of a question when an answer is clicked', async () => {
@@ -95,7 +95,7 @@ describe( 'Recommendations – Site Type', () => {
 			initialState: buildInitialState(),
 		} );
 
-		const personalCheckbox = screen.getByLabelText( 'This is my personal site' );
+		const personalCheckbox = screen.getByLabelText( 'This is my a personal site' );
 		expect( personalCheckbox.checked ).toBe( false );
 
 		await user.click( personalCheckbox );

--- a/projects/plugins/jetpack/changelog/update-site-type-answer-text
+++ b/projects/plugins/jetpack/changelog/update-site-type-answer-text
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Update text on site type question to conflict less with the agency/developer answer

--- a/projects/plugins/jetpack/to-test.md
+++ b/projects/plugins/jetpack/to-test.md
@@ -13,7 +13,7 @@ There have been updates for the Jetpack Recommendations Assistant. In particular
 
 - With the Jetpack Beta Tester [plugin](https://jetpack.com/download-jetpack-beta/) activated, and the 11.4-beta branch active, on the main dashboard page `/wp-admin/admin.php?page=jetpack#/dashboard` there is an option in the footer to "Reset Options (dev only)" which can be used to reset the recommendation steps if they have already been completed.
 - Navigate to `/wp-admin/admin.php?page=jetpack#/recommendations/site-type`
-- Select "This is my personal site".
+- Select "This is a personal site".
 - Then select "Continue", it should skip straight to the Downtime Monitoring recommendation.
 - Navigate back to `/wp-admin/admin.php?page=jetpack#/recommendations/site-type`
 - This time, select the "I build or manage this site for a client" option.


### PR DESCRIPTION
Update text to conflict less with the agency/developer answer so that both can be true

#### Changes proposed in this Pull Request:

This PR changes the text for a site-type recommendation answer from "this is my personal site" to "this is a personal site" so that both that and "I am an agency or developer" can be true at the same time.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

P2: p8oabR-Wd-p2#comment-6606

#### Does this pull request change what data or activity we track or use?

No it does not

#### Testing instructions:

1. Checkout this branch and get your local environment running
2. Go to `/wp-admin/admin.php?page=jetpack#/recommendations/site-type`
3. Confirm the text has been updated
![image](https://user-images.githubusercontent.com/65001528/193117540-f5d68d60-c33c-4adf-8a25-4466d26c56cf.png)
