### PR TITLE
Update site type question on wp admin home

### DIFF
--- a/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
@@ -296,7 +296,7 @@ export const getDataByKey = ( state, key ) => {
 
 const stepToNextStep = {
 	'setup-wizard-completed': 'summary',
-	'banner-completed': 'woocommerce',
+	'banner-completed': 'agency',
 	'not-started': 'site-type-question',
 	'site-type-question': 'agency',
 	agency: 'woocommerce',

--- a/projects/plugins/jetpack/_inc/jetpack-recommendations-banner.js
+++ b/projects/plugins/jetpack/_inc/jetpack-recommendations-banner.js
@@ -22,21 +22,19 @@
 	} );
 
 	recommendationsBannerContinue.on( 'click', function () {
-		var fieldNames = [ 'personal', 'business', 'store', 'other' ];
+		var fieldNames = [ 'builder', 'store', 'personal' ];
 		var formData = {};
 		fieldNames.forEach( function ( name ) {
 			formData[ name ] = $( "input[name='" + name + "']" ).prop( 'checked' );
 		} );
-
 		$.post(
 			jp_banner.ajax_url,
 			{
 				action: 'jetpack_recommendations_banner',
 				nonce: jp_banner.nonce,
 				personal: formData.personal,
-				business: formData.business,
+				builder: formData.builder,
 				store: formData.store,
-				other: formData.other,
 			},
 			function ( response ) {
 				if ( true === response.success ) {

--- a/projects/plugins/jetpack/changelog/update-site-type-question-on-wp-admin-home
+++ b/projects/plugins/jetpack/changelog/update-site-type-question-on-wp-admin-home
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Update site-type question on wp-admin banner

--- a/projects/plugins/jetpack/class-jetpack-recommendations-banner.php
+++ b/projects/plugins/jetpack/class-jetpack-recommendations-banner.php
@@ -208,7 +208,7 @@ class Jetpack_Recommendations_Banner {
 				<h1 class="jp-recommendations-banner__question">
 					<?php
 					/* translators: placeholder is the name of the website */
-					echo sprintf( esc_html__( 'What type of site is %s?', 'jetpack' ), esc_html( $site_name ) );
+					echo sprintf( esc_html__( 'Tell us more about %s?', 'jetpack' ), esc_html( $site_name ) );
 					?>
 				</h1>
 				<p class="jp-recommendations-banner__description">
@@ -217,10 +217,9 @@ class Jetpack_Recommendations_Banner {
 				<div class="jp-recommendations-banner__answer">
 					<form id="jp-recommendations-banner__form" class="jp-recommendations-banner__form">
 						<div class="jp-recommendations-banner__checkboxes">
-							<?php $this->render_checkbox( 'personal', __( 'Personal', 'jetpack' ) ); ?>
-							<?php $this->render_checkbox( 'business', __( 'Business', 'jetpack' ) ); ?>
-							<?php $this->render_checkbox( 'store', __( 'Store', 'jetpack' ) ); ?>
-							<?php $this->render_checkbox( 'other', __( 'Other', 'jetpack' ) ); ?>
+							<?php $this->render_checkbox( 'site-type-agency', __( 'I build or manage this site for a client', 'jetpack' ) ); ?>
+							<?php $this->render_checkbox( 'site-type-store', __( 'This is an e-commerce store', 'jetpack' ) ); ?>
+							<?php $this->render_checkbox( 'site-type-personal', __( 'This is a personal site', 'jetpack' ) ); ?>
 						</div>
 					</form>
 					<a id="jp-recommendations-banner__continue-button" class="jp-banner-cta-button">

--- a/projects/plugins/jetpack/class-jetpack-recommendations-banner.php
+++ b/projects/plugins/jetpack/class-jetpack-recommendations-banner.php
@@ -129,10 +129,10 @@ class Jetpack_Recommendations_Banner {
 			$tracking_answers['personal'] = $value;
 		}
 
-		if ( isset( $_REQUEST['agency'] ) && is_string( $_REQUEST['agency'] ) ) {
-			$value                      = 'true' === $_REQUEST['agency'] ? true : false;
-			$data['site-type-agency']   = $value;
-			$tracking_answers['agency'] = $value;
+		if ( isset( $_REQUEST['builder'] ) && is_string( $_REQUEST['builder'] ) ) {
+			$value                       = 'true' === $_REQUEST['builder'] ? true : false;
+			$data['site-type-agency']    = $value;
+			$tracking_answers['builder'] = $value;
 		}
 
 		if ( isset( $_REQUEST['store'] ) && is_string( $_REQUEST['store'] ) ) {
@@ -212,14 +212,14 @@ class Jetpack_Recommendations_Banner {
 					?>
 				</h1>
 				<p class="jp-recommendations-banner__description">
-					<?php esc_html_e( 'This assistant will help you get the most from Jetpack. Tell us more about your goals and we’ll recommend relevant features to help you succeed.', 'jetpack' ); ?>
+					<?php esc_html_e( 'To help you get the most from Jetpack, tell us about your site. Check all that apply:', 'jetpack' ); ?>
 				</p>
 				<div class="jp-recommendations-banner__answer">
 					<form id="jp-recommendations-banner__form" class="jp-recommendations-banner__form">
 						<div class="jp-recommendations-banner__checkboxes">
-							<?php $this->render_checkbox( 'site-type-agency', __( 'I build or manage this site for a client', 'jetpack' ) ); ?>
-							<?php $this->render_checkbox( 'site-type-store', __( 'This is an e-commerce store', 'jetpack' ) ); ?>
-							<?php $this->render_checkbox( 'site-type-personal', __( 'This is a personal site', 'jetpack' ) ); ?>
+							<?php $this->render_checkbox( 'builder', __( 'I build or manage this site for a client', 'jetpack' ) ); ?>
+							<?php $this->render_checkbox( 'store', __( 'This is an e-commerce store', 'jetpack' ) ); ?>
+							<?php $this->render_checkbox( 'personal', __( 'This is a personal site', 'jetpack' ) ); ?>
 						</div>
 					</form>
 					<a id="jp-recommendations-banner__continue-button" class="jp-banner-cta-button">

--- a/projects/plugins/jetpack/scss/jetpack-recommendations-banner.scss
+++ b/projects/plugins/jetpack/scss/jetpack-recommendations-banner.scss
@@ -103,8 +103,6 @@
 	display: flex;
 	flex-direction: column;
 
-	margin-bottom: 1rem;
-
 	text-align: left;
 }
 
@@ -116,6 +114,7 @@
 	border-radius: 2px;
 	cursor: pointer;
 	background: $studio-white;
+	margin-bottom: 1rem;
 
 	&.checked {
 		background: $studio-gray-0;

--- a/projects/plugins/jetpack/scss/jetpack-recommendations-banner.scss
+++ b/projects/plugins/jetpack/scss/jetpack-recommendations-banner.scss
@@ -75,7 +75,7 @@
 	color: var( --jp-gray-100 );
 
 	font-size: 1rem;
-	
+
 	@media (min-width: $jp-banner-md-breakpoint) {
 		max-width: 600px;
 	}
@@ -100,15 +100,12 @@
 }
 
 .jp-recommendations-banner__checkboxes {
-	display: grid;
-	gap: 1rem;
-	grid-template-rows: auto auto;
-	grid-template-columns: auto auto;
+	display: flex;
+	flex-direction: column;
 
-	@include breakpoint( '<480px' ) {
-		grid-template-rows: auto auto auto auto;
-		grid-template-columns: auto;
-	}
+	margin-bottom: 1rem;
+
+	text-align: left;
 }
 
 .jp-recommendations-answer__checkbox-label {
@@ -223,7 +220,7 @@
 	@include breakpoint( "<480px" ) {
 		margin-top: 0;
 	}
-	
+
 	&:hover,
 	&:active {
 		color: $studio-gray-100;


### PR DESCRIPTION
A [previous PR](https://github.com/Automattic/jetpack/pull/26302) was created to update the `site-type` recommendation question, but the banner version of this question was overlooked. This PR edits the banner version to be the same as the one in the assistant

#### Changes proposed in this Pull Request:

Replace the answers in the `site-type` question on the banner of wp-admin/index.php. It also updates the slugs behind it so that it can correctly direct users to the right recommendations when redirected to the assistant after answering the question.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

P2: p8oabR-Wd-p2#comment-6607 and pbNhbs-3pg-p2

#### Does this pull request change what data or activity we track or use?

No it does not

#### Testing instructions:

1. Check out this branch and fire up your local environment
2. Head to `/wp-admin/admin.php?page=jetpack#/dashboard` and scroll all the way to the bottom. Select the `Reset Options (dev only)` button to make sure your options are clear
![Screen Shot 2022-09-29 at 2 44 50 PM](https://user-images.githubusercontent.com/65001528/193138435-1af07bc5-6e27-4bd6-9827-9b9d7897de27.jpg)
3. Now, head to `/wp-admin/index.php` and notice the updated `site-type` question in the top banner
![image](https://user-images.githubusercontent.com/65001528/193138623-697703d8-a84d-4836-b346-d314360c4a7f.png)
4. Click on `I build or manage this site for a client` and then selecte `Continue`. You should be redirected to the recommendations page and see the new `agency` recommendation
![image](https://user-images.githubusercontent.com/65001528/193138884-ca190a49-5ba3-4a29-972e-c40ee2e76bc6.png)
5. To test out all scenarios, you can reset your options again and try the following
   * Select `I build or manage this site for a client` and `This is an e-commerce store`. You should be directed to the `agency` recommendation and then the `woocommerce` one
   * Select only `This is an e-commerce store` and you should be redirected to the `woocommerce recommedation`
   * Select all 3 answers, you should get directed to the `agency` and then `woocommerce` recommendations (same as number 1 of this list)
   * Select only "This is a personal site", you should see the `monitor` recommendation

Make sure you reset your options between every test, the banner question goes away if you have answered it and have not reset them.