### PR TITLE
VideoPress: Provide the used storage space on the client initial state

### DIFF
--- a/projects/packages/videopress/changelog/add-storage-used-on-initial-state
+++ b/projects/packages/videopress/changelog/add-storage-used-on-initial-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Provide the used storage space on the initial state data, using the site information fetched from the WPCOM API.

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -143,12 +143,20 @@ class Data {
 			$video_data['videos']
 		);
 
+		$storage_used = 0;
+		$site_data    = Site::get_site_info();
+
+		if ( isset( $site_data['options'] ) && isset( $site_data['options']['videopress_storage_used'] ) ) {
+			$storage_used = $site_data['options']['videopress_storage_used'] * 1024 * 1024;
+		}
+
 		return array(
 			'videos' => array(
 				'uploadedVideoCount'           => $video_data['total'],
 				'items'                        => $videos,
 				'isFetching'                   => false,
 				'isFetchingUploadedVideoCount' => false,
+				'storageUsed'                  => $storage_used,
 				'pagination'                   => array(
 					'totalPages' => $video_data['totalPages'],
 					'total'      => $video_data['total'],

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -85,7 +85,7 @@ class Data {
 		$site_data = Site::get_site_info();
 
 		if ( isset( $site_data['options'] ) && isset( $site_data['options']['videopress_storage_used'] ) ) {
-			return $site_data['options']['videopress_storage_used'] * 1024 * 1024;
+			return intval( round( $site_data['options']['videopress_storage_used'] * 1024 * 1024 ) );
 		} else {
 			return 0;
 		}

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -158,15 +158,13 @@ class Data {
 			$video_data['videos']
 		);
 
-		$storage_used = self::get_storage_used();
-
 		return array(
 			'videos' => array(
 				'uploadedVideoCount'           => $video_data['total'],
 				'items'                        => $videos,
 				'isFetching'                   => false,
 				'isFetchingUploadedVideoCount' => false,
-				'storageUsed'                  => $storage_used,
+				'storageUsed'                  => self::get_storage_used(),
 				'pagination'                   => array(
 					'totalPages' => $video_data['totalPages'],
 					'total'      => $video_data['total'],

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -77,6 +77,21 @@ class Data {
 	}
 
 	/**
+	 * Gets the VideoPress used storage space in bytes
+	 *
+	 * @return int the used storage space
+	 */
+	public static function get_storage_used() {
+		$site_data = Site::get_site_info();
+
+		if ( isset( $site_data['options'] ) && isset( $site_data['options']['videopress_storage_used'] ) ) {
+			return $site_data['options']['videopress_storage_used'] * 1024 * 1024;
+		} else {
+			return 0;
+		}
+	}
+
+	/**
 	 * Return the initial state of the VideoPress app,
 	 * used to render initially the app in the frontend.
 	 *
@@ -143,12 +158,7 @@ class Data {
 			$video_data['videos']
 		);
 
-		$storage_used = 0;
-		$site_data    = Site::get_site_info();
-
-		if ( isset( $site_data['options'] ) && isset( $site_data['options']['videopress_storage_used'] ) ) {
-			$storage_used = $site_data['options']['videopress_storage_used'] * 1024 * 1024;
-		}
+		$storage_used = self::get_storage_used();
 
 		return array(
 			'videos' => array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Relates to #26511.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Use the `Site::get_site_info()` to determine the storage space in use and add it to array of initial state data as `storageUsed`

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a site with Jetpack VideoPress plugin installed, go to `Jetpack > VideoPress`
* On the development console, check the value for the `jetpackVideoPressInitialState.initialState.videos` variable
* You will see the new `storageUsed` property there:

![image](https://user-images.githubusercontent.com/6760046/194381858-6bc94337-6b10-4f3e-b2dc-1033f2f24aa5.png)

* Upload one video and refresh the page to check the value again; it should be higher after a new video
* Also, check if the storage meter at the top of the page is now showing some value for the usage (probably "0% of 1 TiB" instead of the prior "0% of 0B"):

![image](https://user-images.githubusercontent.com/6760046/194382188-16a36355-4c73-41fc-913e-ef27fa5dcd0b.png)

Alternativelly, you can:

* Run `jetpack docker wp shell`
* On the new shell that opens, run `Automattic\Jetpack\VideoPress\Admin_UI::initial_state()`
* You should be able to see the new parameter `storageUsed` under the `initialState` property
* Example:

```
[
    "initialState" => [
        "videos" => [
            "uploadedVideoCount" => 8,
            "items" => [
                // ...
            ],
            "isFetching" => false,
            "isFetchingUploadedVideoCount" => false,
            "storageUsed" => 205741096.96, <-- this is new
            "pagination" => [
                "totalPages" => 2,
                "total" => 8,
            ],
            "query" => [
                "order" => "desc",
                "orderBy" => "date",
                "itemsPerPage" => 6,
                "page" => 1,
                "type" => "video/videopress",
            ],
            "_meta" => [
                "relyOnInitialState" => true,
            ],
        ],
    ]
];
```