### PR TITLE
VideoPress: Update uploaded videos count on videos fetch

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-videos-resolver
+++ b/projects/packages/videopress/changelog/update-videopress-videos-resolver
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Update video count on videos fetch

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -135,7 +135,7 @@ class Data {
 
 		return array(
 			'videos' => array(
-				'uploadedVideoCount'           => count( $videos ), // @todo: pick the total number properly
+				'uploadedVideoCount'           => $video_data['total'],
 				'items'                        => $videos,
 				'isFetching'                   => false,
 				'isFetchingUploadedVideoCount' => false,
@@ -143,7 +143,6 @@ class Data {
 					'totalPages' => $video_data['totalPages'],
 					'total'      => $video_data['total'],
 				),
-				'uploadedVideoCount'           => $video_data['total'],
 				'query'                        => $video_data['query'],
 				'_meta'                        => array(
 					'relyOnInitialState' => true,

--- a/projects/packages/videopress/src/client/state/resolvers.js
+++ b/projects/packages/videopress/src/client/state/resolvers.js
@@ -53,12 +53,12 @@ const getVideos = {
 			);
 
 			// pick the pagination data form response header...
-			const pagination = {
-				total: Number( response.headers.get( 'X-WP-Total' ) ),
-				totalPages: Number( response.headers.get( 'X-WP-TotalPages' ) ),
-			};
+			const total = Number( response.headers.get( 'X-WP-Total' ) );
+			const totalPages = Number( response.headers.get( 'X-WP-TotalPages' ) );
 
-			dispatch.setVideosPagination( pagination );
+			// Update pagination and total uploaded videos count.
+			dispatch.setVideosPagination( { total, totalPages } );
+			dispatch.setUploadedVideoCount( total );
 
 			// ... and the videos data from the response body.
 			const videos = await response.json();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Today, when we do a new fetch via `getVideos` resolver, we're not updating the upload video count.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Dispatch action to update uploaded videos count.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start `VideoPress`.
* Delete some video.
* Total video count should update.

