### PR TITLE
Add tracks events for purchasing Search plans, take 2

### DIFF
--- a/projects/packages/search/changelog/add-jetpack-search-add-tracks-event-take-2
+++ b/projects/packages/search/changelog/add-jetpack-search-add-tracks-event-take-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Search: add purchase tracking


### PR DESCRIPTION
We would like to keep track of purchases from wp-admin. This is a second attempt, restricted to only search, since https://github.com/Automattic/jetpack/pull/26964 caused some issues when trying to add more generally.


#### Changes proposed in this Pull Request:
This adds a tracking event for Jetpack Search, (not for other plugins as https://github.com/Automattic/jetpack/pull/26964 attempted)

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
Yes, this adds tracking for clicking on buttons to purchase the Search product
It does not add any additional cookies.

<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
To test, install the Jetpack Search plugin and navigate to the search dashboard. 
Open the Network tab in the browser debugger and search for t.gif. Make sure to select the option to persist logs
Click on either the free or the paid option. 
You should see a t.gif request - see screenshot
<img width="1132" alt="Bildschirmfoto 2022-10-20 um 17 03 20" src="https://user-images.githubusercontent.com/19924/197007039-cbe7d2bf-9120-4298-9660-c8a6b2a07e0d.png">


