### PR TITLE
Site Endpoint: Include atomic_revival_status on site object

### DIFF
--- a/projects/plugins/jetpack/changelog/add-sites-endpoint-atomic-revival-status
+++ b/projects/plugins/jetpack/changelog/add-sites-endpoint-atomic-revival-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+WordPress.com REST API: included `atomic_revival_status` on the sites API response

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -73,6 +73,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_fse_eligible'             => '(bool) If the site is capable of Full Site Editing or not',
 		'is_core_site_editor_enabled' => '(bool) If the site has the core site editor enabled.',
 		'is_wpcom_atomic'             => '(bool) If the site is a WP.com Atomic one.',
+		'atomic_revival_status'       => '(string) A string indicating whether the site is \'reverted\' or \'revived\'',
 		'user_interactions'           => '(array) An array of user interactions with a site.',
 	);
 
@@ -533,6 +534,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				break;
 			case 'is_wpcom_atomic':
 				$response[ $key ] = $this->site->is_wpcom_atomic();
+				break;
+			case 'atomic_revival_status':
+				$response[ $key ] = $this->site->get_atomic_revival_status();
 				break;
 			case 'user_interactions':
 				$response[ $key ] = $this->site->get_user_interactions();

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
@@ -68,6 +68,7 @@ class WPCOM_JSON_API_GET_Site_V1_2_Endpoint extends WPCOM_JSON_API_GET_Site_Endp
 		'is_fse_eligible'             => '(bool) If the site is capable of Full Site Editing or not',
 		'is_core_site_editor_enabled' => '(bool) If the site has the core site editor enabled.',
 		'is_wpcom_atomic'             => '(bool) If the site is a WP.com Atomic one.',
+		'atomic_revival_status'       => '(string) A string indicating whether the site is \'reverted\' or \'revived\'',
 	);
 
 	/**

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -400,6 +400,15 @@ abstract class SAL_Site {
 	abstract protected function is_a8c_publication( $post_id );
 
 	/**
+	 * Determine the Atomic Revival status. Not used in Jetpack
+	 *
+	 * @see class.json-api-site-jetpack.php for implementation.
+	 *
+	 * @return null
+	 */
+	abstract public function get_atomic_revival_status();
+
+	/**
 	 * Return the user interactions with a site. Not used in Jetpack.
 	 *
 	 * @see class.json-api-site-jetpack.php for implementation.

--- a/projects/plugins/jetpack/sal/class.json-api-site-jetpack.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-jetpack.php
@@ -632,6 +632,17 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	}
 
 	/**
+	 * Determine the Atomic Revival status. Not used in Jetpack
+	 *
+	 * @see /wpcom/public.api/rest/sal/trait.json-api-site-wpcom.php.
+	 *
+	 * @return null
+	 */
+	public function get_atomic_revival_status() {
+		return null;
+	}
+
+	/**
 	 * Get user interactions with a site. Not used in Jetpack.
 	 *
 	 * @see /wpcom/public.api/rest/sal/trait.json-api-site-wpcom.php.


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/1016

## Proposed changes

Ports D89712-code over to Jetpack.

## Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

## Jetpack product discussion

N/A.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

Verify nothing explodes.