### PR TITLE
VideoPress: add endpoint to fetch site data without relying on active Jetpack plugin

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-site-info-endpoint
+++ b/projects/packages/videopress/changelog/add-videopress-site-info-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Create new videopress/v1/site endpoint to fetch site data regardless of having the Jetpack plugin active on the target site.

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -14,6 +14,16 @@ use WP_REST_Request;
  * The Data class.
  */
 class Data {
+
+	/**
+	 * Gets the Jetpack blog ID
+	 *
+	 * @return int The blog ID
+	 */
+	public static function get_blog_id() {
+		return VideoPressToken::blog_id();
+	}
+
 	/**
 	 * Gets the video data
 	 *

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -119,6 +119,7 @@ class Initializer {
 		Jwt_Token_Bridge::init();
 		Uploader_Rest_Endpoints::init();
 		VideoPress_Rest_Api_V1_Stats::init();
+		VideoPress_Rest_Api_V1_Site::init();
 		XMLRPC::init();
 		self::register_oembed_providers();
 		if ( self::should_initialize_admin_ui() ) {

--- a/projects/packages/videopress/src/class-site.php
+++ b/projects/packages/videopress/src/class-site.php
@@ -26,8 +26,7 @@ class Site {
 			__( 'Could not fetch site information from the service', 'jetpack-videopress-pkg' )
 		);
 
-		$blog_id      = VideoPressToken::blog_id();
-		$request_path = sprintf( 'sites/%d?force=wpcom', $blog_id );
+		$request_path = sprintf( 'sites/%d?force=wpcom', Data::get_blog_id() );
 		$response     = Client::wpcom_json_api_request_as_blog( $request_path, '1.1', array(), null, 'rest' );
 
 		if ( is_wp_error( $response ) ) {

--- a/projects/packages/videopress/src/class-site.php
+++ b/projects/packages/videopress/src/class-site.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Provides site data sourced from WPCOM
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+use Automattic\Jetpack\Connection\Client;
+use WP_Error;
+
+/**
+ * Provides site data sourced from WPCOM
+ */
+class Site {
+
+	/**
+	 * Returns all the data provided by WPCOM for the site.
+	 *
+	 * @return int|WP_Error the total of plays for today, or WP_Error on failure.
+	 */
+	public static function get_site_info() {
+		$error = new WP_Error(
+			'videopress_site_error',
+			__( 'Could not fetch site information from the service', 'jetpack-videopress-pkg' )
+		);
+
+		$blog_id      = VideoPressToken::blog_id();
+		$request_path = sprintf( 'sites/%d?force=wpcom', $blog_id );
+		$response     = Client::wpcom_json_api_request_as_blog( $request_path, '1.1', array(), null, 'rest' );
+
+		if ( is_wp_error( $response ) ) {
+			return $error;
+		}
+
+		$response_code = wp_remote_retrieve_response_code( $response );
+		if ( 200 !== $response_code ) {
+			return $error;
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+
+		return json_decode( $body, true );
+	}
+}

--- a/projects/packages/videopress/src/class-videopress-rest-api-v1-site.php
+++ b/projects/packages/videopress/src/class-videopress-rest-api-v1-site.php
@@ -7,10 +7,6 @@
 
 namespace Automattic\Jetpack\VideoPress;
 
-use Automattic\Jetpack\Connection\Client;
-use WP_Error;
-use WP_REST_Response;
-
 /**
  * VideoPress rest api class for fetching site information
  */
@@ -56,25 +52,7 @@ class VideoPress_Rest_Api_V1_Site {
 	 * @return WP_Rest_Response The response object.
 	 */
 	public static function get_site_info() {
-		$error = new WP_Error(
-			'videopress_site_error',
-			__( 'Could not fetch site information from the service', 'jetpack-videopress-pkg' )
-		);
-
-		$blog_id      = VideoPressToken::blog_id();
-		$request_path = sprintf( 'sites/%d?force=wpcom', $blog_id );
-		$response     = Client::wpcom_json_api_request_as_blog( $request_path, '1.1', array(), null, 'rest' );
-
-		if ( is_wp_error( $response ) ) {
-			return $error;
-		}
-
-		$response_code = wp_remote_retrieve_response_code( $response );
-		if ( 200 !== $response_code ) {
-			return $error;
-		}
-
-		$body = wp_remote_retrieve_body( $response );
-		return rest_ensure_response( json_decode( $body, true ) );
+		$data = Site::get_site_info();
+		return rest_ensure_response( $data );
 	}
 }

--- a/projects/packages/videopress/src/class-videopress-rest-api-v1-site.php
+++ b/projects/packages/videopress/src/class-videopress-rest-api-v1-site.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * VideoPress Site Info Endpoint
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+use Automattic\Jetpack\Connection\Client;
+use WP_Error;
+use WP_REST_Response;
+
+/**
+ * VideoPress rest api class for fetching site information
+ */
+class VideoPress_Rest_Api_V1_Site {
+	/**
+	 * Initializes the endpoints
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'rest_api_init', array( static::class, 'register_rest_endpoints' ) );
+	}
+
+	/**
+	 * Register the REST API routes.
+	 *
+	 * @return void
+	 */
+	public static function register_rest_endpoints() {
+		register_rest_route(
+			'videopress/v1',
+			'site',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => static::class . '::get_site_info',
+				'permission_callback' => static::class . '::permissions_callback',
+			)
+		);
+	}
+
+	/**
+	 * Checks wether the user have permissions to see the site info
+	 *
+	 * @return boolean
+	 */
+	public static function permissions_callback() {
+		return current_user_can( 'read' ); // TODO: confirm this
+	}
+
+	/**
+	 * Returns all the site information usually provided by Jetpack, without relying on Jetpack
+	 *
+	 * @return WP_Rest_Response The response object.
+	 */
+	public static function get_site_info() {
+		$error = new WP_Error(
+			'videopress_site_error',
+			__( 'Could not fetch site information from the service', 'jetpack-videopress-pkg' )
+		);
+
+		$blog_id      = VideoPressToken::blog_id();
+		$request_path = sprintf( 'sites/%d?force=wpcom', $blog_id );
+		$response     = Client::wpcom_json_api_request_as_blog( $request_path, '1.1', array(), null, 'rest' );
+
+		if ( is_wp_error( $response ) ) {
+			return $error;
+		}
+
+		$response_code = wp_remote_retrieve_response_code( $response );
+		if ( 200 !== $response_code ) {
+			return $error;
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		return rest_ensure_response( json_decode( $body, true ) );
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Relates to #26511.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Create new `videopress/v1/site` endpoint to return site details from WPCOM API, adding a query parameter to overcome the cases where the Jetpack plugin is not active

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use a site with the VideoPress plugin installed
* Do a `GET` request to `yoursite.com/wp-json/videopress/v1/site`, for example:

```
curl -X GET -u "user:pass" http://yoursite.com/wp-json/videopress/v1/site | jq
```

* The expected response is similar to this:

```
{
    "ID": 20000000,
    "name": "Your site",
    "description": "Just another WordPress site",
    "URL": "http://yoursite.com",
    "user_can_manage": false,
    "capabilities": {
        // ...
    },
    "jetpack": false,
    "jetpack_connection": true,
    // ...
    "options": { 
        "timezone": "",
        "gmt_offset": 0,
        "blog_public": 0,
        // ...
        "software_version": "6.0.2",
        // ...
        "videopress_storage_used": 196.21,
        // ...
        "active_modules": [
            "videopress"
        ],
        // ...
        "jetpack_connection_active_plugins": [
            "jetpack-boost",
            "jetpack-videopress"
        ]
    },
    "plan": {
        // ...
    },
    "products": [
        // ...
    ],
    "zendesk_site_meta": {
        // ...
    },
    "meta": {
        // ...
    },
    "quota": {
        // ...
    },
    // ...
}
```

* **Experiment between activating and deactivating the Jetpack plugin:** the endpoint should work and structure of the response should be the same on both cases

Tips:

* If you are using a JN site for testing, you can use [this plugin](https://github.com/WP-API/Basic-Auth) to handle the API authentication