### PR TITLE
RNA: Fix style issue on Button component with icon and text

### DIFF
--- a/projects/js-packages/components/changelog/fix-popover-buttons
+++ b/projects/js-packages/components/changelog/fix-popover-buttons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+RNA: Fix styling issue on Button component due to Gutenberg component update

--- a/projects/js-packages/components/components/button/index.tsx
+++ b/projects/js-packages/components/components/button/index.tsx
@@ -53,11 +53,18 @@ const Button = forwardRef< HTMLInputElement, ButtonProps >( ( props, ref ) => {
 	);
 	const externalTarget = isExternalLink ? '_blank' : undefined;
 
+	// ref https://github.com/WordPress/gutenberg/pull/44198
+	const hasChildren =
+		children?.[ 0 ] &&
+		children[ 0 ] !== null &&
+		// Tooltip should not considered as a child
+		children?.[ 0 ]?.props?.className !== 'components-tooltip';
+
 	return (
 		<WPButton
 			target={ externalTarget }
 			variant={ variant }
-			className={ className }
+			className={ classNames( className, { 'has-text': !! icon && hasChildren } ) }
 			icon={ ! isExternalLink ? icon : undefined }
 			iconSize={ iconSize }
 			disabled={ disabled }

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.22.1",
+	"version": "0.22.2-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26682

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
A [recent update on Gutenberg](https://github.com/WordPress/gutenberg/pull/44198) has changed the way children detection works on the `Button` component, which has broken Jetpack's `Button` component style.
The change checks the existence of `children[ 0 ]`, while RNA's implementation uses a check on the first child that returns `false` when not loading:
```jsx
<WPButton
	target={ externalTarget }
	variant={ variant }
	className={ className }
	icon={ ! isExternalLink ? icon : undefined }
	iconSize={ iconSize }
	disabled={ disabled }
	isDestructive={ isDestructive }
	text={ text }
	{ ...componentProps }
>
	{ isLoading && <Spinner /> } <---------
	<span>{ children }</span>
	{ externalIcon }
</WPButton>
```
This causes the `has-text` class check to fail and it is not added to the class names list.
It can be checked here: https://automattic.github.io/jetpack-storybook/?path=/story/js-packages-components-button--icon

This PR mirrors the check directly on RNA's `Button` children, bypassing the `isLoading` check child and the `span` element.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Storybook:
* Go to the storybook: `( cd projects/js-packages/storybook && pnpm run storybook:dev )`
* On the `Button` component, check that there is a margin between the icon and the text
* Remove the text, keeping only the icon. Check that the margin is gone

VideoPress: (the issue was originally detected there)
* Follow those steps: https://github.com/Automattic/jetpack/issues/26682

Before | After
---------|-------
![2022-10-07_12-12-54](https://user-images.githubusercontent.com/8486249/194588263-8f3b3d2a-ed09-4470-8c0e-a7a03af85fbb.png) | ![2022-10-07_12-11-19](https://user-images.githubusercontent.com/8486249/194588346-451c4580-985f-4f08-8b1a-a8d1446057b7.png)

Before | After
---------|-------
![2022-10-06_17-36-51](https://user-images.githubusercontent.com/8486249/194588618-e2923ea7-44bc-4b4a-b8ea-2418f07497a7.png) | ![2022-10-06_17-37-33](https://user-images.githubusercontent.com/8486249/194588661-daf94e10-c7f9-4256-8417-ddde4c7bf537.png)
