### PR TITLE
VideoPress: move v6 core/video transfrom from VideoPress to Jetpack plugin

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-move-transform-to-jetpack-plugin
+++ b/projects/packages/videopress/changelog/update-videopress-move-transform-to-jetpack-plugin
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+VideoPress: move v6 core/video transfrom from VideoPress to Jetpack plugin

--- a/projects/packages/videopress/composer.json
+++ b/projects/packages/videopress/composer.json
@@ -64,7 +64,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.5.x-dev"
+			"dev-trunk": "0.6.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-package-version.php"

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.5.2-alpha",
+	"version": "0.6.0-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.5.2-alpha';
+	const PACKAGE_VERSION = '0.6.0-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createBlock, registerBlockType } from '@wordpress/blocks';
+import { registerBlockType } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
@@ -17,20 +17,4 @@ registerBlockType( name, {
 	edit: Edit,
 	save,
 	icon,
-	transforms: {
-		from: [
-			{
-				type: 'block',
-				blocks: [ 'core/video' ],
-				transform: attrs => createBlock( 'videopress/video', attrs ),
-			},
-		],
-		to: [
-			{
-				type: 'block',
-				blocks: [ 'core/video' ],
-				transform: attrs => createBlock( 'core/video', attrs ),
-			},
-		],
-	},
 } );

--- a/projects/plugins/jetpack/changelog/update-videopress-move-transform-to-jetpack-plugin
+++ b/projects/plugins/jetpack/changelog/update-videopress-move-transform-to-jetpack-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+VideoPress: move videopress/video transfrom from VideoPress plugin to Jetpack plugin

--- a/projects/plugins/jetpack/changelog/update-videopress-move-transform-to-jetpack-plugin#2
+++ b/projects/plugins/jetpack/changelog/update-videopress-move-transform-to-jetpack-plugin#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -42,7 +42,7 @@
 		"automattic/jetpack-stats": "0.2.x-dev",
 		"automattic/jetpack-status": "1.14.x-dev",
 		"automattic/jetpack-sync": "1.39.x-dev",
-		"automattic/jetpack-videopress": "0.5.x-dev",
+		"automattic/jetpack-videopress": "0.6.x-dev",
 		"automattic/jetpack-waf": "0.6.x-dev",
 		"automattic/jetpack-wordads": "0.2.x-dev",
 		"nojimage/twitter-text-php": "3.1.2"

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1a758a7bcc0d558ef89066c471d615a2",
+    "content-hash": "855f9a1a84a4e7058f1191e285073adc",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -2010,7 +2010,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/videopress",
-                "reference": "211d1094fe9693a501066726cfbd1708320518c1"
+                "reference": "5ae0e851de5a758bfd33d5e268be2d3a2c6f2c97"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -2032,7 +2032,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.5.x-dev"
+                    "dev-trunk": "0.6.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-package-version.php"

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -392,3 +392,44 @@ addFilter(
 	'videopress/add-wp-chapters-support',
 	addVideoPressVideoChaptersSupport
 );
+
+/**
+ * Extend videopress/video transform to/from core/video block.
+ *
+ * @param {object} settings - Block settings.
+ * @param {string} name     - Block name.
+ * @returns {object} Modified block settings.
+ */
+function addVideoPressCoreVideoTransform( settings, name ) {
+	if ( name !== 'videopress/video' ) {
+		return settings;
+	}
+
+	return {
+		...settings,
+		transforms: {
+			from: [
+				...( settings.transforms?.from || [] ),
+				{
+					type: 'block',
+					blocks: [ 'core/video' ],
+					transform: attrs => createBlock( 'videopress/video', attrs ),
+				},
+			],
+			to: [
+				...( settings.transforms?.to || [] ),
+				{
+					type: 'block',
+					blocks: [ 'core/video' ],
+					transform: attrs => createBlock( 'core/video', attrs ),
+				},
+			],
+		},
+	};
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'videopress/add-core-video-transform',
+	addVideoPressCoreVideoTransform
+);

--- a/projects/plugins/videopress/changelog/update-videopress-move-transform-to-jetpack-plugin
+++ b/projects/plugins/videopress/changelog/update-videopress-move-transform-to-jetpack-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/videopress/composer.json
+++ b/projects/plugins/videopress/composer.json
@@ -13,7 +13,7 @@
 		"automattic/jetpack-my-jetpack": "2.2.x-dev",
 		"automattic/jetpack-sync": "1.39.x-dev",
 		"automattic/jetpack-plugins-installer": "0.2.x-dev",
-		"automattic/jetpack-videopress": "0.5.x-dev"
+		"automattic/jetpack-videopress": "0.6.x-dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.0.3",

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0179992e18593e51e854514864698ba7",
+    "content-hash": "92071c986249b09e9a6037061276fcbe",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1277,7 +1277,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/videopress",
-                "reference": "211d1094fe9693a501066726cfbd1708320518c1"
+                "reference": "5ae0e851de5a758bfd33d5e268be2d3a2c6f2c97"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -1299,7 +1299,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.5.x-dev"
+                    "dev-trunk": "0.6.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-package-version.php"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The ability to transform the `v6` block from/to `core/video` should be handled by the Jetpack plugin instead of the VideoPress standalone plugin. This PR takes over of it.

Fixes https://github.com/Automattic/jetpack/issues/26728

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: move v6 core/video transfrom from VideoPress to Jetpack plugin


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the plugins page
* Active Jetpack plugin.
* Enable beta extensions
* Go to block editor
* Create a core/video block
* Upload a video
* Confirm it's possible to transform to `v6` block
* Confirm it's possible to transform from `v6` to `core/video` too
* Deactivate Jetpack plugin
* Active VideoPress plugin
* Go to block editor
* Confirm transform from/to `core/video` are not available


https://user-images.githubusercontent.com/77539/195432141-157c0679-4a56-4d96-9cc2-ea14527e5006.mov

