### PR TITLE
De-Fusion: update some jetpack_require_lib calls

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.media-summary.php
+++ b/projects/plugins/jetpack/_inc/lib/class.media-summary.php
@@ -60,11 +60,7 @@ class Jetpack_Media_Summary {
 		}
 
 		if ( ! class_exists( 'Jetpack_Media_Meta_Extractor' ) ) {
-			if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-				jetpack_require_lib( 'class.wpcom-media-meta-extractor' );
-			} else {
-				jetpack_require_lib( 'class.media-extractor' );
-			}
+			require_once JETPACK__PLUGIN_DIR . '_inc/lib/class.media-extractor.php';
 		}
 
 		$post      = get_post( $post_id );

--- a/projects/plugins/jetpack/changelog/update-jetpack-defusion-media-summary
+++ b/projects/plugins/jetpack/changelog/update-jetpack-defusion-media-summary
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Jetpack De-fusion: update a jetpack_require_lib call"
+
+

--- a/projects/plugins/jetpack/changelog/update-jetpack-defusion-media-summary
+++ b/projects/plugins/jetpack/changelog/update-jetpack-defusion-media-summary
@@ -1,5 +1,5 @@
 Significance: patch
 Type: other
-Comment: Jetpack De-fusion: update a jetpack_require_lib call"
+Comment: Jetpack De-fusion: update require_lib calls for class.media-summary and class.media-extractor
 
 

--- a/projects/plugins/jetpack/class.jetpack-twitter-cards.php
+++ b/projects/plugins/jetpack/class.jetpack-twitter-cards.php
@@ -134,12 +134,8 @@ class Jetpack_Twitter_Cards {
 
 		// Only proceed with media analysis if a featured image has not superseded it already.
 		if ( empty( $og_tags['twitter:image'] ) && empty( $og_tags['twitter:image:src'] ) ) {
-			if ( ! class_exists( 'Jetpack_Media_Summary' ) && defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-				include WP_CONTENT_DIR . '/lib/class.wpcom-media-summary.php';
-			}
-
 			if ( ! class_exists( 'Jetpack_Media_Summary' ) ) {
-				jetpack_require_lib( 'class.media-summary' );
+				require_once JETPACK__PLUGIN_DIR . '_inc/lib/class.media-summary.php';
 			}
 
 			// Test again, class should already be auto-loaded in Jetpack.

--- a/projects/plugins/jetpack/enhanced-open-graph.php
+++ b/projects/plugins/jetpack/enhanced-open-graph.php
@@ -6,11 +6,7 @@
  */
 
 if ( ! class_exists( 'Jetpack_Media_Summary' ) ) {
-	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-		include WP_CONTENT_DIR . '/lib/class.wpcom-media-summary.php';
-	} else {
-		jetpack_require_lib( 'class.media-summary' );
-	}
+	require_once JETPACK__PLUGIN_DIR . '_inc/lib/class.media-summary.php';
 }
 
 /**

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -118,7 +118,7 @@ class Jetpack_RelatedPosts {
 		add_action( 'wp', array( $this, 'action_frontend_init' ) );
 
 		if ( ! class_exists( 'Jetpack_Media_Summary' ) ) {
-			jetpack_require_lib( 'class.media-summary' );
+			require_once JETPACK__PLUGIN_DIR . '_inc/lib/class.media-summary.php';
 		}
 
 		// Add Related Posts to the REST API Post response.

--- a/projects/plugins/jetpack/tests/php/media/test-class.jetpack-media-summary.php
+++ b/projects/plugins/jetpack/tests/php/media/test-class.jetpack-media-summary.php
@@ -1,7 +1,7 @@
 <?php
 
 if ( ! class_exists( 'Jetpack_Media_Summary' ) ) {
-	jetpack_require_lib( 'class.media-summary' );
+	require_once JETPACK__PLUGIN_DIR . '_inc/lib/class.media-summary.php';
 }
 
 class WP_Test_Jetpack_MediaSummary extends WP_UnitTestCase {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- As part of #25216 update some `jetpack_require_lib` call for defusioning.
- The `IS_WPCOM` checks have been removed since the Jetpack and wpcom files are identical (were previously being synced), and we will start loading the jetpack-plugin versions of these files on wpcom.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Proofread.
