### PR TITLE
VideoPress: Expose blog users on initial state

### DIFF
--- a/projects/packages/videopress/changelog/add-expose-blog-users-on-initial-state
+++ b/projects/packages/videopress/changelog/add-expose-blog-users-on-initial-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Expose the list of blog users on the application initial state var

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -83,6 +83,41 @@ class Data {
 	}
 
 	/**
+	 * Gets the user data
+	 *
+	 * @return array
+	 */
+	public static function get_user_data() {
+		$user_data = array(
+			'items' => array(),
+			'query' => array(
+				'order'   => 'asc',
+				'orderBy' => 'name',
+			),
+		);
+
+		$args = array(
+			'order'   => $user_data['query']['order'],
+			'orderby' => $user_data['query']['orderBy'],
+		);
+
+		// Do an internal request for the user list
+		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
+		$request->set_query_params( $args );
+		$response = rest_do_request( $request );
+
+		if ( $response->is_error() ) {
+			// @todo: error handling
+			return $user_data;
+		}
+
+		// load the real values
+		$user_data['items'] = $response->get_data();
+
+		return $user_data;
+	}
+
+	/**
 	 * Gets the VideoPress used storage space in bytes
 	 *
 	 * @return int the used storage space

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -89,8 +89,12 @@ class Data {
 	 */
 	public static function get_user_data() {
 		$user_data = array(
-			'items' => array(),
-			'query' => array(
+			'items'      => array(),
+			'pagination' => array(
+				'total'      => 0,
+				'totalPages' => 1,
+			),
+			'query'      => array(
 				'order'   => 'asc',
 				'orderBy' => 'name',
 			),
@@ -113,6 +117,15 @@ class Data {
 
 		// load the real values
 		$user_data['items'] = $response->get_data();
+		$headers            = $response->get_headers();
+
+		if ( isset( $headers['X-WP-Total'] ) ) {
+			$user_data['pagination']['total'] = $headers['X-WP-Total'];
+		}
+
+		if ( isset( $headers['X-WP-TotalPages'] ) ) {
+			$user_data['pagination']['totalPages'] = $headers['X-WP-TotalPages'];
+		}
 
 		return $user_data;
 	}

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -267,6 +267,7 @@ class Data {
 		);
 
 		$initial_state = array(
+			'users'       => self::get_user_data(),
 			'videos'      => array(
 				'uploadedVideoCount'           => $videopress_data['total'],
 				'items'                        => $videos,

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -98,6 +98,9 @@ class Data {
 				'order'   => 'asc',
 				'orderBy' => 'name',
 			),
+			'_meta'      => array(
+				'relyOnInitialState' => true,
+			),
 		);
 
 		$args = array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Relates to #26168.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Use an internal REST API call to fetch the users from the blog and expose it on the client initial state, so we can use this list on the "Uploader" filter on the VideoPress client

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a site with Jetpack VideoPress plugin installed, go to `Jetpack > VideoPress`
* On the development console, check the value for the `jetpackVideoPressInitialState.initialState` variable
* You will see the new `users` property there:

![image](https://user-images.githubusercontent.com/6760046/195881171-37320d4c-19de-454c-9ed2-90e1f34f6fed.png)