### PR TITLE
[WIP] Change subscription block copy to reflect changes made to subscriber count

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscription-block-copy
+++ b/projects/plugins/jetpack/changelog/fix-subscription-block-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Change the copy of the subscription block to reflect the changes made to the subscriber count.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -179,7 +179,12 @@ export function SubscriptionEdit( props ) {
 				setSubscriberCountString(
 					sprintf(
 						/* translators: Placeholder is a number of subscribers. */
-						_n( 'Join %s other subscriber', 'Join %s other subscribers', count, 'jetpack' ),
+						_n(
+							'Join %s other email subscriber',
+							'Join %s other email subscribers',
+							count,
+							'jetpack'
+						),
 						count
 					)
 				);

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -438,7 +438,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 				<div class="wp-block-jetpack-subscriptions__subscount">
 					<?php
 					/* translators: %s: number of folks following the blog */
-					echo esc_html( sprintf( _n( 'Join %s other follower', 'Join %s other followers', $subscribers_total, 'jetpack' ), number_format_i18n( $subscribers_total ) ) );
+					echo esc_html( sprintf( _n( 'Join %s other email subscriber', 'Join %s other email subscribers', $subscribers_total, 'jetpack' ), number_format_i18n( $subscribers_total ) ) );
 					?>
 				</div>
 			<?php } ?>
@@ -528,7 +528,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 				<div class="wp-block-jetpack-subscriptions__subscount">
 					<?php
 					/* translators: %s: number of folks following the blog */
-					echo esc_html( sprintf( _n( 'Join %s other subscriber', 'Join %s other subscribers', $subscribers_total['value'], 'jetpack' ), number_format_i18n( $subscribers_total['value'] ) ) );
+					echo esc_html( sprintf( _n( 'Join %s other email subscriber', 'Join %s other email subscribers', $subscribers_total['value'], 'jetpack' ), number_format_i18n( $subscribers_total['value'] ) ) );
 					?>
 				</div>
 			<?php } ?>
@@ -768,7 +768,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 						value="1"<?php echo esc_attr( $show_subscribers_total ); ?> />
 					<?php
 					/* translators: %s: Number of followers. */
-					echo esc_html( sprintf( _n( 'Show total number of followers? (%s follower)', 'Show total number of followers? (%s followers)', $subscribers_total, 'jetpack' ), number_format_i18n( $subscribers_total ) ) );
+					echo esc_html( sprintf( _n( 'Show total number of email subscribers? (%s subscriber)', 'Show total number of email subscribers? (%s subscribers)', $subscribers_total, 'jetpack' ), number_format_i18n( $subscribers_total ) ) );
 					?>
 				</label>
 			</p>


### PR DESCRIPTION
Changes the copy from followers to "email subscribers"

Fixes #

#### Changes proposed in this Pull Request:
* Changes the copy from followers to "email subscribers"


#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
p1666295848198789-slack-C02TCEHP3HA

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
- Create a new post and add a subscription form
- Confirm that the new copy is shown