### PR TITLE
Search: Fix upgrade checkout flow

### DIFF
--- a/projects/packages/search/changelog/update-upgrade_checkout_url
+++ b/projects/packages/search/changelog/update-upgrade_checkout_url
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Fetch checkoutProductUrl for upgrade flow redirection.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26823 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Assemble `checkoutProductUrl` directly via `getProductCheckoutUrl` to avoid redundant connection process.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
No

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Purchase the Jetpack Search `Free` plan.
* Navigate to the site with URL `/wp-admin/admin.php?page=jetpack-search&new_pricing_202208=1`.
* Ensure an upgrade link is at the page's top right.
* Click on the upgrade link.
* Ensure the page redirects outside to the checkout flow without a connection process.

