### PR TITLE
VideoPress: hide spinner in frame selector when video is loaded

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-frame-selector-modal-hide-spinner-when-video-loaded
+++ b/projects/packages/videopress/changelog/update-videopress-frame-selector-modal-hide-spinner-when-video-loaded
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: hide spinner in frame selector when video is loaded

--- a/projects/packages/videopress/src/client/components/video-frame-selector/index.jsx
+++ b/projects/packages/videopress/src/client/components/video-frame-selector/index.jsx
@@ -5,7 +5,6 @@ import { RangeControl, Spinner } from '@wordpress/components';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { Icon } from '@wordpress/icons';
 import classNames from 'classnames';
-import React from 'react';
 /**
  * Internal dependencies
  */
@@ -14,6 +13,7 @@ import styles from './style.module.scss';
 
 export const VideoPlayer = ( { src, setMaxDuration = null, currentTime } ) => {
 	const videoPlayer = useRef( null );
+	const [ isVideoLoading, setIsVideoLoading ] = useState( true );
 
 	useEffect( () => {
 		videoPlayer.current.src = src;
@@ -37,10 +37,13 @@ export const VideoPlayer = ( { src, setMaxDuration = null, currentTime } ) => {
 
 	return (
 		<div className={ styles[ 'video-player-wrapper' ] }>
-			<div className={ styles[ 'video-player-spinner-wrapper' ] }>
-				<Spinner className={ styles.spinner } />
-			</div>
+			{ isVideoLoading && (
+				<div className={ styles[ 'video-player-spinner-wrapper' ] }>
+					<Spinner className={ styles.spinner } />
+				</div>
+			) }
 			<video
+				onLoadedData={ () => setIsVideoLoading( false ) }
 				ref={ videoPlayer }
 				muted
 				className={ styles.video }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up of https://github.com/Automattic/jetpack/pull/26684
Addressing [this comment](https://github.com/Automattic/jetpack/pull/26684#discussion_r989526421):

> You could use [loadeddata](https://html.spec.whatwg.org/multipage/media.html#event-media-loadeddata) event o avoid rendering the spinner all time

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: hide spinner in frame selector when video is loaded

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard 
* Edit the video thumbnail by selecting a frame from the video
* Take a look at the DOM elements
* Confirm the Spinner element disappears once the video loads


<img width="1280" alt="Screen Shot 2022-10-06 at 21 23 51" src="https://user-images.githubusercontent.com/77539/194441361-06d4ddc0-12fd-4a65-8498-81f831225e91.png">



