### PR TITLE
VideoPress: fix Maximum update depth exceeded warning

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-fix-maximum-update-depth-bug
+++ b/projects/packages/videopress/changelog/update-videopress-fix-maximum-update-depth-bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: fix Maximum update depth exceeded warning triggered from the useVideoDetails() hook

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/use-edit-details.ts
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/use-edit-details.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useDispatch } from '@wordpress/data';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
 /**
@@ -144,9 +144,11 @@ export default () => {
 	};
 	// Make sure we have the latest data from the API
 	// Used to update the data when user navigates direct from Media Library
-	useEffect( () => {
-		setData( video );
-	}, [ video ] );
+	// removed -> https://github.com/Automattic/jetpack/issues/26574
+	// @todo: move state login to the redux store
+	// useEffect( () => {
+	// 	setData( video );
+	// }, [ video ] );
 
 	return {
 		...data, // data is the local representation of the video


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/26574

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: fix  Maximum update depth exceeded warning when editing video details

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to VideoPress dashboard
* Go to the video details page
* Try to edit title
* **before**: confirm you see the bug in the dev console
* **after**: you should be able to edit the video details

