### PR TITLE
VideoPress: improve UI when loading video in the frame selector modal

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-avoid-modal-resize
+++ b/projects/packages/videopress/changelog/update-videopress-avoid-modal-resize
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: improve UI when loading video in the frame selector modal

--- a/projects/packages/videopress/src/client/admin/components/video-thumbnail-selector-modal/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-thumbnail-selector-modal/index.tsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
-import { Button, ThemeProvider } from '@automattic/jetpack-components';
+import { Button, ThemeProvider, useBreakpointMatch } from '@automattic/jetpack-components';
 import { Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 import { useState } from 'react';
 import { ReactNode } from 'react';
 /**
@@ -27,6 +28,7 @@ const VideoThumbnailSelectorModal = ( {
 	handleConfirmFrame,
 }: VideoThumbnailSelectorModalProps ) => {
 	const [ modalRef, setModalRef ] = useState< HTMLDivElement | null >( null );
+	const [ isSm ] = useBreakpointMatch( 'sm' );
 
 	return (
 		<Modal
@@ -35,7 +37,12 @@ const VideoThumbnailSelectorModal = ( {
 			isDismissible={ false }
 		>
 			<ThemeProvider targetDom={ modalRef }>
-				<div ref={ setModalRef } className={ styles.selector }>
+				<div
+					ref={ setModalRef }
+					className={ classnames( styles.selector, {
+						[ styles[ 'is-small' ] ]: isSm,
+					} ) }
+				>
 					<VideoFrameSelector
 						src={ url }
 						onVideoFrameSelected={ handleVideoFrameSelected }

--- a/projects/packages/videopress/src/client/admin/components/video-thumbnail-selector-modal/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/video-thumbnail-selector-modal/style.module.scss
@@ -1,5 +1,11 @@
 .selector {
-	max-width: 500px;
+	--video-thumbnail-selector-modal-thumbnail-width: 500px;
+
+	max-width: var( --video-thumbnail-selector-modal-thumbnail-width );
+
+	&:not( .is-small ) {
+		width: var( --video-thumbnail-selector-modal-thumbnail-width );
+	}
 
 	.actions {
 		display: flex;

--- a/projects/packages/videopress/src/client/components/video-frame-selector/index.jsx
+++ b/projects/packages/videopress/src/client/components/video-frame-selector/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { RangeControl } from '@wordpress/components';
+import { RangeControl, Spinner } from '@wordpress/components';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { Icon } from '@wordpress/icons';
 import classNames from 'classnames';
@@ -36,12 +36,17 @@ export const VideoPlayer = ( { src, setMaxDuration = null, currentTime } ) => {
 	};
 
 	return (
-		<video
-			ref={ videoPlayer }
-			muted
-			className={ styles.video }
-			onDurationChange={ onDurationChange }
-		/>
+		<div className={ styles[ 'video-player-wrapper' ] }>
+			<div className={ styles[ 'video-player-spinner-wrapper' ] }>
+				<Spinner className={ styles.spinner } />
+			</div>
+			<video
+				ref={ videoPlayer }
+				muted
+				className={ styles.video }
+				onDurationChange={ onDurationChange }
+			/>
+		</div>
 	);
 };
 

--- a/projects/packages/videopress/src/client/components/video-frame-selector/stories/index.jsx
+++ b/projects/packages/videopress/src/client/components/video-frame-selector/stories/index.jsx
@@ -1,4 +1,4 @@
-import VideoFrameSelector from '..';
+import VideoFrameSelector, { VideoPlayer as VideoPlayerComponent } from '..';
 
 export default {
 	title: 'Packages/VideoPress/Video Frame Selector',
@@ -19,5 +19,12 @@ const Template = args => <VideoFrameSelector { ...args } />;
 
 export const Default = Template.bind( {} );
 Default.args = {
+	src: 'https://videos.files.wordpress.com/PnQvSqdF/videopress-upload-demo-7.mp4',
+};
+
+const VideoPlayerTemplate = args => <VideoPlayerComponent { ...args } />;
+
+export const VideoPlayer = VideoPlayerTemplate.bind( {} );
+VideoPlayer.args = {
 	src: 'https://videos.files.wordpress.com/PnQvSqdF/videopress-upload-demo-7.mp4',
 };

--- a/projects/packages/videopress/src/client/components/video-frame-selector/style.module.scss
+++ b/projects/packages/videopress/src/client/components/video-frame-selector/style.module.scss
@@ -7,11 +7,33 @@
 	}
 }
 
+.video-player-wrapper {
+	position: relative;
+}
+
+.video-player-spinner-wrapper {
+	position: absolute;
+	z-index: 0;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+}
+.spinner {
+	transform: scale( 3 );
+}
+
 .video {
 	width: 100%;
 	object-fit: cover;
 	aspect-ratio: 16 / 9;
+	z-index: 1;
+	position: relative;
 }
+
 
 .play-icon {
 	width: 130px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/26678
Fixes https://github.com/Automattic/jetpack/issues/26497

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR improves the UI when loading the video in the frame selector modal

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to VideoPress dashboard
* Change video thumbnail by selecting a frame from video

**before**

https://user-images.githubusercontent.com/77539/194419212-8d26becf-ae00-44bb-8654-49340008ef20.mov

**after**

https://user-images.githubusercontent.com/77539/194419270-8a48a36a-8543-4f62-a24f-89e5e78d0682.mov

