### PR TITLE
Connection: auto-remove connection owner if their user token is missing

### DIFF
--- a/projects/packages/connection/changelog/fix-auto-cleanup-master-user
+++ b/projects/packages/connection/changelog/fix-auto-cleanup-master-user
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Remove connection owner if their user token is missing.

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -15,6 +15,7 @@ use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
 use Jetpack_IXR_Client;
+use Jetpack_Options;
 use WP_Error;
 use WP_User;
 
@@ -760,6 +761,12 @@ class Manager {
 
 		// Make sure user is connected.
 		$user_token = $this->get_tokens()->get_access_token( $user_id );
+
+		// The token is missing, remove `master_user`.
+		if ( ! $user_token ) {
+			Jetpack_Options::delete_option( 'master_user' );
+			return false;
+		}
 
 		$connection_owner = false;
 

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.45.4';
+	const PACKAGE_VERSION = '1.45.5-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Sometimes a site may get into situation where the `master_user` option is still in place, but corresponding user token is missing.
This PR introduces auto-cleanup, so if user token for the connection owner is missing, Jetpack switches into "site-only" mode to continue functioning properly.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
1666278382810049-slack-C02NENKA4GN

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Fully connect Jetpack. Log in as a secondary user and connect them too.
2. Go to "Broken Token" and remove the connection owner's user token.
3. Connection owner ID should also get removed. The secondary user's token should get preserved.