### PR TITLE
Search: WPCOM sites should be considered as fully connected

### DIFF
--- a/projects/packages/search/changelog/add-free-search-product-support-my-jetpack
+++ b/projects/packages/search/changelog/add-free-search-product-support-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: wpcom sites do not should be considered as connected

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -5,11 +5,7 @@ import {
 	Container,
 	Col,
 } from '@automattic/jetpack-components';
-import {
-	useProductCheckoutWorkflow,
-	useConnectionErrorNotice,
-	ConnectionError,
-} from '@automattic/jetpack-connection';
+import { useConnectionErrorNotice, ConnectionError } from '@automattic/jetpack-connection';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import NoticesList from 'components/global-notices';
@@ -17,6 +13,7 @@ import Loading from 'components/loading';
 import MockedSearch from 'components/mocked-search';
 import ModuleControl from 'components/module-control';
 import RecordMeter from 'components/record-meter';
+import useProductCheckoutWorkflow from 'hooks/use-product-checkout-workflow';
 import React, { useCallback } from 'react';
 import { STORE_ID } from 'store';
 import FirstRunSection from './sections/first-run-section';
@@ -35,6 +32,7 @@ export default function DashboardPage( { isLoading = false } ) {
 	useSelect( select => select( STORE_ID ).getSearchModuleStatus(), [] );
 	useSelect( select => select( STORE_ID ).getSearchStats(), [] );
 
+	const isWpcom = useSelect( select => select( STORE_ID ).isWpcom(), [] );
 	const domain = useSelect( select => select( STORE_ID ).getCalypsoSlug() );
 	const siteAdminUrl = useSelect( select => select( STORE_ID ).getSiteAdminUrl() );
 	const { hasConnectionError } = useConnectionErrorNotice();
@@ -51,6 +49,7 @@ export default function DashboardPage( { isLoading = false } ) {
 		siteProductAvailabilityHandler: checkSiteHasSearchProduct,
 		from: 'jetpack-search',
 		siteSuffix: domain,
+		isWpcom,
 	} );
 
 	const isPageLoading = useSelect(

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page.jsx
@@ -14,16 +14,13 @@ import {
 	Button,
 	ThemeProvider,
 } from '@automattic/jetpack-components';
-import {
-	ConnectionError,
-	useConnectionErrorNotice,
-	useProductCheckoutWorkflow,
-} from '@automattic/jetpack-connection';
+import { ConnectionError, useConnectionErrorNotice } from '@automattic/jetpack-connection';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import Loading from 'components/loading';
 import SearchPromotionBlock from 'components/search-promotion';
+import useProductCheckoutWorkflow from 'hooks/use-product-checkout-workflow';
 import React, { useCallback } from 'react';
 import { STORE_ID } from 'store';
 
@@ -45,6 +42,7 @@ export default function UpsellPage( { isLoading = false } ) {
 	useSelect( select => select( STORE_ID ).getSearchPricing(), [] );
 	const domain = useSelect( select => select( STORE_ID ).getCalypsoSlug(), [] );
 	const adminUrl = useSelect( select => select( STORE_ID ).getSiteAdminUrl(), [] );
+	const isWpcom = useSelect( select => select( STORE_ID ).isWpcom(), [] );
 
 	const { fetchSearchPlanInfo } = useDispatch( STORE_ID );
 	const checkSiteHasSearchProduct = useCallback(
@@ -58,6 +56,7 @@ export default function UpsellPage( { isLoading = false } ) {
 		siteProductAvailabilityHandler: checkSiteHasSearchProduct,
 		from: 'jetpack-search',
 		siteSuffix: domain,
+		isWpcom,
 	} );
 
 	const { run: sendToCartFree, hasCheckoutStartedFree } = useProductCheckoutWorkflow( {
@@ -66,6 +65,7 @@ export default function UpsellPage( { isLoading = false } ) {
 		siteProductAvailabilityHandler: checkSiteHasSearchProduct,
 		from: 'jetpack-search',
 		siteSuffix: domain,
+		isWpcom,
 	} );
 
 	const isPageLoading = useSelect(

--- a/projects/packages/search/src/dashboard/hooks/use-product-checkout-workflow.jsx
+++ b/projects/packages/search/src/dashboard/hooks/use-product-checkout-workflow.jsx
@@ -1,0 +1,91 @@
+import restApi from '@automattic/jetpack-api';
+import { getProductCheckoutUrl } from '@automattic/jetpack-components';
+import { useConnection, CONNECTION_STORE_ID } from '@automattic/jetpack-connection';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect, useState } from 'react';
+import { STORE_ID as SEARCH_STORE_ID } from 'store';
+
+const {
+	registrationNonce,
+	apiRoot,
+	apiNonce,
+	siteSuffix: defaultSiteSuffix,
+} = window?.JP_CONNECTION_INITIAL_STATE ? window.JP_CONNECTION_INITIAL_STATE : {};
+
+/**
+ * Custom hook that performs the needed steps
+ * to concrete the checkout workflow.
+ *
+ * @param {object} props              - The props passed to the hook.
+ * @param {string} props.productSlug  - The WordPress product slug.
+ * @param {string} props.redirectUrl  - The URI to redirect to after checkout.
+ * @param {string} [props.siteSuffix] - The site suffix.
+ * @param {Function} props.siteProductAvailabilityHandler - The function used to check whether the site already has the requested product. This will be checked after registration and the checkout page will be skipped if the promise returned resloves true.
+ * @param {Function} props.from       - The plugin slug initiated the flow.
+ * @returns {Function}				  - The useEffect hook.
+ */
+export default function useProductCheckoutWorkflow( {
+	productSlug,
+	redirectUrl,
+	siteSuffix = defaultSiteSuffix,
+	siteProductAvailabilityHandler = null,
+	from,
+} = {} ) {
+	const [ hasCheckoutStarted, setCheckoutStarted ] = useState( false );
+	const { registerSite } = useDispatch( CONNECTION_STORE_ID );
+
+	const { isUserConnected, isRegistered, handleConnectUser } = useConnection( {
+		redirectUri: redirectUrl,
+		from,
+	} );
+
+	const isWpcom = useSelect( select => select( SEARCH_STORE_ID ).isWpcom(), [] );
+
+	// Build the checkout URL.
+	const checkoutProductUrl = getProductCheckoutUrl(
+		productSlug,
+		siteSuffix,
+		redirectUrl,
+		isUserConnected || isWpcom
+	);
+
+	const handleAfterRegistration = () => {
+		return Promise.resolve(
+			siteProductAvailabilityHandler && siteProductAvailabilityHandler()
+		).then( siteHasWpcomProduct => {
+			if ( siteHasWpcomProduct ) {
+				return handleConnectUser();
+			}
+			window.location.href = checkoutProductUrl;
+		} );
+	};
+
+	/**
+	 * Handler to run the checkout workflow.
+	 *
+	 * @param {Event} [event] - Event that dispatched run
+	 * @returns {void}          Nothing.
+	 */
+	const run = event => {
+		event && event.preventDefault();
+		setCheckoutStarted( true );
+
+		if ( isRegistered || isWpcom ) {
+			return handleAfterRegistration();
+		}
+
+		registerSite( { registrationNonce, redirectUri: redirectUrl } ).then( handleAfterRegistration );
+	};
+
+	// Initialize/Setup the REST API.
+	useEffect( () => {
+		restApi.setApiRoot( apiRoot );
+		restApi.setApiNonce( apiNonce );
+	}, [] );
+
+	return {
+		run,
+		isRegistered: isRegistered || isWpcom,
+		hasCheckoutStarted,
+	};
+}

--- a/projects/packages/search/src/dashboard/hooks/use-product-checkout-workflow.jsx
+++ b/projects/packages/search/src/dashboard/hooks/use-product-checkout-workflow.jsx
@@ -1,9 +1,8 @@
 import restApi from '@automattic/jetpack-api';
 import { getProductCheckoutUrl } from '@automattic/jetpack-components';
 import { useConnection, CONNECTION_STORE_ID } from '@automattic/jetpack-connection';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { useEffect, useState } from 'react';
-import { STORE_ID as SEARCH_STORE_ID } from 'store';
 
 const {
 	registrationNonce,
@@ -22,6 +21,7 @@ const {
  * @param {string} [props.siteSuffix] - The site suffix.
  * @param {Function} props.siteProductAvailabilityHandler - The function used to check whether the site already has the requested product. This will be checked after registration and the checkout page will be skipped if the promise returned resloves true.
  * @param {Function} props.from       - The plugin slug initiated the flow.
+ * @param {Function} props.isWpcom    - Whether it's WPCOM site.
  * @returns {Function}				  - The useEffect hook.
  */
 export default function useProductCheckoutWorkflow( {
@@ -30,6 +30,7 @@ export default function useProductCheckoutWorkflow( {
 	siteSuffix = defaultSiteSuffix,
 	siteProductAvailabilityHandler = null,
 	from,
+	isWpcom = false,
 } = {} ) {
 	const [ hasCheckoutStarted, setCheckoutStarted ] = useState( false );
 	const { registerSite } = useDispatch( CONNECTION_STORE_ID );
@@ -38,8 +39,6 @@ export default function useProductCheckoutWorkflow( {
 		redirectUri: redirectUrl,
 		from,
 	} );
-
-	const isWpcom = useSelect( select => select( SEARCH_STORE_ID ).isWpcom(), [] );
 
 	// Build the checkout URL.
 	const checkoutProductUrl = getProductCheckoutUrl(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Forks `useProductCheckoutWorkflow` and changes to treat wpcom sites as fully connected.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
p1665680241558479-dotcom-escalations-slack


#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Ensure Search dashboard still works for Jetpack sites
- Pull changes to your sandbox and ensure it works for simple sites too