### PR TITLE
VideoPress: Check connection before getting connected-only data

### DIFF
--- a/projects/packages/videopress/changelog/fix-check-connection-before-getting-connected-only-data
+++ b/projects/packages/videopress/changelog/fix-check-connection-before-getting-connected-only-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Wrap the request for connection-dependent initial state data around a connection check, so we only set it when there is actually an active connection.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26681.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Moved all the data requests that depends on an active connection to a dedicated method
* Wrapped the call for this data on a connection check

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You need to switch between connection states to test the changes
* Start with a brand new test site without a Jetpack connection and don't connect it yet
* Make sure that the Jetpack plugin is not active
* Go to `Jetpack > VideoPress`
* On the browser development console, check the contents for the `jetpackVideoPressInitialState.initialState.videos`
* It will not contain the `storageUsed` property:

![image](https://user-images.githubusercontent.com/6760046/194426666-0a733134-5b38-4639-a267-86154221d30c.png)

* Proceed with connecting the test site
* Go to `Jetpack > VideoPress` again
* Check the contents for the `jetpackVideoPressInitialState.initialState.videos` again
* Now it contains the `storageUsed` property, with 0 or another value depending on how many videos you have on the test site:

![image](https://user-images.githubusercontent.com/6760046/194427077-b343c7e4-e7ce-4039-b039-6a90f5d43e12.png)

* You can also check the initial state data running the WP debug shell with `jetpack docker wp shell` and then executing the `Automattic\Jetpack\VideoPress\Admin_UI::initial_state()` function