### PR TITLE
Search: fix upgrade paths for free plan

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-search-upgrade-paths
+++ b/projects/packages/my-jetpack/changelog/fix-search-upgrade-paths
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: check if free plan and new pricing is active using wpcom API

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "2.3.0",
+	"version": "2.3.1-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -29,7 +29,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '2.3.0';
+	const PACKAGE_VERSION = '2.3.1-alpha';
 
 	/**
 	 * Initialize My Jetapack

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -155,11 +155,21 @@ class Search extends Hybrid_Product {
 	}
 
 	/**
-	 * Returns true if the new_pricing_202208 is set to not empty in URL for testing purpose.
+	 * Returns true if the new_pricing_202208 is set to not empty in URL for testing purpose, or it's active.
 	 */
 	public static function is_new_pricing_202208() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		return isset( $_GET['new_pricing_202208'] ) && $_GET['new_pricing_202208'];
+		if ( isset( $_GET['new_pricing_202208'] ) && $_GET['new_pricing_202208'] ) {
+			return true;
+		}
+
+		$record_count   = intval( Search_Stats::estimate_count() );
+		$search_pricing = static::get_pricing_from_wpcom( $record_count );
+		if ( is_wp_error( $search_pricing ) ) {
+			return false;
+		}
+
+		return '202208' === $search_pricing['pricing_version'];
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/client/product-descriptions/utils.js
+++ b/projects/plugins/jetpack/_inc/client/product-descriptions/utils.js
@@ -1,6 +1,14 @@
 import { getSiteAdminUrl } from 'state/initial-state';
 import { productDescriptionRoutes } from './constants';
 
+/**
+ * This affects search "Upgrade" buttons, and changes them into "Start for free".
+ * It should use API to check if feature is enabled, but we didn't make it in time.
+ *
+ * Todo: Make it return true once we fully ship and enable new search pricing.
+ *
+ * @returns {boolean} Whether new search pricing and free plan is forced by URL parameter.
+ */
 export const isSearchNewPricingLaunched202208 = () =>
 	URLSearchParams && !! new URLSearchParams( window.location?.search ).get( 'new_pricing_202208' );
 
@@ -18,7 +26,7 @@ export const getProductDescriptionUrl = ( state, productKey ) => {
 	const baseUrl = `${ getSiteAdminUrl( state ) }admin.php?page=jetpack#`;
 
 	// TODO: remove the && condition on Search new pricing launch.
-	if ( productKey === 'search' && isSearchNewPricingLaunched202208() ) {
+	if ( productKey === 'search' ) {
 		return `${ getSiteAdminUrl( state ) }admin.php?page=jetpack-search`;
 	}
 

--- a/projects/plugins/jetpack/changelog/fix-search-upgrade-paths
+++ b/projects/plugins/jetpack/changelog/fix-search-upgrade-paths
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: use search dashboard CTA instead of product page which wasn't detecting if free plan is active correctly


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27003

#### Changes proposed in this Pull Request:
Our free plan should be visible once we flip the `pricing_version` field in API to `202208`.
Currently, in two places it still had to be forced by adding `&new_pricing_202208=1` to URL manually.
Those places were reachable from `My Jetpack`, `Settings -> Performance`, and `Dashboard -> At a glance`.

In this commit, I'm fixing the "My Jetpack" page so that it uses return value from API to see if the new pricing is active.

I also made it so that we redirect to the Search dashboard (which doubles as a pricing page when search isn't purchased)
instead of page `/wp-admin/admin.php?page=my-jetpack#/add-search`.
Search dashboard already does the API check, so it resolves this issue.

The remaining known issue is that `Settings` and `At a glance` still show `Purchase` instead of `Start for free` for Search.
We'll fix that in the next version, once free plan and new pricing is fully released.
It's probably not worth doing the API call to check for it.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
p1666377950913959-slack-C02ME06LF

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
This requires the "Jetpack Sandbox Store" plugin activated to make sure that the free option shows up.

There are 3 places in the full Jetpack plugin to check:
- `My Jetpack`
- `Settings` -> `Performance`
- `Dashboard` -> `At a glance`

In all 3 of those places, the link to Purchase Jetpack Search should lead to a page providing an option to start free plan when the store is sandboxed. With live store, it should show only the paid plan.