### PR TITLE
E2E: Add basic test for My Jetpack loading from the Jetpack plugin. 

### DIFF
--- a/projects/plugins/jetpack/changelog/add-e2e-my-jetpack-basic-test
+++ b/projects/plugins/jetpack/changelog/add-e2e-my-jetpack-basic-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+E2E: Add basic test for My Jetpack loading after connection of Jetpack plugin.

--- a/projects/plugins/jetpack/tests/e2e/specs/post-connection/my-jetpack.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/post-connection/my-jetpack.test.js
@@ -1,0 +1,30 @@
+import { test, expect } from 'jetpack-e2e-commons/fixtures/base-test.js';
+import { MyJetpackPage } from 'jetpack-e2e-commons/pages/wp-admin/index.js';
+import playwrightConfig from '../../playwright.config.cjs';
+import { Plans, prerequisitesBuilder } from 'jetpack-e2e-commons/env/index.js';
+
+test.describe.parallel( 'My Jetpack loading', () => {
+	test.beforeAll( async ( { browser } ) => {
+		const page = await browser.newPage( playwrightConfig.use );
+		/*
+		 * Just a basic free fully-connected site.
+		 */
+		await prerequisitesBuilder( page )
+			.withCleanEnv()
+			.withWpComLoggedIn( true )
+			.withLoggedIn( true )
+			.withConnection( true )
+			.withPlan( Plans.Free )
+			.build();
+		await page.close();
+	} );
+
+	test( 'Connection status card is showing', async ( { page } ) => {
+		let myJetpackPage;
+		await test.step( 'Load My Jetpack page', async () => {
+			myJetpackPage = await MyJetpackPage.visit( page );
+			const isPageVisible = await myJetpackPage.isConnectionStatusCardDisplaying();
+			expect( isPageVisible, 'Connection Card should be showing' ).toBeTruthy();
+		} );
+	} );
+} );

--- a/tools/e2e-commons/pages/wp-admin/index.js
+++ b/tools/e2e-commons/pages/wp-admin/index.js
@@ -9,6 +9,7 @@ export { default as DashboardPage } from './dashboard.js';
 export { default as InPlacePlansPage } from './in-place-plans.js';
 export { default as JetpackPage } from './jetpack.js';
 export { default as JetpackDashboardPage } from './jetpack-dashboard.js';
+export { default as MyJetpackPage } from './jetpack-my-jetpack.js';
 export { default as JetpackMyPlanPage } from './jetpack-my-plan.js';
 export { default as WPLoginPage } from './login.js';
 export { default as PluginsPage } from './plugins.js';

--- a/tools/e2e-commons/pages/wp-admin/jetpack-my-jetpack.js
+++ b/tools/e2e-commons/pages/wp-admin/jetpack-my-jetpack.js
@@ -1,0 +1,19 @@
+import WpPage from '../wp-page.js';
+import logger from '../../logger.cjs';
+import { resolveSiteUrl } from '../../helpers/utils-helper.cjs';
+
+export default class MyJetpackPage extends WpPage {
+	constructor( page ) {
+		const url = resolveSiteUrl() + '/wp-admin/admin.php?page=my-jetpack';
+		super( page, { expectedSelectors: [ '#my-jetpack-container' ], url } );
+	}
+
+	get connectionStatusCard() {
+		return '.jp-connection-status-card';
+	}
+
+	async isConnectionStatusCardDisplaying() {
+		logger.step( 'Checking if Connection card is displaying' );
+		return await this.isElementVisible( this.connectionStatusCard );
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Adds a basic post-connection test to see if My Jetpack is loading. 

#### Other information:

I'm having trouble figuring out how to run this test locally. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

View the tests. 

