### PR TITLE
VideoPress: Fix connection for VideoPress free

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-connection-flow
+++ b/projects/packages/videopress/changelog/fix-videopress-connection-flow
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: fix before releasing
+
+

--- a/projects/packages/videopress/src/client/admin/components/pricing-section/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/pricing-section/index.tsx
@@ -21,7 +21,12 @@ const PricingPage = () => {
 	const { siteSuffix, adminUri } = window.jetpackVideoPressInitialState;
 	const { siteProduct, product } = usePlan();
 	const { pricingForUi } = siteProduct;
-	const { handleRegisterSite, userIsConnecting } = useConnection( { redirectUri: adminUri } );
+	const { registrationNonce } = window.jetpackVideoPressInitialState;
+	const { handleRegisterSite, userIsConnecting } = useConnection( {
+		redirectUri: adminUri,
+		from: 'jetpack-videopress',
+		registrationNonce,
+	} );
 	const [ isConnecting, setIsConnection ] = useState( false );
 
 	const { run } = useProductCheckoutWorkflow( {


### PR DESCRIPTION
Fixes connection flow for free plan

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Passes down `registrationNonce` to `useConnection()`

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

None

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Attempt to connect for free
