### PR TITLE
Search: Update upgrade trigger conditions and messages

### DIFF
--- a/projects/packages/search/changelog/update-upgrade_trigger_conditions
+++ b/projects/packages/search/changelog/update-upgrade_trigger_conditions
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Apply upgrade trigger displaying conditions and messages from API data

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -17,7 +17,7 @@ import RecordMeter from 'components/record-meter';
 import React, { useCallback } from 'react';
 import { STORE_ID } from 'store';
 import FirstRunSection from './sections/first-run-section';
-import PlanUsageSection from './sections/plan-usage-section';
+import PlanUsageSection, { getUpgradeMessages } from './sections/plan-usage-section';
 import './dashboard-page.scss';
 
 /**
@@ -182,27 +182,23 @@ const PlanSummary = ( { latestMonthRequests } ) => {
 };
 
 const UsageMeter = ( { sendPaidPlanToCart } ) => {
-	const upgradeTriggerArgs = {
-		description: __(
-			'Do you want to increase your site records and search requests?',
-			'jetpack-search-pkg'
-		),
-		cta: __( 'Upgrade now and avoid any future interruption!', 'jetpack-search-pkg' ),
-		onClick: sendPaidPlanToCart,
-	};
-
 	const currentPlan = useSelect( select => select( STORE_ID ).getCurrentPlan() );
 	const currentUsage = useSelect( select => select( STORE_ID ).getCurrentUsage() );
 	const latestMonthRequests = useSelect( select => select( STORE_ID ).getLatestMonthRequests() );
 
-	// @TODO Apply the real data `plan_usage.should_upgrade` and `plan_usage.upgrade_reason` after testing
 	let mustUpgradeReason = '';
-	if ( latestMonthRequests.num_requests > currentPlan.monthly_search_request_limit ) {
+	if ( currentUsage.upgrade_reason.requests ) {
 		mustUpgradeReason = 'requests';
 	}
-	if ( currentUsage.num_records > currentPlan.record_limit ) {
+	if ( currentUsage.upgrade_reason.records ) {
 		mustUpgradeReason = mustUpgradeReason === 'requests' ? 'both' : 'records';
 	}
+
+	const upgradeTriggerArgs = {
+		description: mustUpgradeReason && getUpgradeMessages()[ mustUpgradeReason ].description,
+		cta: mustUpgradeReason && getUpgradeMessages()[ mustUpgradeReason ].cta,
+		onClick: sendPaidPlanToCart,
+	};
 
 	return (
 		<div className="jp-search-dashboard-wrap jp-search-dashboard-meter-wrap">

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -232,11 +232,18 @@ const UsageMeter = ( { sendPaidPlanToCart } ) => {
 					<div className="usage-meter-about">
 						{ createInterpolateElement(
 							__(
-								'Tell me more about <u>record indexing and request limits</u>',
+								'Tell me more about <jpPlanLimits>record indexing and request limits</jpPlanLimits>.',
 								'jetpack-search-pkg'
 							),
 							{
-								u: <u />,
+								jpPlanLimits: (
+									<a
+										href="https://jetpack.com/support/search/"
+										rel="noopener noreferrer"
+										target="_blank"
+										className="support-link"
+									/>
+								),
 							}
 						) }
 					</div>

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -195,6 +195,15 @@ const UsageMeter = ( { sendPaidPlanToCart } ) => {
 	const currentUsage = useSelect( select => select( STORE_ID ).getCurrentUsage() );
 	const latestMonthRequests = useSelect( select => select( STORE_ID ).getLatestMonthRequests() );
 
+	// @TODO Apply the real data `plan_usage.should_upgrade` and `plan_usage.upgrade_reason` after testing
+	let mustUpgradeReason = '';
+	if ( latestMonthRequests.num_requests > currentPlan.monthly_search_request_limit ) {
+		mustUpgradeReason = 'requests';
+	}
+	if ( currentUsage.num_records > currentPlan.record_limit ) {
+		mustUpgradeReason = mustUpgradeReason === 'requests' ? 'both' : 'records';
+	}
+
 	return (
 		<div className="jp-search-dashboard-wrap jp-search-dashboard-meter-wrap">
 			<div className="jp-search-dashboard-row">
@@ -214,9 +223,11 @@ const UsageMeter = ( { sendPaidPlanToCart } ) => {
 						/>
 					</div>
 
-					<ThemeProvider>
-						<ContextualUpgradeTrigger { ...upgradeTriggerArgs } />
-					</ThemeProvider>
+					{ mustUpgradeReason && (
+						<ThemeProvider>
+							<ContextualUpgradeTrigger { ...upgradeTriggerArgs } />
+						</ThemeProvider>
+					) }
 
 					<div className="usage-meter-about">
 						{ createInterpolateElement(

--- a/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
@@ -47,7 +47,7 @@ const PlanSummary = () => {
 	);
 };
 
-const getUpgradeMessages = () => {
+export const getUpgradeMessages = () => {
 	const upgradeMessages = {
 		records: {
 			description: __(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Introduce `plan_usage.upgrade_reason.requests` to determine whether show the upgrade notice for requests overage.
* Introduce `plan_usage.upgrade_reason.records` to determine whether show the upgrade notice for records overage.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pcNPJE-140-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

> Note: Since the new pricing API is still in progress, this PR replies on the other codebase update `D88792-code`.

* Purchase the Jetpack Search `Free` plan.
* Navigate to the site with URL `/wp-admin/admin.php?page=jetpack-search&new_pricing_202208=1`.
* Ensure there is an upgrade trigger displaying corresponding to the requests and records overage.

<img width="845" alt="截圖 2022-10-08 上午9 17 54" src="https://user-images.githubusercontent.com/6869813/194680448-46bfb9b0-8eee-480d-b389-b4050054c251.png">
