### PR TITLE
VideoPress: add no_videopress query filter on media endpoint

### DIFF
--- a/projects/packages/videopress/changelog/add-no-videopress-query-filter
+++ b/projects/packages/videopress/changelog/add-no-videopress-query-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Include a new `no_videopress` query string parameter to remove from the list all VideoPress related media.

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
@@ -69,6 +69,33 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Data {
 	}
 
 	/**
+	 * Filter request args to handle the custom VideoPress query filters
+	 *
+	 * Possible filters:
+	 *
+	 * `no_videopress`: the returned attachments should not have a videopress_guid
+	 *
+	 * @param array      $args The original list of args before the filtering.
+	 * @param WP_Request $request The original request data.
+	 */
+	public function filter_attachments_by_jetpack_videopress_fields( $args, $request ) {
+
+		if ( ! isset( $args['meta_query'] ) || ! is_array( $args['meta_query'] ) ) {
+			$args['meta_query'] = array();
+		}
+
+		/* To ignore all VideoPress videos, select only attachments without videopress_guid meta field */
+		if ( isset( $request['no_videopress'] ) ) {
+			$args['meta_query'][] = array(
+				'key'     => 'videopress_guid',
+				'compare' => 'NOT EXISTS',
+			);
+		}
+
+		return $args;
+	}
+
+	/**
 	 * Defines data structure and what elements are visible in which contexts
 	 */
 	public function get_schema() {

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
@@ -40,6 +40,7 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Data {
 	 */
 	public function __construct() {
 		add_action( 'rest_api_init', array( $this, 'register_fields' ) );
+		add_action( 'rest_api_init', array( $this, 'add_jetpack_videopress_custom_query_filters' ) );
 
 		// do this again later to collect any CPTs that get registered later.
 		add_action( 'restapi_theme_init', array( $this, 'register_fields' ), 20 );
@@ -66,6 +67,13 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Data {
 		);
 
 		add_filter( 'rest_prepare_attachment', array( $this, 'remove_field_for_non_videos' ), 10, 2 );
+	}
+
+	/**
+	 * Adds the custom query filters
+	 */
+	public function add_jetpack_videopress_custom_query_filters() {
+		add_filter( 'rest_attachment_query', array( $this, 'filter_attachments_by_jetpack_videopress_fields' ), 999, 2 );
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
@@ -40,7 +40,10 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Data {
 	 */
 	public function __construct() {
 		add_action( 'rest_api_init', array( $this, 'register_fields' ) );
-		add_action( 'rest_api_init', array( $this, 'add_jetpack_videopress_custom_query_filters' ) );
+
+		if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
+			add_action( 'rest_api_init', array( $this, 'add_jetpack_videopress_custom_query_filters' ) );
+		}
 
 		// do this again later to collect any CPTs that get registered later.
 		add_action( 'restapi_theme_init', array( $this, 'register_fields' ), 20 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26502.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Defines a new `no_videopress` query string parameter to allow list media attachments ignoring the files that are VideoPress files (by only allowing files without `videopress_guid` meta field)

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pe4Cmx-fL-p2#comment-135

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Disable Jetpack VideoPress and Jetpack
* Go to `Media > Library` and upload a new video (this will be a non-VideoPress video)
* Enable Jetpack VideoPress
* Go to `Media > Library` again and upload a new video (this will be a VideoPress video)
* Test the media API with the following requests:

1. Requesting **VideoPress** videos:

```
curl -X GET -u "user:pass" "http://your-site.com/wp-json/wp/v2/media?mime_type=video/videopress&per_page=6" | jq
```

* This request should return only the VideoPress videos: the MIME Type will be `video/videopress` and you will find a `jetpack_videopress_guid` field on the response:

![image](https://user-images.githubusercontent.com/6760046/194948274-c8f63fbd-d075-4152-bd91-b31816807828.png)
 
2. Requesting **non-VideoPress (local)** videos:

```
curl -X GET -u "user:pass" "http://your-site.com/wp-json/wp/v2/media?media_type=video&no_videopress&per_page=6" | jq
```

* This request should return only non-VideoPress videos: the MIME Type will be differente from `video/videopress` and you will not find a `jetpack_videopress_guid` value on the response:

![image](https://user-images.githubusercontent.com/6760046/194948823-2359a072-e419-4fd1-a9d2-deff0e8df249.png)