### PR TITLE
jetpack: Fix wufoo shortcode output

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-wufoo-shortcode-printf
+++ b/projects/plugins/jetpack/changelog/fix-wufoo-shortcode-printf
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+shortcodes: Fix wufoo shortcode output

--- a/projects/plugins/jetpack/modules/shortcodes/wufoo.php
+++ b/projects/plugins/jetpack/modules/shortcodes/wufoo.php
@@ -94,7 +94,7 @@ function wufoo_shortcode( $atts ) {
 	 * iframe embed, loaded inside <noscript> tags.
 	 */
 	$iframe_embed = sprintf(
-		'<iframe height="%1$d" src="%2$s" allowTransparency="true" frameborder="0" scrolling="no" style="width:100%;border:none;">
+		'<iframe height="%1$d" src="%2$s" allowTransparency="true" frameborder="0" scrolling="no" style="width:100%%;border:none;">
 			<a href="%3$s" target="_blank" rel="noopener noreferrer">%4$s</a>
 		</iframe>',
 		absint( $attr['height'] ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
A format string being passed to printf contains "100%;". PHP <8 misinterprets this with a warning, generating broken values in a style attribute. PHP 8+ just fatals.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Fixes #26648

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try the shortcode?
