### PR TITLE
VideoPress: Fix polling time when processing video

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-processing-pooling
+++ b/projects/packages/videopress/changelog/fix-videopress-processing-pooling
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-VideoPress: Update pooling time when processing
+VideoPress: Update polling time when processing

--- a/projects/packages/videopress/changelog/fix-videopress-processing-pooling
+++ b/projects/packages/videopress/changelog/fix-videopress-processing-pooling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Update pooling time when processing

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.6.3",
+	"version": "0.6.4-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.6.3';
+	const PACKAGE_VERSION = '0.6.4-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/client/state/actions.js
+++ b/projects/packages/videopress/src/client/state/actions.js
@@ -61,7 +61,11 @@ const pollingUploadedVideoData = async data => {
 		return Promise.resolve( video );
 	}
 
-	return pollingUploadedVideoData( video );
+	return new Promise( ( resolve, reject ) => {
+		setTimeout( () => {
+			pollingUploadedVideoData( data ).then( resolve ).catch( reject );
+		}, 2000 );
+	} );
 };
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27054 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Insert `setTimeout` when polling after uploading.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1666698812383269-slack-C02TQF5VAJD

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start `VideoPress`
* Open network tab and upload a new video.
* You should not see a lot of requests for new uploaded video data.