### PR TITLE
Search Dashboard: New plan usage components

### DIFF
--- a/projects/packages/search/changelog/add-new-section-components
+++ b/projects/packages/search/changelog/add-new-section-components
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Dashboard: Added first run and usage section components.

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -10,6 +10,8 @@ import ModuleControl from 'components/module-control';
 import RecordMeter from 'components/record-meter';
 import React from 'react';
 import { STORE_ID } from 'store';
+import FirstRunSection from './sections/first-run-section';
+import PlanUsageSection from './sections/plan-usage-section';
 import './dashboard-page.scss';
 
 /**
@@ -82,6 +84,8 @@ export default function DashboardPage( { isLoading = false } ) {
 						supportsInstantSearch={ supportsInstantSearch }
 						supportsOnlyClassicSearch={ supportsOnlyClassicSearch }
 					/>
+					<FirstRunSection isVisible={ true } />
+					<PlanUsageSection isVisible={ true } />
 					{ isNewPricing && <MockUsageMeter /> }
 					<RecordMeter
 						postCount={ postCount }

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -84,8 +84,8 @@ export default function DashboardPage( { isLoading = false } ) {
 						supportsInstantSearch={ supportsInstantSearch }
 						supportsOnlyClassicSearch={ supportsOnlyClassicSearch }
 					/>
-					<FirstRunSection isVisible={ true } />
-					<PlanUsageSection isVisible={ true } />
+					<FirstRunSection isVisible={ false } />
+					<PlanUsageSection isVisible={ false } />
 					{ isNewPricing && <MockUsageMeter /> }
 					<RecordMeter
 						postCount={ postCount }

--- a/projects/packages/search/src/dashboard/components/pages/sections/first-run-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/first-run-section.jsx
@@ -1,0 +1,83 @@
+import { IndeterminateProgressBar } from '@automattic/jetpack-components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import SimpleNotice from 'components/notice';
+import React from 'react';
+
+// import './first-run-section.scss';
+
+// TODO: Replace local PlanSummary component with new component when ready.
+const FirstRunSection = props => {
+	if ( ! props.isVisible ) {
+		return null;
+	}
+	return (
+		<div className="jp-search-dashboard-wrap jp-search-dashboard-meter-wrap">
+			<div className="jp-search-dashboard-row">
+				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
+				<div className="jp-search-dashboard-meter-wrap__content lg-col-span-8 md-col-span-6 sm-col-span-4">
+					<PlanSummary />
+					<ProgressWrapper siteTitle="YOUR-FUNNY-SITE" />
+					<NoticeWrapper />
+				</div>
+				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
+			</div>
+		</div>
+	);
+};
+
+const PlanSummary = () => {
+	return (
+		<h2>
+			{ createInterpolateElement(
+				sprintf(
+					// translators: %1$s: usage period, %2$s: plan name
+					__( 'Your usage <s>%1$s (%2$s)</s>', 'jetpack-search-pkg' ),
+					'Sep 28-Oct 28',
+					__( 'Free plan', 'jetpack-search-pkg' )
+				),
+				{
+					s: <span />,
+				}
+			) }
+		</h2>
+	);
+};
+
+const ProgressWrapper = props => {
+	return (
+		<div>
+			<h3>
+				{ sprintf(
+					// translators: %1$s: site name (not translated)
+					__( 'Indexing %1$s', 'jetpack-search-pkg' ),
+					props.siteTitle
+				) }
+			</h3>
+			<IndeterminateProgressBar />
+		</div>
+	);
+};
+
+const NoticeWrapper = () => {
+	const noticeBoxClassName = 'jp-search-notice-box';
+	const header = __( "We're gathering your usage data.", 'jetpack-search-pkg' );
+	const message = __(
+		'If you have recently set up Search, please allow a little time for indexing to complete.',
+		'jetpack-search-pkg'
+	);
+	return (
+		<SimpleNotice
+			isCompact={ false }
+			status={ 'is-info' }
+			className={ noticeBoxClassName }
+			icon={ 'info-outline' }
+			showDismiss={ false }
+		>
+			<h3 className="dops-notice__header">{ header }</h3>
+			<span className="dops-notice__body">{ message }</span>
+		</SimpleNotice>
+	);
+};
+
+export default FirstRunSection;

--- a/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
@@ -1,0 +1,76 @@
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import React from 'react';
+import DonutMeterContainer from '../../donut-meter-container';
+
+// import './plan-usage-section.scss';
+
+// TODO: Replace local PlanSummary component with new component when ready.
+const PlanUsageSection = props => {
+	if ( ! props.isVisible ) {
+		return null;
+	}
+	return (
+		<div className="jp-search-dashboard-wrap jp-search-dashboard-meter-wrap">
+			<div className="jp-search-dashboard-row">
+				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
+				<div className="jp-search-dashboard-meter-wrap__content lg-col-span-8 md-col-span-6 sm-col-span-4">
+					<PlanSummary />
+					<UsageMeters />
+					<UsageMetersAbout />
+				</div>
+				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
+			</div>
+		</div>
+	);
+};
+
+const PlanSummary = () => {
+	return (
+		<h2>
+			{ createInterpolateElement(
+				sprintf(
+					// translators: %1$s: usage period, %2$s: plan name
+					__( 'Your usage <s>%1$s (%2$s)</s>', 'jetpack-search-pkg' ),
+					'Sep 28-Oct 28',
+					__( 'Free plan', 'jetpack-search-pkg' )
+				),
+				{
+					s: <span />,
+				}
+			) }
+		</h2>
+	);
+};
+
+const UsageMeters = () => {
+	return (
+		<div className="usage-meter-group">
+			<DonutMeterContainer
+				title={ __( 'Site records', 'jetpack-search-pkg' ) }
+				current={ 1250 }
+				limit={ 5000 }
+			/>
+			<DonutMeterContainer
+				title={ __( 'Search requests', 'jetpack-search-pkg' ) }
+				current={ 125 }
+				limit={ 500 }
+			/>
+		</div>
+	);
+};
+
+const UsageMetersAbout = () => {
+	return (
+		<div className="usage-meter-about">
+			{ createInterpolateElement(
+				__( 'Tell me more about <u>record indexing and request limits</u>', 'jetpack-search-pkg' ),
+				{
+					u: <u />,
+				}
+			) }
+		</div>
+	);
+};
+
+export default PlanUsageSection;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26637 & #26638.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Adds two new section components that compose UI for "first run" and "usage meters". They are hidden by default but can be toggled on via the React Dev Tools for testing.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1HpG7-hrJ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Visit the Jetpack Search dashboard.
2. Open the React Dev Tools in the Inspector.
3. Look for the FirstRunSection and PlanUsageSection in the component tree.
4. Toggle them on/off via the dev tools to test the layouts.

**Note:** Further CSS tweaks for layout/styling still to come. Not all props are wired up yet. To be addressed in follow-up PRs.