### PR TITLE
Publicize: Show "Share this post" panel open if there are publicize connections enabled

### DIFF
--- a/projects/plugins/jetpack/changelog/update-social-panel-initial-open-behavior
+++ b/projects/plugins/jetpack/changelog/update-social-panel-initial-open-behavior
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Show Publicize pre-publish panel if the site has connections enabled

--- a/projects/plugins/jetpack/extensions/plugins/publicize/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/index.js
@@ -9,19 +9,22 @@
  */
 
 import { JetpackLogo } from '@automattic/jetpack-components';
-import { TwitterThreadListener } from '@automattic/jetpack-publicize-components';
+import {
+	TwitterThreadListener,
+	useSocialMediaConnections as useSelectSocialMediaConnections,
+} from '@automattic/jetpack-publicize-components';
 import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { PostTypeSupportCheck } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';
 import PublicizePanel from './components/panel';
-
 import './editor.scss';
 
 export const name = 'publicize';
 
-export const settings = {
-	render: () => (
+const PublicizeSettings = () => {
+	const { hasEnabledConnections } = useSelectSocialMediaConnections();
+	return (
 		<PostTypeSupportCheck supportKeys="publicize">
 			<TwitterThreadListener />
 
@@ -30,6 +33,7 @@ export const settings = {
 			</JetpackPluginSidebar>
 
 			<PluginPrePublishPanel
+				initialOpen={ hasEnabledConnections }
 				id="publicize-title"
 				title={
 					<span id="publicize-defaults" key="publicize-title-span">
@@ -41,5 +45,9 @@ export const settings = {
 				<PublicizePanel prePublish={ true } />
 			</PluginPrePublishPanel>
 		</PostTypeSupportCheck>
-	),
+	);
+};
+
+export const settings = {
+	render: PublicizeSettings,
 };

--- a/projects/plugins/jetpack/extensions/plugins/publicize/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/index.js
@@ -11,7 +11,7 @@
 import { JetpackLogo } from '@automattic/jetpack-components';
 import {
 	TwitterThreadListener,
-	useSocialMediaConnections as useSelectSocialMediaConnections,
+	useSocialMediaConnections,
 } from '@automattic/jetpack-publicize-components';
 import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { PostTypeSupportCheck } from '@wordpress/editor';
@@ -23,7 +23,7 @@ import './editor.scss';
 export const name = 'publicize';
 
 const PublicizeSettings = () => {
-	const { hasEnabledConnections } = useSelectSocialMediaConnections();
+	const { hasEnabledConnections } = useSocialMediaConnections();
 	return (
 		<PostTypeSupportCheck supportKeys="publicize">
 			<TwitterThreadListener />


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Sets `initialOpen={true}` if there are publicize connections enabled

#### After

<img width="301" alt="Screen Shot 2022-10-06 at 08 31 29" src="https://user-images.githubusercontent.com/746152/194303459-da77e273-5abd-4ad3-8299-2cd3b04c8e11.png">

#### Before

<img width="287" alt="Screen Shot 2022-10-06 at 08 28 48" src="https://user-images.githubusercontent.com/746152/194303465-0d6d374b-b0b3-4b63-903d-89c25130e660.png">

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Without a social connection: Attempt to publish a post and confirm the "Share this post" panel is closed
* Enable one connection: Attempt to publish a post and confirm the "Share this post" panel is open

