### PR TITLE
VideoPress: do not perform async request to get videos in the first rendering

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-do-not-perform-async-request-in-the-first-rendering
+++ b/projects/packages/videopress/changelog/update-videopress-do-not-perform-async-request-in-the-first-rendering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: do not perform async request to get videos in the first rendering

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -107,6 +107,7 @@ class Data {
 		return array(
 			'videos' => array(
 				'uploadedVideoCount'           => count( $videos ), // @todo: pick the total number properly
+				// 'totalVideoCount'              => count( $videos ), // @todo: pick the total number properly
 				'items'                        => $videos,
 				'isFetching'                   => false,
 				'isFetchingUploadedVideoCount' => false,

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -106,8 +106,10 @@ class Data {
 
 		return array(
 			'videos' => array(
-				'uploadedVideoCount' => count( $videos ), // @todo: pick the total number properly
-				'items'              => $videos,
+				'uploadedVideoCount'           => count( $videos ), // @todo: pick the total number properly
+				'items'                        => $videos,
+				'isFetching'                   => false,
+				'isFetchingUploadedVideoCount' => false,
 			),
 		);
 	}

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -107,10 +107,12 @@ class Data {
 		return array(
 			'videos' => array(
 				'uploadedVideoCount'           => count( $videos ), // @todo: pick the total number properly
-				// 'totalVideoCount'              => count( $videos ), // @todo: pick the total number properly
 				'items'                        => $videos,
 				'isFetching'                   => false,
 				'isFetchingUploadedVideoCount' => false,
+				'_meta'                        => array(
+					'relyOnInitialState' => true,
+				),
 			),
 		);
 	}

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -38,15 +38,9 @@ import styles from './styles.module.scss';
 const useDashboardVideos = () => {
 	const { setVideo } = useDispatch( STORE_ID );
 
-	const {
-		items,
-		total: totalVideoCount,
-		uploadedVideoCount,
-		isFetching = true,
-		isFetchingUploadedVideoCount = true,
-	} = useVideos();
+	const { items, total: totalVideoCount, uploadedVideoCount, isFetching } = useVideos();
 
-	const loading = isFetching || isFetchingUploadedVideoCount;
+	const loading = isFetching;
 
 	const poolingUploadedVideoData = async data => {
 		setVideo( data );

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -94,7 +94,6 @@ const useDashboardVideos = () => {
 const Admin = () => {
 	const {
 		videos,
-		totalVideoCount,
 		uploadedVideoCount,
 		uploadStatus,
 		handleFilesUpload,
@@ -159,7 +158,7 @@ const Admin = () => {
 								<Col sm={ 4 } md={ 6 } lg={ 12 }>
 									<VideoPressLibrary
 										videos={ videos }
-										totalVideos={ totalVideoCount }
+										totalVideos={ uploadedVideoCount }
 										loading={ loading }
 									/>
 								</Col>

--- a/projects/packages/videopress/src/client/state/index.js
+++ b/projects/packages/videopress/src/client/state/index.js
@@ -17,6 +17,8 @@ import storeHolder from './store-holder';
  */
 export const stateDebug = debugFactory( 'videopress/media:state' );
 
+const initialState = window.jetpackVideoPressInitialState?.initialState || {};
+
 /**
  * jetpack-videopress redux initializer
  */
@@ -29,7 +31,7 @@ function initStore() {
 		actions,
 		selectors,
 		resolvers,
-		initialState: window.jetpackVideoPressInitialState.initialState || {},
+		initialState,
 	} );
 }
 

--- a/projects/packages/videopress/src/client/state/reducers.js
+++ b/projects/packages/videopress/src/client/state/reducers.js
@@ -34,7 +34,7 @@ export function getDefaultQuery() {
 	};
 }
 
-const videos = ( state = { isFetching: true }, action ) => {
+const videos = ( state, action ) => {
 	switch ( action.type ) {
 		case SET_IS_FETCHING_VIDEOS: {
 			return {
@@ -59,6 +59,10 @@ const videos = ( state = { isFetching: true }, action ) => {
 					...state.query,
 					...action.query,
 				},
+				_meta: {
+					...state._meta,
+					relyOnInitialState: false,
+				},
 			};
 		}
 
@@ -68,6 +72,10 @@ const videos = ( state = { isFetching: true }, action ) => {
 				pagination: {
 					...state.pagination,
 					...action.pagination,
+				},
+				_meta: {
+					...state._meta,
+					relyOnInitialState: false,
 				},
 			};
 		}

--- a/projects/packages/videopress/src/client/state/resolvers.js
+++ b/projects/packages/videopress/src/client/state/resolvers.js
@@ -14,6 +14,10 @@ import { mapVideoFromWPV2MediaEndpoint, mapVideosFromWPV2MediaEndpoint } from '.
 const { apiNonce, apiRoot } = window?.jetpackVideoPressInitialState || {};
 
 const getVideos = {
+	isFulfilled: state => {
+		return !! state?.videos?.items?.length;
+	},
+
 	fulfill: () => async ( { dispatch, select } ) => {
 		dispatch.setIsFetchingVideos( true );
 

--- a/projects/packages/videopress/src/client/state/resolvers.js
+++ b/projects/packages/videopress/src/client/state/resolvers.js
@@ -15,7 +15,7 @@ const { apiNonce, apiRoot } = window?.jetpackVideoPressInitialState || {};
 
 const getVideos = {
 	isFulfilled: state => {
-		return !! state?.videos?.items;
+		return state?.videos?._meta?.relyOnInitialState;
 	},
 
 	fulfill: () => async ( { dispatch, select } ) => {

--- a/projects/packages/videopress/src/client/state/resolvers.js
+++ b/projects/packages/videopress/src/client/state/resolvers.js
@@ -15,7 +15,7 @@ const { apiNonce, apiRoot } = window?.jetpackVideoPressInitialState || {};
 
 const getVideos = {
 	isFulfilled: state => {
-		return !! state?.videos?.items?.length;
+		return !! state?.videos?.items;
 	},
 
 	fulfill: () => async ( { dispatch, select } ) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

https://github.com/Automattic/jetpack/pull/26542 re-introduce the action of the browser performing an async request to get the videos, even when the initial state is populated. This PR restores the ability to avoid this async request in the first rendering.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to VideoPress dashboard
* Confirm it doesn't perform the async request in the first rendering
* Confirm you can get a new video list by searching, etc...

