### PR TITLE
Search: Add upgrade link at the top right of the page

### DIFF
--- a/projects/packages/search/changelog/update-upgrade_link_top_right
+++ b/projects/packages/search/changelog/update-upgrade_link_top_right
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Add upgrade button link with applying upgrade actions.

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -70,7 +70,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.26.x-dev"
+			"dev-trunk": "0.27.x-dev"
 		},
 		"version-constants": {
 			"::VERSION": "src/class-package.php"

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.26.0",
+	"version": "0.27.0-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.26.0';
+	const VERSION = '0.27.0-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -3,6 +3,7 @@ import {
 	JetpackSearchLogo,
 	ThemeProvider,
 	ContextualUpgradeTrigger,
+	Button,
 } from '@automattic/jetpack-components';
 import { useProductCheckoutWorkflow } from '@automattic/jetpack-connection';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -113,7 +114,7 @@ export default function DashboardPage( { isLoading = false } ) {
 			{ isPageLoading && <Loading /> }
 			{ ! isPageLoading && (
 				<div className="jp-search-dashboard-page">
-					<Header />
+					<Header sendPaidPlanToCart={ sendPaidPlanToCart } />
 					<MockedSearchInterface
 						supportsInstantSearch={ supportsInstantSearch }
 						supportsOnlyClassicSearch={ supportsOnlyClassicSearch }
@@ -338,13 +339,20 @@ const Footer = () => {
 	);
 };
 
-const Header = () => {
+const Header = ( { sendPaidPlanToCart } ) => {
+	const buttonLinkArgs = {
+		children: __( 'Upgrade Jetpack Search', 'jetpack-search-pkg' ),
+		variant: 'link',
+		onClick: sendPaidPlanToCart,
+	};
+
 	return (
 		<div className="jp-search-dashboard-header jp-search-dashboard-wrap">
 			<div className="jp-search-dashboard-row">
 				<div className="lg-col-span-12 md-col-span-8 sm-col-span-4">
 					<div className="jp-search-dashboard-header__logo-container">
 						<JetpackSearchLogo className="jp-search-dashboard-header__masthead" />
+						<Button { ...buttonLinkArgs } />
 					</div>
 				</div>
 			</div>

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -1,6 +1,6 @@
 import {
 	JetpackFooter,
-	JetpackLogo,
+	JetpackSearchLogo,
 	ThemeProvider,
 	ContextualUpgradeTrigger,
 } from '@automattic/jetpack-components';
@@ -344,7 +344,7 @@ const Header = () => {
 			<div className="jp-search-dashboard-row">
 				<div className="lg-col-span-12 md-col-span-8 sm-col-span-4">
 					<div className="jp-search-dashboard-header__logo-container">
-						<JetpackLogo className="jp-search-dashboard-header__masthead" />
+						<JetpackSearchLogo className="jp-search-dashboard-header__masthead" />
 					</div>
 				</div>
 			</div>

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -58,6 +58,8 @@ export default function DashboardPage( { isLoading = false } ) {
 	// Introduce the gate for new pricing with URL parameter `new_pricing_202208=1`
 	const isNewPricing = useSelect( select => select( STORE_ID ).isNewPricing202208(), [] );
 
+	const tierSlug = useSelect( select => select( STORE_ID ).getTierSlug() );
+
 	const isDisabledFromOverLimit = useSelect( select =>
 		select( STORE_ID ).getDisabledFromOverLimit()
 	);
@@ -106,7 +108,10 @@ export default function DashboardPage( { isLoading = false } ) {
 			{ isPageLoading && <Loading /> }
 			{ ! isPageLoading && (
 				<div className="jp-search-dashboard-page">
-					<Header sendPaidPlanToCart={ sendPaidPlanToCart } />
+					<Header
+						isUpgradable={ isNewPricing && ! tierSlug }
+						sendPaidPlanToCart={ sendPaidPlanToCart }
+					/>
 					<MockedSearchInterface
 						supportsInstantSearch={ supportsInstantSearch }
 						supportsOnlyClassicSearch={ supportsOnlyClassicSearch }
@@ -115,6 +120,7 @@ export default function DashboardPage( { isLoading = false } ) {
 						<PlanInfo
 							hasIndex={ postCount !== 0 }
 							recordMeterInfo={ recordMeterInfo }
+							tierSlug={ tierSlug }
 							sendPaidPlanToCart={ sendPaidPlanToCart }
 						/>
 					) }
@@ -156,7 +162,7 @@ export default function DashboardPage( { isLoading = false } ) {
 	);
 }
 
-const PlanInfo = ( { hasIndex, recordMeterInfo, sendPaidPlanToCart } ) => {
+const PlanInfo = ( { hasIndex, recordMeterInfo, tierSlug, sendPaidPlanToCart } ) => {
 	// Site Info
 	// TODO: Investigate why this isn't returning anything useful.
 	const siteTitle = useSelect( select => select( STORE_ID ).getSiteTitle() ) || 'your site';
@@ -164,7 +170,6 @@ const PlanInfo = ( { hasIndex, recordMeterInfo, sendPaidPlanToCart } ) => {
 	const currentPlan = useSelect( select => select( STORE_ID ).getCurrentPlan() );
 	const currentUsage = useSelect( select => select( STORE_ID ).getCurrentUsage() );
 	const latestMonthRequests = useSelect( select => select( STORE_ID ).getLatestMonthRequests() );
-	const tierSlug = useSelect( select => select( STORE_ID ).getTierSlug() );
 	const planInfo = { currentPlan, currentUsage, latestMonthRequests, tierSlug };
 
 	return (
@@ -229,7 +234,7 @@ const Footer = () => {
 	);
 };
 
-const Header = ( { sendPaidPlanToCart } ) => {
+const Header = ( { isUpgradable, sendPaidPlanToCart } ) => {
 	const buttonLinkArgs = {
 		children: __( 'Upgrade Jetpack Search', 'jetpack-search-pkg' ),
 		variant: 'link',
@@ -242,7 +247,7 @@ const Header = ( { sendPaidPlanToCart } ) => {
 				<div className="lg-col-span-12 md-col-span-8 sm-col-span-4">
 					<div className="jp-search-dashboard-header__logo-container">
 						<JetpackSearchLogo className="jp-search-dashboard-header__masthead" />
-						<Button { ...buttonLinkArgs } />
+						{ isUpgradable && <Button { ...buttonLinkArgs } /> }
 					</div>
 				</div>
 			</div>

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -120,7 +120,11 @@ export default function DashboardPage( { isLoading = false } ) {
 						supportsOnlyClassicSearch={ supportsOnlyClassicSearch }
 					/>
 					{ isNewPricing && (
-						<PlanInfo hasIndex={ postCount !== 0 } recordMeterInfo={ recordMeterInfo } />
+						<PlanInfo
+							hasIndex={ postCount !== 0 }
+							recordMeterInfo={ recordMeterInfo }
+							sendPaidPlanToCart={ sendPaidPlanToCart }
+						/>
 					) }
 					{ false && <UsageMeter sendPaidPlanToCart={ sendPaidPlanToCart } /> }
 					{ ! isNewPricing && (
@@ -161,9 +165,7 @@ export default function DashboardPage( { isLoading = false } ) {
 	);
 }
 
-const PlanInfo = props => {
-	const hasIndex = props.hasIndex;
-	const info = props.recordMeterInfo;
+const PlanInfo = ( { hasIndex, recordMeterInfo, sendPaidPlanToCart } ) => {
 	// Site Info
 	// TODO: Investigate why this isn't returning anything useful.
 	const siteTitle = useSelect( select => select( STORE_ID ).getSiteTitle() ) || 'your site';
@@ -176,14 +178,16 @@ const PlanInfo = props => {
 	return (
 		<>
 			{ ! hasIndex && <FirstRunSection siteTitle={ siteTitle } planInfo={ planInfo } /> }
-			{ hasIndex && <PlanUsageSection planInfo={ planInfo } /> }
+			{ hasIndex && (
+				<PlanUsageSection planInfo={ planInfo } sendPaidPlanToCart={ sendPaidPlanToCart } />
+			) }
 			{ hasIndex && (
 				<RecordMeter
-					postCount={ info.postCount }
-					postTypeBreakdown={ info.postTypeBreakdown }
-					tierMaximumRecords={ info.tierMaximumRecords }
-					lastIndexedDate={ info.lastIndexedDate }
-					postTypes={ info.postTypes }
+					postCount={ recordMeterInfo.postCount }
+					postTypeBreakdown={ recordMeterInfo.postTypeBreakdown }
+					tierMaximumRecords={ recordMeterInfo.tierMaximumRecords }
+					lastIndexedDate={ recordMeterInfo.lastIndexedDate }
+					postTypes={ recordMeterInfo.postTypes }
 				/>
 			) }
 		</>

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
@@ -30,6 +30,10 @@ body {
 	// 65px = wpfooter height
 	min-height: calc( 100vh - 65px - 32px );
 
+	@include for-phone-down {
+		font-size: 14px;
+	}
+
 	.jp-search-dashboard-page {
 		width: 100%;
 	}
@@ -73,8 +77,10 @@ body {
 		background-color: $white;
 	}
 
-	@include for-phone-down {
-		font-size: 14px;
+	.jp-search-dashboard-header__logo-container {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
 	}
 }
 

--- a/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
@@ -24,6 +24,7 @@ const upgradeTypeFromAPIData = apiData => {
 	if ( ! apiData.currentUsage.must_upgrade ) {
 		return null;
 	}
+
 	// Determine appropriate upgrade message.
 	let mustUpgradeReason = '';
 	if ( apiData.currentUsage.upgrade_reason.requests ) {
@@ -32,21 +33,22 @@ const upgradeTypeFromAPIData = apiData => {
 	if ( apiData.currentUsage.upgrade_reason.records ) {
 		mustUpgradeReason = mustUpgradeReason === 'requests' ? 'both' : 'records';
 	}
+
 	return mustUpgradeReason;
 };
 
-const PlanUsageSection = props => {
+const PlanUsageSection = ( { planInfo, sendPaidPlanToCart } ) => {
 	// TODO: Add logic for plan limits.
-	const upgradeType = upgradeTypeFromAPIData( props.planInfo );
-	const usageInfo = usageInfoFromAPIData( props.planInfo );
+	const upgradeType = upgradeTypeFromAPIData( planInfo );
+	const usageInfo = usageInfoFromAPIData( planInfo );
 	return (
 		<div className="jp-search-dashboard-wrap jp-search-dashboard-meter-wrap">
 			<div className="jp-search-dashboard-row">
 				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
 				<div className="jp-search-dashboard-meter-wrap__content lg-col-span-8 md-col-span-6 sm-col-span-4">
-					<PlanSummary planInfo={ props.planInfo } />
+					<PlanSummary planInfo={ planInfo } />
 					<UsageMeters usageInfo={ usageInfo } />
-					<UpgradeTrigger type={ upgradeType } />
+					<UpgradeTrigger type={ upgradeType } ctaCallback={ sendPaidPlanToCart } />
 					<AboutPlanLimits />
 				</div>
 				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
@@ -91,16 +93,10 @@ export const getUpgradeMessages = () => {
 	return upgradeMessages;
 };
 
-const UpgradeTrigger = props => {
-	// TODO: Replace this callback with prop.
-	const callbackForwarder = event => {
-		event.preventDefault();
-		// callback();
-		// eslint-disable-next-line no-console
-		console.log( 'CUT clicked...' );
-	};
-	const upgradeMessage = props.type && getUpgradeMessages()[ props.type ];
-	const triggerData = upgradeMessage && { ...upgradeMessage, onClick: callbackForwarder };
+const UpgradeTrigger = ( { type, ctaCallback } ) => {
+	const upgradeMessage = type && getUpgradeMessages()[ type ];
+	const triggerData = upgradeMessage && { ...upgradeMessage, onClick: ctaCallback };
+
 	return (
 		<>
 			{ triggerData && (

--- a/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
@@ -57,7 +57,7 @@ const PlanUsageSection = ( { planInfo, sendPaidPlanToCart } ) => {
 	);
 };
 
-export const getUpgradeMessages = () => {
+const getUpgradeMessages = () => {
 	const upgradeMessages = {
 		records: {
 			description: __(

--- a/projects/plugins/jetpack/changelog/update-upgrade_link_top_right
+++ b/projects/plugins/jetpack/changelog/update-upgrade_link_top_right
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -38,7 +38,7 @@
 		"automattic/jetpack-publicize": "0.16.x-dev",
 		"automattic/jetpack-redirect": "1.7.x-dev",
 		"automattic/jetpack-roles": "1.4.x-dev",
-		"automattic/jetpack-search": "0.26.x-dev",
+		"automattic/jetpack-search": "0.27.x-dev",
 		"automattic/jetpack-stats": "0.1.x-dev",
 		"automattic/jetpack-status": "1.14.x-dev",
 		"automattic/jetpack-sync": "1.39.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "800f6a4b093efd3322a787a12a8af15d",
+    "content-hash": "24d9950d141e9f9c3a40acfffa08191d",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1750,7 +1750,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "8b94921ef770da68bfded0ad14835b74fb172a32"
+                "reference": "8b2ba04a496f91adf158d9c4b34d485f6b1c6012"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -1774,7 +1774,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.26.x-dev"
+                    "dev-trunk": "0.27.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"

--- a/projects/plugins/search/changelog/update-upgrade_link_top_right
+++ b/projects/plugins/search/changelog/update-upgrade_link_top_right
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -10,7 +10,7 @@
 		"automattic/jetpack-connection": "1.45.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
 		"automattic/jetpack-my-jetpack": "2.2.x-dev",
-		"automattic/jetpack-search": "0.26.x-dev",
+		"automattic/jetpack-search": "0.27.x-dev",
 		"automattic/jetpack-status": "1.14.x-dev",
 		"automattic/jetpack-sync": "1.39.x-dev",
 		"automattic/jetpack-plugins-installer": "0.2.x-dev"

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "99baea7dbbb79c8e208c3ee7924266a5",
+    "content-hash": "5154a14cd187b5f00efabb4bf153b087",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1096,7 +1096,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "8b94921ef770da68bfded0ad14835b74fb172a32"
+                "reference": "8b2ba04a496f91adf158d9c4b34d485f6b1c6012"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -1120,7 +1120,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.26.x-dev"
+                    "dev-trunk": "0.27.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26730 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add a link Button component on the top right of the page for upgrading from the `free` plan.
* Replace JetpackLogo with `JetpackSearchLogo` on the dashboard page.
* Apply the upgrade action to the `UpgradeTrigger` as well.
* Retire the `UsageMeter` component.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-hEH-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

> Note: Since the new pricing API is still in progress, this PR replies on the other codebase update `D88792-code`.

* Purchase the Jetpack Search `Free` plan.
* Navigate to the site with URL `/wp-admin/admin.php?page=jetpack-search&new_pricing_202208=1`.
* Ensure an upgrade link is at the page's top right.
* Click on the upgrade link.
* Ensure the page redirects outside to the checkout flow for upgrading `Jetpack Search`.

> Note: Since the upgrade path from plan `Free` to plan `Paid` is still in progress, the checkout flow will fail until it is completed.

<img width="1277" alt="截圖 2022-10-11 下午4 10 16" src="https://user-images.githubusercontent.com/6869813/195034998-82dd1a38-b762-426f-b28a-fa448eeba5c3.png">