### PR TITLE
Search: fetch pricing on wpcom without external request

### DIFF
--- a/projects/packages/my-jetpack/changelog/fetch-search-pricing-directly-on-wpcom
+++ b/projects/packages/my-jetpack/changelog/fetch-search-pricing-directly-on-wpcom
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fixed
+Comment: Fetch search pricing on wpcom without making an additional external request

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -190,10 +190,22 @@ class Search extends Hybrid_Product {
 			return $pricings[ $record_count ];
 		}
 
-		$response = wp_remote_get(
-			sprintf( Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' ) . '/wpcom/v2/jetpack-search/pricing?record_count=%1$d&locale=%2$s', $record_count, get_user_locale() ),
-			array( 'timeout' => 5 )
-		);
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			// For simple sites fetch the response directly.
+			$response = Client::wpcom_json_api_request_as_blog(
+				sprintf( '/jetpack-search/pricing?record_count=%1$d&locale=%2$s', $record_count, get_user_locale() ),
+				'2',
+				array( 'timeout' => 5 ),
+				null,
+				'wpcom'
+			);
+		} else {
+			// For non-simple sites we have to use the wp_remote_get, as connection might not be available.
+			$response = wp_remote_get(
+				sprintf( Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' ) . '/wpcom/v2/jetpack-search/pricing?record_count=%1$d&locale=%2$s', $record_count, get_user_locale() ),
+				array( 'timeout' => 5 )
+			);
+		}
 
 		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			return new WP_Error( 'search_pricing_fetch_failed' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Currently, simple sites on wpcom have to make an external API request to fetch the pricing.
This PR makes it fetch data directly on wpcom to optimize it, and simplify sandboxing and testing.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

panfyZ-1pv-p2#comment-3031

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

This requires an internal A8C sandbox.

1. Apply this to your sandbox.
2. Visit wp-admin for a simple site without a search subscription.
3. Go to search dashboard.
4. Switch store to sandbox using one of the methods in PCYsg-IA-p2 
5. Pricing should change.

Without my change the pricing wouldn't change, as we fetch it in a separate request.