### PR TITLE
Test results to Slack: remove duplicated last run button for scheduled event notification

### DIFF
--- a/projects/github-actions/test-results-to-slack/changelog/slack-remove-duplicated-btn
+++ b/projects/github-actions/test-results-to-slack/changelog/slack-remove-duplicated-btn
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Remove duplicated last run button for scheduled event notification

--- a/projects/github-actions/test-results-to-slack/src/message.js
+++ b/projects/github-actions/test-results-to-slack/src/message.js
@@ -73,7 +73,7 @@ async function createMessage( isFailure ) {
 		const commitUrl = `${ serverUrl }/${ repository }/commit/${ sha }`;
 
 		contextElements.push( getTextContextElement( `Last commit: ${ sha.substring( 0, 8 ) }` ) );
-		buttons.push( lastRunButtonBlock, getButton( `Commit ${ sha.substring( 0, 8 ) }`, commitUrl ) );
+		buttons.push( getButton( `Commit ${ sha.substring( 0, 8 ) }`, commitUrl ) );
 	}
 
 	contextElements.push( lastRunBlock );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Notification for `scheduled` event displays the `last run` button twice.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Tests pass

