### PR TITLE
Protect: Check for required plan after site connection during upgrade flow

### DIFF
--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -181,7 +181,7 @@ class Jetpack_Protect {
 			'installedPlugins'  => Plugins_Installer::get_plugins(),
 			'installedThemes'   => Sync_Functions::get_themes(),
 			'wpVersion'         => $wp_version,
-			'adminUrl'          => admin_url( 'admin.php?page=jetpack-protect' ),
+			'adminUrl'          => 'admin.php?page=jetpack-protect',
 			'siteSuffix'        => ( new Jetpack_Status() )->get_site_suffix(),
 			'jetpackScan'       => My_Jetpack_Products::get_product( 'scan' ),
 			'productData'       => My_Jetpack_Products::get_product( 'protect' ),

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -254,6 +254,18 @@ class Jetpack_Protect {
 	public static function register_rest_endpoints() {
 		register_rest_route(
 			'jetpack-protect/v1',
+			'plan',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => __CLASS__ . '::api_get_plan',
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
+			)
+		);
+
+		register_rest_route(
+			'jetpack-protect/v1',
 			'status',
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
@@ -335,6 +347,18 @@ class Jetpack_Protect {
 				},
 			)
 		);
+	}
+
+	/**
+	 * Return site plan data for the API endpoint
+	 *
+	 * @return WP_REST_Response
+	 */
+	public static function api_get_plan() {
+		$plan                 = My_Jetpack_Products::get_product( 'scan' );
+		$plan['pricingForUi'] = Plan::get_product( 'jetpack_scan' );
+
+		return rest_ensure_response( $plan, 200 );
 	}
 
 	/**

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -13,6 +13,7 @@ import {
 	useConnectionErrorNotice,
 	ConnectionError,
 } from '@automattic/jetpack-connection';
+import apiFetch from '@wordpress/api-fetch';
 import { Spinner } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -306,6 +307,11 @@ const Admin = () => {
 	const { run, isRegistered, hasCheckoutStarted } = useProductCheckoutWorkflow( {
 		productSlug: JETPACK_SCAN,
 		redirectUrl: adminUrl,
+		siteProductAvailabilityHandler: async () =>
+			apiFetch( {
+				path: 'jetpack-protect/v1/plan',
+				method: 'GET',
+			} ).then( jetpackScan => jetpackScan?.has_required_plan ),
 	} );
 
 	/*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a `siteProductAvailabilityHandler` argument to the checkout workflow hook, to check if the user has a valid paid Protect plan before directing to checkout.
* Adds an API endpoint to return the state contents of `jetpackScan`.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

1201069996155224-as-1203203119095200

peb6dq-7C-p2#comment-95 

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a Jurassic Ninja site running this branch
* Connect Jetpack and purchase a Scan plan
* Disconnect your site (Bottom right of My Jetpack page makes it easy)
* Visit the Protect admin page
* Click "Get Jetpack Protect"
* You should be prompted ONLY to connect your site, and then be redirected back without going through the checkout process
* The Protect admin screen should show the paid UI