### PR TITLE
Jetpack: Remove Contact Form overlay

### DIFF
--- a/projects/plugins/jetpack/changelog/revert-jetpack-form-overlay
+++ b/projects/plugins/jetpack/changelog/revert-jetpack-form-overlay
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Remove contact-form overlay (used to improve form block selection) as it's messing with the inserter hover behavior

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/edit.js
@@ -70,8 +70,6 @@ export function JetpackContactFormEdit( {
 	variations,
 	defaultVariation,
 	canUserInstallPlugins,
-	isSelected,
-	selectedInnerBlock,
 } ) {
 	const {
 		to,
@@ -359,9 +357,6 @@ export function JetpackContactFormEdit( {
 
 			<div className={ formClassnames }>
 				<InnerBlocks allowedBlocks={ ALLOWED_BLOCKS } templateInsertUpdatesSelection={ false } />
-				{ ! isSelected && ! selectedInnerBlock && (
-					<div className="wp-block-jetpack-contact-form__overlay"></div>
-				) }
 			</div>
 		</>
 	);
@@ -370,7 +365,7 @@ export function JetpackContactFormEdit( {
 export default compose( [
 	withSelect( ( select, props ) => {
 		const { getBlockType, getBlockVariations, getDefaultBlockVariation } = select( 'core/blocks' );
-		const { getBlocks, hasSelectedInnerBlock } = select( 'core/block-editor' );
+		const { getBlocks } = select( 'core/block-editor' );
 		const { getEditedPostAttribute } = select( 'core/editor' );
 		const { getSite, getUser, canUser } = select( 'core' );
 		const innerBlocks = getBlocks( props.clientId );
@@ -394,7 +389,6 @@ export default compose( [
 
 			innerBlocks,
 			hasInnerBlocks: innerBlocks.length > 0,
-			selectedInnerBlock: hasSelectedInnerBlock( props.clientId ),
 			siteTitle: get( getSite && getSite(), [ 'title' ] ),
 			postTitle: postTitle,
 			postAuthorEmail: authorEmail,

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
@@ -62,16 +62,6 @@
 	.block-list-appender {
 		flex: 0 0 100%;
 	}
-
-	.wp-block-jetpack-contact-form__overlay {
-		position: absolute;
-		top: 0;
-		left: 0;
-		width: 100%;
-		height: 100%;
-		background-color: transparent;
-		z-index: 1;
-	}
 }
 
 .jetpack-contact-form .components-placeholder {


### PR DESCRIPTION
This PR removes the overlay previously added on #26687, effectively introducing #26888 

Fixes #26888

#### Changes proposed in this Pull Request:
The changeset is just removing the previous addition, no new behavior should be observed and the form block selection should be back at its usual (tricky) way, we'll address this on another issue/PR

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Insert a form block, see that the effects described on #26687 are now reverted and back to the original state