### PR TITLE
Search Dashboard: Conditional CUTs.

### DIFF
--- a/projects/packages/search/changelog/update-add-conditional-CUTs
+++ b/projects/packages/search/changelog/update-add-conditional-CUTs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Search Dashboard: Add support for conditional CUTs.

--- a/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
@@ -91,8 +91,8 @@ const CUTWrapper = props => {
 		// eslint-disable-next-line no-console
 		console.log( 'CUT clicked...' );
 	};
-	const messages = props.type !== undefined ? getCUTMessages()[ props.type ] : undefined;
-	const trigger = messages !== undefined ? { ...messages, onClick: callbackForwarder } : undefined;
+	const messages = props.type && getCUTMessages()[ props.type ];
+	const trigger = messages && { ...messages, onClick: callbackForwarder };
 	return (
 		<>
 			{ trigger && (

--- a/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
@@ -1,3 +1,4 @@
+import { ContextualUpgradeTrigger, ThemeProvider } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import React from 'react';
@@ -10,6 +11,8 @@ const PlanUsageSection = props => {
 	if ( ! props.isVisible ) {
 		return null;
 	}
+	// TODO: Add logic for plan limits.
+	const upgradeMessage = undefined;
 	return (
 		<div className="jp-search-dashboard-wrap jp-search-dashboard-meter-wrap">
 			<div className="jp-search-dashboard-row">
@@ -17,7 +20,8 @@ const PlanUsageSection = props => {
 				<div className="jp-search-dashboard-meter-wrap__content lg-col-span-8 md-col-span-6 sm-col-span-4">
 					<PlanSummary />
 					<UsageMeters />
-					<UsageMetersAbout />
+					<CUTWrapper type={ upgradeMessage } />
+					<AboutPlanLimits />
 				</div>
 				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
 			</div>
@@ -43,6 +47,63 @@ const PlanSummary = () => {
 	);
 };
 
+const getCUTMessages = () => {
+	const CUTMessages = {
+		records: {
+			description: __(
+				"You’re close to exceeding this plan's number of records.",
+				'jetpack-search-pkg'
+			),
+			cta: __(
+				'Upgrade now to increase your monthly records limit and to avoid interruption!',
+				'jetpack-search-pkg'
+			),
+		},
+		requests: {
+			description: __(
+				"You’re close to exceeding this plan's number of requests.",
+				'jetpack-search-pkg'
+			),
+			cta: __(
+				'Upgrade now to increase your monthly requests limit and to avoid interruption!',
+				'jetpack-search-pkg'
+			),
+		},
+		both: {
+			description: __(
+				'You’re close to exceeding the number of records and search requests available in the free plan.',
+				'jetpack-search-pkg'
+			),
+			cta: __(
+				'Upgrade now to increase your limits and to avoid interruption!',
+				'jetpack-search-pkg'
+			),
+		},
+	};
+	return CUTMessages;
+};
+
+const CUTWrapper = props => {
+	// TODO: Replace this callback with prop.
+	const callbackForwarder = event => {
+		event.preventDefault();
+		// callback();
+		// eslint-disable-next-line no-console
+		console.log( 'CUT clicked...' );
+	};
+	const messages = props.type !== undefined ? getCUTMessages()[ props.type ] : undefined;
+	const trigger = messages !== undefined ? { ...messages, onClick: callbackForwarder } : undefined;
+	return (
+		<>
+			{ trigger && (
+				<ThemeProvider>
+					<ContextualUpgradeTrigger { ...trigger } />
+				</ThemeProvider>
+			) }
+		</>
+	);
+};
+
 const UsageMeters = () => {
 	return (
 		<div className="usage-meter-group">
@@ -60,11 +121,11 @@ const UsageMeters = () => {
 	);
 };
 
-const UsageMetersAbout = () => {
+const AboutPlanLimits = () => {
 	return (
 		<div className="usage-meter-about">
 			{ createInterpolateElement(
-				__( 'Tell me more about <u>record indexing and request limits</u>', 'jetpack-search-pkg' ),
+				__( 'Tell me more about <u>record indexing and request limits</u>.', 'jetpack-search-pkg' ),
 				{
 					u: <u />,
 				}


### PR DESCRIPTION
Adds the localized upgrade triggers and a component for displaying one in the Plan Usage section.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26655.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Adds a `CUTWrapper` component that accepts an upgrade type and displays the appropriate localized UI.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1HpG7-hrJ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Visit the Jetpack Search dashboard.
2. Open the React Dev Tools in the Inspector.
3. Select the `PlanUsageSection` component and toggle visibility to `on`.
4. Update the `type` prop to see the various CUT messages displayed. Options are `records`, `requests`, or `both`.

**Note:** Callback currently just logs clicks to console. Integration with real data to be addressed in follow-up PRs.