### PR TITLE
Boost: Move Contextual Upgrade trigger on top of the setting toggles

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -2,6 +2,7 @@
 	import { getRedirectUrl } from '@automattic/jetpack-components';
 	import { __ } from '@wordpress/i18n';
 	import TemplatedString from '../../../elements/TemplatedString.svelte';
+	import { modules } from '../../../stores/modules';
 	import {
 		requestCloudCss,
 		pollCloudCssStatus,
@@ -20,10 +21,15 @@
 
 	// svelte-ignore unused-export-let - Ignored values supplied by svelte-navigator.
 	export let location, navigate;
+
+	$: cloudCssAvailable = !! $modules[ 'cloud-css' ];
 </script>
 
 <div class="jb-container--narrow">
-	<PremiumCTA />
+	{#if ! cloudCssAvailable}
+		<PremiumCTA />
+	{/if}
+
 	<Module
 		slug={'critical-css'}
 		on:enabled={maybeGenerateCriticalCss}

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -23,6 +23,7 @@
 </script>
 
 <div class="jb-container--narrow">
+	<PremiumCTA />
 	<Module
 		slug={'critical-css'}
 		on:enabled={maybeGenerateCriticalCss}
@@ -43,7 +44,6 @@
 
 		<div slot="meta">
 			<CriticalCssMeta />
-			<PremiumCTA />
 		</div>
 	</Module>
 

--- a/projects/plugins/boost/changelog/update-boost-cut-location
+++ b/projects/plugins/boost/changelog/update-boost-cut-location
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Moved an upgrade trigger upwards
+
+


### PR DESCRIPTION
The current upgrade nudge is hidden from the user until they interact with the Critical CSS toggle.

Most certainly people have no idea that they have to regenerate CSS at any point in time, so the value we're offering gets masked until they ever come back here. 

Also, when first generating, critical CSS, we hide the "Regenerate CSS" button, so harder to realize about the value of the Premium offer anyways.


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Moves rendering of `<PremiumCTA/>` to be on top of toggles instead of just being hidden under the Critical CSS toggle

#### After

<img width="1677" alt="image" src="https://user-images.githubusercontent.com/746152/194780130-988e2e6c-3640-432e-be9f-2d558e551a7f.png">


#### Before when Critical CSS disabled

<img width="1677" alt="image" src="https://user-images.githubusercontent.com/746152/194778208-75616f33-07d6-4278-b628-f0a057680502.png">


#### Before when Critical CSS enabled and running

<img width="986" alt="image" src="https://user-images.githubusercontent.com/746152/194778177-148d475c-36af-4416-9922-8467492bb961.png">

#### Before - what it currently takes to see the upgrade nudge

https://user-images.githubusercontent.com/746152/194778298-f3261457-6e15-4e30-a4b9-3521ec814281.mov






#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

pc9hqz-18k-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

1. Checkout this branch
2. Run `jetpack watch plugins/boost`
3. Connect the plugin
4. Expect to see the upgrade nudge right away