### PR TITLE
Update lazy image status on admin page load

### DIFF
--- a/projects/plugins/boost/changelog/boost-update-option-on-pageload
+++ b/projects/plugins/boost/changelog/boost-update-option-on-pageload
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: This change updates the approach already logged in the chanelog.
+
+

--- a/projects/plugins/boost/compatibility/jetpack.php
+++ b/projects/plugins/boost/compatibility/jetpack.php
@@ -77,5 +77,12 @@ add_action( 'update_option_jetpack_boost_status_lazy-images', __NAMESPACE__ . '\
 function lazy_images_sync_with_jetpack() {
 	update_option( 'jetpack_boost_status_lazy-images', \Jetpack::is_module_active( 'lazy-images' ) );
 }
+
 add_action( 'jetpack_deactivate_module_lazy-images', __NAMESPACE__ . '\lazy_images_sync_with_jetpack', 10, 2 );
 add_action( 'jetpack_activate_module_lazy-images', __NAMESPACE__ . '\lazy_images_sync_with_jetpack', 10, 2 );
+
+/**
+ * Update the Jetpack Boost option to match the Jetpack option,
+ * in case the options are out of sync when the page is loaded.
+ */
+add_action( 'load-jetpack_page_jetpack-boost', __NAMESPACE__ . '\lazy_images_sync_with_jetpack' );


### PR DESCRIPTION
After a recommendation from @thingalon - ensure that Jetpack and Jetpack Boost lazy-image status is always in sync on every Jetpack Boost admin page refresh, just in case it loses sync (for example with direct database edit or an another unforeseen change).

Improves #26795

#### Changes proposed in this Pull Request:
Runs the `lazy_images_sync_with_jetpack` function on Jetpack Boost admin page load.

#### Other information:
Have you written new tests for your changes, if applicable?
Not necessary.

Have you checked the E2E test CI results, and verified that your changes do not break them?
Yes

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
1. Activate Lazy images in Boost
2. Deactivate Lazy images in Jetpack
3. Activate Lazy images in Boost
4. Observe the toggle flipping back
5. Apply patch and repeat steps 1-3
6. Observe the toggle functioning properly
7. Alter `jetpack_boost_status_lazy-images` entry in `wp_options` and ensure that it changes to the correct state after loading the admin page.

