### PR TITLE
Social: Fix the connection test URL

### DIFF
--- a/projects/plugins/social/changelog/fix-social-connections-url
+++ b/projects/plugins/social/changelog/fix-social-connections-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fix the connection test endpoint URL

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -256,7 +256,7 @@ class Jetpack_Social {
 				'siteFragment' => ( new Status() )->get_site_suffix(),
 				'social'       => array(
 					'sharesData'              => $publicize->get_publicize_shares_info( Jetpack_Options::get_option( 'id' ) ),
-					'connectionRefreshPath'   => '/jetpack/v4/publicize/connections-test-results',
+					'connectionRefreshPath'   => '/jetpack/v4/publicize/connection-test-results',
 					'publicizeConnectionsUrl' => esc_url_raw(
 						'https://jetpack.com/redirect/?source=jetpack-social-connections-block-editor&site='
 					),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

In #26420 a typo crept into the connection test URL meaning that it always resulted in a 404. This fixes that issue, by removing the extra `s`

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?


#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* With Jetpack Social active open the editor.
* Toggle the Social sidebar
* In the network tab notic the request to test the connections.
* Without this change it will request `connections-test-results` which will result in a 404
* With this change it will request `connection-test-results` which will succeed


