### PR TITLE
 VideoPress: show video thumbnails for private videos in the list view

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-render-private-videos-thumb-in-video-list-view
+++ b/projects/packages/videopress/changelog/update-videopress-render-private-videos-thumb-in-video-list-view
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: show video thumbnails for private videos in the list view

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -247,7 +247,7 @@ class Data {
 				$privacy_setting = $jetpack_videopress['privacy_setting'];
 
 				$original      = $videopress_media_details['original'];
-				$poster        = $privacy_setting !== 2 ? $videopress_media_details['poster'] : null;
+				$poster        = $privacy_setting !== 1 ? $videopress_media_details['poster'] : null;
 				$upload_date   = $videopress_media_details['upload_date'];
 				$duration      = $videopress_media_details['duration'];
 				$is_private    = $videopress_media_details['is_private'];
@@ -255,7 +255,7 @@ class Data {
 				$finished      = $videopress_media_details['finished'];
 				$files         = $videopress_media_details['files'];
 
-				if ( isset( $files['dvd']['original_img'] ) && $privacy_setting !== 2 ) {
+				if ( isset( $files['dvd']['original_img'] ) && $privacy_setting !== 1 ) {
 					$thumbnail = $file_url_base['https'] . $files['dvd']['original_img'];
 				} else {
 					$thumbnail = null;

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -247,7 +247,7 @@ class Data {
 				$privacy_setting = $jetpack_videopress['privacy_setting'];
 
 				$original      = $videopress_media_details['original'];
-				$poster        = $videopress_media_details['poster'];
+				$poster        = $privacy_setting !== 2 ? $videopress_media_details['poster'] : null;
 				$upload_date   = $videopress_media_details['upload_date'];
 				$duration      = $videopress_media_details['duration'];
 				$is_private    = $videopress_media_details['is_private'];
@@ -255,7 +255,7 @@ class Data {
 				$finished      = $videopress_media_details['finished'];
 				$files         = $videopress_media_details['files'];
 
-				if ( isset( $files['dvd']['original_img'] ) ) {
+				if ( isset( $files['dvd']['original_img'] ) && $privacy_setting !== 2 ) {
 					$thumbnail = $file_url_base['https'] . $files['dvd']['original_img'];
 				} else {
 					$thumbnail = null;

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
@@ -190,9 +190,7 @@ const EditVideoDetails = () => {
 	// We may need the playback token on the video URL as well
 	const videoUrl = playbackToken ? `${ url }?metadata_token=${ playbackToken }` : url;
 
-	let thumbnail: string | JSX.Element = playbackToken
-		? `${ posterImage }?metadata_token=${ playbackToken }`
-		: posterImage;
+	let thumbnail = posterImage;
 
 	if ( posterImageSource === 'video' && useVideoAsThumbnail ) {
 		thumbnail = <VideoPlayer src={ videoUrl } currentTime={ selectedTime } />;

--- a/projects/packages/videopress/src/client/admin/components/video-thumbnail/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-thumbnail/index.tsx
@@ -117,9 +117,6 @@ const VideoThumbnail = ( {
 }: VideoThumbnailProps ) => {
 	const [ isSmall ] = useBreakpointMatch( 'sm' );
 
-	/** If the thumbnail is private, do not try to show it */
-	thumbnail = isPrivate ? null : thumbnail;
-
 	thumbnail =
 		typeof thumbnail === 'string' && thumbnail !== '' ? (
 			<img src={ thumbnail } alt={ __( 'Video thumbnail', 'jetpack-videopress-pkg' ) } />

--- a/projects/packages/videopress/src/client/state/resolvers.js
+++ b/projects/packages/videopress/src/client/state/resolvers.js
@@ -160,7 +160,7 @@ const getVideo = {
 		const video = videos.find( ( { id: videoId } ) => videoId === id );
 
 		// Private videos require a token to be fetched.
-		if ( VIDEO_PRIVACY_LEVELS[ video.privacySetting ] === VIDEO_PRIVACY_LEVEL_PRIVATE ) {
+		if ( video && VIDEO_PRIVACY_LEVELS[ video.privacySetting ] === VIDEO_PRIVACY_LEVEL_PRIVATE ) {
 			const tokens = state?.playbackTokens?.items || [];
 			const token = tokens.find( t => t?.guid === video.guid );
 

--- a/projects/packages/videopress/src/client/state/resolvers.js
+++ b/projects/packages/videopress/src/client/state/resolvers.js
@@ -44,8 +44,13 @@ async function populateVideoDataWithToken( video, resolveSelect ) {
 	}
 
 	const { token } = await resolveSelect.getPlaybackToken( video.guid );
-	video.posterImage += `?metadata_token=${ token }`;
-	video.thumbnail += `?metadata_token=${ token }`;
+	if ( ! /metadata_token=/.test( video.posterImage ) ) {
+		video.posterImage += `?metadata_token=${ token }`;
+	}
+
+	if ( ! /metadata_token=/.test( video.thumbnail ) ) {
+		video.thumbnail += `?metadata_token=${ token }`;
+	}
 
 	return video;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds changes in the data handling to visualize thumbnail images for private videos, too.

Fixes https://github.com/Automattic/jetpack/issues/26675

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*  VideoPress: show video thumbnails for private videos, too, in the list view

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard
* Ensure you have some private and public videos there. It will be useful to test.
* Ensure all videos get the thumbnail.
* Ensure the thumbnail image also shows on the video details page.

* You'd like to take a look at the implementation's behavior.

<img width="1707" alt="Screen Shot 2022-10-24 at 08 33 33" src="https://user-images.githubusercontent.com/77539/197526971-bc13bba2-459c-4f2b-a439-c4784928be55.png">

In the screenshot below:
* there are four private videos and two public
* The network tab shows the additional requests that the client needs to do to tokenized the private resources

https://user-images.githubusercontent.com/77539/197527561-54b08132-7469-48b8-b25d-b4b9285510f1.mov

