### PR TITLE
VideoPress: make tracks works

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-tracks-hook
+++ b/projects/packages/videopress/changelog/update-videopress-tracks-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: make tracks works

--- a/projects/packages/videopress/src/class-admin-ui.php
+++ b/projects/packages/videopress/src/class-admin-ui.php
@@ -140,6 +140,8 @@ class Admin_UI {
 		);
 		Assets::enqueue_script( self::JETPACK_VIDEOPRESS_PKG_NAMESPACE );
 
+		wp_enqueue_media();
+
 		// Required for Analytics.
 		if ( self::can_use_analytics() ) {
 			Tracking::register_tracks_functions_scripts( true );

--- a/projects/packages/videopress/src/class-admin-ui.php
+++ b/projects/packages/videopress/src/class-admin-ui.php
@@ -10,9 +10,12 @@ namespace Automattic\Jetpack\VideoPress;
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\My_Jetpack\Products as My_Jetpack_Products;
 use Automattic\Jetpack\Status as Status;
+use Automattic\Jetpack\Terms_Of_Service;
+use Automattic\Jetpack\Tracking;
 
 /**
  * Initialized the VideoPress package
@@ -111,6 +114,18 @@ class Admin_UI {
 	}
 
 	/**
+	 * Returns whether we are in condition to track to use
+	 * Analytics functionality like Tracks, MC, or GA.
+	 */
+	public static function can_use_analytics() {
+		$status     = new Status();
+		$connection = new Connection_Manager();
+		$tracking   = new Tracking( 'jetpack', $connection );
+
+		return $tracking->should_enable_tracking( new Terms_Of_Service(), $status );
+	}
+
+	/**
 	 * Enqueue plugin admin scripts and styles.
 	 */
 	public static function enqueue_admin_scripts() {
@@ -125,10 +140,10 @@ class Admin_UI {
 		);
 		Assets::enqueue_script( self::JETPACK_VIDEOPRESS_PKG_NAMESPACE );
 
-		wp_enqueue_media();
-
 		// Required for Analytics.
-		wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
+		if ( self::can_use_analytics() ) {
+			Tracking::register_tracks_functions_scripts( true );
+		}
 
 		// Initial JS state including JP Connection data.
 		wp_add_inline_script( self::JETPACK_VIDEOPRESS_PKG_NAMESPACE, Connection_Initial_State::render(), 'before' );

--- a/projects/packages/videopress/src/class-admin-ui.php
+++ b/projects/packages/videopress/src/class-admin-ui.php
@@ -127,6 +127,9 @@ class Admin_UI {
 
 		wp_enqueue_media();
 
+		// Required for Analytics.
+		wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
+
 		// Initial JS state including JP Connection data.
 		wp_add_inline_script( self::JETPACK_VIDEOPRESS_PKG_NAMESPACE, Connection_Initial_State::render(), 'before' );
 		wp_add_inline_script( self::JETPACK_VIDEOPRESS_PKG_NAMESPACE, self::render_initial_state(), 'before' );

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -108,7 +108,7 @@ const Admin = () => {
 	const addFirstLabel = __( 'Add your first video', 'jetpack-videopress-pkg' );
 	const addVideoLabel = hasVideos ? addNewLabel : addFirstLabel;
 
-	useAnalyticsTracks( { pageViewEventName: 'admin' } );
+	useAnalyticsTracks( { pageViewEventName: 'jetpack_videopress_admin_page_view' } );
 
 	return (
 		<AdminPage

--- a/projects/packages/videopress/src/client/admin/hooks/use-analytics-tracks/Readme.md
+++ b/projects/packages/videopress/src/client/admin/hooks/use-analytics-tracks/Readme.md
@@ -34,22 +34,6 @@ function MyAdminApp( init ) {
 
 When defined, it will record a **page-view** event. See [Recording a Page View event](#recording-a-page-view-event) section for more info.
 
-### `pageViewNamespace`
-
--   Type: `String`
--   Optional
--   Default: `jetpack-videopress`
-
-The prefix of the whole name of the **page-view** event. You may like to define a different prefix when recording events in other apps, contexts, etc. For instance, `calypso`, `woocommerce`, etc
-
-### `pageViewSuffix`
-
--   Type: `String`
--   Optional
--   Default: `page_view`
-
-The suffix of the whole name of the **page-view** event. **We strongly do not recommend changing it** unless you really consider the need to do.
-
 ### `pageViewEventProperties`
 
 -   Type: `object`
@@ -139,12 +123,6 @@ function MyAdminApp() {
 
 Recording a **page-view** event is something so usual that deserves simple and automatic usage.
 Taking advantage of the React hooks, it makes sense to induce that it happens when the component is mounted.
-Also, and by convention to get even more straightforward, a **page-view** event has the following shape:
-
-`{ pageViewNamespace }_{ eventName }_{ suffix }`, where the values of `pageViewNamespace` is `jetpack_videopress` and `suffix` is `page_view` by default.
-This naming convention aims to be consistent among all page-view events recorded by different apps, contexts, etc.
-
-Being said that, it's possible to record the **page-view** event simply by defining the event name via the [pageViewEventName](#pagevieweventname-optional) of the hook settings:
 
 ```jsx
 import useAnalyticsTracks from './hooks/use-analytics-tracks';
@@ -155,7 +133,7 @@ function MyAdminApp() {
 	 * the `jetpack_videopress_my_section_page_view` event.
 	 */
 	useAnalyticsTracks( {
-		pageViewEventName: 'my_section'
+		pageViewEventName: 'jetpack_videopress_my_section_page_view'
 	} );
 
 	return <div>Hello, tracking world!</div>;

--- a/projects/packages/videopress/src/client/admin/hooks/use-analytics-tracks/Readme.md
+++ b/projects/packages/videopress/src/client/admin/hooks/use-analytics-tracks/Readme.md
@@ -12,7 +12,9 @@ function MyAdminApp( init ) {
 	 * Get the recordEvent helper,
 	 * registering the page-view record on the fly.
 	 */
-	const { recordEvent } = useAnalyticsTracks( { pageViewEventName: 'my_section' } );
+	const { recordEvent } = useAnalyticsTracks( {
+		pageViewEventName: 'jetpack_videopress_my_section_page_view',
+	} );
 
 	if ( init ) {
 		// Record generic event.

--- a/projects/packages/videopress/src/client/admin/hooks/use-analytics-tracks/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-analytics-tracks/index.ts
@@ -14,7 +14,8 @@ const useAnalyticsTracks = ( {
 	pageViewEventProperties = {},
 }: useAnalyticsTracksProps ) => {
 	const { isUserConnected, isRegistered, userConnectionData } = useConnection();
-	const { login, ID } = userConnectionData.currentUser?.wpcomUser || {};
+	const { blogId } = userConnectionData?.currentUser || {};
+	const { login, ID } = userConnectionData?.currentUser?.wpcomUser || {};
 
 	// Tracks
 	const { tracks } = jetpackAnalytics;
@@ -36,9 +37,14 @@ const useAnalyticsTracks = ( {
 			callback = typeof properties === 'function' ? properties : callback;
 			properties = typeof properties === 'function' ? {} : properties;
 
+			// Populate event props with blog ID when it's available.
+			if ( blogId ) {
+				properties.blog_id = blogId;
+			}
+
 			return () => recordEventAsync( eventName, properties ).then( callback );
 		},
-		[ recordEventAsync ]
+		[ recordEventAsync, blogId ]
 	);
 
 	// Initialize Analytics identifying the user.
@@ -65,8 +71,12 @@ const useAnalyticsTracks = ( {
 			return;
 		}
 
+		if ( blogId ) {
+			pageViewEventProperties.blog_id = blogId;
+		}
+
 		recordEvent( pageViewEventName, pageViewEventProperties );
-	}, [] );
+	}, [ blogId ] );
 
 	return {
 		recordEvent: recordEventAsync,

--- a/projects/packages/videopress/src/client/admin/hooks/use-analytics-tracks/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-analytics-tracks/index.ts
@@ -11,8 +11,6 @@ import { useAnalyticsTracksProps } from './types';
 
 const useAnalyticsTracks = ( {
 	pageViewEventName,
-	pageViewNamespace = 'jetpack_videopress',
-	pageViewSuffix = 'page_view',
 	pageViewEventProperties = {},
 }: useAnalyticsTracksProps ) => {
 	const { isUserConnected, isRegistered, userConnectionData } = useConnection();
@@ -57,21 +55,17 @@ const useAnalyticsTracks = ( {
 	 * It's considered a page view event
 	 * when the component is mounted.
 	 */
-	const pageViewEvent = pageViewEventName
-		? `${ pageViewNamespace }_${ pageViewEventName }_${ pageViewSuffix }`
-		: null;
-
 	useEffect( () => {
 		// Also, only run if the site is registered.
 		if ( ! isRegistered ) {
 			return;
 		}
 
-		if ( ! pageViewEvent ) {
+		if ( ! pageViewEventName ) {
 			return;
 		}
 
-		recordEvent( pageViewEvent, pageViewEventProperties );
+		recordEvent( pageViewEventName, pageViewEventProperties );
 	}, [] );
 
 	return {

--- a/projects/packages/videopress/src/client/admin/hooks/use-analytics-tracks/types.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-analytics-tracks/types.ts
@@ -5,5 +5,7 @@ type eventPageViewNameProp = `${ eventPrefix }_${ eventName }_${ eventSuffix }`;
 
 export type useAnalyticsTracksProps = {
 	pageViewEventName?: eventPageViewNameProp;
-	pageViewEventProperties?: object;
+	pageViewEventProperties?: {
+		[ key: string ]: string | number | boolean;
+	};
 };

--- a/projects/packages/videopress/src/client/admin/hooks/use-analytics-tracks/types.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-analytics-tracks/types.ts
@@ -1,6 +1,9 @@
+type eventPrefix = 'jetpack_videopress';
+type eventSuffix = 'page_view';
+type eventName = string;
+type eventPageViewNameProp = `${ eventPrefix }_${ eventName }_${ eventSuffix }`;
+
 export type useAnalyticsTracksProps = {
-	pageViewEventName?: string;
-	pageViewNamespace?: string;
-	pageViewSuffix?: string;
+	pageViewEventName?: eventPageViewNameProp;
 	pageViewEventProperties?: object;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Currently, the tracking system is not working because, in short, we forgot to add the assets file 🤦 .
This PR adds the file and re-implemented the useAnalyticsTracks() hook following the design guides, for instance, avoiding programmatically creating event names.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: make tracks works

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Yes: 
* track `jetpack_videopress_admin_page_view` event when the VideoPress standalone dashboard renders
* track `jetpack_videopress_upgrade_trigger_link_click` when user checkout by clicking on the upgrade trigger component

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard page
* Open dev-console
* Set the `debug` local storage to be able to see tracks logs
```
localStorage.setItem( 'debug', '*' )
```

You may want to ensure to see all logs (verbose) and also preserve them when the client performs a redirect.

<img width="672" alt="Screen Shot 2022-10-17 at 17 04 56" src="https://user-images.githubusercontent.com/77539/196272618-69093ab9-0eee-490a-942f-d1c0d9ee1e84.png">

* Confirm there are not any logs when the site is not connected
* Connect the site
* Confirm you see the app tracks the `jetpack_videopress_admin_page_view` event.

<img width="763" alt="Screen Shot 2022-10-17 at 17 13 29" src="https://user-images.githubusercontent.com/77539/196274211-327819f2-eec7-48e3-b95e-532791f7c3cb.png">

* Confirm you see the app tracks the `jetpack_videopress_upgrade_trigger_link_click` when check out the product:

<img width="807" alt="Screen Shot 2022-10-17 at 17 18 47" src="https://user-images.githubusercontent.com/77539/196275341-4fe91450-0cb7-40ea-ac2b-ed834d94d39e.png">

<img width="766" alt="image" src="https://user-images.githubusercontent.com/77539/196273960-039c0c24-bd24-47ba-a1d0-52449d03653f.png">

* open the network tab
* filter by images
* filter by `t.gif`
* Confirm the image is there
<img width="814" alt="image" src="https://user-images.githubusercontent.com/77539/197625023-543c3843-6f00-4f9d-9ea6-248dd0efae61.png">
