### PR TITLE
Update site settings endpoint files to sync them with their WPCOM counterparts

### DIFF
--- a/projects/plugins/jetpack/changelog/update-site-settings-endpoint-files
+++ b/projects/plugins/jetpack/changelog/update-site-settings-endpoint-files
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Manually sync site settings endpoint files with their WPCOM counterparts

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -576,7 +576,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					}
 					break;
 				case 'launchpad_screen':
-					if ( in_array( $value, array( 'full', 'off', 'minimized' ) ) ) {
+					if ( in_array( $value, array( 'full', 'off', 'minimized' ), true ) ) {
 						if ( update_option( $key, $value ) ) {
 							$updated[ $key ] = $value;
 						}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -576,7 +576,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					}
 					break;
 				case 'launchpad_screen':
-					if ( in_array( $value, [ 'full', 'off', 'minimized' ] ) ) {
+					if ( in_array( $value, array( 'full', 'off', 'minimized' ) ) ) {
 						if ( update_option( $key, $value ) ) {
 							$updated[ $key ] = $value;
 						}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -113,6 +113,7 @@ new WPCOM_JSON_API_Site_Settings_Endpoint(
 			'posts_per_page'                          => '(int) Number of posts to show on blog pages',
 			'posts_per_rss'                           => '(int) Number of posts to show in the RSS feed',
 			'rss_use_excerpt'                         => '(bool) Whether the RSS feed will use post excerpts',
+			'launchpad_screen'                        => '(string) Whether or not launchpad is presented and what size it will be',
 		),
 
 		'response_format'     => array(
@@ -291,8 +292,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 		$response_format = apply_filters( 'site_settings_site_format', self::$site_format );
 
 		$blog_id = (int) $this->api->get_blog_id_for_output();
-		/** This filter is documented in class.json-api-endpoints.php */
-		$is_jetpack = true === apply_filters( 'is_jetpack_site', false, $blog_id );
+		$site    = $this->get_platform()->get_site( $blog_id );
 
 		foreach ( array_keys( $response_format ) as $key ) {
 
@@ -331,22 +331,18 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						$jetpack_relatedposts_options['enabled'] = true;
 					}
 
-					if ( method_exists( 'Jetpack', 'is_module_active' ) ) {
-						$jetpack_relatedposts_options['enabled'] = Jetpack::is_module_active( 'related-posts' );
-					}
+					$jetpack_relatedposts_options['enabled'] =
+						$jetpack_relatedposts_options['enabled']
+						&& $site->is_module_active( 'related-posts' );
 
 					$jetpack_search_supported = false;
 					if ( function_exists( 'wpcom_is_jetpack_search_supported' ) ) {
 						$jetpack_search_supported = wpcom_is_jetpack_search_supported( $blog_id );
 					}
 
-					$jetpack_search_active = false;
-					if ( method_exists( 'Jetpack', 'is_module_active' ) ) {
-						$jetpack_search_active = Jetpack::is_module_active( 'search' );
-					}
-					if ( function_exists( 'is_jetpack_module_active' ) ) {
-						$jetpack_search_active = is_jetpack_module_active( 'search', $blog_id );
-					}
+					$jetpack_search_active =
+						$jetpack_search_supported
+						&& $site->is_module_active( 'search' );
 
 					// array_values() is necessary to ensure the array starts at index 0.
 					$post_categories = array_values(
@@ -356,7 +352,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						)
 					);
 
-					$api_cache = $is_jetpack ? (bool) get_option( 'jetpack_api_cache_enabled' ) : true;
+					$api_cache = $site->is_jetpack() ? (bool) get_option( 'jetpack_api_cache_enabled' ) : true;
 
 					$response[ $key ] = array(
 						// also exists as "options".
@@ -403,6 +399,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'lang_id'                          => defined( 'IS_WPCOM' ) && IS_WPCOM
 						? get_lang_id_by_code( wpcom_l10n_get_blog_locale_variant( $blog_id, true ) )
 						: get_option( 'lang_id' ),
+						'site_vertical_id'                 => (string) get_option( 'site_vertical_id' ),
 						'wga'                              => $this->get_google_analytics(),
 						'jetpack_cloudflare_analytics'     => get_option( 'jetpack_cloudflare_analytics' ),
 						'disabled_likes'                   => (bool) get_option( 'disabled_likes' ),
@@ -437,6 +434,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'posts_per_page'                   => (int) get_option( 'posts_per_page' ),
 						'posts_per_rss'                    => (int) get_option( 'posts_per_rss' ),
 						'rss_use_excerpt'                  => (bool) get_option( 'rss_use_excerpt' ),
+						'launchpad_screen'                 => (string) get_option( 'launchpad_screen' ),
 					);
 
 					if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -562,6 +560,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 			if ( ! is_array( $value ) ) {
 				$value = trim( $value );
 			}
+
 			// preserve the raw value before unslashing the value. The slashes need to be preserved for date and time formats.
 			$raw_value = $value;
 			$value     = wp_unslash( $value );
@@ -574,6 +573,13 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					$coerce_value = ( $value ) ? 'open' : 'closed';
 					if ( update_option( $key, $coerce_value ) ) {
 						$updated[ $key ] = $value;
+					}
+					break;
+				case 'launchpad_screen':
+					if ( in_array( $value, [ 'full', 'off', 'minimized' ] ) ) {
+						if ( update_option( $key, $value ) ) {
+							$updated[ $key ] = $value;
+						}
 					}
 					break;
 				case 'jetpack_protect_whitelist':
@@ -589,18 +595,10 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					Jetpack_Options::update_option( 'sync_non_public_post_stati', $value );
 					break;
 				case 'jetpack_search_enabled':
-					if ( ! method_exists( 'Jetpack', 'activate_module' ) ) {
-						break;
-					}
-					$is_wpcom = defined( 'IS_WPCOM' ) && IS_WPCOM;
 					if ( $value ) {
-						$is_wpcom
-							? Jetpack::activate_module( $blog_id, 'search' )
-							: Jetpack::activate_module( 'search', false, false );
+						Jetpack::activate_module( $blog_id, 'search' );
 					} else {
-						$is_wpcom
-							? Jetpack::deactivate_module( $blog_id, 'search' )
-							: Jetpack::deactivate_module( 'search' );
+						Jetpack::deactivate_module( $blog_id, 'search' );
 					}
 					$updated[ $key ] = (bool) $value;
 					break;
@@ -610,16 +608,11 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					if ( ! $this->jetpack_relatedposts_supported() ) {
 						break;
 					}
-					if ( 'jetpack_relatedposts_enabled' === $key && method_exists( 'Jetpack', 'is_module_active' ) && $this->jetpack_relatedposts_supported() ) {
-						$before_action = Jetpack::is_module_active( 'related-posts' );
+					if ( 'jetpack_relatedposts_enabled' === $key ) {
 						if ( $value ) {
-							Jetpack::activate_module( 'related-posts', false, false );
+							Jetpack::activate_module( $blog_id, 'related-posts' );
 						} else {
-							Jetpack::deactivate_module( 'related-posts' );
-						}
-						$after_action = Jetpack::is_module_active( 'related-posts' );
-						if ( $after_action === $before_action ) {
-							break;
+							Jetpack::deactivate_module( $blog_id, 'related-posts' );
 						}
 					}
 					$just_the_key                                  = substr( $key, 21 );
@@ -672,7 +665,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					}
 					break;
 
-				case 'jetpack_cloudflare_analytics':
+				case 'cloudflare_analytics':
 					if ( ! isset( $value['code'] ) || ! preg_match( '/^$|^[a-fA-F0-9]+$/i', $value['code'] ) ) {
 						return new WP_Error( 'invalid_code', __( 'Invalid Cloudflare Analytics ID', 'jetpack' ) );
 					}
@@ -926,7 +919,6 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						$updated[ $key ] = $value;
 						break;
 					}
-
 					// no worries, we've already whitelisted and casted arguments above.
 					if ( update_option( $key, $value ) ) {
 						$updated[ $key ] = $value;

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -74,6 +74,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			'disallowed_keys'                         => '(string) Words or phrases that mark comment spam, one per line',
 			'lang_id'                                 => '(int) ID for language blog is written in',
 			'locale'                                  => '(string) locale code for language blog is written in',
+			'site_vertical_id'                        => '(string) The site vertical ID',
 			'wga'                                     => '(array) Google Analytics Settings',
 			'jetpack_cloudflare_analytics'            => '(array) Cloudflare Analytics Settings',
 			'disabled_likes'                          => '(bool) Are likes globally disabled (they can still be turned on per post)?',
@@ -111,6 +112,9 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			'posts_per_page'                          => '(int) Number of posts to show on blog pages',
 			'posts_per_rss'                           => '(int) Number of posts to show in the RSS feed',
 			'rss_use_excerpt'                         => '(bool) Whether the RSS feed will use post excerpts',
+			'wpcom_publish_posts_with_markdown'       => '(bool) Whether markdown is enabled for posts',
+			'wpcom_publish_comments_with_markdown'    => '(bool) Whether markdown is enabled for comments',
+			'launchpad_screen'                        => '(string) Whether or not launchpad is presented and what size it will be',
 		),
 
 		'response_format' => array(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The proposed changes manually update the following two site settings endpoint files that are currently out of sync (when compared to their WPCOM counterparts) and block further endpoint-related PR (https://github.com/Automattic/jetpack/pull/26696):
- `class.wpcom-json-api-site-settings-v1-4-endpoint.php`
- `class.wpcom-json-api-site-settings-endpoint.php`

Related discussion: p1665390129292649-slack-CBG1CP4EN
Related issue: https://github.com/Automattic/wp-calypso/issues/69019

Side note: In order for this PR to go through, it was necessary to update the `class.wpcom-json-api-site-settings-endpoint.php` manually through D89665-code on the WPCOM side.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
- p1665390129292649-slack-CBG1CP4EN

<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No, it does not.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Both updated JP files should match their current WPCOM counterparts:

- `class.wpcom-json-api-site-settings-v1-4-endpoint.php`
- `class.wpcom-json-api-site-settings-endpoint.php`

We can compare the files manually.

2. The proposed changes should not cause any regressions.