### PR TITLE
VideoPress: expose local videos in the initial state

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-local-videos-reduxify
+++ b/projects/packages/videopress/changelog/update-videopress-local-videos-reduxify
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: reduxify local videos. first approach

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -27,7 +27,7 @@ import classnames from 'classnames';
  */
 import { STORE_ID } from '../../../state';
 import { usePlan } from '../../hooks/use-plan';
-import useVideos from '../../hooks/use-videos';
+import useVideos, { useLocalVideos } from '../../hooks/use-videos';
 import Logo from '../logo';
 import PricingSection from '../pricing-section';
 import { ConnectVideoStorageMeter } from '../video-storage-meter';
@@ -39,11 +39,11 @@ const useDashboardVideos = () => {
 	const { uploadVideo } = useDispatch( STORE_ID );
 
 	const { items, uploading, uploadedVideoCount, isFetching } = useVideos();
+	const { items: localVideos } = useLocalVideos();
 
 	let videos = [ ...uploading, ...items ];
 
 	const hasVideos = uploadedVideoCount > 0 || isFetching || uploading?.length > 0;
-	const localVideos = [];
 	const localTotalVideoCount = 0;
 	const hasLocalVideos = localVideos && localVideos.length > 0;
 

--- a/projects/packages/videopress/src/client/admin/hooks/use-videos/index.js
+++ b/projects/packages/videopress/src/client/admin/hooks/use-videos/index.js
@@ -42,3 +42,12 @@ export default function useVideos() {
 			dispatch( STORE_ID ).setVideosQuery( { search: querySearch, page: 1 } ),
 	};
 }
+
+export const useLocalVideos = () => {
+	// Data
+	const items = useSelect( select => select( STORE_ID ).getLocalVideos() );
+
+	return {
+		items,
+	};
+};

--- a/projects/packages/videopress/src/client/state/reducers.js
+++ b/projects/packages/videopress/src/client/state/reducers.js
@@ -364,6 +364,10 @@ const videos = ( state, action ) => {
 	}
 };
 
+const localVideos = state => {
+	return state;
+};
+
 const purchases = ( state, action ) => {
 	switch ( action.type ) {
 		case SET_IS_FETCHING_PURCHASES: {
@@ -388,6 +392,7 @@ const purchases = ( state, action ) => {
 
 const reducers = combineReducers( {
 	videos,
+	localVideos,
 	purchases,
 } );
 

--- a/projects/packages/videopress/src/client/state/selectors.js
+++ b/projects/packages/videopress/src/client/state/selectors.js
@@ -56,6 +56,10 @@ export const getPurchases = state => {
 	return state?.purchases?.items || [];
 };
 
+export const getLocalVideos = state => {
+	return state?.localVideos?.items || [];
+};
+
 const selectors = {
 	getVideos,
 	getUploadingVideos,
@@ -71,6 +75,8 @@ const selectors = {
 
 	getPurchases,
 	isFetchingPurchases,
+
+	getLocalVideos,
 };
 
 export default selectors;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

On this PR:

* Add `localVideos` reducer
* Add a basic selector to get the local videos data
* Create a `useLocalVideos()` hook to connect data with UI
* Get the local videos data from the UI via hook and implement the initial rendering

Disclaimer:
Need to implement
* Pagination
* Maybe a Search
* Maybe add a link that leads to the regular gallery

Part of https://github.com/Automattic/jetpack/issues/26738
Follow-up of https://github.com/Automattic/jetpack/pull/26743

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: expose local videos in the initial state

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to VideoPress dashboard
* Ensure your site has local videos
* Confirm you see the `Local videos` section
<img width="1216" alt="Screen Shot 2022-10-11 at 16 52 17" src="https://user-images.githubusercontent.com/77539/195185797-23152637-6152-4bfe-a099-bee3abe87e4d.png">
* Take a look at the initial global state:
<img width="788" alt="Screen Shot 2022-10-11 at 16 50 35" src="https://user-images.githubusercontent.com/77539/195185627-875eee7b-c57c-4de1-bf37-6817384294c0.png">

* and the store
<img width="539" alt="image" src="https://user-images.githubusercontent.com/77539/195185575-b9e91c99-0486-4282-9092-42b2d2e2dd4e.png">

