### PR TITLE
Search: Refactoring of new dashboard UI.

### DIFF
--- a/projects/packages/search/changelog/update-wire-up-new-meters
+++ b/projects/packages/search/changelog/update-wire-up-new-meters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Dashboard: Refactoring of new UI components.

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -159,13 +159,16 @@ export default function DashboardPage( { isLoading = false } ) {
 const PlanInfo = props => {
 	const hasIndex = props.hasIndex;
 	const info = props.recordMeterInfo;
+	// Site Info
+	// TODO: Investigate why this isn't returning anything useful.
+	const siteTitle = useSelect( select => select( STORE_ID ).getSiteTitle() ) || 'your site';
 	// Plan Info data
 	const latestMonthRequests = useSelect( select => select( STORE_ID ).getLatestMonthRequests() );
 	const tierSlug = useSelect( select => select( STORE_ID ).getTierSlug() );
 	const planInfo = { latestMonthRequests, tierSlug };
 	return (
 		<>
-			{ ! hasIndex && <FirstRunSection planInfo={ planInfo } /> }
+			{ ! hasIndex && <FirstRunSection siteTitle={ siteTitle } planInfo={ planInfo } /> }
 			{ hasIndex && <PlanUsageSection planInfo={ planInfo } /> }
 			{ hasIndex && (
 				<RecordMeter

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -96,6 +96,15 @@ export default function DashboardPage( { isLoading = false } ) {
 	const handleLocalNoticeDismissClick = useDispatch( STORE_ID ).removeNotice;
 	const notices = useSelect( select => select( STORE_ID ).getNotices(), [] );
 
+	// Plan Info data
+	const recordMeterInfo = {
+		lastIndexedDate,
+		postCount,
+		postTypeBreakdown,
+		postTypes,
+		tierMaximumRecords,
+	};
+
 	return (
 		<>
 			{ isPageLoading && <Loading /> }
@@ -106,16 +115,19 @@ export default function DashboardPage( { isLoading = false } ) {
 						supportsInstantSearch={ supportsInstantSearch }
 						supportsOnlyClassicSearch={ supportsOnlyClassicSearch }
 					/>
-					<FirstRunSection isVisible={ false } />
-					<PlanUsageSection isVisible={ false } />
-					{ isNewPricing && <UsageMeter sendPaidPlanToCart={ sendPaidPlanToCart } /> }
-					<RecordMeter
-						postCount={ postCount }
-						postTypeBreakdown={ postTypeBreakdown }
-						tierMaximumRecords={ tierMaximumRecords }
-						lastIndexedDate={ lastIndexedDate }
-						postTypes={ postTypes }
-					/>
+					{ isNewPricing && (
+						<PlanInfo hasIndex={ postCount !== 0 } recordMeterInfo={ recordMeterInfo } />
+					) }
+					{ false && <UsageMeter sendPaidPlanToCart={ sendPaidPlanToCart } /> }
+					{ ! isNewPricing && (
+						<RecordMeter
+							postCount={ postCount }
+							postTypeBreakdown={ postTypeBreakdown }
+							tierMaximumRecords={ tierMaximumRecords }
+							lastIndexedDate={ lastIndexedDate }
+							postTypes={ postTypes }
+						/>
+					) }
 					<div className="jp-search-dashboard-bottom">
 						<ModuleControl
 							siteAdminUrl={ siteAdminUrl }
@@ -143,6 +155,26 @@ export default function DashboardPage( { isLoading = false } ) {
 		</>
 	);
 }
+
+const PlanInfo = props => {
+	const hasIndex = props.hasIndex;
+	const info = props.recordMeterInfo;
+	return (
+		<>
+			{ ! hasIndex && <FirstRunSection /> }
+			{ hasIndex && <PlanUsageSection /> }
+			{ hasIndex && (
+				<RecordMeter
+					postCount={ info.postCount }
+					postTypeBreakdown={ info.postTypeBreakdown }
+					tierMaximumRecords={ info.tierMaximumRecords }
+					lastIndexedDate={ info.lastIndexedDate }
+					postTypes={ info.postTypes }
+				/>
+			) }
+		</>
+	);
+};
 
 const PlanSummary = ( { latestMonthRequests } ) => {
 	const tierSlug = useSelect( select => select( STORE_ID ).getTierSlug() );

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -163,9 +163,11 @@ const PlanInfo = props => {
 	// TODO: Investigate why this isn't returning anything useful.
 	const siteTitle = useSelect( select => select( STORE_ID ).getSiteTitle() ) || 'your site';
 	// Plan Info data
+	const currentPlan = useSelect( select => select( STORE_ID ).getCurrentPlan() );
+	const currentUsage = useSelect( select => select( STORE_ID ).getCurrentUsage() );
 	const latestMonthRequests = useSelect( select => select( STORE_ID ).getLatestMonthRequests() );
 	const tierSlug = useSelect( select => select( STORE_ID ).getTierSlug() );
-	const planInfo = { latestMonthRequests, tierSlug };
+	const planInfo = { currentPlan, currentUsage, latestMonthRequests, tierSlug };
 	return (
 		<>
 			{ ! hasIndex && <FirstRunSection siteTitle={ siteTitle } planInfo={ planInfo } /> }

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -159,10 +159,14 @@ export default function DashboardPage( { isLoading = false } ) {
 const PlanInfo = props => {
 	const hasIndex = props.hasIndex;
 	const info = props.recordMeterInfo;
+	// Plan Info data
+	const latestMonthRequests = useSelect( select => select( STORE_ID ).getLatestMonthRequests() );
+	const tierSlug = useSelect( select => select( STORE_ID ).getTierSlug() );
+	const planInfo = { latestMonthRequests, tierSlug };
 	return (
 		<>
-			{ ! hasIndex && <FirstRunSection /> }
-			{ hasIndex && <PlanUsageSection /> }
+			{ ! hasIndex && <FirstRunSection planInfo={ planInfo } /> }
+			{ hasIndex && <PlanUsageSection planInfo={ planInfo } /> }
 			{ hasIndex && (
 				<RecordMeter
 					postCount={ info.postCount }

--- a/projects/packages/search/src/dashboard/components/pages/sections/first-run-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/first-run-section.jsx
@@ -8,9 +8,6 @@ import React from 'react';
 
 // TODO: Replace local PlanSummary component with new component when ready.
 const FirstRunSection = props => {
-	if ( ! props.isVisible ) {
-		return null;
-	}
 	return (
 		<div className="jp-search-dashboard-wrap jp-search-dashboard-meter-wrap">
 			<div className="jp-search-dashboard-row">

--- a/projects/packages/search/src/dashboard/components/pages/sections/first-run-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/first-run-section.jsx
@@ -12,7 +12,7 @@ const FirstRunSection = props => {
 			<div className="jp-search-dashboard-row">
 				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
 				<div className="jp-search-dashboard-meter-wrap__content lg-col-span-8 md-col-span-6 sm-col-span-4">
-					<PlanSummary />
+					<PlanSummary planInfo={ props.planInfo } />
 					<ProgressWrapper siteTitle="YOUR-FUNNY-SITE" />
 					<NoticeWrapper />
 				</div>

--- a/projects/packages/search/src/dashboard/components/pages/sections/first-run-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/first-run-section.jsx
@@ -13,7 +13,7 @@ const FirstRunSection = props => {
 				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
 				<div className="jp-search-dashboard-meter-wrap__content lg-col-span-8 md-col-span-6 sm-col-span-4">
 					<PlanSummary planInfo={ props.planInfo } />
-					<ProgressWrapper siteTitle="YOUR-FUNNY-SITE" />
+					<ProgressWrapper siteTitle={ props.siteTitle } />
 					<NoticeWrapper />
 				</div>
 				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>

--- a/projects/packages/search/src/dashboard/components/pages/sections/first-run-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/first-run-section.jsx
@@ -22,6 +22,9 @@ const FirstRunSection = props => {
 	);
 };
 
+// TODO: Move this back inline.
+// Per Jason's feedback, doesn't think we should break this out.
+// https://github.com/Automattic/jetpack/pull/26639#discussion_r989592860
 const ProgressWrapper = props => {
 	return (
 		<div>
@@ -39,6 +42,9 @@ const ProgressWrapper = props => {
 	);
 };
 
+// TODO: Remove const variables.
+// Per Jason's feedback, thinks we should put these inline.
+// https://github.com/Automattic/jetpack/pull/26639#discussion_r989593312
 const NoticeWrapper = () => {
 	const noticeBoxClassName = 'jp-search-notice-box';
 	const header = __( "We're gathering your usage data.", 'jetpack-search-pkg' );

--- a/projects/packages/search/src/dashboard/components/pages/sections/first-run-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/first-run-section.jsx
@@ -1,12 +1,11 @@
 import { IndeterminateProgressBar } from '@automattic/jetpack-components';
-import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import SimpleNotice from 'components/notice';
 import React from 'react';
+import PlanSummary from './plan-summary';
 
 // import './first-run-section.scss';
 
-// TODO: Replace local PlanSummary component with new component when ready.
 const FirstRunSection = props => {
 	return (
 		<div className="jp-search-dashboard-wrap jp-search-dashboard-meter-wrap">
@@ -20,24 +19,6 @@ const FirstRunSection = props => {
 				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
 			</div>
 		</div>
-	);
-};
-
-const PlanSummary = () => {
-	return (
-		<h2>
-			{ createInterpolateElement(
-				sprintf(
-					// translators: %1$s: usage period, %2$s: plan name
-					__( 'Your usage <s>%1$s (%2$s)</s>', 'jetpack-search-pkg' ),
-					'Sep 28-Oct 28',
-					__( 'Free plan', 'jetpack-search-pkg' )
-				),
-				{
-					s: <span />,
-				}
-			) }
-		</h2>
 	);
 };
 

--- a/projects/packages/search/src/dashboard/components/pages/sections/first-run-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/first-run-section.jsx
@@ -1,4 +1,4 @@
-import { IndeterminateProgressBar } from '@automattic/jetpack-components';
+import { IndeterminateProgressBar, ThemeProvider } from '@automattic/jetpack-components';
 import { __, sprintf } from '@wordpress/i18n';
 import SimpleNotice from 'components/notice';
 import React from 'react';
@@ -32,7 +32,9 @@ const ProgressWrapper = props => {
 					props.siteTitle
 				) }
 			</h3>
-			<IndeterminateProgressBar />
+			<ThemeProvider>
+				<IndeterminateProgressBar />
+			</ThemeProvider>
 		</div>
 	);
 };

--- a/projects/packages/search/src/dashboard/components/pages/sections/plan-summary.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/plan-summary.jsx
@@ -1,0 +1,28 @@
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import React from 'react';
+
+// import './plan-summary.scss';
+
+const PlanSummary = props => {
+	// TODO: Pull values from props.
+	const planName = 'Free or Paid?!';
+	const displayPeriod = 'Sep 28-Oct 28';
+	return (
+		<h2>
+			{ createInterpolateElement(
+				sprintf(
+					// translators: %1$s: usage period, %2$s: plan name
+					__( 'Your usage <s>%1$s (%2$s)</s>', 'jetpack-search-pkg' ),
+					displayPeriod,
+					planName
+				),
+				{
+					s: <span />,
+				}
+			) }
+		</h2>
+	);
+};
+
+export default PlanSummary;

--- a/projects/packages/search/src/dashboard/components/pages/sections/plan-summary.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/plan-summary.jsx
@@ -4,10 +4,36 @@ import React from 'react';
 
 // import './plan-summary.scss';
 
-const PlanSummary = props => {
-	// TODO: Pull values from props.
-	const planName = 'Free or Paid?!';
-	const displayPeriod = 'Sep 28-Oct 28';
+const planNameFromAPIData = apiData => {
+	// Determine plan name for display.
+	const planType = apiData?.tierSlug;
+	const planName = planType
+		? __( 'Paid Plan', 'jetpack-search-pkg' )
+		: __( 'Free Plan', 'jetpack-search-pkg' );
+	return planName;
+};
+
+const displayPeriodFromAPIData = apiData => {
+	const startDate = new Date( apiData.latestMonthRequests.start_date );
+	const endDate = new Date( apiData.latestMonthRequests.end_date );
+
+	// Date formatted as: MMM DD
+	// Example: Feb 02
+	const localeOptions = {
+		month: 'short',
+		day: '2-digit',
+	};
+
+	// Leave the locale as `undefined` to apply the browser host locale.
+	const startDateText = startDate.toLocaleDateString( undefined, localeOptions );
+	const endDateText = endDate.toLocaleDateString( undefined, localeOptions );
+
+	return `${ startDateText } - ${ endDateText }`;
+};
+
+const PlanSummary = ( { planInfo } ) => {
+	const planName = planNameFromAPIData( planInfo );
+	const displayPeriod = displayPeriodFromAPIData( planInfo );
 	return (
 		<h2>
 			{ createInterpolateElement(

--- a/projects/packages/search/src/dashboard/components/pages/sections/plan-summary.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/plan-summary.jsx
@@ -1,15 +1,14 @@
-import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import React from 'react';
 
 // import './plan-summary.scss';
 
 const planNameFromAPIData = apiData => {
 	// Determine plan name for display.
+	const paidText = __( 'Paid Plan', 'jetpack-search-pkg' );
+	const freeText = __( 'Free Plan', 'jetpack-search-pkg' );
 	const planType = apiData?.tierSlug;
-	const planName = planType
-		? __( 'Paid Plan', 'jetpack-search-pkg' )
-		: __( 'Free Plan', 'jetpack-search-pkg' );
+	const planName = planType ? paidText : freeText;
 	return planName;
 };
 
@@ -36,17 +35,13 @@ const PlanSummary = ( { planInfo } ) => {
 	const displayPeriod = displayPeriodFromAPIData( planInfo );
 	return (
 		<h2>
-			{ createInterpolateElement(
-				sprintf(
-					// translators: %1$s: usage period, %2$s: plan name
-					__( 'Your usage <s>%1$s (%2$s)</s>', 'jetpack-search-pkg' ),
-					displayPeriod,
-					planName
-				),
-				{
-					s: <span />,
-				}
-			) }
+			{
+				// translators: Header for section showing search records and requests usage.
+				__( 'Your usage', 'jetpack-search-pkg' )
+			}{ ' ' }
+			<span>
+				{ displayPeriod } ({ planName })
+			</span>
 		</h2>
 	);
 };

--- a/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
@@ -8,9 +8,6 @@ import DonutMeterContainer from '../../donut-meter-container';
 
 // TODO: Replace local PlanSummary component with new component when ready.
 const PlanUsageSection = props => {
-	if ( ! props.isVisible ) {
-		return null;
-	}
 	// TODO: Add logic for plan limits.
 	const upgradeMessage = null;
 	return (

--- a/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
@@ -7,17 +7,29 @@ import PlanSummary from './plan-summary';
 
 // import './plan-usage-section.scss';
 
-// TODO: Replace local PlanSummary component with new component when ready.
+const usageInfoFromAPIData = apiData => {
+	// Transform the data as necessary.
+	// Are there better defaults for the Max values?
+	// Should we recored, log, or otherwise surface potential errors here?
+	return {
+		recordCount: apiData?.currentUsage?.num_records || 0,
+		recordMax: apiData?.currentPlan?.record_limit || 0,
+		requestCount: apiData?.latestMonthRequests?.num_requests || 0,
+		requestMax: apiData?.currentPlan.monthly_search_request_limit || 0,
+	};
+};
+
 const PlanUsageSection = props => {
 	// TODO: Add logic for plan limits.
 	const upgradeMessage = null;
+	const usageInfo = usageInfoFromAPIData( props.planInfo );
 	return (
 		<div className="jp-search-dashboard-wrap jp-search-dashboard-meter-wrap">
 			<div className="jp-search-dashboard-row">
 				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
 				<div className="jp-search-dashboard-meter-wrap__content lg-col-span-8 md-col-span-6 sm-col-span-4">
 					<PlanSummary planInfo={ props.planInfo } />
-					<UsageMeters />
+					<UsageMeters usageInfo={ usageInfo } />
 					<UpgradeTrigger type={ upgradeMessage } />
 					<AboutPlanLimits />
 				</div>
@@ -84,18 +96,18 @@ const UpgradeTrigger = props => {
 	);
 };
 
-const UsageMeters = () => {
+const UsageMeters = ( { usageInfo } ) => {
 	return (
 		<div className="usage-meter-group">
 			<DonutMeterContainer
 				title={ __( 'Site records', 'jetpack-search-pkg' ) }
-				current={ 1250 }
-				limit={ 5000 }
+				current={ usageInfo.recordCount }
+				limit={ usageInfo.recordMax }
 			/>
 			<DonutMeterContainer
 				title={ __( 'Search requests', 'jetpack-search-pkg' ) }
-				current={ 125 }
-				limit={ 500 }
+				current={ usageInfo.requestCount }
+				limit={ usageInfo.requestMax }
 			/>
 		</div>
 	);

--- a/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
@@ -1,8 +1,9 @@
 import { ContextualUpgradeTrigger, ThemeProvider } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import React from 'react';
 import DonutMeterContainer from '../../donut-meter-container';
+import PlanSummary from './plan-summary';
 
 // import './plan-usage-section.scss';
 
@@ -23,24 +24,6 @@ const PlanUsageSection = props => {
 				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
 			</div>
 		</div>
-	);
-};
-
-const PlanSummary = () => {
-	return (
-		<h2>
-			{ createInterpolateElement(
-				sprintf(
-					// translators: %1$s: usage period, %2$s: plan name
-					__( 'Your usage <s>%1$s (%2$s)</s>', 'jetpack-search-pkg' ),
-					'Sep 28-Oct 28',
-					__( 'Free plan', 'jetpack-search-pkg' )
-				),
-				{
-					s: <span />,
-				}
-			) }
-		</h2>
 	);
 };
 

--- a/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
@@ -16,7 +16,7 @@ const PlanUsageSection = props => {
 			<div className="jp-search-dashboard-row">
 				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
 				<div className="jp-search-dashboard-meter-wrap__content lg-col-span-8 md-col-span-6 sm-col-span-4">
-					<PlanSummary />
+					<PlanSummary planInfo={ props.planInfo } />
 					<UsageMeters />
 					<UpgradeTrigger type={ upgradeMessage } />
 					<AboutPlanLimits />

--- a/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
@@ -19,9 +19,25 @@ const usageInfoFromAPIData = apiData => {
 	};
 };
 
+const upgradeTypeFromAPIData = apiData => {
+	// Determine if upgrade message is needed.
+	if ( ! apiData.currentUsage.must_upgrade ) {
+		return null;
+	}
+	// Determine appropriate upgrade message.
+	let mustUpgradeReason = '';
+	if ( apiData.currentUsage.upgrade_reason.requests ) {
+		mustUpgradeReason = 'requests';
+	}
+	if ( apiData.currentUsage.upgrade_reason.records ) {
+		mustUpgradeReason = mustUpgradeReason === 'requests' ? 'both' : 'records';
+	}
+	return mustUpgradeReason;
+};
+
 const PlanUsageSection = props => {
 	// TODO: Add logic for plan limits.
-	const upgradeMessage = null;
+	const upgradeType = upgradeTypeFromAPIData( props.planInfo );
 	const usageInfo = usageInfoFromAPIData( props.planInfo );
 	return (
 		<div className="jp-search-dashboard-wrap jp-search-dashboard-meter-wrap">
@@ -30,7 +46,7 @@ const PlanUsageSection = props => {
 				<div className="jp-search-dashboard-meter-wrap__content lg-col-span-8 md-col-span-6 sm-col-span-4">
 					<PlanSummary planInfo={ props.planInfo } />
 					<UsageMeters usageInfo={ usageInfo } />
-					<UpgradeTrigger type={ upgradeMessage } />
+					<UpgradeTrigger type={ upgradeType } />
 					<AboutPlanLimits />
 				</div>
 				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>

--- a/projects/packages/search/src/dashboard/store/selectors/site-data.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-data.js
@@ -8,6 +8,7 @@ const siteDataSelectors = {
 	getVersion: state => state.siteData?.version ?? 'development',
 	getCalypsoSlug: state => state.siteData?.calypsoSlug,
 	getPostTypes: state => state.siteData?.postTypes,
+	getSiteTitle: state => state.siteData?.title || '',
 	isWpcom: state => state.siteData?.isWpcom ?? false,
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26693 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

- Refactors/integrates new UI components 
- Adds the "Indexing your site" UI
- Fixes styling issues with progress bar

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Visit the Jetpack Search dashboard. Confirm the standard Record Meter UI appears.
2. Add `&new_pricing_202208=1` to URL. Confirm the new UI appears. It should show the correct First Run state if we do not yet have an index for the site.
3. Open the React Dev Tools in the Inspector. Find the `PlanInfo` section. Toggle the `hasIndex` property to see the two UI states.
4. Confirm the "Your usage…" line is correct in both states.
5. Confirm the meters have values.

**Note:** There are still some known issues to address:

- The API can return a huge value for the requests limit
- The API can return nonsensical dates for some sites
- The siteTitle value is not being fetched correctly and falls back to "your site"
- The CSS needs some tweaking in the `FirstRunSection`
- We can remove the "View details" link from the meters (for now)
- Possibly remove the "i" icon too?

All to be addressed in follow-up PRs.