### PR TITLE
VideoPress: track page view and check out events

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1106,7 +1106,7 @@ importers:
   projects/packages/videopress:
     specifiers:
       '@automattic/calypso-color-schemes': 2.1.1
-      '@automattic/jetpack-analytics': workspace:0.1.19
+      '@automattic/jetpack-analytics': workspace:* || ^0.1
       '@automattic/jetpack-api': workspace:* || ^0.14
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
       '@automattic/jetpack-components': workspace:* || ^0.24

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1106,6 +1106,7 @@ importers:
   projects/packages/videopress:
     specifiers:
       '@automattic/calypso-color-schemes': 2.1.1
+      '@automattic/jetpack-analytics': workspace:0.1.19
       '@automattic/jetpack-api': workspace:* || ^0.14
       '@automattic/jetpack-base-styles': workspace:* || ^0.3
       '@automattic/jetpack-components': workspace:* || ^0.24
@@ -1157,6 +1158,7 @@ importers:
       webpack: 5.72.1
       webpack-cli: 4.9.1
     dependencies:
+      '@automattic/jetpack-analytics': link:../../js-packages/analytics
       '@automattic/jetpack-api': link:../../js-packages/api
       '@automattic/jetpack-base-styles': link:../../js-packages/base-styles
       '@automattic/jetpack-components': link:../../js-packages/components
@@ -3754,6 +3756,7 @@ packages:
   /@colors/colors/1.5.0:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
+    requiresBuild: true
     dev: true
 
   /@dabh/diagnostics/2.0.3:

--- a/projects/packages/videopress/changelog/update-track-admin-view-event
+++ b/projects/packages/videopress/changelog/update-track-admin-view-event
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: track page view and checking out events

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -61,7 +61,7 @@
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	},
 	"dependencies": {
-		"@automattic/jetpack-analytics": "workspace:0.1.19",
+		"@automattic/jetpack-analytics": "workspace:* || ^0.1",
 		"@automattic/jetpack-api": "workspace:* || ^0.14",
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3",
 		"@automattic/jetpack-components": "workspace:* || ^0.24",

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -61,6 +61,7 @@
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
 	},
 	"dependencies": {
+		"@automattic/jetpack-analytics": "workspace:0.1.19",
 		"@automattic/jetpack-api": "workspace:* || ^0.14",
 		"@automattic/jetpack-base-styles": "workspace:* || ^0.3",
 		"@automattic/jetpack-components": "workspace:* || ^0.24",

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -193,7 +193,14 @@ const UpgradeTrigger = ( { hasUsedVideo = false }: { hasUsedVideo: boolean } ) =
 		siteSuffix,
 		productSlug: product.productSlug,
 		redirectUrl: adminUrl,
+		isFetchingPurchases,
 	} );
+
+	const { recordEventHandler } = useAnalyticsTracks( {} );
+	const onButtonClickHandler = recordEventHandler(
+		'jetpack_videopress_upgrade_trigger_link_click',
+		run
+	);
 
 	const description = hasUsedVideo
 		? __( 'You have used your free video upload', 'jetpack-videopress-pkg' )
@@ -213,7 +220,7 @@ const UpgradeTrigger = ( { hasUsedVideo = false }: { hasUsedVideo: boolean } ) =
 			description={ description }
 			cta={ cta }
 			className={ styles[ 'upgrade-trigger' ] }
-			onClick={ run }
+			onClick={ onButtonClickHandler }
 		/>
 	);
 };

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -28,6 +28,7 @@ import classnames from 'classnames';
 import { STORE_ID } from '../../../state';
 import uid from '../../../utils/uid';
 import { fileInputExtensions } from '../../../utils/video-extensions';
+import useAnalyticsTracks from '../../hooks/use-analytics-tracks';
 import { usePlan } from '../../hooks/use-plan';
 import useVideos, { useLocalVideos } from '../../hooks/use-videos';
 import Logo from '../logo';
@@ -94,6 +95,8 @@ const Admin = () => {
 	const addNewLabel = __( 'Add new video', 'jetpack-videopress-pkg' );
 	const addFirstLabel = __( 'Add your first video', 'jetpack-videopress-pkg' );
 	const addVideoLabel = hasVideos ? addNewLabel : addFirstLabel;
+
+	useAnalyticsTracks( { pageViewEventName: 'admin' } );
 
 	return (
 		<AdminPage

--- a/projects/packages/videopress/src/client/admin/hooks/use-analytics-tracks/Readme.md
+++ b/projects/packages/videopress/src/client/admin/hooks/use-analytics-tracks/Readme.md
@@ -122,13 +122,15 @@ import useAnalyticsTracks from './hooks/use-analytics-tracks';
 function MyAdminApp() {
 	const { recordEventHandler } = useAnalyticsTracks();
 
-	const addProduct = recordEventHandler(
-		'jetpack_product_add_click',
-		onContinueHere
+	const onButtonClickHandler = recordEventHandler(
+		'jetpack_videopress_button_click',
+		function() {
+			// Continue here...
+		}
 	);
 
 	return (
-		<Button onClick={ addProduct }>Get the product!</Button>
+		<Button onClick={ onButtonClickHandler }>On click!</Button>
 	);
 }
 ```

--- a/projects/packages/videopress/src/client/admin/hooks/use-analytics-tracks/Readme.md
+++ b/projects/packages/videopress/src/client/admin/hooks/use-analytics-tracks/Readme.md
@@ -1,0 +1,161 @@
+# `useAnalyticsTracks`
+
+React custom hook to handle tracks events.
+
+## Example
+
+```jsx
+import useAnalyticsTracks from './use-analytics-tracks';
+
+function MyAdminApp( init ) {
+	/*
+	 * Get the recordEvent helper,
+	 * registering the page-view record on the fly.
+	 */
+	const { recordEvent } = useAnalyticsTracks( { pageViewEventName: 'my_section' } );
+
+	if ( init ) {
+		// Record generic event.
+		recordEvent( 'jetpack_app_init', { dev: 'env', type: 'testing' } )
+	}
+
+	return (
+		// ...
+	);
+}
+```
+# API
+
+## Input Object Properties
+
+### `pageViewEventName`
+
+-   Type: `String`
+
+When defined, it will record a **page-view** event. See [Recording a Page View event](#recording-a-page-view-event) section for more info.
+
+### `pageViewNamespace`
+
+-   Type: `String`
+-   Optional
+-   Default: `jetpack-videopress`
+
+The prefix of the whole name of the **page-view** event. You may like to define a different prefix when recording events in other apps, contexts, etc. For instance, `calypso`, `woocommerce`, etc
+
+### `pageViewSuffix`
+
+-   Type: `String`
+-   Optional
+-   Default: `page_view`
+
+The suffix of the whole name of the **page-view** event. **We strongly do not recommend changing it** unless you really consider the need to do.
+
+### `pageViewEventProperties`
+
+-   Type: `object`
+-   Optional
+
+Optional properties to add to the **page-view** event.
+
+## Return Object Properties
+
+### `recordEvent( eventName, [props] )`
+
+-   Type: `Function`
+
+Helper function to record an event with optional properties. It accepts two arguments:
+
+- `eventName`: The whole name of the event to record. Type: `String`
+- `props`: Optional properties to add to the event. Type: `Object`
+
+```jsx
+import useAnalyticsTracks from './hooks/use-analytics-tracks';
+
+function MyAdminApp( init ) {
+	const { recordEvent } = useAnalyticsTracks();
+
+	if ( init ) {
+		recordEvent( 'jetpack_app_init', { dev: 'env', type: 'testing' } )
+	}
+
+	return (
+		// ...
+	);
+}
+```
+
+`recordEvent()` is an async function that allows optionally to chain, and thus run, a function to it.
+
+```jsx
+import useAnalyticsTracks from '../../hooks/use-analytics-tracks';
+
+function MyAdminApp( init, onContinueHere ) {
+	const { recordEvent } = useAnalyticsTracks();
+
+	if ( init ) {
+		recordEvent( 'jetpack_app_init' ).then( () => {
+			// let's continue here.
+		}) );
+	}
+
+	return (
+		// ...
+	);
+}
+```
+
+### `recordEventHandler( eventName, [props], [callback] )`
+
+-   Type: `Function`
+
+`recordEventHandler()` is a helper that returns a function that can be used to record the event defined by `eventName` and, optionally, with the `props` object.
+
+- `eventName`: The whole name of the event to record. Type: `String`
+- `props`: Optional properties to add to the event. Type: `Object`
+- `callback`: Function callback to run when recording the event.
+
+This function tries to simplify the usage of tracking event tied to events in React components context. The following example shows how to use it when user clicks on a button.
+
+```jsx
+import useAnalyticsTracks from './hooks/use-analytics-tracks';
+
+function MyAdminApp() {
+	const { recordEventHandler } = useAnalyticsTracks();
+
+	const addProduct = recordEventHandler(
+		'jetpack_product_add_click',
+		onContinueHere
+	);
+
+	return (
+		<Button onClick={ addProduct }>Get the product!</Button>
+	);
+}
+```
+
+## Recording a Page-View event
+
+Recording a **page-view** event is something so usual that deserves simple and automatic usage.
+Taking advantage of the React hooks, it makes sense to induce that it happens when the component is mounted.
+Also, and by convention to get even more straightforward, a **page-view** event has the following shape:
+
+`{ pageViewNamespace }_{ eventName }_{ suffix }`, where the values of `pageViewNamespace` is `jetpack_videopress` and `suffix` is `page_view` by default.
+This naming convention aims to be consistent among all page-view events recorded by different apps, contexts, etc.
+
+Being said that, it's possible to record the **page-view** event simply by defining the event name via the [pageViewEventName](#pagevieweventname-optional) of the hook settings:
+
+```jsx
+import useAnalyticsTracks from './hooks/use-analytics-tracks';
+
+function MyAdminApp() {
+	/*
+	 * the following code will record
+	 * the `jetpack_videopress_my_section_page_view` event.
+	 */
+	useAnalyticsTracks( {
+		pageViewEventName: 'my_section'
+	} );
+
+	return <div>Hello, tracking world!</div>;
+}
+```

--- a/projects/packages/videopress/src/client/admin/hooks/use-analytics-tracks/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-analytics-tracks/index.ts
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import jetpackAnalytics from '@automattic/jetpack-analytics';
+import { useConnection } from '@automattic/jetpack-connection';
+import { useCallback, useEffect } from 'react';
+/**
+ * Internal dependencies
+ */
+import { useAnalyticsTracksProps } from './types';
+
+const useAnalyticsTracks = ( {
+	pageViewEventName,
+	pageViewNamespace = 'jetpack_videopress',
+	pageViewSuffix = 'page_view',
+	pageViewEventProperties = {},
+}: useAnalyticsTracksProps ) => {
+	const { isUserConnected, isRegistered, userConnectionData } = useConnection();
+	const { login, ID } = userConnectionData.currentUser?.wpcomUser || {};
+
+	// Tracks
+	const { tracks } = jetpackAnalytics;
+	const { recordEvent } = tracks;
+
+	const recordEventAsync = useCallback(
+		async ( event, properties ) => {
+			recordEvent( event, properties );
+		},
+		[ recordEvent ]
+	);
+
+	const recordEventHandler = useCallback(
+		( eventName, properties, callback = () => ( {} ) ) => {
+			/*
+			 * `properties` is optional,
+			 * meaning it can be actually the `callback`.
+			 */
+			callback = typeof properties === 'function' ? properties : callback;
+			properties = typeof properties === 'function' ? {} : properties;
+
+			return () => recordEventAsync( eventName, properties ).then( callback );
+		},
+		[ recordEventAsync ]
+	);
+
+	// Initialize Analytics identifying the user.
+	useEffect( () => {
+		if ( ! ( isUserConnected && ID && login ) ) {
+			return;
+		}
+
+		jetpackAnalytics.initialize( ID, login );
+	}, [ isUserConnected, ID, login ] );
+
+	/*
+	 * Track page-view event.
+	 * It's considered a page view event
+	 * when the component is mounted.
+	 */
+	const pageViewEvent = pageViewEventName
+		? `${ pageViewNamespace }_${ pageViewEventName }_${ pageViewSuffix }`
+		: null;
+
+	useEffect( () => {
+		// Also, only run if the site is registered.
+		if ( ! isRegistered ) {
+			return;
+		}
+
+		if ( ! pageViewEvent ) {
+			return;
+		}
+
+		recordEvent( pageViewEvent, pageViewEventProperties );
+	}, [] );
+
+	return {
+		recordEvent: recordEventAsync,
+		recordEventHandler,
+	};
+};
+export default useAnalyticsTracks;

--- a/projects/packages/videopress/src/client/admin/hooks/use-analytics-tracks/types.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-analytics-tracks/types.ts
@@ -1,0 +1,6 @@
+export type useAnalyticsTracksProps = {
+	pageViewEventName: string;
+	pageViewNamespace?: string;
+	pageViewSuffix?: string;
+	pageViewEventProperties?: object;
+};

--- a/projects/packages/videopress/src/client/admin/hooks/use-analytics-tracks/types.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-analytics-tracks/types.ts
@@ -1,5 +1,5 @@
 export type useAnalyticsTracksProps = {
-	pageViewEventName: string;
+	pageViewEventName?: string;
 	pageViewNamespace?: string;
 	pageViewSuffix?: string;
 	pageViewEventProperties?: object;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/26887

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: track page view and check out events

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Yes:
- track `jetpack_videopress_admin_page_view` event when the VideoPress standalone dashboard renders
- track `jetpack_videopress_upgrade_trigger_link_click` when user checkout by clicking on the upgrade trigger component

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard page
* Open dev-console
* Set the `debug` local storage to be able to see tracks logs
```
localStorage.setItem( 'debug', '*' )
```

You may want to ensure to see all logs (verbose) and also preserve them when the client performs a redirect.

<img width="672" alt="Screen Shot 2022-10-17 at 17 04 56" src="https://user-images.githubusercontent.com/77539/196272618-69093ab9-0eee-490a-942f-d1c0d9ee1e84.png">

* Confirm there are not any logs when the site is not connected
* Connect the site
* Confirm you see the app tracks the `jetpack_videopress_admin_page_view` event.

<img width="763" alt="Screen Shot 2022-10-17 at 17 13 29" src="https://user-images.githubusercontent.com/77539/196274211-327819f2-eec7-48e3-b95e-532791f7c3cb.png">

* Confirm you see the app tracks the `jetpack_videopress_upgrade_trigger_link_click` when check out the product:

<img width="807" alt="Screen Shot 2022-10-17 at 17 18 47" src="https://user-images.githubusercontent.com/77539/196275341-4fe91450-0cb7-40ea-ac2b-ed834d94d39e.png">

<img width="766" alt="image" src="https://user-images.githubusercontent.com/77539/196273960-039c0c24-bd24-47ba-a1d0-52449d03653f.png">