### PR TITLE
Search: Update UsageMeter with data from new pricing API

### DIFF
--- a/projects/packages/search/changelog/update-search_dashboard_plan_summary
+++ b/projects/packages/search/changelog/update-search_dashboard_plan_summary
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Apply tier and latest month usage to plan summary

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -144,6 +144,43 @@ export default function DashboardPage( { isLoading = false } ) {
 	);
 }
 
+const PlanSummary = () => {
+	const tierSlug = useSelect( select => select( STORE_ID ).getTierSlug() );
+	const latestMonthUsage = useSelect( select => select( STORE_ID ).getLatestMonthUsage() );
+
+	const startDate = new Date( latestMonthUsage.start_date );
+	const endDate = new Date( latestMonthUsage.end_date );
+
+	const localeOptions = {
+		month: 'short',
+		day: '2-digit',
+	};
+
+	// Leave the locale as `undefined` to apply the browser host locale.
+	const startDateText = startDate.toLocaleDateString( undefined, localeOptions );
+	const endDateText = endDate.toLocaleDateString( undefined, localeOptions );
+
+	const planText = tierSlug
+		? __( 'Paid Plan', 'jetpack-search-pkg' )
+		: __( 'Free Plan', 'jetpack-search-pkg' );
+
+	return (
+		<h2>
+			{ createInterpolateElement(
+				sprintf(
+					// translators: %1$s: usage period, %2$s: plan name
+					__( 'Your usage <s>%1$s (%2$s)</s>', 'jetpack-search-pkg' ),
+					`${ startDateText }-${ endDateText }`,
+					planText
+				),
+				{
+					s: <span />,
+				}
+			) }
+		</h2>
+	);
+};
+
 const MockUsageMeter = ( { sendPaidPlanToCart } ) => {
 	const upgradeTriggerArgs = {
 		description: __(
@@ -159,19 +196,7 @@ const MockUsageMeter = ( { sendPaidPlanToCart } ) => {
 			<div className="jp-search-dashboard-row">
 				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
 				<div className="jp-search-dashboard-meter-wrap__content lg-col-span-8 md-col-span-6 sm-col-span-4">
-					<h2>
-						{ createInterpolateElement(
-							sprintf(
-								// translators: %1$s: usage period, %2$s: plan name
-								__( 'Your usage <s>%1$s (%2$s)</s>', 'jetpack-search-pkg' ),
-								'Sep 28-Oct 28',
-								__( 'Free plan', 'jetpack-search-pkg' )
-							),
-							{
-								s: <span />,
-							}
-						) }
-					</h2>
+					<PlanSummary />
 					<div className="usage-meter-group">
 						<DonutMeterContainer
 							title={ __( 'Site records', 'jetpack-search-pkg' ) }

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -108,7 +108,7 @@ export default function DashboardPage( { isLoading = false } ) {
 					/>
 					<FirstRunSection isVisible={ false } />
 					<PlanUsageSection isVisible={ false } />
-					{ isNewPricing && <MockUsageMeter sendPaidPlanToCart={ sendPaidPlanToCart } /> }
+					{ isNewPricing && <UsageMeter sendPaidPlanToCart={ sendPaidPlanToCart } /> }
 					<RecordMeter
 						postCount={ postCount }
 						postTypeBreakdown={ postTypeBreakdown }
@@ -144,12 +144,11 @@ export default function DashboardPage( { isLoading = false } ) {
 	);
 }
 
-const PlanSummary = () => {
+const PlanSummary = ( { latestMonthRequests } ) => {
 	const tierSlug = useSelect( select => select( STORE_ID ).getTierSlug() );
-	const latestMonthUsage = useSelect( select => select( STORE_ID ).getLatestMonthUsage() );
 
-	const startDate = new Date( latestMonthUsage.start_date );
-	const endDate = new Date( latestMonthUsage.end_date );
+	const startDate = new Date( latestMonthRequests.start_date );
+	const endDate = new Date( latestMonthRequests.end_date );
 
 	const localeOptions = {
 		month: 'short',
@@ -182,7 +181,7 @@ const PlanSummary = () => {
 	);
 };
 
-const MockUsageMeter = ( { sendPaidPlanToCart } ) => {
+const UsageMeter = ( { sendPaidPlanToCart } ) => {
 	const upgradeTriggerArgs = {
 		description: __(
 			'Do you want to increase your site records and search requests?',
@@ -192,22 +191,26 @@ const MockUsageMeter = ( { sendPaidPlanToCart } ) => {
 		onClick: sendPaidPlanToCart,
 	};
 
+	const currentPlan = useSelect( select => select( STORE_ID ).getCurrentPlan() );
+	const currentUsage = useSelect( select => select( STORE_ID ).getCurrentUsage() );
+	const latestMonthRequests = useSelect( select => select( STORE_ID ).getLatestMonthRequests() );
+
 	return (
 		<div className="jp-search-dashboard-wrap jp-search-dashboard-meter-wrap">
 			<div className="jp-search-dashboard-row">
 				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
 				<div className="jp-search-dashboard-meter-wrap__content lg-col-span-8 md-col-span-6 sm-col-span-4">
-					<PlanSummary />
+					<PlanSummary latestMonthRequests={ latestMonthRequests } />
 					<div className="usage-meter-group">
 						<DonutMeterContainer
 							title={ __( 'Site records', 'jetpack-search-pkg' ) }
-							current={ 1250 }
-							limit={ 5000 }
+							current={ currentUsage.num_records }
+							limit={ currentPlan.record_limit }
 						/>
 						<DonutMeterContainer
 							title={ __( 'Search requests', 'jetpack-search-pkg' ) }
-							current={ 125 }
-							limit={ 500 }
+							current={ latestMonthRequests.num_requests }
+							limit={ currentPlan.monthly_search_request_limit }
 						/>
 					</div>
 

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -160,15 +160,16 @@ const PlanSummary = () => {
 	const startDateText = startDate.toLocaleDateString( undefined, localeOptions );
 	const endDateText = endDate.toLocaleDateString( undefined, localeOptions );
 
-	const planText = tierSlug
-		? __( 'Paid Plan', 'jetpack-search-pkg' )
-		: __( 'Free Plan', 'jetpack-search-pkg' );
+	let planText = __( 'Paid Plan', 'jetpack-search-pkg' );
+	if ( ! tierSlug ) {
+		planText = __( 'Free Plan', 'jetpack-search-pkg' );
+	}
 
 	return (
 		<h2>
 			{ createInterpolateElement(
 				sprintf(
-					// translators: %1$s: usage period, %2$s: plan name
+					// translators: %1$s: Usage period, %2$s: Plan name
 					__( 'Your usage <s>%1$s (%2$s)</s>', 'jetpack-search-pkg' ),
 					`${ startDateText }-${ endDateText }`,
 					planText

--- a/projects/packages/search/src/dashboard/scss/rna-styles.scss
+++ b/projects/packages/search/src/dashboard/scss/rna-styles.scss
@@ -25,7 +25,7 @@
 
 		& span {
 			color: $studio-gray-80;
-			font-weight: 200;
+			font-weight: 300;
 		}
 	}
 }

--- a/projects/packages/search/src/dashboard/store/selectors/site-plan.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-plan.js
@@ -8,6 +8,8 @@ const sitePlanSelectors = {
 	supportsSearch: state =>
 		state.sitePlan.supports_instant_search || state.sitePlan.supports_only_classic_search,
 	getTierMaximumRecords: state => state.sitePlan.tier_maximum_records,
+	getTierSlug: state => state.sitePlan.effective_subscription.tier,
+	getLatestMonthUsage: state => state.sitePlan.plan_usage.num_requests_3m[ 0 ],
 };
 
 export default sitePlanSelectors;

--- a/projects/packages/search/src/dashboard/store/selectors/site-plan.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-plan.js
@@ -9,7 +9,9 @@ const sitePlanSelectors = {
 		state.sitePlan.supports_instant_search || state.sitePlan.supports_only_classic_search,
 	getTierMaximumRecords: state => state.sitePlan.tier_maximum_records,
 	getTierSlug: state => state.sitePlan.tier_slug,
-	getLatestMonthUsage: state => state.sitePlan.plan_usage.num_requests_3m[ 0 ],
+	getLatestMonthRequests: state => state.sitePlan.plan_usage.num_requests_3m[ 0 ],
+	getCurrentPlan: state => state.sitePlan.plan_current,
+	getCurrentUsage: state => state.sitePlan.plan_usage,
 };
 
 export default sitePlanSelectors;

--- a/projects/packages/search/src/dashboard/store/selectors/site-plan.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-plan.js
@@ -8,7 +8,7 @@ const sitePlanSelectors = {
 	supportsSearch: state =>
 		state.sitePlan.supports_instant_search || state.sitePlan.supports_only_classic_search,
 	getTierMaximumRecords: state => state.sitePlan.tier_maximum_records,
-	getTierSlug: state => state.sitePlan.effective_subscription.tier,
+	getTierSlug: state => state.sitePlan.tier_slug,
 	getLatestMonthUsage: state => state.sitePlan.plan_usage.num_requests_3m[ 0 ],
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26054
Fixes #26653 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Introduce `sitePlan.tier_slug` to get the current subscription plan name.
* Introduce `sitePlan.plan_usage.num_requests_3m` to display the monthly usage period.
* Introduce `sitePlan.plan_usage.num_requests_3m` to display the monthly requests usage.
* Introduce `sitePlan.plan_usage.num_records` to display the records usage.
* Introduce `sitePlan.plan_current` to display the limit numbers of records and requests on the current plan.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pcNPJE-140-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

> Note: Since the new pricing API is still in progress, this PR replies on the other codebase update `D88792-code`.

* Purchase the Jetpack Search `Free` plan.
* Navigate to the site with URL `/wp-admin/admin.php?page=jetpack-search&new_pricing_202208=1`.
* Ensure there is a `usage period` and `purchased plan name` displayed.
* Ensure there are usage and limit numbers of `requests` and `records` on donut meters.

<img width="1185" alt="截圖 2022-10-07 下午4 10 43" src="https://user-images.githubusercontent.com/6869813/194505748-cd9a0fba-780d-4513-b981-38a574f4474a.png">