### PR TITLE
Add tracks events for purchasing items in wp-admin

### DIFF
--- a/projects/js-packages/connection/changelog/add-jetpack-search-add-tracks-events
+++ b/projects/js-packages/connection/changelog/add-jetpack-search-add-tracks-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added Tracks Events for making purchases from within wp-admin

--- a/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
+++ b/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
@@ -1,6 +1,7 @@
+import analytics from '@automattic/jetpack-analytics';
 import restApi from '@automattic/jetpack-api';
 import { getProductCheckoutUrl } from '@automattic/jetpack-components';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, select as syncSelect } from '@wordpress/data';
 import { useEffect, useState } from 'react';
 import useConnection from '../../components/use-connection';
 import { STORE_ID } from '../../state/store.jsx';
@@ -39,6 +40,17 @@ export default function useProductCheckoutWorkflow( {
 		from,
 	} );
 
+	const initializeAnalytics = () => {
+		const tracksUser = syncSelect( STORE_ID ).getWpcomUser();
+		const blogId = syncSelect( STORE_ID ).getBlogId();
+
+		if ( tracksUser ) {
+			analytics.initialize( tracksUser.ID, tracksUser.login, {
+				blog_id: blogId,
+			} );
+		}
+	};
+
 	// Build the checkout URL.
 	const checkoutProductUrl = getProductCheckoutUrl(
 		productSlug,
@@ -67,6 +79,8 @@ export default function useProductCheckoutWorkflow( {
 	const run = event => {
 		event && event.preventDefault();
 		setCheckoutStarted( true );
+		initializeAnalytics();
+		analytics.tracks.recordEvent( productSlug + '_purchase_button_click', {} );
 
 		if ( isRegistered ) {
 			return handleAfterRegistration();

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.22.4",
+	"version": "0.22.5-alpha",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/packages/search/changelog/add-jetpack-search-add-tracks-events
+++ b/projects/packages/search/changelog/add-jetpack-search-add-tracks-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added Tracks Events for making purchases from within wp-admin


### PR DESCRIPTION
We would like to keep track of purchases from wp-admin.


#### Changes proposed in this Pull Request:
This adds a tracking event for Jetpack Search, as well as other plugins which use the `useProductCheckoutWorkflow` method, including Protect and VideoPress. 

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
Yes, this adds tracking for clicking on buttons to purchase products such as VideoPress, Search, and Protect. 
It does not add any additional cookies.

<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
To test, install the Jetpack Search plugin and navigate to the search dashboard. 
Open the Network tab in the browser debugger and search for t.gif. Make sure to select the option to persist logs
Click on either the free or the paid option. 
You should see a t.gif request - see screenshots
<img width="1132" alt="Bildschirmfoto 2022-10-20 um 17 03 20" src="https://user-images.githubusercontent.com/19924/197007039-cbe7d2bf-9120-4298-9660-c8a6b2a07e0d.png">
<img width="1127" alt="Bildschirmfoto 2022-10-20 um 18 03 36" src="https://user-images.githubusercontent.com/19924/197007047-2150e196-bb5f-4fb8-bff5-1e5bace9a360.png">


* Go to '..'
*

