### PR TITLE
Anchor FM: Make the post-publish panel initially closed

### DIFF
--- a/projects/plugins/jetpack/changelog/update-anchor-fm-close-postpublish-panel
+++ b/projects/plugins/jetpack/changelog/update-anchor-fm-close-postpublish-panel
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Anchor FM: Make post-publish panel initially closed

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/editor.js
@@ -56,7 +56,6 @@ const ConvertToAudio = () => {
 			className="anchor-post-publish-outbound-link"
 			icon={ <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" /> }
 			title={ __( 'Convert to audio', 'jetpack' ) }
-			initialOpen={ true }
 		>
 			<PanelRow>
 				<p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/68486

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Make the **Convert to audio** post-publish panel closed by default

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pbAok1-3fI-p2#comment-5536

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure your local development environment is a Jetpack connected site and that you can access it publicly (using [Jurassic Tube](https://github.com/Automattic/jetpack/blob/trunk/docs/quick-start.md#setting-up-jurassic-tube), for example)
* Build the Jetpack plugin again using `jetpack build plugins/jetpack`
* Go to **Posts > Add New** and add some title to start writing a new post
* Click the **Publish** button. This should display pre-publish panels
* Click the **Publish** button again
* You should see the **Convert to audio** panel initially closed
![Screen Shot 2022-09-30 at 14 41 04](https://user-images.githubusercontent.com/2019970/193272103-1882863c-d52c-4537-81b3-a803a4d1d2b5.png)



