### PR TITLE
Search Dashboard: Update variable names to avoid jargon.

### DIFF
--- a/projects/packages/search/changelog/update-better-variable-naming
+++ b/projects/packages/search/changelog/update-better-variable-naming
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Dashboard: Rename variables to avoid jargon.

--- a/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
@@ -12,7 +12,7 @@ const PlanUsageSection = props => {
 		return null;
 	}
 	// TODO: Add logic for plan limits.
-	const upgradeMessage = undefined;
+	const upgradeMessage = null;
 	return (
 		<div className="jp-search-dashboard-wrap jp-search-dashboard-meter-wrap">
 			<div className="jp-search-dashboard-row">
@@ -20,7 +20,7 @@ const PlanUsageSection = props => {
 				<div className="jp-search-dashboard-meter-wrap__content lg-col-span-8 md-col-span-6 sm-col-span-4">
 					<PlanSummary />
 					<UsageMeters />
-					<CUTWrapper type={ upgradeMessage } />
+					<UpgradeTrigger type={ upgradeMessage } />
 					<AboutPlanLimits />
 				</div>
 				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
@@ -47,8 +47,8 @@ const PlanSummary = () => {
 	);
 };
 
-const getCUTMessages = () => {
-	const CUTMessages = {
+const getUpgradeMessages = () => {
+	const upgradeMessages = {
 		records: {
 			description: __(
 				"You’re close to exceeding this plan's number of records.",
@@ -80,10 +80,10 @@ const getCUTMessages = () => {
 			),
 		},
 	};
-	return CUTMessages;
+	return upgradeMessages;
 };
 
-const CUTWrapper = props => {
+const UpgradeTrigger = props => {
 	// TODO: Replace this callback with prop.
 	const callbackForwarder = event => {
 		event.preventDefault();
@@ -91,13 +91,13 @@ const CUTWrapper = props => {
 		// eslint-disable-next-line no-console
 		console.log( 'CUT clicked...' );
 	};
-	const messages = props.type && getCUTMessages()[ props.type ];
-	const trigger = messages && { ...messages, onClick: callbackForwarder };
+	const upgradeMessage = props.type && getUpgradeMessages()[ props.type ];
+	const triggerData = upgradeMessage && { ...upgradeMessage, onClick: callbackForwarder };
 	return (
 		<>
-			{ trigger && (
+			{ triggerData && (
 				<ThemeProvider>
-					<ContextualUpgradeTrigger { ...trigger } />
+					<ContextualUpgradeTrigger { ...triggerData } />
 				</ThemeProvider>
 			) }
 		</>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Addresses feedback in #26656.

- Use `null` instead of `undefined` for placeholder variable.
- Rename `CUTWrapper` component to `UpgradeTrigger` for clarity.
- Update variable names for clarity.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

See above linked GH Issue.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
 
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Visit the Jetpack Search dashboard.
2. Open the React Dev Tools in the Inspector.
3. Select the `PlanUsageSection` component and toggle visibility to `on`.
4. Update the `type` prop to see the various CUT messages displayed. Options are `records`, `requests`, or `both`.

**Note:** Callback currently just logs clicks to console. Integration with real data to be addressed in follow-up PRs.