### PR TITLE
VideoPress: Expire playback tokens

### DIFF
--- a/projects/packages/videopress/changelog/add-expire-playback-tokens
+++ b/projects/packages/videopress/changelog/add-expire-playback-tokens
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Expire a VideoPress playback token on the local state when it reachs it's expire time.

--- a/projects/packages/videopress/src/client/state/resolvers.js
+++ b/projects/packages/videopress/src/client/state/resolvers.js
@@ -7,6 +7,7 @@ import { addQueryArgs } from '@wordpress/url';
 /**
  * Internal dependencies
  */
+import { playbackTokenExpired } from '../utils/playback-token';
 import {
 	SET_VIDEOS_QUERY,
 	SET_VIDEOS_FILTER,
@@ -325,7 +326,9 @@ const getUsers = {
 const getPlaybackToken = {
 	isFulfilled: ( state, guid ) => {
 		const playbackTokens = state?.playbackTokens?.items ?? [];
-		return playbackTokens?.some( token => token?.guid === guid );
+		return playbackTokens?.some( token => {
+			token?.guid === guid && ! playbackTokenExpired( token?.token );
+		} );
 	},
 	fulfill: guid => async ( { dispatch } ) => {
 		dispatch.setIsFetchingPlaybackToken( true );

--- a/projects/packages/videopress/src/client/utils/playback-token/index.ts
+++ b/projects/packages/videopress/src/client/utils/playback-token/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Extracts the expire time from a JWT token
+ *
+ * @param {string} jwt - The JWT token to extract the expire time
+ * @returns {number} The expire timestamp for the token
+ */
+const getJWTExpireTime = ( jwt: string ): number => {
+	try {
+		const encodedPayload = jwt.split( '.' )[ 1 ];
+		const jwtPayload = JSON.parse( Buffer.from( encodedPayload, 'base64' ).toString() );
+
+		return jwtPayload.exp;
+	} catch ( e ) {
+		return null;
+	}
+};
+
+/**
+ * Check if some JWT token has expired
+ *
+ * @param {string} jwt - The JWT to verify
+ * @returns {boolean} If the token had expired or not
+ */
+export const playbackTokenExpired = ( jwt: string ): boolean => {
+	if ( jwt ) {
+		const jwtExpireTime = getJWTExpireTime( jwt );
+		if ( jwtExpireTime ) {
+			return jwtExpireTime <= Date.now();
+		}
+	}
+
+	return true;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Relates to #26675.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Change the VideoPress playback token resolver to return expired tokens as unfulfilled, so a new one gets fetched

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
* 

This is a draft.