### PR TITLE
Subscription block: show subscriber count when there is 1 subscriber 

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscription-block-show-1-subscriber
+++ b/projects/plugins/jetpack/changelog/fix-subscription-block-show-1-subscriber
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscription block: subscriber count was not being shown in the panel when you only have 1 subscriber.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/controls.js
@@ -53,7 +53,7 @@ export default function SubscriptionControls( {
 } ) {
 	return (
 		<>
-			{ subscriberCount > 1 && (
+			{ subscriberCount > 0 && (
 				<InspectorNotice>
 					{ createInterpolateElement(
 						sprintf(


### PR DESCRIPTION
When there is only 1 subscriber, the panel didn't show the subscription count.

| 1 subscriber | 2 or more subscribers |
| ------------- | ------------- |
| <img width="274" alt="CleanShot 2022-10-17 at 09 38 19@2x" src="https://user-images.githubusercontent.com/528287/196117214-f38d4860-e8f4-4a7a-a2ef-b93b321825f3.png">  | <img width="275" alt="CleanShot 2022-10-17 at 09 39 44@2x" src="https://user-images.githubusercontent.com/528287/196117333-3c644591-afd1-4f0b-926c-2f4a3d1b9e5d.png">  |

This PR fixes this behavior.
This bug was discovered by @coder-karen in #26751

#### Changes proposed in this Pull Request:
This PR changes the check to show this panel from `subscriberCount > 1` to `subscriberCount > 0`

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
1. Apply this PR
2. Create a new page/post and add the subscription block, make sure you (only) have 1 subscriber
3. The panel should show

(Testing can be tricky due to caching in both Jetpack & WPCOM, the easiest way is to stub the subscriber count in `projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/subscribers.php`)