### PR TITLE
QR Code: Make the post-publish panel initially closed

### DIFF
--- a/projects/plugins/jetpack/changelog/update-post-publish-qr-post-panel-closed
+++ b/projects/plugins/jetpack/changelog/update-post-publish-qr-post-panel-closed
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+QR code: Make the post-publish panel closed by default

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/index.js
@@ -17,7 +17,6 @@ export const settings = {
 			title: __( 'QR Code', 'jetpack' ),
 			className: 'post-publish-qr-post-panel',
 			icon: <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" />,
-			initialOpen: true,
 		};
 
 		const isPostPublished = useSelect(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/68385

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Make the post-publish QR code panel initially closed

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pbAok1-3fI-p2#comment-5523

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure your local development environment is a Jetpack connected site and that you can access it publicly (using [Jurassic Tube](https://github.com/Automattic/jetpack/blob/trunk/docs/quick-start.md#setting-up-jurassic-tube), for example)
* Build the Jetpack plugin again using `jetpack build plugins/jetpack`
* Go to **Posts > Add New** and add some title to start writing a new post
* Click the **Publish** button. This should display pre-publish panels
* Click the **Publish** button again
* You should see the **QR Code** panel initially closed
![Screen Shot 2022-09-30 at 14 54 26](https://user-images.githubusercontent.com/2019970/193274084-6d180eae-ca47-4c2d-81d9-21bace79f25a.png)
