### PR TITLE
VideoPress: style checkout button when checking out

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-tweak-checkout-button-when-checking-out
+++ b/projects/packages/videopress/changelog/update-videopress-tweak-checkout-button-when-checking-out
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: style checkout button when checking out

--- a/projects/packages/videopress/src/client/admin/components/pricing-section/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/pricing-section/index.tsx
@@ -29,7 +29,7 @@ const PricingPage = () => {
 	} );
 	const [ isConnecting, setIsConnection ] = useState( false );
 
-	const { run } = useProductCheckoutWorkflow( {
+	const { run, hasCheckoutStarted } = useProductCheckoutWorkflow( {
 		siteSuffix,
 		productSlug: product.productSlug,
 		redirectUrl: adminUri,
@@ -58,7 +58,12 @@ const PricingPage = () => {
 						legend={ __( '/month, billed yearly', 'jetpack-videopress-pkg' ) }
 						currency={ pricingForUi.currencyCode }
 					/>
-					<Button onClick={ run } fullWidth disabled={ isConnecting }>
+					<Button
+						onClick={ run }
+						isLoading={ hasCheckoutStarted }
+						fullWidth
+						disabled={ isConnecting || hasCheckoutStarted }
+					>
 						{ __( 'Get VideoPress', 'jetpack-videopress-pkg' ) }
 					</Button>
 				</PricingTableHeader>
@@ -82,8 +87,8 @@ const PricingPage = () => {
 							setIsConnection( true );
 							handleRegisterSite();
 						} }
-						isLoading={ userIsConnecting || isConnecting }
-						disabled={ userIsConnecting || isConnecting }
+						isLoading={ userIsConnecting }
+						disabled={ userIsConnecting || isConnecting || hasCheckoutStarted }
 					>
 						{ __( 'Start for free', 'jetpack-videopress-pkg' ) }
 					</Button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/26764

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: style checkout button when checking out

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard
* Get the Pricing section
* Confirm buttons get disabled when checking out the VideoPress plan
* Confirm checkout button gets `uploading` state

https://user-images.githubusercontent.com/77539/195426020-e71bf2a3-6521-4869-926d-bf1595408b98.mov

