### PR TITLE
API Package: Export client constructor instead of singleton for Search package

### DIFF
--- a/projects/js-packages/api/changelog/fix-wpcom-search-cors-issue
+++ b/projects/js-packages/api/changelog/fix-wpcom-search-cors-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Made API client exportable and removed now-unused wpcomOriginApi.

--- a/projects/js-packages/api/index.jsx
+++ b/projects/js-packages/api/index.jsx
@@ -31,7 +31,6 @@ export const FetchNetworkError = createCustomError( 'FetchNetworkError' );
  */
 function JetpackRestApiClient( root, nonce ) {
 	let apiRoot = root,
-		wpcomOriginApiUrl = root,
 		headers = {
 			'X-WP-Nonce': nonce,
 		},
@@ -51,17 +50,6 @@ function JetpackRestApiClient( root, nonce ) {
 	const methods = {
 		setApiRoot( newRoot ) {
 			apiRoot = newRoot;
-		},
-		/**
-		 * Sets API root for search endpoints.
-		 * They are routed through wpcom API for wpcom simple sites,
-		 * so we add `/wp-json/wpcom-origin/` to this path on wpcom.
-		 * For non-wpcom sites, this is the same as apiRoot.
-		 *
-		 * @param {string} newRoot - API root for search endpoints.
-		 */
-		setWpcomOriginApiUrl( newRoot ) {
-			wpcomOriginApiUrl = newRoot;
 		},
 		setApiNonce( newNonce ) {
 			headers = {
@@ -489,21 +477,21 @@ function JetpackRestApiClient( root, nonce ) {
 				.then( checkStatus )
 				.then( parseJsonResponse ),
 		fetchSearchPlanInfo: () =>
-			getRequest( `${ wpcomOriginApiUrl }jetpack/v4/search/plan`, getParams )
+			getRequest( `${ apiRoot }jetpack/v4/search/plan`, getParams )
 				.then( checkStatus )
 				.then( parseJsonResponse ),
 		fetchSearchSettings: () =>
-			getRequest( `${ wpcomOriginApiUrl }jetpack/v4/search/settings`, getParams )
+			getRequest( `${ apiRoot }jetpack/v4/search/settings`, getParams )
 				.then( checkStatus )
 				.then( parseJsonResponse ),
 		updateSearchSettings: newSettings =>
-			postRequest( `${ wpcomOriginApiUrl }jetpack/v4/search/settings`, postParams, {
+			postRequest( `${ apiRoot }jetpack/v4/search/settings`, postParams, {
 				body: JSON.stringify( newSettings ),
 			} )
 				.then( checkStatus )
 				.then( parseJsonResponse ),
 		fetchSearchStats: () =>
-			getRequest( `${ wpcomOriginApiUrl }jetpack/v4/search/stats`, getParams )
+			getRequest( `${ apiRoot }jetpack/v4/search/stats`, getParams )
 				.then( checkStatus )
 				.then( parseJsonResponse ),
 		fetchWafSettings: () =>
@@ -519,7 +507,7 @@ function JetpackRestApiClient( root, nonce ) {
 				body: JSON.stringify( newSettings ),
 			} ),
 		fetchSearchPricing: () =>
-			getRequest( `${ wpcomOriginApiUrl }jetpack/v4/search/pricing`, getParams )
+			getRequest( `${ apiRoot }jetpack/v4/search/pricing`, getParams )
 				.then( checkStatus )
 				.then( parseJsonResponse ),
 	};

--- a/projects/js-packages/api/index.jsx
+++ b/projects/js-packages/api/index.jsx
@@ -29,7 +29,7 @@ export const FetchNetworkError = createCustomError( 'FetchNetworkError' );
  * @param {string} root - The API root
  * @param {string} nonce - The API Nonce
  */
-function JetpackRestApiClient( root, nonce ) {
+export function JetpackRestApiClient( root, nonce ) {
 	let apiRoot = root,
 		headers = {
 			'X-WP-Nonce': nonce,

--- a/projects/packages/search/changelog/fix-wpcom-search-cors-issue
+++ b/projects/packages/search/changelog/fix-wpcom-search-cors-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use the restApi client constructor for creating an exclusive singleton for the Search dashboard.

--- a/projects/packages/search/src/dashboard/class-initial-state.php
+++ b/projects/packages/search/src/dashboard/class-initial-state.php
@@ -58,8 +58,7 @@ class Initial_State {
 	public function get_initial_state() {
 		return array(
 			'siteData'        => array(
-				'WP_API_root'       => esc_url_raw( rest_url() ),
-				'wpcomOriginApiUrl' => $this->get_wp_api_root(),
+				'WP_API_root'       => $this->get_wp_api_root(),
 				'WP_API_nonce'      => wp_create_nonce( 'wp_rest' ),
 				'registrationNonce' => wp_create_nonce( 'jetpack-registration-nonce' ),
 				'purchaseToken'     => $this->get_purchase_token(),

--- a/projects/packages/search/src/dashboard/components/dashboard/wrapped-dashboard.jsx
+++ b/projects/packages/search/src/dashboard/components/dashboard/wrapped-dashboard.jsx
@@ -31,10 +31,8 @@ export default function WrappedDashboard() {
 
 	useMemo( () => {
 		const apiRootUrl = syncSelect( STORE_ID ).getAPIRootUrl();
-		const wpcomOriginApiUrl = syncSelect( STORE_ID ).getWpcomOriginApiUrl();
 		const apiNonce = syncSelect( STORE_ID ).getAPINonce();
 		apiRootUrl && restApi.setApiRoot( apiRootUrl );
-		wpcomOriginApiUrl && restApi.setWpcomOriginApiUrl( wpcomOriginApiUrl );
 		apiNonce && restApi.setApiNonce( apiNonce );
 		initializeAnalytics();
 		analytics.tracks.recordEvent( 'jetpack_search_admin_page_view', {

--- a/projects/packages/search/src/dashboard/components/dashboard/wrapped-dashboard.jsx
+++ b/projects/packages/search/src/dashboard/components/dashboard/wrapped-dashboard.jsx
@@ -1,5 +1,4 @@
 import analytics from '@automattic/jetpack-analytics';
-import restApi from '@automattic/jetpack-api';
 import { useSelect, select as syncSelect } from '@wordpress/data';
 import SearchConnectionPage from 'components/pages/connection-page';
 import SearchDashboardPage from 'components/pages/dashboard-page';
@@ -7,6 +6,7 @@ import UpsellPage from 'components/pages/upsell-page';
 import useConnection from 'hooks/use-connection';
 import React, { useMemo } from 'react';
 import { STORE_ID } from 'store';
+import { restApi } from 'store/controls';
 
 /**
  * Return appropriate components.
@@ -29,11 +29,15 @@ export default function WrappedDashboard() {
 		}
 	};
 
-	useMemo( () => {
+	const initializeApi = () => {
 		const apiRootUrl = syncSelect( STORE_ID ).getAPIRootUrl();
 		const apiNonce = syncSelect( STORE_ID ).getAPINonce();
 		apiRootUrl && restApi.setApiRoot( apiRootUrl );
 		apiNonce && restApi.setApiNonce( apiNonce );
+	};
+
+	useMemo( () => {
+		initializeApi();
 		initializeAnalytics();
 		analytics.tracks.recordEvent( 'jetpack_search_admin_page_view', {
 			current_version: syncSelect( STORE_ID ).getVersion(),

--- a/projects/packages/search/src/dashboard/store/controls.js
+++ b/projects/packages/search/src/dashboard/store/controls.js
@@ -1,10 +1,13 @@
-import restApi from '@automattic/jetpack-api';
+import { JetpackRestApiClient } from '@automattic/jetpack-api';
 
 export const FETCH_JETPACK_SETTINGS = 'FETCH_JETPACK_SETTINGS';
 export const UPDATE_JETPACK_SETTINGS = 'UPDATE_JETPACK_SETTINGS';
 export const FETCH_SEARCH_PLAN_INFO = 'FETCH_SEARCH_PLAN_INFO';
 export const FETCH_SEARCH_STATS = 'FETCH_SEARCH_STATS';
 export const FETCH_SEARCH_PRICING = 'FETCH_SEARCH_PRICING';
+
+// Instantiates an API singleton for the Search Dashboard.
+export const restApi = new JetpackRestApiClient();
 
 /**
  * fetchJetpackSettings action

--- a/projects/packages/search/src/dashboard/store/selectors/site-data.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-data.js
@@ -1,6 +1,5 @@
 const siteDataSelectors = {
 	getAPIRootUrl: state => state.siteData?.WP_API_root ?? null,
-	getWpcomOriginApiUrl: state => state.siteData?.wpcomOriginApiUrl ?? null,
 	getAPINonce: state => state.siteData?.WP_API_nonce ?? null,
 	getRegistrationNonce: state => state.siteData?.registrationNonce ?? null,
 	getSiteAdminUrl: state => state.siteData?.adminUrl ?? null,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up on #26713. This PR is necessary because the Search dashboard can also make API requests to other, non-search-related endpoints.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Exports the REST API client constructor for API package consumers who do not want to use the same singleton used by other package consumers.
* Use the newly exported constructor to create an API client singleton exclusive to the search dashboard.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1665680241558479-slack-C02FMH4G8.

This is is currently preventing customers from purchasing Jetpack Search on WordPress.com.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Jetpack sites:
* Apply this change to your local Jetpack site with the Search plugin.
* Navigate to the Search dashboard (`/wp-admin/admin.php?page=jetpack-search`).
* If you have a subscription, ensure that the dashboard loads as expected. If you don't, ensure that the new pricing loads as expected.

WPCOM sites (a12s only):
* Apply this change to your sandbox.
* Navigate to the Search dashboard (`https://some-sample-site.wordpress.com/wp-admin/admin.php?page=jetpack-search`).
* If you have a subscription, ensure that the dashboard loads as expected. If you don't, ensure that the new pricing loads as expected.