### PR TITLE
VideoPress: allow empty video title on details update

### DIFF
--- a/projects/packages/videopress/changelog/fix-allow-empty-video-title
+++ b/projects/packages/videopress/changelog/fix-allow-empty-video-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Allows empty title value so it's possible to save empty fields from the frontend.

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
@@ -300,8 +300,9 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 			 * but as post_content, post_title and post_excerpt on the attachment's post object.
 			 * We need to update those fields here, too.
 			 */
-			$post_title = isset( $json_params['title'] ) ? sanitize_text_field( $json_params['title'] ) : null;
-			if ( $post_title ) {
+			$post_title = null;
+			if ( isset( $json_params['title'] ) ) {
+				$post_title = sanitize_text_field( $json_params['title'] );
 				wp_update_post(
 					array(
 						'ID'         => $post_id,
@@ -356,7 +357,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 					$should_update_meta           = true;
 				}
 
-				if ( isset( $post_title ) ) {
+				if ( isset( $json_params['title'] ) ) {
 					$meta['videopress']['title'] = $post_title;
 					$should_update_meta          = true;
 				}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26588.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Change the title value checks to allow empty values, but only when the field is really present on the request body; the current media library allows empty titles, so we are keeping the same decision here
* This is similar to #26564, but for the `title` field

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test on a site with at least one video
* Go to `Jetpack > Videopress` to see your VideoPress library
* Click the `Edit video details` button for some video
* Delete the title of the video and click `Save changes`
* Check the new (empty) title for the video both on the list and on the details page again

Reference:

https://user-images.githubusercontent.com/6760046/193883386-39e995e4-c0fd-44da-940b-70f9cf4fac73.mp4