### PR TITLE
Search: Update colophon link

### DIFF
--- a/projects/packages/search/changelog/fix-jetpack-search-colophon-upgrade-link
+++ b/projects/packages/search/changelog/fix-jetpack-search-colophon-upgrade-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Tweak colophon link to Search upgrade page

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.29.0",
+	"version": "0.29.1-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.29.0';
+	const VERSION = '0.29.1-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/instant-search/components/jetpack-colophon.jsx
+++ b/projects/packages/search/src/instant-search/components/jetpack-colophon.jsx
@@ -45,8 +45,8 @@ const JetpackColophon = props => {
 	const locale_prefix = typeof props.locale === 'string' ? props.locale.split( '-', 1 )[ 0 ] : null;
 	const url =
 		locale_prefix && locale_prefix !== 'en'
-			? 'https://' + locale_prefix + '.jetpack.com/support/search?utm_source=poweredby'
-			: 'https://jetpack.com/support/search/?utm_source=poweredby';
+			? 'https://' + locale_prefix + '.jetpack.com/upgrade/search?utm_source=poweredby'
+			: 'https://jetpack.com/upgrade/search/?utm_source=poweredby';
 	return (
 		<div className="jetpack-instant-search__jetpack-colophon">
 			<a
@@ -57,7 +57,7 @@ const JetpackColophon = props => {
 			>
 				{ svg }
 				<span className="jetpack-instant-search__jetpack-colophon-text">
-					{ __( 'Search powered by Jetpack Search', 'jetpack-search-pkg' ) }
+					{ __( 'Search powered by Jetpack', 'jetpack-search-pkg' ) }
 				</span>
 			</a>
 		</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26897.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The colophon link at the bottom of the Instant Search interface now links to the upgrade page instead of the support page.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See parent issue and panfyZ-1pv-p2#comment-3096.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this change to your site with a Jetpack Search subscription.
* Ensure you've enabled the Jetpack colophon display in Customberg or the Customizer.
* Summon the instant search interface and click the colophon at the bottom.
* Ensure it links to the search upgrade page.

