### PR TITLE
jetpack: Fix Jetpack_PostImages::get_image return value

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-Jetpack_PostImages-get_image-return-value
+++ b/projects/plugins/jetpack/changelog/fix-Jetpack_PostImages-get_image-return-value
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack_PostImages::get_image now returns null, not empty array, on failure to find an image.

--- a/projects/plugins/jetpack/class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/class.jetpack-post-images.php
@@ -593,10 +593,10 @@ class Jetpack_PostImages {
 	 *
 	 * @param int   $post_id Post ID.
 	 * @param array $args Other arguments (currently width and height required for images where possible to determine).
-	 * @return array containing details of the best image to be used
+	 * @return array|null containing details of the best image to be used, or null if no image is found.
 	 */
 	public static function get_image( $post_id, $args = array() ) {
-		$image = array();
+		$image = null;
 
 		/**
 		 * Fires before we find a single good image for a specific post.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Historically, the function has been declared as returning an array, but returned the empty string on failure to find an image.

In #26110 this was changed to return an empty array. Which mostly worked, but one caller was assuming that any array return was a success.

Let's change it to return null on failure instead. That will still work with most of the callers that check for `empty()`, as well as the one checking for a falsey value, as well as this one that checks for `is_array()`. Overall a null or false return probably makes more sense semantically too.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Fixes #26643

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try to reproduce #26643. Looks like you'll need the related posts feature active, with a related post not having any image.