### PR TITLE
Fix lazy loading images toggle

### DIFF
--- a/projects/plugins/boost/changelog/boost-fix-lazy-image-sync
+++ b/projects/plugins/boost/changelog/boost-fix-lazy-image-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed lazy image toggle breaking if it was also used in Jetpack dashboard while Boost is active.

--- a/projects/plugins/boost/compatibility/jetpack.php
+++ b/projects/plugins/boost/compatibility/jetpack.php
@@ -65,3 +65,17 @@ function lazy_images_sync_status( $_unused, $new_value ) {
 
 add_action( 'add_option_jetpack_boost_status_lazy-images', __NAMESPACE__ . '\lazy_images_sync_status', 10, 2 );
 add_action( 'update_option_jetpack_boost_status_lazy-images', __NAMESPACE__ . '\lazy_images_sync_status', 10, 2 );
+
+/**
+ * The compatibility layer uses Jetpack as the single source of truth for lazy images.
+ * As a fallback, Boost still keeps track of the value in the database,
+ * This ensures that the value is still present when Jetpack is dactivated.
+ *
+ * This filter is going to track changes to the Jetpack lazy-images option
+ * And make sure that Jetpack Boost is in sync.
+ */
+function lazy_images_sync_with_jetpack() {
+	update_option( 'jetpack_boost_status_lazy-images', \Jetpack::is_module_active( 'lazy-images' ) );
+}
+add_action( 'jetpack_deactivate_module_lazy-images', __NAMESPACE__ . '\lazy_images_sync_with_jetpack', 10, 2 );
+add_action( 'jetpack_activate_module_lazy-images', __NAMESPACE__ . '\lazy_images_sync_with_jetpack', 10, 2 );

--- a/projects/plugins/boost/tests/e2e/specs/jetpack-compatibility.test.js
+++ b/projects/plugins/boost/tests/e2e/specs/jetpack-compatibility.test.js
@@ -58,4 +58,36 @@ test.describe( 'Jetpack compatibility', () => {
 		const isActive = await isModuleActive( 'lazy-images' );
 		expect( isActive, 'lazy-images module should not be active' ).toBe( false );
 	} );
+
+	test( 'Lazy Image Toggle should work in Boost after using Jetpack dashboard to toogle lazy images.', async ( {
+		page,
+	} ) => {
+		const lazyImagesModule = 'lazy-images';
+		await boostPrerequisitesBuilder( page )
+			.withConnection( true )
+			.withInactiveModules( [ lazyImagesModule ] )
+			.build();
+
+		const jetpackBoostPage = await JetpackBoostPage.visit( page );
+
+		await boostPrerequisitesBuilder( page ).build();
+		await deactivateBoostModules( [ lazyImagesModule ] );
+
+		// Turn on Lazy Images in Jetpack Boost via the UI
+		await jetpackBoostPage.toggleModule( lazyImagesModule );
+
+		// Turn off Lazy Images with Jetpack
+		await deactivateModules( [ lazyImagesModule ] );
+
+		// Turn on Lazy Images in Jetpack Boost via the UI
+		await jetpackBoostPage.reload();
+		await jetpackBoostPage.toggleModule( lazyImagesModule );
+
+		await jetpackBoostPage.reload();
+		const isActiveInBoost = await jetpackBoostPage.isModuleEnabled( lazyImagesModule );
+		const isActiveInJetpack = await isModuleActive( lazyImagesModule );
+
+		expect( isActiveInBoost, 'lazy-images module should be active in Jetpack Boost' ).toBe( true );
+		expect( isActiveInJetpack, 'lazy-images module should be active in Jetpack' ).toBe( true );
+	} );
 } );


### PR DESCRIPTION
If Jetpack and Jetpack Boost plugins are active at the same time, Jetpack Boost defers to Jetpack as the single source of truth for lazy-image state using WordPress hooks.

However, when lazy loading images are toggled from Jetpack dashboard, Boost doesn't note that change. As a result, the Boost option in the database can be the inverse of what Jetpack Modules state is. This becomes a problem if the user interacts with lazy images again from the Boost dashboard.


#### Changes proposed in this Pull Request:
When Boost calls `update_option` to change the value in the database , the the SQL query doesn't perform any updates and `update_option` returns false, resulting in the switch flipping back.

With this PR, Boost is now also going to observe Jetpack lazy-image module state change and update the option accordingly.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Testing instructions:

1. Activate Lazy images in Boost
2. Deactivate Lazy images in Jetpack
3. Activate Lazy images in Boost
4. Observe the toggle flipping back
5. Apply patch and repeat steps 1-3
6. Observe the toggle functioning properly

#### Does this pull request change what data or activity we track or use?

No


