### PR TITLE
VideoPress: improve the checkout stuff

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-checkout-flow
+++ b/projects/packages/videopress/changelog/update-videopress-checkout-flow
@@ -1,0 +1,7 @@
+Significance: patch
+Type: added
+
+VideoPress:
+  - Request Product data not tied to the site
+  - Expose that data to the client
+  - Use them to show the price in the UI

--- a/projects/packages/videopress/src/class-admin-ui.php
+++ b/projects/packages/videopress/src/class-admin-ui.php
@@ -134,8 +134,9 @@ class Admin_UI {
 				'isVideoPress1TBSupported'       => Current_Plan::supports( 'videopress-1tb-storage' ),
 				'isVideoPressUnlimitedSupported' => Current_Plan::supports( 'videopress-unlimited-storage' ),
 			),
-			'productData'       => My_Jetpack_Products::get_product( 'videopress' ),
+			'siteProductData'   => My_Jetpack_Products::get_product( 'videopress' ),
 			'siteSuffix'        => ( new Status() )->get_site_suffix(),
+			'productData'       => Plan::get_product(),
 		);
 	}
 

--- a/projects/packages/videopress/src/class-plan.php
+++ b/projects/packages/videopress/src/class-plan.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * The Plan class.
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+/**
+ * The Plan class.
+ */
+class Plan {
+	/**
+	 * Return the product data provided by the /products wpcom endpoint
+	 *
+	 * @param string $wpcom_product_slug - The product slug.
+	 * @return array
+	 */
+	public static function get_product( $wpcom_product_slug = 'jetpack_videopress' ) {
+		$request_url   = 'https://public-api.wordpress.com/rest/v1.1/products?locale=' . get_user_locale() . '&type=jetpack';
+		$wpcom_request = wp_remote_get( esc_url_raw( $request_url ) );
+		$response_code = wp_remote_retrieve_response_code( $wpcom_request );
+
+		if ( 200 === $response_code ) {
+			$products = json_decode( wp_remote_retrieve_body( $wpcom_request ) );
+			return $products->{$wpcom_product_slug};
+		}
+
+		return new \WP_Error(
+			'failed_to_fetch_data',
+			esc_html__( 'Unable to fetch the requested data.', 'jetpack-videopress-pkg' ),
+			array(
+				'status'  => $response_code,
+				'request' => $wpcom_request,
+			)
+		);
+	}
+}

--- a/projects/packages/videopress/src/class-plan.php
+++ b/projects/packages/videopress/src/class-plan.php
@@ -12,19 +12,67 @@ namespace Automattic\Jetpack\VideoPress;
  */
 class Plan {
 	/**
-	 * Return the product data provided by the /products wpcom endpoint
+	 * The meta name used to store the cache date
 	 *
-	 * @param string $wpcom_product_slug - The product slug.
+	 * @var string
+	 */
+	const CACHE_DATE_META_NAME = 'videopress-cache-date';
+
+	/**
+	 * Valid pediord for the cache: One week.
+	 */
+	const CACHE_VALIDITY_PERIOD = 7 * DAY_IN_SECONDS;
+
+	/**
+	 * The meta name used to store the cache
+	 *
+	 * @var string
+	 */
+	const CACHE_META_NAME = 'videopress-cache';
+
+	/**
+	 * Checks if the cache is old, meaning we need to fetch new data from WPCOM
+	 */
+	private static function is_cache_old() {
+		if ( empty( self::get_product_from_cache() ) ) {
+			return true;
+		}
+
+		$cache_date = get_user_meta( get_current_user_id(), self::CACHE_DATE_META_NAME, true );
+		return time() - (int) $cache_date > ( self::CACHE_VALIDITY_PERIOD );
+	}
+
+	/**
+	 * Gets the product list from the user cache
+	 */
+	private static function get_product_from_cache() {
+		return get_user_meta( get_current_user_id(), self::CACHE_META_NAME, true );
+	}
+
+	/**
+	 * Gets the product data
+	 *
+	 * @param string $wpcom_product The product slug.
 	 * @return array
 	 */
-	public static function get_product( $wpcom_product_slug = 'jetpack_videopress' ) {
+	public static function get_product( $wpcom_product = 'jetpack_videopress' ) {
+		if ( ! self::is_cache_old() ) {
+			return self::get_product_from_cache();
+		}
+
 		$request_url   = 'https://public-api.wordpress.com/rest/v1.1/products?locale=' . get_user_locale() . '&type=jetpack';
 		$wpcom_request = wp_remote_get( esc_url_raw( $request_url ) );
 		$response_code = wp_remote_retrieve_response_code( $wpcom_request );
 
 		if ( 200 === $response_code ) {
 			$products = json_decode( wp_remote_retrieve_body( $wpcom_request ) );
-			return $products->{$wpcom_product_slug};
+
+			// Pick the desired product...
+			$product = $products->{$wpcom_product};
+
+			// ... and store it into the cache.
+			update_user_meta( get_current_user_id(), self::CACHE_DATE_META_NAME, time() );
+			return update_user_meta( get_current_user_id(), self::CACHE_META_NAME, $product );
 		}
 
 		return new \WP_Error(

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -26,6 +26,7 @@ import useUploader from '../../../hooks/use-uploader';
 import { STORE_ID } from '../../../state';
 import { WP_REST_API_MEDIA_ENDPOINT } from '../../../state/constants';
 import { mapVideoFromWPV2MediaEndpoint } from '../../../state/utils/map-videos';
+import { usePlan } from '../../hooks/use-plan';
 import useVideos from '../../hooks/use-videos';
 import Logo from '../logo';
 import PricingSection from '../pricing-section';
@@ -185,9 +186,14 @@ const UpgradeTrigger = () => {
 	const {
 		paidFeatures: { isVideoPress1TBSupported, isVideoPressUnlimitedSupported },
 		adminUrl,
+		siteSuffix,
 	} = window.jetpackVideoPressInitialState;
+
+	const { product } = usePlan();
+
 	const { run } = useProductCheckoutWorkflow( {
-		productSlug: 'jetpack_videopress',
+		siteSuffix,
+		productSlug: product.slug,
 		redirectUrl: adminUrl,
 	} );
 

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -193,7 +193,7 @@ const UpgradeTrigger = () => {
 
 	const { run } = useProductCheckoutWorkflow( {
 		siteSuffix,
-		productSlug: product.slug,
+		productSlug: product.productSlug,
 		redirectUrl: adminUrl,
 	} );
 

--- a/projects/packages/videopress/src/client/admin/components/admin-page/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/types.ts
@@ -14,7 +14,7 @@ declare global {
 				isVideoPress1TBSupported: boolean;
 				isVideoPressUnlimitedSupported: boolean;
 			};
-			productData: productOriginalProps;
+			siteProductData: productOriginalProps;
 			adminUrl: string;
 			adminUri: string;
 			siteSuffix: string;

--- a/projects/packages/videopress/src/client/admin/components/admin-page/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/types.ts
@@ -1,4 +1,4 @@
-import { productOriginalProps } from '../../hooks/use-plan/types';
+import { productOriginalProps, siteProductOriginalProps } from '../../hooks/use-plan/types';
 import { VideoPressVideo } from '../../types';
 
 declare global {
@@ -14,7 +14,8 @@ declare global {
 				isVideoPress1TBSupported: boolean;
 				isVideoPressUnlimitedSupported: boolean;
 			};
-			siteProductData: productOriginalProps;
+			siteProductData: siteProductOriginalProps;
+			productData: productOriginalProps;
 			adminUrl: string;
 			adminUri: string;
 			siteSuffix: string;

--- a/projects/packages/videopress/src/client/admin/components/pricing-section/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/pricing-section/index.tsx
@@ -8,9 +8,8 @@ import {
 	PricingTableHeader,
 	PricingTableItem,
 	ProductPrice,
-	getRedirectUrl,
 } from '@automattic/jetpack-components';
-import { useConnection } from '@automattic/jetpack-connection';
+import { useConnection, useProductCheckoutWorkflow } from '@automattic/jetpack-connection';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 /**
@@ -24,6 +23,12 @@ const PricingPage = () => {
 	const { pricingForUi } = siteProduct;
 	const { handleRegisterSite, userIsConnecting } = useConnection( { redirectUri: adminUri } );
 	const [ isConnecting, setIsConnection ] = useState( false );
+
+	const { run } = useProductCheckoutWorkflow( {
+		siteSuffix,
+		productSlug: product.productSlug,
+		redirectUrl: adminUri,
+	} );
 
 	const pricingItems = siteProduct.features.map( feature => ( { name: feature } ) );
 
@@ -48,14 +53,7 @@ const PricingPage = () => {
 						leyend={ __( '/month, billed yearly', 'jetpack-videopress-pkg' ) }
 						currency={ pricingForUi.currencyCode }
 					/>
-					<Button
-						href={ getRedirectUrl( 'videopress-upgrade', {
-							site: siteSuffix,
-							query: 'redirect_to=' + window.location.href,
-						} ) }
-						fullWidth
-						disabled={ isConnecting }
-					>
+					<Button onClick={ run } fullWidth disabled={ isConnecting }>
 						{ __( 'Get VideoPress', 'jetpack-videopress-pkg' ) }
 					</Button>
 				</PricingTableHeader>

--- a/projects/packages/videopress/src/client/admin/components/pricing-section/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/pricing-section/index.tsx
@@ -20,12 +20,22 @@ import { usePlan } from '../../hooks/use-plan';
 
 const PricingPage = () => {
 	const { siteSuffix, adminUri } = window.jetpackVideoPressInitialState;
-	const { siteProduct } = usePlan();
+	const { siteProduct, product } = usePlan();
 	const { pricingForUi } = siteProduct;
 	const { handleRegisterSite, userIsConnecting } = useConnection( { redirectUri: adminUri } );
 	const [ isConnecting, setIsConnection ] = useState( false );
 
 	const pricingItems = siteProduct.features.map( feature => ( { name: feature } ) );
+
+	/*
+	 * Fallback to the product price if the site product price is not available.
+	 * This can happen when the site is not connected yet.
+	 */
+	if ( ! pricingForUi?.fullPrice ) {
+		pricingForUi.fullPrice = product.cost;
+		pricingForUi.discountPrice = product.introductoryOffer.costPerInterval;
+		pricingForUi.currencyCode = product.currencyCode;
+	}
 
 	return (
 		<PricingTable title={ siteProduct.description } items={ pricingItems }>

--- a/projects/packages/videopress/src/client/admin/components/pricing-section/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/pricing-section/index.tsx
@@ -20,15 +20,15 @@ import { usePlan } from '../../hooks/use-plan';
 
 const PricingPage = () => {
 	const { siteSuffix, adminUri } = window.jetpackVideoPressInitialState;
-	const { product } = usePlan();
-	const { pricingForUi } = product;
+	const { siteProduct } = usePlan();
+	const { pricingForUi } = siteProduct;
 	const { handleRegisterSite, userIsConnecting } = useConnection( { redirectUri: adminUri } );
 	const [ isConnecting, setIsConnection ] = useState( false );
 
-	const pricingItems = product.features.map( feature => ( { name: feature } ) );
+	const pricingItems = siteProduct.features.map( feature => ( { name: feature } ) );
 
 	return (
-		<PricingTable title={ product.description } items={ pricingItems }>
+		<PricingTable title={ siteProduct.description } items={ pricingItems }>
 			<PricingTableColumn primary>
 				<PricingTableHeader>
 					<ProductPrice

--- a/projects/packages/videopress/src/client/admin/components/pricing-section/stories/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/pricing-section/stories/index.tsx
@@ -18,7 +18,7 @@ window.jetpackVideoPressInitialState = {
 	},
 	adminUrl: 'https://admin-url.com',
 	siteSuffix: 'site-suffix',
-	productData: {
+	siteProductData: {
 		slug: 'videopress',
 		plugin_slug: 'jetpack-videopress',
 		name: 'VideoPress',

--- a/projects/packages/videopress/src/client/admin/hooks/use-plan/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-plan/index.ts
@@ -12,6 +12,6 @@ export const usePlan = (): usePlanProps => {
 
 	return {
 		features: paidFeatures,
-		product: { ...mapObjectKeysToCamel( { ...siteProductData }, true ), pricingForUi },
+		siteProduct: { ...mapObjectKeysToCamel( { ...siteProductData }, true ), pricingForUi },
 	};
 };

--- a/projects/packages/videopress/src/client/admin/hooks/use-plan/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-plan/index.ts
@@ -2,16 +2,27 @@
  * types
  */
 import { mapObjectKeysToCamel } from '../../../utils/map-object-keys-to-camel-case';
-import { paidFeaturesProp, productOriginalProps, usePlanProps } from './types';
+import {
+	paidFeaturesProp,
+	productOriginalProps,
+	siteProductOriginalProps,
+	usePlanProps,
+} from './types';
 
-const { paidFeatures = <paidFeaturesProp>{}, siteProductData = <productOriginalProps>{} } =
-	window && window.jetpackVideoPressInitialState ? window.jetpackVideoPressInitialState : {};
+const {
+	paidFeatures = <paidFeaturesProp>{},
+	siteProductData = <siteProductOriginalProps>{},
+	productData = <productOriginalProps>{},
+} = window && window.jetpackVideoPressInitialState ? window.jetpackVideoPressInitialState : {};
 
 export const usePlan = (): usePlanProps => {
 	const pricingForUi = mapObjectKeysToCamel( siteProductData.pricing_for_ui, true );
 
+	const introductoryOffer = mapObjectKeysToCamel( productData.introductory_offer, true );
+
 	return {
 		features: paidFeatures,
 		siteProduct: { ...mapObjectKeysToCamel( { ...siteProductData }, true ), pricingForUi },
+		product: { ...mapObjectKeysToCamel( productData, true ), introductoryOffer },
 	};
 };

--- a/projects/packages/videopress/src/client/admin/hooks/use-plan/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-plan/index.ts
@@ -4,14 +4,14 @@
 import { mapObjectKeysToCamel } from '../../../utils/map-object-keys-to-camel-case';
 import { paidFeaturesProp, productOriginalProps, usePlanProps } from './types';
 
-const { paidFeatures = <paidFeaturesProp>{}, productData = <productOriginalProps>{} } =
+const { paidFeatures = <paidFeaturesProp>{}, siteProductData = <productOriginalProps>{} } =
 	window && window.jetpackVideoPressInitialState ? window.jetpackVideoPressInitialState : {};
 
 export const usePlan = (): usePlanProps => {
-	const pricingForUi = mapObjectKeysToCamel( productData.pricing_for_ui, true );
+	const pricingForUi = mapObjectKeysToCamel( siteProductData.pricing_for_ui, true );
 
 	return {
 		features: paidFeatures,
-		product: { ...mapObjectKeysToCamel( { ...productData }, true ), pricingForUi },
+		product: { ...mapObjectKeysToCamel( { ...siteProductData }, true ), pricingForUi },
 	};
 };

--- a/projects/packages/videopress/src/client/admin/hooks/use-plan/types.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-plan/types.ts
@@ -57,5 +57,5 @@ export type productProps = {
 
 export type usePlanProps = {
 	features?: paidFeaturesProp;
-	product?: productProps;
+	siteProduct?: productProps;
 };

--- a/projects/packages/videopress/src/client/admin/hooks/use-plan/types.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-plan/types.ts
@@ -4,7 +4,7 @@ export type paidFeaturesProp = {
 	isVideoPressUnlimitedSupported: boolean;
 };
 
-export type productOriginalProps = {
+export type siteProductOriginalProps = {
 	title: string;
 	name: string;
 	description: string;
@@ -30,7 +30,31 @@ export type productOriginalProps = {
 	wpcom_product_slug: string;
 };
 
-export type productProps = {
+export type productOriginalProps = {
+	product_id: number;
+	product_name: string;
+	product_slug: 'jetpack_videopress';
+	description: string;
+	available: boolean;
+	billing_product_slug: 'jetpack-videopress';
+	is_domain_registration: false;
+	cost_display: string;
+	combined_cost_display: string;
+	cost: number;
+	cost_smallest_unit: number;
+	currency_code: string;
+	product_term: string;
+	price_tier_slug: string;
+	introductory_offer: {
+		interval_unit: string;
+		interval_count: number;
+		cost_per_interval: number;
+		transition_after_renewal_count: number;
+		should_prorate_when_offer_ends: boolean;
+	};
+};
+
+export type siteProductProps = {
 	title: string;
 	name: string;
 	description: string;
@@ -55,7 +79,32 @@ export type productProps = {
 	wpcomProductSlug: string;
 };
 
+export type productProps = {
+	productId: number;
+	productName: string;
+	productSlug: 'jetpack_videopress';
+	description: string;
+	available: boolean;
+	billingProductSlug: 'jetpack-videopress';
+	isDomainRegistration: false;
+	costDisplay: string;
+	combinedCostDisplay: string;
+	cost: number;
+	costSmallestUnit: number;
+	currencyCode: string;
+	productTerm: string;
+	priceTierSlug: string;
+	introductoryOffer: {
+		intervalUnit: string;
+		intervalCount: number;
+		costPerInterval: number;
+		transitionAfterRenewalCount: number;
+		shouldProrateWhenOfferEnds: boolean;
+	};
+};
+
 export type usePlanProps = {
 	features?: paidFeaturesProp;
-	siteProduct?: productProps;
+	siteProduct?: siteProductProps;
+	product?: productProps;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR improves the checkout process:

* Request product data independently whether the site is connected
* This data is cached into the site meta
* When the site is connected, it uses the product site data
* use the useProductCheckoutWorkflow() hook to perform the checkout flow

### About getting the product data

This PR allows getting the product data even when the site is not connected, hitting the `v1.1` `/products` endpoint. This is useful in the first landing to the VideoPress standalone plugin.
The current method to get the data, provided by My_Jetpack Product class, requires the site to be connected.

The code also implements a cache system to avoid hitting the wpcom side.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress:
  - Request Product data not tied to the site
  - Expose that data to the client
  - Use them to show the price in the UI

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**with JN**

* enable the beta plugin
* active with `Bleeding Edge`
* Go to VideoPress dashboard

before | after
------|------
<img width="1137" alt="image" src="https://user-images.githubusercontent.com/77539/193139536-453af70c-5875-4af8-89ac-52794ff8580e.png"> |<img width="1133" alt="image" src="https://user-images.githubusercontent.com/77539/193142086-30c6f7d5-89bf-4b58-9e27-d748424a9e85.png">


* Open the dev console of your browser
* Confirm the `procing_for_ui` doesn't provide the price values

```
jetpackVideoPressInitialState.siteProductData.pricing_for_ui
```

<img width="449" alt="image" src="https://user-images.githubusercontent.com/77539/193141303-79a376e1-ddc9-4648-af47-46a77e7e9d31.png">

* Confirm the `productData` object contains valid information about the product

```
jetpackVideoPressInitialState.productData
```

<img width="478" alt="image" src="https://user-images.githubusercontent.com/77539/193141553-de218707-02d7-42e2-b182-dcef470c155f.png">

Buying the plan without the user connected

https://user-images.githubusercontent.com/77539/193141825-a26f3689-ce21-4cfa-bd4b-e88a494fb554.mov
