### PR TITLE
Connection: Check if user is connected before attempting to initialize analytics with a user in useProductCheckoutWorkflow hook

### DIFF
--- a/projects/js-packages/connection/changelog/fix-tracking-without-wpcom-user
+++ b/projects/js-packages/connection/changelog/fix-tracking-without-wpcom-user
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix to an unreleased bug
+
+

--- a/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
+++ b/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
@@ -79,7 +79,7 @@ export default function useProductCheckoutWorkflow( {
 	const run = event => {
 		event && event.preventDefault();
 		setCheckoutStarted( true );
-		initializeAnalytics();
+		isUserConnected && initializeAnalytics();
 		analytics.tracks.recordEvent( productSlug + '_purchase_button_click', {} );
 
 		if ( isRegistered ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes bug introduced in https://github.com/Automattic/jetpack/pull/26964

![image](https://user-images.githubusercontent.com/746152/197072573-2e62ec01-f98c-4e47-b0b4-f0863f4c565f.png)



#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Checks for connection before initializing JS analytics library

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion


#### Does this pull request change what data or activity we track or use?

Yes and no. It fixes something in one analytics hook.

#### Testing instructions:

* Go to '..'
*

