### PR TITLE
VideoPress: Allow empty video description and caption

### DIFF
--- a/projects/packages/videopress/changelog/fix-allow-empty-video-details
+++ b/projects/packages/videopress/changelog/fix-allow-empty-video-details
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Allows empty caption and description values so it's possible to save empty fields from the frontend.

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
@@ -310,8 +310,9 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 				);
 			}
 
-			$post_content = isset( $json_params['description'] ) ? sanitize_textarea_field( $json_params['description'] ) : null;
-			if ( $post_content ) {
+			$post_content = null;
+			if ( isset( $json_params['description'] ) ) {
+				$post_content = sanitize_textarea_field( $json_params['description'] );
 				wp_update_post(
 					array(
 						'ID'           => $post_id,
@@ -320,8 +321,9 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 				);
 			}
 
-			$post_excerpt = isset( $json_params['caption'] ) ? sanitize_textarea_field( $json_params['caption'] ) : null;
-			if ( $post_excerpt ) {
+			$post_excerpt = null;
+			if ( isset( $json_params['caption'] ) ) {
+				$post_excerpt = sanitize_textarea_field( $json_params['caption'] );
 				wp_update_post(
 					array(
 						'ID'           => $post_id,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26528.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Change the caption and description value checks to allow empty values, but only when the field is really present on the request body

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On your test site, upload one video and get it's attachment ID (or use one that you already uploaded before)
* Do a GET request to `http://your-site.com/wp-json/wp/v2/media/{ID}` to get the video information
* Check the value for the description and caption fields inside the `jetpack_videopress` field
* Now do a POST request to `http://your-site.com/wp-json/wpcom/v2/videopress/meta` with the following `body` to set a new value for the description

```
{
    "id": {ID},
    "description": "Some value"
}
```

* Check the value of the description inside jetpack_videopress field again; the value must be same that you put on the POST request (this was already working before this PR)
* Now do another POST request to `http://your-site.com/wp-json/wpcom/v2/videopress/meta`, but use an empty string for the the description
* Check the value of the description inside jetpack_videopress field again; the value must be empty as you sent (this is the fiexed behavior)
* Do the same for the `caption` field

Some snippets:

**getting the video details**
```cli
curl -X GET -u "user:pass" http://your-site.com/wp-json/wp/v2/media/{ID} | jq
```

**posting the new value for description...**

```cli
curl -X POST -u "user:pass" http://your-site.com/wp-json/wpcom/v2/videopress/meta -H 'Content-Type: application/json' -d '{"id": {ID},"description": "Some value"}' | jq
```

**... and for caption...**
```cli
curl -X POST -u "user:pass" http://your-site.com/wp-json/wpcom/v2/videopress/meta -H 'Content-Type: application/json' -d '{"id": {ID},"caption": "Some value"}' | jq
```

**... or both**
```cli
curl -X POST -u "user:pass" http://your-site.com/wp-json/wpcom/v2/videopress/meta -H 'Content-Type: application/json' -d '{"id": {ID},"caption": "Some value","description": "Some value"}' | jq
```