### PR TITLE
Implement cosmetic changes to recommendations

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
@@ -1,6 +1,7 @@
 import { PartnerCouponRedeem } from '@automattic/jetpack-partner-coupon';
 import { __ } from '@wordpress/i18n';
 import DashSectionHeader from 'components/dash-section-header';
+import QueryRecommendationsData from 'components/data/query-recommendations-data';
 import QueryScanStatus from 'components/data/query-scan-status';
 import QuerySite from 'components/data/query-site';
 import QuerySitePlugins from 'components/data/query-site-plugins';
@@ -189,6 +190,7 @@ class AtAGlance extends Component {
 					</h1>
 					<QuerySitePlugins />
 					<QuerySite />
+					<QueryRecommendationsData />
 					<QueryScanStatus />
 					{ redeemPartnerCoupon }
 					<DashStats { ...settingsProps } { ...urls } />

--- a/projects/plugins/jetpack/_inc/client/components/navigation/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/navigation/index.jsx
@@ -15,12 +15,12 @@ import {
 	getSiteRawUrl,
 	showRecommendations,
 	showMyJetpack,
-	getNewRecommendationsCount,
 	userCanManageModules as _userCanManageModules,
 	userCanViewStats as _userCanViewStats,
 	getPurchaseToken,
 } from 'state/initial-state';
 import { isModuleActivated as _isModuleActivated } from 'state/modules';
+import { getNonViewedRecommendationsCount } from 'state/recommendations';
 
 export class Navigation extends React.Component {
 	trackNavClick = target => {
@@ -187,7 +187,7 @@ export default connect( state => {
 		isLinked: isCurrentUserLinked( state ),
 		hasConnectedOwner: hasConnectedOwner( state ),
 		showRecommendations: showRecommendations( state ),
-		newRecommendationsCount: getNewRecommendationsCount( state ),
+		newRecommendationsCount: getNonViewedRecommendationsCount( state ),
 		siteUrl: getSiteRawUrl( state ),
 		adminUrl: getSiteAdminUrl( state ),
 		purchaseToken: getPurchaseToken( state ),

--- a/projects/plugins/jetpack/_inc/client/components/navigation/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/navigation/index.jsx
@@ -1,6 +1,7 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { _x, sprintf } from '@wordpress/i18n';
+import classNames from 'classnames';
 import SectionNav from 'components/section-nav';
 import NavItem from 'components/section-nav/item';
 import NavTabs from 'components/section-nav/tabs';
@@ -131,10 +132,11 @@ export class Navigation extends React.Component {
 								{
 									count: (
 										<span
-											className={
-												'dops-section-nav-tab__update-badge count-' +
-												this.props.newRecommendationsCount
-											}
+											className={ classNames( 'dops-section-nav-tab__update-badge', {
+												[ 'is-hidden' ]:
+													this.props.location.pathname.startsWith( '/recommendations' ) ||
+													! this.props.newRecommendationsCount,
+											} ) }
 										></span>
 									),
 								}

--- a/projects/plugins/jetpack/_inc/client/components/section-nav/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/section-nav/style.scss
@@ -362,7 +362,7 @@
 	line-height: 1.6;
 	text-align: center;
 
-	&.count-0 {
+	&.is-hidden {
 		display: none;
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/my-plan/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/my-plan/index.jsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import QueryRecommendationsData from 'components/data/query-recommendations-data';
 import QuerySite from 'components/data/query-site';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -28,6 +29,7 @@ export function MyPlan( props ) {
 		<React.Fragment>
 			<h1 className="screen-reader-text">{ __( 'Jetpack My Plan Details', 'jetpack' ) }</h1>
 			<QuerySite />
+			<QueryRecommendationsData />
 			<MyPlanPartnerCoupon siteRawUrl={ props.siteRawUrl } />
 			<MyPlanHeader
 				activeProducts={ props.activeProducts }

--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/feature-prompt/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/feature-prompt/index.jsx
@@ -14,7 +14,7 @@ import {
 	updateRecommendationsStep as updateRecommendationsStepAction,
 	startFeatureInstall as startFeatureInstallAction,
 	endFeatureInstall as endFeatureInstallAction,
-	getOnboardingProgressValueIfEligible,
+	getOnboardingStepProgressValueIfEligible,
 	getNextRoute,
 	getStep,
 	isUpdatingRecommendationsStep,
@@ -33,7 +33,9 @@ import {
 } from '../../feature-utils';
 import DiscountCard from '../../sidebar/discount-card';
 import { ProductSpotlight } from '../../sidebar/product-spotlight';
+import { StepProgressBar } from '../../step-progress-bar';
 import { PromptLayout } from '../prompt-layout';
+
 const FeaturePromptComponent = props => {
 	const {
 		activateFeature,
@@ -50,6 +52,7 @@ const FeaturePromptComponent = props => {
 		illustration,
 		nextRoute,
 		progressValue,
+		stepProgressValue,
 		question,
 		stepSlug,
 		stateStepSlug,
@@ -141,11 +144,21 @@ const FeaturePromptComponent = props => {
 		sidebarCard = <DiscountCard />;
 	}
 
+	const progressBarComponent = useMemo( () => {
+		if ( stepProgressValue ) {
+			return <StepProgressBar { ...stepProgressValue } />;
+		}
+
+		if ( progressValue ) {
+			return <ProgressBar color={ '#00A32A' } value={ progressValue } />;
+		}
+
+		return null;
+	}, [ stepProgressValue, progressValue ] );
+
 	return (
 		<PromptLayout
-			progressBar={
-				progressValue ? <ProgressBar color={ '#00A32A' } value={ progressValue } /> : null
-			}
+			progressBar={ progressBarComponent }
 			isNew={ isNew }
 			question={ question }
 			description={ createInterpolateElement( description, {
@@ -238,7 +251,7 @@ const FeaturePrompt = connect(
 		spotlightProduct: getProductSlugForStep( state, ownProps.stepSlug ),
 		...( getIsOnboardingActive( state )
 			? {
-					progressValue: getOnboardingProgressValueIfEligible( state ),
+					stepProgressValue: getOnboardingStepProgressValueIfEligible( state ),
 					summaryViewed: false,
 			  }
 			: {} ),

--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/resource-prompt/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/resource-prompt/index.jsx
@@ -4,13 +4,13 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import Button from 'components/button';
 import analytics from 'lib/analytics';
-import React, { useEffect, useCallback } from 'react';
+import React, { useEffect, useCallback, useMemo } from 'react';
 import { connect } from 'react-redux';
 import { ProductSpotlight } from 'recommendations/sidebar/product-spotlight';
 import {
 	addViewedRecommendation as addViewedRecommendationAction,
 	updateRecommendationsStep as updateRecommendationsStepAction,
-	getOnboardingProgressValueIfEligible,
+	getOnboardingStepProgressValueIfEligible,
 	getNextRoute,
 	getStep,
 	isUpdatingRecommendationsStep,
@@ -20,6 +20,7 @@ import {
 } from 'state/recommendations';
 import { DEFAULT_ILLUSTRATION } from '../../constants';
 import { getStepContent } from '../../feature-utils';
+import { StepProgressBar } from '../../step-progress-bar';
 import { PromptLayout } from '../prompt-layout';
 
 /**
@@ -34,6 +35,7 @@ const ResourcePromptComponent = props => {
 	const {
 		isNew,
 		progressValue,
+		stepProgressValue,
 		question,
 		description,
 		descriptionList,
@@ -99,11 +101,21 @@ const ResourcePromptComponent = props => {
 		} );
 	}, [ stepSlug ] );
 
+	const progressBarComponent = useMemo( () => {
+		if ( stepProgressValue ) {
+			return <StepProgressBar { ...stepProgressValue } />;
+		}
+
+		if ( progressValue ) {
+			return <ProgressBar color={ '#00A32A' } value={ progressValue } />;
+		}
+
+		return null;
+	}, [ stepProgressValue, progressValue ] );
+
 	return (
 		<PromptLayout
-			progressBar={
-				progressValue ? <ProgressBar color={ '#00A32A' } value={ progressValue } /> : null
-			}
+			progressBar={ progressBarComponent }
 			isNew={ isNew }
 			question={ question }
 			description={ createInterpolateElement( description, {
@@ -180,7 +192,8 @@ const ResourcePrompt = connect(
 		spotlightProduct: getProductSlugForStep( state, ownProps.stepSlug ),
 		...( getIsOnboardingActive( state )
 			? {
-					progressValue: getOnboardingProgressValueIfEligible( state ),
+					stepProgressValue: getOnboardingStepProgressValueIfEligible( state ),
+					progressValue: null,
 					summaryViewed: false,
 			  }
 			: {} ),

--- a/projects/plugins/jetpack/_inc/client/recommendations/step-progress-bar/index.tsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/step-progress-bar/index.tsx
@@ -1,0 +1,29 @@
+import ProgressBar from '@automattic/components/dist/esm/progress-bar';
+import { __, sprintf } from '@wordpress/i18n';
+import './style.scss';
+
+type Props = {
+	currentStepIndex: number;
+	totalSteps: number;
+};
+export const StepProgressBar = ( { currentStepIndex, totalSteps }: Props ) => {
+	if ( -1 === currentStepIndex ) {
+		return null;
+	}
+
+	const progressValue = ( currentStepIndex / ( totalSteps - 1 ) ) * 100;
+
+	return (
+		<div className="step-progress-bar">
+			<ProgressBar color={ '#00A32A' } value={ progressValue } />
+			<span className="step-progress-bar__label">
+				{ sprintf(
+					/* Translators: %1$s is the current step number, %2$s are total steps */
+					__( 'Step %1$s of %2$s', 'jetpack' ),
+					currentStepIndex + 1,
+					totalSteps
+				) }
+			</span>
+		</div>
+	);
+};

--- a/projects/plugins/jetpack/_inc/client/recommendations/step-progress-bar/style.scss
+++ b/projects/plugins/jetpack/_inc/client/recommendations/step-progress-bar/style.scss
@@ -1,0 +1,10 @@
+.step-progress-bar {
+    display: flex;
+    align-items: center;
+}
+
+.step-progress-bar__label {
+    margin-left: 1rem;
+    font-size: 11px;
+    color: var( --jp-gray-50 );
+}

--- a/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
@@ -721,7 +721,7 @@ export const getStep = state => {
 	return step;
 };
 
-export const getOnboardingProgressValueIfEligible = state => {
+export const getOnboardingStepProgressValueIfEligible = state => {
 	const onboardingData = getOnboardingData( state );
 
 	if ( ! onboardingData || ! onboardingData.active ) {
@@ -731,7 +731,10 @@ export const getOnboardingProgressValueIfEligible = state => {
 	const step = getStep( state );
 	const steps = getStepsForOnboarding( onboardingData.active );
 
-	return `${ ( steps.indexOf( step ) / steps.length ) * 100 }`;
+	return {
+		currentStepIndex: steps.indexOf( step ),
+		totalSteps: steps.length,
+	};
 };
 
 export const getNextRoute = state => {

--- a/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/recommendations/reducer.js
@@ -50,7 +50,11 @@ import {
 	JETPACK_RECOMMENDATIONS_DATA_ONBOARDING_DATA_UPDATE,
 } from 'state/action-types';
 import { hasConnectedOwner } from 'state/connection';
-import { getNewRecommendations, getInitialRecommendationsStep } from 'state/initial-state';
+import {
+	getNewRecommendations,
+	getInitialRecommendationsStep,
+	getNewRecommendationsCount,
+} from 'state/initial-state';
 import { getRewindStatus } from 'state/rewind';
 import { getSetting } from 'state/settings';
 import {
@@ -491,6 +495,19 @@ export const isProductSuggestionsAvailable = state => {
 	const suggestionsResult = getProductSuggestions( state );
 
 	return isArray( suggestionsResult ) && ! isEmpty( suggestionsResult );
+};
+
+export const getNonViewedRecommendationsCount = state => {
+	const onboarding = getOnboardingData( state );
+
+	if ( onboarding && onboarding.active ) {
+		const step = getStep( state );
+		const steps = getStepsForOnboarding( onboarding.active );
+
+		return steps.length - ( steps.indexOf( step ) + 1 );
+	}
+
+	return getNewRecommendationsCount( state );
 };
 
 export const getProductSlugForStep = ( state, step ) => {


### PR DESCRIPTION
This PR adds cosmetic improvements to the recommendations flow, especially after introducing post-purchase onboarding.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adjust the unviewed recommendation count to include the post-purchase onboarding process
* Adds progress text into the progress indicator of the post-purchase onboarding process

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Related PR: https://github.com/Automattic/jetpack/pull/26484

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to WP Admin and https://jetpack.com/redirect/?source=jetpack-plans&site=<your_test_site>
* Purchase any of the supported plans (see below), or if already having one, go to `<your_test_site>/wp-admin/admin.php?page=jetpack#/recommendations`, "Reset Options (dev only)" and reload the page.
* While landing in the post-purchase onboarding flow, notice that there is the text displayed on the right of progress bar
<img width="440" alt="image" src="https://user-images.githubusercontent.com/8419292/194680516-841e3f5b-9295-4c0c-b4f3-400faaaeef92.png">

* Do not proceed with onboarding, go to other tab on jetpack dashboard
* Notice that the recommendation has a badge count with unviewed steps of currently active onboarding
<img width="930" alt="image" src="https://user-images.githubusercontent.com/8419292/194680508-2375fc57-3247-49a5-881d-98d638f68d5e.png">

* Reload the page, and see that recommendation badge will appear without a necessity of going to "Recommendations" tab

----
Supported plans:
1. Jetpack Scan
2. Jetpack Search
3. Jetpack VideoPress
4. Jetpack AntiSpam
5. Jetpack Backup
6. Jetpack Security
7. Jetpack Complete

