### PR TITLE
tools: Add option for partial dep updates for hard-way package releases

### DIFF
--- a/tools/changelogger-release.sh
+++ b/tools/changelogger-release.sh
@@ -10,7 +10,7 @@ BASE=$(cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
 # Print help and exit.
 function usage {
 	cat <<-EOH
-		usage: $0 [-v] [-p] [-a|-b|-r <version>] <slug>
+		usage: $0 [-v] [-p] [-H] [-a|-b|-r <version>] <slug>
 
 		Prepare a release of the specified project and everything it depends on.
 		 - Run \`changelogger write\`
@@ -21,6 +21,7 @@ function usage {
 		Pass \`-a\` to prepare a developer release by passing \`--prerelease=a.N\` to changelogger.
 		Pass \`-b\` to prepare a beta release by passing \`--prerelease=beta\` to changelogger.
 		Pass \`-r <version>\` to prepare a release for a specific version number, passing \`--use-version=<version>\` to changelogger.
+		Pass \`-H\` if doing a hard-way package release on a plugin release branch.
 	EOH
 	exit 1
 }
@@ -33,7 +34,8 @@ fi
 VERBOSE=
 ADDPRNUM=
 ALPHABETA=
-while getopts ":vpabhr:" opt; do
+HARDWAY=
+while getopts ":vpabhHr:" opt; do
 	case ${opt} in
 		v)
 			if [[ -n "$VERBOSE" ]]; then
@@ -53,6 +55,9 @@ while getopts ":vpabhr:" opt; do
 			;;
 		r)
 			ALPHABETA=$OPTARG
+			;;
+		H)
+			HARDWAY=-H
 			;;
 		h)
 			usage
@@ -195,11 +200,11 @@ TEMP=$(mktemp "${TMPDIR%/}/changelogger-release-XXXXXXXX")
 
 for SLUG in "${SLUGS[@]}"; do
 	if [[ -n "${RELEASED[$SLUG]}" ]]; then
-		debug "  tools/check-intra-monorepo-deps.sh $VERBOSE -U $SLUG"
-		PACKAGE_VERSIONS_CACHE="$TEMP" tools/check-intra-monorepo-deps.sh $VERBOSE -U "$SLUG"
+		debug "  tools/check-intra-monorepo-deps.sh $VERBOSE $HARDWAY -U $SLUG"
+		PACKAGE_VERSIONS_CACHE="$TEMP" tools/check-intra-monorepo-deps.sh $VERBOSE $HARDWAY -U "$SLUG"
 	else
-		debug "  tools/check-intra-monorepo-deps.sh $VERBOSE -u $SLUG"
-		PACKAGE_VERSIONS_CACHE="$TEMP" tools/check-intra-monorepo-deps.sh $VERBOSE -u "$SLUG"
+		debug "  tools/check-intra-monorepo-deps.sh $VERBOSE $HARDWAY -u $SLUG"
+		PACKAGE_VERSIONS_CACHE="$TEMP" tools/check-intra-monorepo-deps.sh $VERBOSE $HARDWAY -u "$SLUG"
 	fi
 done
 

--- a/tools/fixup-project-versions.sh
+++ b/tools/fixup-project-versions.sh
@@ -10,23 +10,28 @@ BASE=$PWD
 # Print help and exit.
 function usage {
 	cat <<-EOH
-		usage: $0 [-v]
+		usage: $0 [-v] [-H]
 
 		Make sure that all package versions and intra-monorepo dependencies are
 		up to date.
 
 		Options:
 		 -v: Output debug information. Repeat to output additional information.
+		 -H: When on a release branch, skip updating the corresponding plugin.
 	EOH
 	exit 1
 }
 
 # Sets options.
 VERBOSE=
-while getopts ":vh" opt; do
+HARDWAY=
+while getopts ":vhH" opt; do
 	case ${opt} in
 		v)
 			VERBOSE="${VERBOSE:--}v"
+			;;
+		H)
+			HARDWAY="-H"
 			;;
 		h)
 			usage
@@ -47,4 +52,4 @@ info 'Checking project versions'
 tools/changelogger-validate-all.sh -f $VERBOSE
 
 info 'Checking intra-monorepo dependencies'
-tools/check-intra-monorepo-deps.sh -ua $VERBOSE
+tools/check-intra-monorepo-deps.sh -ua $VERBOSE $HARDWAY


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
When doing a "hard way" package release off of a plugin's release branch, we now need to add some extra steps to the process.

* When running `changelogger-release.sh`, we now have to pass it the `-H` option to avoid trying to update the release plugin.
* After doing the package releases, run `check-intra-monorepo-deps.sh -aU` to update the release plugin with the newly published packages.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1664833870945289/1664830256.239569-slack-C01U2KGS2PQ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check out ff86212a7175a73c58204665ad3c8531ced28f1c as a branch named something like "jetpack/branch-11.4-test".
* Cherry-pick this.
* For good measure, disable the "Push to mirror repos" job and "Inform Beta Download webhook" step in the Build workflow.
* Run `tools/changelogger-release.sh -p -H packages/search` to re-do the Search package 0.24.0 release. Commit and push.
* Check that the build artifact was correctly created, and the "Check plugin monorepo dep versions" test correctly failed.
  * [x] Build artifact at https://github.com/Automattic/jetpack/actions/runs/3183295989
  * [x] Expected fail at https://github.com/Automattic/jetpack/actions/runs/3183295986/jobs/5190345063#step:4:36
* Run `tools/check-intra-monorepo-deps.sh -aU` to update the plugin. Check that the resulting state is valid.