### PR TITLE
Update/cache error when fetching stats and revert cache key

### DIFF
--- a/projects/packages/stats/changelog/update-cache-error-when-fetching-stats-and-revert-cache-key
+++ b/projects/packages/stats/changelog/update-cache-error-when-fetching-stats-and-revert-cache-key
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Caching errors when fetching stats and revered cache prefix.

--- a/projects/packages/stats/composer.json
+++ b/projects/packages/stats/composer.json
@@ -49,7 +49,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-stats/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.2.x-dev"
+			"dev-trunk": "0.3.x-dev"
 		},
 		"textdomain": "jetpack-stats"
 	},

--- a/projects/packages/stats/src/class-wpcom-stats.php
+++ b/projects/packages/stats/src/class-wpcom-stats.php
@@ -26,7 +26,7 @@ class WPCOM_Stats {
 	 *
 	 * @var string
 	 */
-	const STATS_CACHE_TRANSIENT_PREFIX = 'jetpack_restapi_cached_stats_';
+	const STATS_CACHE_TRANSIENT_PREFIX = 'jetpack_restapi_stats_cache_';
 
 	/**
 	 * Time, in minutes, to cache stats results from the REST API.
@@ -339,12 +339,8 @@ class WPCOM_Stats {
 
 		$wpcom_stats = $this->fetch_remote_stats( $endpoint, $args );
 
-		if ( is_wp_error( $wpcom_stats ) ) {
-			return $wpcom_stats;
-		}
-
 		// To reduce size in storage: store with time as key, store JSON encoded data.
-		$cached_value = wp_json_encode( $wpcom_stats );
+		$cached_value = is_wp_error( $wpcom_stats ) ? $wpcom_stats : wp_json_encode( $wpcom_stats );
 		$expiration   = self::STATS_CACHE_EXPIRATION_IN_MINUTES * MINUTE_IN_SECONDS;
 		set_transient( $transient_name, array( time() => $cached_value ), $expiration );
 

--- a/projects/packages/stats/src/class-wpcom-stats.php
+++ b/projects/packages/stats/src/class-wpcom-stats.php
@@ -332,7 +332,11 @@ class WPCOM_Stats {
 
 		if ( $stats_cache ) {
 			$time = key( $stats_cache );
-			$data = $stats_cache[ $time ]; // JSON encoded data.
+			$data = $stats_cache[ $time ]; // WP_Error or string (JSON encoded object).
+
+			if ( is_wp_error( $data ) ) {
+				return $data;
+			}
 
 			return array_merge( array( 'cached_at' => $time ), (array) json_decode( $data, true ) );
 		}

--- a/projects/packages/stats/tests/php/test-wpcom-stats.php
+++ b/projects/packages/stats/tests/php/test-wpcom-stats.php
@@ -600,6 +600,24 @@ class Test_WPCOM_Stats extends StatsBaseTestCase {
 	}
 
 	/**
+	 * Test get_stats with cached error.
+	 */
+	public function test_get_stats_with_cached_error() {
+		$expected_error = new WP_Error( 'dummy' );
+
+		$this->wpcom_stats
+			->expects( $this->once() )
+			->method( 'fetch_remote_stats' )
+			->willReturn( $expected_error );
+
+		$this->wpcom_stats->get_stats();
+
+		$stats = $this->wpcom_stats->get_stats();
+		$this->assertSame( $expected_error, $stats );
+		$this->assertSame( $expected_error, self::get_stats_transient( '/sites/1234/stats/' ) );
+	}
+
+	/**
 	 * Test get_stats with error.
 	 */
 	public function test_get_stats_with_error() {

--- a/projects/packages/stats/tests/php/test-wpcom-stats.php
+++ b/projects/packages/stats/tests/php/test-wpcom-stats.php
@@ -612,7 +612,7 @@ class Test_WPCOM_Stats extends StatsBaseTestCase {
 
 		$stats = $this->wpcom_stats->get_stats();
 		$this->assertSame( $expected_error, $stats );
-		$this->assertFalse( self::get_stats_transient( '/sites/1234/stats/' ) );
+		$this->assertSame( $expected_error, self::get_stats_transient( '/sites/1234/stats/' ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-cache-error-when-fetching-stats-and-revert-cache-key
+++ b/projects/plugins/jetpack/changelog/update-cache-error-when-fetching-stats-and-revert-cache-key
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -39,7 +39,7 @@
 		"automattic/jetpack-redirect": "1.7.x-dev",
 		"automattic/jetpack-roles": "1.4.x-dev",
 		"automattic/jetpack-search": "0.29.x-dev",
-		"automattic/jetpack-stats": "0.2.x-dev",
+		"automattic/jetpack-stats": "0.3.x-dev",
 		"automattic/jetpack-status": "1.14.x-dev",
 		"automattic/jetpack-sync": "1.40.x-dev",
 		"automattic/jetpack-videopress": "0.6.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d954978e5bebc7b1f0ff10170d072bed",
+    "content-hash": "e924d64476fd670af37dc41fe25c90d9",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1833,7 +1833,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats",
-                "reference": "d24b02912091655053d60afac4c2220ccc2b4669"
+                "reference": "0732fd866630adb288a5883afe6133199fd9e7ba"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.45",
@@ -1853,7 +1853,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-stats/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.2.x-dev"
+                    "dev-trunk": "0.3.x-dev"
                 },
                 "textdomain": "jetpack-stats"
             },

--- a/projects/plugins/search/changelog/update-cache-error-when-fetching-stats-and-revert-cache-key
+++ b/projects/plugins/search/changelog/update-cache-error-when-fetching-stats-and-revert-cache-key
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -11,7 +11,7 @@
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
 		"automattic/jetpack-my-jetpack": "2.3.x-dev",
 		"automattic/jetpack-search": "0.29.x-dev",
-		"automattic/jetpack-stats": "0.2.x-dev",
+		"automattic/jetpack-stats": "0.3.x-dev",
 		"automattic/jetpack-status": "1.14.x-dev",
 		"automattic/jetpack-sync": "1.40.x-dev",
 		"automattic/jetpack-plugins-installer": "0.2.x-dev"

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "05f1b5692769ae10e1f69580a1ec8dd9",
+    "content-hash": "c4de47e8fd97891ab53934b2bf6c75d1",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1179,7 +1179,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats",
-                "reference": "d24b02912091655053d60afac4c2220ccc2b4669"
+                "reference": "0732fd866630adb288a5883afe6133199fd9e7ba"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.45",
@@ -1199,7 +1199,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-stats/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.2.x-dev"
+                    "dev-trunk": "0.3.x-dev"
                 },
                 "textdomain": "jetpack-stats"
             },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Related to #26530 and #26719 


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Errors are now cached when fetching stats
* Cache prefix has been reverted to the previous one

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-63f-p2
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This is a change in the package. There are 4 places at the moment that will go through the changes.

Create a JN and test the different scenarios **first on JP 11.5-a.3 (to cache responses) and then switch to the PR's branch**. Nothing should change.

1. `get_stats_data` in `class.jetpack-core-api-module-endpoints.php`: This gets triggered when navigating to the Jetpack dashboard in wp-admin. (`/wp-admin/admin.php?page=jetpack#/dashboard`) Make sure stats for Day, Month and week are working fine.
![image](https://user-images.githubusercontent.com/13239096/195426540-63e2f982-c7b8-4044-96ef-4e538fe6bb48.png)

2. `get_benefits` in `class.jetpack-core-api-site-endpoints.php`. This gets triggered when navigating to the Jetpack dashboard in wp-admin as well. (`/wp-admin/admin.php?page=jetpack#/dashboard`) But have not been able to see where the information is being used in the UI. 

The two remaining tests are related to widgets so prior to testing, it is needed to:
- In in Jetpack settings -> Writing; Activate Make extra widgets available for use on your site including subscription forms and Twitter streams 
- Go to Appearance > Widgets and add the corresponding widget ("Top Posts & Pages" Widget and "Blog Stats" Widget)

3. `get_stats` in `widgets/blog-stats.php`. Navigate to a post and check that the widget information is displaying the information.
4. `get_by_views` in `widgets/top-posts.php`. Navigate to a post and check that the widget information is displaying the information.
 

