### PR TITLE
[Boost] and [Super Cache] Test/wordpress 6 1 compatibility tests

### DIFF
--- a/projects/plugins/boost/changelog/test-wordpress-6-1-compatibility-tests
+++ b/projects/plugins/boost/changelog/test-wordpress-6-1-compatibility-tests
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Tested with v6.1 of WordPress

--- a/projects/plugins/boost/changelog/test-wordpress-6-1-compatibility-tests
+++ b/projects/plugins/boost/changelog/test-wordpress-6-1-compatibility-tests
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: added
 
 Tested with v6.1 of WordPress

--- a/projects/plugins/boost/readme.txt
+++ b/projects/plugins/boost/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, xwp, adnan007, bjorsch, danwalmsley, davidlonjon, ebin
 Donate link: https://automattic.com
 Tags: performance, speed, pagespeed, web vitals, critical css, optimize, defer
 Requires at least: 5.5
-Tested up to: 6.0
+Tested up to: 6.1
 Requires PHP: 7.0
 Stable tag: 1.5.0
 License: GPLv2 or later

--- a/projects/plugins/super-cache/changelog/test-wordpress-6-1-compatibility-tests
+++ b/projects/plugins/super-cache/changelog/test-wordpress-6-1-compatibility-tests
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Tested with v6.1 of WordPress

--- a/projects/plugins/super-cache/changelog/test-wordpress-6-1-compatibility-tests
+++ b/projects/plugins/super-cache/changelog/test-wordpress-6-1-compatibility-tests
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: added
 
 Tested with v6.1 of WordPress

--- a/projects/plugins/super-cache/readme.txt
+++ b/projects/plugins/super-cache/readme.txt
@@ -3,7 +3,7 @@ Contributors: donncha, automattic
 Tags: performance, caching, wp-cache, wp-super-cache, cache
 Requires at least: 5.9
 Requires PHP: 5.6
-Tested up to: 6.0
+Tested up to: 6.1
 Stable tag: 1.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
### Description
Tested Boost and Super Cache with the latest version of WordPress 6.1 nightly release (13 Oct)

### Testing instructions
* Used [WP Beta Tester plugin ](https://en-gb.wordpress.org/plugins/wordpress-beta-tester/) to be on the latest build
* Loaded Jetpack Boost, no errors showing up in console or the debug log via `jetpack docker tail`

There's one warning showing up, but it's in core and not Boost or Super Cache

```
i18n.js?ver=0343553cc8c879477a4a:122 sprintf error: 

TypeError: [sprintf] expecting number but found undefined
memoized @ i18n.js?ver=0343553cc8c879477a4a:122
index.css:1          Failed to load resource: the server responded with a status of 404 ()
```

### Does this pull request change what data or activity we track or use?
No

