### PR TITLE
VideoPress: expose local videos data in the initial state

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-local-videos-expose-initial-state
+++ b/projects/packages/videopress/changelog/update-videopress-local-videos-expose-initial-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: expose local videos in the initial state

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.5.1",
+	"version": "0.5.2-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -129,8 +129,7 @@ class Data {
 	 * @return array
 	 */
 	public static function get_initial_state() {
-
-		$video_data = self::get_video_data();
+		$videopress_data = self::get_video_data();
 
 		$videos = array_map(
 			function ( $video ) {
@@ -186,20 +185,20 @@ class Data {
 					'finished'       => $finished,
 				);
 			},
-			$video_data['videos']
+			$videopress_data['videos']
 		);
 
 		$initial_state = array(
 			'videos' => array(
-				'uploadedVideoCount'           => $video_data['total'],
+				'uploadedVideoCount'           => $videopress_data['total'],
 				'items'                        => $videos,
 				'isFetching'                   => false,
 				'isFetchingUploadedVideoCount' => false,
 				'pagination'                   => array(
-					'totalPages' => $video_data['totalPages'],
-					'total'      => $video_data['total'],
+					'totalPages' => $videopress_data['totalPages'],
+					'total'      => $videopress_data['total'],
 				),
-				'query'                        => $video_data['query'],
+				'query'                        => $videopress_data['query'],
 				'_meta'                        => array(
 					'relyOnInitialState' => true,
 				),

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -171,7 +171,7 @@ class Data {
 			$local_videos_data['videos']
 		);
 
-		// Tweak local videos data.
+		// Tweak VideoPress videos data.
 		$videos = array_map(
 			function ( $video ) {
 				$id                 = $video['id'];

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -27,9 +27,10 @@ class Data {
 	/**
 	 * Gets the video data
 	 *
+	 * @param boolean $is_videopress - True when getting VideoPress data.
 	 * @return array
 	 */
-	public static function get_video_data() {
+	public static function get_video_data( $is_videopress = true ) {
 		$video_data = array(
 			'videos'     => array(),
 			'total'      => 0,
@@ -39,17 +40,22 @@ class Data {
 				'orderBy'      => 'date',
 				'itemsPerPage' => 6,
 				'page'         => 1,
-				'type'         => 'video/videopress',
 			),
 		);
 
 		$args = array(
-			'order'     => $video_data['query']['order'],
-			'orderby'   => $video_data['query']['orderBy'],
-			'per_page'  => $video_data['query']['itemsPerPage'],
-			'page'      => $video_data['query']['page'],
-			'mime_type' => $video_data['query']['type'],
+			'order'      => $video_data['query']['order'],
+			'orderby'    => $video_data['query']['orderBy'],
+			'per_page'   => $video_data['query']['itemsPerPage'],
+			'page'       => $video_data['query']['page'],
+			'media_type' => 'video',
 		);
+
+		if ( $is_videopress ) {
+			$args['mime_type'] = 'video/videopress';
+		} else {
+			$args['no_videopress'] = true;
+		}
 
 		// Do an internal request for the media list
 		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
@@ -129,8 +135,43 @@ class Data {
 	 * @return array
 	 */
 	public static function get_initial_state() {
-		$videopress_data = self::get_video_data();
+		$videopress_data   = self::get_video_data();
+		$local_videos_data = self::get_video_data( false );
 
+		// Tweak local videos data.
+		$local_videos = array_map(
+			function ( $video ) {
+				$id                 = $video['id'];
+				$media_details      = $video['media_details'];
+				$jetpack_videopress = $video['jetpack_videopress'];
+
+				$upload_date = $video['date'];
+				$url         = $video['source_url'];
+
+				$title       = $jetpack_videopress['title'];
+				$description = $jetpack_videopress['description'];
+				$caption     = $jetpack_videopress['caption'];
+
+				$width    = $media_details['width'];
+				$height   = $media_details['height'];
+				$duration = $media_details['length'];
+
+				return array(
+					'id'          => $id,
+					'title'       => $title,
+					'description' => $description,
+					'caption'     => $caption,
+					'width'       => $width,
+					'height'      => $height,
+					'url'         => $url,
+					'uploadDate'  => $upload_date,
+					'duration'    => $duration,
+				);
+			},
+			$local_videos_data['videos']
+		);
+
+		// Tweak local videos data.
 		$videos = array_map(
 			function ( $video ) {
 				$id                 = $video['id'];
@@ -189,7 +230,7 @@ class Data {
 		);
 
 		$initial_state = array(
-			'videos' => array(
+			'videos'      => array(
 				'uploadedVideoCount'           => $videopress_data['total'],
 				'items'                        => $videos,
 				'isFetching'                   => false,
@@ -199,6 +240,21 @@ class Data {
 					'total'      => $videopress_data['total'],
 				),
 				'query'                        => $videopress_data['query'],
+				'_meta'                        => array(
+					'relyOnInitialState' => true,
+				),
+			),
+
+			'localVideos' => array(
+				'uploadedVideoCount'           => $local_videos_data['total'],
+				'items'                        => $local_videos,
+				'isFetching'                   => false,
+				'isFetchingUploadedVideoCount' => false,
+				'pagination'                   => array(
+					'totalPages' => $local_videos_data['totalPages'],
+					'total'      => $local_videos_data['total'],
+				),
+				'query'                        => $local_videos_data['query'],
 				'_meta'                        => array(
 					'relyOnInitialState' => true,
 				),

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.5.1';
+	const PACKAGE_VERSION = '0.5.2-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

* Part of https://github.com/Automattic/jetpack/issues/26738
* Follow-up of https://github.com/Automattic/jetpack/pull/26734

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: expose local videos data in the initial state

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to VideoPress admin dashboard
* Ensure your site has local videos
* Open the dev console of your browser
* print the initial global state
* Confirm there is a new `localVideos` field
* Confirm the data: `items`, `pagination`, etc.
<img width="718" alt="Screen Shot 2022-10-11 at 06 22 33" src="https://user-images.githubusercontent.com/77539/195051892-6222a2e6-f8d6-44cd-bec5-589895e0c0b4.png">


