### PR TITLE
Social: Add an extra check for a valid user connection

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-publicize-user-connection
+++ b/projects/plugins/jetpack/changelog/fix-publicize-user-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Social: Ensure we have a user connection when loading the module

--- a/projects/plugins/jetpack/modules/publicize.php
+++ b/projects/plugins/jetpack/modules/publicize.php
@@ -102,12 +102,19 @@ class Jetpack_Publicize {
 
 // On Jetpack, we instantiate Jetpack_Publicize only if the Publicize module is active.
 if ( ! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
+	global $publicize;
 
-	$modules = new Automattic\Jetpack\Modules();
-
-	if ( $modules->is_active( 'publicize' ) ) {
-		new Jetpack_Publicize();
+	// None of this should be the case, but we can get here with a broken user connection. If that's the case
+	// then we want to stop loading any more of the module code.
+	if (
+		! ( new Automattic\Jetpack\Modules() )->is_active( 'publicize' )
+		|| ! Jetpack::connection()->has_connected_user()
+		|| ! $publicize
+	) {
+		return;
 	}
+
+	new Jetpack_Publicize();
 
 	if ( ! function_exists( 'publicize_init' ) ) {
 		/**

--- a/projects/plugins/jetpack/tests/php/modules/publicize/test_class.publicize.php
+++ b/projects/plugins/jetpack/tests/php/modules/publicize/test_class.publicize.php
@@ -1,5 +1,18 @@
 <?php
-require __DIR__ . '/../../../../modules/publicize.php';
+
+if ( ! function_exists( 'publicize_init' ) ) {
+	/**
+	 * Some tests rely on this function which won't get defined unless we mock lots
+	 * of things and require the module code. Instead we'll define it here.
+	 *
+	 * @return Publicize Object
+	 */
+	function publicize_init() {
+		global $publicize;
+
+		return $publicize;
+	}
+}
 
 /**
  * @group publicize


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Without a valid user connection, the module code was being loaded, but the package code was not. This caused problems, sometimes resulting in fatal errors.

This adds an extra check for the user connection, and that the `$publicize` global has been set up. If not then we bail out of the module code.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1666278382810049-slack-C02NENKA4GN

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Enable social auto sharing on a site with the Jetpack plugin
* Use Jetpack Debug to clear the user tokens
* Without this change you'll receive a fatal error
* With this change it should prevent the module from loading and make it inactive.