### PR TITLE
Fix a warning that is thrown when plugins are auto-updated.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-wpcom-api-warning-autoupdate
+++ b/projects/plugins/jetpack/changelog/fix-wpcom-api-warning-autoupdate
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: This fixes a warning, nothing special here
+
+

--- a/projects/plugins/jetpack/changelog/fix-wpcom-api-warning-autoupdate
+++ b/projects/plugins/jetpack/changelog/fix-wpcom-api-warning-autoupdate
@@ -1,5 +1,5 @@
 Significance: patch
 Type: other
-Comment: This fixes a warning, nothing special here
+Comment: Fix a warning that is thrown when plugins are auto-updated.
 
 

--- a/projects/plugins/jetpack/class.jetpack-autoupdate.php
+++ b/projects/plugins/jetpack/class.jetpack-autoupdate.php
@@ -344,12 +344,12 @@ class Jetpack_Autoupdate {
 	public static function get_plugin_slug( $plugin_file ) {
 		$update_plugins = get_site_transient( 'update_plugins' );
 		if ( isset( $update_plugins->no_update ) ) {
-			if ( isset( $update_plugins->no_update[ $plugin_file ] ) && isset( $update_plugins->no_update[ $plugin_file ]->slug ) ) {
+			if ( isset( $update_plugins->no_update[ $plugin_file ]->slug ) ) {
 				$slug = $update_plugins->no_update[ $plugin_file ]->slug;
 			}
 		}
 		if ( empty( $slug ) && isset( $update_plugins->response ) ) {
-			if ( isset( $update_plugins->response[ $plugin_file ] ) && isset( $update_plugins->response[ $plugin_file ]->slug ) ) {
+			if ( isset( $update_plugins->response[ $plugin_file ]->slug ) ) {
 				$slug = $update_plugins->response[ $plugin_file ]->slug;
 			}
 		}

--- a/projects/plugins/jetpack/class.jetpack-autoupdate.php
+++ b/projects/plugins/jetpack/class.jetpack-autoupdate.php
@@ -344,12 +344,12 @@ class Jetpack_Autoupdate {
 	public static function get_plugin_slug( $plugin_file ) {
 		$update_plugins = get_site_transient( 'update_plugins' );
 		if ( isset( $update_plugins->no_update ) ) {
-			if ( isset( $update_plugins->no_update[ $plugin_file ] ) ) {
+			if ( isset( $update_plugins->no_update[ $plugin_file ] ) && isset( $update_plugins->no_update[ $plugin_file ]->slug ) ) {
 				$slug = $update_plugins->no_update[ $plugin_file ]->slug;
 			}
 		}
 		if ( empty( $slug ) && isset( $update_plugins->response ) ) {
-			if ( isset( $update_plugins->response[ $plugin_file ] ) ) {
+			if ( isset( $update_plugins->response[ $plugin_file ] ) && isset( $update_plugins->response[ $plugin_file ]->slug ) ) {
 				$slug = $update_plugins->response[ $plugin_file ]->slug;
 			}
 		}


### PR DESCRIPTION
Fixes #25365

#### Changes proposed in this Pull Request:

Fix a warning at `Jetpack_Autoupdate::get_plugin_slug` when a plugin is missing the `slug` property.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
No.
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->


#### Testing instructions:

In order to test this pr, you need to be in "Online" mode, as this pr needs API access.
The change we are making fixes a warning based on the logs review, so we propose testing it using a small snippet.

<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

##### Before

1. Create a jurassic-tube site.
2. Run jetpack locally
3. At `/projects/plugins/jetpack/class.jetpack-autoupdate.php` before `if ( isset( $update_plugins->no_update[ $plugin_file ] ) ) ` at line `347` add the following

  ```
    unset($update_plugins->no_update[ $plugin_file ]->slug);
  ```
  to replicate the issue. (a plugin without a properly slug set).
4. At a terminal run `jetpack docker tail` command.
5. Navigate to [API console](https://developer.wordpress.com/docs/api/console/) and search for
  `/sites/<your site>/plugins`
6. Hit this endpoint.
7. Make sure you see a warning like the following:

  ```
    PHP Warning:  Undefined property: stdClass::$slug in /usr/local/src/jetpack-monorepo/projects/plugins/jetpack/class.jetpack-autoupdate.php on line 350
  ```

##### After

1. Create a Jurassic-tube site.
2. Run jetpack locally
3. At `/projects/plugins/jetpack/class.jetpack-autoupdate.php` before `			if ( isset( $update_plugins->no_update[ $plugin_file ] ) && isset( $update_plugins->no_update[ $plugin_file ]->slug ) )` at line `347` add the following

  ```
    unset($update_plugins->no_update[ $plugin_file ]->slug);
  ```

  to replicate the issue. (a plugin without a properly slug set).
4. At a terminal run the `jetpack docker tail` command.
5. Navigate to [API console](https://developer.wordpress.com/docs/api/console/) and search for
  `/sites/<your site>/plugins`
6. Hit this endpoint.
7. Make sure that there are no warnings in the console.

