### PR TITLE
Boost: Fix first user flow issues

### DIFF
--- a/projects/packages/my-jetpack/changelog/add-introductory-offer-flag
+++ b/projects/packages/my-jetpack/changelog/add-introductory-offer-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a flag to indicate if the pricing is introductory with product price

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "2.3.0",
+	"version": "2.3.1-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -29,7 +29,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '2.3.0';
+	const PACKAGE_VERSION = '2.3.1-alpha';
 
 	/**
 	 * Initialize My Jetapack

--- a/projects/packages/my-jetpack/src/class-wpcom-products.php
+++ b/projects/packages/my-jetpack/src/class-wpcom-products.php
@@ -157,18 +157,21 @@ class Wpcom_Products {
 			return array();
 		}
 
-		$cost           = $product->cost;
-		$discount_price = $cost;
+		$cost                  = $product->cost;
+		$discount_price        = $cost;
+		$is_introductory_offer = false;
 
 		// Get/compute the discounted price.
 		if ( isset( $product->introductory_offer->cost_per_interval ) ) {
-			$discount_price = $product->introductory_offer->cost_per_interval;
+			$discount_price        = $product->introductory_offer->cost_per_interval;
+			$is_introductory_offer = true;
 		}
 
 		$pricing = array(
-			'currency_code'  => $product->currency_code,
-			'full_price'     => $cost,
-			'discount_price' => $discount_price,
+			'currency_code'         => $product->currency_code,
+			'full_price'            => $cost,
+			'discount_price'        => $discount_price,
+			'is_introductory_offer' => $is_introductory_offer,
 		);
 
 		return self::populate_with_discount( $product, $pricing, $discount_price );

--- a/projects/packages/my-jetpack/tests/php/test-wpcom-products.php
+++ b/projects/packages/my-jetpack/tests/php/test-wpcom-products.php
@@ -211,10 +211,11 @@ class Test_Wpcom_Products extends TestCase {
 		remove_filter( 'pre_http_request', array( $this, 'mock_success_response' ) );
 
 		$expected = array(
-			'currency_code'   => 'BRL',
-			'full_price'      => 4.9,
-			'discount_price'  => 2.45,
-			'coupon_discount' => 50,
+			'currency_code'         => 'BRL',
+			'full_price'            => 4.9,
+			'discount_price'        => 2.45,
+			'is_introductory_offer' => false,
+			'coupon_discount'       => 50,
 		);
 
 		$this->assertSame( $expected, $product_price );

--- a/projects/plugins/boost/app/assets/src/css/main/dashboard.scss
+++ b/projects/plugins/boost/app/assets/src/css/main/dashboard.scss
@@ -37,6 +37,7 @@
 
 .jb-container {
 	width: 80%;
+	max-width: 1320px;
 	margin-left: auto;
 	margin-right: auto;
 

--- a/projects/plugins/boost/app/assets/src/js/global.d.ts
+++ b/projects/plugins/boost/app/assets/src/js/global.d.ts
@@ -52,6 +52,7 @@ declare global {
 				priceBefore: number;
 				priceAfter: number;
 				currencyCode: string;
+				isIntroductoryOffer: boolean;
 			};
 		};
 	};

--- a/projects/plugins/boost/app/assets/src/js/react-components/BoostPricingTable.tsx
+++ b/projects/plugins/boost/app/assets/src/js/react-components/BoostPricingTable.tsx
@@ -52,17 +52,10 @@ export const BoostPricingTable = ( { pricing, onPremiumCTA, onFreeCTA } ) => {
 		onFreeCTA();
 	};
 
-	const discountPercentage =
-		pricing.yearly.priceBefore !== undefined && pricing.yearly.priceAfter !== undefined
-			? Math.floor(
-					( ( pricing.yearly.priceBefore - pricing.yearly.priceAfter ) /
-						pricing.yearly.priceBefore ) *
-						100
-			  )
-			: 0;
-
 	// If the first year discount ends, we want to remove the label without updating the plugin.
-	const promoLabel = discountPercentage === 50 ? __( 'First Year Discount', 'jetpack-boost' ) : '';
+	const promoLabel = pricing.yearly.isIntroductoryOffer
+		? __( 'First Year Discount', 'jetpack-boost' )
+		: '';
 
 	return (
 		<PricingTable

--- a/projects/plugins/boost/app/assets/src/js/react-components/BoostPricingTable.tsx
+++ b/projects/plugins/boost/app/assets/src/js/react-components/BoostPricingTable.tsx
@@ -52,6 +52,18 @@ export const BoostPricingTable = ( { pricing, onPremiumCTA, onFreeCTA } ) => {
 		onFreeCTA();
 	};
 
+	const discountPercentage =
+		pricing.yearly.priceBefore !== undefined && pricing.yearly.priceAfter !== undefined
+			? Math.floor(
+					( ( pricing.yearly.priceBefore - pricing.yearly.priceAfter ) /
+						pricing.yearly.priceBefore ) *
+						100
+			  )
+			: 0;
+
+	// If the first year discount ends, we want to remove the label without updating the plugin.
+	const promoLabel = discountPercentage === 50 ? __( 'First Year Discount', 'jetpack-boost' ) : '';
+
 	return (
 		<PricingTable
 			title={ __( 'The easiest speed optimization plugin for WordPress', 'jetpack-boost' ) }
@@ -81,6 +93,7 @@ export const BoostPricingTable = ( { pricing, onPremiumCTA, onFreeCTA } ) => {
 						offPrice={ pricing.yearly.priceAfter / 12 }
 						currency={ pricing.yearly.currencyCode }
 						hideDiscountLabel={ false }
+						promoLabel={ promoLabel }
 					/>
 					<Button
 						onClick={ handlePremiumCTA }

--- a/projects/plugins/boost/app/lib/Premium_Pricing.php
+++ b/projects/plugins/boost/app/lib/Premium_Pricing.php
@@ -22,9 +22,10 @@ class Premium_Pricing {
 		}
 
 		$constants['pricing']['yearly'] = array(
-			'priceBefore'  => $yearly_pricing['full_price'],
-			'priceAfter'   => $yearly_pricing['discount_price'],
-			'currencyCode' => $yearly_pricing['currency_code'],
+			'priceBefore'         => $yearly_pricing['full_price'],
+			'priceAfter'          => $yearly_pricing['discount_price'],
+			'currencyCode'        => $yearly_pricing['currency_code'],
+			'isIntroductoryOffer' => $yearly_pricing['is_introductory_offer'] === true,
 		);
 		return $constants;
 	}

--- a/projects/plugins/boost/changelog/fix-first-user-flow
+++ b/projects/plugins/boost/changelog/fix-first-user-flow
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed some issues raised in pc9hqz-1fV-p2#comment-943
+
+


### PR DESCRIPTION
Fixes Automattic/boost-cloud#157

#### Changes proposed in this Pull Request:
* Constrained the width of the container in boost dashboard and pricing page
* Added promo text to indicate that the discount is for first year only

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
pc9hqz-1fV-p2#comment-943

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Open the admin.php?page=jetpack-boost#/getting-started.
* Make sure the table constrains to 1320px on very large monitors.
* Make sure it has the badge "First Year Discount" under the price for premium plan.


![fbq8Pj.png](https://user-images.githubusercontent.com/3737780/197132820-0a54eb1b-b4ac-4b36-ac96-ba4c201451f9.png)