### PR TITLE
Update jetpack-search team name to red

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,11 +4,9 @@
 ############################################
 
 # Packages
-/projects/packages/search @Automattic/jetpack-search
 /projects/packages/search/src/wpes @Automattic/prometheus
 
 # Plugins
-/projects/plugins/search @Automattic/jetpack-search
 
 # Other bits of the Codebase
 /projects/plugins/jetpack/_inc/lib/debugger/ @kraftbj

--- a/.github/files/required-review.yaml
+++ b/.github/files/required-review.yaml
@@ -79,7 +79,7 @@
    - jetpack-approvers
    - '@donnchawp'
 
-# The Search team reviews changes to the Search plugin, and the Search package.
+# The Red team reviews changes to the Search plugin, and the Search package.
 - name: Search
   paths:
    - 'projects/plugins/search/**'

--- a/.github/files/required-review.yaml
+++ b/.github/files/required-review.yaml
@@ -19,8 +19,8 @@
    - jetpack-approvers
    - yamato-backup-and-security
    - heart-of-gold
-   - jetpack-search
    - jetpack-reach
+   - red
 
 # Jetpack Approvers review the Jetpack plugin and all packages, except for those with specific team ownership.
 - name: Jetpack and packages
@@ -88,7 +88,7 @@
    - '!projects/plugins/*/composer.json'
    - '!projects/plugins/*/changelog/*'
   teams:
-   - jetpack-search
+   - red
    - jetpack-approvers
 
 # The Reach team reviews changes to the Social plugin, and the Publicize package.


### PR DESCRIPTION
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
"Jetpack Search" is now "Red" team, this PR updates the approvers list to match the new team name.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pLwCt-bvy-p2
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* proof it
*