### PR TITLE
Change credentials check to use the /scan endpoint and verify the credentials array

### DIFF
--- a/projects/plugins/protect/src/class-credentials.php
+++ b/projects/plugins/protect/src/class-credentials.php
@@ -14,13 +14,13 @@ use Jetpack_Options;
 /**
  * Class that handles the rewind api call.
  */
-class Rewind {
+class Credentials {
 	/**
 	 * Get the rewind state, if no creds are set the state will be 'awaiting_for_credentials'
 	 *
 	 * @return bool
 	 */
-	public static function get_rewind_state() {
+	public static function get_credential_array() {
 		$blog_id      = Jetpack_Options::get_option( 'id' );
 		$is_connected = ( new Connection_Manager() )->is_connected();
 
@@ -28,7 +28,7 @@ class Rewind {
 			return false;
 		}
 
-		$api_url = sprintf( '/sites/%d/rewind', $blog_id );
+		$api_url = sprintf( '/sites/%d/scan', $blog_id );
 
 		$response = Client::wpcom_json_api_request_as_blog(
 			$api_url,
@@ -50,7 +50,7 @@ class Rewind {
 			return false;
 		}
 
-		return $parsed_response->state;
+		return $parsed_response->credentials ? $parsed_response->credentials : array();
 	}
 
 }

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -18,9 +18,9 @@ use Automattic\Jetpack\JITMS\JITM as JITM;
 use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
 use Automattic\Jetpack\My_Jetpack\Products as My_Jetpack_Products;
 use Automattic\Jetpack\Plugins_Installer;
+use Automattic\Jetpack\Protect\Credentials;
 use Automattic\Jetpack\Protect\Plan;
 use Automattic\Jetpack\Protect\Protect_Status;
-use Automattic\Jetpack\Protect\Rewind;
 use Automattic\Jetpack\Protect\Scan_Status;
 use Automattic\Jetpack\Protect\Site_Health;
 use Automattic\Jetpack\Protect\Status;
@@ -436,13 +436,13 @@ class Jetpack_Protect {
 	 * @return WP_REST_Response
 	 */
 	public static function api_check_credentials() {
-		$rewind_state = Rewind::get_rewind_state();
+		$credential_array = Credentials::get_credential_array();
 
-		if ( ! $rewind_state ) {
-			return new WP_REST_Response( 'An error occured while attempting to fetch the rewind state', 500 );
+		if ( ! isset( $credential_array ) ) {
+			return new WP_REST_Response( 'An error occured while attempting to fetch the credentials array', 500 );
 		}
 
-		return new WP_REST_Response( array( 'state' => $rewind_state ) );
+		return new WP_REST_Response( array( 'credentials' => $credential_array ) );
 	}
 
 	/**

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -442,7 +442,7 @@ class Jetpack_Protect {
 			return new WP_REST_Response( 'An error occured while attempting to fetch the credentials array', 500 );
 		}
 
-		return new WP_REST_Response( array( 'credentials' => $credential_array ) );
+		return new WP_REST_Response( $credential_array );
 	}
 
 	/**

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -91,21 +91,21 @@ const InterstitialPage = ( { run, hasCheckoutStarted } ) => {
 	);
 };
 
-const useCredentialState = () => {
-	const { checkCredentialsState } = useDispatch( STORE_ID );
-	const credentialState = useSelect( select => select( STORE_ID ).getCredentialState() );
+const useCredential = () => {
+	const { checkCredentials } = useDispatch( STORE_ID );
+	const Credential = useSelect( select => select( STORE_ID ).getCredential() );
 
 	useEffect( () => {
-		if ( ! credentialState.state ) {
-			checkCredentialsState();
+		if ( ! Credential.state ) {
+			checkCredentials();
 		}
-	}, [ checkCredentialsState, credentialState.state ] );
+	}, [ checkCredentials, Credential.state ] );
 };
 
 const ProtectAdminPage = () => {
 	const { lastChecked, currentStatus, errorCode, errorMessage } = useProtectData();
 	const { hasConnectionError } = useConnectionErrorNotice();
-	useCredentialState();
+	useCredential();
 
 	let currentScanStatus;
 	if ( 'error' === currentStatus ) {

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -96,7 +96,7 @@ const useCredentials = () => {
 	const credentials = useSelect( select => select( STORE_ID ).getCredentials() );
 
 	useEffect( () => {
-		if ( ! credentials ) {
+		if ( ! credentials.length ) {
 			checkCredentials();
 		}
 	}, [ checkCredentials, credentials ] );

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -91,21 +91,21 @@ const InterstitialPage = ( { run, hasCheckoutStarted } ) => {
 	);
 };
 
-const useCredential = () => {
+const useCredentials = () => {
 	const { checkCredentials } = useDispatch( STORE_ID );
-	const Credential = useSelect( select => select( STORE_ID ).getCredential() );
+	const credentials = useSelect( select => select( STORE_ID ).getCredentials() );
 
 	useEffect( () => {
-		if ( ! Credential.state ) {
+		if ( ! credentials ) {
 			checkCredentials();
 		}
-	}, [ checkCredentials, Credential.state ] );
+	}, [ checkCredentials, credentials ] );
 };
 
 const ProtectAdminPage = () => {
 	const { lastChecked, currentStatus, errorCode, errorMessage } = useProtectData();
 	const { hasConnectionError } = useConnectionErrorNotice();
-	useCredential();
+	useCredentials();
 
 	let currentScanStatus;
 	if ( 'error' === currentStatus ) {

--- a/projects/plugins/protect/src/js/components/credentials-gate/index.jsx
+++ b/projects/plugins/protect/src/js/components/credentials-gate/index.jsx
@@ -8,16 +8,16 @@ import styles from './styles.module.scss';
 const CredentialsGate = ( { children } ) => {
 	const { checkCredentials } = useDispatch( STORE_ID );
 
-	const { credential, CredentialIsFetching } = useSelect( select => ( {
-		Credential: select( STORE_ID ).getCredential(),
-		CredentialIsFetching: select( STORE_ID ).getCredentialIsFetching(),
+	const { credentials, credentialsIsFetching } = useSelect( select => ( {
+		credentials: select( STORE_ID ).getCredentials(),
+		credentialsIsFetching: select( STORE_ID ).getCredentialsIsFetching(),
 	} ) );
 
-	if ( ! credential.credentials && ! CredentialIsFetching ) {
+	if ( ! credentials && ! credentialsIsFetching ) {
 		checkCredentials();
 	}
 
-	if ( ! credential.credentials ) {
+	if ( ! credentials ) {
 		return (
 			<div className={ styles.loading }>
 				<Spinner
@@ -35,7 +35,7 @@ const CredentialsGate = ( { children } ) => {
 		);
 	}
 
-	if ( credential.credentials.length === 0 ) {
+	if ( credentials.length === 0 ) {
 		return <CredentialsNeededModal />;
 	}
 

--- a/projects/plugins/protect/src/js/components/credentials-gate/index.jsx
+++ b/projects/plugins/protect/src/js/components/credentials-gate/index.jsx
@@ -6,18 +6,18 @@ import CredentialsNeededModal from '../credentials-needed-modal';
 import styles from './styles.module.scss';
 
 const CredentialsGate = ( { children } ) => {
-	const { checkCredentialsState } = useDispatch( STORE_ID );
+	const { checkCredentials } = useDispatch( STORE_ID );
 
-	const { credentialState, credentialStateIsFetching } = useSelect( select => ( {
-		credentialState: select( STORE_ID ).getCredentialState(),
-		credentialStateIsFetching: select( STORE_ID ).getCredentialStateIsFetching(),
+	const { Credential, CredentialIsFetching } = useSelect( select => ( {
+		Credential: select( STORE_ID ).getCredential(),
+		CredentialIsFetching: select( STORE_ID ).getCredentialIsFetching(),
 	} ) );
 
-	if ( ! credentialState.state && ! credentialStateIsFetching ) {
-		checkCredentialsState();
+	if ( ! Credential.credentials && ! CredentialIsFetching ) {
+		checkCredentials();
 	}
 
-	if ( ! credentialState.state ) {
+	if ( ! Credential.credentials ) {
 		return (
 			<div className={ styles.loading }>
 				<Spinner
@@ -35,7 +35,7 @@ const CredentialsGate = ( { children } ) => {
 		);
 	}
 
-	if ( [ 'awaiting_credentials', 'unavailable' ].indexOf( credentialState.state ) >= 0 ) {
+	if ( Credential.credentials.length === 0 ) {
 		return <CredentialsNeededModal />;
 	}
 

--- a/projects/plugins/protect/src/js/components/credentials-gate/index.jsx
+++ b/projects/plugins/protect/src/js/components/credentials-gate/index.jsx
@@ -8,16 +8,16 @@ import styles from './styles.module.scss';
 const CredentialsGate = ( { children } ) => {
 	const { checkCredentials } = useDispatch( STORE_ID );
 
-	const { Credential, CredentialIsFetching } = useSelect( select => ( {
+	const { credential, CredentialIsFetching } = useSelect( select => ( {
 		Credential: select( STORE_ID ).getCredential(),
 		CredentialIsFetching: select( STORE_ID ).getCredentialIsFetching(),
 	} ) );
 
-	if ( ! Credential.credentials && ! CredentialIsFetching ) {
+	if ( ! credential.credentials && ! CredentialIsFetching ) {
 		checkCredentials();
 	}
 
-	if ( ! Credential.credentials ) {
+	if ( ! credential.credentials ) {
 		return (
 			<div className={ styles.loading }>
 				<Spinner
@@ -35,7 +35,7 @@ const CredentialsGate = ( { children } ) => {
 		);
 	}
 
-	if ( Credential.credentials.length === 0 ) {
+	if ( credential.credentials.length === 0 ) {
 		return <CredentialsNeededModal />;
 	}
 

--- a/projects/plugins/protect/src/js/components/credentials-needed-modal/index.jsx
+++ b/projects/plugins/protect/src/js/components/credentials-needed-modal/index.jsx
@@ -10,8 +10,8 @@ const CredentialsNeededModal = () => {
 	const { setModal } = useDispatch( STORE_ID );
 	const { siteSuffix } = window.jetpackProtectInitialState;
 
-	const { checkCredentialsState } = useDispatch( STORE_ID );
-	const credentialState = useSelect( select => select( STORE_ID ).getCredentialState() );
+	const { checkCredentials } = useDispatch( STORE_ID );
+	const Credential = useSelect( select => select( STORE_ID ).getCredential() );
 
 	const handleCancelClick = () => {
 		return event => {
@@ -26,15 +26,15 @@ const CredentialsNeededModal = () => {
 	useEffect( () => {
 		const interval = setInterval( () => {
 			if (
-				! credentialState.state ||
-				[ 'awaiting_credentials', 'unavailable' ].indexOf( credentialState.state ) >= 0
+				! Credential.state ||
+				[ 'awaiting_credentials', 'unavailable' ].indexOf( Credential.state ) >= 0
 			) {
-				checkCredentialsState();
+				checkCredentials();
 			}
 		}, 3000 );
 
 		return () => clearInterval( interval );
-	}, [ checkCredentialsState, credentialState.state ] );
+	}, [ checkCredentials, Credential.state ] );
 
 	return (
 		<>

--- a/projects/plugins/protect/src/js/components/credentials-needed-modal/index.jsx
+++ b/projects/plugins/protect/src/js/components/credentials-needed-modal/index.jsx
@@ -11,7 +11,7 @@ const CredentialsNeededModal = () => {
 	const { siteSuffix } = window.jetpackProtectInitialState;
 
 	const { checkCredentials } = useDispatch( STORE_ID );
-	const Credential = useSelect( select => select( STORE_ID ).getCredential() );
+	const credential = useSelect( select => select( STORE_ID ).getCredential() );
 
 	const handleCancelClick = () => {
 		return event => {
@@ -25,16 +25,13 @@ const CredentialsNeededModal = () => {
 	 */
 	useEffect( () => {
 		const interval = setInterval( () => {
-			if (
-				! Credential.state ||
-				[ 'awaiting_credentials', 'unavailable' ].indexOf( Credential.state ) >= 0
-			) {
+			if ( ! credential.credentials || credential.credentials.length === 0 ) {
 				checkCredentials();
 			}
 		}, 3000 );
 
 		return () => clearInterval( interval );
-	}, [ checkCredentials, Credential.state ] );
+	}, [ checkCredentials, credential.credentials ] );
 
 	return (
 		<>

--- a/projects/plugins/protect/src/js/components/credentials-needed-modal/index.jsx
+++ b/projects/plugins/protect/src/js/components/credentials-needed-modal/index.jsx
@@ -11,7 +11,7 @@ const CredentialsNeededModal = () => {
 	const { siteSuffix } = window.jetpackProtectInitialState;
 
 	const { checkCredentials } = useDispatch( STORE_ID );
-	const credential = useSelect( select => select( STORE_ID ).getCredential() );
+	const credentials = useSelect( select => select( STORE_ID ).getCredentials() );
 
 	const handleCancelClick = () => {
 		return event => {
@@ -25,13 +25,13 @@ const CredentialsNeededModal = () => {
 	 */
 	useEffect( () => {
 		const interval = setInterval( () => {
-			if ( ! credential.credentials || credential.credentials.length === 0 ) {
+			if ( ! credentials || credentials.length === 0 ) {
 				checkCredentials();
 			}
 		}, 3000 );
 
 		return () => clearInterval( interval );
-	}, [ checkCredentials, credential.credentials ] );
+	}, [ checkCredentials, credentials ] );
 
 	return (
 		<>

--- a/projects/plugins/protect/src/js/hooks/use-protect-data/index.js
+++ b/projects/plugins/protect/src/js/hooks/use-protect-data/index.js
@@ -7,15 +7,12 @@ import { STORE_ID } from '../../state/store';
  * @returns {object} The information available in Protect's initial state.
  */
 export default function useProtectData() {
-	const { statusIsFetching, status, jetpackScan, productData, Credential } = useSelect(
-		select => ( {
-			statusIsFetching: select( STORE_ID ).getStatusIsFetching(),
-			status: select( STORE_ID ).getStatus(),
-			jetpackScan: select( STORE_ID ).getJetpackScan(),
-			productData: select( STORE_ID ).getProductData(),
-			Credential: select( STORE_ID ).getCredential(),
-		} )
-	);
+	const { statusIsFetching, status, jetpackScan, productData } = useSelect( select => ( {
+		statusIsFetching: select( STORE_ID ).getStatusIsFetching(),
+		status: select( STORE_ID ).getStatus(),
+		jetpackScan: select( STORE_ID ).getJetpackScan(),
+		productData: select( STORE_ID ).getProductData(),
+	} ) );
 
 	let currentStatus = 'error';
 	if ( true === statusIsFetching ) {
@@ -43,6 +40,5 @@ export default function useProtectData() {
 		hasUncheckedItems: status.hasUncheckedItems,
 		jetpackScan,
 		productData,
-		Credential,
 	};
 }

--- a/projects/plugins/protect/src/js/hooks/use-protect-data/index.js
+++ b/projects/plugins/protect/src/js/hooks/use-protect-data/index.js
@@ -7,13 +7,13 @@ import { STORE_ID } from '../../state/store';
  * @returns {object} The information available in Protect's initial state.
  */
 export default function useProtectData() {
-	const { statusIsFetching, status, jetpackScan, productData, credentialState } = useSelect(
+	const { statusIsFetching, status, jetpackScan, productData, Credential } = useSelect(
 		select => ( {
 			statusIsFetching: select( STORE_ID ).getStatusIsFetching(),
 			status: select( STORE_ID ).getStatus(),
 			jetpackScan: select( STORE_ID ).getJetpackScan(),
 			productData: select( STORE_ID ).getProductData(),
-			credentialState: select( STORE_ID ).getCredentialState(),
+			Credential: select( STORE_ID ).getCredential(),
 		} )
 	);
 
@@ -43,6 +43,6 @@ export default function useProtectData() {
 		hasUncheckedItems: status.hasUncheckedItems,
 		jetpackScan,
 		productData,
-		credentialState,
+		Credential,
 	};
 }

--- a/projects/plugins/protect/src/js/state/actions.js
+++ b/projects/plugins/protect/src/js/state/actions.js
@@ -2,8 +2,8 @@ import apiFetch from '@wordpress/api-fetch';
 import { sprintf, __ } from '@wordpress/i18n';
 import camelize from 'camelize';
 
-const SET_CREDENTIAL_STATE_IS_FETCHING = 'SET_CREDENTIAL_STATE_IS_FETCHING';
-const SET_CREDENTIAL_STATE = 'SET_CREDENTIAL_STATE';
+const SET_CREDENTIALS_STATE_IS_FETCHING = 'SET_CREDENTIALS_STATE_IS_FETCHING';
+const SET_CREDENTIALS_STATE = 'SET_CREDENTIALS_STATE';
 const SET_STATUS = 'SET_STATUS';
 const SET_STATUS_IS_FETCHING = 'SET_STATUS_IS_FETCHING';
 const SET_SCAN_IS_ENQUEUING = 'SET_SCAN_IS_ENQUEUING';
@@ -71,30 +71,30 @@ const refreshStatusUntilScanning = () => async ( { dispatch } ) => {
  */
 const checkCredentials = () => async ( { dispatch } ) => {
 	return await new Promise( ( resolve, reject ) => {
-		dispatch( setCredentialIsFetching( true ) );
+		dispatch( setCredentialsIsFetching( true ) );
 		return apiFetch( {
 			path: 'jetpack-protect/v1/check-credentials',
 			method: 'POST',
 		} )
 			.then( credentials => {
-				dispatch( setCredential( credentials ) );
+				dispatch( setCredentials( credentials ) );
 				resolve( credentials );
 			} )
 			.catch( error => {
 				reject( error );
 			} )
 			.finally( () => {
-				dispatch( setCredentialIsFetching( false ) );
+				dispatch( setCredentialsIsFetching( false ) );
 			} );
 	} );
 };
 
-const setCredentialIsFetching = isFetching => {
-	return { type: SET_CREDENTIAL_STATE_IS_FETCHING, isFetching };
+const setCredentialsIsFetching = isFetching => {
+	return { type: SET_CREDENTIALS_STATE_IS_FETCHING, isFetching };
 };
 
-const setCredential = Credential => {
-	return { type: SET_CREDENTIAL_STATE, Credential };
+const setCredentials = credentials => {
+	return { type: SET_CREDENTIALS_STATE, credentials };
 };
 
 const setStatusIsFetching = status => {
@@ -316,8 +316,8 @@ const setNotice = notice => {
 
 const actions = {
 	checkCredentials,
-	setCredential,
-	setCredentialIsFetching,
+	setCredentials,
+	setCredentialsIsFetching,
 	setStatus,
 	refreshStatus,
 	setStatusIsFetching,
@@ -336,8 +336,8 @@ const actions = {
 };
 
 export {
-	SET_CREDENTIAL_STATE,
-	SET_CREDENTIAL_STATE_IS_FETCHING,
+	SET_CREDENTIALS_STATE,
+	SET_CREDENTIALS_STATE_IS_FETCHING,
 	SET_STATUS,
 	SET_STATUS_IS_FETCHING,
 	SET_SCAN_IS_ENQUEUING,

--- a/projects/plugins/protect/src/js/state/actions.js
+++ b/projects/plugins/protect/src/js/state/actions.js
@@ -69,32 +69,32 @@ const refreshStatusUntilScanning = () => async ( { dispatch } ) => {
  *
  * @returns {Promise} - Promise which resolves when the status is refreshed from an API fetch.
  */
-const checkCredentialsState = () => async ( { dispatch } ) => {
+const checkCredentials = () => async ( { dispatch } ) => {
 	return await new Promise( ( resolve, reject ) => {
-		dispatch( setCredentialStateIsFetching( true ) );
+		dispatch( setCredentialIsFetching( true ) );
 		return apiFetch( {
 			path: 'jetpack-protect/v1/check-credentials',
 			method: 'POST',
 		} )
-			.then( state => {
-				dispatch( setCredentialState( state ) );
-				resolve( state );
+			.then( credentials => {
+				dispatch( setCredential( credentials ) );
+				resolve( credentials );
 			} )
 			.catch( error => {
 				reject( error );
 			} )
 			.finally( () => {
-				dispatch( setCredentialStateIsFetching( false ) );
+				dispatch( setCredentialIsFetching( false ) );
 			} );
 	} );
 };
 
-const setCredentialStateIsFetching = isFetching => {
+const setCredentialIsFetching = isFetching => {
 	return { type: SET_CREDENTIAL_STATE_IS_FETCHING, isFetching };
 };
 
-const setCredentialState = credentialState => {
-	return { type: SET_CREDENTIAL_STATE, credentialState };
+const setCredential = Credential => {
+	return { type: SET_CREDENTIAL_STATE, Credential };
 };
 
 const setStatusIsFetching = status => {
@@ -315,9 +315,9 @@ const setNotice = notice => {
 };
 
 const actions = {
-	checkCredentialsState,
-	setCredentialState,
-	setCredentialStateIsFetching,
+	checkCredentials,
+	setCredential,
+	setCredentialIsFetching,
 	setStatus,
 	refreshStatus,
 	setStatusIsFetching,

--- a/projects/plugins/protect/src/js/state/reducers.js
+++ b/projects/plugins/protect/src/js/state/reducers.js
@@ -15,15 +15,15 @@ import {
 	SET_THREATS_ARE_FIXING,
 } from './actions';
 
-const credentialState = ( state = {}, action ) => {
+const Credential = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case SET_CREDENTIAL_STATE:
-			return action.credentialState;
+			return action.Credential;
 	}
 	return state;
 };
 
-const credentialStateIsFetching = ( state = false, action ) => {
+const CredentialIsFetching = ( state = false, action ) => {
 	switch ( action.type ) {
 		case SET_CREDENTIAL_STATE_IS_FETCHING:
 			return action.isFetching;
@@ -128,8 +128,8 @@ const notice = ( state = {}, action ) => {
 };
 
 const reducers = combineReducers( {
-	credentialState,
-	credentialStateIsFetching,
+	Credential,
+	CredentialIsFetching,
 	status,
 	statusIsFetching,
 	scanIsEnqueuing,

--- a/projects/plugins/protect/src/js/state/reducers.js
+++ b/projects/plugins/protect/src/js/state/reducers.js
@@ -1,7 +1,7 @@
 import { combineReducers } from '@wordpress/data';
 import {
-	SET_CREDENTIAL_STATE,
-	SET_CREDENTIAL_STATE_IS_FETCHING,
+	SET_CREDENTIALS_STATE,
+	SET_CREDENTIALS_STATE_IS_FETCHING,
 	SET_STATUS,
 	SET_STATUS_IS_FETCHING,
 	SET_SCAN_IS_ENQUEUING,
@@ -15,17 +15,17 @@ import {
 	SET_THREATS_ARE_FIXING,
 } from './actions';
 
-const Credential = ( state = {}, action ) => {
+const credentials = ( state = [], action ) => {
 	switch ( action.type ) {
-		case SET_CREDENTIAL_STATE:
-			return action.Credential;
+		case SET_CREDENTIALS_STATE:
+			return action.credentials;
 	}
 	return state;
 };
 
-const CredentialIsFetching = ( state = false, action ) => {
+const credentialsIsFetching = ( state = false, action ) => {
 	switch ( action.type ) {
-		case SET_CREDENTIAL_STATE_IS_FETCHING:
+		case SET_CREDENTIALS_STATE_IS_FETCHING:
 			return action.isFetching;
 	}
 	return state;
@@ -128,8 +128,8 @@ const notice = ( state = {}, action ) => {
 };
 
 const reducers = combineReducers( {
-	Credential,
-	CredentialIsFetching,
+	credentials,
+	credentialsIsFetching,
 	status,
 	statusIsFetching,
 	scanIsEnqueuing,

--- a/projects/plugins/protect/src/js/state/selectors.js
+++ b/projects/plugins/protect/src/js/state/selectors.js
@@ -1,6 +1,6 @@
 const selectors = {
-	getCredential: state => state.Credential || {},
-	getCredentialIsFetching: state => state.CredentialIsFetching || false,
+	getCredentials: state => state.credentials || [],
+	getCredentialsIsFetching: state => state.credentialsIsFetching || false,
 	getInstalledPlugins: state => state.installedPlugins || {},
 	getInstalledThemes: state => state.installedThemes || {},
 	getStatus: state => state.status || {},

--- a/projects/plugins/protect/src/js/state/selectors.js
+++ b/projects/plugins/protect/src/js/state/selectors.js
@@ -1,6 +1,6 @@
 const selectors = {
-	getCredentialState: state => state.credentialState || {},
-	getCredentialStateIsFetching: state => state.credentialStateIsFetching || false,
+	getCredential: state => state.Credential || {},
+	getCredentialIsFetching: state => state.CredentialIsFetching || false,
 	getInstalledPlugins: state => state.installedPlugins || {},
 	getInstalledThemes: state => state.installedThemes || {},
 	getStatus: state => state.status || {},


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes the issue where we were only properly verifying credentials for sites with the security bundle.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* We changed the way we determine if the site has credentials, now we use the /scan endpoint instead of the /rewind endpoint and check the length of the credentials array.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create test sites with Scan 
* Use this branch of Protect
* Verify that the credentials check is working and that adding credentials makes the modal go away

