### PR TITLE
VideoPress: Fix `Thumbnail` not responsive

### DIFF
--- a/projects/packages/videopress/changelog/fix-uploading-states-alignment
+++ b/projects/packages/videopress/changelog/fix-uploading-states-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Uploading states responsive behavior

--- a/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
@@ -84,7 +84,7 @@ export const VideoCard = ( {
 	const isBlank = ! title && ! duration && ! plays && ! defaultThumbnail && ! loading;
 
 	// Mapping thumbnail (Ordered by priority)
-	let thumbnail = loading ? <Placeholder width={ 360 } /> : defaultThumbnail;
+	let thumbnail = loading ? <Placeholder /> : defaultThumbnail;
 	thumbnail = uploading ? <UploadingThumbnail /> : thumbnail;
 	thumbnail = processing ? <ProcessingThumbnail /> : thumbnail;
 

--- a/projects/packages/videopress/src/client/admin/components/video-card/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/video-card/style.module.scss
@@ -75,6 +75,7 @@
 	margin-top: calc( var( --spacing-base ) * 2 );
 	margin-bottom: calc( var( --spacing-base ) * 2 );
 	justify-content: space-between;
+	gap: var(--spacing-base);
 }
 
 .video-card__title {
@@ -122,8 +123,6 @@
 	// Change spinner color
 	--wp-admin-theme-color: var( --jp-green-50 );
 
-	width: 360px;
-	height: 100%;
 	display: flex;
 	justify-content: center;
 	align-items: center;

--- a/projects/packages/videopress/src/client/admin/components/video-thumbnail/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/video-thumbnail/style.module.scss
@@ -5,8 +5,6 @@
 	.thumbnail-placeholder {
 		width: 100%;
 		height: 100%;
-		max-width: 360px;
-		max-height: 202px;
 		overflow: hidden;
 		background-color: var( --jp-gray-0 );
 
@@ -22,7 +20,6 @@
 		}
 
 		.thumbnail-blank {
-			width: 360px;
 			height: 100%;
 			display: flex;
 			align-items: center;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26749 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update `VideoCard` and `VideoThumbnail` to make them responsive.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start `Storybook`
* Navigate to `VideoPress/Components/Video Card`
* Search for `<div id="root" />` element.
* Set a `width` for it and change it value for something `<392px (max-height)`.
* Interact with possible modes (`loading`, `processing`, `uploading`).
* All them should be responsive.

#### Demo

![image](https://user-images.githubusercontent.com/1663717/195189419-40b1aed9-49e7-4477-a7d5-09f44ccb4bae.png)

![image](https://user-images.githubusercontent.com/1663717/195189446-8732b83f-89f9-413a-bcf9-397843ec9c3c.png)


