### PR TITLE
Protect: add connection error notice

### DIFF
--- a/projects/plugins/protect/changelog/add-connection-error-to-protect
+++ b/projects/plugins/protect/changelog/add-connection-error-to-protect
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add connection error notice to the plugin.

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -7,7 +7,12 @@ import {
 	Text,
 	useBreakpointMatch,
 } from '@automattic/jetpack-components';
-import { useProductCheckoutWorkflow, useConnection } from '@automattic/jetpack-connection';
+import {
+	useProductCheckoutWorkflow,
+	useConnection,
+	useConnectionErrorNotice,
+	ConnectionError,
+} from '@automattic/jetpack-connection';
 import { Spinner } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -90,6 +95,7 @@ const InterstitialPage = ( { run, hasCheckoutStarted } ) => {
 
 const ProtectAdminPage = () => {
 	const { lastChecked, currentStatus, errorCode, errorMessage } = useProtectData();
+	const { hasConnectionError } = useConnectionErrorNotice();
 
 	let currentScanStatus;
 	if ( 'error' === currentStatus ) {
@@ -119,6 +125,11 @@ const ProtectAdminPage = () => {
 			<AdminPage moduleName={ __( 'Jetpack Protect', 'jetpack-protect' ) } header={ <Logo /> }>
 				<AdminSectionHero>
 					<Container horizontalSpacing={ 0 }>
+						{ hasConnectionError && (
+							<Col className={ styles[ 'connection-error-col' ] }>
+								<ConnectionError />
+							</Col>
+						) }
 						<Col>
 							<div id="jp-admin-notices" className="my-jetpack-jitm-card" />
 						</Col>
@@ -150,6 +161,11 @@ const ProtectAdminPage = () => {
 			<AdminPage moduleName={ __( 'Jetpack Protect', 'jetpack-protect' ) } header={ <Logo /> }>
 				<AdminSectionHero>
 					<Container horizontalSpacing={ 0 }>
+						{ hasConnectionError && (
+							<Col className={ styles[ 'connection-error-col' ] }>
+								<ConnectionError />
+							</Col>
+						) }
 						<Col>
 							<div id="jp-admin-notices" className="my-jetpack-jitm-card" />
 						</Col>
@@ -197,6 +213,11 @@ const ProtectAdminPage = () => {
 		<AdminPage moduleName={ __( 'Jetpack Protect', 'jetpack-protect' ) } header={ <Logo /> }>
 			<AdminSectionHero>
 				<Container horizontalSpacing={ 0 }>
+					{ hasConnectionError && (
+						<Col className={ styles[ 'connection-error-col' ] }>
+							<ConnectionError />
+						</Col>
+					) }
 					<Col>
 						<div id="jp-admin-notices" className="my-jetpack-jitm-card" />
 					</Col>

--- a/projects/plugins/protect/src/js/components/admin-page/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/admin-page/styles.module.scss
@@ -40,3 +40,7 @@
 		margin-bottom: calc( var( --spacing-base ) * 3 );
 	}
 }
+
+.connection-error-col {
+	margin-top: 25px;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Add connection error notice to the Protect plugin

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
p9dueE-5zL-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

1. Checkout the branch, rebuild `plugins/protect` if needed.
2. Connect Jetpack, go to "Broken Token" and set an invalid blog token.
3. Go to "Jetpack -> My Jetpack" to trigger the connection error.
4. Go to "Jetpack -> Protect", confirm that the error notice shows up:  <img width="1117" alt="Screen Shot 2022-10-10 at 16 16 10" src="https://user-images.githubusercontent.com/1341249/194945487-5a1add3e-8617-4e4e-8b1b-7f999682903b.png">
5. Click "Restore", the notice should say "Reconnecting Jetpack" instead, and display the spinning loader.
6. The page should reload, the notice should disappear.
7. Go back to the "Broken Token", confirm the blog token has been restored.


_If the error notice doesn't show up, you might need to clean the transients using the following SQL query:_
```
delete from wp_options where option_name like '%jetpack_connection_error_reporting_gate_%';
```
_Then, please visit "Jetpack -> My Jetpack" again, and the error notice should appear._