### PR TITLE
VideoPress: Fix empty VideoPress block rendering the text "null"

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-block-null
+++ b/projects/packages/videopress/changelog/fix-videopress-block-null
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Add a check for video url before rendering VideoPress block

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/save.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/save.js
@@ -63,9 +63,11 @@ export default function save( { attributes } ) {
 
 	return (
 		<figure { ...blockProps } style={ style }>
-			<div className="jetpack-videopress-player__wrapper">
-				{ `\n${ videoPressUrl }\n` /* URL needs to be on its own line. */ }
-			</div>
+			{ videoPressUrl && (
+				<div className="jetpack-videopress-player__wrapper">
+					{ `\n${ videoPressUrl }\n` /* URL needs to be on its own line. */ }
+				</div>
+			) }
 
 			{ ! RichText.isEmpty( caption ) && (
 				<RichText.Content tagName="figcaption" value={ caption } />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #25950

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a check for the video URL before rendering the VideoPress block

Note: If a blog has an empty video block, it needs manual update. ref: https://github.com/Automattic/jetpack/issues/25950#issuecomment-1253839521

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On the block editor, add a `VideoPress (beta)` block
* Leave it empty and publish the post
* Check that there is no `null` rendered on the post

Before | After
----------|------
![2022-10-03_10-03-50](https://user-images.githubusercontent.com/8486249/193583901-8d9a0f39-5b8c-482f-80e7-5dfde2ecdf4f.png) | ![2022-10-03_10-04-56](https://user-images.githubusercontent.com/8486249/193583926-d00c30b6-b534-434e-b068-3d414c30471e.png)
