### PR TITLE
Update agency recommendation links

### DIFF
--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
@@ -194,10 +194,9 @@ export const getStepContent = stepSlug => {
 				question: __( 'Manage your clients’ sites with ease', 'jetpack' ),
 				// eslint-disable-next-line @wordpress/i18n-translator-comments
 				description: __(
-					'Jetpack’s world-class security features are now easier to manage for anyone with at least five WordPress websites.<br/><br/>Purchase and manage licenses, and get a 60% discount with our licensing platform.<br/><br/><ExternalLink>Learn More</ExternalLink>',
+					'Jetpack’s world-class security features are now easier to manage for anyone with at least five WordPress websites.<br/><br/>Purchase and manage licenses, and get a 60% discount with our licensing platform.',
 					'jetpack'
 				),
-				descriptionLink: getRedirectUrl( 'jetpack-for-agencies-assistant-recommendation' ),
 				ctaText: __( 'Get Jetpack for Agencies', 'jetpack' ),
 				ctaLink: getRedirectUrl( 'jetpack-for-agencies-signup-assistant-recommendation' ),
 				illustration: 'assistant-agency',

--- a/projects/plugins/jetpack/changelog/update-agency-recommendation-links
+++ b/projects/plugins/jetpack/changelog/update-agency-recommendation-links
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Remove Learn More link from agency recommendation


### PR DESCRIPTION
Update agency recommendation to not include the Learn More external link. The CTA was updated to go to the same place as this link, so it is no longer needed.

#### Changes proposed in this Pull Request:

Remove Learn More link from agency recommendation

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

P2: p8oabR-Wd-p2#comment-6628

#### Does this pull request change what data or activity we track or use?

There is now one less link being tracked when it is clicked

#### Testing instructions:

1. Check out this branch
2. Get your local environment up and running
3. Go to `/wp-admin/admin.php?page=jetpack#/recommendations/agency`
4. Notice "Learn More" is no longer there
![image](https://user-images.githubusercontent.com/65001528/193622488-8b138479-345c-4b73-97cd-0557dbc85790.png)
5. Click on the CTA to ensure it goes to https://jetpack.com/for/agencies
![image](https://user-images.githubusercontent.com/65001528/193622667-a1f16d3c-a82f-4c1f-8622-387da6b5b0c5.png)
