### PR TITLE
VideoPress: do not block quick actions when uploading poster image

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-do-not-block-card-when-uploading-poster
+++ b/projects/packages/videopress/changelog/update-videopress-do-not-block-card-when-uploading-poster
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: do not block quick actions when uploading poster image

--- a/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
@@ -77,6 +77,7 @@ export const VideoCard = ( {
 	editable,
 	showQuickActions = true,
 	loading = false,
+	uploadingPoster = false,
 	uploading = false,
 	processing = false,
 	onVideoDetailsClick,
@@ -85,7 +86,7 @@ export const VideoCard = ( {
 
 	// Mapping thumbnail (Ordered by priority)
 	let thumbnail = loading ? <Placeholder /> : defaultThumbnail;
-	thumbnail = uploading ? <UploadingThumbnail /> : thumbnail;
+	thumbnail = uploading || uploadingPoster ? <UploadingThumbnail /> : thumbnail;
 	thumbnail = processing ? <ProcessingThumbnail /> : thumbnail;
 
 	const hasPlays = typeof plays !== 'undefined';
@@ -178,8 +179,7 @@ export const VideoCard = ( {
 export const ConnectVideoCard = ( { id, ...restProps }: VideoCardProps ) => {
 	const { isDeleting, uploading, processing, isUpdatingPoster } = useVideo( id );
 
-	const loading =
-		( isDeleting || restProps?.loading || isUpdatingPoster ) && ! uploading && ! processing;
+	const loading = ( isDeleting || restProps?.loading ) && ! uploading && ! processing;
 	const editable = restProps?.editable && ! isDeleting && ! uploading && ! processing;
 
 	return (
@@ -188,6 +188,7 @@ export const ConnectVideoCard = ( { id, ...restProps }: VideoCardProps ) => {
 			{ ...restProps }
 			loading={ loading }
 			uploading={ uploading }
+			uploadingPoster={ isUpdatingPoster }
 			processing={ processing }
 			editable={ editable }
 		/>

--- a/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
@@ -77,7 +77,7 @@ export const VideoCard = ( {
 	editable,
 	showQuickActions = true,
 	loading = false,
-	uploadingPoster = false,
+	isUploadingPoster = false,
 	uploading = false,
 	processing = false,
 	onVideoDetailsClick,
@@ -86,7 +86,7 @@ export const VideoCard = ( {
 
 	// Mapping thumbnail (Ordered by priority)
 	let thumbnail = loading ? <Placeholder /> : defaultThumbnail;
-	thumbnail = uploading || uploadingPoster ? <UploadingThumbnail /> : thumbnail;
+	thumbnail = uploading || isUploadingPoster ? <UploadingThumbnail /> : thumbnail;
 	thumbnail = processing ? <ProcessingThumbnail /> : thumbnail;
 
 	const hasPlays = typeof plays !== 'undefined';
@@ -113,6 +113,7 @@ export const VideoCard = ( {
 				{ ! isSm && <div className={ styles[ 'video-card__background' ] } /> }
 
 				<VideoThumbnail
+					videoId={ id }
 					className={ styles[ 'video-card__thumbnail' ] }
 					thumbnail={ thumbnail }
 					duration={ loading ? null : duration }
@@ -188,7 +189,7 @@ export const ConnectVideoCard = ( { id, ...restProps }: VideoCardProps ) => {
 			{ ...restProps }
 			loading={ loading }
 			uploading={ uploading }
-			uploadingPoster={ isUpdatingPoster }
+			isUploadingPoster={ isUpdatingPoster }
 			processing={ processing }
 			editable={ editable }
 		/>

--- a/projects/packages/videopress/src/client/admin/components/video-card/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/video-card/types.ts
@@ -32,7 +32,7 @@ export type VideoCardProps = Pick< VideoPressVideo, 'title' | 'plays' | 'id' > &
 		/**
 		 * True when is uploading a poster image.
 		 */
-		uploadingPoster?: boolean;
+		isUploadingPoster?: boolean;
 
 		/**
 		 * True when is in processing mode.

--- a/projects/packages/videopress/src/client/admin/components/video-card/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/video-card/types.ts
@@ -30,6 +30,11 @@ export type VideoCardProps = Pick< VideoPressVideo, 'title' | 'plays' | 'id' > &
 		uploading?: boolean;
 
 		/**
+		 * True when is uploading a poster image.
+		 */
+		uploadingPoster?: boolean;
+
+		/**
 		 * True when is in processing mode.
 		 */
 		processing?: boolean;

--- a/projects/packages/videopress/src/client/admin/components/video-quick-actions/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-quick-actions/index.tsx
@@ -67,7 +67,11 @@ const ActionItem = ( { icon, children, className, ...props }: ActionItemProps ) 
 	);
 };
 
-const ThumbnailActionsDropdown = ( { description, onUpdate }: ThumbnailActionsDropdownProps ) => {
+const ThumbnailActionsDropdown = ( {
+	description,
+	onUpdate,
+	isUpdatingPoster,
+}: ThumbnailActionsDropdownProps ) => {
 	const [ anchorRef, setAnchorRef ] = useState( null );
 	const [ showPopover, setShowPopover ] = useState( false );
 
@@ -96,6 +100,7 @@ const ThumbnailActionsDropdown = ( { description, onUpdate }: ThumbnailActionsDr
 			) }
 			renderContent={ ( { onClose } ) => (
 				<VideoThumbnailDropdownButtons
+					isUpdatingPoster={ isUpdatingPoster }
 					onClose={ onClose }
 					onUseDefaultThumbnail={ () => onUpdate( 'default' ) }
 					onSelectFromVideo={ () => onUpdate( 'select-from-video' ) }
@@ -199,6 +204,7 @@ const VideoQuickActions = ( {
 	className,
 	privacySetting,
 	isUpdatingPrivacy,
+	isUpdatingPoster,
 	onUpdateVideoThumbnail,
 	onUpdateVideoPrivacy,
 	onDeleteVideo,
@@ -208,6 +214,7 @@ const VideoQuickActions = ( {
 			<ThumbnailActionsDropdown
 				onUpdate={ onUpdateVideoThumbnail }
 				description={ __( 'Update thumbnail', 'jetpack-videopress-pkg' ) }
+				isUpdatingPoster={ isUpdatingPoster }
 			/>
 
 			<PrivacyActionsDropdown
@@ -231,7 +238,9 @@ export const ConnectVideoQuickActions = ( props: ConnectVideoQuickActionsProps )
 		return null;
 	}
 
-	const { data, updateVideoPrivacy, deleteVideo, isUpdatingPrivacy } = useVideo( videoId );
+	const { data, updateVideoPrivacy, deleteVideo, isUpdatingPrivacy, isUpdatingPoster } = useVideo(
+		videoId
+	);
 
 	const [ showDeleteModal, setShowDeleteModal ] = useState( false );
 	const {
@@ -325,6 +334,7 @@ export const ConnectVideoQuickActions = ( props: ConnectVideoQuickActionsProps )
 			onDeleteVideo={ () => setShowDeleteModal( true ) }
 			privacySetting={ privacySetting }
 			isUpdatingPrivacy={ isUpdatingPrivacy }
+			isUpdatingPoster={ isUpdatingPoster }
 		/>
 	);
 };

--- a/projects/packages/videopress/src/client/admin/components/video-quick-actions/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/video-quick-actions/types.ts
@@ -42,6 +42,7 @@ export interface VideoQuickActionsProps {
 
 	privacySetting?: privacySetting;
 	isUpdatingPrivacy?: boolean;
+	isUpdatingPoster?: boolean;
 
 	onUpdateVideoThumbnail?: ( action: 'default' | 'select-from-video' | 'upload-image' ) => void;
 	onUpdateVideoPrivacy?: ( action: 'site-default' | 'public' | 'private' ) => void;
@@ -67,6 +68,7 @@ export interface ConnectVideoQuickActionsProps {
 export type ThumbnailActionsDropdownProps = {
 	onUpdate: ( action: 'default' | 'select-from-video' | 'upload-image' ) => void;
 	description: string;
+	isUpdatingPoster?: boolean;
 };
 
 export type PrivacyActionsDropdownProps = {

--- a/projects/packages/videopress/src/client/admin/components/video-thumbnail/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-thumbnail/index.tsx
@@ -22,6 +22,7 @@ export const VideoThumbnailDropdownButtons = ( {
 	onSelectFromVideo,
 	onUploadImage,
 	onClose,
+	isUpdatingPoster = false,
 } ) => {
 	return (
 		<>
@@ -54,6 +55,7 @@ export const VideoThumbnailDropdownButtons = ( {
 				fullWidth
 				variant="tertiary"
 				icon={ cloud }
+				disabled={ isUpdatingPoster }
 				onClick={ () => {
 					onClose();
 					onUploadImage?.();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: do not block quick actions when uploading poster image

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard
* Grid view
* Upload a poster image
* Confirm the quick actions are not blocked
* Confirm it shows the uploading state
* Confirm it's possible to edit video details, changes privacy, etc


https://user-images.githubusercontent.com/77539/195841915-a5bde658-c2a1-43d0-aec2-0160debd35c8.mov

