### PR TITLE
Contact Form: Remove contact-form from compatibility checks

### DIFF
--- a/projects/plugins/jetpack/changelog/update-remove-contact-form-from-conflicting-plugins-mechanism
+++ b/projects/plugins/jetpack/changelog/update-remove-contact-form-from-conflicting-plugins-mechanism
@@ -1,0 +1,4 @@
+Significance: major
+Type: compat
+
+Removed compatibility checks involving automatic deactivation of contact form functionality

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -187,14 +187,6 @@ class Jetpack {
 		'comment-likes'      => array(
 			'Epoch' => 'epoch/plugincore.php',
 		),
-		'contact-form'       => array(
-			'Contact Form 7'           => 'contact-form-7/wp-contact-form-7.php',
-			'Gravity Forms'            => 'gravityforms/gravityforms.php',
-			'Contact Form Plugin'      => 'contact-form-plugin/contact_form.php',
-			'Easy Contact Forms'       => 'easy-contact-forms/easy-contact-forms.php',
-			'Fast Secure Contact Form' => 'si-contact-form/si-contact-form.php',
-			'Ninja Forms'              => 'ninja-forms/ninja-forms.php',
-		),
 		'latex'              => array(
 			'LaTeX for WordPress'     => 'latex/latex.php',
 			'Youngwhans Simple Latex' => 'youngwhans-simple-latex/yw-latex.php',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes contact-form entry from compability 

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
None yet

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a new site (Jn site)
* Install as many as you can of these plugins Contact Form 7, Gravity Forms, Contact Form Plugin, Easy Contact Forms, Fast Secure Contact Form, and Ninja Forms.
* Connect Jetpack
* Write a post
* Expect to find the Form block shown in the Inserter

