### PR TITLE
VideoPress: define initial state of the APP in the backend

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-send-initial-state-to-the-client
+++ b/projects/packages/videopress/changelog/update-videopress-send-initial-state-to-the-client
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: send initial state to the client

--- a/projects/packages/videopress/src/class-admin-ui.php
+++ b/projects/packages/videopress/src/class-admin-ui.php
@@ -160,6 +160,7 @@ class Admin_UI {
 			'siteSuffix'             => ( new Status() )->get_site_suffix(),
 			'productData'            => Plan::get_product(),
 			'allowedVideoExtensions' => self::get_allowed_video_extensions(),
+			'initialState'           => Data::get_initial_state(),
 		);
 	}
 

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -106,7 +106,7 @@ class Data {
 
 		return array(
 			'videos' => array(
-				'uploadedVideoCount' => 6, // @todo: pick the total number properly
+				'uploadedVideoCount' => count( $videos ), // @todo: pick the total number properly
 				'items'              => $videos,
 			),
 		);

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * The Data class.
+ * This class provides methods for data VideoPress access and manipulation.
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+use Automattic\Jetpack\Connection\Client;
+use Jetpack_Options;
+
+/**
+ * The Data class.
+ */
+class Data {
+	/**
+	 * Gets the product data
+	 *
+	 * @return array
+	 */
+	public static function get_videos() {
+		$blog_id = Jetpack_Options::get_option( 'id' );
+
+		// @todo: build a proper query string for request.
+		$endpoint = "/sites/{$blog_id}/media?per_page=6&mime_type=video/videopress";
+
+		$args = array(
+			'method' => 'GET',
+		);
+
+		$response = Client::wpcom_json_api_request_as_user( $endpoint, '2', $args, null, 'wp' );
+		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			// @todo: error handling
+			return array();
+		}
+
+		return json_decode( $response['body'], true );
+	}
+
+	/**
+	 * Return the initial state of the VideoPress app,
+	 * used to render initially the app in the frontend.
+	 *
+	 * @return array
+	 */
+	public static function get_initial_state() {
+
+		$videos = array_map(
+			function ( $video ) {
+				$id                 = $video['id'];
+				$guid               = $video['jetpack_videopress_guid'];
+				$media_details      = $video['media_details'];
+				$jetpack_videopress = $video['jetpack_videopress'];
+
+				$videopress_media_details = $media_details['videopress'];
+				$width                    = $media_details['width'];
+				$height                   = $media_details['height'];
+
+				$title           = $jetpack_videopress['title'];
+				$description     = $jetpack_videopress['description'];
+				$caption         = $jetpack_videopress['caption'];
+				$rating          = $jetpack_videopress['rating'];
+				$allow_download  = $jetpack_videopress['allow_download'];
+				$privacy_setting = $jetpack_videopress['privacy_setting'];
+
+				$original      = $videopress_media_details['original'];
+				$poster        = $videopress_media_details['poster'];
+				$upload_date   = $videopress_media_details['upload_date'];
+				$duration      = $videopress_media_details['duration'];
+				$is_private    = $videopress_media_details['is_private'];
+				$file_url_base = $videopress_media_details['file_url_base'];
+				$finished      = $videopress_media_details['finished'];
+				$files         = $videopress_media_details['files'];
+
+				if ( isset( $files['dvd']['original_img'] ) ) {
+					$thumbnail = $file_url_base['https'] . $files['dvd']['original_img'];
+				}
+
+				return array(
+					'id'             => $id,
+					'guid'           => $guid,
+					'title'          => $title,
+					'description'    => $description,
+					'caption'        => $caption,
+					'url'            => $original,
+					'uploadDate'     => $upload_date,
+					'duration'       => $duration,
+					'isPrivate'      => $is_private,
+					'posterImage'    => $poster,
+					'allowDownload'  => $allow_download,
+					'rating'         => $rating,
+					'privacySetting' => $privacy_setting,
+					'poster'         => array(
+						'src'    => $poster,
+						'width'  => $width,
+						'height' => $height,
+					),
+					'thumnbail'      => $thumbnail,
+					'finished'       => $finished,
+				);
+			},
+			self::get_videos()
+		);
+
+		return array(
+			'videos' => array(
+				'uploadedVideoCount' => 6, // @todo: pick the total number properly
+				'items'              => $videos,
+			),
+		);
+	}
+}

--- a/projects/packages/videopress/src/client/state/index.js
+++ b/projects/packages/videopress/src/client/state/index.js
@@ -29,7 +29,7 @@ function initStore() {
 		actions,
 		selectors,
 		resolvers,
-		initialState: window.myJetpackInitialState || {},
+		initialState: window.jetpackVideoPressInitialState.initialState || {},
 	} );
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR requests the videos on the backend side and serves them to the client to be used in the first rendering of the dashboard page.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: send initial state to the client

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to VideoPress dashboard
* Confirm the video list is rendering without performing an async request. Visually, it doesn't show the upload placeholder when the site has videos. 

https://user-images.githubusercontent.com/77539/193256589-61ef5d05-fe34-4384-9650-b816a60b4727.mov


Disclaimer: we need to expose the total videos properly and probably other data valid for the initial state.
