### PR TITLE
Search: Fix configure page sidebar options styles

### DIFF
--- a/projects/packages/search/changelog/update-configure_page_sidebar_options
+++ b/projects/packages/search/changelog/update-configure_page_sidebar_options
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Fix styles of Control components on page side to avoid deprecating component styles affecting.

--- a/projects/packages/search/src/customberg/components/sidebar/styles.scss
+++ b/projects/packages/search/src/customberg/components/sidebar/styles.scss
@@ -98,9 +98,12 @@
 	.components-base-control {
 		margin-bottom: $grid-unit-30;
 
-		&.components-checkbox-control,
+		&.components-checkbox-control {
+			margin-bottom: $grid-unit-10;
+		}
+
 		&.components-toggle-control {
-			margin-bottom: 0;
+			margin-bottom: $grid-unit-15;
 		}
 
 		&:last-child {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix `margin-bottom` of `.components-base-control` on the page side to avoid broken styles by deprecating component styles changed.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p8oabR-Wd#comment-6617-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Navigate the site with URL `/wp-admin/admin.php?page=jetpack-search-configure`.
* Find `Excluded post types` and `Additional settings` sections on the sidebar options.
* Open Browser Dev Tool.
* Find `.components-base-control__field` selectors and cancel all `margin-bottom` related styles on them.
* Ensure the `margin-bottom` attribute still works for visual coherence.
<img width="1517" alt="截圖 2022-10-01 上午7 18 37" src="https://user-images.githubusercontent.com/6869813/193368684-06a7d77c-552f-4d35-abb1-a8e058553310.png">
<img width="1520" alt="截圖 2022-10-01 上午7 18 58" src="https://user-images.githubusercontent.com/6869813/193368686-d4450fcc-715c-46b9-8e10-5c5f3ccd968e.png">