### PR TITLE
Protect: Calculate threat counts on the client side

### DIFF
--- a/projects/plugins/protect/src/js/hooks/use-protect-data/index.js
+++ b/projects/plugins/protect/src/js/hooks/use-protect-data/index.js
@@ -1,4 +1,5 @@
 import { useSelect } from '@wordpress/data';
+import { useMemo } from 'react';
 import { STORE_ID } from '../../state/store';
 
 /**
@@ -21,19 +22,27 @@ export default function useProtectData() {
 		currentStatus = status.status;
 	}
 
-	const numCoreThreats = status.core?.threat?.length || 0;
+	const numCoreThreats = useMemo( () => status.core?.threat?.length || 0, [ status.core ] );
 
-	const numPluginsThreats = ( status.plugins || [] ).reduce( ( numThreats, plugin ) => {
-		return numThreats + plugin.threats.length;
-	}, 0 );
+	const numPluginsThreats = useMemo(
+		() =>
+			( status.plugins || [] ).reduce( ( numThreats, plugin ) => {
+				return numThreats + plugin.threats.length;
+			}, 0 ),
+		[ status.plugins ]
+	);
 
-	const numThemesThreats = ( status.themes || [] ).reduce( ( numThreats, theme ) => {
-		return numThreats + theme.threats.length;
-	}, 0 );
+	const numThemesThreats = useMemo(
+		() =>
+			( status.themes || [] ).reduce( ( numThreats, theme ) => {
+				return numThreats + theme.threats.length;
+			}, 0 ),
+		[ status.themes ]
+	);
 
-	const numFilesThreats = status.files?.length || 0;
+	const numFilesThreats = useMemo( () => status.files?.length || 0, [ status.files ] );
 
-	const numDatabaseThreats = status.database?.length || 0;
+	const numDatabaseThreats = useMemo( () => status.database?.length || 0, [ status.database ] );
 
 	const numThreats =
 		numCoreThreats + numPluginsThreats + numThemesThreats + numFilesThreats + numDatabaseThreats;

--- a/projects/plugins/protect/src/js/hooks/use-protect-data/index.js
+++ b/projects/plugins/protect/src/js/hooks/use-protect-data/index.js
@@ -21,13 +21,30 @@ export default function useProtectData() {
 		currentStatus = status.status;
 	}
 
+	const numCoreThreats = status.core?.threat?.length || 0;
+
+	const numPluginsThreats = ( status.plugins || [] ).reduce( ( numThreats, plugin ) => {
+		return numThreats + plugin.threats.length;
+	}, 0 );
+
+	const numThemesThreats = ( status.themes || [] ).reduce( ( numThreats, theme ) => {
+		return numThreats + theme.threats.length;
+	}, 0 );
+
+	const numFilesThreats = status.files?.length || 0;
+
+	const numDatabaseThreats = status.database?.length || 0;
+
+	const numThreats =
+		numCoreThreats + numPluginsThreats + numThemesThreats + numFilesThreats + numDatabaseThreats;
+
 	return {
-		numThreats: status.numThreats || 0,
-		numCoreThreats: status.core?.threats?.length || 0,
-		numPluginsThreats: status.numPluginsThreats || 0,
-		numThemesThreats: status.numThemesThreats || 0,
-		numFilesThreats: status.files?.length || 0,
-		numDatabaseThreats: status.database?.length || 0,
+		numThreats,
+		numCoreThreats,
+		numPluginsThreats,
+		numThemesThreats,
+		numFilesThreats,
+		numDatabaseThreats,
 		lastChecked: status.lastChecked || null,
 		errorCode: status.errorCode || null,
 		errorMessage: status.errorMessage || null,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds the calculation of threat counts to the front end, to avoid mismatches due to uninstalled extensions or manually fixed threats.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Generates threat count variables in `useProtectData()` based on the `length` of threat arrays provided by the status.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

1201069996155224-as-1203082372816269

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install a vulnerable plugin such as WooCommerce 3.0.0
* Initialize Protect and generate a report
* Delete the vulnerable plugin
* View the Protect admin page again, validate that the threat is gone and threat counts are correct.