### PR TITLE
SAL: stub for site's `p2_thumbnail_elements` field

### DIFF
--- a/projects/plugins/jetpack/changelog/fusion-sync-philipmjackson-D89929-code-1665959551
+++ b/projects/plugins/jetpack/changelog/fusion-sync-philipmjackson-D89929-code-1665959551
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+WordPress.com REST API: exposed P2 design elements in API response

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -62,6 +62,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_following'                => '(bool) If the current user is subscribed to this site in the reader',
 		'organization_id'             => '(int) P2 Organization identifier.',
 		'options'                     => '(array) An array of options/settings for the blog. Only viewable by users with post editing rights to the site. Note: Post formats is deprecated, please see /sites/$id/post-formats/',
+		'p2_thumbnail_elements'       => '(array) Details used to render a thumbnail of the site. P2020 themed sites only.',
 		'plan'                        => '(array) Details of the current plan for this site.',
 		'updates'                     => '(array) An array of available updates for plugins, themes, wordpress, and languages.',
 		'jetpack_modules'             => '(array) A list of active Jetpack modules.',
@@ -537,6 +538,8 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			case 'user_interactions':
 				$response[ $key ] = $this->site->get_user_interactions();
 				break;
+			case 'p2_thumbnail_elements':
+				$response[ $key ] = $this->site->get_p2_thumbnail_elements();
 		}
 
 		do_action( 'post_render_site_response_key', $key );

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -457,6 +457,15 @@ abstract class SAL_Site {
 	}
 
 	/**
+	 * Get details used to render a thumbnail of the site. P2020 themed sites only.
+	 *
+	 * @return ?array
+	 */
+	public function get_p2_thumbnail_elements() {
+		return null;
+	}
+
+	/**
 	 * Detect whether a site is a WordPress.com on Atomic site.
 	 *
 	 * @return bool


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

I created this PR from D89929-code using the fusion script, however the script only brought across the API change. I recreated the changes to SAL myself. The de-fusion effort for SAL and the API is paused (p9dueE-60P-p2) but I suspect the fusion changes for SAL were already underway.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Adds stub implementation for a new field which is used by Calypso.

* `get_p2_thumbnail_elements()` method added to SAL. Returns `null` by default.
* `p2_thumbnail_elements` field added to `/me/sites` endpoint

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
  _Tests added in D89929-code_
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
New field powers this front-end change in Calypso: Automattic/wp-calypso#68892. The implementation used by Calypso is here: D89929-code. Jetpack sites won't need this field.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

There should be no discernible changes from the user's point of view.