### PR TITLE
VideoPress: Use playback tokens on private video resources

### DIFF
--- a/projects/packages/videopress/changelog/add-use-playback-token-on-private-resources
+++ b/projects/packages/videopress/changelog/add-use-playback-token-on-private-resources
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Add support to the use of playback tokens on the details page, so it's possible to see thumbnails on videos that are private.

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
@@ -142,7 +142,9 @@ const EditVideoDetails = () => {
 		title,
 		description,
 		caption,
+		// Playback Token
 		playbackToken,
+		isFetchingPlaybackToken,
 		// Page State/Actions
 		hasChanges,
 		updating,
@@ -187,6 +189,8 @@ const EditVideoDetails = () => {
 		thumbnail = libraryAttachment.url;
 	}
 
+	const isFetchingData = isFetching || isFetchingPlaybackToken;
+
 	return (
 		<>
 			<Prompt when={ hasChanges } message={ unsavedChangesMessage } />
@@ -221,12 +225,12 @@ const EditVideoDetails = () => {
 								onChangeDescription={ setDescription }
 								caption={ caption ?? '' }
 								onChangeCaption={ setCaption }
-								loading={ isFetching }
+								loading={ isFetchingData }
 							/>
 						</Col>
 						<Col sm={ 4 } md={ 8 } lg={ { start: 9, end: 12 } }>
 							<VideoThumbnail
-								thumbnail={ isFetching ? <Placeholder height={ 200 } /> : thumbnail }
+								thumbnail={ isFetchingData ? <Placeholder height={ 200 } /> : thumbnail }
 								duration={ duration }
 								editable
 								onSelectFromVideo={ handleOpenSelectFrame }
@@ -236,7 +240,7 @@ const EditVideoDetails = () => {
 								filename={ filename ?? '' }
 								uploadDate={ uploadDate ?? '' }
 								src={ url ?? '' }
-								loading={ isFetching }
+								loading={ isFetchingData }
 							/>
 						</Col>
 					</Container>

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
@@ -194,7 +194,6 @@ const EditVideoDetails = () => {
 		? `${ posterImage }?metadata_token=${ playbackToken }`
 		: posterImage;
 
-	let thumbnail: string | JSX.Element = posterImage;
 	if ( posterImageSource === 'video' && useVideoAsThumbnail ) {
 		thumbnail = <VideoPlayer src={ videoUrl } currentTime={ selectedTime } />;
 	} else if ( posterImageSource === 'upload' ) {

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
@@ -142,6 +142,7 @@ const EditVideoDetails = () => {
 		title,
 		description,
 		caption,
+		playbackToken,
 		// Page State/Actions
 		hasChanges,
 		updating,
@@ -174,9 +175,14 @@ const EditVideoDetails = () => {
 		message: unsavedChangesMessage,
 	} );
 
-	let thumbnail: string | JSX.Element = posterImage;
+	// We may need the playback token on the video URL as well
+	const videoUrl = playbackToken ? `${ url }?metadata_token=${ playbackToken }` : url;
+
+	let thumbnail: string | JSX.Element = playbackToken
+		? `${ posterImage }?metadata_token=${ playbackToken }`
+		: posterImage;
 	if ( posterImageSource === 'video' && useVideoAsThumbnail ) {
-		thumbnail = <VideoPlayer src={ url } currentTime={ selectedTime } />;
+		thumbnail = <VideoPlayer src={ videoUrl } currentTime={ selectedTime } />;
 	} else if ( posterImageSource === 'upload' ) {
 		thumbnail = libraryAttachment.url;
 	}
@@ -188,7 +194,7 @@ const EditVideoDetails = () => {
 			{ frameSelectorIsOpen && (
 				<VideoThumbnailSelectorModal
 					handleCloseSelectFrame={ handleCloseSelectFrame }
-					url={ url }
+					url={ videoUrl }
 					handleVideoFrameSelected={ handleVideoFrameSelected }
 					selectedTime={ selectedTime }
 					handleConfirmFrame={ handleConfirmFrame }

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/use-edit-details.ts
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/use-edit-details.ts
@@ -10,17 +10,9 @@ import { useParams, useHistory } from 'react-router-dom';
  */
 import useMetaUpdate from '../../../hooks/use-meta-update';
 import { STORE_ID } from '../../../state';
-import { VIDEO_PRIVACY_LEVELS, VIDEO_PRIVACY_LEVEL_PRIVATE } from '../../../state/constants';
 import usePlaybackToken from '../../hooks/use-playback-token';
 import usePosterEdit from '../../hooks/use-poster-edit';
 import useVideo from '../../hooks/use-video';
-import { VideoPressVideo } from '../../types';
-
-const videoNeedsPlaybackToken = ( video: VideoPressVideo ): boolean => {
-	return video.privacySetting
-		? VIDEO_PRIVACY_LEVELS[ video.privacySetting ] === VIDEO_PRIVACY_LEVEL_PRIVATE
-		: false;
-};
 
 const useMetaEdit = ( { videoId, data, video, updateData } ) => {
 	const updateMeta = useMetaUpdate( videoId );
@@ -74,9 +66,7 @@ export default () => {
 	const videoId = Number( videoIdFromParams );
 	const { data: video, isFetching } = useVideo( Number( videoId ) );
 
-	const { playbackToken, isFetchingPlaybackToken } = videoNeedsPlaybackToken( video )
-		? usePlaybackToken( video.guid )
-		: { playbackToken: null, isFetchingPlaybackToken: false };
+	const { playbackToken, isFetchingPlaybackToken } = usePlaybackToken( video );
 
 	const [ libraryAttachment, setLibraryAttachment ] = useState( null );
 	const [ posterImageSource, setPosterImageSource ] = useState<

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/use-edit-details.ts
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/use-edit-details.ts
@@ -10,8 +10,17 @@ import { useParams, useHistory } from 'react-router-dom';
  */
 import useMetaUpdate from '../../../hooks/use-meta-update';
 import { STORE_ID } from '../../../state';
+import { VIDEO_PRIVACY_LEVELS, VIDEO_PRIVACY_LEVEL_PRIVATE } from '../../../state/constants';
+import usePlaybackToken from '../../hooks/use-playback-token';
 import usePosterEdit from '../../hooks/use-poster-edit';
 import useVideo from '../../hooks/use-video';
+import { VideoPressVideo } from '../../types';
+
+const videoNeedsPlaybackToken = ( video: VideoPressVideo ): boolean => {
+	return video.privacySetting
+		? VIDEO_PRIVACY_LEVELS[ video.privacySetting ] === VIDEO_PRIVACY_LEVEL_PRIVATE
+		: false;
+};
 
 const useMetaEdit = ( { videoId, data, video, updateData } ) => {
 	const updateMeta = useMetaUpdate( videoId );
@@ -64,6 +73,10 @@ export default () => {
 	const { videoId: videoIdFromParams } = useParams();
 	const videoId = Number( videoIdFromParams );
 	const { data: video, isFetching } = useVideo( Number( videoId ) );
+
+	const { playbackToken, isFetchingPlaybackToken } = videoNeedsPlaybackToken( video )
+		? usePlaybackToken( video.guid )
+		: { playbackToken: null, isFetchingPlaybackToken: false };
 
 	const [ libraryAttachment, setLibraryAttachment ] = useState( null );
 	const [ posterImageSource, setPosterImageSource ] = useState<
@@ -168,6 +181,8 @@ export default () => {
 	}, [ initialLoading ] );
 
 	return {
+		playbackToken,
+		isFetchingPlaybackToken,
 		...video,
 		...data, // data is the local representation of the video
 		hasChanges,

--- a/projects/packages/videopress/src/client/admin/hooks/use-playback-token/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-playback-token/index.ts
@@ -5,25 +5,44 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_ID } from '../../../state/constants';
-import { VideopressSelectors } from '../../types';
+import {
+	STORE_ID,
+	VIDEO_PRIVACY_LEVELS,
+	VIDEO_PRIVACY_LEVEL_PRIVATE,
+} from '../../../state/constants';
+import { VideopressSelectors, VideoPressVideo } from '../../types';
 
 /**
  * React custom hook to get the Users.
  *
  * @param {string} guid - The VideoPress video identifier
+ * @param video
  * @returns {object} Playback token
  */
-export default function usePlaybackToken( guid: string ) {
+export default function usePlaybackToken( video: VideoPressVideo ) {
+	const videoNeedsPlaybackToken = video.privacySetting
+		? VIDEO_PRIVACY_LEVELS[ video.privacySetting ] === VIDEO_PRIVACY_LEVEL_PRIVATE
+		: false;
+
 	// Data
 	const playbackToken = useSelect(
-		select => ( select( STORE_ID ) as VideopressSelectors ).getPlaybackToken( guid ),
-		[ guid ]
+		select => {
+			if ( videoNeedsPlaybackToken ) {
+				return ( select( STORE_ID ) as VideopressSelectors ).getPlaybackToken( video.guid );
+			}
+			return null;
+		},
+		[ video.guid ]
 	);
 
 	const isFetchingPlaybackToken = useSelect(
-		select => ( select( STORE_ID ) as VideopressSelectors ).isFetchingPlaybackToken(),
-		[ guid ]
+		select => {
+			if ( videoNeedsPlaybackToken ) {
+				return ( select( STORE_ID ) as VideopressSelectors ).isFetchingPlaybackToken();
+			}
+			return false;
+		},
+		[ video.guid ]
 	);
 
 	return {

--- a/projects/packages/videopress/src/client/admin/hooks/use-playback-token/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-playback-token/index.ts
@@ -15,8 +15,7 @@ import { VideopressSelectors, VideoPressVideo } from '../../types';
 /**
  * React custom hook to get the Users.
  *
- * @param {string} guid - The VideoPress video identifier
- * @param video
+ * @param {VideoPressVideo} video - The VideoPress video
  * @returns {object} Playback token
  */
 export default function usePlaybackToken( video: VideoPressVideo ) {

--- a/projects/packages/videopress/src/client/admin/hooks/use-playback-token/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-playback-token/index.ts
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+/**
+ * Internal dependencies
+ */
+import { STORE_ID } from '../../../state/constants';
+import { VideopressSelectors } from '../../types';
+
+/**
+ * React custom hook to get the Users.
+ *
+ * @param {string} guid - The VideoPress video identifier
+ * @returns {object} Playback token
+ */
+export default function usePlaybackToken( guid: string ) {
+	// Data
+	const playbackToken = useSelect(
+		select => ( select( STORE_ID ) as VideopressSelectors ).getPlaybackToken( guid ),
+		[ guid ]
+	);
+
+	const isFetchingPlaybackToken = useSelect(
+		select => ( select( STORE_ID ) as VideopressSelectors ).isFetchingPlaybackToken(),
+		[ guid ]
+	);
+
+	return {
+		playbackToken: playbackToken?.token,
+		isFetchingPlaybackToken,
+	};
+}

--- a/projects/packages/videopress/src/client/admin/types/index.ts
+++ b/projects/packages/videopress/src/client/admin/types/index.ts
@@ -201,5 +201,8 @@ export type VideopressSelectors = {
 	getIsFetching: () => boolean;
 	getPurchases: () => Array< object >;
 
+	getPlaybackToken: ( guid: string ) => { guid: string; token: string };
+	isFetchingPlaybackToken: () => boolean;
+
 	getUploadedLocalVideoCount: () => number;
 };

--- a/projects/packages/videopress/src/client/state/actions.js
+++ b/projects/packages/videopress/src/client/state/actions.js
@@ -41,6 +41,8 @@ import {
 	SET_USERS,
 	SET_USERS_PAGINATION,
 	SET_LOCAL_VIDEO_UPLOADED,
+	SET_IS_FETCHING_PLAYBACK_TOKEN,
+	SET_PLAYBACK_TOKEN,
 } from './constants';
 import { mapVideoFromWPV2MediaEndpoint } from './utils/map-videos';
 
@@ -313,6 +315,14 @@ const setUsersPagination = pagination => {
 	return { type: SET_USERS_PAGINATION, pagination };
 };
 
+const setIsFetchingPlaybackToken = isFetching => {
+	return { type: SET_IS_FETCHING_PLAYBACK_TOKEN, isFetching };
+};
+
+const setPlaybackToken = playbackToken => {
+	return { type: SET_PLAYBACK_TOKEN, playbackToken };
+};
+
 const actions = {
 	setIsFetchingVideos,
 	setFetchVideosError,
@@ -348,6 +358,9 @@ const actions = {
 
 	setUsers,
 	setUsersPagination,
+
+	setIsFetchingPlaybackToken,
+	setPlaybackToken,
 };
 
 export { actions as default };

--- a/projects/packages/videopress/src/client/state/constants.js
+++ b/projects/packages/videopress/src/client/state/constants.js
@@ -11,6 +11,7 @@ export const WP_REST_API_USERS_ENDPOINT = 'wp/v2/users';
 export const WP_REST_API_MEDIA_ENDPOINT = 'wp/v2/media';
 export const WP_REST_API_VIDEOPRESS_ENDPOINT = 'wpcom/v2/videopress';
 export const WP_REST_API_VIDEOPRESS_META_ENDPOINT = 'wpcom/v2/videopress/meta';
+export const WP_REST_API_VIDEOPRESS_PLAYBACK_TOKEN_ENDPOINT = 'wpcom/v2/videopress/playback-jwt';
 export const REST_API_SITE_PURCHASES_ENDPOINT = 'my-jetpack/v1/site/purchases';
 export const REST_API_SITE_INFO_ENDPOINT = 'videopress/v1/site';
 
@@ -43,6 +44,9 @@ export const PROCESSING_VIDEO = 'PROCESSING_VIDEO';
 export const UPLOADED_VIDEO = 'UPLOADED_VIDEO';
 export const SET_IS_FETCHING_PURCHASES = 'SET_IS_FETCHING_PURCHASES';
 export const SET_PURCHASES = 'SET_PURCHASES';
+
+export const SET_IS_FETCHING_PLAYBACK_TOKEN = 'SET_IS_FETCHING_PLAYBACK_TOKEN';
+export const SET_PLAYBACK_TOKEN = 'SET_PLAYBACK_TOKEN';
 
 export const SET_USERS = 'SET_USERS';
 export const SET_USERS_PAGINATION = 'SET_USERS_PAGINATION';

--- a/projects/packages/videopress/src/client/state/reducers.js
+++ b/projects/packages/videopress/src/client/state/reducers.js
@@ -34,6 +34,8 @@ import {
 	SET_USERS,
 	SET_USERS_PAGINATION,
 	SET_LOCAL_VIDEO_UPLOADED,
+	SET_IS_FETCHING_PLAYBACK_TOKEN,
+	SET_PLAYBACK_TOKEN,
 } from './constants';
 
 /**
@@ -563,11 +565,49 @@ const purchases = ( state, action ) => {
 	}
 };
 
+const playbackTokens = ( state, action ) => {
+	switch ( action.type ) {
+		case SET_IS_FETCHING_PLAYBACK_TOKEN: {
+			return {
+				...state,
+				isFetching: action.isFetching,
+			};
+		}
+
+		case SET_PLAYBACK_TOKEN: {
+			const { playbackToken } = action;
+			const items = [ ...( state.items ?? [] ) ];
+			const playbackTokenIndex = items.findIndex( item => item.guid === playbackToken.guid );
+
+			if ( playbackTokenIndex === -1 ) {
+				// Add it to the array
+				items.unshift( playbackToken );
+			} else {
+				// Update it
+				items[ playbackTokenIndex ] = {
+					...items[ playbackTokenIndex ],
+					...playbackToken,
+				};
+			}
+
+			return {
+				...state,
+				items,
+				isFetching: false,
+			};
+		}
+
+		default:
+			return state;
+	}
+};
+
 const reducers = combineReducers( {
 	videos,
 	localVideos,
 	purchases,
 	users,
+	playbackTokens,
 } );
 
 export default reducers;

--- a/projects/packages/videopress/src/client/state/resolvers.js
+++ b/projects/packages/videopress/src/client/state/resolvers.js
@@ -17,6 +17,7 @@ import {
 	PROCESSING_VIDEO,
 	SET_LOCAL_VIDEOS_QUERY,
 	WP_REST_API_USERS_ENDPOINT,
+	WP_REST_API_VIDEOPRESS_PLAYBACK_TOKEN_ENDPOINT,
 } from './constants';
 import { getDefaultQuery } from './reducers';
 import {
@@ -321,6 +322,34 @@ const getUsers = {
 	},
 };
 
+const getPlaybackToken = {
+	isFulfilled: ( state, guid ) => {
+		const playbackTokens = state?.playbackTokens?.items ?? [];
+		return playbackTokens?.some( token => token?.guid === guid );
+	},
+	fulfill: guid => async ( { dispatch } ) => {
+		dispatch.setIsFetchingPlaybackToken( true );
+
+		try {
+			const playbackTokenResponse = await apiFetch( {
+				path: addQueryArgs( `${ WP_REST_API_VIDEOPRESS_PLAYBACK_TOKEN_ENDPOINT }/${ guid }` ),
+				method: 'POST',
+			} );
+
+			const playbackToken = {
+				guid,
+				token: playbackTokenResponse.playback_token,
+			};
+
+			dispatch.setPlaybackToken( playbackToken );
+
+			return playbackToken;
+		} catch ( error ) {
+			console.error( error ); // eslint-disable-line no-console
+		}
+	},
+};
+
 export default {
 	getStorageUsed,
 	getUploadedVideoCount,
@@ -332,4 +361,6 @@ export default {
 	getUsers,
 
 	getPurchases,
+
+	getPlaybackToken,
 };

--- a/projects/packages/videopress/src/client/state/selectors.js
+++ b/projects/packages/videopress/src/client/state/selectors.js
@@ -88,6 +88,16 @@ export const getUsersPagination = state => {
 	return state?.users?.pagination;
 };
 
+export const getPlaybackToken = ( state, guid ) => {
+	const tokens = state?.playbackTokens?.items || [];
+	const token = tokens.find( t => t?.guid === guid );
+	return token;
+};
+
+export const isFetchingPlaybackToken = state => {
+	return state?.playbackTokens?.isFetching;
+};
+
 const selectors = {
 	// VideoPress videos
 	getVideos,
@@ -115,6 +125,9 @@ const selectors = {
 
 	getPurchases,
 	isFetchingPurchases,
+
+	getPlaybackToken,
+	isFetchingPlaybackToken,
 };
 
 export default selectors;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Relates to #26675.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add support for VideoPress playback tokens on the client local state
* Try to use playback tokens when loading resources for private videos (thumbnails and the video file itself), so they can be loaded

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Upload one video and then set it to private
* Click the `Edit video details` button for the video
* Confirm that the thumbnail for the video is being showed (this was the first problem, the thumb would fail to load)
* Confirm that the `src` attribute for the thumbnail image contains a `metadata_token` parameter
* Click on the pencil button to edit the video thumbnail
* Click the option `Select from video`
* Confirm that the video is loading so you can pick a new thumb (this was the second problem, the video would fail to load)