### PR TITLE
jetpack: Add DB query caching in sharedaddy module

### DIFF
--- a/projects/plugins/jetpack/changelog/add-sharedaddy-db-query-caching
+++ b/projects/plugins/jetpack/changelog/add-sharedaddy-db-query-caching
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sharing: Add caching for DB queries.

--- a/tools/phpcs-excludelist.json
+++ b/tools/phpcs-excludelist.json
@@ -46,7 +46,6 @@
 	"projects/plugins/jetpack/modules/markdown/easy-markdown.php",
 	"projects/plugins/jetpack/modules/protect.php",
 	"projects/plugins/jetpack/modules/protect/transient-cleanup.php",
-	"projects/plugins/jetpack/modules/sharedaddy/sharing-service.php",
 	"projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php",
 	"projects/plugins/jetpack/modules/sitemaps/sitemap-librarian.php",
 	"projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The DB queries can be slow in some cases.

The 5-minute expiration is arbitrary. Probably we could drop the expiration entirely once we're sure all the code inserting into this table has proper invalidation being done.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1666191802274709-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* ?