### PR TITLE
Fix `featured_image_email_enabled` option update

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-featured_image_email_enabled-option-update
+++ b/projects/plugins/jetpack/changelog/fix-featured_image_email_enabled-option-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Featured image email template toggle: Add missing 'featured_image_email_enabled' option update

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -906,6 +906,11 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					$updated[ $key ] = (int) $value;
 					break;
 
+				case 'featured_image_email_enabled':
+					update_option( 'featured_image_email_enabled', (int) (bool) $value );
+					$updated[ $key ] = (int) (bool) $value;
+					break;
+
 				default:
 					// allow future versions of this endpoint to support additional settings keys.
 					if ( has_filter( 'site_settings_endpoint_update_' . $key ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

While introducing the new `featured_image_email_enabled` option in https://github.com/Automattic/jetpack/pull/26696, I missed adding the section that handles option update in `class.wpcom-json-api-site-settings-endpoint.php`.

This PR fixes that and brings the missing section in.

The `featured_image_email_enabled` option setting is saved to the database as integer of `1` (for enabled) or `0` (for disabled).

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
This PR is part of the _Featured Image Template Toggle_ project: pdDOJh-Nu-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
It is not clear to me whether the privacy update is necessary so I am tagging this PR with the "[Status] Needs Privacy Updates" label.

We will be saving user's preference on whether the Featured image should or should not be displayed in the _New Post_ email template sent to the site subscribers when a new post is published.

#### Testing instructions:
The proposed changes need to be tested most thoroughly with **Atomic** and **Jetpack-connected** sites.

1. Check out the branch, build it and apply it to the tested site. These two sets of instructions may be helpful: pdWQjU-77-p2 and pb5gDS-1rQ-p2.
2. In Calypso **staging** environment navigate to the _Settings → Writing_ page while applying the `settings/featured-image-template-toggle` feature flag. This feature flag can be applied with the help of URL parameter, e.g.: `https://wordpress.com/settings/writing/yourtestsite.wordpress.com?flags=settings/featured-image-template-toggle`.
3. Enable the _Featured image in the New Post email template_ toggle (or leave it disabled).
![Markup on 2022-10-25 at 12:09:50](https://user-images.githubusercontent.com/25105483/197746540-fd99a98c-7005-496d-9611-09f622d47a38.png)

4. Create a post with a Featured image on your test site.
5. [Follow these steps](PdDOJh-jM-p2) to trigger the _New Post_ email - or - trigger the email manually by publishing a post on the test site (this requires having email follower/subscriber on the site).
6. Review the received email. It should or shouldn't include the Featured image - depending on the setting selected in the step 3.
![Markup on 2022-10-25 at 12:00:58](https://user-images.githubusercontent.com/25105483/197746659-41072dfc-85f3-4e5c-9703-655a40b79578.png)

7. Review the email in different email clients / screen sizes / mobile. The Featured image should be formatted correctly. The Featured image should not display if the post is password-protected.
8. Experiment with the toggle enabling / disabling. It should work as expected. Test with Simple, Atomic and Jetpack-connected site.

Related issue: https://github.com/Automattic/wp-calypso/issues/68485