### PR TITLE
Search: Disable controls when users reach plan limit usage over months

### DIFF
--- a/projects/packages/search/changelog/update-stop_controls_over_plan_limit_usage
+++ b/projects/packages/search/changelog/update-stop_controls_over_plan_limit_usage
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Stop controls when usage over plan limit months.

--- a/projects/packages/search/src/dashboard/components/module-control/index.jsx
+++ b/projects/packages/search/src/dashboard/components/module-control/index.jsx
@@ -164,8 +164,10 @@ const InstantSearchToggle = ( {
 		isSavingEitherOption ||
 		! isModuleEnabled ||
 		! isInstantSearchEnabled ||
-		! supportsInstantSearch;
-	const isWidgetsEditorButtonDisabled = isSavingEitherOption || ! isModuleEnabled;
+		! supportsInstantSearch ||
+		! hasActiveSearchPurchase;
+	const isWidgetsEditorButtonDisabled =
+		isSavingEitherOption || ! isModuleEnabled || ! hasActiveSearchPurchase;
 
 	return (
 		<div className="jp-form-search-settings-group__toggle is-instant-search jp-search-dashboard-wrap">

--- a/projects/packages/search/src/dashboard/components/module-control/index.jsx
+++ b/projects/packages/search/src/dashboard/components/module-control/index.jsx
@@ -32,7 +32,7 @@ const WIDGETS_EDITOR_URL = 'widgets.php';
  * @param {string} props.siteAdminUrl - site admin URL.
  * @param {string} props.upgradeBillPeriod - billing cycle for upgrades.
  * @param {Function} props.updateOptions - function to update settings.
- * @param {boolean} props.hasActiveSearchPurchase - true if the subscription is valid to manipulate controls.
+ * @param {boolean} props.isDisabledFromOverLimit - true if the subscription is invalid to manipulate controls.
  * @param {boolean} props.isSavingEitherOption - true if Saving options.
  * @param {boolean} props.isModuleEnabled - true if Search module is enabled.
  * @param {boolean} props.isInstantSearchEnabled - true if Instant Search is enabled.
@@ -48,7 +48,7 @@ export default function SearchModuleControl( {
 	siteAdminUrl,
 	updateOptions,
 	domain,
-	hasActiveSearchPurchase,
+	isDisabledFromOverLimit,
 	isSavingEitherOption,
 	isModuleEnabled,
 	isInstantSearchEnabled,
@@ -66,7 +66,7 @@ export default function SearchModuleControl( {
 	);
 
 	const toggleSearchModule = useCallback( () => {
-		if ( ! hasActiveSearchPurchase ) {
+		if ( isDisabledFromOverLimit ) {
 			return;
 		}
 
@@ -83,11 +83,11 @@ export default function SearchModuleControl( {
 		isModuleEnabled,
 		updateOptions,
 		isInstantSearchEnabled,
-		hasActiveSearchPurchase,
+		isDisabledFromOverLimit,
 	] );
 
 	const toggleInstantSearch = useCallback( () => {
-		if ( ! hasActiveSearchPurchase ) {
+		if ( isDisabledFromOverLimit ) {
 			return;
 		}
 
@@ -99,13 +99,13 @@ export default function SearchModuleControl( {
 		}
 		updateOptions( newOption );
 		analytics.tracks.recordEvent( 'jetpack_search_instant_toggle', newOption );
-	}, [ supportsInstantSearch, isInstantSearchEnabled, updateOptions, hasActiveSearchPurchase ] );
+	}, [ supportsInstantSearch, isInstantSearchEnabled, updateOptions, isDisabledFromOverLimit ] );
 
 	return (
 		<div
 			className={ classNames( {
 				'jp-form-settings-group jp-form-search-settings-group': true,
-				'jp-form-search-settings-group--disabled': ! hasActiveSearchPurchase,
+				'jp-form-search-settings-group--disabled': isDisabledFromOverLimit,
 			} ) }
 		>
 			<Card
@@ -120,7 +120,7 @@ export default function SearchModuleControl( {
 						isTogglingModule={ isTogglingModule }
 						supportsSearch={ supportsSearch }
 						toggleSearchModule={ toggleSearchModule }
-						hasActiveSearchPurchase={ hasActiveSearchPurchase }
+						isDisabledFromOverLimit={ isDisabledFromOverLimit }
 					/>
 
 					<InstantSearchToggle
@@ -134,7 +134,7 @@ export default function SearchModuleControl( {
 						supportsOnlyClassicSearch={ supportsOnlyClassicSearch }
 						toggleInstantSearch={ toggleInstantSearch }
 						upgradeUrl={ upgradeUrl }
-						hasActiveSearchPurchase={ hasActiveSearchPurchase }
+						isDisabledFromOverLimit={ isDisabledFromOverLimit }
 					/>
 				</div>
 			</Card>
@@ -153,21 +153,21 @@ const InstantSearchToggle = ( {
 	supportsOnlyClassicSearch,
 	toggleInstantSearch,
 	upgradeUrl,
-	hasActiveSearchPurchase,
+	isDisabledFromOverLimit,
 } ) => {
 	const isInstantSearchToggleChecked =
-		isModuleEnabled && isInstantSearchEnabled && supportsInstantSearch && hasActiveSearchPurchase;
+		isModuleEnabled && isInstantSearchEnabled && supportsInstantSearch && ! isDisabledFromOverLimit;
 	const isInstantSearchToggleDisabled =
-		isSavingEitherOption || ! supportsInstantSearch || ! hasActiveSearchPurchase;
+		isSavingEitherOption || ! supportsInstantSearch || isDisabledFromOverLimit;
 
 	const isInstantSearchCustomizeButtonDisabled =
 		isSavingEitherOption ||
 		! isModuleEnabled ||
 		! isInstantSearchEnabled ||
 		! supportsInstantSearch ||
-		! hasActiveSearchPurchase;
+		isDisabledFromOverLimit;
 	const isWidgetsEditorButtonDisabled =
-		isSavingEitherOption || ! isModuleEnabled || ! hasActiveSearchPurchase;
+		isSavingEitherOption || ! isModuleEnabled || isDisabledFromOverLimit;
 
 	return (
 		<div className="jp-form-search-settings-group__toggle is-instant-search jp-search-dashboard-wrap">
@@ -266,11 +266,11 @@ const SearchToggle = ( {
 	isTogglingModule,
 	supportsSearch,
 	toggleSearchModule,
-	hasActiveSearchPurchase,
+	isDisabledFromOverLimit,
 } ) => {
-	const isSearchToggleChecked = isModuleEnabled && supportsSearch && hasActiveSearchPurchase;
+	const isSearchToggleChecked = isModuleEnabled && supportsSearch && ! isDisabledFromOverLimit;
 	const isSearchToggleDisabled =
-		isSavingEitherOption || ! supportsSearch || ! hasActiveSearchPurchase;
+		isSavingEitherOption || ! supportsSearch || isDisabledFromOverLimit;
 
 	return (
 		<div className="jp-form-search-settings-group__toggle is-search jp-search-dashboard-wrap">

--- a/projects/packages/search/src/dashboard/components/module-control/style.scss
+++ b/projects/packages/search/src/dashboard/components/module-control/style.scss
@@ -11,13 +11,28 @@ $toggle-width: 3em;
 
 .jp-form-search-settings-group {
 	width: 100%;
+	position: relative;
+
 	.dops-card {
 		box-shadow: none;
 		padding: 0;
 		padding-top: 4em;
 	}
+
 	.form-toggle__label {
 		margin: 0;
+	}
+
+	&.jp-form-search-settings-group--disabled {
+		&:after {
+			content: ' ';
+			position: absolute;
+			top: 0;
+			left: 0;
+			width: 100%;
+			height: 100%;
+			background-color: rgba( 255, 255, 255, 0.7 );
+		}
 	}
 }
 

--- a/projects/packages/search/src/dashboard/components/module-control/style.scss
+++ b/projects/packages/search/src/dashboard/components/module-control/style.scss
@@ -31,7 +31,7 @@ $toggle-width: 3em;
 			left: 0;
 			width: 100%;
 			height: 100%;
-			background-color: rgba( 255, 255, 255, 0.7 );
+			background-color: rgba( 255, 255, 255, 0.6 );
 		}
 	}
 }

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -65,8 +65,8 @@ export default function DashboardPage( { isLoading = false } ) {
 	// Introduce the gate for new pricing with URL parameter `new_pricing_202208=1`
 	const isNewPricing = useSelect( select => select( STORE_ID ).isNewPricing202208(), [] );
 
-	const hasActiveSearchPurchase = useSelect( select =>
-		select( STORE_ID ).hasActiveSearchPurchase()
+	const isDisabledFromOverLimit = useSelect( select =>
+		select( STORE_ID ).getDisabledFromOverLimit()
 	);
 	const updateOptions = useDispatch( STORE_ID ).updateJetpackSettings;
 	const isInstantSearchPromotionActive = useSelect( select =>
@@ -124,7 +124,7 @@ export default function DashboardPage( { isLoading = false } ) {
 							siteAdminUrl={ siteAdminUrl }
 							updateOptions={ updateOptions }
 							domain={ domain }
-							hasActiveSearchPurchase={ hasActiveSearchPurchase }
+							isDisabledFromOverLimit={ isDisabledFromOverLimit }
 							isInstantSearchPromotionActive={ isInstantSearchPromotionActive }
 							upgradeBillPeriod={ upgradeBillPeriod }
 							supportsOnlyClassicSearch={ supportsOnlyClassicSearch }

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -65,6 +65,9 @@ export default function DashboardPage( { isLoading = false } ) {
 	// Introduce the gate for new pricing with URL parameter `new_pricing_202208=1`
 	const isNewPricing = useSelect( select => select( STORE_ID ).isNewPricing202208(), [] );
 
+	const hasActiveSearchPurchase = useSelect( select =>
+		select( STORE_ID ).hasActiveSearchPurchase()
+	);
 	const updateOptions = useDispatch( STORE_ID ).updateJetpackSettings;
 	const isInstantSearchPromotionActive = useSelect( select =>
 		select( STORE_ID ).isInstantSearchPromotionActive()
@@ -121,6 +124,7 @@ export default function DashboardPage( { isLoading = false } ) {
 							siteAdminUrl={ siteAdminUrl }
 							updateOptions={ updateOptions }
 							domain={ domain }
+							hasActiveSearchPurchase={ hasActiveSearchPurchase }
 							isInstantSearchPromotionActive={ isInstantSearchPromotionActive }
 							upgradeBillPeriod={ upgradeBillPeriod }
 							supportsOnlyClassicSearch={ supportsOnlyClassicSearch }

--- a/projects/packages/search/src/dashboard/store/selectors/site-plan.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-plan.js
@@ -1,7 +1,11 @@
+const OVER_PLAN_LIMIT_MONTHS = 3;
+
 const sitePlanSelectors = {
 	getSearchPlanInfo: state => state.sitePlan,
 	hasBusinessPlan: state => state.sitePlan.supports_only_classic_search,
-	hasActiveSearchPurchase: state => state.sitePlan.supports_instant_search,
+	hasActiveSearchPurchase: state =>
+		state.sitePlan.plan_usage.months_over_plan_requests_limit < OVER_PLAN_LIMIT_MONTHS &&
+		state.sitePlan.plan_usage.months_over_plan_records_limit < OVER_PLAN_LIMIT_MONTHS,
 	supportsInstantSearch: state => state.sitePlan.supports_instant_search,
 	supportsOnlyClassicSearch: state => state.sitePlan.supports_only_classic_search,
 	getUpgradeBillPeriod: state => state.sitePlan?.default_upgrade_bill_period,

--- a/projects/packages/search/src/dashboard/store/selectors/site-plan.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-plan.js
@@ -1,11 +1,7 @@
-const OVER_PLAN_LIMIT_MONTHS = 3;
-
 const sitePlanSelectors = {
 	getSearchPlanInfo: state => state.sitePlan,
 	hasBusinessPlan: state => state.sitePlan.supports_only_classic_search,
-	hasActiveSearchPurchase: state =>
-		state.sitePlan.plan_usage.months_over_plan_requests_limit < OVER_PLAN_LIMIT_MONTHS &&
-		state.sitePlan.plan_usage.months_over_plan_records_limit < OVER_PLAN_LIMIT_MONTHS,
+	getDisabledFromOverLimit: state => state.sitePlan.plan_usage.must_upgrade,
 	supportsInstantSearch: state => state.sitePlan.supports_instant_search,
 	supportsOnlyClassicSearch: state => state.sitePlan.supports_only_classic_search,
 	getUpgradeBillPeriod: state => state.sitePlan?.default_upgrade_bill_period,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26717 
Fixes #26718 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Remove duplicated state of `hasActiveSearchPurchase`.
* Introduce `isDisabledFromOverLimit` with `plan_usage.must_upgrade` as the disabled property into Module Control to avoid polluting other flags.
* Stop controls operation even if the overlay displays failed.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-hCY-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

> Note: Since the present usage must not have been reached over the plan limit, we have to test it by changing the code.

* Purchase the Jetpack Search `Free` plan.
* Navigate to the site with URL `/wp-admin/admin.php?page=jetpack-search&new_pricing_202208=1`.
* Ensure the control toggles display as usual.
* Append ` || true` to `plan_usage.must_upgrade` state condition and reload the page.
* Ensure the control toggles are disabled with an overlay.

| Usual | Disabled |
| --- | --- |
| <img width="1261" alt="截圖 2022-10-11 上午3 05 40" src="https://user-images.githubusercontent.com/6869813/194936128-7c724975-942e-4d74-b204-6b35a9121dda.png"> | <img width="1287" alt="截圖 2022-10-11 上午3 05 21" src="https://user-images.githubusercontent.com/6869813/194936176-78247315-edc5-4518-ad69-c32842aa1f5c.png"> |


