### PR TITLE
VideoPress: Fix unsaved changes prompt when updating thumbnail

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-unsaved-changes-prompt
+++ b/projects/packages/videopress/changelog/fix-videopress-unsaved-changes-prompt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fix unsaved changes prompt when updating video thumbnail

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
@@ -13,6 +13,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronRightSmall } from '@wordpress/icons';
 import classnames from 'classnames';
+import { useEffect } from 'react';
 import { useHistory, Prompt } from 'react-router-dom';
 /**
  * Internal dependencies
@@ -145,6 +146,7 @@ const EditVideoDetails = () => {
 		// Page State/Actions
 		hasChanges,
 		updating,
+		updated,
 		isFetching,
 		handleSaveChanges,
 		// Metadata
@@ -170,9 +172,17 @@ const EditVideoDetails = () => {
 	);
 
 	useUnloadPrevent( {
-		shouldPrevent: hasChanges,
+		shouldPrevent: hasChanges && ! updated,
 		message: unsavedChangesMessage,
 	} );
+
+	const history = useHistory();
+
+	useEffect( () => {
+		if ( updated === true ) {
+			history.push( '/' );
+		}
+	}, [ updated ] );
 
 	let thumbnail: string | JSX.Element = posterImage;
 	if ( posterImageSource === 'video' && useVideoAsThumbnail ) {
@@ -183,7 +193,7 @@ const EditVideoDetails = () => {
 
 	return (
 		<>
-			<Prompt when={ hasChanges } message={ unsavedChangesMessage } />
+			<Prompt when={ hasChanges && ! updated } message={ unsavedChangesMessage } />
 
 			{ frameSelectorIsOpen && (
 				<VideoThumbnailSelectorModal

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/use-edit-details.ts
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/use-edit-details.ts
@@ -71,6 +71,7 @@ export default () => {
 	>( null );
 
 	const [ updating, setUpdating ] = useState( false );
+	const [ updated, setUpdated ] = useState( false );
 
 	const [ data, setData ] = useState( {
 		title: video?.title,
@@ -136,7 +137,7 @@ export default () => {
 
 			setUpdating( false );
 			dispatch?.setVideo( videoData );
-			history.push( '/' );
+			setUpdated( true );
 		} );
 	};
 
@@ -177,6 +178,7 @@ export default () => {
 		handleSaveChanges,
 		isFetching,
 		updating,
+		updated,
 		selectedTime,
 		...metaEditData,
 		...posterEditData,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26975

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes the unsaved changes prompt when updating thumbnail, setting an `updated` state.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard
* Go to the video edit page
* Change the thumbnail and click `Save`
* Check that you are redirected to the main page without a prompt
* Repeat the test, but do not save, instead clicking on the `Jetpack VideoPress` logo
* Check that the prompt is shown


https://user-images.githubusercontent.com/8486249/197208008-72106d49-42f2-4e27-8751-04478f7f4431.mp4

