### PR TITLE
VideoPress: Add loading state to video row thumbnail when uploading new poster image

### DIFF
--- a/projects/packages/videopress/changelog/update-thumbnail-upload-video-row
+++ b/projects/packages/videopress/changelog/update-thumbnail-upload-video-row
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Add thumbnail and loading state when uploading poster image on video row

--- a/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
@@ -77,7 +77,7 @@ export const VideoCard = ( {
 	editable,
 	showQuickActions = true,
 	loading = false,
-	isUploadingPoster = false,
+	isUpdatingPoster = false,
 	uploading = false,
 	processing = false,
 	onVideoDetailsClick,
@@ -86,7 +86,7 @@ export const VideoCard = ( {
 
 	// Mapping thumbnail (Ordered by priority)
 	let thumbnail = loading ? <Placeholder /> : defaultThumbnail;
-	thumbnail = uploading || isUploadingPoster ? <UploadingThumbnail /> : thumbnail;
+	thumbnail = uploading || isUpdatingPoster ? <UploadingThumbnail /> : thumbnail;
 	thumbnail = processing ? <ProcessingThumbnail /> : thumbnail;
 
 	const hasPlays = typeof plays !== 'undefined';
@@ -189,7 +189,7 @@ export const ConnectVideoCard = ( { id, ...restProps }: VideoCardProps ) => {
 			{ ...restProps }
 			loading={ loading }
 			uploading={ uploading }
-			isUploadingPoster={ isUpdatingPoster }
+			isUpdatingPoster={ isUpdatingPoster }
 			processing={ processing }
 			editable={ editable }
 		/>

--- a/projects/packages/videopress/src/client/admin/components/video-card/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/video-card/types.ts
@@ -32,7 +32,7 @@ export type VideoCardProps = Pick< VideoPressVideo, 'title' | 'plays' | 'id' > &
 		/**
 		 * True when is uploading a poster image.
 		 */
-		isUploadingPoster?: boolean;
+		isUpdatingPoster?: boolean;
 
 		/**
 		 * True when is in processing mode.

--- a/projects/packages/videopress/src/client/admin/components/video-row/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-row/index.tsx
@@ -100,7 +100,7 @@ export const VideoRow = ( {
 	showEditButton = true,
 	showQuickActions = true,
 	loading = false,
-	isUploadingPoster = false,
+	isUpdatingPoster = false,
 }: VideoRowProps ) => {
 	const textRef = useRef( null );
 	const checkboxRef = useRef( null );
@@ -119,7 +119,7 @@ export const VideoRow = ( {
 	const showBottom = ! isSmall || ( isSmall && expanded );
 
 	let thumbnail = defaultThumbnail;
-	thumbnail = loading || isUploadingPoster ? <Placeholder width={ 90 } height={ 50 } /> : thumbnail;
+	thumbnail = loading || isUpdatingPoster ? <Placeholder width={ 90 } height={ 50 } /> : thumbnail;
 
 	const canExpand =
 		isSmall &&
@@ -297,7 +297,7 @@ export const ConnectVideoRow = ( { id, ...restProps }: VideoRowProps ) => {
 			id={ id }
 			{ ...restProps }
 			loading={ loading }
-			isUploadingPoster={ isUpdatingPoster }
+			isUpdatingPoster={ isUpdatingPoster }
 			showThumbnail
 		/>
 	);

--- a/projects/packages/videopress/src/client/admin/components/video-row/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-row/index.tsx
@@ -100,6 +100,7 @@ export const VideoRow = ( {
 	showEditButton = true,
 	showQuickActions = true,
 	loading = false,
+	isUploadingPoster = false,
 }: VideoRowProps ) => {
 	const textRef = useRef( null );
 	const checkboxRef = useRef( null );
@@ -118,7 +119,7 @@ export const VideoRow = ( {
 	const showBottom = ! isSmall || ( isSmall && expanded );
 
 	let thumbnail = defaultThumbnail;
-	thumbnail = loading ? <Placeholder width={ 90 } height={ 50 } /> : thumbnail;
+	thumbnail = loading || isUploadingPoster ? <Placeholder width={ 90 } height={ 50 } /> : thumbnail;
 
 	const canExpand =
 		isSmall &&
@@ -289,9 +290,17 @@ export const VideoRow = ( {
 };
 
 export const ConnectVideoRow = ( { id, ...restProps }: VideoRowProps ) => {
-	const { isDeleting, uploading, processing } = useVideo( id );
+	const { isDeleting, uploading, processing, isUpdatingPoster } = useVideo( id );
 	const loading = ( isDeleting || restProps?.loading ) && ! uploading && ! processing;
-	return <VideoRow id={ id } { ...restProps } loading={ loading } />;
+	return (
+		<VideoRow
+			id={ id }
+			{ ...restProps }
+			loading={ loading }
+			isUploadingPoster={ isUpdatingPoster }
+			showThumbnail
+		/>
+	);
 };
 
 export type { VideoRowProps };

--- a/projects/packages/videopress/src/client/admin/components/video-row/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/video-row/types.ts
@@ -23,6 +23,10 @@ type VideoRowBaseProps = {
 	 */
 	loading?: boolean;
 	/**
+	 * True when is uploading a poster image.
+	 */
+	isUploadingPoster?: boolean;
+	/**
 	 * Callback to be invoked when clicking on the row.
 	 */
 	onSelect?: ( check: boolean ) => void;

--- a/projects/packages/videopress/src/client/admin/components/video-row/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/video-row/types.ts
@@ -25,7 +25,7 @@ type VideoRowBaseProps = {
 	/**
 	 * True when is uploading a poster image.
 	 */
-	isUploadingPoster?: boolean;
+	isUpdatingPoster?: boolean;
 	/**
 	 * Callback to be invoked when clicking on the row.
 	 */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26855
Fixes #26854

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Checks for poster image upload status to render a loading state on video row

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard and select the list view
* Update the poster image of a video
* Check that it shows the loading state

https://user-images.githubusercontent.com/8486249/195873051-b7672878-b20f-49e0-88f0-d21b18ac00dd.mp4