### PR TITLE
VideoPress: Remove popover arrows on video quick actions

### DIFF
--- a/projects/packages/videopress/changelog/fix-popover-arrows
+++ b/projects/packages/videopress/changelog/fix-popover-arrows
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: Remove arrows from video quick action popovers

--- a/projects/packages/videopress/src/client/admin/components/video-quick-actions/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-quick-actions/index.tsx
@@ -42,7 +42,7 @@ const PopoverWithAnchor = ( { anchorRef, children = null }: PopoverWithAnchorPro
 	};
 
 	return (
-		<Popover position="top left" noArrow={ false } { ...popoverProps }>
+		<Popover position="top left" noArrow { ...popoverProps }>
 			<Text variant="body-small" className={ styles.popover }>
 				{ children }
 			</Text>

--- a/projects/packages/videopress/src/client/admin/components/video-quick-actions/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-quick-actions/index.tsx
@@ -42,7 +42,7 @@ const PopoverWithAnchor = ( { anchorRef, children = null }: PopoverWithAnchorPro
 	};
 
 	return (
-		<Popover position="top left" noArrow { ...popoverProps }>
+		<Popover position="top center" noArrow { ...popoverProps }>
 			<Text variant="body-small" className={ styles.popover }>
 				{ children }
 			</Text>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26621

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes the arrow from the video quick action popovers due to a difference in the Popover component when Gutenberg is not installed

p1665168219853739-slack-C02TQF5VAJD

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

On Storybook:
* Go to the storybook: `( cd projects/js-packages/storybook && pnpm run storybook:dev )`
* Go to VideoPress / Video Quick Actions
* Hover over the actions and notice that there are no arrows

On VideoPress:
* Go to the VideoPress dashboard
* Hover over the actions on a video card
* Notice that there are no arrows
* Activate or deactivate the Gutenberg plugin
* Repeat the test, there should be no difference

Before (Firefox) | Before (Chrome) | After
---------------------|------------------------|---------
![Screenshot_2022-10-10_11-09-26](https://user-images.githubusercontent.com/8486249/194886060-c4a804a0-a84c-4112-84f0-5a38fd36365b.png) | ![Screenshot_2022-10-10_11-10-10](https://user-images.githubusercontent.com/8486249/194886090-ef276785-52a7-470c-9874-4db3343004f7.png) | ![Screenshot_2022-10-10_11-08-28](https://user-images.githubusercontent.com/8486249/194886109-9193fca4-7a88-416d-9747-025d0fb3ff77.png)
