### PR TITLE
Search: Hide post-purchase tooltips for free plan activation

### DIFF
--- a/projects/packages/search/changelog/fix-jetpack-search-tooltips-for-free-plan
+++ b/projects/packages/search/changelog/fix-jetpack-search-tooltips-for-free-plan
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: Hide post-purchase tooltips for free plan activation

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page.jsx
@@ -68,7 +68,7 @@ export default function UpsellPage( { isLoading = false } ) {
 		hasCheckoutStarted: hasCheckoutStartedFree,
 	} = useProductCheckoutWorkflow( {
 		productSlug: 'jetpack_search_free',
-		redirectUrl: `${ adminUrl }admin.php?page=jetpack-search&just_upgraded=1`,
+		redirectUrl: `${ adminUrl }admin.php?page=jetpack-search`,
 		siteProductAvailabilityHandler: checkSiteHasSearchProduct,
 		from: 'jetpack-search',
 		siteSuffix: domain,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26935.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Hides post-purchase tooltips for free plan activation.

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See parent issue and panfyZ-1pv-p2#comment-3096.


#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this change to your site without a free Jetpack Search plan.
(Alternatively, use a site with a free Jetpack Search plan, but execute `delete localStorage.upgrade_tooltip_finished` in your browser's console.)
* Purchase a free Search plan.
(Or navigate directly to `/wp-admin/admin.php?page=jetpack-search&just_upgraded=1` and ensure you've executed the localStorage value deletion above.)
* Ensure that you're not shown any post-purchase tooltips.

