### PR TITLE
jetpack: Remove a hack from class.wpcom-json-api-render-endpoint.php

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-apply-D59313
+++ b/projects/plugins/jetpack/changelog/fix-apply-D59313
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Remove an obsolete hack in class.wpcom-json-api-render-endpoint.php

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-render-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-render-endpoint.php
@@ -161,18 +161,6 @@ abstract class WPCOM_JSON_API_Render_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 * @return string|false
 	 */
 	public function do_embed( $embed_url ) {
-		// in order for oEmbed to fire in the `$wp_embed->shortcode` method, we need to set a post as the current post
-		$_posts = get_posts(
-			array(
-				'posts_per_page'   => 1,
-				'suppress_filters' => false,
-			)
-		);
-		if ( ! empty( $_posts ) ) {
-			global $post;
-			$post = array_shift( $_posts ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		}
-
 		global $wp_embed;
 		return $wp_embed->shortcode( array(), $embed_url );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This was done in wpcom in D59313-code, but the corresponding change was never made in Jetpack.

The hack being removed here was apparently working around something fixed in WP Core about 5 years ago.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/issues/26774#issuecomment-1279384585

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

It seems you can hit this code path by doing like this:
* Go to https://developer.wordpress.com/docs/api/console/
* Select the `/sites/$id/embeds/reversal` endpoint.
* Fill in your site ID, and enter an embeddable URL for the "maybe_embed" parameter under "body".

