### PR TITLE
VideoPress: fix redirect URL after purchasing product

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-fix-getting-videopress-product
+++ b/projects/packages/videopress/changelog/update-videopress-fix-getting-videopress-product
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: fix redirect URL after purchasing product

--- a/projects/packages/videopress/src/client/admin/components/pricing-section/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/pricing-section/index.tsx
@@ -18,16 +18,16 @@ import { useState } from 'react';
 import { usePlan } from '../../hooks/use-plan';
 
 const PricingPage = () => {
-	const { siteSuffix, adminUri } = window.jetpackVideoPressInitialState;
+	const { siteSuffix, adminUrl } = window.jetpackVideoPressInitialState;
 	const { siteProduct, product } = usePlan();
 	const { pricingForUi } = siteProduct;
-	const { handleRegisterSite, userIsConnecting } = useConnection( { redirectUri: adminUri } );
+	const { handleRegisterSite, userIsConnecting } = useConnection( { redirectUri: adminUrl } );
 	const [ isConnecting, setIsConnection ] = useState( false );
 
 	const { run } = useProductCheckoutWorkflow( {
 		siteSuffix,
 		productSlug: product.productSlug,
-		redirectUrl: adminUri,
+		redirectUrl: adminUrl,
 	} );
 
 	const pricingItems = siteProduct.features.map( feature => ( { name: feature } ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes the checkout flow, using the absolute path to define the URL to go back after purchasing the product.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: fix redirect URL after purchasing product 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Buy VideoPress product
* Confirm the browser redirect to the initial WordPress site

