### PR TITLE
Social: Prevent upgrade links from opening in a new tab

### DIFF
--- a/projects/js-packages/components/changelog/change-add-new-tab-option-to-external-links
+++ b/projects/js-packages/components/changelog/change-add-new-tab-option-to-external-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Do not open upgrade links from Jetpack Social in a new tab

--- a/projects/js-packages/components/components/contextual-upgrade-trigger/README.md
+++ b/projects/js-packages/components/components/contextual-upgrade-trigger/README.md
@@ -71,3 +71,11 @@ URL to link to
 - Type: `String`
 - Default: `undefined`
 - Required: `false`
+
+### openInNewTab
+
+Indicate if the link should open in a new tab
+
+- Type: `Boolean`
+- Default: `false`
+- Required: `false`

--- a/projects/js-packages/components/components/contextual-upgrade-trigger/index.tsx
+++ b/projects/js-packages/components/components/contextual-upgrade-trigger/index.tsx
@@ -10,10 +10,12 @@ const ContextualUpgradeTrigger: React.FC< CutBaseProps > = ( {
 	cta,
 	onClick,
 	href,
+	openInNewTab = false,
 	className,
 } ) => {
 	const Tag = href !== undefined ? 'a' : 'button';
-	const tagProps = Tag === 'a' ? { href, target: '_blank' } : { onClick };
+	const tagProps =
+		Tag === 'a' ? { href, ...( openInNewTab ? { target: '_blank' } : {} ) } : { onClick };
 
 	return (
 		<div className={ classnames( styles.cut, className ) }>

--- a/projects/js-packages/components/components/contextual-upgrade-trigger/index.tsx
+++ b/projects/js-packages/components/components/contextual-upgrade-trigger/index.tsx
@@ -15,7 +15,7 @@ const ContextualUpgradeTrigger: React.FC< CutBaseProps > = ( {
 } ) => {
 	const Tag = href !== undefined ? 'a' : 'button';
 	const tagProps =
-		Tag === 'a' ? { href, ...( openInNewTab ? { target: '_blank' } : {} ) } : { onClick };
+		Tag === 'a' ? { href, ...( openInNewTab && { target: '_blank' } ) } : { onClick };
 
 	return (
 		<div className={ classnames( styles.cut, className ) }>

--- a/projects/js-packages/components/components/contextual-upgrade-trigger/types.ts
+++ b/projects/js-packages/components/components/contextual-upgrade-trigger/types.ts
@@ -3,5 +3,6 @@ export type CutBaseProps = {
 	cta: string;
 	className?: string;
 	href?: string;
+	openInNewTab?: boolean;
 	onClick?: () => void;
 };

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.22.0",
+	"version": "0.22.1-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/publicize-components/changelog/change-add-new-tab-option-to-external-links
+++ b/projects/js-packages/publicize-components/changelog/change-add-new-tab-option-to-external-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Do not open upgrade links from Jetpack Social in a new tab

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.7.1",
+	"version": "0.7.2-alpha",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/src/components/form/index.js
+++ b/projects/js-packages/publicize-components/src/components/form/index.js
@@ -9,7 +9,7 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { Connection as PublicizeConnection } from '@automattic/jetpack-publicize-components';
 import { getSiteFragment } from '@automattic/jetpack-shared-extension-utils';
-import { PanelRow, Disabled, ExternalLink } from '@wordpress/components';
+import { PanelRow, Disabled } from '@wordpress/components';
 import { Fragment, createInterpolateElement } from '@wordpress/element';
 import { _n, sprintf } from '@wordpress/i18n';
 import useSocialMediaConnections from '../../hooks/use-social-media-connections';
@@ -70,7 +70,7 @@ export default function PublicizeForm( {
 									),
 									{
 										upgradeLink: (
-											<ExternalLink
+											<a
 												href={ getRedirectUrl( 'jetpack-social-basic-plan-block-editor', {
 													site: getSiteFragment(),
 													query: 'redirect_to=' + window.location.href,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Upgrade links in Jetpack Social are opening in a new tab, and then redirecting back to the admin page after the upgrade process is complete, resulting in two tabs with the admin page open. This PR updates these links to no longer open in a new tab.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1664972742289299-slack-C02JJ910CNL

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Have Jetpack Social enabled (not Jetpack) and share limits enabled.
* Go to the Jetpack Social admin page.
* Make sure the upgrade nudge opens in the same tab.
* Go to the New Post screen and open the Jetpack Social sidebar panel.
* Click the Upgrade link in the notice and make sure it opens in the same tab.