### PR TITLE
actions: Unpin phpcs in phpcompatibility-dev

### DIFF
--- a/.github/workflows/phpcompatibility-dev.yml
+++ b/.github/workflows/phpcompatibility-dev.yml
@@ -69,7 +69,7 @@ jobs:
             exit 1
           fi
           composer remove --dev automattic/jetpack-codesniffer
-          composer require --dev phpcompatibility/php-compatibility=dev-develop
+          composer require --dev phpcompatibility/php-compatibility=dev-develop "squizlabs/php_codesniffer=^$(jq -r '.["require-dev"]["squizlabs/php_codesniffer"]' composer.json)"
 
       - name: Run phpcs for PHPCompatibility
         run: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
phpcompatibility's dev-develop has updated their phpcs dep to 3.7.1 (maybe they'll finally do a release sometime soon?), which breaks with our pinned dep on 3.6.2.

We can't update our dep yet since mediawiki-codesniffer also pins to that exact version, but since we're already uninstalling mediawiki-codesniffer for the phpcompatibility dev-develop run we can also unpin phpcs at the same time. So let's do that.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1665406997257319-slack-CDLH4C1UZ
p1666004405349949-slack-CDLH4C1UZ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is the CI check passing now?