### PR TITLE
VideoPress: show an actionable notice when user connection is required

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-add-actionable-user-connection-error
+++ b/projects/packages/videopress/changelog/update-videopress-add-actionable-user-connection-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: show an actionable notice when user connection is required

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -33,7 +33,7 @@ import { fileInputExtensions } from '../../../utils/video-extensions';
 import useAnalyticsTracks from '../../hooks/use-analytics-tracks';
 import { usePlan } from '../../hooks/use-plan';
 import useVideos, { useLocalVideos } from '../../hooks/use-videos';
-import GlobalNotice from '../global-notice';
+import { NeedUserConnectionGlobalNotice } from '../global-notice';
 import Logo from '../logo';
 import PricingSection from '../pricing-section';
 import { ConnectVideoStorageMeter } from '../video-storage-meter';
@@ -136,12 +136,7 @@ const Admin = () => {
 
 							{ ! hasConnectedOwner ? (
 								<Col sm={ 4 } md={ 8 } lg={ 12 }>
-									<GlobalNotice addConnectUserLink={ true }>
-										{ __(
-											'Some actions need a user connection to WordPress.com to be able to work',
-											'jetpack-videopress-pkg'
-										) }
-									</GlobalNotice>
+									<NeedUserConnectionGlobalNotice />
 								</Col>
 							) : (
 								<ConnectionErrorNotice />

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -17,6 +17,7 @@ import {
 	useConnection,
 	useConnectionErrorNotice,
 	ConnectionError,
+	ConnectionErrorNotice,
 } from '@automattic/jetpack-connection';
 import { FormFileUpload } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
@@ -32,6 +33,7 @@ import { fileInputExtensions } from '../../../utils/video-extensions';
 import useAnalyticsTracks from '../../hooks/use-analytics-tracks';
 import { usePlan } from '../../hooks/use-plan';
 import useVideos, { useLocalVideos } from '../../hooks/use-videos';
+import GlobalNotice from '../global-notice';
 import Logo from '../logo';
 import PricingSection from '../pricing-section';
 import { ConnectVideoStorageMeter } from '../video-storage-meter';
@@ -96,7 +98,7 @@ const Admin = () => {
 
 	const { hasVideoPressPurchase } = usePlan();
 
-	const { isRegistered } = useConnection();
+	const { isRegistered, hasConnectedOwner } = useConnection();
 	const { hasConnectionError } = useConnectionErrorNotice();
 
 	const [ showPricingSection, setShowPricingSection ] = useState( ! isRegistered );
@@ -130,6 +132,19 @@ const Admin = () => {
 								<Col>
 									<ConnectionError />
 								</Col>
+							) }
+
+							{ ! hasConnectedOwner ? (
+								<Col sm={ 4 } md={ 8 } lg={ 12 }>
+									<GlobalNotice addConnectUserLink={ true }>
+										{ __(
+											'Some actions need a user connection to WordPress.com to be able to work',
+											'jetpack-videopress-pkg'
+										) }
+									</GlobalNotice>
+								</Col>
+							) : (
+								<ConnectionErrorNotice />
 							) }
 							<Col sm={ 4 } md={ 4 } lg={ 8 }>
 								<Text variant="headline-small" mb={ 3 }>

--- a/projects/packages/videopress/src/client/admin/components/global-notice/stories/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/global-notice/stories/index.tsx
@@ -23,10 +23,8 @@ const Template = args => <GlobalNotice { ...args } />;
 export const _default = Template.bind( {} );
 _default.args = {
 	children: 'Typical error message',
-	addConnectUserLink: true,
 	isDismissible: true,
 	status: 'error',
 
 	onRemove: action( 'onRemove' ),
-	onConnectUserClick: action( 'onConnectUserClick' ),
 };

--- a/projects/packages/videopress/src/client/admin/components/global-notice/styles.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/global-notice/styles.module.scss
@@ -55,5 +55,6 @@
 
 	.message {
 		margin-left: 8px;
+		white-space: nowrap;
 	}
 }

--- a/projects/packages/videopress/src/client/admin/components/global-notice/styles.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/global-notice/styles.module.scss
@@ -55,6 +55,5 @@
 
 	.message {
 		margin-left: 8px;
-		white-space: nowrap;
 	}
 }

--- a/projects/packages/videopress/src/client/admin/components/pricing-section/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/pricing-section/index.tsx
@@ -18,10 +18,9 @@ import { useState } from 'react';
 import { usePlan } from '../../hooks/use-plan';
 
 const PricingPage = ( { onRedirecting } ) => {
-	const { siteSuffix, adminUri } = window.jetpackVideoPressInitialState;
+	const { siteSuffix, adminUri, registrationNonce } = window.jetpackVideoPressInitialState;
 	const { siteProduct, product } = usePlan();
 	const { pricingForUi } = siteProduct;
-	const { registrationNonce } = window.jetpackVideoPressInitialState;
 	const { handleRegisterSite, userIsConnecting } = useConnection( {
 		redirectUri: adminUri,
 		from: 'jetpack-videopress',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

~Depend on https://github.com/Automattic/jetpack/pull/26977~

VideoPress requires a connected user to run some admin actions. For instance, it isn't possible to upload a video. The endpoint responds with an error:

<img width="652" alt="image" src="https://user-images.githubusercontent.com/77539/197172236-1bc14b75-a8d6-4881-8e97-0061a13add7a.png">

This PR shows an actionable notice when a user connection is required to prompt to fix it.

<img width="1033" alt="image" src="https://user-images.githubusercontent.com/77539/197169759-19bda556-8e94-42c9-85dc-0dd13e42cd8c.png">

Fixes https://github.com/Automattic/jetpack/issues/26968

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: show an actionable notice when user connection is required

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Admin page
* Try to get a site with the user disconnected
* Confirm you see the actionable notice in My Jetpack

<img width="1057" alt="Screen Shot 2022-10-21 at 07 14 25" src="https://user-images.githubusercontent.com/77539/197172677-7f4d2247-8027-4d81-acb5-8fb31d3436b4.png">

* Confirm you see a similar Notice now, in the VideoPress dashboard too
VideoPress: show an actionable notice when a user connection is required

* confirm the connection is established by clicking on the link

