### PR TITLE
Protect: Add clear notice action

### DIFF
--- a/projects/plugins/protect/src/js/state/actions.js
+++ b/projects/plugins/protect/src/js/state/actions.js
@@ -16,6 +16,7 @@ const SET_THREAT_IS_UPDATING = 'SET_THREAT_IS_UPDATING';
 const SET_THREATS_ARE_FIXING = 'SET_THREATS_ARE_FIXING';
 const SET_MODAL = 'SET_MODAL';
 const SET_NOTICE = 'SET_NOTICE';
+const CLEAR_NOTICE = 'CLEAR_NOTICE';
 
 const setStatus = status => {
 	return { type: SET_STATUS, status };
@@ -281,6 +282,11 @@ const scan = ( callback = () => {} ) => async ( { dispatch } ) => {
 				);
 			} )
 			.then( () => {
+				setTimeout( () => {
+					return dispatch( clearNotice() );
+				}, 1000 );
+			} )
+			.then( () => {
 				return dispatch( refreshStatusUntilScanning() );
 			} )
 			.catch( () => {
@@ -314,6 +320,10 @@ const setNotice = notice => {
 	return { type: SET_NOTICE, payload: notice };
 };
 
+const clearNotice = () => {
+	return { type: CLEAR_NOTICE };
+};
+
 const actions = {
 	checkCredentials,
 	setCredentials,
@@ -330,6 +340,7 @@ const actions = {
 	ignoreThreat,
 	setModal,
 	setNotice,
+	clearNotice,
 	fixThreats,
 	scan,
 	setThreatsAreFixing,
@@ -348,6 +359,7 @@ export {
 	SET_THREAT_IS_UPDATING,
 	SET_MODAL,
 	SET_NOTICE,
+	CLEAR_NOTICE,
 	SET_THREATS_ARE_FIXING,
 	actions as default,
 };

--- a/projects/plugins/protect/src/js/state/reducers.js
+++ b/projects/plugins/protect/src/js/state/reducers.js
@@ -12,6 +12,7 @@ import {
 	SET_THREAT_IS_UPDATING,
 	SET_MODAL,
 	SET_NOTICE,
+	CLEAR_NOTICE,
 	SET_THREATS_ARE_FIXING,
 } from './actions';
 
@@ -123,6 +124,8 @@ const notice = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case SET_NOTICE:
 			return { ...state, ...action.payload };
+		case CLEAR_NOTICE:
+			return {};
 	}
 	return state;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Description
This PR introduces an action for clearing admin notices. Currently, after initiating a scan the success notice persists for longer than necessary and is then only dismissed after refreshing the page.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a new `CLEAR_NOTICE` action
* Applies the accompanying `clearNotice` function within the `scan` action so the notice is dismissed shortly after the initial display 

#### Other information:
- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- 1201069996155224-as-1203211926808780

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Fire up a Jurassic Ninja instance w/ the Jetpack Beta plugin installed using this Protect branch
* Upgrade to Scan inclusive plan
* Queue a scan from the UI and verify that the success notice only displays for a short period before being permanently dismissed
* Ensure all related actions remain functional and perform as expected

