### PR TITLE
VideoPress: handle show admin or pricing based on a local state

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-keep-pricing-table-when-redirecting
+++ b/projects/packages/videopress/changelog/update-videopress-keep-pricing-table-when-redirecting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: handle show admin or pricing based on a local state

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -99,7 +99,7 @@ const Admin = () => {
 	const { hasConnectionError } = useConnectionErrorNotice();
 
 	const [ isSm ] = useBreakpointMatch( 'sm' );
-	const showConnectionCard = ! isRegistered || siteIsRegistering || userIsConnecting;
+	const showPricingSection = ! isRegistered || siteIsRegistering || userIsConnecting;
 
 	const addNewLabel = __( 'Add new video', 'jetpack-videopress-pkg' );
 	const addFirstLabel = __( 'Add your first video', 'jetpack-videopress-pkg' );
@@ -112,7 +112,7 @@ const Admin = () => {
 			moduleName={ __( 'Jetpack VideoPress', 'jetpack-videopress-pkg' ) }
 			header={ <Logo /> }
 		>
-			{ showConnectionCard ? (
+			{ showPricingSection ? (
 				<AdminSectionHero>
 					<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 						<Col sm={ 4 } md={ 8 } lg={ 12 }>

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -22,6 +22,7 @@ import { FormFileUpload } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
+import { useState } from 'react';
 /**
  * Internal dependencies
  */
@@ -95,11 +96,12 @@ const Admin = () => {
 
 	const { hasVideoPressPurchase } = usePlan();
 
-	const { isRegistered, siteIsRegistering, userIsConnecting } = useConnection();
+	const { isRegistered } = useConnection();
 	const { hasConnectionError } = useConnectionErrorNotice();
 
+	const [ showPricingSection, setShowPricingSection ] = useState( ! isRegistered );
+
 	const [ isSm ] = useBreakpointMatch( 'sm' );
-	const showPricingSection = ! isRegistered || siteIsRegistering || userIsConnecting;
 
 	const addNewLabel = __( 'Add new video', 'jetpack-videopress-pkg' );
 	const addFirstLabel = __( 'Add your first video', 'jetpack-videopress-pkg' );
@@ -116,7 +118,7 @@ const Admin = () => {
 				<AdminSectionHero>
 					<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 						<Col sm={ 4 } md={ 8 } lg={ 12 }>
-							<PricingSection />
+							<PricingSection onRedirecting={ () => setShowPricingSection( true ) } />
 						</Col>
 					</Container>
 				</AdminSectionHero>

--- a/projects/packages/videopress/src/client/admin/components/pricing-section/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/pricing-section/index.tsx
@@ -17,7 +17,7 @@ import { useState } from 'react';
  */
 import { usePlan } from '../../hooks/use-plan';
 
-const PricingPage = () => {
+const PricingPage = ( { onRedirecting } ) => {
 	const { siteSuffix, adminUri } = window.jetpackVideoPressInitialState;
 	const { siteProduct, product } = usePlan();
 	const { pricingForUi } = siteProduct;
@@ -59,7 +59,10 @@ const PricingPage = () => {
 						currency={ pricingForUi.currencyCode }
 					/>
 					<Button
-						onClick={ run }
+						onClick={ () => {
+							onRedirecting?.();
+							run();
+						} }
 						isLoading={ hasCheckoutStarted }
 						fullWidth
 						disabled={ isConnecting || hasCheckoutStarted || userIsConnecting }
@@ -86,6 +89,7 @@ const PricingPage = () => {
 						onClick={ () => {
 							setIsConnecting( true );
 							handleRegisterSite();
+							onRedirecting?.();
 						} }
 						isLoading={ userIsConnecting || isConnecting }
 						disabled={ userIsConnecting || isConnecting || hasCheckoutStarted }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Many variables define which page to show: the admin page or the pricing section, and relying on these sometimes gets tricky and unstable, especially when the user tries to connect the site or starts the checking out product process:

https://user-images.githubusercontent.com/77539/197074234-b220011e-4b23-47c4-8200-50a977fb9746.mov

This PR sets the flag to show the proper view based on user actions (click on the Get VideoPress button, for instance)

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: handle show admin or pricing based on a local state

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to VideoPress dashboard
* Connect the site
* Checkout the product
* Confirm the app shows the proper page all the time
* Confirm there are no visual jumps when redirecting

