### PR TITLE
VideoPress: handle UI when setting private video in the quick actions component

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-handle-ui-when-setting-private-video
+++ b/projects/packages/videopress/changelog/update-videopress-handle-ui-when-setting-private-video
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: handle UI when setting private video in the quick actions component

--- a/projects/packages/videopress/src/client/admin/components/video-quick-actions/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-quick-actions/index.tsx
@@ -16,6 +16,7 @@ import {
 	VIDEO_PRIVACY_LEVEL_PUBLIC,
 	VIDEO_PRIVACY_LEVEL_SITE_DEFAULT,
 } from '../../../state/constants';
+import usePlaybackToken from '../../hooks/use-playback-token';
 import usePosterEdit from '../../hooks/use-poster-edit';
 import useVideo from '../../hooks/use-video';
 import { VideoThumbnailDropdownButtons } from '../video-thumbnail';
@@ -242,6 +243,8 @@ export const ConnectVideoQuickActions = ( props: ConnectVideoQuickActionsProps )
 		videoId
 	);
 
+	const { isFetchingPlaybackToken } = usePlaybackToken( data );
+
 	const [ showDeleteModal, setShowDeleteModal ] = useState( false );
 	const {
 		frameSelectorIsOpen,
@@ -333,7 +336,7 @@ export const ConnectVideoQuickActions = ( props: ConnectVideoQuickActionsProps )
 			onUpdateVideoThumbnail={ onUpdateVideoThumbnail }
 			onDeleteVideo={ () => setShowDeleteModal( true ) }
 			privacySetting={ privacySetting }
-			isUpdatingPrivacy={ isUpdatingPrivacy }
+			isUpdatingPrivacy={ isUpdatingPrivacy || isFetchingPlaybackToken }
 			isUpdatingPoster={ isUpdatingPoster }
 		/>
 	);

--- a/projects/packages/videopress/src/client/state/actions.js
+++ b/projects/packages/videopress/src/client/state/actions.js
@@ -129,7 +129,7 @@ const setVideosStorageUsed = used => {
 	return { type: SET_VIDEOS_STORAGE_USED, used };
 };
 
-const updateVideoPrivacy = ( id, level ) => async ( { dispatch } ) => {
+const updateVideoPrivacy = ( id, level ) => async ( { dispatch, select, resolveSelect } ) => {
 	const privacySetting = Number( level );
 	if ( isNaN( privacySetting ) ) {
 		throw new Error( `Invalid privacy level: '${ level }'` );
@@ -138,6 +138,12 @@ const updateVideoPrivacy = ( id, level ) => async ( { dispatch } ) => {
 	if ( 0 > privacySetting || privacySetting >= VIDEO_PRIVACY_LEVELS.length ) {
 		// @todo: implement error handling / UI
 		throw new Error( `Invalid privacy level: '${ level }'` );
+	}
+
+	// Request a video token asap when it becomes private.
+	if ( level === 1 ) {
+		const video = await select.getVideo( id );
+		await resolveSelect.getPlaybackToken( video?.guid );
 	}
 
 	// Let's be optimistic and update the UI right away.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Currently, when setting the video's privacy to `private,` the app performs a request for all videos, which is acceptable but not ideal.
This PR adds changes to make the client request the token just after running the process to make the video private, pulling the token to be ready to use before it becomes private (sync behavior ftw).

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: handle UI when setting private video in the quick actions component

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to VideoPress dashboard
* Ensure you have a public video
* Set video privacy to `private`
* Before, the app request all videos showing six placeholders there
* After, it updates the privacy as expected. No side effects there.
* You could look at the network tab to see how the client requests the token when it's needed.


https://user-images.githubusercontent.com/77539/197597946-8d4b819c-fd18-4fe6-aab9-bc4056d3b9a3.mov

