### PR TITLE
Backup: Fix continuous backup status loading

### DIFF
--- a/projects/packages/backup/changelog/fix-infinite-backup-load
+++ b/projects/packages/backup/changelog/fix-infinite-backup-load
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stopped continuous state loading after good backup.

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.9.2';
+	const PACKAGE_VERSION = '1.9.3-alpha';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/backup/src/js/components/Backups.js
+++ b/projects/packages/backup/src/js/components/Backups.js
@@ -2,7 +2,7 @@ import { getRedirectUrl } from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { getDate, dateI18n } from '@wordpress/date';
-import { createInterpolateElement, useEffect, useCallback } from '@wordpress/element';
+import { createInterpolateElement, useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { BACKUP_STATE } from '../constants';
 import useAnalytics from '../hooks/useAnalytics';
@@ -22,18 +22,7 @@ import UploadsIcon from './icons/uploads.svg';
 
 /* eslint react/react-in-jsx-scope: 0 */
 const Backups = () => {
-	const {
-		backupState,
-		fetchBackupsState,
-		latestTime,
-		progress,
-		trackProgress,
-		stats,
-	} = useBackupsState();
-	// Loads data on startup and whenever progress updates.
-	useEffect( () => {
-		fetchBackupsState();
-	}, [ trackProgress ] ); // eslint-disable-line react-hooks/exhaustive-deps
+	const { backupState, latestTime, progress, stats } = useBackupsState();
 
 	return (
 		<div className="jp-wrap jp-content">

--- a/projects/packages/backup/src/js/components/Backups.js
+++ b/projects/packages/backup/src/js/components/Backups.js
@@ -22,11 +22,18 @@ import UploadsIcon from './icons/uploads.svg';
 
 /* eslint react/react-in-jsx-scope: 0 */
 const Backups = () => {
-	const { backupState, fetchBackupsState, latestTime, progress, stats } = useBackupsState();
+	const {
+		backupState,
+		fetchBackupsState,
+		latestTime,
+		progress,
+		trackProgress,
+		stats,
+	} = useBackupsState();
 	// Loads data on startup and whenever progress updates.
 	useEffect( () => {
 		fetchBackupsState();
-	}, [ fetchBackupsState ] );
+	}, [ trackProgress ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	return (
 		<div className="jp-wrap jp-content">

--- a/projects/packages/backup/src/js/hooks/useBackupsState.js
+++ b/projects/packages/backup/src/js/hooks/useBackupsState.js
@@ -1,6 +1,6 @@
 import apiFetch from '@wordpress/api-fetch';
 import { date } from '@wordpress/date';
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { BACKUP_STATE } from '../constants';
 
 const useBackupsState = () => {
@@ -15,7 +15,6 @@ const useBackupsState = () => {
 		themes: 0,
 		warnings: false,
 	} );
-	const [ trackProgress, setTrackProgress ] = useState( 0 );
 
 	const fetchBackupsState = () =>
 		apiFetch( { path: '/jetpack/v4/backups' } ).then(
@@ -70,7 +69,7 @@ const useBackupsState = () => {
 				if ( res.length === 0 || 'started' === latestBackup.status ) {
 					// Grab progress and update every progressInterval until complete.
 					setTimeout( () => {
-						setTrackProgress( trackProgress + 1 );
+						fetchBackupsState();
 					}, progressInterval );
 				}
 			},
@@ -78,12 +77,17 @@ const useBackupsState = () => {
 				setBackupState( BACKUP_STATE.NO_GOOD_BACKUPS );
 			}
 		);
+
+	// Start the initial state fetch
+	useEffect( () => {
+		fetchBackupsState();
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
+
 	return {
 		backupState,
 		fetchBackupsState,
 		latestTime,
 		progress,
-		trackProgress,
 		stats,
 	};
 };

--- a/projects/packages/backup/src/js/hooks/useBackupsState.js
+++ b/projects/packages/backup/src/js/hooks/useBackupsState.js
@@ -83,6 +83,7 @@ const useBackupsState = () => {
 		fetchBackupsState,
 		latestTime,
 		progress,
+		trackProgress,
 		stats,
 	};
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes an issue where the backup status end point continues to be called after we have a complete good backup

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new Jurassic Ninja site with this branch (it's a bit harder to fully test locally)
* Connect your site, purchase a plan and return to the Backup screen
* Open the Network Panel in your dev tools to watch API requests (you can filter to `backups`)
* Ensure the initial backup of the site shows progress as it backups up
* When the backup is complete ensure that the requests stop

