### PR TITLE
Jetpack VideoPress: Prepare release 1.0

### DIFF
--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.4] - 2022-10-25
+### Fixed
+- VideoPress: Update polling time when processing [#27056]
+
 ## [0.6.3] - 2022-10-25
 ### Added
 - VideoPress: Add component unload prevention on video details edit when there are unsaved changes [#26919]
@@ -356,6 +360,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.6.4]: https://github.com/Automattic/jetpack-videopress/compare/v0.6.3...v0.6.4
 [0.6.3]: https://github.com/Automattic/jetpack-videopress/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/Automattic/jetpack-videopress/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/Automattic/jetpack-videopress/compare/v0.6.0...v0.6.1

--- a/projects/packages/videopress/changelog/fix-videopress-processing-pooling
+++ b/projects/packages/videopress/changelog/fix-videopress-processing-pooling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-VideoPress: Update polling time when processing

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.6.4-alpha",
+	"version": "0.6.4",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.6.4-alpha';
+	const PACKAGE_VERSION = '0.6.4';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/plugins/videopress/CHANGELOG.md
+++ b/projects/plugins/videopress/CHANGELOG.md
@@ -5,23 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.1.0 - 2022-07-06
+## 1.0.0 - 2022-10-25
 ### Added
-- Add activation and deactivation hooks. [#24250]
-- E2E tests boilerplate. [#24723]
-- Enable beta plugin support. [#23836]
-- Initial release. [#23434]
+- Initial release.
 
-### Changed
-- Changed the method used to disconnect. [#24299]
-- Configure Sync with the minimal amount of data. [#23759]
-- Janitorial: require a more recent version of WordPress now that WP 6.0 is coming out. [#24083]
-- Remove use of `pnpx` in preparation for pnpm 7.0. [#24210]
-- Renaming master to trunk. [#24661]
-- Renaming `master` references to `trunk`. [#24712]
-- Reorder JS imports for `import/order` eslint rule. [#24601]
-- Updated package dependencies.
-
-### Fixed
-- Jetpack CLI: correctly replace project description and release-branch-prefix. [#23911]
-- Updated .gitattributes file so it is able to build properly by the CI build jobs. [#23591]

--- a/projects/plugins/videopress/changelog/add-backup-disclaimer-text-to-product-card
+++ b/projects/plugins/videopress/changelog/add-backup-disclaimer-text-to-product-card
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/add-cli-watch-command-to-videopress-plugin
+++ b/projects/plugins/videopress/changelog/add-cli-watch-command-to-videopress-plugin
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Included `watch` script on composer file to run the packages/videopress watch command.

--- a/projects/plugins/videopress/changelog/add-connection-verified-errors-react-initial-state
+++ b/projects/plugins/videopress/changelog/add-connection-verified-errors-react-initial-state
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-connection-verified-errors-react-initial-state#2
+++ b/projects/plugins/videopress/changelog/add-connection-verified-errors-react-initial-state#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-custom-taxonomy-slugs
+++ b/projects/plugins/videopress/changelog/add-custom-taxonomy-slugs
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/add-db-post-type-breakdown
+++ b/projects/plugins/videopress/changelog/add-db-post-type-breakdown
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/add-free-search-product-support-my-jetpack
+++ b/projects/plugins/videopress/changelog/add-free-search-product-support-my-jetpack
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/add-icon_tooltip
+++ b/projects/plugins/videopress/changelog/add-icon_tooltip
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/add-jetpack-connect-error-notice-react-component
+++ b/projects/plugins/videopress/changelog/add-jetpack-connect-error-notice-react-component
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/add-jetpack-connection-errors-react-vars
+++ b/projects/plugins/videopress/changelog/add-jetpack-connection-errors-react-vars
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/add-jetpack-connection-errors-react-vars#2
+++ b/projects/plugins/videopress/changelog/add-jetpack-connection-errors-react-vars#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/add-jetpack-social-add-share-meter
+++ b/projects/plugins/videopress/changelog/add-jetpack-social-add-share-meter
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/add-jetpack-social-plan-changes
+++ b/projects/plugins/videopress/changelog/add-jetpack-social-plan-changes
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-jitm-my-jetpack
+++ b/projects/plugins/videopress/changelog/add-jitm-my-jetpack
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-My Jetpack includes JITMs

--- a/projects/plugins/videopress/changelog/add-pricing-table-component
+++ b/projects/plugins/videopress/changelog/add-pricing-table-component
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/add-reconnect-notice-restore
+++ b/projects/plugins/videopress/changelog/add-reconnect-notice-restore
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/add-record-meter-donut-chart
+++ b/projects/plugins/videopress/changelog/add-record-meter-donut-chart
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/add-sync-sl-insta-media-to-blacklist
+++ b/projects/plugins/videopress/changelog/add-sync-sl-insta-media-to-blacklist
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/add-upgrade-trigger-in-jetpack-social
+++ b/projects/plugins/videopress/changelog/add-upgrade-trigger-in-jetpack-social
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/add-upgraded_tooltips
+++ b/projects/plugins/videopress/changelog/add-upgraded_tooltips
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/add-upload-from-media-lib
+++ b/projects/plugins/videopress/changelog/add-upload-from-media-lib
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-verify-rest-api-errors
+++ b/projects/plugins/videopress/changelog/add-verify-rest-api-errors
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-verify-rest-api-errors#2
+++ b/projects/plugins/videopress/changelog/add-verify-rest-api-errors#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/add-videopress-option-to-load-amdin-ui
+++ b/projects/plugins/videopress/changelog/add-videopress-option-to-load-amdin-ui
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Initialize VideoPress admin UI from the package

--- a/projects/plugins/videopress/changelog/add-videopress-option-to-load-amdin-ui#2
+++ b/projects/plugins/videopress/changelog/add-videopress-option-to-load-amdin-ui#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-videopress-plugin
+++ b/projects/plugins/videopress/changelog/add-videopress-plugin
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-videopress-plugin-connection-errors
+++ b/projects/plugins/videopress/changelog/add-videopress-plugin-connection-errors
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/add-videopress-plugin-readme
+++ b/projects/plugins/videopress/changelog/add-videopress-plugin-readme
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: modify videopress plugin readme
-
-

--- a/projects/plugins/videopress/changelog/add-videopress-uploader-pro-mode
+++ b/projects/plugins/videopress/changelog/add-videopress-uploader-pro-mode
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/add-videopress-video-storage-meter-component
+++ b/projects/plugins/videopress/changelog/add-videopress-video-storage-meter-component
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/change-move-sharing-limits-to-publicize-package
+++ b/projects/plugins/videopress/changelog/change-move-sharing-limits-to-publicize-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/e2e-bump-dependencies
+++ b/projects/plugins/videopress/changelog/e2e-bump-dependencies
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-E2E tests: bump dependencies

--- a/projects/plugins/videopress/changelog/e2e-fix-pre-scripts
+++ b/projects/plugins/videopress/changelog/e2e-fix-pre-scripts
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-E2E tests: fixed pretest cleanup script not running

--- a/projects/plugins/videopress/changelog/e2e-slack-notifications-cleanup
+++ b/projects/plugins/videopress/changelog/e2e-slack-notifications-cleanup
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-E2E tests: removed deprecated Slack notification code

--- a/projects/plugins/videopress/changelog/e2e-use-built-artefacts-in-ci
+++ b/projects/plugins/videopress/changelog/e2e-use-built-artefacts-in-ci
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-E2E tests: use CI build artifacts in e2e tests

--- a/projects/plugins/videopress/changelog/fix-add-unique-name-to-videopress-e2e-tests-package
+++ b/projects/plugins/videopress/changelog/fix-add-unique-name-to-videopress-e2e-tests-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Use unique name for VideoPress e2e tests package

--- a/projects/plugins/videopress/changelog/fix-check-intra-monorepo-deps-for-plugin-release-branches
+++ b/projects/plugins/videopress/changelog/fix-check-intra-monorepo-deps-for-plugin-release-branches
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/fix-user-token-after-restore-error
+++ b/projects/plugins/videopress/changelog/fix-user-token-after-restore-error
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/fix-user-token-after-restore-error#2
+++ b/projects/plugins/videopress/changelog/fix-user-token-after-restore-error#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/modify-backup-review-request-logic
+++ b/projects/plugins/videopress/changelog/modify-backup-review-request-logic
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/modify-connection-react-component-connection-error-notice
+++ b/projects/plugins/videopress/changelog/modify-connection-react-component-connection-error-notice
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/modify-connection-react-component-connection-error-notice#2
+++ b/projects/plugins/videopress/changelog/modify-connection-react-component-connection-error-notice#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/remove-connection-ui-package
+++ b/projects/plugins/videopress/changelog/remove-connection-ui-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: This is a cleanup task
-
-

--- a/projects/plugins/videopress/changelog/renovate-babel-monorepo
+++ b/projects/plugins/videopress/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-babel-monorepo#2
+++ b/projects/plugins/videopress/changelog/renovate-babel-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-babel-monorepo#3
+++ b/projects/plugins/videopress/changelog/renovate-babel-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/videopress/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-lock-file-maintenance#2
+++ b/projects/plugins/videopress/changelog/renovate-lock-file-maintenance#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-lock-file-maintenance#3
+++ b/projects/plugins/videopress/changelog/renovate-lock-file-maintenance#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-lock-file-maintenance#4
+++ b/projects/plugins/videopress/changelog/renovate-lock-file-maintenance#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-lock-file-maintenance#5
+++ b/projects/plugins/videopress/changelog/renovate-lock-file-maintenance#5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-major-symfony
+++ b/projects/plugins/videopress/changelog/renovate-major-symfony
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-pin-dependencies
+++ b/projects/plugins/videopress/changelog/renovate-pin-dependencies
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/renovate-playwright-monorepo
+++ b/projects/plugins/videopress/changelog/renovate-playwright-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/videopress/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-wordpress-monorepo#2
+++ b/projects/plugins/videopress/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-wordpress-monorepo#3
+++ b/projects/plugins/videopress/changelog/renovate-wordpress-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-wordpress-monorepo#4
+++ b/projects/plugins/videopress/changelog/renovate-wordpress-monorepo#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/update-auto-publish-standalones
+++ b/projects/plugins/videopress/changelog/update-auto-publish-standalones
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Adds ability to autotag, autorelease and autopublish releases

--- a/projects/plugins/videopress/changelog/update-auto-redirect-after-install-condition
+++ b/projects/plugins/videopress/changelog/update-auto-redirect-after-install-condition
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/update-components-apply-icon-button-styles
+++ b/projects/plugins/videopress/changelog/update-components-apply-icon-button-styles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/update-icon-tooltip-component
+++ b/projects/plugins/videopress/changelog/update-icon-tooltip-component
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/update-integrate-stats-pkg-in-jetpack-plugin
+++ b/projects/plugins/videopress/changelog/update-integrate-stats-pkg-in-jetpack-plugin
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/update-jetpack-fix-sanitize-description
+++ b/projects/plugins/videopress/changelog/update-jetpack-fix-sanitize-description
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/update-jetpack-videopress-plugin-doc-improve
+++ b/projects/plugins/videopress/changelog/update-jetpack-videopress-plugin-doc-improve
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-VideoPress plugin: minor doc improvement

--- a/projects/plugins/videopress/changelog/update-migrate-videopress-class
+++ b/projects/plugins/videopress/changelog/update-migrate-videopress-class
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/update-migrating-videopress-ui-to-package
+++ b/projects/plugins/videopress/changelog/update-migrating-videopress-ui-to-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-VideoPress needs everything in Sync

--- a/projects/plugins/videopress/changelog/update-move-restore-connection
+++ b/projects/plugins/videopress/changelog/update-move-restore-connection
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/update-move-restore-connection#2
+++ b/projects/plugins/videopress/changelog/update-move-restore-connection#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/update-my-jetpack-add-scroll-to-top
+++ b/projects/plugins/videopress/changelog/update-my-jetpack-add-scroll-to-top
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/update-pnpm-7.5.0
+++ b/projects/plugins/videopress/changelog/update-pnpm-7.5.0
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove `.engines.pnpm` from `package.json`. It's not needed, as pnpm always checks the monorepo root `package.json` anyway. Further, `.engines` is stripped from the mirror repos.
-
-

--- a/projects/plugins/videopress/changelog/update-pricing-table-design
+++ b/projects/plugins/videopress/changelog/update-pricing-table-design
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/update-refactor_upgrade_tooltips
+++ b/projects/plugins/videopress/changelog/update-refactor_upgrade_tooltips
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/update-search-require-only-site-connection
+++ b/projects/plugins/videopress/changelog/update-search-require-only-site-connection
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/update-search-support-woo-brands-plugin
+++ b/projects/plugins/videopress/changelog/update-search-support-woo-brands-plugin
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/update-sync-debug-info
+++ b/projects/plugins/videopress/changelog/update-sync-debug-info
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/update-videopress-activation
+++ b/projects/plugins/videopress/changelog/update-videopress-activation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Activation: only redirect when activating from the Plugins page in the browser

--- a/projects/plugins/videopress/changelog/update-videopress-add-client-scaffolding
+++ b/projects/plugins/videopress/changelog/update-videopress-add-client-scaffolding
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Migrate VideoPress block to pkg

--- a/projects/plugins/videopress/changelog/update-videopress-add-client-scaffolding#2
+++ b/projects/plugins/videopress/changelog/update-videopress-add-client-scaffolding#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/update-videopress-add-client-scaffolding#3
+++ b/projects/plugins/videopress/changelog/update-videopress-add-client-scaffolding#3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/update-videopress-add-client-scaffolding#4
+++ b/projects/plugins/videopress/changelog/update-videopress-add-client-scaffolding#4
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/update-videopress-add-client-scaffolding#5
+++ b/projects/plugins/videopress/changelog/update-videopress-add-client-scaffolding#5
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/update-videopress-add-client-scaffolding#6
+++ b/projects/plugins/videopress/changelog/update-videopress-add-client-scaffolding#6
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/update-videopress-hybrid-product
+++ b/projects/plugins/videopress/changelog/update-videopress-hybrid-product
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Change VideoPress into a Hybrid product in My Jetpack

--- a/projects/plugins/videopress/changelog/update-videopress-initializer
+++ b/projects/plugins/videopress/changelog/update-videopress-initializer
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Initialize VideoPress package from the Config pkg

--- a/projects/plugins/videopress/changelog/update-videopress-move-compiling-process-to-pkg
+++ b/projects/plugins/videopress/changelog/update-videopress-move-compiling-process-to-pkg
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-VideoPress: move client-source files from plugin to package

--- a/projects/plugins/videopress/changelog/update-videopress-move-transform-to-jetpack-plugin
+++ b/projects/plugins/videopress/changelog/update-videopress-move-transform-to-jetpack-plugin
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/update-videopress-only-enqueue-bridge-when-player-is-rendered
+++ b/projects/plugins/videopress/changelog/update-videopress-only-enqueue-bridge-when-player-is-rendered
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/update-videopress-pgk-serve-token-min-version
+++ b/projects/plugins/videopress/changelog/update-videopress-pgk-serve-token-min-version
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-VideoPress: update pkg version

--- a/projects/plugins/videopress/changelog/update-videopress-pkg-capital-p
+++ b/projects/plugins/videopress/changelog/update-videopress-pkg-capital-p
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-VideoPress: update names using VideoPress name (capital P)

--- a/projects/plugins/videopress/changelog/update-videopress-rename-block
+++ b/projects/plugins/videopress/changelog/update-videopress-rename-block
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-VideoPress: update to the lastest changes of the VideoPress pkg API

--- a/projects/plugins/videopress/changelog/update-videopress-use-register-blocks-method
+++ b/projects/plugins/videopress/changelog/update-videopress-use-register-blocks-method
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-VideoPress: use register_videopress_blocks() to register VideoPress video block

--- a/projects/plugins/videopress/changelog/update-wordbless
+++ b/projects/plugins/videopress/changelog/update-wordbless
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated a dev dependency. No functional change.
-
-

--- a/projects/plugins/videopress/changelog/update-wordbless#2
+++ b/projects/plugins/videopress/changelog/update-wordbless#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/composer.json
+++ b/projects/plugins/videopress/composer.json
@@ -56,6 +56,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_videopressⓥ0_2_0_alpha"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_videopressⓥ0_2_0"
 	}
 }

--- a/projects/plugins/videopress/composer.json
+++ b/projects/plugins/videopress/composer.json
@@ -56,6 +56,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_videopressⓥ0_2_0"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_videopressⓥ1_0_0"
 	}
 }

--- a/projects/plugins/videopress/jetpack-videopress.php
+++ b/projects/plugins/videopress/jetpack-videopress.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack VideoPress
  * Plugin URI: https://wordpress.org/plugins/jetpack-videopress
  * Description: High quality, ad-free video.
- * Version: 0.2.0
+ * Version: 1.0.0
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later

--- a/projects/plugins/videopress/jetpack-videopress.php
+++ b/projects/plugins/videopress/jetpack-videopress.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack VideoPress
  * Plugin URI: https://wordpress.org/plugins/jetpack-videopress
  * Description: High quality, ad-free video.
- * Version: 0.2.0-alpha
+ * Version: 0.2.0
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later

--- a/projects/plugins/videopress/readme.txt
+++ b/projects/plugins/videopress/readme.txt
@@ -73,5 +73,7 @@ The file size limit is 5 GB. However, on slower networks, there is a chance the 
 2. Edit your video details, cover image, and privacy from your VideoPress library.
 
 == Changelog ==
+### 1.0.0 - 2022-10-25
+#### Added
+- Initial release.
 
-Introduce new VideoPress block and dashboard


### PR DESCRIPTION
Release for Jetpack VideoPress standalone plugin


Testing instructions:
- Read the changelogs and readmes.