### PR TITLE
[JS Packages]Add Calypso redirect to ManageConnectionDialog

### DIFF
--- a/projects/js-packages/connection/changelog/add-wpcom-redirect-to-connection-manager
+++ b/projects/js-packages/connection/changelog/add-wpcom-redirect-to-connection-manager
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Added JP redirect to unused component
+
+

--- a/projects/js-packages/connection/components/manage-connection-dialog/index.jsx
+++ b/projects/js-packages/connection/components/manage-connection-dialog/index.jsx
@@ -34,7 +34,14 @@ const ManageConnectionDialog = props => {
 							'jetpack'
 						) }
 					</H3>
-					<Button variant="primary" isExternalLink={ true } fullWidth={ true }>
+					<Button
+						variant="primary"
+						isExternalLink={ true }
+						fullWidth={ true }
+						href={ getRedirectUrl( 'calypso-settings-manage-connection', {
+							site: window?.myJetpackInitialState?.siteSuffix,
+						} ) }
+					>
 						{ __( 'Transfer ownership to another admin', 'jetpack' ) }
 					</Button>
 					<Button


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Completes the second task of #26577 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add redirect from the ManageConnectionDialog component to the Calypso settings page to transfer the Jetpack connection.
* Introduce new Jetpack redirect ( PCYsg-pY7-p2 ):  `calypso-settings-manage-connection`. 

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the component in the Storybook
* Click the `Transfer ownership to another admin` button
* Confirm that the redirect works, it should take to:
`https://jetpack.com/redirect/?source=calypso-settings-manage-connection&site=my-jetpack-mock-site.com`
