### PR TITLE
VideoPress: show placeholder when removing video from the card view

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-improve-deleting-video-ui
+++ b/projects/packages/videopress/changelog/update-videopress-improve-deleting-video-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: show placeholder when removing video from the card view

--- a/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
@@ -102,7 +102,7 @@ export const VideoCard = ( {
 				/>
 
 				<div className={ styles[ 'video-card__title-section' ] }>
-					{ isSm && (
+					{ isSm && ! ( loading || deleting ) && (
 						<div className={ styles.chevron }>
 							{ isOpen && <Icon icon={ chevronUp } /> }
 							{ ! isOpen && <Icon icon={ chevronDown } /> }

--- a/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
@@ -14,10 +14,10 @@ import classnames from 'classnames';
 import React from 'react';
 import { useState } from 'react';
 import useVideo from '../../hooks/use-video';
-import Placeholder from '../placeholder';
 /**
  * Internal dependencies
  */
+import Placeholder from '../placeholder';
 import { ConnectVideoQuickActions } from '../video-quick-actions';
 import VideoThumbnail from '../video-thumbnail';
 import styles from './style.module.scss';
@@ -63,10 +63,14 @@ export const VideoCard = ( {
 	editable,
 	showQuickActions = true,
 	loading = false,
+	deleting = false,
 	onVideoDetailsClick,
 }: VideoCardProps ) => {
-	const isBlank = ! title && ! duration && ! plays && ! thumbnail;
 	thumbnail = loading ? <Placeholder width={ 360 } /> : thumbnail;
+
+	// @todo: implement removing video state properly
+	const isBlank = ! title && ! duration && ! plays && ! thumbnail;
+	thumbnail = deleting ? <Placeholder width={ 360 } /> : thumbnail;
 
 	const hasPlays = typeof plays !== 'undefined';
 	const playsCount = hasPlays
@@ -93,8 +97,8 @@ export const VideoCard = ( {
 				<VideoThumbnail
 					className={ styles[ 'video-card__thumbnail' ] }
 					thumbnail={ thumbnail }
-					duration={ loading ? null : duration }
-					editable={ loading ? false : editable }
+					duration={ loading || deleting ? null : duration }
+					editable={ loading || deleting ? false : editable }
 				/>
 
 				<div className={ styles[ 'video-card__title-section' ] }>
@@ -105,7 +109,7 @@ export const VideoCard = ( {
 						</div>
 					) }
 
-					{ loading ? (
+					{ loading || deleting ? (
 						<Placeholder width="60%" height={ 30 } />
 					) : (
 						<Title className={ styles[ 'video-card__title' ] } mb={ 0 } size="small">
@@ -113,7 +117,7 @@ export const VideoCard = ( {
 						</Title>
 					) }
 
-					{ loading ? (
+					{ loading || deleting ? (
 						<Placeholder width={ 96 } height={ 24 } />
 					) : (
 						<>
@@ -155,8 +159,8 @@ export const VideoCard = ( {
 };
 
 export const ConnectVideoCard = ( { id, ...restProps }: VideoCardProps ) => {
-	const { isDeleting } = useVideo( id );
-	return <VideoCard id={ id } { ...restProps } loading={ isDeleting || restProps?.loading } />;
+	const { deleting } = useVideo( id );
+	return <VideoCard id={ id } { ...restProps } loading={ deleting || restProps?.loading } />;
 };
 
 export default ConnectVideoCard;

--- a/projects/packages/videopress/src/client/admin/components/video-card/stories/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-card/stories/index.tsx
@@ -44,6 +44,7 @@ _default.args = {
 	editable: false,
 	duration: ( 34 * 60 + 25 ) * 1000, // 34 minutes and 25 seconds
 	plays: 972,
+	deleting: false,
 	onVideoDetailsClick: action( 'onVideoDetailsClick' ),
 	onUpdateVideoThumbnail: action( 'onUpdateVideoThumbnail' ),
 	onUpdateVideoPrivacy: action( 'onUpdateVideoPrivacy' ),

--- a/projects/packages/videopress/src/client/admin/components/video-card/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/video-card/style.module.scss
@@ -10,6 +10,7 @@
 
 		.video-card__quick-actions-section,
 		.video-card__title-section,
+		.thumbnail,
 		.video-card__quick-actions-section {
 			visibility: hidden;
 		}

--- a/projects/packages/videopress/src/client/admin/components/video-card/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/video-card/types.ts
@@ -17,7 +17,7 @@ export type VideoCardProps = Pick< VideoPressVideo, 'title' | 'plays' | 'id' > &
 		/**
 		 * True when the video is being deleted.
 		 */
-		isDeleting?: boolean;
+		deleting?: boolean;
 
 		/**
 		 * True when is in loading mode.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: show placeholder when removing video from the card view

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use Storybook
* Go to VideoCard component story
* Open the Addons panel
* enable/disable the `isDeleting` prop

https://user-images.githubusercontent.com/77539/193271450-e8e952fc-8c8c-4271-8c49-a4ef75ab03df.mov
