### PR TITLE
Search: don't show discounted price when it's the same

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -207,7 +207,9 @@ const ProductDetailCard = ( { slug, onClick, trackButtonClick, className, suppor
 				{ needsPurchase && (
 					<>
 						<div className={ styles[ 'price-container' ] }>
-							<Price value={ price } currency={ currencyCode } isOld={ true } />
+							{ discountPrice < price && (
+								<Price value={ price } currency={ currencyCode } isOld={ true } />
+							) }
 							<Price value={ discountPrice } currency={ currencyCode } isOld={ false } />
 						</div>
 						<Text className={ styles[ 'price-description' ] }>

--- a/projects/packages/my-jetpack/changelog/fix-dont-show-no-discount
+++ b/projects/packages/my-jetpack/changelog/fix-dont-show-no-discount
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Don't show old price when it's the same as new one

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "2.3.0",
+	"version": "2.3.1-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -29,7 +29,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '2.3.0';
+	const PACKAGE_VERSION = '2.3.1-alpha';
 
 	/**
 	 * Initialize My Jetapack


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
On `/wp-admin/admin.php?page=my-jetpack#/add-search` don't show discounted price
when it is the same as final price.

Before:

![image](https://user-images.githubusercontent.com/6437642/197309783-abd31224-d3b0-4acb-8129-2792ce1973bf.png)


After:

![image](https://user-images.githubusercontent.com/6437642/197309775-16ff9d5f-077e-40f3-b200-2504e6d37743.png)

 
#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
It's just a bug I've noticed while looking at #27003

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:


* Enable sandboxed store. The price for Jetpack Search is not discounted there.
* Enable full Jetpack plugin.
* Go to `/wp-admin/admin.php?page=my-jetpack#/add-search` (or go to My Jetpack and click  `Purchase`/`Start for free` next to Search).
* Verify that there's only one price.
* Visit other products, like Backup or Scan, and verify that the discounted price is still visible there.

