### PR TITLE
Add unit tests for recommendation onboardings

### DIFF
--- a/projects/plugins/jetpack/_inc/client/recommendations/summary/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/summary/index.jsx
@@ -82,7 +82,13 @@ const SummaryComponent = props => {
 				</h1>
 				{ summaryPrimarySections.map( ( { name, slugs } ) => (
 					<section key={ name } aria-labelledby={ `primary-onboarding-${ name }` }>
-						<h2 id={ `primary-onboarding-${ name }` }>Part of your { name } plan</h2>
+						<h2 id={ `primary-onboarding-${ name }` }>
+							{ sprintf(
+								/* translators: %s is the jetpack plan name */
+								__( 'Part of your %s plan', 'jetpack' ),
+								name
+							) }
+						</h2>
 						{ slugs.map( slug => (
 							<PrimarySummary key={ slug } slug={ slug } />
 						) ) }

--- a/projects/plugins/jetpack/_inc/client/recommendations/summary/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/summary/test/component.js
@@ -7,7 +7,7 @@ import {
 	PLAN_JETPACK_SEARCH,
 	PLAN_JETPACK_SECURITY_T1_MONTHLY,
 } from '../../../lib/plans/constants';
-import { getOnboardingNameByProductSlug } from '../../onboarding-utils';
+import { getOnboardingNameByProductSlug } from '../../../state/recommendations/onboarding-utils';
 import { Summary as SummaryFeature } from '../index';
 import { buildInitialState } from './fixtures';
 

--- a/projects/plugins/jetpack/_inc/client/recommendations/summary/test/fixtures.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/summary/test/fixtures.js
@@ -17,14 +17,20 @@ function rewindFixture( rewindStatus ) {
  *
  * @param {object} options - Options
  * @param {string} options.productSlug - – product slug of the site's plan
+ * @param {Array} options.sitePurchases - mocked site purchases
  * @returns {object} Fixture.
  */
-function siteDataFixture( { productSlug } ) {
+function siteDataFixture( { productSlug, sitePurchases } ) {
 	return {
 		requests: {
+			isFetchingSiteData: false,
+			isFetchingSiteFeatures: false,
+			isFetchingSitePlans: false,
+			isFetchingSitePurchases: false,
 			isFetchingSiteDiscount: false,
 		},
 		data: {
+			sitePurchases,
 			plan: {
 				product_slug: productSlug,
 			},
@@ -105,6 +111,9 @@ function upsellFixture( { hideUpsell } ) {
  * @param {object} options.rewindStatus - – rewind status of the site
  * @param {object} options.enabledRecommendations - Enabled recommendations.
  * @param {object} options.skippedRecommendations - Skipped recommendations.
+ * @param {string} options.onboardingActive - Active onboarding name.
+ * @param {Array} options.onboardingViewed - Viewed onboarding names.
+ * @param {Array} options.sitePurchases - Mocked Site Purchases.
  * @returns {object} – initial Redux state
  */
 export function buildInitialState( {
@@ -113,6 +122,9 @@ export function buildInitialState( {
 	hideUpsell = false,
 	productSlug,
 	rewindStatus = { state: 'unavailable' },
+	onboardingActive = null,
+	onboardingViewed = [],
+	sitePurchases = [],
 } = {} ) {
 	return {
 		jetpack: {
@@ -142,17 +154,21 @@ export function buildInitialState( {
 			},
 			recommendations: {
 				upsell: upsellFixture( { hideUpsell } ),
-				requests: {},
+				requests: {
+					isRecommendationsDataLoaded: true,
+				},
 				data: {
+					onboardingActive,
+					onboardingViewed,
 					skippedRecommendations,
 				},
 				installing: {},
 			},
 			rewind: rewindFixture( rewindStatus ),
 			settings: {
-				items: enabledRecommendations,
+				items: { foo: 'bar', ...enabledRecommendations },
 			},
-			siteData: siteDataFixture( { productSlug } ),
+			siteData: siteDataFixture( { productSlug, sitePurchases } ),
 			introOffers: introOffersFixture(),
 		},
 	};

--- a/projects/plugins/jetpack/_inc/client/state/recommendations/onboarding-utils.ts
+++ b/projects/plugins/jetpack/_inc/client/state/recommendations/onboarding-utils.ts
@@ -1,4 +1,4 @@
-import { ONBOARDING_NAME_BY_PRODUCT_SLUG, ONBOARDING_ORDER } from './constants';
+import { ONBOARDING_NAME_BY_PRODUCT_SLUG, ONBOARDING_ORDER } from '../../recommendations/constants';
 
 /**
  * Function to get an onboarding for the specific product

--- a/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
@@ -19,10 +19,6 @@ import {
 	RECOMMENDATION_WIZARD_STEP,
 	ONBOARDING_SUPPORT_START_TIMESTAMP,
 } from 'recommendations/constants';
-import {
-	sortByOnboardingPriority,
-	getOnboardingNameByProductSlug,
-} from 'recommendations/onboarding-utils';
 import { combineReducers } from 'redux';
 import {
 	JETPACK_RECOMMENDATIONS_DATA_ADD_SELECTED_RECOMMENDATION,
@@ -65,6 +61,7 @@ import {
 	hasActiveBackupPurchase,
 } from 'state/site';
 import { isPluginActive } from 'state/site/plugins';
+import { sortByOnboardingPriority, getOnboardingNameByProductSlug } from './onboarding-utils';
 
 const mergeArrays = ( x, y ) => {
 	if ( Array.isArray( x ) && Array.isArray( y ) ) {
@@ -612,10 +609,10 @@ const getNextEligibleStep = ( state, step ) => {
 const getStepsForOnboarding = onboarding =>
 	Object.keys( get( stepToNextStepByPath, `onboarding.${ onboarding }`, {} ) );
 
-const getInitialStepForOnboarding = onboarding => getStepsForOnboarding( onboarding )[ 0 ];
+export const getInitialStepForOnboarding = onboarding => getStepsForOnboarding( onboarding )[ 0 ];
 
 // Gets the step to show when one has not been set in the state yet.
-const getInitialStep = state => {
+export const getInitialStep = state => {
 	// Gets new recommendations from initial state.
 	const newRecommendations = getNewRecommendations( state );
 	const initialStep = getInitialRecommendationsStep( state );
@@ -748,7 +745,7 @@ const isFeatureEligibleToShowInSummary = ( state, slug ) => {
 	}
 };
 
-const isOnboardingEligibleToShowInSummary = ( state, onboardingName ) => {
+export const isOnboardingEligibleToShowInSummary = ( state, onboardingName ) => {
 	const onboardingData = getOnboardingData( state );
 	const viewedOnboardings = onboardingData ? onboardingData.viewed : [];
 

--- a/projects/plugins/jetpack/_inc/client/state/recommendations/test/onboarding-utils.js
+++ b/projects/plugins/jetpack/_inc/client/state/recommendations/test/onboarding-utils.js
@@ -1,0 +1,36 @@
+import { PLAN_JETPACK_ANTI_SPAM } from '../../../lib/plans/constants';
+import {
+	ONBOARDING_JETPACK_ANTI_SPAM,
+	ONBOARDING_JETPACK_BACKUP,
+	ONBOARDING_JETPACK_COMPLETE,
+} from '../../../recommendations/constants';
+import { getOnboardingNameByProductSlug, sortByOnboardingPriority } from '../onboarding-utils';
+
+describe( 'Onboarding Utils', () => {
+	describe( 'getOnboardingNameByProductSlug()', () => {
+		it( 'Returns onboarding name for specific product slug', () => {
+			const onboardingName = getOnboardingNameByProductSlug( PLAN_JETPACK_ANTI_SPAM );
+			expect( onboardingName ).toBe( ONBOARDING_JETPACK_ANTI_SPAM );
+		} );
+
+		it( 'Returns null when no related onboarding name is found for given product slug', () => {
+			const onboardingName = getOnboardingNameByProductSlug( 'FOOBAR' );
+			expect( onboardingName ).toBeNull();
+		} );
+	} );
+
+	describe( 'sortByOnboardingPriority()', () => {
+		it( 'Puts the most important onboarding on the first position (sorts descending)', () => {
+			const mostImportantOnboarding = ONBOARDING_JETPACK_COMPLETE;
+			const intialOnboardings = [
+				ONBOARDING_JETPACK_ANTI_SPAM,
+				ONBOARDING_JETPACK_BACKUP,
+				mostImportantOnboarding,
+			];
+
+			const sortedOnboardings = intialOnboardings.sort( sortByOnboardingPriority );
+
+			expect( sortedOnboardings[ 0 ] ).toBe( mostImportantOnboarding );
+		} );
+	} );
+} );

--- a/projects/plugins/jetpack/_inc/client/state/recommendations/test/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/recommendations/test/reducer.js
@@ -1,0 +1,265 @@
+import {
+	PLAN_JETPACK_ANTI_SPAM,
+	PLAN_JETPACK_COMPLETE,
+	PLAN_JETPACK_SECURITY_DAILY,
+} from '../../../lib/plans/constants';
+import {
+	ONBOARDING_JETPACK_ANTI_SPAM,
+	ONBOARDING_JETPACK_COMPLETE,
+	ONBOARDING_JETPACK_SECURITY,
+} from '../../../recommendations/constants';
+import { getOnboardingNameByProductSlug } from '../onboarding-utils';
+import {
+	getInitialStep,
+	getInitialStepForOnboarding,
+	getOnboardingData,
+	isOnboardingEligibleToShowInSummary,
+} from '../reducer';
+
+const defaultOnboardingData = { active: null, viewed: [], hasStarted: false };
+const mockEligiblePurchase = product_slug => ( {
+	product_slug,
+	active: '1',
+	subscribed_date: new Date( 2022, 9, 1 ), // 2022-10-01
+} );
+
+const mockNonEligiblePurchase = product_slug => ( {
+	product_slug,
+	active: null,
+	subscribed_date: new Date( 2022, 5, 1 ), // 2022-6-01
+} );
+
+const getMockedState = ( {
+	fetchingInProgress = false,
+	onboarding = defaultOnboardingData,
+	sitePurchases = [],
+	initialStep = undefined,
+	viewedRecommendations = [],
+} ) => ( {
+	jetpack: {
+		initialState: {
+			recommendationsStep: initialStep,
+		},
+		siteData: {
+			requests: {
+				isFetchingSiteData: fetchingInProgress,
+				isFetchingSiteFeatures: fetchingInProgress,
+				isFetchingSitePlans: fetchingInProgress,
+				isFetchingSitePurchases: fetchingInProgress,
+			},
+			data: {
+				sitePurchases,
+			},
+		},
+		recommendations: {
+			requests: {
+				isRecommendationsDataLoaded: ! fetchingInProgress,
+			},
+			data: {
+				onboardingActive: onboarding.active,
+				onboardingViewed: onboarding.viewed,
+				onboardingHasStarted: onboarding.hasStarted,
+				viewedRecommendations,
+			},
+		},
+	},
+} );
+
+describe( 'Recommendations reducer', () => {
+	describe( 'getOnboardingData()', () => {
+		it( 'Returns null when fetching is in progress', () => {
+			const mockedState = getMockedState( { fetchingInProgress: true } );
+
+			expect( getOnboardingData( mockedState ) ).toBeNull();
+		} );
+
+		it( 'Returns current state if onboarding is active', () => {
+			const mockedOnboardingData = {
+				...defaultOnboardingData,
+				active: ONBOARDING_JETPACK_ANTI_SPAM,
+			};
+			const mockedState = getMockedState( {
+				onboarding: mockedOnboardingData,
+			} );
+
+			const result = getOnboardingData( mockedState );
+			expect( result ).toMatchObject( mockedOnboardingData );
+		} );
+
+		it( 'Sets onboarding as active if one is eligible', () => {
+			const mockedPurchases = [ mockEligiblePurchase( PLAN_JETPACK_ANTI_SPAM ) ];
+			const mockedState = getMockedState( {
+				sitePurchases: mockedPurchases,
+			} );
+
+			const result = getOnboardingData( mockedState );
+			expect( result ).toMatchObject( {
+				active: getOnboardingNameByProductSlug( PLAN_JETPACK_ANTI_SPAM ),
+				viewed: [ getOnboardingNameByProductSlug( PLAN_JETPACK_ANTI_SPAM ) ],
+				hasStarted: false,
+			} );
+		} );
+
+		it( 'Returns current state if no onboarding is eligible to activate', () => {
+			const mockedOnboardingData = defaultOnboardingData;
+			const mockedPurchases = [ mockNonEligiblePurchase( PLAN_JETPACK_ANTI_SPAM ) ];
+			const mockedState = getMockedState( {
+				onboarding: mockedOnboardingData,
+				sitePurchases: mockedPurchases,
+			} );
+
+			const result = getOnboardingData( mockedState );
+			expect( result ).toMatchObject( mockedOnboardingData );
+		} );
+
+		it( 'Does not activate onboarding if it was already viewed', () => {
+			const mockedOnboardingData = {
+				...defaultOnboardingData,
+				viewed: [ ONBOARDING_JETPACK_ANTI_SPAM ],
+			};
+			const mockedPurchases = [ mockEligiblePurchase( PLAN_JETPACK_ANTI_SPAM ) ];
+			const mockedState = getMockedState( {
+				onboarding: mockedOnboardingData,
+				sitePurchases: mockedPurchases,
+			} );
+
+			const result = getOnboardingData( mockedState );
+			expect( result.active ).toBeNull();
+		} );
+
+		it( 'Does not return onboarding as viewed when purchase is not eligible anymore', () => {
+			const mockedOnboardingData = {
+				...defaultOnboardingData,
+				viewed: [ ONBOARDING_JETPACK_ANTI_SPAM ],
+			};
+			const mockedPurchases = [ mockNonEligiblePurchase( PLAN_JETPACK_ANTI_SPAM ) ];
+			const mockedState = getMockedState( {
+				onboarding: mockedOnboardingData,
+				sitePurchases: mockedPurchases,
+			} );
+
+			const result = getOnboardingData( mockedState );
+			expect( result.viewed ).toHaveLength( 0 );
+		} );
+	} );
+	describe( 'isOnboardingEligibleToShowInSummary()', () => {
+		it( 'Returns true if onboarding was viewed', () => {
+			const mockedState = getMockedState( {
+				onboarding: {
+					...defaultOnboardingData,
+					viewed: [ ONBOARDING_JETPACK_ANTI_SPAM ],
+				},
+				sitePurchases: [ mockEligiblePurchase( PLAN_JETPACK_ANTI_SPAM ) ],
+			} );
+
+			const result = isOnboardingEligibleToShowInSummary(
+				mockedState,
+				ONBOARDING_JETPACK_ANTI_SPAM
+			);
+
+			expect( result ).toBe( true );
+		} );
+
+		it( 'Returns false if onboarding was not viewed', () => {
+			const mockedState = getMockedState( {} );
+
+			const result = isOnboardingEligibleToShowInSummary(
+				mockedState,
+				ONBOARDING_JETPACK_ANTI_SPAM
+			);
+
+			expect( result ).toBe( false );
+		} );
+
+		it( 'Returns false when Complete onboarding is viewed (for VideoPress, Search, Security)', () => {
+			const mockedState = getMockedState( {
+				onboarding: {
+					...defaultOnboardingData,
+					viewed: [ ONBOARDING_JETPACK_COMPLETE, ONBOARDING_JETPACK_SECURITY ],
+				},
+				sitePurchases: [
+					mockEligiblePurchase( PLAN_JETPACK_COMPLETE, PLAN_JETPACK_SECURITY_DAILY ),
+				],
+			} );
+
+			const result = isOnboardingEligibleToShowInSummary(
+				mockedState,
+				ONBOARDING_JETPACK_SECURITY
+			);
+
+			expect( result ).toBe( false );
+		} );
+
+		it( 'Returns false when Complete or Security onboarding is viewed (for Backup, Anti-Spam, Scan)', () => {
+			const mockedState = getMockedState( {
+				onboarding: {
+					...defaultOnboardingData,
+					viewed: [ ONBOARDING_JETPACK_SECURITY ],
+				},
+				sitePurchases: [
+					mockEligiblePurchase( PLAN_JETPACK_SECURITY_DAILY, PLAN_JETPACK_ANTI_SPAM ),
+				],
+			} );
+
+			const result = isOnboardingEligibleToShowInSummary(
+				mockedState,
+				ONBOARDING_JETPACK_ANTI_SPAM
+			);
+
+			expect( result ).toBe( false );
+		} );
+	} );
+
+	describe( 'getInitialStep()', () => {
+		it( 'Redirects to site-type question when not viewed and in summary', () => {
+			const mockedState = getMockedState( {
+				initialStep: 'summary',
+			} );
+
+			const result = getInitialStep( mockedState );
+
+			expect( result ).toBe( 'site-type-question' );
+		} );
+
+		it( 'Returns initialStep when site-type question was viewed and onboarding finished', () => {
+			const mockedState = getMockedState( {
+				initialStep: 'foobar',
+				viewedRecommendations: [ 'foobar' ],
+			} );
+
+			const result = getInitialStep( mockedState );
+
+			expect( result ).toBe( 'foobar' );
+		} );
+
+		it( 'Returns first step for onboarding when active but not started', () => {
+			const mockedState = getMockedState( {
+				initialStep: 'foobar',
+				onboarding: {
+					...defaultOnboardingData,
+					active: ONBOARDING_JETPACK_ANTI_SPAM,
+				},
+				viewedRecommendations: [ 'foobar' ],
+			} );
+
+			const result = getInitialStep( mockedState );
+			expect( result ).toBe( getInitialStepForOnboarding( ONBOARDING_JETPACK_ANTI_SPAM ) );
+		} );
+
+		it( 'Returns initialStep when onboarding has started', () => {
+			const mockedState = getMockedState( {
+				initialStep: 'foobar',
+				onboarding: {
+					...defaultOnboardingData,
+					active: ONBOARDING_JETPACK_ANTI_SPAM,
+					hasStarted: true,
+				},
+				viewedRecommendations: [ 'foobar' ],
+			} );
+
+			const result = getInitialStep( mockedState );
+
+			expect( result ).toBe( 'foobar' );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR adds unit tests supporting the functionality of post-purchase recommendation onboardings (#26484)

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### For more information visit related PR
#26484
