### PR TITLE
VideoPress: refresh video list right after a video is removed

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-request-videos-right-after-revoving-video
+++ b/projects/packages/videopress/changelog/update-videopress-request-videos-right-after-revoving-video
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: refresh video list right after a video is removed

--- a/projects/packages/videopress/src/client/state/reducers.js
+++ b/projects/packages/videopress/src/client/state/reducers.js
@@ -179,6 +179,7 @@ const videos = ( state, action ) => {
 				...state,
 				_meta: {
 					...state._meta,
+					relyOnInitialState: false,
 					items: {
 						..._metaItems,
 						[ id ]: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR stops relying on the initial state when a video is removed. It forces the app to perform an async request to get a fresh video list right after the video is removed.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: refresh video list right after a video is removed

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to VideoPress dashboard
* Ensure you have. a couple of videos
* Remove one of them
* Confirm the app gets a fresh video list right after the video is removed

https://user-images.githubusercontent.com/77539/193820602-fcd706ea-e1d9-4570-ad61-de9451405bf1.mov

