### PR TITLE
VideoPress: handle core/embed videopress block variation

### DIFF
--- a/projects/packages/videopress/changelog/update-unregister-videopress-embed-block
+++ b/projects/packages/videopress/changelog/update-unregister-videopress-embed-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: handle core/oembed videopress block variation

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/utils/url.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/utils/url.js
@@ -45,3 +45,13 @@ export const getVideoPressUrl = (
 	};
 	return addQueryArgs( `https://videopress.com/v/${ guid }`, options );
 };
+
+export const pickGUIDFromUrl = url => {
+	if ( ! url ) {
+		return null;
+	}
+
+	const urlParts = url.split( 'https://videopress.com/v/' );
+	const guid = urlParts[ urlParts.length - 1 ];
+	return guid;
+};

--- a/projects/packages/videopress/src/client/block-editor/extend/core-embed/edit.js
+++ b/projects/packages/videopress/src/client/block-editor/extend/core-embed/edit.js
@@ -21,6 +21,11 @@ const withCoreEmbedVideoPressBlock = createHigherOrderComponent( CoreEmbedBlockE
 			return <CoreEmbedBlockEdit { ...props } />;
 		}
 
+		const { keepUsingOEmbedVariation } = attributes;
+		if ( keepUsingOEmbedVariation === true ) {
+			return <CoreEmbedBlockEdit { ...props } />;
+		}
+
 		return (
 			<div>
 				<Warning

--- a/projects/packages/videopress/src/client/block-editor/extend/core-embed/edit.js
+++ b/projects/packages/videopress/src/client/block-editor/extend/core-embed/edit.js
@@ -1,27 +1,58 @@
 /**
  * External dependencies
  */
-import { Warning } from '@wordpress/block-editor';
+import { Warning, store as blockEditorStore } from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
 import { Button } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
 import './editor.scss';
+import { pickGUIDFromUrl } from '../../blocks/video/utils/url';
 
 const withCoreEmbedVideoPressBlock = createHigherOrderComponent( CoreEmbedBlockEdit => {
 	return props => {
+		const { clientId } = props;
+		const { attributes, setAttributes } = props;
+		const { url, keepUsingOEmbedVariation } = attributes;
+		const { replaceBlock } = useDispatch( blockEditorStore );
+
+		const guid = pickGUIDFromUrl( url );
+
+		useEffect( () => {
+			if ( keepUsingOEmbedVariation !== false ) {
+				return;
+			}
+
+			replaceBlock(
+				clientId,
+				createBlock( 'videopress/video', {
+					...attributes,
+					guid,
+				} )
+			);
+		}, [ keepUsingOEmbedVariation, guid ] );
+
+		// Check if the block is a core/embed block.
 		if ( props.name !== 'core/embed' ) {
 			return <CoreEmbedBlockEdit { ...props } />;
 		}
 
-		const { attributes } = props;
+		// ...and if it's a `videopress` variation.
 		if ( ! attributes?.providerNameSlug || attributes.providerNameSlug !== 'videopress' ) {
 			return <CoreEmbedBlockEdit { ...props } />;
 		}
 
-		const { keepUsingOEmbedVariation } = attributes;
+		// ... and if was possible to pick the GUID from the URL.
+		if ( ! guid ) {
+			return <CoreEmbedBlockEdit { ...props } />;
+		}
+
+		// ... and if the user has already decided to keep using the oEmbed variation.
 		if ( keepUsingOEmbedVariation === true ) {
 			return <CoreEmbedBlockEdit { ...props } />;
 		}
@@ -31,10 +62,18 @@ const withCoreEmbedVideoPressBlock = createHigherOrderComponent( CoreEmbedBlockE
 				<Warning
 					className="videopress-embed-warning"
 					actions={ [
-						<Button key="convert" variant="primary">
+						<Button
+							key="convert"
+							variant="primary"
+							onClick={ () => setAttributes( { keepUsingOEmbedVariation: false } ) }
+						>
 							{ __( 'Use the new VideoPress Video block', 'jetpack-videopress-pkg' ) }
 						</Button>,
-						<Button key="convert" variant="tertiary">
+						<Button
+							key="convert"
+							variant="tertiary"
+							onClick={ () => setAttributes( { keepUsingOEmbedVariation: true } ) }
+						>
 							{ __( 'Keep using the VideoPress Embed block variation', 'jetpack-videopress-pkg' ) }
 						</Button>,
 					] }

--- a/projects/packages/videopress/src/client/block-editor/extend/core-embed/edit.js
+++ b/projects/packages/videopress/src/client/block-editor/extend/core-embed/edit.js
@@ -1,7 +1,14 @@
 /**
  * External dependencies
  */
+import { Warning } from '@wordpress/block-editor';
+import { Button } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
 
 const withCoreEmbedVideoPressBlock = createHigherOrderComponent( CoreEmbedBlockEdit => {
 	return props => {
@@ -15,9 +22,29 @@ const withCoreEmbedVideoPressBlock = createHigherOrderComponent( CoreEmbedBlockE
 		}
 
 		return (
-			<>
-				<CoreEmbedBlockEdit { ...props } />
-			</>
+			<div>
+				<Warning
+					className="videopress-embed-warning"
+					actions={ [
+						<Button key="convert" variant="primary">
+							{ __( 'Use the new VideoPress Video block', 'jetpack-videopress-pkg' ) }
+						</Button>,
+						<Button key="convert" variant="tertiary">
+							{ __( 'Keep using the VideoPress Embed block variation', 'jetpack-videopress-pkg' ) }
+						</Button>,
+					] }
+				>
+					{ __(
+						'Your site currently supports the VideoPress Video block.',
+						'jetpack-videopress-pkg'
+					) }
+				</Warning>
+
+				<div className="wp-block-core-embed-wrapper is-disabled">
+					<div className="core-embed-videopress-player__overlay" />
+					<CoreEmbedBlockEdit { ...props } />
+				</div>
+			</div>
 		);
 	};
 }, 'withCoreEmbedVideoPressBlock' );

--- a/projects/packages/videopress/src/client/block-editor/extend/core-embed/edit.js
+++ b/projects/packages/videopress/src/client/block-editor/extend/core-embed/edit.js
@@ -67,14 +67,14 @@ const withCoreEmbedVideoPressBlock = createHigherOrderComponent( CoreEmbedBlockE
 							variant="primary"
 							onClick={ () => setAttributes( { keepUsingOEmbedVariation: false } ) }
 						>
-							{ __( 'Use the new VideoPress Video block', 'jetpack-videopress-pkg' ) }
+							{ __( 'Use VideoPress Video block', 'jetpack-videopress-pkg' ) }
 						</Button>,
 						<Button
 							key="convert"
 							variant="tertiary"
 							onClick={ () => setAttributes( { keepUsingOEmbedVariation: true } ) }
 						>
-							{ __( 'Keep using the VideoPress Embed block variation', 'jetpack-videopress-pkg' ) }
+							{ __( 'Keep using VideoPress Embed block', 'jetpack-videopress-pkg' ) }
 						</Button>,
 					] }
 				>

--- a/projects/packages/videopress/src/client/block-editor/extend/core-embed/edit.js
+++ b/projects/packages/videopress/src/client/block-editor/extend/core-embed/edit.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { createHigherOrderComponent } from '@wordpress/compose';
+
+const withCoreEmbedVideoPressBlock = createHigherOrderComponent( CoreEmbedBlockEdit => {
+	return props => {
+		if ( props.name !== 'core/embed' ) {
+			return <CoreEmbedBlockEdit { ...props } />;
+		}
+
+		const { attributes } = props;
+		if ( ! attributes?.providerNameSlug || attributes.providerNameSlug !== 'videopress' ) {
+			return <CoreEmbedBlockEdit { ...props } />;
+		}
+
+		return (
+			<>
+				<CoreEmbedBlockEdit { ...props } />
+			</>
+		);
+	};
+}, 'withCoreEmbedVideoPressBlock' );
+
+export default withCoreEmbedVideoPressBlock;

--- a/projects/packages/videopress/src/client/block-editor/extend/core-embed/editor.scss
+++ b/projects/packages/videopress/src/client/block-editor/extend/core-embed/editor.scss
@@ -1,5 +1,9 @@
 .videopress-embed-warning {
 	margin-bottom: 8px;
+
+	.block-editor-warning__actions {
+		flex-wrap: wrap;
+	}
 }
 
 .wp-block-core-embed-wrapper {

--- a/projects/packages/videopress/src/client/block-editor/extend/core-embed/editor.scss
+++ b/projects/packages/videopress/src/client/block-editor/extend/core-embed/editor.scss
@@ -1,0 +1,21 @@
+.videopress-embed-warning {
+	margin-bottom: 8px;
+}
+
+.wp-block-core-embed-wrapper {
+	position: relative;
+
+	&.is-disabled {
+		opacity: 0.5;
+	}
+
+	.core-embed-videopress-player__overlay {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		background-color: transparent;
+		z-index: 2;
+	}
+}

--- a/projects/packages/videopress/src/client/block-editor/extend/core-embed/index.js
+++ b/projects/packages/videopress/src/client/block-editor/extend/core-embed/index.js
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import { unregisterBlockVariation } from '@wordpress/blocks';
+import domReady from '@wordpress/dom-ready';
+
+domReady( function () {
+	// @todo: horrible hack to make the unregister work
+	setTimeout( () => {
+		unregisterBlockVariation( 'core/embed', 'videopress' );
+	}, 0 );
+} );

--- a/projects/packages/videopress/src/client/block-editor/extend/core-embed/index.js
+++ b/projects/packages/videopress/src/client/block-editor/extend/core-embed/index.js
@@ -3,6 +3,28 @@
  */
 import { unregisterBlockVariation } from '@wordpress/blocks';
 import domReady from '@wordpress/dom-ready';
+import { addFilter } from '@wordpress/hooks';
+/**
+ * Internal dependencies
+ */
+import withCoreEmbedVideoPressBlock from './edit';
+
+const extendCoreEmbedVideoPressBlock = ( settings, name ) => {
+	if ( name !== 'core/embed' ) {
+		return settings;
+	}
+
+	return {
+		...settings,
+		edit: withCoreEmbedVideoPressBlock( settings.edit ),
+	};
+};
+
+addFilter(
+	'blocks.registerBlockType',
+	'videopress/core-embed/handle-representation',
+	extendCoreEmbedVideoPressBlock
+);
 
 domReady( function () {
 	// @todo: horrible hack to make the unregister work

--- a/projects/packages/videopress/src/client/block-editor/extend/core-embed/index.js
+++ b/projects/packages/videopress/src/client/block-editor/extend/core-embed/index.js
@@ -16,6 +16,12 @@ const extendCoreEmbedVideoPressBlock = ( settings, name ) => {
 
 	return {
 		...settings,
+		attributes: {
+			...settings.attributes,
+			keepUsingOEmbedVariation: {
+				type: 'boolean',
+			},
+		},
 		edit: withCoreEmbedVideoPressBlock( settings.edit ),
 	};
 };

--- a/projects/packages/videopress/src/client/block-editor/extend/index.js
+++ b/projects/packages/videopress/src/client/block-editor/extend/index.js
@@ -1,0 +1,1 @@
+import './core-embed';

--- a/projects/packages/videopress/src/client/block-editor/index.js
+++ b/projects/packages/videopress/src/client/block-editor/index.js
@@ -2,3 +2,8 @@
  * Internal dependencies
  */
 import './blocks/video';
+
+/*
+ * extensibility
+ */
+import './extend';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/25940
Fixes https://github.com/Automattic/jetpack/issues/26729

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR handles the `core/embed` `videopress` block variation:
  * Unregister the variation
  * Allow the user to keep using the variation, or...
  * Transform it into a VideoPress Video block

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Block editor
* Create an Embed block with a VideoPress URL (`https://videopress.com/v/SEhvBzm2`)
* Confirm you see the warning:
<img width="667" alt="image" src="https://user-images.githubusercontent.com/77539/194951171-95669b5d-1012-4606-a213-647546f78ceb.png">
* Click on `Keep using VideoPress Embed block` button
* Confirm you see the Embed block there
<img width="1022" alt="Screen Shot 2022-10-10 at 17 58 31" src="https://user-images.githubusercontent.com/77539/194951388-a6ca4ad9-0199-412f-8b60-b2855c38649e.png">
* Save the post
* Confirm the dialog doesn't appear anymore
* Click on `Use VideoPress Video block` button
* Confirm you see a VideoPress Video block instance
<img width="1010" alt="Screen Shot 2022-10-10 at 18 00 21" src="https://user-images.githubusercontent.com/77539/194951616-c0eac7f4-1e7c-4990-8a67-82b9706547d5.png">


