### PR TITLE
Admin: Improve logic for displaying backup link in menu

### DIFF
--- a/projects/plugins/jetpack/changelog/update-backup-ui-fix
+++ b/projects/plugins/jetpack/changelog/update-backup-ui-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Added a new method for displaying Backup link in the menu

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -924,7 +924,7 @@ class Jetpack {
 
 		Partner::init();
 		My_Jetpack_Initializer::init();
-		if ( $this->is_rewind_enabled() ) {
+		if ( $this->should_show_backup() ) {
 			Jetpack_Backup::initialize();
 		}
 
@@ -939,6 +939,31 @@ class Jetpack {
 		do_action( 'jetpack_loaded', $this );
 
 		add_filter( 'map_meta_cap', array( $this, 'jetpack_custom_caps' ), 1, 2 );
+	}
+
+	/**
+	 * Checks if Jetpack Backup is active or waiting credentials.
+	 * Will return true if the state of Backup is anything except "unavailable".
+	 *
+	 * @return bool|int|mixed
+	 */
+	public static function should_show_backup() {
+		// Backup is a paid feature, therefore requires a user-level connection.
+		if ( ! static::connection()->has_connected_owner() ) {
+			return false;
+		}
+		$backup_enabled = get_transient( 'jetpack_rewind_state' );
+		$recheck        = ( is_admin() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) && '0' === $backup_enabled;
+		if ( false === $backup_enabled || $recheck ) {
+			jetpack_require_lib( 'class.core-rest-api-endpoints' );
+			$backup_data    = (array) Jetpack_Core_Json_Api_Endpoints::rewind_data();
+			$backup_enabled = ( ! is_wp_error( $backup_data )
+				&& ! empty( $backup_data['state'] )
+				&& 'unavailable' !== $backup_data['state'] )
+				? 1
+				: 0;
+		}
+		return $backup_enabled;
 	}
 
 	/**

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -6555,7 +6555,7 @@ endif;
 			$rewind_data    = (array) Jetpack_Core_Json_Api_Endpoints::rewind_data();
 			$rewind_enabled = ( ! is_wp_error( $rewind_data )
 				&& ! empty( $rewind_data['state'] )
-				&& 'unavailable' !== $rewind_data['state'] )
+				&& 'active' === $rewind_data['state'] )
 				? 1
 				: 0;
 			set_transient( 'jetpack_rewind_enabled', $rewind_enabled, 10 * MINUTE_IN_SECONDS );


### PR DESCRIPTION
Reverted changes addid in #23532 as the jetpack_rewind_state needs to stay as is for sites that use VaultPress but have Jetpack Backup 
available.
Added a new method to make sure the backup link is showing up for sites that have burchased the Backup plan.

- Revert the rewind_enabled change
- Add method for checking if backup should show up in the menu
- Add changelog

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Undo using jetpack_rewind_state()
* Add should_show_backup()

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1664887720686599-slack-CS8UYNPEE

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Same as in #23532