### PR TITLE
Update/wpcom stats class to return object instead of associative arrays

### DIFF
--- a/projects/packages/stats/changelog/update-wpcom-stats-class-to-return-object-instead-of-associative-arrays
+++ b/projects/packages/stats/changelog/update-wpcom-stats-class-to-return-object-instead-of-associative-arrays
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Changed return from array to Object in WPCOM_Stats methods to be consistent with previous behavior in stats module.

--- a/projects/packages/stats/src/class-wpcom-stats.php
+++ b/projects/packages/stats/src/class-wpcom-stats.php
@@ -54,7 +54,7 @@ class WPCOM_Stats {
 	 *
 	 * @link https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/
 	 * @param array $args Optional query parameters.
-	 * @return array| WP_Error
+	 * @return Object| WP_Error
 	 */
 	public function get_stats( $args = array() ) {
 		$this->resource = '';
@@ -67,7 +67,7 @@ class WPCOM_Stats {
 	 *
 	 * @link https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/summary/
 	 * @param array $args Optional query parameters.
-	 * @return array|WP_Error
+	 * @return Object|WP_Error
 	 */
 	public function get_stats_summary( $args = array() ) {
 		$this->resource = 'summary';
@@ -81,7 +81,7 @@ class WPCOM_Stats {
 	 *
 	 * @link https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/top-posts/
 	 * @param array $args Optional query parameters.
-	 * @return array|WP_Error
+	 * @return Object|WP_Error
 	 */
 	public function get_top_posts( $args = array() ) {
 		$this->resource = 'top-posts';
@@ -95,7 +95,7 @@ class WPCOM_Stats {
 	 * @link https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/video/%24post_id/
 	 * @param int   $post_id The video's ID.
 	 * @param array $args    Optional query parameters.
-	 * @return array|WP_Error
+	 * @return Object|WP_Error
 	 */
 	public function get_video_details( $post_id, $args = array() ) {
 		$this->resource = sprintf( 'video/%d', $post_id );
@@ -108,7 +108,7 @@ class WPCOM_Stats {
 	 *
 	 * @link https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/referrers/
 	 * @param array $args Optional query parameters.
-	 * @return array|WP_Error
+	 * @return Object|WP_Error
 	 */
 	public function get_referrers( $args = array() ) {
 		$this->resource = 'referrers';
@@ -121,7 +121,7 @@ class WPCOM_Stats {
 	 *
 	 * @link https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/clicks/
 	 * @param array $args Optional query parameters.
-	 * @return array|WP_Error
+	 * @return Object|WP_Error
 	 */
 	public function get_clicks( $args = array() ) {
 		$this->resource = 'clicks';
@@ -134,7 +134,7 @@ class WPCOM_Stats {
 	 *
 	 * @link https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/tags/
 	 * @param array $args Optional query parameters.
-	 * @return array|WP_Error
+	 * @return Object|WP_Error
 	 */
 	public function get_tags( $args = array() ) {
 		$this->resource = 'tags';
@@ -147,7 +147,7 @@ class WPCOM_Stats {
 	 *
 	 * @link https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/top-authors/
 	 * @param array $args Optional query parameters.
-	 * @return array|WP_Error
+	 * @return Object|WP_Error
 	 */
 	public function get_top_authors( $args = array() ) {
 		$this->resource = 'top-authors';
@@ -160,7 +160,7 @@ class WPCOM_Stats {
 	 *
 	 * @link https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/comments/
 	 * @param array $args Optional query parameters.
-	 * @return array|WP_Error
+	 * @return Object|WP_Error
 	 */
 	public function get_top_comments( $args = array() ) {
 		$this->resource = 'comments';
@@ -173,7 +173,7 @@ class WPCOM_Stats {
 	 *
 	 * @link https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/video-plays/
 	 * @param array $args Optional query parameters.
-	 * @return array|WP_Error
+	 * @return Object|WP_Error
 	 */
 	public function get_video_plays( $args = array() ) {
 		$this->resource = 'video-plays';
@@ -186,7 +186,7 @@ class WPCOM_Stats {
 	 *
 	 * @link https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/file-downloads/
 	 * @param array $args Optional query parameters.
-	 * @return array|WP_Error
+	 * @return Object|WP_Error
 	 */
 	public function get_file_downloads( $args = array() ) {
 		$this->resource = 'file-downloads';
@@ -200,7 +200,7 @@ class WPCOM_Stats {
 	 * @link https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/post/%24post_id/
 	 * @param int   $post_id The video's ID.
 	 * @param array $args    Optional query parameters.
-	 * @return array|WP_Error
+	 * @return Object|WP_Error
 	 */
 	public function get_post_views( $post_id, $args = array() ) {
 		$this->resource = sprintf( 'post/%d', $post_id );
@@ -213,7 +213,7 @@ class WPCOM_Stats {
 	 *
 	 * @link https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/country-views/
 	 * @param array $args Optional query parameters.
-	 * @return array|WP_Error
+	 * @return Object|WP_Error
 	 */
 	public function get_views_by_country( $args = array() ) {
 
@@ -227,7 +227,7 @@ class WPCOM_Stats {
 	 *
 	 * @link https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/followers/
 	 * @param array $args Optional query parameters.
-	 * @return array|WP_Error
+	 * @return Object|WP_Error
 	 */
 	public function get_followers( $args = array() ) {
 
@@ -241,7 +241,7 @@ class WPCOM_Stats {
 	 *
 	 * @link https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/comment-followers/
 	 * @param array $args Optional query parameters.
-	 * @return array|WP_Error
+	 * @return Object|WP_Error
 	 */
 	public function get_comment_followers( $args = array() ) {
 
@@ -255,7 +255,7 @@ class WPCOM_Stats {
 	 *
 	 * @link https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/publicize/
 	 * @param array $args Optional query parameters.
-	 * @return array|WP_Error
+	 * @return Object|WP_Error
 	 */
 	public function get_publicize_followers( $args = array() ) {
 
@@ -269,7 +269,7 @@ class WPCOM_Stats {
 	 *
 	 * @link https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/search-terms/
 	 * @param array $args Optional query parameters.
-	 * @return array|WP_Error
+	 * @return Object|WP_Error
 	 */
 	public function get_search_terms( $args = array() ) {
 
@@ -283,7 +283,7 @@ class WPCOM_Stats {
 	 *
 	 * @link https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/views/posts/
 	 * @param array $args Optional query parameters.
-	 * @return array|WP_Error
+	 * @return Object|WP_Error
 	 */
 	public function get_total_post_views( $args = array() ) {
 
@@ -308,7 +308,7 @@ class WPCOM_Stats {
 	 *
 	 * @param array $args Optional query parameters.
 	 *
-	 * @return array|WP_Error
+	 * @return Object|WP_Error
 	 */
 	protected function fetch_stats( $args = array() ) {
 		$endpoint       = $this->build_endpoint();
@@ -321,7 +321,7 @@ class WPCOM_Stats {
 			$time = key( $stats_cache );
 			$data = $stats_cache[ $time ]; // JSON encoded data.
 
-			return array_merge( array( 'cached_at' => $time ), (array) json_decode( $data, true ) );
+			return (object) array_merge( array( 'cached_at' => $time ), (array) json_decode( $data, true ) );
 		}
 
 		$wpcom_stats = $this->fetch_remote_stats( $endpoint, $args );
@@ -344,7 +344,7 @@ class WPCOM_Stats {
 	 * @link https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/
 	 * @param string $endpoint The stats endpoint.
 	 * @param array  $args The query arguments.
-	 * @return array|WP_Error.
+	 * @return Object|WP_Error.
 	 */
 	protected function fetch_remote_stats( $endpoint, $args ) {
 		$response      = Client::wpcom_json_api_request_as_blog( $endpoint, self::STATS_REST_API_VERSION, $args );
@@ -355,6 +355,6 @@ class WPCOM_Stats {
 			return is_wp_error( $response ) ? $response : new WP_Error( 'stats_error', 'Failed to fetch Stats from WPCOM' );
 		}
 
-		return json_decode( $response_body, true );
+		return json_decode( $response_body );
 	}
 }

--- a/projects/packages/stats/tests/php/test-wpcom-stats.php
+++ b/projects/packages/stats/tests/php/test-wpcom-stats.php
@@ -554,8 +554,8 @@ class Test_WPCOM_Stats extends StatsBaseTestCase {
 
 		$stats = $this->wpcom_stats->get_stats();
 
-		$this->assertArrayHasKey( 'dummy', $stats );
-		$this->assertArrayHasKey( 'cached_at', $stats );
+		$this->assertObjectHasAttribute( 'dummy', $stats );
+		$this->assertObjectHasAttribute( 'cached_at', $stats );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Relates to #26530 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This is a proposal to change the return type for the methods in WPCOM_Stats class so that they are more equivalent to the methods in Stats Module. This way migration of functionality from old methods to the stats package will be smooth.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No 
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
Look at the code and unit tests.

