### PR TITLE
Update/videopress check storage is wp error

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-check-storage-is-wp-error
+++ b/projects/packages/videopress/changelog/update-videopress-check-storage-is-wp-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: check whether the $site_data is a WP_Error instance before to het the storage used data

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -83,6 +83,9 @@ class Data {
 	 */
 	public static function get_storage_used() {
 		$site_data = Site::get_site_info();
+		if ( is_wp_error( $site_data ) ) {
+			return 0;
+		}
 
 		if ( isset( $site_data['options'] ) && isset( $site_data['options']['videopress_storage_used'] ) ) {
 			return intval( round( $site_data['options']['videopress_storage_used'] * 1024 * 1024 ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes a fatal when trying to pick storage used from the `/sites/$site` response body. However, if the request fails, the `$site_data` will be a WP_Error() instamce:

![image](https://user-images.githubusercontent.com/77539/194408252-661d066b-8fc0-434f-ba19-8054aee2222c.png)


Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test the Fatal is fixed

