### PR TITLE
VideorPress: change the dialog message to convert from core/oembed to VideoPress video block

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-v6-add-info-link-to-convert-dialog
+++ b/projects/packages/videopress/changelog/update-videopress-v6-add-info-link-to-convert-dialog
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideorPress: change the dialog message to convert from core/oembed to VideoPress video block

--- a/projects/packages/videopress/src/client/block-editor/extend/core-embed/edit.js
+++ b/projects/packages/videopress/src/client/block-editor/extend/core-embed/edit.js
@@ -87,7 +87,7 @@ const withCoreEmbedVideoPressBlock = createHigherOrderComponent( CoreEmbedBlockE
 							variant="tertiary"
 							onClick={ () => setAttributes( { keepUsingOEmbedVariation: true } ) }
 						>
-							{ __( 'Keep using VideoPress Embed block', 'jetpack-videopress-pkg' ) }
+							{ __( 'Keep using the Embed block', 'jetpack-videopress-pkg' ) }
 						</Button>,
 					] }
 				>

--- a/projects/packages/videopress/src/client/block-editor/extend/core-embed/edit.js
+++ b/projects/packages/videopress/src/client/block-editor/extend/core-embed/edit.js
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
+import { getRedirectUrl } from '@automattic/jetpack-components';
 import { Warning, store as blockEditorStore } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
-import { Button } from '@wordpress/components';
+import { Button, ExternalLink } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useEffect, createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -57,6 +58,18 @@ const withCoreEmbedVideoPressBlock = createHigherOrderComponent( CoreEmbedBlockE
 			return <CoreEmbedBlockEdit { ...props } />;
 		}
 
+		const moreAboutVideoPress = createInterpolateElement(
+			__(
+				'Convert this embed to a VideoPress video block to unlock advanced video player options. <moreAboutVideoPressLink>More about the VideoPress block</moreAboutVideoPressLink>',
+				'jetpack-videopress-pkg'
+			),
+			{
+				moreAboutVideoPressLink: (
+					<ExternalLink href={ getRedirectUrl( 'jetpack-videopress-about-page' ) } />
+				),
+			}
+		);
+
 		return (
 			<div>
 				<Warning
@@ -78,10 +91,7 @@ const withCoreEmbedVideoPressBlock = createHigherOrderComponent( CoreEmbedBlockE
 						</Button>,
 					] }
 				>
-					{ __(
-						'Your site currently supports the VideoPress Video block.',
-						'jetpack-videopress-pkg'
-					) }
+					{ moreAboutVideoPress }
 				</Warning>
 
 				<div className="wp-block-core-embed-wrapper is-disabled">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideorPress: change the dialog message to convert from core/oembed to VideoPress video block

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Block editor
* Create an Embed block by pasting a VideoPress URL (https://videopress.com/v/SEhvBzm2)
* Confirm you see the dialog with the text updated

before | after
------|------
<img width="670" alt="image" src="https://user-images.githubusercontent.com/77539/195056427-f871151d-3830-4911-95ac-7df5c9c31b89.png"> | <img width="605" alt="image" src="https://user-images.githubusercontent.com/77539/195069965-f711af65-abfc-413f-a2d0-5569e78ff5d1.png">

