### PR TITLE
Add compatibility module for WP Super Cache

### DIFF
--- a/projects/plugins/boost/app/lib/Status.php
+++ b/projects/plugins/boost/app/lib/Status.php
@@ -39,8 +39,19 @@ class Status {
 
 		if ( update_option( $this->get_option_name( $this->slug ), (bool) $new_status ) ) {
 			$this->update_mapped_modules( $new_status );
+
 			// Only record analytics event if the config update succeeds.
 			$this->track_module_status( (bool) $new_status );
+
+			/**
+			 * Fires when a module is enabled or disabled.
+			 *
+			 * @param string $module The module slug.
+			 * @param bool   $status The new status.
+			 * @since 1.5.2
+			 */
+			do_action( 'jetpack_boost_module_status_updated', $this->slug, (bool) $new_status );
+
 			return true;
 		}
 		return false;

--- a/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
+++ b/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
@@ -282,7 +282,7 @@ class Critical_CSS_State {
 				// For each URL
 				// Track the state and errors in a state array.
 				$sources[ $key ] = array(
-					'urls'          => $urls,
+					'urls'          => apply_filters( 'jetpack_boost_critical_css_urls', $urls ),
 					'status'        => self::REQUESTING,
 					'error'         => null,
 					'success_ratio' => $provider::get_success_ratio(),

--- a/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
+++ b/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
@@ -223,6 +223,13 @@ class Critical_CSS_State {
 
 		if ( 100 === $this->get_percent_complete() ) {
 			$this->state = self::SUCCESS;
+
+			/**
+			 * Fires when Critical CSS has been generated - whether locally or remotely.
+			 *
+			 * @since 1.5.2
+			 */
+			do_action( 'jetpack_boost_critical_css_generated', $this->state );
 		}
 
 		$this->save();

--- a/projects/plugins/boost/changelog/add-wp-super-cache-compatibility
+++ b/projects/plugins/boost/changelog/add-wp-super-cache-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add compatibility module for WP Super Cache

--- a/projects/plugins/boost/compatibility/wp-super-cache.php
+++ b/projects/plugins/boost/compatibility/wp-super-cache.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Super Cache compatibility for Boost
+ *
+ * @package automattic/jetpack-boost
+ */
+
+namespace Automattic\Jetpack_Boost\Compatibility\Super_Cache;
+
+/**
+ * Add WP Super Cache bypass query param to the URL.
+ *
+ * @param string $url The URL.
+ */
+function add_bypass_query_param( $url ) {
+	global $cache_page_secret;
+
+	return add_query_arg( 'donotcachepage', $cache_page_secret, $url );
+}
+
+/**
+ * Add WP Super Cache bypass query params to Critical CSS URLs.
+ *
+ * @param array $urls list of URLs to generate Critical CSS for.
+ */
+function critical_css_bypass_super_cache( $urls ) {
+	return array_map( __NAMESPACE__ . '\add_bypass_query_param', $urls );
+}
+add_filter( 'jetpack_boost_critical_css_urls', __NAMESPACE__ . '\critical_css_bypass_super_cache' );

--- a/projects/plugins/boost/compatibility/wp-super-cache.php
+++ b/projects/plugins/boost/compatibility/wp-super-cache.php
@@ -27,3 +27,33 @@ function critical_css_bypass_super_cache( $urls ) {
 	return array_map( __NAMESPACE__ . '\add_bypass_query_param', $urls );
 }
 add_filter( 'jetpack_boost_critical_css_urls', __NAMESPACE__ . '\critical_css_bypass_super_cache' );
+
+/**
+ * Clear Super Cache's cache. Called when Critical CSS finishes generating, or
+ * when a module is enabled or disabled.
+ */
+function clear_cache() {
+	global $wpdb;
+
+	if ( function_exists( 'wp_cache_clear_cache' ) ) {
+		wp_cache_clear_cache( $wpdb->blogid );
+	}
+}
+add_action( 'jetpack_boost_critical_css_generated', __NAMESPACE__ . '\clear_cache' );
+
+/**
+ * Clear Super Cache's cache when a module is enabled or disabled.
+ *
+ * @param string $module The module slug.
+ * @param bool   $status The new status.
+ */
+function module_status_updated( $module, $status ) {
+	// Special case: don't clear when enabling Critical or Cloud CSS, as they will
+	// be handled after generation.
+	if ( $status && ( $module === 'critical-css' || $module === 'cloud-css' ) ) {
+		return;
+	}
+
+	clear_cache();
+}
+add_action( 'jetpack_boost_module_status_updated', __NAMESPACE__ . '\module_status_updated', 10, 2 );

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -146,6 +146,10 @@ function include_compatibility_files() {
 	if ( function_exists( 'amp_is_request' ) ) {
 		require_once __DIR__ . '/compatibility/amp.php';
 	}
+
+	if ( function_exists( 'wp_cache_is_enabled' ) ) {
+		require_once __DIR__ . '/compatibility/wp-super-cache.php';
+	}
 }
 
 add_action( 'plugins_loaded', __NAMESPACE__ . '\include_compatibility_files' );


### PR DESCRIPTION
I've reviewed all of the features of WP Super Cache in combination with Jetpack Boost. As far as I can tell, the only hiccups were around needing to clear the cache at strategic times, and ensuring that both the local and remove Critical CSS generators bypass the cache.

This PR adds appropriately timed cache clearing and cache bypass to Boost, ensuring compatibility with WP Super Cache.

#### Changes proposed in this Pull Request:
* If WP Super Cache is installed:
  * Clear the cache after generating new Critical CSS or toggling a feature, and
  * Ensure the cache is bypassed during Critical CSS Generation.

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Use Jetpack Boost and Super Cache side-by-side
* Ensure that all Jetpack Boost features apply immediately to the front-end, non-logged in users, even when caching is enabled.
* Ensure that both local and remote Critical CSS bypass the cache