### PR TITLE
Jetpack: Add Salesforce Lead form template

### DIFF
--- a/projects/plugins/jetpack/3rd-party/3rd-party.php
+++ b/projects/plugins/jetpack/3rd-party/3rd-party.php
@@ -23,6 +23,7 @@ function load_3rd_party() {
 		'class.jetpack-amp-support.php',
 		'class-jetpack-crm-data.php',
 		'class-jetpack-modules-overrides.php', // Special case. Tools to be used to override module settings.
+		'class-salesforce-lead-form.php', // not a module but the handler for Salesforce forms
 		'creative-mail.php',
 		'jetpack-backup.php',
 		'jetpack-boost.php',

--- a/projects/plugins/jetpack/3rd-party/class-salesforce-lead-form.php
+++ b/projects/plugins/jetpack/3rd-party/class-salesforce-lead-form.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Salesforce Lead Form using Jetpack Contact Forms.
+ *
+ * @package automattic/jetpack
+ */
+
+namespace Automattic\Jetpack;
+
+/**
+ * Class Salesforce_Lead_Form
+ *
+ * Hooks on Jetpack's Contact form to send form data to Salesforce.
+ */
+class Salesforce_Lead_Form {
+	/**
+	 * Salesforce_Contact_Form constructor.
+	 * Hooks on `grunion_after_feedback_post_inserted` action to send form data to Salesforce.
+	 */
+	public static function initialize() {
+		add_action( 'grunion_after_feedback_post_inserted', array( __CLASS__, 'process_salesforce_form' ), 10, 4 );
+	}
+
+	/**
+	 * Process Salesforce Lead forms
+	 *
+	 * @param int   $post_id - the post_id for the CPT that is created.
+	 * @param array $fields - Grunion_Contact_Form_Field array.
+	 * @param bool  $is_spam - marked as spam by Akismet(?).
+	 * @param array $entry_values - extra fields added to from the contact form.
+	 *
+	 * @return null|void
+	 */
+	public static function process_salesforce_form( $post_id, $fields, $is_spam, $entry_values ) {
+		// if spam (hinted by akismet?), don't process
+		if ( $is_spam ) {
+			return;
+		}
+
+		$blocks = parse_blocks( get_the_content() );
+
+		$filtered_blocks = self::get_salesforce_contact_form_blocks( $blocks );
+
+		// no contact-form blocks with salesforceData and organizationId, move on
+		if ( empty( $filtered_blocks ) ) {
+			return;
+		}
+
+		// more than one form on post, skipping process
+		if ( count( $filtered_blocks ) > 1 ) {
+			return;
+		}
+
+		$attrs           = $filtered_blocks[0]['attrs']['salesforceData'];
+		$organization_id = $attrs['organizationId'];
+		// Double sanity check: no organization ID? Abort.
+		if ( empty( $organization_id ) ) {
+			return;
+		}
+
+		$keyed_fields = array_map(
+			function ( $field ) {
+				return $field->value;
+			},
+			$fields
+		);
+
+		// this is yet TBD, campaign IDs are hard to get from SF app/UI, but if
+		// the user filled it, then send as API field Campaign_ID
+		if ( ! empty( $attrs['campaignId'] ) ) {
+			$keyed_fields['Campaign_ID'] = $attrs['campaignId'];
+		}
+
+		// add post/page URL as lead_source
+		$keyed_fields['lead_source'] = $entry_values['entry_permalink'];
+		$keyed_fields['oid']         = $organization_id;
+
+		// we got this far, try and send it. Need to check for errors on submit
+		try {
+			self::send_to_salesforce( $keyed_fields );
+		} catch ( \Exception $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+			trigger_error( sprintf( 'Jetpack Form: Sending lead to Salesforce failed: %s', esc_html( $e->getMessage() ) ) );
+		}
+	}
+
+	/**
+	 * POST to Salesforce WebToLead servlet
+	 *
+	 * @param array $data The data key/value pairs to send in POST.
+	 * @param array $options Options for POST.
+	 *
+	 * @return array|WP_Error The result value from wp_remote_post
+	 */
+	public static function send_to_salesforce( $data, $options = array() ) {
+		global $wp_version;
+
+		$user_agent = "WordPress/{$wp_version} | Jetpack/" . constant( 'JETPACK__VERSION' ) . '; ' . get_bloginfo( 'url' );
+		$url        = 'https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8';
+		$args       = array(
+			'body'      => $data,
+			'headers'   => array(
+				'Content-Type' => 'application/x-www-form-urlencoded',
+				'user-agent'   => $user_agent,
+			),
+			'sslverify' => empty( $options['sslverify'] ) ? false : $options['sslverify'],
+		);
+
+		$args = apply_filters( 'jetpack_contactform_salesforce_request_args', $args );
+		return wp_remote_post( $url, $args );
+	}
+
+	/**
+	 * Extracts any jetpack/contact-form found on post.
+	 *
+	 * @param array $block_array - Array of blocks.
+	 *
+	 * @return array Array of jetpack/contact-form blocks found.
+	 */
+	public static function get_salesforce_contact_form_blocks( $block_array ) {
+		$jetpack_form_blocks = array();
+		foreach ( $block_array as $block ) {
+			if (
+				$block['blockName'] === 'jetpack/contact-form' &&
+				isset( $block['attrs']['salesforceData'] ) &&
+				$block['attrs']['salesforceData'] &&
+				isset( $block['attrs']['salesforceData']['sendToSalesforce'] ) &&
+				$block['attrs']['salesforceData']['sendToSalesforce'] &&
+				isset( $block['attrs']['salesforceData']['organizationId'] ) &&
+				$block['attrs']['salesforceData']['organizationId']
+				) {
+				$jetpack_form_blocks[] = $block;
+			} elseif ( isset( $block['innerBlocks'] ) ) {
+				$jetpack_form_blocks = array_merge( $jetpack_form_blocks, self::get_salesforce_contact_form_blocks( $block['innerBlocks'] ) );
+			}
+		}
+
+		return $jetpack_form_blocks;
+	}
+}
+
+Salesforce_Lead_Form::initialize();

--- a/projects/plugins/jetpack/changelog/add-salesforce-form-template
+++ b/projects/plugins/jetpack/changelog/add-salesforce-form-template
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Contact Form Block: adds a new form variation and template for a Salesforce Lead form.

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/attributes.js
@@ -31,4 +31,13 @@ export default {
 		type: 'string',
 		default: '',
 	},
+	// salesforce integration: these don't make sense except on the variation.
+	// needed to persist in order show editor options and backend submit process
+	salesforceData: {
+		type: 'object',
+		default: {
+			organizationId: '',
+			sendToSalesforce: false,
+		},
+	},
 };

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings.js
@@ -1,0 +1,125 @@
+import { BaseControl, PanelBody, TextControl, ExternalLink, Path } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { getIconColor } from '../../../../shared/block-icons';
+import renderMaterialIcon from '../../../../shared/render-material-icon';
+
+export const salesforceLeadFormVariation = {
+	name: 'salesforce-web-to-lead-form',
+	title: __( 'Salesforce Lead Form', 'jetpack' ),
+	description: __( 'Add a Salesforce Lead form to your site', 'jetpack' ),
+	icon: renderMaterialIcon(
+		<Path
+			d="m113 21.3c8.78-9.14 21-14.8 34.5-14.8 18 0 33.6 10 42 24.9a58 58 0 0 1 23.7-5.05c32.4 0 58.7 26.5 58.7 59.2s-26.3 59.2-58.7 59.2c-3.96 0-7.82-0.398-11.6-1.15-7.35 13.1-21.4 22-37.4 22a42.7 42.7 0 0 1-18.8-4.32c-7.45 17.5-24.8 29.8-45 29.8-21.1 0-39-13.3-45.9-32a45.1 45.1 0 0 1-9.34 0.972c-25.1 0-45.4-20.6-45.4-45.9 0-17 9.14-31.8 22.7-39.8a52.6 52.6 0 0 1-4.35-21c0-29.2 23.7-52.8 52.9-52.8 17.1 0 32.4 8.15 42 20.8"
+			fill={ getIconColor() }
+		/>,
+		48,
+		48,
+		'-16 -48 300 320'
+	),
+	innerBlocks: [
+		[
+			'jetpack/field-email',
+			{
+				required: true,
+				label: __( 'Business Email', 'jetpack' ),
+				id: 'email',
+			},
+		],
+		[
+			'jetpack/field-name',
+			{
+				required: true,
+				label: __( 'First Name', 'jetpack' ),
+				id: 'first_name',
+			},
+		],
+		[
+			'jetpack/field-name',
+			{
+				required: true,
+				label: __( 'Last Name', 'jetpack' ),
+				id: 'last_name',
+			},
+		],
+		[
+			'jetpack/field-text',
+			{
+				required: true,
+				label: __( 'Job Title', 'jetpack' ),
+				id: 'title',
+			},
+		],
+		[
+			'jetpack/field-text',
+			{
+				required: true,
+				label: __( 'Company', 'jetpack' ),
+				id: 'company',
+			},
+		],
+		[
+			'jetpack/field-telephone',
+			{
+				required: true,
+				label: __( 'Phone Number', 'jetpack' ),
+				id: 'phone',
+			},
+		],
+		[
+			'jetpack/button',
+			{
+				text: __( 'Submit', 'jetpack' ),
+				element: 'button',
+				lock: { remove: true },
+			},
+		],
+	],
+	attributes: {
+		subject: __( 'New lead received from your website', 'jetpack' ),
+		salesforceData: {
+			organizationId: '',
+			sendToSalesforce: true,
+		},
+		style: {
+			spacing: {
+				padding: {
+					top: '16px',
+					right: '16px',
+					bottom: '16px',
+					left: '16px',
+				},
+			},
+		},
+	},
+};
+
+export default ( { salesforceData, setAttributes } ) => {
+	const setSalesforceData = attributePair => {
+		setAttributes( {
+			salesforceData: {
+				...salesforceData,
+				...attributePair,
+			},
+		} );
+	};
+
+	return (
+		<Fragment>
+			<PanelBody title={ __( 'Salesforce', 'jetpack' ) } initialOpen={ true }>
+				<BaseControl>
+					<TextControl
+						label={ __( 'Organization ID', 'jetpack' ) }
+						value={ salesforceData.organizationId || '' }
+						placeholder={ __( 'Enter your Organization ID', 'jetpack' ) }
+						onChange={ organizationId => setSalesforceData( { organizationId } ) }
+						help={ __( 'Enter the Salesforce organization ID to send Leads to.', 'jetpack' ) }
+					/>
+					<ExternalLink href="https://help.salesforce.com/s/articleView?id=000325251&type=1">
+						Where to find your Salesforce Organization ID
+					</ExternalLink>
+				</BaseControl>
+			</PanelBody>
+		</Fragment>
+	);
+};

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings.js
@@ -1,7 +1,8 @@
 import { BaseControl, PanelBody, TextControl, ExternalLink, Path } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
+import { Fragment, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getIconColor } from '../../../../shared/block-icons';
+import HelpMessage from '../../../../shared/help-message';
 import renderMaterialIcon from '../../../../shared/render-material-icon';
 
 export const salesforceLeadFormVariation = {
@@ -94,7 +95,9 @@ export const salesforceLeadFormVariation = {
 	},
 };
 
-export default ( { salesforceData, setAttributes } ) => {
+export default ( { salesforceData, setAttributes, instanceId } ) => {
+	const [ organizationIdError, setOrganizationIdError ] = useState( false );
+
 	const setSalesforceData = attributePair => {
 		setAttributes( {
 			salesforceData: {
@@ -102,6 +105,15 @@ export default ( { salesforceData, setAttributes } ) => {
 				...attributePair,
 			},
 		} );
+	};
+
+	const setOrganizationId = value => {
+		setOrganizationIdError( false );
+		setSalesforceData( { organizationId: value.trim() } );
+	};
+
+	const onBlurOrgIdField = e => {
+		setOrganizationIdError( ! e.target.value.trim().match( /^[a-zA-Z0-9]{15,18}$/ ) );
 	};
 
 	return (
@@ -112,11 +124,20 @@ export default ( { salesforceData, setAttributes } ) => {
 						label={ __( 'Organization ID', 'jetpack' ) }
 						value={ salesforceData.organizationId || '' }
 						placeholder={ __( 'Enter your Organization ID', 'jetpack' ) }
-						onChange={ organizationId => setSalesforceData( { organizationId } ) }
+						onBlur={ onBlurOrgIdField }
+						onChange={ setOrganizationId }
 						help={ __( 'Enter the Salesforce organization ID to send Leads to.', 'jetpack' ) }
 					/>
+					{ organizationIdError && (
+						<HelpMessage isError id={ `contact-form-${ instanceId }-email-error` }>
+							{ __(
+								'Invalid Organization ID. Should be a 15 - 18 alphanumeric string.',
+								'jetpack'
+							) }
+						</HelpMessage>
+					) }
 					<ExternalLink href="https://help.salesforce.com/s/articleView?id=000325251&type=1">
-						Where to find your Salesforce Organization ID
+						{ __( 'Where to find your Salesforce Organization ID', 'jetpack' ) }
 					</ExternalLink>
 				</BaseControl>
 			</PanelBody>

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings.js
@@ -131,7 +131,7 @@ export default ( { salesforceData, setAttributes, instanceId } ) => {
 					{ organizationIdError && (
 						<HelpMessage isError id={ `contact-form-${ instanceId }-email-error` }>
 							{ __(
-								'Invalid Organization ID. Should be a 15 - 18 alphanumeric string.',
+								'Invalid Organization ID. Should be a 15 - 18 characters long alphanumeric string.',
 								'jetpack'
 							) }
 						</HelpMessage>

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/edit.js
@@ -226,10 +226,11 @@ export function JetpackContactFormEdit( {
 					/>
 				</PanelBody>
 
-				{ ! isSimpleSite() && isSalesForceExtensionEnabled && salesforceData?.sendToSalesforce && (
+				{ isSalesForceExtensionEnabled && salesforceData?.sendToSalesforce && (
 					<SalesforceLeadFormSettings
 						salesforceData={ salesforceData }
 						setAttributes={ setAttributes }
+						instanceId={ instanceId }
 					/>
 				) }
 				{ ! isSimpleSite() && (

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/edit.js
@@ -26,6 +26,9 @@ import CRMIntegrationSettings from './components/jetpack-crm-integration/jetpack
 import JetpackEmailConnectionSettings from './components/jetpack-email-connection-settings';
 import JetpackManageResponsesSettings from './components/jetpack-manage-responses-settings';
 import NewsletterIntegrationSettings from './components/jetpack-newsletter-integration-settings';
+import SalesforceLeadFormSettings, {
+	salesforceLeadFormVariation,
+} from './components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings';
 import defaultVariations from './variations';
 
 const ALLOWED_BLOCKS = [
@@ -69,11 +72,19 @@ export function JetpackContactFormEdit( {
 		customThankyouRedirect,
 		jetpackCRM,
 		formTitle,
+		salesforceData,
 	} = attributes;
 
 	const formClassnames = classnames( className, 'jetpack-contact-form', {
 		'is-placeholder': ! hasInnerBlocks && registerBlockVariation,
 	} );
+	const isSalesForceExtensionEnabled = !! window?.Jetpack_Editor_Initial_State?.available_blocks[
+		'contact-form/salesforce-lead-form'
+	];
+
+	if ( isSalesForceExtensionEnabled ) {
+		variations = [ ...variations, salesforceLeadFormVariation ];
+	}
 
 	const createBlocksFromInnerBlocksTemplate = innerBlocksTemplate => {
 		const blocks = map( innerBlocksTemplate, ( [ name, attr, innerBlocks = [] ] ) =>
@@ -214,6 +225,13 @@ export function JetpackContactFormEdit( {
 						setAttributes={ setAttributes }
 					/>
 				</PanelBody>
+
+				{ ! isSimpleSite() && isSalesForceExtensionEnabled && salesforceData?.sendToSalesforce && (
+					<SalesforceLeadFormSettings
+						salesforceData={ salesforceData }
+						setAttributes={ setAttributes }
+					/>
+				) }
 				{ ! isSimpleSite() && (
 					<Fragment>
 						{ canUserInstallPlugins && (

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
@@ -83,6 +83,7 @@
 	.help-message,
 	.components-placeholder__fieldset {
 		text-align: left;
+		max-width: none;
 	}
 
 	.help-message {

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/test/fixtures/jetpack__contact-form.json
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/test/fixtures/jetpack__contact-form.json
@@ -12,7 +12,11 @@
 			"customThankyouRedirect": "",
 			"formTitle": "",
 			"jetpackCRM": true,
-			"className": "noodles"
+			"className": "noodles",
+			"salesforceData": {
+				"organizationId": "",
+				"sendToSalesforce": false
+			}
 		},
 		"innerBlocks": [],
 		"originalContent": "<div class=\"wp-block-jetpack-contact-form noodles\">\n\n\n    \n\n    \n</div>"

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/test/fixtures/jetpack__contact-form__deprecated-1.json
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/test/fixtures/jetpack__contact-form__deprecated-1.json
@@ -12,7 +12,11 @@
 			"customThankyouRedirect": "",
 			"formTitle": "",
 			"jetpackCRM": true,
-			"className": "noodles"
+			"className": "noodles",
+			"salesforceData": {
+				"organizationId": "",
+				"sendToSalesforce": false
+			}
 		},
 		"innerBlocks": [],
 		"originalContent": ""

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/test/fixtures/jetpack__contact-form__deprecated-2.json
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/test/fixtures/jetpack__contact-form__deprecated-2.json
@@ -12,7 +12,11 @@
 			"customThankyouRedirect": "",
 			"formTitle": "",
 			"jetpackCRM": true,
-			"className": "noodles"
+			"className": "noodles",
+			"salesforceData": {
+				"organizationId": "",
+				"sendToSalesforce": false
+			}
 		},
 		"innerBlocks": [],
 		"originalContent": ""

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -45,6 +45,7 @@
 	],
 	"beta": [
 		"amazon",
+		"contact-form/salesforce-lead-form",
 		"google-docs-embed",
 		"recipe",
 		"videopress/video",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This PR adds a new form template: Salesforce Lead Form. The form is a variation of the contact-form with a fixed set of inputs:
- Email
- First name
- Last name
- Job/Title
- Company
- Phone number

Sidebar settings include the Organization ID and (optional) a Campaign ID

Closes #26868 

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
The change is being discussed/tracked at pcsBup-dV-p2

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:
You'll need a Salesforce developer account, you can get one for free at salesforce.com.
Once you do, use the Jurassic Ninja link to create a new instance with this PR.
Change the Jetpack Constant JETPACK_BETA_BLOCKS to `true` by visiting the Settings->Jetpack Constants entry on WP-ADMIN

**NOTE: do NOT check JETPACK_EXPERIMENTAL_BLOCKS as it will override the BETA list. If it's checked, uncheck it.**

Edit a post and add a `/form`.

- [ ] you should see a new entry: Salesforce Lead Form

Add a Salesforce Lead Form.

- [ ] mentioned list of inputs should be present
- [ ] settings on the sidebar should allow you to enter an Organization ID

Follow the instructions on the settings to get your Organization ID, enter it on the settings
Visit the post and fill the form. Then, on your Salesforce instance, go to Apps -> Marketing. You should see a "Leads" tab.

- [ ] verify a lead now exists with the data you filled the form with

