### PR TITLE
Search: Hide toggles for showing the Jetpack logo on free plans

### DIFF
--- a/projects/packages/search/changelog/disable-powered-by-jetpack-option-for-free-plans
+++ b/projects/packages/search/changelog/disable-powered-by-jetpack-option-for-free-plans
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Hide Jetpack logo toggle, enforce display for free plans

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.29.0",
+	"version": "0.29.1-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.29.0';
+	const VERSION = '0.29.1-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/customberg/class-customberg.php
+++ b/projects/packages/search/src/customberg/class-customberg.php
@@ -44,6 +44,8 @@ class Customberg {
 	 */
 	public function init_hooks() {
 		add_action( 'admin_menu', array( $this, 'add_wp_admin_page' ), 999 );
+		add_action( 'pre_option_jetpack_search_show_powered_by', array( $this, 'get_show_powered_by' ) );
+		$this->plan = new Plan();
 	}
 
 	/**
@@ -66,6 +68,18 @@ class Customberg {
 
 		add_action( "admin_print_scripts-$hook", array( $this, 'load_assets' ) );
 		add_action( 'admin_footer', array( 'Automattic\Jetpack\Search\Helper', 'print_instant_search_sidebar' ) );
+	}
+
+	/**
+	 * Force option value to be true if in free plan.
+	 *
+	 * @param string $value The incoming value to be replaced.
+	 */
+	public function get_show_powered_by( $value ) {
+		if ( $this->plan->is_free_plan() ) {
+			return true;
+		}
+		return $value;
 	}
 
 	/**

--- a/projects/packages/search/src/customberg/class-customberg.php
+++ b/projects/packages/search/src/customberg/class-customberg.php
@@ -44,7 +44,7 @@ class Customberg {
 	 */
 	public function init_hooks() {
 		add_action( 'admin_menu', array( $this, 'add_wp_admin_page' ), 999 );
-		add_action( 'pre_option_jetpack_search_show_powered_by', array( $this, 'get_show_powered_by' ) );
+		add_filter( 'pre_option_jetpack_search_show_powered_by', array( $this, 'get_show_powered_by' ) );
 		$this->plan = new Plan();
 	}
 

--- a/projects/packages/search/src/customberg/components/sidebar/sidebar-options.jsx
+++ b/projects/packages/search/src/customberg/components/sidebar/sidebar-options.jsx
@@ -10,9 +10,12 @@ import classNames from 'classnames';
 import useEntityRecordState from 'hooks/use-entity-record-state';
 import useSiteLoadingState from 'hooks/use-loading-state';
 import useSearchOptions from 'hooks/use-search-options';
+import { SERVER_OBJECT_NAME } from 'instant-search/lib/constants';
 import ColorControl from './color-control';
 import ExcludedPostTypesControl from './excluded-post-types-control';
 import ThemeControl from './theme-control';
+
+const { isFreePlan = false } = window[ SERVER_OBJECT_NAME ];
 
 /* eslint-disable react/jsx-no-bind */
 
@@ -128,13 +131,15 @@ export default function SidebarOptions() {
 					label={ __( 'Enable infinite scroll', 'jetpack-search-pkg' ) }
 					onChange={ setInfiniteScroll }
 				/>
-				<ToggleControl
-					className="jp-search-configure-show-logo-toggle"
-					checked={ showLogo }
-					disabled={ isDisabled }
-					label={ __( 'Show "Powered by Jetpack"', 'jetpack-search-pkg' ) }
-					onChange={ setShowLogo }
-				/>
+				{ ! isFreePlan && (
+					<ToggleControl
+						className="jp-search-configure-show-logo-toggle"
+						checked={ showLogo }
+						disabled={ isDisabled }
+						label={ __( 'Show "Powered by Jetpack"', 'jetpack-search-pkg' ) }
+						onChange={ setShowLogo }
+					/>
+				) }
 			</PanelBody>
 		</Panel>
 	);

--- a/projects/packages/search/src/customizer/class-customizer.php
+++ b/projects/packages/search/src/customizer/class-customizer.php
@@ -21,6 +21,7 @@ class Customizer {
 	public function __construct() {
 		add_action( 'customize_register', array( $this, 'customize_register' ) );
 		add_action( 'customize_controls_enqueue_scripts', array( $this, 'customize_controls_enqueue_scripts' ) );
+		$this->plan = new Plan();
 	}
 
 	/**
@@ -242,14 +243,17 @@ class Customizer {
 				'type'                 => 'option',
 			)
 		);
-		$wp_customize->add_control(
-			$id,
-			array(
-				'type'    => 'checkbox',
-				'section' => $section_id,
-				'label'   => __( 'Display "Powered by Jetpack"', 'jetpack-search-pkg' ),
-			)
-		);
+
+		if ( ! $this->plan->is_free_plan() ) {
+			$wp_customize->add_control(
+				$id,
+				array(
+					'type'    => 'checkbox',
+					'section' => $section_id,
+					'label'   => __( 'Display "Powered by Jetpack"', 'jetpack-search-pkg' ),
+				)
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26901.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Hides the toggle for showing the Jetpack logo in the Customizer.
* Hides the toggle for showing the Jetpack logo in Customberg.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See parent issue and panfyZ-1pv-p2#comment-3096.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this change to your site with a free Jetpack Search subscription.
* Ensure that you can't see the toggle within the Customizer (`/wp-admin/customize.php`).
* Ensure that you can't see the toggle within Customberg (`/wp-admin/admin.php?page=jetpack-search-configure`).

