### PR TITLE
VideoPress: fix showing product price at the very first rendering

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-get-product-data-first-rendering
+++ b/projects/packages/videopress/changelog/update-videopress-get-product-data-first-rendering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: fix showing product price at the very first rendering

--- a/projects/packages/videopress/src/class-plan.php
+++ b/projects/packages/videopress/src/class-plan.php
@@ -72,7 +72,9 @@ class Plan {
 
 			// ... and store it into the cache.
 			update_user_meta( get_current_user_id(), self::CACHE_DATE_META_NAME, time() );
-			return update_user_meta( get_current_user_id(), self::CACHE_META_NAME, $product );
+			update_user_meta( get_current_user_id(), self::CACHE_META_NAME, $product );
+
+			return $product;
 		}
 
 		return new \WP_Error(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The app shows empty prices at the very first rendering of the VideoPress dashboard:

<img width="1171" alt="image" src="https://user-images.githubusercontent.com/77539/193660370-e8076027-e92b-4686-8e8f-fe9dd9212372.png">

This PR fixes the issue, showing the correct price.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: fix showing product price at the very first rendering


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with a [fresh JN site](https://jurassic.ninja/create/?jetpack-beta&branches.jetpack-videopress=update/videopress-get-product-data-first-rendering&wp-debug-log&nojetpack). No Jetpack.
*  Go to VideoPress dashboard 

before | after
------|------
<img width="1171" alt="image" src="https://user-images.githubusercontent.com/77539/193660370-e8076027-e92b-4686-8e8f-fe9dd9212372.png"> | <img width="1168" alt="image" src="https://user-images.githubusercontent.com/77539/193661065-4c97cbe3-c85b-40e4-94fa-568061015fa8.png">

