### PR TITLE
Social: Integrate connection error React component

### DIFF
--- a/projects/plugins/social/changelog/add-social-plugin-connection-errors
+++ b/projects/plugins/social/changelog/add-social-plugin-connection-errors
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Integrate the ConnectionError react component to the Social plugin.

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -78,6 +78,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_socialⓥ1_4_1_alpha"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_socialⓥ1_5_0_alpha"
 	}
 }

--- a/projects/plugins/social/jetpack-social.php
+++ b/projects/plugins/social/jetpack-social.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Social
  * Plugin URI: https://wordpress.org/plugins/jetpack-social
  * Description: Share your site’s posts on several social media networks automatically when you publish a new post.
- * Version: 1.4.1-alpha
+ * Version: 1.5.0-alpha
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later

--- a/projects/plugins/social/src/js/components/header/index.js
+++ b/projects/plugins/social/src/js/components/header/index.js
@@ -8,6 +8,7 @@ import {
 	getRedirectUrl,
 	getUserLocale,
 } from '@automattic/jetpack-components';
+import { useConnectionErrorNotice, ConnectionError } from '@automattic/jetpack-connection';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Icon, postList } from '@wordpress/icons';
@@ -39,6 +40,7 @@ const Header = () => {
 			siteSuffix: select( STORE_ID ).getSiteSuffix(),
 		};
 	} );
+	const { hasConnectionError } = useConnectionErrorNotice();
 
 	const formatter = Intl.NumberFormat( getUserLocale(), {
 		notation: 'compact',
@@ -48,6 +50,11 @@ const Header = () => {
 	return (
 		<>
 			<Container horizontalSpacing={ 0 }>
+				{ hasConnectionError && (
+					<Col className={ styles[ 'connection-error-col' ] }>
+						<ConnectionError />
+					</Col>
+				) }
 				<Col>
 					<div id="jp-admin-notices" className="jetpack-social-jitm-card" />
 				</Col>

--- a/projects/plugins/social/src/js/components/header/styles.module.scss
+++ b/projects/plugins/social/src/js/components/header/styles.module.scss
@@ -58,3 +58,7 @@
 .cut {
 	margin-top: calc( var( --spacing-base ) * 3 );
 }
+
+.connection-error-col {
+	margin-top: 25px;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Integrate the `ConnectionErrorNotice` React component into Social. This is part of a bigger project (1202697549597858-as) to provide consistent failed connection error reporting and an interface to reconnect (1202697549597858-as-1202697549597864) to all plugins and projects in the monorepo.

The changes will affect the following:
* Social

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
* p9dueE-5w8-p2

#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:
1. Run `jetpack build plugins/social`.
1. Enable the "Jetpack Debug Tools" plugin.
1. Go to Jetpack Debug > Jetpack Debug.
1. Enable "Broken token Utilities" and click "Save".
1. Go to Jetpack > Social.
1. Confirm that no errors display below the "Jetpack Social" heading.
1. Go to Jetpack Debug > Broken Token.
1. Click the "Set invalid blog token" button and the "Set invalid user tokens" button.
1. Run the following query on the database to clear connection error-related transients (if running the docker Jetpack environment, run `jetpack docker db`):
```delete from wp_options where option_name like '%jetpack_connection_error_reporting_gate_%';```
1. Go to Jetpack > My Jetpack.
1. Go to Jetpack > Social.
1. You should see an error message as shown in the below screenshot:
![jetpack-connection-error-example-generic](https://user-images.githubusercontent.com/56307/193151665-e2cee674-2084-4d5c-9054-6d1313bb447a.png)
1. Click on "Restore Connection".
1. The "Reconnecting Jetpack" message appears with the animating wait image.
1. The "Reconnecting Jetpack" connection disappears.
1. You are taken to the Jetpack connection page.