### PR TITLE
Search: mark new pricing as complete

### DIFF
--- a/projects/packages/search/changelog/update-mark-new-pricing-as-complete
+++ b/projects/packages/search/changelog/update-mark-new-pricing-as-complete
@@ -1,0 +1,4 @@
+Significance: major
+Type: added
+
+Search: enable new pricing if pricing_version is set to 202208 from API

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -70,7 +70,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.28.x-dev"
+			"dev-trunk": "0.29.x-dev"
 		},
 		"version-constants": {
 			"::VERSION": "src/class-package.php"

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.28.1-alpha",
+	"version": "0.29.0-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-helper.php
+++ b/projects/packages/search/src/class-helper.php
@@ -24,11 +24,6 @@ class Helper {
 	const FILTER_WIDGET_BASE = 'jetpack-search-filters';
 
 	/**
-	 * TODO: remove the lock once the functionalities are finished.
-	 */
-	const NEW_PRICING_202208_READY = false;
-
-	/**
 	 * Create a URL for the current search that doesn't include the "paged" parameter.
 	 *
 	 * @since 5.8.0
@@ -872,7 +867,7 @@ class Helper {
 			'postTypes'             => $post_type_labels,
 			'webpackPublicPath'     => plugins_url( '/build/instant-search/', __DIR__ ),
 			'isPhotonEnabled'       => ( $is_wpcom || $is_jetpack_photon_enabled ) && ! $is_private_site,
-			'isFreeTier'            => ( new Plan() )->is_free_tier(),
+			'isFreePlan'            => ( new Plan() )->is_free_plan(),
 
 			// config values related to private site support.
 			'apiRoot'               => esc_url_raw( rest_url() ),
@@ -957,11 +952,11 @@ class Helper {
 	}
 
 	/**
-	 * Returns true if the free_tier is set to not empty in URL, which is used for testing purpose.
+	 * Returns true if the free_plan is set to not empty in URL, which is used for testing purpose.
 	 */
-	public static function is_forced_free_tier() {
+	public static function is_forced_free_plan() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		return isset( $_GET['free_tier'] ) && $_GET['free_tier'];
+		return isset( $_GET['free_plan'] ) && $_GET['free_plan'];
 	}
 
 	/**
@@ -971,12 +966,5 @@ class Helper {
 		$referrer = wp_get_referer();
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 		return ( isset( $_GET['new_pricing_202208'] ) && $_GET['new_pricing_202208'] ) || $referrer && strpos( $referrer, 'new_pricing_202208=1' ) !== false;
-	}
-
-	/**
-	 * Return true if the new pricing is finished and ready to be used in production.
-	 */
-	public static function is_new_pricing_202208_ready() {
-		return self::NEW_PRICING_202208_READY;
 	}
 }

--- a/projects/packages/search/src/class-helper.php
+++ b/projects/packages/search/src/class-helper.php
@@ -839,11 +839,6 @@ class Helper {
 		$is_private_site           = '-1' === get_option( 'blog_public' );
 		$is_jetpack_photon_enabled = method_exists( 'Jetpack', 'is_module_active' ) && Jetpack::is_module_active( 'photon' );
 
-		// @todo Determine $show_powered_by by real pricing tier
-		// $show_powered_by = get_option( $prefix . 'show_powered_by', '1' ) === '1';
-		//phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$show_powered_by = isset( $_GET['free_tier'] ) && $_GET['free_tier'] === '1';
-
 		$options = array(
 			'overlayOptions'        => array(
 				'colorTheme'        => get_option( $prefix . 'color_theme', 'light' ),
@@ -852,7 +847,7 @@ class Helper {
 				'highlightColor'    => get_option( $prefix . 'highlight_color', '#FFC' ),
 				'overlayTrigger'    => get_option( $prefix . 'overlay_trigger', Options::DEFAULT_OVERLAY_TRIGGER ),
 				'resultFormat'      => get_option( $prefix . 'result_format', Options::RESULT_FORMAT_MINIMAL ),
-				'showPoweredBy'     => $show_powered_by || ( get_option( $prefix . 'show_powered_by', '1' ) === '1' ),
+				'showPoweredBy'     => ( new Plan() )->is_free_plan() || ( get_option( $prefix . 'show_powered_by', '1' ) === '1' ),
 
 				// These options require kicking off a new search.
 				'defaultSort'       => get_option( $prefix . 'default_sort', 'relevance' ),

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.28.1-alpha';
+	const VERSION = '0.29.0-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/class-plan.php
+++ b/projects/packages/search/src/class-plan.php
@@ -21,6 +21,7 @@ class Plan {
 
 	// The pricing update starting from August 2022.
 	const JETPACK_SEARCH_NEW_PRICING_VERSION = '202208';
+	const JETPACK_SEARCH_FREE_PRODUCT_SLUG   = 'jetpack_search_free';
 
 	/**
 	 * Whether we have hooked the actions.
@@ -119,9 +120,9 @@ class Plan {
 	/**
 	 * Returns true if the site is on free plan.
 	 */
-	public function is_free_tier() {
+	public function is_free_plan() {
 		$plan_info = $this->get_plan_info();
-		return Helper::is_forced_free_tier() || ( isset( $plan_info['is_free_tier'] ) && $plan_info['is_free_tier'] );
+		return Helper::is_forced_free_plan() || ( isset( $plan_info['effective_subscription']['product_slug'] ) && $plan_info['effective_subscription']['product_slug'] === self::JETPACK_SEARCH_FREE_PRODUCT_SLUG );
 	}
 
 	/**

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -422,11 +422,7 @@ class REST_Controller {
 	 */
 	public function product_pricing() {
 		$tier_pricing = Search_Product::get_pricing_for_ui();
-		// We don't want to show the half finished new pricing, even when it's set to open from the API.
-		if ( ! Helper::is_new_pricing_202208_ready() ) {
-			unset( $tier_pricing['pricing_version'] );
-		}
-		// Unless we are testing.
+		// we can force the plugin to use the new pricing by appending `pricing_version=202208` to URL.
 		if ( Helper::is_forced_new_pricing_202208() ) {
 			$tier_pricing['pricing_version'] = Plan::JETPACK_SEARCH_NEW_PRICING_VERSION;
 		}

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -422,7 +422,7 @@ class REST_Controller {
 	 */
 	public function product_pricing() {
 		$tier_pricing = Search_Product::get_pricing_for_ui();
-		// we can force the plugin to use the new pricing by appending `pricing_version=202208` to URL.
+		// we can force the plugin to use the new pricing by appending `new_pricing_202208=1` to URL.
 		if ( Helper::is_forced_new_pricing_202208() ) {
 			$tier_pricing['pricing_version'] = Plan::JETPACK_SEARCH_NEW_PRICING_VERSION;
 		}

--- a/projects/packages/search/src/dashboard/store/selectors/site-plan.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-plan.js
@@ -1,3 +1,5 @@
+const productSlugFree = 'jetpack_search_free';
+
 const sitePlanSelectors = {
 	getSearchPlanInfo: state => state.sitePlan,
 	hasBusinessPlan: state => state.sitePlan.supports_only_classic_search,
@@ -8,7 +10,7 @@ const sitePlanSelectors = {
 	supportsSearch: state =>
 		state.sitePlan.supports_instant_search || state.sitePlan.supports_only_classic_search,
 	getTierMaximumRecords: state => state.sitePlan.tier_maximum_records,
-	isFreePlan: state => !! state.isFreePlan,
+	isFreePlan: state => state.sitePlan.effective_subscription?.product_slug === productSlugFree,
 	getLatestMonthRequests: state => state.sitePlan.plan_usage.num_requests_3m[ 0 ],
 	getCurrentPlan: state => state.sitePlan.plan_current,
 	getCurrentUsage: state => state.sitePlan.plan_usage,

--- a/projects/packages/search/src/dashboard/store/selectors/site-plan.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-plan.js
@@ -1,5 +1,3 @@
-const productSlugFree = 'jetpack_search_free';
-
 const sitePlanSelectors = {
 	getSearchPlanInfo: state => state.sitePlan,
 	hasBusinessPlan: state => state.sitePlan.supports_only_classic_search,
@@ -10,7 +8,7 @@ const sitePlanSelectors = {
 	supportsSearch: state =>
 		state.sitePlan.supports_instant_search || state.sitePlan.supports_only_classic_search,
 	getTierMaximumRecords: state => state.sitePlan.tier_maximum_records,
-	isFreePlan: state => state.sitePlan.effective_subscription?.product_slug === productSlugFree,
+	isFreePlan: state => !! state.isFreePlan,
 	getLatestMonthRequests: state => state.sitePlan.plan_usage.num_requests_3m[ 0 ],
 	getCurrentPlan: state => state.sitePlan.plan_current,
 	getCurrentUsage: state => state.sitePlan.plan_usage,

--- a/projects/plugins/jetpack/changelog/update-mark-new-pricing-as-complete
+++ b/projects/plugins/jetpack/changelog/update-mark-new-pricing-as-complete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -38,7 +38,7 @@
 		"automattic/jetpack-publicize": "0.16.x-dev",
 		"automattic/jetpack-redirect": "1.7.x-dev",
 		"automattic/jetpack-roles": "1.4.x-dev",
-		"automattic/jetpack-search": "0.28.x-dev",
+		"automattic/jetpack-search": "0.29.x-dev",
 		"automattic/jetpack-stats": "0.2.x-dev",
 		"automattic/jetpack-status": "1.14.x-dev",
 		"automattic/jetpack-sync": "1.40.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6d1d9bf05655f8a7928c226eeb833d58",
+    "content-hash": "d954978e5bebc7b1f0ff10170d072bed",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1750,7 +1750,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "f6faf7d4aeecb2700918512f64c4c81290b650d2"
+                "reference": "ada327eb4ea60d312c5964e8cb8387685a52a41e"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -1774,7 +1774,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.28.x-dev"
+                    "dev-trunk": "0.29.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"

--- a/projects/plugins/search/changelog/update-mark-new-pricing-as-complete
+++ b/projects/plugins/search/changelog/update-mark-new-pricing-as-complete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -10,7 +10,7 @@
 		"automattic/jetpack-connection": "1.45.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
 		"automattic/jetpack-my-jetpack": "2.3.x-dev",
-		"automattic/jetpack-search": "0.28.x-dev",
+		"automattic/jetpack-search": "0.29.x-dev",
 		"automattic/jetpack-stats": "0.2.x-dev",
 		"automattic/jetpack-status": "1.14.x-dev",
 		"automattic/jetpack-sync": "1.40.x-dev",

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e1f0c2980c9f9cb71a9d22ce988af5ea",
+    "content-hash": "05f1b5692769ae10e1f69580a1ec8dd9",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1096,7 +1096,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "f6faf7d4aeecb2700918512f64c4c81290b650d2"
+                "reference": "ada327eb4ea60d312c5964e8cb8387685a52a41e"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -1120,7 +1120,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.28.x-dev"
+                    "dev-trunk": "0.29.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"


### PR DESCRIPTION
Fixes: #26899

#### Changes proposed in this Pull Request:
The PR proposes to enable the feature when `pricing_version` is set to '202208' from the pricing API. The WPCOM change is `D90075-code`. They could be merged regardless of order.

It also forces free plan user to show powered by.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
pcNPJE-145#comment-1819-p2

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Apply `D90075-code` to your sandbox
- Sandbox your Jetpack test site
- Ensure new pricing is showing and purchase flow etc work
- Unsandbox the test site
- Ensure old pricing works

NOTE: please do test on WPCOM simple and ensure it doesn't break anything.
