### PR TITLE
VideoPress: Remove connection error notice when there is no connection issue

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-connection-error-warning
+++ b/projects/packages/videopress/changelog/fix-videopress-connection-error-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Remove ConnectionErrorNotice component on dashboard when there is no connection issue

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -17,7 +17,6 @@ import {
 	useConnection,
 	useConnectionErrorNotice,
 	ConnectionError,
-	ConnectionErrorNotice,
 } from '@automattic/jetpack-connection';
 import { FormFileUpload } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
@@ -134,12 +133,10 @@ const Admin = () => {
 								</Col>
 							) }
 
-							{ ! hasConnectedOwner ? (
+							{ ! hasConnectedOwner && (
 								<Col sm={ 4 } md={ 8 } lg={ 12 }>
 									<NeedUserConnectionGlobalNotice />
 								</Col>
-							) : (
-								<ConnectionErrorNotice />
 							) }
 							<Col sm={ 4 } md={ 4 } lg={ 8 }>
 								<Text variant="headline-small" mb={ 3 }>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26995

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes ConnectionErrorNotice component when there is no connection issue and the owner is connected

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard running locally (not on JN)
* Notice there are no warnings anymore