### PR TITLE
Boost: Fix tracks on upgrade

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/benefits/BenefitsInterstitial.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/benefits/BenefitsInterstitial.svelte
@@ -12,9 +12,9 @@
 	import { jetpackURL } from '../../utils/jetpack-url';
 	import { getUpgradeURL } from '../../utils/upgrade';
 
-	function goToCheckout() {
+	async function goToCheckout() {
 		const eventProps = {};
-		recordBoostEvent( 'checkout_from_pricing_page_in_plugin', eventProps );
+		await recordBoostEvent( 'checkout_from_pricing_page_in_plugin', eventProps );
 		window.location.href = getUpgradeURL();
 	}
 

--- a/projects/plugins/boost/changelog/fix-tracks-on-upgrade
+++ b/projects/plugins/boost/changelog/fix-tracks-on-upgrade
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix tracks on upgrade cta click


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix tracking on CTA click from upgrade page

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Go to `/wp-admin/admin.php?page=jetpack-boost#/upgrade`
* Click the upgrade button
* Make sure you receive tracking events for `boost_checkout_from_pricing_page_in_plugin`

