### PR TITLE
Search: Add missing upgrade triggers.

### DIFF
--- a/projects/packages/search/changelog/update-add-missing-upgrade-triggers
+++ b/projects/packages/search/changelog/update-add-missing-upgrade-triggers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Dashboard: Add missing CTAs and associated logic.

--- a/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
@@ -154,7 +154,7 @@ const upgradeMessageRequests = apiData => {
 	return { description: message, cta: cta };
 };
 
-const upgradeMessageNoOverage = apiData => {
+const upgradeMessageNoOverage = () => {
 	// Always returns a valid message.
 	const message = __(
 		'Do you want to increase your site records and search requests?.',

--- a/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
@@ -24,6 +24,207 @@ const usageInfoFromAPIData = apiData => {
 	};
 };
 
+const upgradeMessageRecords = apiData => {
+	// Return a valid message or null.
+	const isRecordsScenario =
+		apiData.currentUsage.upgrade_reason.records && ! apiData.currentUsage.upgrade_reason.requests;
+	if ( ! isRecordsScenario ) {
+		return null;
+	}
+	// Possible "near" messages here.
+	// Interesting that the design for records differs from requests.
+	// We only have the one message here vs three for requests.
+	const messageNearLimit = __(
+		'You’re close to exceeding the number of site records available on the free plan.',
+		'jetpack-search-pkg'
+	);
+	// Possible "over" messages here.
+	const messageOverLimitOne = __(
+		'You’ve exceeded the number of site records available on the free plan.',
+		'jetpack-search-pkg'
+	);
+	const messageOverLimitTwo = __(
+		'You’ve exceeded the number of site records available on the free plan for two consecutive months.',
+		'jetpack-search-pkg'
+	);
+	const messageOverLimitThree = __(
+		'You’ve exceeded the number of site records available on the free plan for three consecutive months.',
+		'jetpack-search-pkg'
+	);
+	// Note: The API doesn't give us enough data to make use of all the near cases.
+	// Start by containing the index.
+	let index = apiData.currentUsage.months_over_plan_records_limit;
+	if ( index < 0 ) {
+		index = 0;
+	} else if ( index > 3 ) {
+		index = 3;
+	}
+	// Pick the appropriate message.
+	const message = [
+		messageNearLimit,
+		messageOverLimitOne,
+		messageOverLimitTwo,
+		messageOverLimitThree,
+	][ index ];
+	// Possible CTA messages here.
+	const ctaUpgradeToAvoid = __(
+		'Upgrade now to increase your monthly record limit and avoid interruption!',
+		'jetpack-search-pkg'
+	);
+	const ctaUpgradeToContinue = __(
+		'Upgrade now to continue using Jetpack Search.',
+		'jetpack-search-pkg'
+	);
+	// Pick the appropriate CTA.
+	let cta = ctaUpgradeToAvoid;
+	if ( apiData.currentUsage.months_over_plan_records_limit >= 3 ) {
+		cta = ctaUpgradeToContinue;
+	}
+
+	return { description: message, cta: cta };
+};
+
+const upgradeMessageRequests = apiData => {
+	// Return a valid message or null.
+	const isRequestsScenario =
+		! apiData.currentUsage.upgrade_reason.records && apiData.currentUsage.upgrade_reason.requests;
+	if ( ! isRequestsScenario ) {
+		return null;
+	}
+	// Possible "near" messages here.
+	// Interesting that the design for records differs from requests.
+	// We have three message here vs one for records.
+	const messageNearLimitOne = __(
+		'You’re close to exceeding the number of search requests available on the free plan.',
+		'jetpack-search-pkg'
+	);
+	const messageNearLimitTwo = __(
+		'You’re close to exceeding the number of search requests available on the free plan for two consecutive months.',
+		'jetpack-search-pkg'
+	);
+	const messageNearLimitThree = __(
+		'You’re close to exceeding the number of search requests available on the free plan for three consecutive months.',
+		'jetpack-search-pkg'
+	);
+	// Possible "over" messages here.
+	const messageOverLimitOne = __(
+		'You’ve exceeded the number of search requests available on the free plan.',
+		'jetpack-search-pkg'
+	);
+	const messageOverLimitTwo = __(
+		'You’ve exceeded the number of search requests available on the free plan for two consecutive months.',
+		'jetpack-search-pkg'
+	);
+	const messageOverLimitThree = __(
+		'You’ve exceeded the number of search requests available on the free plan for three consecutive months.',
+		'jetpack-search-pkg'
+	);
+	// Note: The API doesn't give us enough data to determine the near cases.
+	// Start by containing the index.
+	let index = apiData.currentUsage.months_over_plan_requests_limit;
+	if ( index < 0 ) {
+		index = 0;
+	} else if ( index > 3 ) {
+		index = 3;
+	}
+	// Pick the appropriate message.
+	const message = [
+		messageNearLimitOne,
+		messageOverLimitOne,
+		messageOverLimitTwo,
+		messageOverLimitThree,
+		messageNearLimitTwo, // not used
+		messageNearLimitThree, // not used
+	][ index ];
+	// Possible CTA messages here.
+	const ctaUpgradeToAvoid = __(
+		'Upgrade now to increase your monthly request limit and avoid interruption.',
+		'jetpack-search-pkg'
+	);
+	const ctaUpgradeToContinue = __(
+		'Upgrade now to contineu using Jetpack Search.',
+		'jetpack-search-pkg'
+	);
+	// Pick the appropriate CTA.
+	let cta = ctaUpgradeToAvoid;
+	if ( apiData.currentUsage.months_over_plan_requests_limit >= 3 ) {
+		cta = ctaUpgradeToContinue;
+	}
+
+	return { description: message, cta: cta };
+};
+
+const upgradeMessageNoOverage = apiData => {
+	// Always returns a valid message.
+	const message = __(
+		'Do you want to increase your site records and search requests?.',
+		'jetpack-search-pkg'
+	);
+	const cta = __( 'Upgrade now and avoid any future interruption!', 'jetpack-search-pkg' );
+	return { description: message, cta: cta };
+};
+
+const upgradeMessageBoth = apiData => {
+	// Return a valid message or null.
+	const isBothScenario =
+		apiData.currentUsage.upgrade_reason.records && apiData.currentUsage.upgrade_reason.requests;
+	if ( ! isBothScenario ) {
+		return null;
+	}
+	// Determine upgrade message.
+	const messageNearLimit = __(
+		'You’re close to exceeding the number of site records and search requests available for the free plan.',
+		'jetpack-search-pkg'
+	);
+	const messageOverLimit = __(
+		'You’ve exceeded the number of site records and search requests available for the free plan.',
+		'jetpack-search-pkg'
+	);
+	// If the "months over" is zero, use the near messaging.
+	let message = messageOverLimit;
+	if ( apiData.currentUsage.months_over_plan_records_limit === 0 ) {
+		message = messageNearLimit;
+	}
+	// Add the shared CTA.
+	const sharedCTA = __(
+		'Upgrade now to increase your limits and avoid interruption!',
+		'jetpack-search-pkg'
+	);
+	return { description: message, cta: sharedCTA };
+};
+
+const upgradeMessageFromAPIData = apiData => {
+	// What's the data we're working with?
+	// apiData.currentUsage.must_upgrade
+	// apiData.currentUsage.upgrade_reason.records
+	// apiData.currentUsage.upgrade_reason.requests
+	// apiData.currentUsage.months_over_plan_records_limit
+	// apiData.currentUsage.months_over_plan_requests_limit
+	if ( ! apiData.currentUsage.must_upgrade ) {
+		return null;
+	}
+	// Handle both case.
+	let message = upgradeMessageBoth( apiData );
+	if ( message ) {
+		return message;
+	}
+	// Handle Records overages.
+	message = upgradeMessageRecords( apiData );
+	if ( message ) {
+		return message;
+	}
+	// Handle Requests overages.
+	message = upgradeMessageRequests( apiData );
+	if ( message ) {
+		return message;
+	}
+	// Handle the default case.
+	return upgradeMessageNoOverage();
+};
+
+// TODO: Remove this if no longer needed.
+// Currently not called. Not removing yet, pending review of new CTA logic (which feels messy).
+// eslint-disable-next-line no-unused-vars
 const upgradeTypeFromAPIData = apiData => {
 	// Determine if upgrade message is needed.
 	if ( ! apiData.currentUsage.must_upgrade ) {
@@ -43,7 +244,8 @@ const upgradeTypeFromAPIData = apiData => {
 };
 
 const PlanUsageSection = ( { planInfo, sendPaidPlanToCart, isPlanJustUpgraded } ) => {
-	const upgradeType = upgradeTypeFromAPIData( planInfo );
+	// const upgradeType = upgradeTypeFromAPIData( planInfo );
+	const upgradeMessage = upgradeMessageFromAPIData( planInfo );
 	const usageInfo = usageInfoFromAPIData( planInfo );
 	return (
 		<div className="jp-search-dashboard-wrap jp-search-dashboard-meter-wrap">
@@ -52,7 +254,7 @@ const PlanUsageSection = ( { planInfo, sendPaidPlanToCart, isPlanJustUpgraded } 
 				<div className="jp-search-dashboard-meter-wrap__content lg-col-span-8 md-col-span-6 sm-col-span-4">
 					<PlanSummary planInfo={ planInfo } />
 					<UsageMeters usageInfo={ usageInfo } isPlanJustUpgraded={ isPlanJustUpgraded } />
-					<UpgradeTrigger type={ upgradeType } ctaCallback={ sendPaidPlanToCart } />
+					<UpgradeTrigger upgradeMessage={ upgradeMessage } ctaCallback={ sendPaidPlanToCart } />
 					<AboutPlanLimits />
 				</div>
 				<div className="lg-col-span-2 md-col-span-1 sm-col-span-0"></div>
@@ -61,6 +263,9 @@ const PlanUsageSection = ( { planInfo, sendPaidPlanToCart, isPlanJustUpgraded } 
 	);
 };
 
+// TODO: Remove this if no longer needed.
+// Currently not called. Not removing yet, pending review of new CTA logic (which feels messy).
+// eslint-disable-next-line no-unused-vars
 const getUpgradeMessages = () => {
 	const upgradeMessages = {
 		records: {
@@ -97,8 +302,8 @@ const getUpgradeMessages = () => {
 	return upgradeMessages;
 };
 
-const UpgradeTrigger = ( { type, ctaCallback } ) => {
-	const upgradeMessage = type && getUpgradeMessages()[ type ];
+const UpgradeTrigger = ( { upgradeMessage, ctaCallback } ) => {
+	// const upgradeMessage = type && getUpgradeMessages()[ type ];
 	const triggerData = upgradeMessage && { ...upgradeMessage, onClick: ctaCallback };
 
 	return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26692.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Adds missing upgrade triggers (referred to as CUTs in the design). The logic here feels messy due to the various states of the UI and the associated messages. Any feedback on how this can be handled in a more elegant manner would be greatly appreciated!

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Visit the Search dashboard.
2. Append `&new_pricing_202208=1` to the URL.
3. Open the React Dev Tools and select the `PlanUsageSection` component.
4. Adjust the `planInfo.currentUsage.months_over_` and `planInfo.currentUsage.upgrade_reason` values to see the new messages.

Note: The meters will not upgrade to match the upgrade messages as they rely on separate data.

