### PR TITLE
tool-setup: Configure composer to not use GitHub's API (retry)

### DIFF
--- a/.github/actions/tool-setup/action.yml
+++ b/.github/actions/tool-setup/action.yml
@@ -67,6 +67,13 @@ runs:
         extensions: mysql, imagick
         coverage: ${{ inputs.coverage }}
 
+    - name: Configure composer
+      if: steps.versions.outputs.php-version != 'false'
+      shell: bash
+      run: |
+        composer config --global github-protocols https
+        composer config --global use-github-api false
+
     - name: Get Composer cache directory
       if: steps.versions.outputs.php-version != 'false'
       id: composer-cache

--- a/composer.json
+++ b/composer.json
@@ -100,6 +100,7 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"config": {
+		"use-github-api": false,
 		"sort-packages": true,
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true

--- a/composer.lock
+++ b/composer.lock
@@ -975,7 +975,7 @@
             "version": "3.6.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Automattic/PHP_CodeSniffer.git",
+                "url": "https://github.com/Automattic/PHP_CodeSniffer",
                 "reference": "ea57e56ab3b5e23fe543c6a47154e2a17728a03f"
             },
             "dist": {
@@ -1023,14 +1023,14 @@
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki",
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer"
             },
-            "time": "2022-03-23T15:14:42+00:00"
+            "time": "2021-05-24T17:35:41+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
             "version": "2022-02-07",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Automattic/WordPress-Coding-Standards.git",
+                "url": "https://github.com/Automattic/WordPress-Coding-Standards",
                 "reference": "7b39722c38cbf2fe64c55be7154ee6f1807d304c"
             },
             "dist": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We had to revert #26763 because setting use-github-api caused a change to the root composer.lock file, apparently not using GH's API also makes it lock to a slightly different URL.

This reinstates the change, with the root composer.json also explicitly setting use-github-api so composer in people's local environments will behave the same way.

Should a project someday both use a "vcs" repository and check in composer.lock, it would need to do the same thing. As it is, none of the plugins use a vcs repository entry and none of the packages using a vcs repository entry check in composer.lock, so they're all good.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
#26763
p1665562718688409-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* The "Linting / Lock files are up to date" CI check should run here, and should pass.
* Run `tools/composer-update-monorepo.sh --root-reqs` for every directory containing a composer.lock file. There should be no changes.