### PR TITLE
VideoPress: Add videopress_privacy_setting and videopress_rating query filters

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-privacy-setting-and-rating-query-filters
+++ b/projects/packages/videopress/changelog/add-videopress-privacy-setting-and-rating-query-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Add support to `videopress_privacy_setting` and `videopress_rating` query filters to filter media attachments using the respectives meta keys.

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
@@ -112,6 +112,15 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Data {
 			);
 		}
 
+		/* Filter using rating meta key */
+		if ( isset( $request['videopress_rating'] ) ) {
+			$videopress_rating    = sanitize_text_field( $request['videopress_rating'] );
+			$args['meta_query'][] = array(
+				'key'   => 'videopress_rating',
+				'value' => $videopress_rating,
+			);
+		}
+
 		return $args;
 	}
 

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
@@ -103,6 +103,15 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Data {
 			);
 		}
 
+		/* Filter using privacy setting meta key */
+		if ( isset( $request['videopress_privacy_setting'] ) ) {
+			$videopress_privacy_setting = sanitize_text_field( $request['videopress_privacy_setting'] );
+			$args['meta_query'][]       = array(
+				'key'   => 'videopress_privacy_setting',
+				'value' => $videopress_privacy_setting,
+			);
+		}
+
 		return $args;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Relates to #26168.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Register a `videopress_privacy_setting` query parameter to filter VideoPress videos using the `videopress_privacy_setting` metadata key
* Register a `videopress_rating` query parameter to filter VideoPress videos using the `videopress_rating` metadata key

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* To test this, we need to play with the values for the `rating` and the `privacy_setting`
* To filter videos using the `privacy_setting` value, request data in this way:

```
curl -X GET -u "user:pass" "http://your-site.com/wp-json/wp/v2/media?mime_type=video/videopress&per_page=6&videopress_privacy_setting={ PRIVACY VALUE }" | jq
```

* Possible values for `videopress_privacy_setting` are `0`, `1` or `2`
* To filter videos using the `rating` value, request data in this way:

```
curl -X GET -u "user:pass" "http://your-site.com/wp-json/wp/v2/media?mime_type=video/videopress&per_page=6&videopress_rating={ RATING VALUE }" | jq
```

* Possible values for `videopress_rating` are `G`, `PG-13` or `R`
* You can also combine the parameters on the same request:

```
curl -X GET -u "user:pass" "http://your-site.com/wp-json/wp/v2/media?mime_type=video/videopress&per_page=6&videopress_rating={ RATING VALUE }&videopress_privacy_setting={ PRIVACY VALUE }" | jq
```

* After doing the request, confirm that only videos with the given `privacy_setting` or `rating` are returned
* To change the value for the `privacy_setting` or `rating`, do a request this way:

```
curl -X POST -u "user:pass" http://your-site.com/wp-json/wpcom/v2/videopress/meta -H 'Content-Type: application/json' -d '{"id": { ATTACHMENT ID },"rating": "PG-13","privacy_setting":"0" }' | jq
```

* You can also change the `privacy_setting` using the client:

![image](https://user-images.githubusercontent.com/6760046/195603806-8b05ea7c-5db8-4ae8-ac49-62af7a209335.png)