### PR TITLE
VideoPress: Change anchorRef prop to anchor following deprecation notice

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-quick-actions-anchor-ref
+++ b/projects/packages/videopress/changelog/update-videopress-quick-actions-anchor-ref
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: Change deprecated prop on VideoQuickActions

--- a/projects/packages/videopress/src/client/admin/components/video-quick-actions/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-quick-actions/index.tsx
@@ -31,12 +31,12 @@ import {
 	ConnectVideoQuickActionsProps,
 } from './types';
 
-const PopoverWithAnchor = ( { anchorRef, children = null }: PopoverWithAnchorProps ) => {
-	if ( ! anchorRef ) {
+const PopoverWithAnchor = ( { anchor, children = null }: PopoverWithAnchorProps ) => {
+	if ( ! anchor ) {
 		return null;
 	}
 	const popoverProps = {
-		anchorRef,
+		anchor,
 		offset: 15,
 	};
 
@@ -50,11 +50,11 @@ const PopoverWithAnchor = ( { anchorRef, children = null }: PopoverWithAnchorPro
 };
 
 const ActionItem = ( { icon, children, className, ...props }: ActionItemProps ) => {
-	const [ anchorRef, setAnchorRef ] = useState( null );
+	const [ anchor, setAnchor ] = useState( null );
 	const [ showPopover, setShowPopover ] = useState( false );
 
 	return (
-		<div ref={ setAnchorRef } className={ className }>
+		<div ref={ setAnchor } className={ className }>
 			<Button
 				size="small"
 				variant="tertiary"
@@ -63,7 +63,7 @@ const ActionItem = ( { icon, children, className, ...props }: ActionItemProps ) 
 				onMouseLeave={ () => setShowPopover( false ) }
 				{ ...props }
 			/>
-			{ showPopover && <PopoverWithAnchor anchorRef={ anchorRef }>{ children }</PopoverWithAnchor> }
+			{ showPopover && <PopoverWithAnchor anchor={ anchor }>{ children }</PopoverWithAnchor> }
 		</div>
 	);
 };
@@ -73,7 +73,7 @@ const ThumbnailActionsDropdown = ( {
 	onUpdate,
 	isUpdatingPoster,
 }: ThumbnailActionsDropdownProps ) => {
-	const [ anchorRef, setAnchorRef ] = useState( null );
+	const [ anchor, setAnchor ] = useState( null );
 	const [ showPopover, setShowPopover ] = useState( false );
 
 	return (
@@ -83,7 +83,7 @@ const ThumbnailActionsDropdown = ( {
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<>
 					<Button
-						ref={ setAnchorRef }
+						ref={ setAnchor }
 						size="small"
 						variant="tertiary"
 						icon={ image }
@@ -97,7 +97,7 @@ const ThumbnailActionsDropdown = ( {
 						onMouseLeave={ () => setShowPopover( false ) }
 					/>
 					{ showPopover && (
-						<PopoverWithAnchor anchorRef={ anchorRef }>{ description }</PopoverWithAnchor>
+						<PopoverWithAnchor anchor={ anchor }>{ description }</PopoverWithAnchor>
 					) }
 				</>
 			) }
@@ -120,7 +120,7 @@ const PrivacyActionsDropdown = ( {
 	isUpdatingPrivacy,
 	onUpdate,
 }: PrivacyActionsDropdownProps ) => {
-	const [ anchorRef, setAnchorRef ] = useState( null );
+	const [ anchor, setAnchor ] = useState( null );
 	const [ showPopover, setShowPopover ] = useState( false );
 
 	let currentPrivacyIcon = siteDefaultPrivacyIcon;
@@ -136,7 +136,7 @@ const PrivacyActionsDropdown = ( {
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<>
 					<Button
-						ref={ setAnchorRef }
+						ref={ setAnchor }
 						size="small"
 						variant="tertiary"
 						icon={ currentPrivacyIcon }
@@ -150,7 +150,7 @@ const PrivacyActionsDropdown = ( {
 						disabled={ isUpdatingPrivacy }
 					/>
 					{ showPopover && (
-						<PopoverWithAnchor anchorRef={ anchorRef }>{ description }</PopoverWithAnchor>
+						<PopoverWithAnchor anchor={ anchor }>{ description }</PopoverWithAnchor>
 					) }
 				</>
 			) }

--- a/projects/packages/videopress/src/client/admin/components/video-quick-actions/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/video-quick-actions/types.ts
@@ -19,7 +19,7 @@ export interface PopoverWithAnchorProps {
 	/**
 	 * Ref that anchors the popover
 	 */
-	anchorRef: HTMLElement | null;
+	anchor: HTMLElement | null;
 	/**
 	 * Popover content
 	 */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes this warning:
![2022-10-25_10-39-43](https://user-images.githubusercontent.com/8486249/197788909-bef53b07-134c-4368-84f2-75a706cacecf.png)


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Changes `anchorRef` to `anchor` when using the `Popover` component as per the deprecation notice.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Running locally, hover over one of the video quick actions
* Check that there is no warning on the console
