### PR TITLE
Connection: Add selectors to get user and blog data

### DIFF
--- a/projects/js-packages/connection/changelog/fix-connection-getitng-wpcom-user-id
+++ b/projects/js-packages/connection/changelog/fix-connection-getitng-wpcom-user-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+

--- a/projects/js-packages/connection/changelog/fix-connection-getitng-wpcom-user-id
+++ b/projects/js-packages/connection/changelog/fix-connection-getitng-wpcom-user-id
@@ -1,5 +1,5 @@
 Significance: patch
-Type: fixed
+Type: added
 
 Connection: add getWpcomUser() and getBlogId() selectors.
 

--- a/projects/js-packages/connection/changelog/fix-connection-getitng-wpcom-user-id
+++ b/projects/js-packages/connection/changelog/fix-connection-getitng-wpcom-user-id
@@ -1,4 +1,5 @@
 Significance: patch
 Type: fixed
 
+Connection: add getWpcomUser() and getBlogId() selectors.
 

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.22.4",
+	"version": "0.22.5-alpha",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/state/selectors.jsx
+++ b/projects/js-packages/connection/state/selectors.jsx
@@ -1,9 +1,9 @@
 const getWpcomUser = state => {
-	return state?.userConnectionData.currentUser?.wpcomUser;
+	return state?.userConnectionData?.currentUser?.wpcomUser;
 };
 
 const getBlogId = state => {
-	return state?.userConnectionData.currentUser?.blogId;
+	return state?.userConnectionData?.currentUser?.blogId;
 };
 
 const connectionSelectors = {

--- a/projects/js-packages/connection/state/selectors.jsx
+++ b/projects/js-packages/connection/state/selectors.jsx
@@ -2,6 +2,10 @@ const getWpcomUser = state => {
 	return state?.userConnectionData.currentUser?.wpcomUser;
 };
 
+const getBlogId = state => {
+	return state?.userConnectionData.currentUser?.blogId;
+};
+
 const connectionSelectors = {
 	getConnectionStatus: state => state.connectionStatus || {},
 	/**
@@ -20,6 +24,7 @@ const connectionSelectors = {
 	getConnectionErrors: state => state.connectionErrors || [],
 
 	getWpcomUser,
+	getBlogId,
 };
 
 const selectors = {

--- a/projects/js-packages/connection/state/selectors.jsx
+++ b/projects/js-packages/connection/state/selectors.jsx
@@ -1,3 +1,7 @@
+const getWpcomUser = state => {
+	return state?.userConnectionData.currentUser?.wpcomUser;
+};
+
 const connectionSelectors = {
 	getConnectionStatus: state => state.connectionStatus || {},
 	/**
@@ -14,6 +18,8 @@ const connectionSelectors = {
 	getUserConnectionData: state => state.userConnectionData || false,
 	getConnectedPlugins: state => state.connectedPlugins || [],
 	getConnectionErrors: state => state.connectionErrors || [],
+
+	getWpcomUser,
 };
 
 const selectors = {

--- a/projects/packages/connection/changelog/fix-connection-getitng-wpcom-user-id
+++ b/projects/packages/connection/changelog/fix-connection-getitng-wpcom-user-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+

--- a/projects/packages/connection/changelog/fix-connection-getitng-wpcom-user-id
+++ b/projects/packages/connection/changelog/fix-connection-getitng-wpcom-user-id
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fixed
+Type: added
 
 Connection: expose BlogId in the global state

--- a/projects/packages/connection/changelog/fix-connection-getitng-wpcom-user-id
+++ b/projects/packages/connection/changelog/fix-connection-getitng-wpcom-user-id
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-
+Connection: expose BlogId in the global state

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.45.4';
+	const PACKAGE_VERSION = '1.45.5-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -432,6 +432,8 @@ class REST_Connector {
 	 * @return \WP_REST_Response|array
 	 */
 	public static function get_user_connection_data( $rest_response = true ) {
+		$blog_id = \Jetpack_Options::get_option( 'id' );
+
 		$connection = new Manager();
 
 		$current_user     = wp_get_current_user();
@@ -464,6 +466,7 @@ class REST_Connector {
 			'isMaster'    => $is_master_user,
 			'username'    => $current_user->user_login,
 			'id'          => $current_user->ID,
+			'blogId'      => $blog_id,
 			'wpcomUser'   => $wpcom_user_data,
 			'gravatar'    => get_avatar_url( $current_user->ID, 64, 'mm', '', array( 'force_display' => true ) ),
 			'permissions' => array(

--- a/projects/packages/connection/tests/php/test-rest-endpoints.php
+++ b/projects/packages/connection/tests/php/test-rest-endpoints.php
@@ -764,6 +764,7 @@ class Test_REST_Endpoints extends TestCase {
 				'isMaster'    => false,
 				'username'    => $user->user_login,
 				'id'          => $user->ID,
+				'blogId'      => false,
 				'wpcomUser'   => array(
 					'avatar' => false,
 				),
@@ -806,6 +807,7 @@ class Test_REST_Endpoints extends TestCase {
 				'isMaster'    => false,
 				'username'    => $user->user_login,
 				'id'          => $user->ID,
+				'blogId'      => self::BLOG_ID,
 				'wpcomUser'   => array(
 					'avatar' => false,
 				),
@@ -856,6 +858,7 @@ class Test_REST_Endpoints extends TestCase {
 				'isMaster'    => true,
 				'username'    => $user->user_login,
 				'id'          => $user->ID,
+				'blogId'      => self::BLOG_ID,
 				'wpcomUser'   => $dummy_wpcom_user_data,
 				'permissions' => array(
 					'connect'      => true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds two selectors to get the wpcom user data and the blog ID required to register events in the checkout process.

Fixes https://github.com/Automattic/jetpack/pull/26976#issuecomment-1286252894

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Connection: Fix when registering event in checkout hook #26978

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to a Jetpack product page: My Jetpack, Backup, etc...
* Open a dev console
* Confirm you can get the user data by running the getWpcomUser() selector

```
wp.data.select( 'jetpack-connection' ).getWpcomUser()
```

* Confirm you can get the blog ID data by running the getBlogId() selector
```
wp.data.select( 'jetpack-connection' ).getBlogId()
```