### PR TITLE
VideoPress: Hide thumbnail update actions and open library directly

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-hide-thumbnail-actions
+++ b/projects/packages/videopress/changelog/update-videopress-hide-thumbnail-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: Hide thumbnail actions and open library directly

--- a/projects/packages/videopress/src/client/admin/components/video-quick-actions/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-quick-actions/index.tsx
@@ -79,6 +79,7 @@ const ThumbnailActionsDropdown = ( {
 	return (
 		<Dropdown
 			position="bottom left"
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<>
 					<Button
@@ -88,7 +89,8 @@ const ThumbnailActionsDropdown = ( {
 						icon={ image }
 						onClick={ () => {
 							setShowPopover( false );
-							onToggle();
+							// Uploading image directly instead of toggling the content for now
+							onUpdate( 'upload-image' );
 						} }
 						aria-expanded={ isOpen }
 						onMouseEnter={ () => setShowPopover( true ) }

--- a/projects/packages/videopress/src/client/admin/components/video-thumbnail/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-thumbnail/index.tsx
@@ -76,12 +76,13 @@ export const VideoThumbnailDropdown = ( {
 		<div className={ styles[ 'video-thumbnail-edit' ] }>
 			<Dropdown
 				position="bottom left"
+				// eslint-disable-next-line @typescript-eslint/no-unused-vars
 				renderToggle={ ( { isOpen, onToggle } ) => (
 					<Button
 						variant="secondary"
 						className={ styles[ 'thumbnail__edit-button' ] }
 						icon={ edit }
-						onClick={ onToggle }
+						onClick={ onUploadImage }
 						aria-expanded={ isOpen }
 					/>
 				) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #27037

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Hides the actions dropdown, opening the library directly to upload a new thumbnail

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard
* Click on `Update thumbnail` on a video
* Check that the library opens directly, with no actions dropdown
* Go to the video details edit page
* Click on the pencil action
* Check that the library opens directly, with no actions dropdown

https://user-images.githubusercontent.com/8486249/197622024-b4d20abd-9cfa-4a3f-8fba-1d5c125afb3a.mp4