### PR TITLE
Jetpack: Add default spacing on form block variations

### DIFF
--- a/projects/plugins/jetpack/changelog/add-default-variation-spacing
+++ b/projects/plugins/jetpack/changelog/add-default-variation-spacing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add default spacing attributes on all form variations. This achieves an easier way to select the form (parent) block while retaining wysiwyg capabilities: the user might choose to remove the spacing.

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/variations.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/variations.js
@@ -5,6 +5,19 @@ import { compact } from 'lodash';
 import { getIconColor } from '../../shared/block-icons';
 import renderMaterialIcon from '../../shared/render-material-icon';
 
+const defaultBlockStyling = {
+	style: {
+		spacing: {
+			padding: {
+				top: '16px',
+				right: '16px',
+				bottom: '16px',
+				left: '16px',
+			},
+		},
+	},
+};
+
 const variations = compact( [
 	{
 		name: 'contact-form',
@@ -33,16 +46,7 @@ const variations = compact( [
 			],
 		],
 		attributes: {
-			style: {
-				spacing: {
-					padding: {
-						top: '16px',
-						right: '16px',
-						bottom: '16px',
-						left: '16px',
-					},
-				},
-			},
+			...defaultBlockStyling,
 		},
 	},
 	! isSimpleSite() && {
@@ -75,16 +79,7 @@ const variations = compact( [
 			],
 		],
 		attributes: {
-			style: {
-				spacing: {
-					padding: {
-						top: '16px',
-						right: '16px',
-						bottom: '16px',
-						left: '16px',
-					},
-				},
-			},
+			...defaultBlockStyling,
 		},
 	},
 	{
@@ -122,17 +117,8 @@ const variations = compact( [
 			],
 		],
 		attributes: {
+			...defaultBlockStyling,
 			subject: __( 'A new RSVP from your website', 'jetpack' ),
-			style: {
-				spacing: {
-					padding: {
-						top: '16px',
-						right: '16px',
-						bottom: '16px',
-						left: '16px',
-					},
-				},
-			},
 		},
 	},
 	{
@@ -176,17 +162,8 @@ const variations = compact( [
 			],
 		],
 		attributes: {
+			...defaultBlockStyling,
 			subject: __( 'A new registration from your website', 'jetpack' ),
-			style: {
-				spacing: {
-					padding: {
-						top: '16px',
-						right: '16px',
-						bottom: '16px',
-						left: '16px',
-					},
-				},
-			},
 		},
 	},
 	{
@@ -226,17 +203,8 @@ const variations = compact( [
 			],
 		],
 		attributes: {
+			...defaultBlockStyling,
 			subject: __( 'A new appointment booked from your website', 'jetpack' ),
-			style: {
-				spacing: {
-					padding: {
-						top: '16px',
-						right: '16px',
-						bottom: '16px',
-						left: '16px',
-					},
-				},
-			},
 		},
 	},
 	{
@@ -280,17 +248,8 @@ const variations = compact( [
 			],
 		],
 		attributes: {
+			...defaultBlockStyling,
 			subject: __( 'New feedback received from your website', 'jetpack' ),
-			style: {
-				spacing: {
-					padding: {
-						top: '16px',
-						right: '16px',
-						bottom: '16px',
-						left: '16px',
-					},
-				},
-			},
 		},
 	},
 ] );

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/variations.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/variations.js
@@ -32,6 +32,18 @@ const variations = compact( [
 				},
 			],
 		],
+		attributes: {
+			style: {
+				spacing: {
+					padding: {
+						top: '16px',
+						right: '16px',
+						bottom: '16px',
+						left: '16px',
+					},
+				},
+			},
+		},
 	},
 	! isSimpleSite() && {
 		name: 'newsletter-form',
@@ -62,6 +74,18 @@ const variations = compact( [
 				},
 			],
 		],
+		attributes: {
+			style: {
+				spacing: {
+					padding: {
+						top: '16px',
+						right: '16px',
+						bottom: '16px',
+						left: '16px',
+					},
+				},
+			},
+		},
 	},
 	{
 		name: 'rsvp-form',
@@ -99,6 +123,16 @@ const variations = compact( [
 		],
 		attributes: {
 			subject: __( 'A new RSVP from your website', 'jetpack' ),
+			style: {
+				spacing: {
+					padding: {
+						top: '16px',
+						right: '16px',
+						bottom: '16px',
+						left: '16px',
+					},
+				},
+			},
 		},
 	},
 	{
@@ -143,6 +177,16 @@ const variations = compact( [
 		],
 		attributes: {
 			subject: __( 'A new registration from your website', 'jetpack' ),
+			style: {
+				spacing: {
+					padding: {
+						top: '16px',
+						right: '16px',
+						bottom: '16px',
+						left: '16px',
+					},
+				},
+			},
 		},
 	},
 	{
@@ -183,6 +227,16 @@ const variations = compact( [
 		],
 		attributes: {
 			subject: __( 'A new appointment booked from your website', 'jetpack' ),
+			style: {
+				spacing: {
+					padding: {
+						top: '16px',
+						right: '16px',
+						bottom: '16px',
+						left: '16px',
+					},
+				},
+			},
 		},
 	},
 	{
@@ -227,6 +281,16 @@ const variations = compact( [
 		],
 		attributes: {
 			subject: __( 'New feedback received from your website', 'jetpack' ),
+			style: {
+				spacing: {
+					padding: {
+						top: '16px',
+						right: '16px',
+						bottom: '16px',
+						left: '16px',
+					},
+				},
+			},
 		},
 	},
 ] );


### PR DESCRIPTION
This PR improves form (parent) block selection by adding a `style` section on all form variation blocks.

#### Changes proposed in this Pull Request:

* add a `style: { spacing: { padding: { ... } } }` as attribute on all form variation blocks

The change effectively adds a padding on the forms, making the form parent block more easily selectable. The padding is an option the user can later remove (hence, removing the ease of selection of the form), but it serves as a starting point while we figure out better ways to achieve the same result.

Alongside #26914 the form layout looks more consistent with the overall look n'feel of blocks in the editor.

Before:
<img width="701" alt="image" src="https://user-images.githubusercontent.com/157240/196530938-eef6ce3e-128b-4300-809f-46c882c6ecb9.png">

After:
<img width="670" alt="image" src="https://user-images.githubusercontent.com/157240/196531007-078e1afb-498a-4728-9920-01de2057bfcc.png">


#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Insert a form on a post. See that the form block shows a Dimensions setting already set as padding: 16px:
<img width="316" alt="image" src="https://user-images.githubusercontent.com/157240/196530860-5acb5aea-abda-48f7-8fba-dfeb26312151.png">
