### PR TITLE
cli: `jetpack rsync` needs a non-empty destination

### DIFF
--- a/tools/cli/commands/rsync.js
+++ b/tools/cli/commands/rsync.js
@@ -313,7 +313,9 @@ async function maybePromptForDest( argv ) {
 		response = await inquirer.prompt( {
 			name: 'dest',
 			type: 'input',
-			message: 'Input destination path to the /plugins dir: ',
+			message:
+				"Input destination host:path to the plugin's dir or the /plugins or /mu-plugins dir: ",
+			validate: v => ( v === '' ? 'Please enter a host:path' : true ),
 		} );
 		argv.dest = response.dest;
 	} else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
When prompting for the destination, do not accept the empty string. It will wind up trying to rsync to `/` on the local system, which at best will fail and at worst will delete everything on the system.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pdWQjU-6L-p2#comment-133

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try hitting enter without typing anything at the "Input destination" prompt.