### PR TITLE
VideoPress: Add check for empty video poster on polling after update

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-thumbnail-on-upload
+++ b/projects/packages/videopress/changelog/fix-videopress-thumbnail-on-upload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Check for empty poster image on video polling after upload

--- a/projects/packages/videopress/src/client/state/actions.js
+++ b/projects/packages/videopress/src/client/state/actions.js
@@ -55,7 +55,7 @@ const pollingUploadedVideoData = async data => {
 
 	const video = mapVideoFromWPV2MediaEndpoint( response );
 
-	if ( video?.posterImage !== null ) {
+	if ( video?.posterImage !== null && video?.posterImage !== '' ) {
 		return Promise.resolve( video );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26998

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a check for empty poster on video polling after update
Sometimes the poster image is returned as an empty string instead of `null` and that stops the video polling

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This one is hard to test. On the VideoPress dashboard, every uploaded video should show its thumbnail.
A way to verify this is by looking for the requests for the video information on polling using the network dev tools and check `media_details.videopress.poster` for a time where it is `""` instead of `null` and check that the polling continues.