### PR TITLE
Search: fix CORS errors on simple sites' search dashboard

### DIFF
--- a/projects/js-packages/api/changelog/fix-search-dashboard-on-simple-sites
+++ b/projects/js-packages/api/changelog/fix-search-dashboard-on-simple-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Jetpack Search dashboard for WPCOM simple sites by allowing using different API root for search endpoints.

--- a/projects/js-packages/api/index.jsx
+++ b/projects/js-packages/api/index.jsx
@@ -31,6 +31,7 @@ export const FetchNetworkError = createCustomError( 'FetchNetworkError' );
  */
 function JetpackRestApiClient( root, nonce ) {
 	let apiRoot = root,
+		wpcomOriginApiUrl = root,
 		headers = {
 			'X-WP-Nonce': nonce,
 		},
@@ -50,6 +51,17 @@ function JetpackRestApiClient( root, nonce ) {
 	const methods = {
 		setApiRoot( newRoot ) {
 			apiRoot = newRoot;
+		},
+		/**
+		 * Sets API root for search endpoints.
+		 * They are routed through wpcom API for wpcom simple sites,
+		 * so we add `/wp-json/wpcom-origin/` to this path on wpcom.
+		 * For non-wpcom sites, this is the same as apiRoot.
+		 *
+		 * @param {string} newRoot - API root for search endpoints.
+		 */
+		setWpcomOriginApiUrl( newRoot ) {
+			wpcomOriginApiUrl = newRoot;
 		},
 		setApiNonce( newNonce ) {
 			headers = {
@@ -477,21 +489,21 @@ function JetpackRestApiClient( root, nonce ) {
 				.then( checkStatus )
 				.then( parseJsonResponse ),
 		fetchSearchPlanInfo: () =>
-			getRequest( `${ apiRoot }jetpack/v4/search/plan`, getParams )
+			getRequest( `${ wpcomOriginApiUrl }jetpack/v4/search/plan`, getParams )
 				.then( checkStatus )
 				.then( parseJsonResponse ),
 		fetchSearchSettings: () =>
-			getRequest( `${ apiRoot }jetpack/v4/search/settings`, getParams )
+			getRequest( `${ wpcomOriginApiUrl }jetpack/v4/search/settings`, getParams )
 				.then( checkStatus )
 				.then( parseJsonResponse ),
 		updateSearchSettings: newSettings =>
-			postRequest( `${ apiRoot }jetpack/v4/search/settings`, postParams, {
+			postRequest( `${ wpcomOriginApiUrl }jetpack/v4/search/settings`, postParams, {
 				body: JSON.stringify( newSettings ),
 			} )
 				.then( checkStatus )
 				.then( parseJsonResponse ),
 		fetchSearchStats: () =>
-			getRequest( `${ apiRoot }jetpack/v4/search/stats`, getParams )
+			getRequest( `${ wpcomOriginApiUrl }jetpack/v4/search/stats`, getParams )
 				.then( checkStatus )
 				.then( parseJsonResponse ),
 		fetchWafSettings: () =>
@@ -507,7 +519,7 @@ function JetpackRestApiClient( root, nonce ) {
 				body: JSON.stringify( newSettings ),
 			} ),
 		fetchSearchPricing: () =>
-			getRequest( `${ apiRoot }jetpack/v4/search/pricing`, getParams )
+			getRequest( `${ wpcomOriginApiUrl }jetpack/v4/search/pricing`, getParams )
 				.then( checkStatus )
 				.then( parseJsonResponse ),
 	};

--- a/projects/js-packages/api/package.json
+++ b/projects/js-packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-api",
-	"version": "0.14.1",
+	"version": "0.14.2-alpha",
 	"description": "Jetpack Api Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/packages/search/changelog/fix-search-dashboard-on-simple-sites
+++ b/projects/packages/search/changelog/fix-search-dashboard-on-simple-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed search dashboard for simple sites.

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -58,7 +58,8 @@ class Initial_State {
 	public function get_initial_state() {
 		return array(
 			'siteData'        => array(
-				'WP_API_root'       => $this->get_wp_api_root(),
+				'WP_API_root'       => esc_url_raw( rest_url() ),
+				'wpcomOriginApiUrl' => $this->get_wp_api_root(),
 				'WP_API_nonce'      => wp_create_nonce( 'wp_rest' ),
 				'registrationNonce' => wp_create_nonce( 'jetpack-registration-nonce' ),
 				'purchaseToken'     => $this->get_purchase_token(),

--- a/projects/packages/search/src/dashboard/components/dashboard/wrapped-dashboard.jsx
+++ b/projects/packages/search/src/dashboard/components/dashboard/wrapped-dashboard.jsx
@@ -31,8 +31,10 @@ export default function WrappedDashboard() {
 
 	useMemo( () => {
 		const apiRootUrl = syncSelect( STORE_ID ).getAPIRootUrl();
+		const wpcomOriginApiUrl = syncSelect( STORE_ID ).getWpcomOriginApiUrl();
 		const apiNonce = syncSelect( STORE_ID ).getAPINonce();
 		apiRootUrl && restApi.setApiRoot( apiRootUrl );
+		wpcomOriginApiUrl && restApi.setWpcomOriginApiUrl( wpcomOriginApiUrl );
 		apiNonce && restApi.setApiNonce( apiNonce );
 		initializeAnalytics();
 		analytics.tracks.recordEvent( 'jetpack_search_admin_page_view', {

--- a/projects/packages/search/src/dashboard/store/selectors/site-data.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-data.js
@@ -1,5 +1,6 @@
 const siteDataSelectors = {
 	getAPIRootUrl: state => state.siteData?.WP_API_root ?? null,
+	getWpcomOriginApiUrl: state => state.siteData?.wpcomOriginApiUrl ?? null,
 	getAPINonce: state => state.siteData?.WP_API_nonce ?? null,
 	getRegistrationNonce: state => state.siteData?.registrationNonce ?? null,
 	getSiteAdminUrl: state => state.siteData?.adminUrl ?? null,


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

When I tried to create a simple site and visit the search dashboard, it did not work. I got CORS errors.

Simple sites support for dashboard was added in #25094

Before my change, the API root for `JetpackRestApiClient` was set to URL `site_url( '/wp-json/wpcom-origin/' )` in search dashboard. However, API has a global instance, and multiple places are calling `JetpackRestApiClient.setApiRoot`.
That causes the API root to revert to `rest_url()`, and the requests are no longer working after a certain point. It is overwritten with value from `JP_CONNECTION_INITIAL_STATE` instead.

In this diff, I propose adding separate value `wpcomOriginApiUrl` to JetpackRestApiClient. For simple wpcom sites, it is set to `site_url( '/wp-json/wpcom-origin/' )`, for all other sites it's just `rest_url()` as always.
This new `wpcomOriginApiUrl` value is only used for the search endpoint that can be proxied through the first party wpcom jetpack API.
#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

p1665165674962619-slack-C02ME06LF

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:
Similar to `D84235-code`