### PR TITLE
VideoPress: Add confirmation before leaving page when upload is in progress

### DIFF
--- a/projects/packages/videopress/changelog/add-upload-confirmation
+++ b/projects/packages/videopress/changelog/add-upload-confirmation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Add confirmation before leaving page when upload is in progress

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/use-edit-details.ts
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/use-edit-details.ts
@@ -3,8 +3,7 @@
  */
 import { useDispatch } from '@wordpress/data';
 import { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
-import { useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 /**
  * Internal dependencies
  */

--- a/projects/packages/videopress/src/client/admin/hooks/use-upload-unload-check/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-upload-unload-check/index.ts
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useEffect } from 'react';
+/**
+ * Internal dependencies
+ */
+import useVideos from '../use-videos';
+
+const useUploadUnloadCheck = () => {
+	const { isUploading } = useVideos();
+
+	useEffect( () => {
+		if ( ! isUploading ) {
+			return;
+		}
+
+		const beforeUnloadListener = event => {
+			event.preventDefault();
+			// Note: The message only shows on older browsers, with a standard non-customizable message on current browsers
+			// ref https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event#compatibility_notes
+			event.returnValue = __(
+				'Leaving will cancel the upload. Are you sure you want to exit?',
+				'jetpack-videopress-pkg'
+			);
+			return;
+		};
+
+		window.addEventListener( 'beforeunload', beforeUnloadListener );
+
+		return () => {
+			window.removeEventListener( 'beforeunload', beforeUnloadListener );
+		};
+	}, [ isUploading ] );
+};
+
+export default useUploadUnloadCheck;

--- a/projects/packages/videopress/src/client/admin/hooks/use-videos/index.js
+++ b/projects/packages/videopress/src/client/admin/hooks/use-videos/index.js
@@ -16,6 +16,7 @@ export default function useVideos() {
 	// Data
 	const items = useSelect( select => select( STORE_ID ).getVideos() );
 	const uploading = useSelect( select => select( STORE_ID ).getUploadingVideos() );
+	const isUploading = uploading.length > 0;
 	const search = '';
 	const uploadedVideoCount = useSelect( select => select( STORE_ID ).getUploadedVideoCount() );
 	const isFetching = useSelect( select => select( STORE_ID ).getIsFetching() );
@@ -29,6 +30,7 @@ export default function useVideos() {
 	return {
 		items,
 		uploading,
+		isUploading,
 		search,
 		uploadedVideoCount,
 		isFetching,

--- a/projects/packages/videopress/src/client/admin/index.js
+++ b/projects/packages/videopress/src/client/admin/index.js
@@ -1,25 +1,36 @@
+/**
+ * External dependencies
+ */
 import { ThemeProvider } from '@automattic/jetpack-components';
 import ReactDOM from 'react-dom';
 import { HashRouter, Routes, Route } from 'react-router-dom';
+/**
+ * Internal dependencies
+ */
 import { initStore } from '../state';
 import AdminPage from './components/admin-page';
 import EditVideoDetails from './components/edit-video-details';
+import useUploadUnloadCheck from './hooks/use-upload-unload-check';
 import './style.module.scss';
 
 initStore();
 
-const VideoPress = () => (
-	<ThemeProvider>
-		<HashRouter>
-			<Routes>
-				<Route path="/" element={ <AdminPage /> } />
-				<Route path="video">
-					<Route path=":videoId/edit" element={ <EditVideoDetails /> } />
-				</Route>
-			</Routes>
-		</HashRouter>
-	</ThemeProvider>
-);
+const VideoPress = () => {
+	useUploadUnloadCheck();
+
+	return (
+		<ThemeProvider>
+			<HashRouter>
+				<Routes>
+					<Route path="/" element={ <AdminPage /> } />
+					<Route path="video">
+						<Route path=":videoId/edit" element={ <EditVideoDetails /> } />
+					</Route>
+				</Routes>
+			</HashRouter>
+		</ThemeProvider>
+	);
+};
 
 /**
  * Initial render function.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26499

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds an event listener for `beforeunload` whenever there is an upload in progress, prompting the user to stay in the page

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard
* Start the upload of a video
* Click on a link for another page, outside of the VideoPress dashboard
* Check that a browser prompt is shown

Going to the edit details page does not stop the upload. If the user is on the edit details page with an upload in progress, the prompt should be shown when the user tries to leave the page.

![2022-10-18_15-23-03](https://user-images.githubusercontent.com/8486249/196515349-9597c6f4-9136-4c3c-9967-70f8fdd3a5f5.png)
![2022-10-18_15-22-45](https://user-images.githubusercontent.com/8486249/196515351-0a655412-ee39-42b4-8f84-ce848cdc548d.png)

