### PR TITLE
RNA: locate product labels next to `legend` text in the ProductPrice component

### DIFF
--- a/projects/js-packages/components/changelog/update-rna-product-price-off-label-layout-changes
+++ b/projects/js-packages/components/changelog/update-rna-product-price-off-label-layout-changes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+RNA: move product labels next to `legend` text

--- a/projects/js-packages/components/components/product-price/index.tsx
+++ b/projects/js-packages/components/components/product-price/index.tsx
@@ -57,10 +57,12 @@ const ProductPrice: React.FC< ProductPriceProps > = ( {
 						/>
 					) }
 				</div>
+			</div>
+			<div className={ styles.footer }>
+				{ children ? children : <Text className={ styles.legend }>{ legend }</Text> }
 				{ promoLabel && <Text className={ styles[ 'promo-label' ] }>{ promoLabel }</Text> }
 				{ discountElt && <Text className={ styles[ 'promo-label' ] }>{ discountElt }</Text> }
 			</div>
-			{ children ? children : <Text className={ styles.legend }>{ legend }</Text> }
 		</>
 	);
 };

--- a/projects/js-packages/components/components/product-price/stories/index.tsx
+++ b/projects/js-packages/components/components/product-price/stories/index.tsx
@@ -24,6 +24,7 @@ const DefaultArgs = {
 	hidePriceFraction: false,
 	hideDiscountLabel: false,
 	promoLabel: 'NEW',
+	legend: '/month, paid yearly',
 };
 
 // Export Default story

--- a/projects/js-packages/components/components/product-price/style.module.scss
+++ b/projects/js-packages/components/components/product-price/style.module.scss
@@ -36,10 +36,16 @@
 		}
 	}
 }
+.footer {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: flex-start;
+	justify-content: flex-start;
+	margin-bottom: calc( var( --spacing-base ) * 3 );
+}
 
 .legend {
 	color: var( --jp-gray-40 );
-	margin-bottom: calc( var( --spacing-base ) * 3 );
 	font-size: var(--font-body-small);
 	line-height: 20px;
 
@@ -49,13 +55,13 @@
 }
 
 .promo-label {
-	display: inline-flex;
 	background-color:  var( --jp-yellow-10);
 	border-radius: 4px;
 	padding-left: var( --spacing-base );
 	padding-right: var( --spacing-base );
 	font-weight: 600;
 	font-size: 13px;
+	margin-left: var( --spacing-base );
 }
 
 .symbol {

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.24.0-alpha",
+	"version": "0.24.1-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/26871

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* RNA: move product labels next to `legend` text in the ProductPrice component

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with Storybook
* Go to [ProductPrice story](http://localhost:50240/?path=/story/js-packages-components-product-price--default)
* Confirm labels are located next to `legend` text
<img width="641" alt="image" src="https://user-images.githubusercontent.com/77539/196201472-c6c33f7b-f677-4bb1-ad6c-e89a5c896bdc.png">

* Additionally, we can test using VideoPress PriceSection component:

https://user-images.githubusercontent.com/77539/196200642-b6e13bbf-e3c4-45d0-bb4d-eae1efb9ded0.mov

