### PR TITLE
VideoPress: fix Undefined variable thumbnail notice

### DIFF
--- a/projects/packages/videopress/changelog/fix-undefined-variable-thumbnail-notice
+++ b/projects/packages/videopress/changelog/fix-undefined-variable-thumbnail-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Make sure the thumbnail var is set before using it to prevent "Undefined variable" notice

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -201,6 +201,8 @@ class Data {
 
 				if ( isset( $files['dvd']['original_img'] ) ) {
 					$thumbnail = $file_url_base['https'] . $files['dvd']['original_img'];
+				} else {
+					$thumbnail = null;
 				}
 
 				return array(

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -224,7 +224,7 @@ class Data {
 						'width'  => $width,
 						'height' => $height,
 					),
-					'thumnbail'      => $thumbnail,
+					'thumbnail'      => $thumbnail,
 					'finished'       => $finished,
 				);
 			},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26765.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Make sure the `$thumbnail` variable is set before using it, covering the alternative paths on the conditional set

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to your VideoPress library on `Jetpack > VideoPress`
* Start the upload of a new video
* As soon as the label on video placeholder changes from "Uploading" to "Processing", refresh the page
* Before the fix, a notice would appear at the top of the page
* After the fix, **you should not see any notice** there

Tips:

* This is how the notice looked like:

![image](https://user-images.githubusercontent.com/6760046/195432454-bdee2049-f9ef-424a-8238-b93eeae2ead7.png)

* If you are using Query Monitor on your test site, you would not see the notice but the message would be present on the "PHP Errors" section of the Query Monitor toolbar:

![image](https://user-images.githubusercontent.com/6760046/195432798-d62b1808-07b3-4d57-b9d3-22ba50898344.png)

In this case, make sure you check for errors or notices on the Query Monitor toolbar after you refreshed the page