### PR TITLE
Boost: Add tracking to upsell and purchase CTA links

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/benefits/BenefitsInterstitial.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/benefits/BenefitsInterstitial.svelte
@@ -4,6 +4,7 @@
 	import { derived } from 'svelte/store';
 	import { createInterpolateElement } from '@wordpress/element';
 	import { __ } from '@wordpress/i18n';
+	import { recordBoostEvent } from '../../../js/utils/analytics';
 	import BackButton from '../../elements/BackButton.svelte';
 	import ReactComponent from '../../elements/ReactComponent.svelte';
 	import config from '../../stores/config';
@@ -12,6 +13,7 @@
 	import { getUpgradeURL } from '../../utils/upgrade';
 
 	function goToCheckout() {
+		recordBoostEvent( 'upsell_from_settings_page' );
 		window.location.href = getUpgradeURL();
 	}
 

--- a/projects/plugins/boost/app/assets/src/js/pages/benefits/BenefitsInterstitial.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/benefits/BenefitsInterstitial.svelte
@@ -4,16 +4,17 @@
 	import { derived } from 'svelte/store';
 	import { createInterpolateElement } from '@wordpress/element';
 	import { __ } from '@wordpress/i18n';
-	import { recordBoostEvent } from '../../../js/utils/analytics';
 	import BackButton from '../../elements/BackButton.svelte';
 	import ReactComponent from '../../elements/ReactComponent.svelte';
 	import config from '../../stores/config';
 	import Logo from '../../svg/jetpack-green.svg';
+	import { recordBoostEvent } from '../../utils/analytics';
 	import { jetpackURL } from '../../utils/jetpack-url';
 	import { getUpgradeURL } from '../../utils/upgrade';
 
 	function goToCheckout() {
-		recordBoostEvent( 'upsell_from_settings_page' );
+		const eventProps = {};
+		recordBoostEvent( 'checkout_from_pricing_page_in_plugin', eventProps );
 		window.location.href = getUpgradeURL();
 	}
 

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PremiumCTA.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PremiumCTA.svelte
@@ -1,11 +1,14 @@
 <script>
 	import { __ } from '@wordpress/i18n';
 	import RightArrow from '../../../svg/right-arrow.svg';
+	import { recordBoostEvent } from '../../../utils/analytics';
 	import routerHistory from '../../../utils/router-history';
 
 	const { navigate } = routerHistory;
 
 	function showBenefits() {
+		const eventProps = {};
+		recordBoostEvent( 'upsell_cta_from_settings_page_in_plugin', eventProps );
 		navigate( '/upgrade' );
 	}
 </script>

--- a/projects/plugins/boost/changelog/boost-add-purchase-cta-tracking
+++ b/projects/plugins/boost/changelog/boost-add-purchase-cta-tracking
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added tracking to purchase CTA

--- a/projects/plugins/boost/changelog/boost-add-purchase-cta-tracking
+++ b/projects/plugins/boost/changelog/boost-add-purchase-cta-tracking
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: added
 
 Added tracking to purchase CTA


### PR DESCRIPTION
### Decscription

This PR adds tracking to the purchase button on the page that's reached after clicking the upsell notice on the settings page. I've just logged the event itself tracks already [tracks a lot of stuff](https://github.com/Automattic/nosara/tree/master/tracks_etl). What we want to see is how many clicks we are getting. 


#### Changes proposed in this Pull Request:
* Adds tracking code to the plugin for click tracking

#### Jetpack product discussion
See pc9hqz-Vx-p2 for more info

#### Does this pull request change what data or activity we track or use?
Tracks click events

#### Testing instructions:
* Enable critical CSS
* Click the upsell which appears [event 1]
* From the page showing pricing, click upgrade [event 2]
* Both events should show up in tracks

