### PR TITLE
VideoPress: Use camera icon as thumbnail on private videos

### DIFF
--- a/projects/packages/videopress/changelog/fix-use-camera-icon-as-thumbnail-on-private-videos
+++ b/projects/packages/videopress/changelog/fix-use-camera-icon-as-thumbnail-on-private-videos
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Use camera icon as thumbnail when the video is private;

--- a/projects/packages/videopress/changelog/fix-use-camera-icon-as-thumbnail-on-private-videos
+++ b/projects/packages/videopress/changelog/fix-use-camera-icon-as-thumbnail-on-private-videos
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-VideoPress: Use camera icon as thumbnail when the video is private;
+VideoPress: Use camera icon as thumbnail when the video is private.

--- a/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
@@ -63,12 +63,6 @@ const ProcessingThumbnail = () => (
 	</div>
 );
 
-const PrivateThumbnail = () => (
-	<div className={ styles[ 'video-card__custom-thumbnail' ] }>
-		<Icon icon={ captureVideo } size={ 96 } />
-	</div>
-);
-
 /**
  * Video Card component
  *
@@ -97,7 +91,13 @@ export const VideoCard = ( {
 		: false;
 	// Mapping thumbnail (Ordered by priority)
 	let thumbnail = loading ? <Placeholder /> : defaultThumbnail;
-	thumbnail = privacyIsPrivate ? <PrivateThumbnail /> : thumbnail;
+	thumbnail = privacyIsPrivate ? (
+		<div className={ styles[ 'video-card__custom-thumbnail' ] }>
+			<Icon icon={ captureVideo } size={ 96 } />
+		</div>
+	) : (
+		thumbnail
+	);
 	thumbnail = uploading || isUpdatingPoster ? <UploadingThumbnail /> : thumbnail;
 	thumbnail = processing ? <ProcessingThumbnail /> : thumbnail;
 

--- a/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '@automattic/jetpack-components';
 import { Spinner } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { Icon, chartBar, chevronDown, chevronUp, captureVideo } from '@wordpress/icons';
+import { Icon, chartBar, chevronDown, chevronUp } from '@wordpress/icons';
 import classnames from 'classnames';
 import React from 'react';
 import { useState } from 'react';
@@ -92,13 +92,6 @@ export const VideoCard = ( {
 
 	// Mapping thumbnail (Ordered by priority)
 	let thumbnail = loading ? <Placeholder /> : defaultThumbnail;
-	thumbnail = privacyIsSetToPrivate ? (
-		<div className={ styles[ 'video-card__custom-thumbnail' ] }>
-			<Icon icon={ captureVideo } size={ 96 } />
-		</div>
-	) : (
-		thumbnail
-	);
 	thumbnail = uploading || isUpdatingPoster ? <UploadingThumbnail /> : thumbnail;
 	thumbnail = processing ? <ProcessingThumbnail /> : thumbnail;
 
@@ -131,6 +124,7 @@ export const VideoCard = ( {
 					thumbnail={ thumbnail }
 					duration={ loading ? null : duration }
 					editable={ loading ? false : editable }
+					isPrivate={ privacyIsSetToPrivate }
 				/>
 
 				<div className={ styles[ 'video-card__title-section' ] }>

--- a/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
@@ -10,10 +10,11 @@ import {
 } from '@automattic/jetpack-components';
 import { Spinner } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { Icon, chartBar, chevronDown, chevronUp } from '@wordpress/icons';
+import { Icon, chartBar, chevronDown, chevronUp, captureVideo } from '@wordpress/icons';
 import classnames from 'classnames';
 import React from 'react';
 import { useState } from 'react';
+import { VIDEO_PRIVACY_LEVELS, VIDEO_PRIVACY_LEVEL_PRIVATE } from '../../../state/constants';
 import useVideo from '../../hooks/use-video';
 import Placeholder from '../placeholder';
 /**
@@ -62,6 +63,12 @@ const ProcessingThumbnail = () => (
 	</div>
 );
 
+const PrivateThumbnail = () => (
+	<div className={ styles[ 'video-card__custom-thumbnail' ] }>
+		<Icon icon={ captureVideo } size={ 96 } />
+	</div>
+);
+
 /**
  * Video Card component
  *
@@ -80,12 +87,17 @@ export const VideoCard = ( {
 	isUpdatingPoster = false,
 	uploading = false,
 	processing = false,
+	privacySetting,
 	onVideoDetailsClick,
 }: VideoCardProps ) => {
 	const isBlank = ! title && ! duration && ! plays && ! defaultThumbnail && ! loading;
 
+	const privacyIsPrivate = privacySetting
+		? VIDEO_PRIVACY_LEVELS[ privacySetting ] === VIDEO_PRIVACY_LEVEL_PRIVATE
+		: false;
 	// Mapping thumbnail (Ordered by priority)
 	let thumbnail = loading ? <Placeholder /> : defaultThumbnail;
+	thumbnail = privacyIsPrivate ? <PrivateThumbnail /> : thumbnail;
 	thumbnail = uploading || isUpdatingPoster ? <UploadingThumbnail /> : thumbnail;
 	thumbnail = processing ? <ProcessingThumbnail /> : thumbnail;
 

--- a/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
@@ -86,12 +86,13 @@ export const VideoCard = ( {
 }: VideoCardProps ) => {
 	const isBlank = ! title && ! duration && ! plays && ! defaultThumbnail && ! loading;
 
-	const privacyIsPrivate = privacySetting
+	const privacyIsSetToPrivate = privacySetting
 		? VIDEO_PRIVACY_LEVELS[ privacySetting ] === VIDEO_PRIVACY_LEVEL_PRIVATE
 		: false;
+
 	// Mapping thumbnail (Ordered by priority)
 	let thumbnail = loading ? <Placeholder /> : defaultThumbnail;
-	thumbnail = privacyIsPrivate ? (
+	thumbnail = privacyIsSetToPrivate ? (
 		<div className={ styles[ 'video-card__custom-thumbnail' ] }>
 			<Icon icon={ captureVideo } size={ 96 } />
 		</div>
@@ -190,7 +191,7 @@ export const VideoCard = ( {
 };
 
 export const ConnectVideoCard = ( { id, ...restProps }: VideoCardProps ) => {
-	const { isDeleting, uploading, processing, isUpdatingPoster } = useVideo( id );
+	const { isDeleting, uploading, processing, isUpdatingPoster, data } = useVideo( id );
 
 	const loading = ( isDeleting || restProps?.loading ) && ! uploading && ! processing;
 	const editable = restProps?.editable && ! isDeleting && ! uploading && ! processing;
@@ -204,6 +205,7 @@ export const ConnectVideoCard = ( { id, ...restProps }: VideoCardProps ) => {
 			isUpdatingPoster={ isUpdatingPoster }
 			processing={ processing }
 			editable={ editable }
+			privacySetting={ data.privacySetting }
 		/>
 	);
 };

--- a/projects/packages/videopress/src/client/admin/components/video-grid/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-grid/index.tsx
@@ -32,6 +32,7 @@ const VideoGrid = ( { videos, count = 6, onVideoDetailsClick, loading }: VideoGr
 							<VideoCard
 								id={ video?.id }
 								title={ video.title }
+								privacySetting={ video.privacySetting }
 								thumbnail={ video?.posterImage } // TODO: we should use thumbnail when the API is ready https://github.com/Automattic/jetpack/issues/26319
 								duration={ video.duration }
 								plays={ video.plays }

--- a/projects/packages/videopress/src/client/admin/components/video-grid/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-grid/index.tsx
@@ -32,7 +32,6 @@ const VideoGrid = ( { videos, count = 6, onVideoDetailsClick, loading }: VideoGr
 							<VideoCard
 								id={ video?.id }
 								title={ video.title }
-								privacySetting={ video.privacySetting }
 								thumbnail={ video?.posterImage } // TODO: we should use thumbnail when the API is ready https://github.com/Automattic/jetpack/issues/26319
 								duration={ video.duration }
 								plays={ video.plays }

--- a/projects/packages/videopress/src/client/admin/components/video-row/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-row/index.tsx
@@ -5,6 +5,7 @@ import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useState, useRef } from 'react';
 import privacy from '../../../components/icons/crossed-eye-icon';
+import { VIDEO_PRIVACY_LEVELS, VIDEO_PRIVACY_LEVEL_PRIVATE } from '../../../state/constants';
 import useVideo from '../../hooks/use-video';
 import Checkbox from '../checkbox';
 import Placeholder from '../placeholder';
@@ -95,6 +96,7 @@ export const VideoRow = ( {
 	uploadDate,
 	plays,
 	isPrivate,
+	privacySetting,
 	onVideoDetailsClick,
 	onSelect,
 	showEditButton = true,
@@ -117,6 +119,10 @@ export const VideoRow = ( {
 	const showTitleLabel = ! isSmall && isEllipsisActive;
 	const showStats = ( ! showActions && ! isSmall ) || ( isSmall && expanded ) || loading;
 	const showBottom = ! isSmall || ( isSmall && expanded );
+
+	const privacyIsSetToPrivate = privacySetting
+		? VIDEO_PRIVACY_LEVELS[ privacySetting ] === VIDEO_PRIVACY_LEVEL_PRIVATE
+		: false;
 
 	let thumbnail = defaultThumbnail;
 	thumbnail = loading || isUpdatingPoster ? <Placeholder width={ 90 } height={ 50 } /> : thumbnail;
@@ -229,7 +235,11 @@ export const VideoRow = ( {
 				>
 					{ showThumbnail && (
 						<div className={ styles.poster }>
-							<VideoThumbnail thumbnail={ thumbnail } blankIconSize={ 28 } />
+							<VideoThumbnail
+								isPrivate={ privacyIsSetToPrivate }
+								thumbnail={ thumbnail }
+								blankIconSize={ 28 }
+							/>
 						</div>
 					) }
 					<div className={ styles[ 'title-wrapper' ] }>
@@ -290,7 +300,7 @@ export const VideoRow = ( {
 };
 
 export const ConnectVideoRow = ( { id, ...restProps }: VideoRowProps ) => {
-	const { isDeleting, uploading, processing, isUpdatingPoster } = useVideo( id );
+	const { isDeleting, uploading, processing, isUpdatingPoster, data } = useVideo( id );
 	const loading = ( isDeleting || restProps?.loading ) && ! uploading && ! processing;
 	return (
 		<VideoRow
@@ -299,6 +309,7 @@ export const ConnectVideoRow = ( { id, ...restProps }: VideoRowProps ) => {
 			loading={ loading }
 			isUpdatingPoster={ isUpdatingPoster }
 			showThumbnail
+			privacySetting={ data.privacySetting }
 		/>
 	);
 };

--- a/projects/packages/videopress/src/client/admin/components/video-row/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/video-row/types.ts
@@ -37,7 +37,10 @@ type VideoRowBaseProps = {
 };
 
 type VideoPressVideoProps = VideoRowBaseProps &
-	Pick< VideoPressVideo, 'id' | 'title' | 'duration' | 'uploadDate' | 'plays' | 'isPrivate' > &
+	Pick<
+		VideoPressVideo,
+		'id' | 'title' | 'duration' | 'uploadDate' | 'plays' | 'isPrivate' | 'privacySetting'
+	> &
 	Pick< VideoThumbnailProps, 'thumbnail' >;
 
 export type VideoRowProps = VideoPressVideoProps & {

--- a/projects/packages/videopress/src/client/admin/components/video-thumbnail/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-thumbnail/index.tsx
@@ -5,7 +5,7 @@ import { Text, Button, useBreakpointMatch } from '@automattic/jetpack-components
 import { Dropdown } from '@wordpress/components';
 import { gmdateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
-import { Icon, edit, cloud, image, media, video } from '@wordpress/icons';
+import { Icon, edit, captureVideo, cloud, image, media, video } from '@wordpress/icons';
 import classnames from 'classnames';
 /**
  * Internal dependencies
@@ -110,11 +110,15 @@ const VideoThumbnail = ( {
 	duration,
 	editable,
 	blankIconSize = 96,
+	isPrivate,
 	onUseDefaultThumbnail,
 	onSelectFromVideo,
 	onUploadImage,
 }: VideoThumbnailProps ) => {
 	const [ isSmall ] = useBreakpointMatch( 'sm' );
+
+	/** If the thumbnail is private, do not try to show it */
+	thumbnail = isPrivate ? null : thumbnail;
 
 	thumbnail =
 		typeof thumbnail === 'string' && thumbnail !== '' ? (
@@ -123,12 +127,15 @@ const VideoThumbnail = ( {
 			thumbnail
 		);
 
+	/** Use a different icon for private videos */
+	const blankIcon = isPrivate ? captureVideo : video;
+
 	/** If the thumbnail is not set, use the placeholder with an icon */
 	thumbnail = thumbnail ? (
 		thumbnail
 	) : (
 		<div className={ styles[ 'thumbnail-blank' ] }>
-			<Icon icon={ video } size={ blankIconSize } />
+			<Icon icon={ blankIcon } size={ blankIconSize } />
 		</div>
 	);
 

--- a/projects/packages/videopress/src/client/admin/components/video-thumbnail/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-thumbnail/index.tsx
@@ -123,6 +123,15 @@ const VideoThumbnail = ( {
 			thumbnail
 		);
 
+	/** If the thumbnail is not set, use the placeholder with an icon */
+	thumbnail = thumbnail ? (
+		thumbnail
+	) : (
+		<div className={ styles[ 'thumbnail-blank' ] }>
+			<Icon icon={ video } size={ blankIconSize } />
+		</div>
+	);
+
 	return (
 		<div
 			className={ classnames( className, styles.thumbnail, { [ styles[ 'is-small' ] ]: isSmall } ) }
@@ -144,15 +153,7 @@ const VideoThumbnail = ( {
 				</div>
 			) }
 
-			<div className={ styles[ 'thumbnail-placeholder' ] }>
-				{ thumbnail ? (
-					thumbnail
-				) : (
-					<div className={ styles[ 'thumbnail-blank' ] }>
-						<Icon icon={ video } size={ blankIconSize } />
-					</div>
-				) }
-			</div>
+			<div className={ styles[ 'thumbnail-placeholder' ] }>{ thumbnail }</div>
 		</div>
 	);
 };

--- a/projects/packages/videopress/src/client/admin/components/video-thumbnail/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/video-thumbnail/types.ts
@@ -39,6 +39,11 @@ export type VideoThumbnailProps = VideoThumbnailDropdownProps & {
 	editable?: boolean;
 
 	/**
+	 * Whether the thumbnail is private or not
+	 */
+	isPrivate?: boolean;
+
+	/**
 	 * Blank icon size
 	 */
 	blankIconSize?: number;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Relates to #26675.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* On the VideoPress videos, show a camera icon as the thumbnail when the video is private; this will prevent the `403` response when trying to load the original thumbnail, that is private in this case
* The change works on both the grid and list view
* Note: this will not solve the problem inside the video details page (I am planning another PR and another approach inside that page)

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `Jetpack > VideoPress` to see the grid of videos 
* Set the privacy for some video to "Private":

![image](https://user-images.githubusercontent.com/6760046/196524103-556f0aae-ee62-47b2-811d-cefdedcfb9b1.png)

* Confirm that now it shows a camera icon as the thumbnail:

![image](https://user-images.githubusercontent.com/6760046/196524219-9870a87b-2651-4b48-9921-f9fa6a5e8c00.png)

* Confirm that every other private video is showing the same camera icon as well:

![image](https://user-images.githubusercontent.com/6760046/196524320-e6057c92-b2b8-4862-949d-625a57d2a0a0.png)

* Confirm that the same happens when you switch the view from grid to list:

![image](https://user-images.githubusercontent.com/6760046/196524442-41836fca-0e08-48be-904f-7e535f34e05f.png)
