### PR TITLE
Search: Refactor IconTooltip and usage on upgrade tooltips

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,7 +207,7 @@ importers:
       '@automattic/jetpack-analytics': workspace:* || ^0.1
       '@automattic/jetpack-api': workspace:* || ^0.14
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.23
+      '@automattic/jetpack-components': workspace:* || ^0.24
       '@automattic/jetpack-config': workspace:* || ^0.1
       '@babel/core': 7.19.3
       '@babel/preset-react': 7.18.6
@@ -328,7 +328,7 @@ importers:
       '@automattic/jetpack-analytics': workspace:* || ^0.1
       '@automattic/jetpack-api': workspace:* || ^0.14
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.23
+      '@automattic/jetpack-components': workspace:* || ^0.24
       '@babel/core': 7.19.3
       '@babel/preset-react': 7.18.6
       '@wordpress/base-styles': 4.10.0
@@ -367,7 +367,7 @@ importers:
       '@automattic/jetpack-analytics': workspace:* || ^0.1
       '@automattic/jetpack-api': workspace:* || ^0.14
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.23
+      '@automattic/jetpack-components': workspace:* || ^0.24
       '@babel/core': 7.19.3
       '@babel/preset-react': 7.18.6
       '@testing-library/dom': 8.16.0
@@ -409,7 +409,7 @@ importers:
     specifiers:
       '@automattic/jetpack-analytics': workspace:* || ^0.1
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.23
+      '@automattic/jetpack-components': workspace:* || ^0.24
       '@automattic/jetpack-connection': workspace:* || ^0.22
       '@babel/core': 7.19.3
       '@babel/preset-react': 7.18.6
@@ -456,7 +456,7 @@ importers:
     specifiers:
       '@automattic/color-studio': 2.5.0
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.23
+      '@automattic/jetpack-components': workspace:* || ^0.24
       '@automattic/jetpack-shared-extension-utils': workspace:* || ^0.6
       '@automattic/jetpack-webpack-config': workspace:* || ^1.3
       '@automattic/social-previews': 1.1.5
@@ -559,7 +559,7 @@ importers:
 
   projects/js-packages/storybook:
     specifiers:
-      '@automattic/jetpack-components': workspace:* || ^0.23
+      '@automattic/jetpack-components': workspace:* || ^0.24
       '@babel/core': 7.19.3
       '@babel/plugin-syntax-jsx': 7.18.6
       '@babel/preset-react': 7.18.6
@@ -757,7 +757,7 @@ importers:
       '@automattic/jetpack-analytics': workspace:* || ^0.1
       '@automattic/jetpack-api': workspace:* || ^0.14
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.23
+      '@automattic/jetpack-components': workspace:* || ^0.24
       '@automattic/jetpack-connection': workspace:* || ^0.22
       '@automattic/jetpack-webpack-config': workspace:* || ^1.3
       '@babel/core': 7.19.3
@@ -890,7 +890,7 @@ importers:
       '@automattic/format-currency': 1.0.1
       '@automattic/jetpack-analytics': workspace:* || ^0.1
       '@automattic/jetpack-api': workspace:* || ^0.14
-      '@automattic/jetpack-components': workspace:* || ^0.23
+      '@automattic/jetpack-components': workspace:* || ^0.24
       '@automattic/jetpack-connection': workspace:* || ^0.22
       '@automattic/jetpack-licensing': workspace:* || ^0.6
       '@automattic/jetpack-webpack-config': workspace:* || ^1.3
@@ -986,7 +986,7 @@ importers:
       '@automattic/jetpack-analytics': workspace:* || ^0.1
       '@automattic/jetpack-api': workspace:* || ^0.14
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.23
+      '@automattic/jetpack-components': workspace:* || ^0.24
       '@automattic/jetpack-connection': workspace:* || ^0.22
       '@automattic/jetpack-webpack-config': workspace:* || ^1.3
       '@babel/core': 7.19.3
@@ -1108,7 +1108,7 @@ importers:
       '@automattic/calypso-color-schemes': 2.1.1
       '@automattic/jetpack-api': workspace:* || ^0.14
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.23
+      '@automattic/jetpack-components': workspace:* || ^0.24
       '@automattic/jetpack-connection': workspace:* || ^0.22
       '@automattic/jetpack-webpack-config': workspace:* || ^1.3
       '@babel/core': 7.19.3
@@ -1216,7 +1216,7 @@ importers:
       '@automattic/color-studio': 2.5.0
       '@automattic/jetpack-analytics': workspace:* || ^0.1
       '@automattic/jetpack-api': workspace:* || ^0.14
-      '@automattic/jetpack-components': workspace:* || ^0.23
+      '@automattic/jetpack-components': workspace:* || ^0.24
       '@automattic/jetpack-webpack-config': workspace:* || ^1.3
       '@babel/core': 7.19.3
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6
@@ -1328,7 +1328,7 @@ importers:
   projects/plugins/boost:
     specifiers:
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.23
+      '@automattic/jetpack-components': workspace:* || ^0.24
       '@babel/core': 7.19.3
       '@babel/preset-env': 7.19.3
       '@babel/preset-react': 7.18.6
@@ -1425,7 +1425,7 @@ importers:
       '@automattic/jetpack-analytics': workspace:* || ^0.1
       '@automattic/jetpack-api': workspace:* || ^0.14
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.23
+      '@automattic/jetpack-components': workspace:* || ^0.24
       '@automattic/jetpack-connection': workspace:* || ^0.22
       '@automattic/jetpack-licensing': workspace:* || ^0.6
       '@automattic/jetpack-partner-coupon': workspace:* || ^0.2
@@ -1654,7 +1654,7 @@ importers:
     specifiers:
       '@automattic/jetpack-analytics': workspace:* || ^0.1
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.23
+      '@automattic/jetpack-components': workspace:* || ^0.24
       '@automattic/jetpack-connection': workspace:* || ^0.22
       '@automattic/jetpack-webpack-config': workspace:* || ^1.3
       '@babel/core': 7.19.3
@@ -1729,7 +1729,7 @@ importers:
       '@automattic/calypso-color-schemes': 2.1.1
       '@automattic/color-studio': 2.5.0
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.23
+      '@automattic/jetpack-components': workspace:* || ^0.24
       '@automattic/jetpack-connection': workspace:* || ^0.22
       '@automattic/jetpack-publicize-components': workspace:* || ^0.7
       '@automattic/jetpack-webpack-config': workspace:* || ^1.3
@@ -1790,7 +1790,7 @@ importers:
   projects/plugins/starter-plugin:
     specifiers:
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.23
+      '@automattic/jetpack-components': workspace:* || ^0.24
       '@automattic/jetpack-connection': workspace:* || ^0.22
       '@automattic/jetpack-webpack-config': workspace:* || ^1.3
       '@babel/core': 7.19.3
@@ -1870,7 +1870,7 @@ importers:
   projects/plugins/videopress:
     specifiers:
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
-      '@automattic/jetpack-components': workspace:* || ^0.23
+      '@automattic/jetpack-components': workspace:* || ^0.24
       '@automattic/jetpack-connection': workspace:* || ^0.22
       '@automattic/jetpack-webpack-config': workspace:* || ^1.3
       '@babel/core': 7.19.3

--- a/projects/js-packages/components/changelog/update-refactor_icon_tooltip
+++ b/projects/js-packages/components/changelog/update-refactor_icon_tooltip
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Refactor IconTooltip with prop popoverAnchorStyle for alignment with Popover anchor.

--- a/projects/js-packages/components/components/icon-tooltip/index.tsx
+++ b/projects/js-packages/components/components/icon-tooltip/index.tsx
@@ -36,7 +36,7 @@ const IconTooltip: React.FC< IconTooltipProps > = ( {
 	offset = 10,
 	title,
 	children,
-	shadowAnchor = false,
+	popoverAnchorStyle = 'icon',
 	forceShow = false,
 } ) => {
 	const POPOVER_HELPER_WIDTH = 124;
@@ -58,16 +58,18 @@ const IconTooltip: React.FC< IconTooltipProps > = ( {
 		className: 'icon-tooltip-container',
 	};
 
+	const isAnchorWrapper = popoverAnchorStyle === 'wrapper';
+
 	const wrapperClassNames = classNames( 'icon-tooltip-wrapper', className );
 	const iconShiftBySize = {
-		left: shadowAnchor ? 0 : -( POPOVER_HELPER_WIDTH / 2 - iconSize / 2 ) + 'px',
+		left: isAnchorWrapper ? 0 : -( POPOVER_HELPER_WIDTH / 2 - iconSize / 2 ) + 'px',
 	};
 
-	const isForcedToShow = shadowAnchor && forceShow;
+	const isForcedToShow = isAnchorWrapper && forceShow;
 
 	return (
 		<div className={ wrapperClassNames } data-testid="icon-tooltip_wrapper">
-			{ ! shadowAnchor && (
+			{ ! isAnchorWrapper && (
 				<Button variant="link" onClick={ showTooltip }>
 					<Gridicon className={ iconClassName } icon={ iconCode } size={ iconSize } />
 				</Button>

--- a/projects/js-packages/components/components/icon-tooltip/stories/index.tsx
+++ b/projects/js-packages/components/components/icon-tooltip/stories/index.tsx
@@ -1,5 +1,3 @@
-import Button from '../../button';
-import DonutMeter from '../../donut-meter';
 import IconTooltip from '../index';
 import './style.scss';
 import type { Placement } from '../types';
@@ -54,17 +52,15 @@ const Template = args => (
 	</div>
 );
 
-const NewTemplate = args => (
+const WrapperAnchorTemplate = args => (
 	<div style={ { position: 'absolute', height: '1000px', left: '300px', top: '300px' } }>
-		<div className="donut-meter-wrapper">
-			<DonutMeter segmentCount={ 100 } totalCount={ 500 } />
-			<div className="upgrade-tooltip-shadow-anchor">
+		<div className="tooltip-wrapper">
+			<div className="tooltip-wrapper-anchor">
 				<IconTooltip { ...args }>
 					<>
 						<div>Thank you for upgrading! Now your visitors can search up to 500 records.</div>
-						<div className="upgrade-tooltip-actions">
+						<div className="tooltip-actions">
 							<span>1 of 2</span>
-							<Button>Next</Button>
 						</div>
 					</>
 				</IconTooltip>
@@ -87,9 +83,9 @@ HasContent.args = {
 	),
 };
 
-export const ShadowAnchor = NewTemplate.bind( {} );
-ShadowAnchor.args = {
-	shadowAnchor: true,
+export const WrapperAnchor = WrapperAnchorTemplate.bind( {} );
+WrapperAnchor.args = {
+	popoverAnchorStyle: 'wrapper',
 	title: 'Site records increased',
 	placement: 'top',
 	forceShow: true,

--- a/projects/js-packages/components/components/icon-tooltip/stories/style.scss
+++ b/projects/js-packages/components/components/icon-tooltip/stories/style.scss
@@ -1,4 +1,4 @@
-.upgrade-tooltip-shadow-anchor {
+.tooltip-wrapper-anchor {
 	position: absolute;
 	top: 0;
 	left: 0;
@@ -26,7 +26,7 @@
 		font-size: var( --font-body );
 	}
 
-	.upgrade-tooltip-actions {
+	.tooltip-actions {
 		display: flex;
 		align-items: center;
 		justify-content: space-between;

--- a/projects/js-packages/components/components/icon-tooltip/types.ts
+++ b/projects/js-packages/components/components/icon-tooltip/types.ts
@@ -60,12 +60,12 @@ export type IconTooltipProps = {
 	offset?: number;
 
 	/**
-	 * Keep the Popover placement aligned with its parent wrapper rather than the icon.
+	 * Set the Popover anchor for its alignment with placement.
 	 */
-	shadowAnchor?: boolean;
+	popoverAnchorStyle?: 'icon' | 'wrapper';
 
 	/**
-	 * Force the Popover to show without event triggering.
+	 * Force the Popover to show without an event trigger.
 	 */
 	forceShow?: boolean;
 };

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.23.0",
+	"version": "0.24.0-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/changelog/update-refactor_upgrade_tooltips
+++ b/projects/js-packages/connection/changelog/update-refactor_upgrade_tooltips
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,13 +1,13 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.22.2",
+	"version": "0.22.3-alpha",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",
 	"dependencies": {
 		"@automattic/jetpack-analytics": "workspace:* || ^0.1",
 		"@automattic/jetpack-config": "workspace:* || ^0.1",
-		"@automattic/jetpack-components": "workspace:* || ^0.23",
+		"@automattic/jetpack-components": "workspace:* || ^0.24",
 		"@automattic/jetpack-api": "workspace:* || ^0.14",
 		"@wordpress/base-styles": "4.10.0",
 		"@wordpress/browserslist-config": "5.2.0",

--- a/projects/js-packages/idc/changelog/update-refactor_upgrade_tooltips
+++ b/projects/js-packages/idc/changelog/update-refactor_upgrade_tooltips
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-idc",
-	"version": "0.10.24",
+	"version": "0.10.25-alpha",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",
@@ -8,7 +8,7 @@
 		"@automattic/jetpack-analytics": "workspace:* || ^0.1",
 		"@automattic/jetpack-api": "workspace:* || ^0.14",
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3",
-		"@automattic/jetpack-components": "workspace:* || ^0.23",
+		"@automattic/jetpack-components": "workspace:* || ^0.24",
 		"@wordpress/base-styles": "4.10.0",
 		"@wordpress/components": "21.2.0",
 		"@wordpress/compose": "5.17.0",

--- a/projects/js-packages/licensing/changelog/update-refactor_upgrade_tooltips
+++ b/projects/js-packages/licensing/changelog/update-refactor_upgrade_tooltips
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.6.1",
+	"version": "0.6.2-alpha",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {
@@ -22,7 +22,7 @@
 	"dependencies": {
 		"@automattic/jetpack-analytics": "workspace:* || ^0.1",
 		"@automattic/jetpack-api": "workspace:* || ^0.14",
-		"@automattic/jetpack-components": "workspace:* || ^0.23",
+		"@automattic/jetpack-components": "workspace:* || ^0.24",
 		"@wordpress/components": "21.2.0",
 		"@wordpress/element": "4.17.0",
 		"@wordpress/i18n": "4.19.0",

--- a/projects/js-packages/partner-coupon/changelog/update-refactor_upgrade_tooltips
+++ b/projects/js-packages/partner-coupon/changelog/update-refactor_upgrade_tooltips
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.29",
+	"version": "0.2.30-alpha",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {
@@ -42,7 +42,7 @@
 		"react-dom": "17.0.2"
 	},
 	"dependencies": {
-		"@automattic/jetpack-components": "workspace:* || ^0.23",
+		"@automattic/jetpack-components": "workspace:* || ^0.24",
 		"@automattic/jetpack-connection": "workspace:* || ^0.22",
 		"@wordpress/i18n": "4.19.0",
 		"classnames": "2.3.1",

--- a/projects/js-packages/publicize-components/changelog/update-refactor_upgrade_tooltips
+++ b/projects/js-packages/publicize-components/changelog/update-refactor_upgrade_tooltips
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.7.3",
+	"version": "0.7.4-alpha",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {
@@ -19,7 +19,7 @@
 		"test-coverage": "pnpm run test --coverageDirectory=\"$COVERAGE_DIR\" --coverage --coverageReporters=clover"
 	},
 	"dependencies": {
-		"@automattic/jetpack-components": "workspace:* || ^0.23",
+		"@automattic/jetpack-components": "workspace:* || ^0.24",
 		"@automattic/jetpack-shared-extension-utils": "workspace:* || ^0.6",
 		"@automattic/social-previews": "1.1.5",
 		"@wordpress/annotations": "2.19.0",

--- a/projects/js-packages/storybook/changelog/update-refactor_upgrade_tooltips
+++ b/projects/js-packages/storybook/changelog/update-refactor_upgrade_tooltips
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/js-packages/storybook/package.json
+++ b/projects/js-packages/storybook/package.json
@@ -22,7 +22,7 @@
 		"test-coverage": "jest tests/ --coverage --collectCoverageFrom='src/**/*.js' --coverageDirectory=\"$COVERAGE_DIR\" --coverageReporters=clover"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-components": "workspace:* || ^0.23",
+		"@automattic/jetpack-components": "workspace:* || ^0.24",
 		"@babel/core": "7.19.3",
 		"@babel/plugin-syntax-jsx": "7.18.6",
 		"@babel/preset-react": "7.18.6",

--- a/projects/packages/backup/changelog/update-refactor_upgrade_tooltips
+++ b/projects/packages/backup/changelog/update-refactor_upgrade_tooltips
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/backup/package.json
+++ b/projects/packages/backup/package.json
@@ -27,7 +27,7 @@
 	"dependencies": {
 		"@automattic/jetpack-analytics": "workspace:* || ^0.1",
 		"@automattic/jetpack-api": "workspace:* || ^0.14",
-		"@automattic/jetpack-components": "workspace:* || ^0.23",
+		"@automattic/jetpack-components": "workspace:* || ^0.24",
 		"@automattic/jetpack-connection": "workspace:* || ^0.22",
 		"@wordpress/api-fetch": "6.16.0",
 		"@wordpress/data": "7.3.0",

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.9.0';
+	const PACKAGE_VERSION = '1.9.1-alpha';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/my-jetpack/changelog/update-refactor_upgrade_tooltips
+++ b/projects/packages/my-jetpack/changelog/update-refactor_upgrade_tooltips
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "2.2.2",
+	"version": "2.2.3-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {
@@ -25,7 +25,7 @@
 		"@automattic/format-currency": "1.0.1",
 		"@automattic/jetpack-analytics": "workspace:* || ^0.1",
 		"@automattic/jetpack-api": "workspace:* || ^0.14",
-		"@automattic/jetpack-components": "workspace:* || ^0.23",
+		"@automattic/jetpack-components": "workspace:* || ^0.24",
 		"@automattic/jetpack-connection": "workspace:* || ^0.22",
 		"@automattic/jetpack-licensing": "workspace:* || ^0.6",
 		"@wordpress/api-fetch": "6.16.0",

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -29,7 +29,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '2.2.2';
+	const PACKAGE_VERSION = '2.2.3-alpha';
 
 	/**
 	 * Initialize My Jetapack

--- a/projects/packages/search/changelog/update-refactor_upgrade_tooltips
+++ b/projects/packages/search/changelog/update-refactor_upgrade_tooltips
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Refactor upgrade tooltips.

--- a/projects/packages/search/changelog/update-refactor_upgrade_tooltips#2
+++ b/projects/packages/search/changelog/update-refactor_upgrade_tooltips#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -42,7 +42,7 @@
 		"@automattic/jetpack-analytics": "workspace:* || ^0.1",
 		"@automattic/jetpack-api": "workspace:* || ^0.14",
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3",
-		"@automattic/jetpack-components": "workspace:* || ^0.23",
+		"@automattic/jetpack-components": "workspace:* || ^0.24",
 		"@automattic/jetpack-connection": "workspace:* || ^0.22",
 		"@wordpress/base-styles": "4.10.0",
 		"@wordpress/block-editor": "10.2.0",

--- a/projects/packages/search/src/dashboard/components/donut-meter-container/index.jsx
+++ b/projects/packages/search/src/dashboard/components/donut-meter-container/index.jsx
@@ -67,7 +67,7 @@ const DonutMeterContainer = ( {
 	const usageInfo = usageInfoMessage( current, limit );
 
 	const tooltipArgs = {
-		shadowAnchor: true,
+		popoverAnchorStyle: 'wrapper',
 		title: tooltip.title,
 		placement: 'top',
 		forceShow: tooltip.forceShow,

--- a/projects/packages/search/src/dashboard/components/donut-meter-container/index.jsx
+++ b/projects/packages/search/src/dashboard/components/donut-meter-container/index.jsx
@@ -11,26 +11,34 @@ import React from 'react';
 
 import './style.scss';
 
-// Format numbers with separators.
-const formatNumberWithSeparators = x => {
+const localizedUnlimited = __( 'Unlimited', 'jetpack-search-pkg' );
+
+// Format numbers with separators or convert to `Unlimited`.
+export const formatNumber = x => {
+	if ( x > 1e18 ) {
+		return localizedUnlimited;
+	}
+
 	return numberFormat( x );
 };
 
 const usageInfoMessage = ( current, limit ) => {
 	const isUnlimitedRequests = limit > 1e18;
+
 	// Standard case of current/limit.
 	if ( ! isUnlimitedRequests ) {
-		return formatNumberWithSeparators( current ) + '/' + formatNumberWithSeparators( limit );
+		return `${ formatNumber( current ) } / ${ formatNumber( limit ) }`;
 	}
+
 	// Special case for "unlimited" requests. API returning 64-bit PHP_INT_MAX.
 	// Return "Unlimited" if the current count is zero.
-	const localizedUnlimited = __( 'Unlimited', 'jetpack-search-pkg' );
 	if ( current === 0 ) {
 		return localizedUnlimited;
 	}
+
 	// We have a request count so include it in the info string.
 	// ie: "123/Unlimited"
-	return `${ formatNumberWithSeparators( current ) }/${ localizedUnlimited }`;
+	return `${ formatNumber( current ) } / ${ localizedUnlimited }`;
 };
 
 /**

--- a/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
@@ -111,6 +111,7 @@ const UpgradeTrigger = ( { type, ctaCallback } ) => {
 const UsageMeters = ( { usageInfo, isPlanJustUpgraded } ) => {
 	const [ currentTooltipIndex, setCurrentTooltipIndex ] = useState( 0 );
 	const myStorage = window.localStorage;
+
 	useMemo(
 		() =>
 			setCurrentTooltipIndex(
@@ -118,6 +119,7 @@ const UsageMeters = ( { usageInfo, isPlanJustUpgraded } ) => {
 			),
 		[ setCurrentTooltipIndex, myStorage, isPlanJustUpgraded ]
 	);
+
 	const setTooltipRead = useCallback( () => myStorage.setItem( 'upgrade_tooltip_finished', 1 ), [
 		myStorage,
 	] );

--- a/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
@@ -1,13 +1,9 @@
-import {
-	ContextualUpgradeTrigger,
-	ThemeProvider,
-	numberFormat,
-} from '@automattic/jetpack-components';
+import { ContextualUpgradeTrigger, ThemeProvider } from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import React, { useState, useCallback, useMemo } from 'react';
-import DonutMeterContainer from '../../donut-meter-container';
+import DonutMeterContainer, { formatNumber } from '../../donut-meter-container';
 import PlanSummary from './plan-summary';
 
 // import './plan-usage-section.scss';
@@ -145,7 +141,7 @@ const UsageMeters = ( { usageInfo, isPlanJustUpgraded } ) => {
 					'Thank you for upgrading! Now your visitors can search up to %1$s records.',
 					'jetpack-search-pkg'
 				),
-				numberFormat( usageInfo.recordMax )
+				formatNumber( usageInfo.recordMax )
 			),
 			section: __( '1 of 2', 'jetpack-search-pkg' ),
 			next: __( 'Next', 'jetpack-search-pkg' ),
@@ -161,7 +157,7 @@ const UsageMeters = ( { usageInfo, isPlanJustUpgraded } ) => {
 					'Your search plugin now supports up to %1$s search requests per month.',
 					'jetpack-search-pkg'
 				),
-				numberFormat( usageInfo.requestMax )
+				formatNumber( usageInfo.requestMax )
 			),
 			section: __( '2 of 2', 'jetpack-search-pkg' ),
 			next: __( 'Finish', 'jetpack-search-pkg' ),

--- a/projects/packages/videopress/changelog/update-refactor_upgrade_tooltips
+++ b/projects/packages/videopress/changelog/update-refactor_upgrade_tooltips
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -63,7 +63,7 @@
 	"dependencies": {
 		"@automattic/jetpack-api": "workspace:* || ^0.14",
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3",
-		"@automattic/jetpack-components": "workspace:* || ^0.23",
+		"@automattic/jetpack-components": "workspace:* || ^0.24",
 		"@automattic/jetpack-connection": "workspace:* || ^0.22",
 		"@storybook/addon-actions": "6.5.10",
 		"@wordpress/api-fetch": "6.16.0",

--- a/projects/packages/wordads/changelog/update-refactor_upgrade_tooltips
+++ b/projects/packages/wordads/changelog/update-refactor_upgrade_tooltips
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.2.19",
+	"version": "0.2.20-alpha",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",
@@ -34,7 +34,7 @@
 		"@automattic/color-studio": "2.5.0",
 		"@automattic/jetpack-analytics": "workspace:* || ^0.1",
 		"@automattic/jetpack-api": "workspace:* || ^0.14",
-		"@automattic/jetpack-components": "workspace:* || ^0.23",
+		"@automattic/jetpack-components": "workspace:* || ^0.24",
 		"@wordpress/base-styles": "4.10.0",
 		"@wordpress/block-editor": "10.2.0",
 		"@wordpress/data": "7.3.0",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.2.19';
+	const VERSION = '0.2.20-alpha';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/boost/changelog/update-refactor_upgrade_tooltips
+++ b/projects/plugins/boost/changelog/update-refactor_upgrade_tooltips
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -15,7 +15,7 @@
 		"svelte-navigator": "3.1.5"
 	},
 	"devDependencies": {
-		"@automattic/jetpack-components": "workspace:* || ^0.23",
+		"@automattic/jetpack-components": "workspace:* || ^0.24",
 		"@babel/core": "7.19.3",
 		"@babel/preset-env": "7.19.3",
 		"@babel/preset-react": "7.18.6",

--- a/projects/plugins/jetpack/changelog/update-refactor_upgrade_tooltips
+++ b/projects/plugins/jetpack/changelog/update-refactor_upgrade_tooltips
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -50,7 +50,7 @@
 		"@automattic/format-currency": "1.0.1",
 		"@automattic/jetpack-analytics": "workspace:* || ^0.1",
 		"@automattic/jetpack-api": "workspace:* || ^0.14",
-		"@automattic/jetpack-components": "workspace:* || ^0.23",
+		"@automattic/jetpack-components": "workspace:* || ^0.24",
 		"@automattic/jetpack-connection": "workspace:* || ^0.22",
 		"@automattic/jetpack-licensing": "workspace:* || ^0.6",
 		"@automattic/jetpack-partner-coupon": "workspace:* || ^0.2",

--- a/projects/plugins/protect/changelog/update-refactor_upgrade_tooltips
+++ b/projects/plugins/protect/changelog/update-refactor_upgrade_tooltips
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/protect/package.json
+++ b/projects/plugins/protect/package.json
@@ -26,7 +26,7 @@
 	],
 	"dependencies": {
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3",
-		"@automattic/jetpack-components": "workspace:* || ^0.23",
+		"@automattic/jetpack-components": "workspace:* || ^0.24",
 		"@automattic/jetpack-connection": "workspace:* || ^0.22",
 		"@automattic/jetpack-analytics": "workspace:* || ^0.1",
 		"@wordpress/api-fetch": "6.16.0",

--- a/projects/plugins/social/changelog/update-refactor_upgrade_tooltips
+++ b/projects/plugins/social/changelog/update-refactor_upgrade_tooltips
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/social/package.json
+++ b/projects/plugins/social/package.json
@@ -27,7 +27,7 @@
 	],
 	"dependencies": {
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3",
-		"@automattic/jetpack-components": "workspace:* || ^0.23",
+		"@automattic/jetpack-components": "workspace:* || ^0.24",
 		"@automattic/jetpack-connection": "workspace:* || ^0.22",
 		"@automattic/jetpack-publicize-components": "workspace:* || ^0.7",
 		"@wordpress/data": "7.3.0",

--- a/projects/plugins/starter-plugin/changelog/update-refactor_upgrade_tooltips
+++ b/projects/plugins/starter-plugin/changelog/update-refactor_upgrade_tooltips
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/starter-plugin/package.json
+++ b/projects/plugins/starter-plugin/package.json
@@ -26,7 +26,7 @@
 	],
 	"dependencies": {
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3",
-		"@automattic/jetpack-components": "workspace:* || ^0.23",
+		"@automattic/jetpack-components": "workspace:* || ^0.24",
 		"@automattic/jetpack-connection": "workspace:* || ^0.22",
 		"@wordpress/data": "7.3.0",
 		"@wordpress/element": "4.17.0",

--- a/projects/plugins/videopress/changelog/update-refactor_upgrade_tooltips
+++ b/projects/plugins/videopress/changelog/update-refactor_upgrade_tooltips
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/videopress/package.json
+++ b/projects/plugins/videopress/package.json
@@ -17,7 +17,7 @@
 	],
 	"dependencies": {
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3",
-		"@automattic/jetpack-components": "workspace:* || ^0.23",
+		"@automattic/jetpack-components": "workspace:* || ^0.24",
 		"@automattic/jetpack-connection": "workspace:* || ^0.22",
 		"@wordpress/data": "7.3.0",
 		"@wordpress/element": "4.17.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This is a follow-up PR for #26828 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Introduce prop `popoverAnchorStyle` to `IconTooltip` with value `icon` | `wrapper`.
* Refactor upgrade tooltips with the limit numbers formatting.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
No

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Prepare a site with `Jetpack Search` and an old Jetpack Search subscription.
* Navigate to the site with URL `/wp-admin/admin.php?page=jetpack-search&new_pricing_202208=1&just_upgraded=1`.
* Ensure there are upgraded usage limit tooltips displayed above the DonutMeter.
* Ensure the `limit` numbers displayed on tooltips are reasonable or `Unlimited`.
* Ensure the tooltips work as previously.

| Before | After |
| --- | --- |
| <img width="417" alt="截圖 2022-10-14 下午4 52 14" src="https://user-images.githubusercontent.com/6869813/195805894-c1a1606d-43d9-4b28-a1e0-efa7057ed4d3.png"> | <img width="545" alt="截圖 2022-10-14 下午4 51 17" src="https://user-images.githubusercontent.com/6869813/195805969-6df36016-c610-4a26-b495-e845c8921980.png"> |

