### PR TITLE
jetpack: Apply wpcom change in class.wpcom-json-api-list-post-types-endpoint.php

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-apply-D17161
+++ b/projects/plugins/jetpack/changelog/fix-apply-D17161
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Copy wpcom hack from D17161

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-post-types-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-post-types-endpoint.php
@@ -68,18 +68,27 @@ class WPCOM_JSON_API_List_Post_Types_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			$this->load_theme_functions();
-		}
 
-		/**
-		 * Whether API responses should be returned in a custom locale.  False
-		 * for Jetpack; may be true for WP.com requests.
-		 *
-		 * @since 3.9.2
-		 */
-		if ( apply_filters( 'rest_api_localize_response', false ) ) {
-			// API localization occurs after the initial post types have been
-			// registered, so re-register if localizing response.
-			create_initial_post_types();
+			/**
+			 * Whether API responses should be returned in a custom locale.  False
+			 * for Jetpack; may be true for WP.com requests.
+			 *
+			 * @since 3.9.2
+			 */
+			if ( apply_filters( 'rest_api_localize_response', false ) ) {
+				// API localization occurs after the initial post types have been
+				// registered, so let's get the post type labels translated.
+				if ( 'en' !== get_locale() ) {
+					global $wp_post_types;
+					foreach ( $wp_post_types as $post_type_object ) {
+						foreach ( array_keys( (array) $post_type_object->labels ) as $label_key ) {
+							// Direct use of translate call because this doesn't need to be extracted.
+							// phpcs:ignore WordPress.WP.I18n
+							$post_type_object->labels->$label_key = translate( $post_type_object->labels->$label_key, 'default' );
+						}
+					}
+				}
+			}
 		}
 
 		// Get a list of available post types.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
It seems that on wpcom there is a somewhat hacky mechanism for specifying the locale to API requests, which doesn't take effect early enough to affect the post type labels.

The hack for that that was here before only works for WP Core post types, not for any other post types that may be registered.

This new hack has its own drawbacks: it'll fail or do the wrong thing for labels using `_x()`, and it assumes that every label is translated in the "default" domain. Apparently that's good enough on wpcom simple sites, so let's only run it there. The corresponding filter seems to be a wpcom-specific thing anyway.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/issues/26773#issuecomment-1281321336

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load D90052-code in your wpcom sandbox
* Set the language in your profile to something non-English.
* Go to https://wordpress.com/types/feedback for your sandbox site and make sure the messages there are in your profile language. See also pxLjZ-4OC-p2#comment-15262