### PR TITLE
VideoPress: Use new site info endpoint on client

### DIFF
--- a/projects/packages/videopress/changelog/fix-update-site-info-endpoint-on-client
+++ b/projects/packages/videopress/changelog/fix-update-site-info-endpoint-on-client
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Change the endpoint used by the client to fetch the site information, so we request the storage usage from the new VideoPress-specific endpoint.

--- a/projects/packages/videopress/src/client/state/constants.js
+++ b/projects/packages/videopress/src/client/state/constants.js
@@ -10,6 +10,7 @@ export const WP_ADMIN_AJAX_API_URL = '/wp-admin/admin-ajax.php';
 export const WP_REST_API_MEDIA_ENDPOINT = 'wp/v2/media';
 export const WP_REST_API_VIDEOPRESS_META_ENDPOINT = 'wpcom/v2/videopress/meta';
 export const REST_API_SITE_PURCHASES_ENDPOINT = 'my-jetpack/v1/site/purchases';
+export const REST_API_SITE_INFO_ENDPOINT = 'videopress/v1/site';
 
 /*
  * Actions

--- a/projects/packages/videopress/src/client/state/resolvers.js
+++ b/projects/packages/videopress/src/client/state/resolvers.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import restApi from '@automattic/jetpack-api';
 import { CONNECTION_STORE_ID } from '@automattic/jetpack-connection';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
@@ -13,11 +12,12 @@ import {
 	WP_REST_API_MEDIA_ENDPOINT,
 	DELETE_VIDEO,
 	REST_API_SITE_PURCHASES_ENDPOINT,
+	REST_API_SITE_INFO_ENDPOINT,
 } from './constants';
 import { getDefaultQuery } from './reducers';
 import { mapVideoFromWPV2MediaEndpoint, mapVideosFromWPV2MediaEndpoint } from './utils/map-videos';
 
-const { apiNonce, apiRoot } = window?.jetpackVideoPressInitialState || {};
+const { apiRoot } = window?.jetpackVideoPressInitialState || {};
 
 const getVideos = {
 	isFulfilled: state => {
@@ -158,10 +158,8 @@ const getStorageUsed = {
 	},
 
 	fulfill: () => async ( { dispatch } ) => {
-		restApi.setApiRoot( apiRoot );
-		restApi.setApiNonce( apiNonce );
 		try {
-			const response = await restApi.fetchSiteData();
+			const response = await apiFetch( { path: REST_API_SITE_INFO_ENDPOINT } );
 			if ( ! response?.options?.videopress_storage_used ) {
 				return;
 			}

--- a/projects/packages/videopress/src/client/state/resolvers.js
+++ b/projects/packages/videopress/src/client/state/resolvers.js
@@ -169,7 +169,7 @@ const getStorageUsed = {
 			 * Let's compute the value in bytes.
 			 */
 			const storageUsed = response.options.videopress_storage_used
-				? Number( response.options.videopress_storage_used ) * 1024 * 1024
+				? Math.round( Number( response.options.videopress_storage_used ) * 1024 * 1024 )
 				: 0;
 
 			dispatch.setVideosStorageUsed( storageUsed );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Relates to #26511

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update the endpoint used by the client to fetch site information, moving away from the Jetpack-dependent `jetpack/v4/site` in favor of the new, Jetpack-independent `videopress/v1/site`
* This endpoint is used to fetch the storage usage information that will be displayed on the storage meter component

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test on a site whitout the Jetpack plugin
* If the site does not have any videos, add one or two
* Go to `Jetpack > VideoPress`
* Confirm that there is no requests to a `/site` endpoint (the first load of the page brings the site information from the backend):

![image](https://user-images.githubusercontent.com/6760046/194432067-718c8f0e-6af7-4689-b596-0f4d4e23458a.png)

* Type something in the search box or use the pagination to trigger a refresh of the storage usage data (this may be odd but it's the only actions that are triggering the new load by now; we may need to check if this should not be triggered by adding or removing videos)
* Notice on the console that a request to `/site` is made:

![image](https://user-images.githubusercontent.com/6760046/194432667-765a2ef1-83da-4c87-bc77-d3e2d3a0d7d3.png)

* Confirm that the endpoint requested is `videopress/v1/site` instead of `jetpack/v4/site`:

![image](https://user-images.githubusercontent.com/6760046/194432810-7e6129b7-cf27-450a-b021-88a3cf416a1e.png)