### PR TITLE
Revert "Add tracks events for purchasing items in wp-admin #26964"

### DIFF
--- a/projects/js-packages/connection/changelog/add-jetpack-search-add-tracks-events
+++ b/projects/js-packages/connection/changelog/add-jetpack-search-add-tracks-events
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added Tracks Events for making purchases from within wp-admin

--- a/projects/js-packages/connection/changelog/fix-tracking-without-wpcom-user
+++ b/projects/js-packages/connection/changelog/fix-tracking-without-wpcom-user
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix to an unreleased bug
-
-

--- a/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
+++ b/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
@@ -1,7 +1,6 @@
-import analytics from '@automattic/jetpack-analytics';
 import restApi from '@automattic/jetpack-api';
 import { getProductCheckoutUrl } from '@automattic/jetpack-components';
-import { useDispatch, select as syncSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { useEffect, useState } from 'react';
 import useConnection from '../../components/use-connection';
 import { STORE_ID } from '../../state/store.jsx';
@@ -40,17 +39,6 @@ export default function useProductCheckoutWorkflow( {
 		from,
 	} );
 
-	const initializeAnalytics = () => {
-		const tracksUser = syncSelect( STORE_ID ).getWpcomUser();
-		const blogId = syncSelect( STORE_ID ).getBlogId();
-
-		if ( tracksUser ) {
-			analytics.initialize( tracksUser.ID, tracksUser.login, {
-				blog_id: blogId,
-			} );
-		}
-	};
-
 	// Build the checkout URL.
 	const checkoutProductUrl = getProductCheckoutUrl(
 		productSlug,
@@ -79,8 +67,6 @@ export default function useProductCheckoutWorkflow( {
 	const run = event => {
 		event && event.preventDefault();
 		setCheckoutStarted( true );
-		initializeAnalytics();
-		analytics.tracks.recordEvent( productSlug + '_purchase_button_click', {} );
 
 		if ( isRegistered ) {
 			return handleAfterRegistration();

--- a/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
+++ b/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
@@ -79,7 +79,7 @@ export default function useProductCheckoutWorkflow( {
 	const run = event => {
 		event && event.preventDefault();
 		setCheckoutStarted( true );
-		isUserConnected && initializeAnalytics();
+		initializeAnalytics();
 		analytics.tracks.recordEvent( productSlug + '_purchase_button_click', {} );
 
 		if ( isRegistered ) {

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.22.5-alpha",
+	"version": "0.22.4",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/packages/search/changelog/add-jetpack-search-add-tracks-events
+++ b/projects/packages/search/changelog/add-jetpack-search-add-tracks-events
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added Tracks Events for making purchases from within wp-admin

--- a/projects/packages/search/src/dashboard/hooks/use-product-checkout-workflow.jsx
+++ b/projects/packages/search/src/dashboard/hooks/use-product-checkout-workflow.jsx
@@ -1,10 +1,8 @@
-import analytics from '@automattic/jetpack-analytics';
 import restApi from '@automattic/jetpack-api';
 import { getProductCheckoutUrl } from '@automattic/jetpack-components';
 import { useConnection, CONNECTION_STORE_ID } from '@automattic/jetpack-connection';
-import { useDispatch, select as syncSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { useEffect, useState } from 'react';
-import { STORE_ID } from 'store';
 
 const {
 	registrationNonce,
@@ -42,17 +40,6 @@ export default function useProductCheckoutWorkflow( {
 		from,
 	} );
 
-	const initializeAnalytics = () => {
-		const tracksUser = syncSelect( STORE_ID ).getWpcomUser();
-		const blogId = syncSelect( STORE_ID ).getBlogId();
-
-		if ( tracksUser ) {
-			analytics.initialize( tracksUser.ID, tracksUser.login, {
-				blog_id: blogId,
-			} );
-		}
-	};
-
 	// Build the checkout URL.
 	const checkoutProductUrl = getProductCheckoutUrl(
 		productSlug,
@@ -81,11 +68,6 @@ export default function useProductCheckoutWorkflow( {
 	const run = event => {
 		event && event.preventDefault();
 		setCheckoutStarted( true );
-		initializeAnalytics();
-		analytics.tracks.recordEvent( productSlug + '_purchase_button_click', {
-			isWpcom: isWpcom,
-			current_version: syncSelect( STORE_ID ).getVersion(),
-		} );
 
 		if ( isRegistered || isWpcom ) {
 			return handleAfterRegistration();


### PR DESCRIPTION
Reverts changes from #26964 and the fix attempt from  #26976

#26978 attempted to address further bugs, but has some tests failing and I'm not sure we should continue pursuing bugfixes like this right now. We're blocking many devs

#### Changes proposed in this Pull Request:

Reverts Automattic/jetpack#26976
Reverts Automattic/jetpack#26964


#### Does this pull request change what data or activity we track or use?

Yes. It reverts #26964

#### Testing instructions:

* Build the search package 
* Visit the search package disconnect
* Open the console
* Attempt to connect for free
* Confirm the are no errors