### PR TITLE
Options: Sync `featured_image_email_enabled` option

### DIFF
--- a/projects/packages/sync/changelog/add-sync-enable-featured-image-site-option
+++ b/projects/packages/sync/changelog/add-sync-enable-featured-image-site-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added featured_image_email_enabled option for syncing

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -57,6 +57,7 @@ class Defaults {
 		'disabled_reblogs',
 		'disallowed_keys',
 		'enable_header_ad',
+		'featured_image_email_enabled',
 		'gmt_offset',
 		'gravatar_disable_hovercards',
 		'highlander_comment_form_prompt',

--- a/projects/plugins/jetpack/changelog/add-sync-enable-featured-image-site-option
+++ b/projects/plugins/jetpack/changelog/add-sync-enable-featured-image-site-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Comment: Added featured_image_email_enabled_for_syncing

--- a/projects/plugins/jetpack/changelog/add-sync-enable-featured-image-site-option
+++ b/projects/plugins/jetpack/changelog/add-sync-enable-featured-image-site-option
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Comment: Added featured_image_email_enabled_for_syncing
+Comment: Added featured_image_email_enabled for syncing

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -225,6 +225,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'ce4wp_referred_by'                            => array(),
 			'wpcom_is_fse_activated'                       => '1',
 			'videopress_private_enabled_for_site'          => false,
+			'featured_image_email_enabled'                 => false,
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/68485

![image](https://user-images.githubusercontent.com/2019970/197280294-0906d9e8-e527-4b60-8276-107c1a708ed1.png)

This is a follow up to D88807-code, https://github.com/Automattic/wp-calypso/issues/68747

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* add new `featured_image_email_enabled` site option for jetpack syncing

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- pdDOJh-Nu-p2
- p1666343640133449-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- no

#### Testing instructions:

* I am not aware of a proper way of testing this other than included tests. The PR is done as per the guide: PCYsg-sBM-p2