### PR TITLE
Search: change Search CTA links on Jetpack Dashboard to Search Dashboard (upsell page)

### DIFF
--- a/projects/packages/search/changelog/update-redirect-to-search-upsell-page-for-jetpack-dashboard-banners
+++ b/projects/packages/search/changelog/update-redirect-to-search-upsell-page-for-jetpack-dashboard-banners
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search: always add Search Dashboard page even when submenu is hidden

--- a/projects/packages/search/src/dashboard/class-dashboard.php
+++ b/projects/packages/search/src/dashboard/class-dashboard.php
@@ -93,23 +93,33 @@ class Dashboard {
 	 * The page to be added to submenu
 	 */
 	public function add_wp_admin_submenu() {
-		if ( ! $this->should_add_search_submenu() ) {
-			return;
-		}
-
 		// Jetpack of version <= 10.5 would register `jetpack-search` submenu with its built-in search module.
 		$this->remove_search_submenu_if_exists();
 
-		$page_suffix = Admin_Menu::add_menu(
-			__( 'Jetpack Search', 'jetpack-search-pkg' ),
-			_x( 'Search', 'product name shown in menu', 'jetpack-search-pkg' ),
-			'manage_options',
-			'jetpack-search',
-			array( $this, 'render' ),
-			100
-		);
+		if ( $this->should_add_search_submenu() ) {
+			$page_suffix = Admin_Menu::add_menu(
+				__( 'Jetpack Search', 'jetpack-search-pkg' ),
+				_x( 'Search', 'product name shown in menu', 'jetpack-search-pkg' ),
+				'manage_options',
+				'jetpack-search',
+				array( $this, 'render' ),
+				100
+			);
+		} else {
+			// always add the page, but hide it from the menu.
+			$page_suffix = add_submenu_page(
+				null,
+				__( 'Jetpack Search', 'jetpack-search-pkg' ),
+				_x( 'Search', 'product name shown in menu', 'jetpack-search-pkg' ),
+				'manage_options',
+				'jetpack-search',
+				array( $this, 'render' )
+			);
+		}
 
-		add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );
+		if ( $page_suffix ) {
+			add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/search.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/search.jsx
@@ -108,7 +108,7 @@ class DashSearch extends Component {
 				pro_inactive: true,
 				overrideContent: this.props.hasConnectedOwner ? (
 					<JetpackBanner
-						callToAction={ __( 'Upgrade', 'jetpack' ) }
+						callToAction={ __( 'Start for free', 'jetpack' ) }
 						title={ SEARCH_DESCRIPTION }
 						disableHref="false"
 						href={ this.props.upgradeUrl }

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/search.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/search.jsx
@@ -112,7 +112,7 @@ class DashSearch extends Component {
 				overrideContent: this.props.hasConnectedOwner ? (
 					<JetpackBanner
 						callToAction={
-							isSearchNewPricingLaunched202208
+							isSearchNewPricingLaunched202208()
 								? __( 'Start for free', 'jetpack' )
 								: __( 'Upgrade', 'jetpack' )
 						}

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/search.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/search.jsx
@@ -7,7 +7,10 @@ import JetpackBanner from 'components/jetpack-banner';
 import analytics from 'lib/analytics';
 import { getJetpackProductUpsellByFeature, FEATURE_SEARCH_JETPACK } from 'lib/plans/constants';
 import { noop } from 'lodash';
-import { getProductDescriptionUrl } from 'product-descriptions/utils';
+import {
+	getProductDescriptionUrl,
+	isSearchNewPricingLaunched202208,
+} from 'product-descriptions/utils';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -108,7 +111,11 @@ class DashSearch extends Component {
 				pro_inactive: true,
 				overrideContent: this.props.hasConnectedOwner ? (
 					<JetpackBanner
-						callToAction={ __( 'Start for free', 'jetpack' ) }
+						callToAction={
+							isSearchNewPricingLaunched202208
+								? __( 'Start for free', 'jetpack' )
+								: __( 'Upgrade', 'jetpack' )
+						}
 						title={ SEARCH_DESCRIPTION }
 						disableHref="false"
 						href={ this.props.upgradeUrl }

--- a/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
@@ -16,7 +16,10 @@ import {
 } from 'lib/plans/constants';
 import { get, includes } from 'lodash';
 import ProStatus from 'pro-status';
-import { getProductDescriptionUrl } from 'product-descriptions/utils';
+import {
+	getProductDescriptionUrl,
+	isSearchNewPricingLaunched202208,
+} from 'product-descriptions/utils';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -233,7 +236,11 @@ export const SettingsCard = props => {
 
 				return props.hasConnectedOwner ? (
 					<JetpackBanner
-						callToAction={ __( 'Start for free', 'jetpack' ) }
+						callToAction={
+							isSearchNewPricingLaunched202208()
+								? __( 'Start for free', 'jetpack' )
+								: __( 'Upgrade', 'jetpack' )
+						}
 						title={ __(
 							'Help visitors quickly find answers with highly relevant instant search results and powerful filtering.',
 							'jetpack'

--- a/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
@@ -233,7 +233,7 @@ export const SettingsCard = props => {
 
 				return props.hasConnectedOwner ? (
 					<JetpackBanner
-						callToAction={ upgradeLabel }
+						callToAction={ __( 'Start for free', 'jetpack' ) }
 						title={ __(
 							'Help visitors quickly find answers with highly relevant instant search results and powerful filtering.',
 							'jetpack'

--- a/projects/plugins/jetpack/_inc/client/product-descriptions/utils.js
+++ b/projects/plugins/jetpack/_inc/client/product-descriptions/utils.js
@@ -1,6 +1,9 @@
 import { getSiteAdminUrl } from 'state/initial-state';
 import { productDescriptionRoutes } from './constants';
 
+export const isSearchNewPricingLaunched202208 = () =>
+	URLSearchParams && !! new URLSearchParams( window.location?.search ).get( 'new_pricing_202208' );
+
 /**
  * Get product description URL by product key.
  *
@@ -14,7 +17,8 @@ import { productDescriptionRoutes } from './constants';
 export const getProductDescriptionUrl = ( state, productKey ) => {
 	const baseUrl = `${ getSiteAdminUrl( state ) }admin.php?page=jetpack#`;
 
-	if ( productKey === 'search' ) {
+	// TODO: remove the && condition on Search new pricing launch.
+	if ( productKey === 'search' && isSearchNewPricingLaunched202208() ) {
 		return `${ getSiteAdminUrl( state ) }admin.php?page=jetpack-search`;
 	}
 

--- a/projects/plugins/jetpack/_inc/client/product-descriptions/utils.js
+++ b/projects/plugins/jetpack/_inc/client/product-descriptions/utils.js
@@ -14,6 +14,10 @@ import { productDescriptionRoutes } from './constants';
 export const getProductDescriptionUrl = ( state, productKey ) => {
 	const baseUrl = `${ getSiteAdminUrl( state ) }admin.php?page=jetpack#`;
 
+	if ( productKey === 'search' ) {
+		return `${ getSiteAdminUrl( state ) }admin.php?page=jetpack-search`;
+	}
+
 	if ( productDescriptionRoutes.includes( `/product/${ productKey }` ) ) {
 		return `${ baseUrl }/product/${ productKey }`;
 	}

--- a/projects/plugins/jetpack/changelog/update-redirect-to-search-upsell-page-for-jetpack-dashboard-banners
+++ b/projects/plugins/jetpack/changelog/update-redirect-to-search-upsell-page-for-jetpack-dashboard-banners
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Search: changed Search CTA link to Search upsell page of the search package


### PR DESCRIPTION
Fixes #26805 

#### Changes proposed in this Pull Request:
- Changes Search CTA link on performance tab to Search Dashboard `/wp-admin/admin.php?page=jetpack-search`
- Changes Search CTA link on At a glance to Search Dashboard `/wp-admin/admin.php?page=jetpack-search`
- Always add Search Dashboard page even when Search submenu is hidden


#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
pcNPJE-1f2-p2

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Create a fresh JN site with Jetpack the plugin only on the current branch
- Connect site
- Open `/wp-admin/admin.php?page=jetpack&new_pricing_202208=1#/dashboard` and scroll to Search section
- Ensure the button displays `Start for free`
- Click the button
- Ensure you are taken to `/wp-admin/admin.php?page=jetpack-search` and it displays the upsell page

<img width="438" alt="image" src="https://user-images.githubusercontent.com/1425433/195481366-3d4969ad-4205-4220-a5b1-3a1adf52dd6f.png">


- Open `/wp-admin/admin.php?page=jetpack&new_pricing_202208=1#/performance`
- Find Search section
- Ensure the button displays `Start for free`
- Click the button
- Ensure you are taken to `/wp-admin/admin.php?page=jetpack-search` and it displays the upsell page

<img width="876" alt="image" src="https://user-images.githubusercontent.com/1425433/195481308-8040a8f1-6ce7-4b9d-ab54-faa8d6f5d56b.png">

