### PR TITLE
Social: Change pricing table prices

### DIFF
--- a/projects/plugins/social/changelog/add-jetpack-social-pricing-page-notice
+++ b/projects/plugins/social/changelog/add-jetpack-social-pricing-page-notice
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Changed the values on the pricing table, and fixed a redirect

--- a/projects/plugins/social/src/js/components/header/index.js
+++ b/projects/plugins/social/src/js/components/header/index.js
@@ -25,6 +25,7 @@ const Header = () => {
 		postsCount,
 		isShareLimitEnabled,
 		hasPaidPlan,
+		siteSuffix,
 	} = useSelect( select => {
 		const store = select( STORE_ID );
 		return {
@@ -35,6 +36,7 @@ const Header = () => {
 			postsCount: select( STORE_ID ).getPostsCount(),
 			isShareLimitEnabled: select( STORE_ID ).isShareLimitEnabled(),
 			hasPaidPlan: select( STORE_ID ).hasPaidPlan(),
+			siteSuffix: select( STORE_ID ).getSiteSuffix(),
 		};
 	} );
 
@@ -75,7 +77,10 @@ const Header = () => {
 									'jetpack-social'
 								) }
 								cta={ __( 'Get a Jetpack Social Plan', 'jetpack-social' ) }
-								href={ getRedirectUrl( 'jetpack-social-admin-page-upsell' ) }
+								href={ getRedirectUrl( 'jetpack-social-basic-plan-plugin-admin-page', {
+									site: siteSuffix,
+									query: 'redirect_to=' + window.location.href,
+								} ) }
 							/>
 						</>
 					) : (

--- a/projects/plugins/social/src/js/components/pricing-page/index.js
+++ b/projects/plugins/social/src/js/components/pricing-page/index.js
@@ -6,11 +6,13 @@ import {
 	PricingTableItem,
 	ProductPrice,
 	getRedirectUrl,
+	Text,
 } from '@automattic/jetpack-components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { useCallback } from 'react';
 import { STORE_ID } from '../../store';
+import styles from './styles.module.scss';
 
 const PricingPage = () => {
 	const siteSuffix = useSelect( select => select( STORE_ID ).getSiteSuffix() );
@@ -38,9 +40,11 @@ const PricingPage = () => {
 				<PricingTableHeader>
 					<ProductPrice
 						price={ 10 }
-						promoLabel={ __( 'New!', 'jetpack-social' ) }
+						offPrice={ 1 }
+						promoLabel={ __( '90% off*', 'jetpack-social' ) }
 						leyend={ __( '/month, billed yearly', 'jetpack-social' ) }
 						currency="USD"
+						hidePriceFraction={ true }
 					/>
 					<Button
 						href={ getRedirectUrl( 'jetpack-social-basic-plan-plugin-admin-page', {
@@ -51,10 +55,23 @@ const PricingPage = () => {
 					>
 						{ __( 'Get Social', 'jetpack-social' ) }
 					</Button>
+					<Text variant="body-extra-small" className={ styles.notice }>
+						(*) { __( 'Limited offer for the first month', 'jetpack-social' ) }
+					</Text>
 				</PricingTableHeader>
 				<PricingTableItem
 					isIncluded={ true }
-					label={ <strong>{ __( 'Up to 1000', 'jetpack-social' ) }</strong> }
+					label={
+						<>
+							<del>{ __( 'Up to 1000', 'jetpack-social' ) }</del>&nbsp;
+							<strong>{ __( 'Unlimited', 'jetpack-social' ) }</strong>
+						</>
+					}
+					tooltipTitle={ __( 'Unlimited shares', 'jetpack-social' ) }
+					tooltipInfo={ __(
+						'We are working on exciting new features for Jetpack Social. In the meantime, enjoy unlimited shares for a limited time!',
+						'jetpack-social'
+					) }
 				/>
 				<PricingTableItem isIncluded={ true } />
 				<PricingTableItem isIncluded={ true } />

--- a/projects/plugins/social/src/js/components/pricing-page/styles.module.scss
+++ b/projects/plugins/social/src/js/components/pricing-page/styles.module.scss
@@ -1,0 +1,5 @@
+// Double selector because otherwise margin gets overruled
+.notice.notice {
+	color: var( --jp-gray-40 );
+	margin-top: calc( var( --spacing-base ) * 2 );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update the pricing and information in the pricing table.
* Fix a redirect from the admin page.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up a new site, activate and connect Jetpack Social.
* Navigate to the admin page of Jetpack Social.
* Confirm that the pricing table looks like the screenshot shown below and that the tooltip works.
* Click "Start for free"
* Click the upsell underneath the share counter and ensure it takes you to the checkout page.

<img width="1163" alt="Screenshot 2022-10-04 at 14 06 37@2x" src="https://user-images.githubusercontent.com/1713699/193815303-0da492dd-d0bd-42d3-8f0e-84fc31a93fa7.png">


