### PR TITLE
VideoPress: change the videopress-redirect value to lead to product page

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-update-jetpack-videopress-redirect
+++ b/projects/packages/videopress/changelog/update-videopress-update-jetpack-videopress-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: change the videopress redirect value to lead to product page

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
@@ -270,9 +270,7 @@ const VideoPressUploader = ( {
 			),
 			{
 				connectLink: <a href={ jwtError?.data?.connect_url } rel="noreferrer noopener" />,
-				moreAboutVideoPressLink: (
-					<ExternalLink href={ getRedirectUrl( 'jetpack-videopress-about-page' ) } />
-				),
+				moreAboutVideoPressLink: <ExternalLink href={ getRedirectUrl( 'jetpack-videopress' ) } />,
 			}
 		);
 

--- a/projects/packages/videopress/src/client/block-editor/extend/core-embed/edit.js
+++ b/projects/packages/videopress/src/client/block-editor/extend/core-embed/edit.js
@@ -64,9 +64,7 @@ const withCoreEmbedVideoPressBlock = createHigherOrderComponent( CoreEmbedBlockE
 				'jetpack-videopress-pkg'
 			),
 			{
-				moreAboutVideoPressLink: (
-					<ExternalLink href={ getRedirectUrl( 'jetpack-videopress-about-page' ) } />
-				),
+				moreAboutVideoPressLink: <ExternalLink href={ getRedirectUrl( 'jetpack-videopress' ) } />,
 			}
 		);
 

--- a/projects/packages/videopress/src/client/block-editor/extend/core-video/index.js
+++ b/projects/packages/videopress/src/client/block-editor/extend/core-video/index.js
@@ -98,9 +98,7 @@ const handleJetpackCoreVideoDeprecation = createHigherOrderComponent( BlockListB
 				'jetpack-videopress-pkg'
 			),
 			{
-				moreAboutVideoPressLink: (
-					<ExternalLink href={ getRedirectUrl( 'jetpack-videopress-about-page' ) } />
-				),
+				moreAboutVideoPressLink: <ExternalLink href={ getRedirectUrl( 'jetpack-videopress' ) } />,
 			}
 		);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/26885

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: change the videopress-redirect value to lead to product page


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate VideoPress standalone plugin
* Ensure your site is disconnected
* Go to the block editor
* Add a VideoPress video block
* Confirm the external link in the block instructions leads to the VideoPress product page

<img width="688" alt="Screen Shot 2022-10-17 at 13 49 56" src="https://user-images.githubusercontent.com/77539/196236767-237b66d8-201f-4997-aa4a-725403e85b6f.png">

