### PR TITLE
Jetpack: Likes: "De-Fusion" by removing wpcom code paths

### DIFF
--- a/projects/plugins/jetpack/changelog/update-de-fusion-likes-by-forever-desyncing
+++ b/projects/plugins/jetpack/changelog/update-de-fusion-likes-by-forever-desyncing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Likes: Delete wpcom code paths. Things are just too different to de-Fusion.

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -51,8 +51,7 @@ class Jetpack_Likes {
 	 * Constructs Likes class
 	 */
 	public function __construct() {
-		$this->in_jetpack = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ? false : true;
-		$this->settings   = new Jetpack_Likes_Settings();
+		$this->settings = new Jetpack_Likes_Settings();
 
 		// We need to run on wp hook rather than init because we check is_amp_endpoint()
 		// when bootstrapping hooks.
@@ -60,42 +59,35 @@ class Jetpack_Likes {
 
 		add_action( 'admin_init', array( $this, 'admin_init' ) );
 
-		if ( $this->in_jetpack ) {
-			add_action( 'jetpack_activate_module_likes', array( $this, 'set_social_notifications_like' ) );
-			add_action( 'jetpack_deactivate_module_likes', array( $this, 'delete_social_notifications_like' ) );
+		add_action( 'jetpack_activate_module_likes', array( $this, 'set_social_notifications_like' ) );
+		add_action( 'jetpack_deactivate_module_likes', array( $this, 'delete_social_notifications_like' ) );
 
-			Jetpack::enable_module_configurable( __FILE__ );
-			add_filter( 'jetpack_module_configuration_url_likes', array( $this, 'jetpack_likes_configuration_url' ) );
-			add_action( 'admin_print_scripts-settings_page_sharing', array( $this, 'load_jp_css' ) );
-			add_filter( 'sharing_show_buttons_on_row_start', array( $this, 'configuration_target_area' ) );
+		Jetpack::enable_module_configurable( __FILE__ );
+		add_filter( 'jetpack_module_configuration_url_likes', array( $this, 'jetpack_likes_configuration_url' ) );
+		add_action( 'admin_print_scripts-settings_page_sharing', array( $this, 'load_jp_css' ) );
+		add_filter( 'sharing_show_buttons_on_row_start', array( $this, 'configuration_target_area' ) );
 
-			$active = Jetpack::get_active_modules();
+		$active = Jetpack::get_active_modules();
 
-			if ( ! in_array( 'sharedaddy', $active, true ) && ! in_array( 'publicize', $active, true ) ) {
-				// we don't have a sharing page yet.
-				add_action( 'admin_menu', array( $this->settings, 'sharing_menu' ) );
-			}
+		if ( ! in_array( 'sharedaddy', $active, true ) && ! in_array( 'publicize', $active, true ) ) {
+			// we don't have a sharing page yet.
+			add_action( 'admin_menu', array( $this->settings, 'sharing_menu' ) );
+		}
 
-			if ( in_array( 'publicize', $active, true ) && ! in_array( 'sharedaddy', $active, true ) ) {
-				// we have a sharing page but not the global options area.
-				add_action( 'pre_admin_screen_sharing', array( $this->settings, 'sharing_block' ), 20 );
-				add_action( 'pre_admin_screen_sharing', array( $this->settings, 'updated_message' ), -10 );
-			}
+		if ( in_array( 'publicize', $active, true ) && ! in_array( 'sharedaddy', $active, true ) ) {
+			// we have a sharing page but not the global options area.
+			add_action( 'pre_admin_screen_sharing', array( $this->settings, 'sharing_block' ), 20 );
+			add_action( 'pre_admin_screen_sharing', array( $this->settings, 'updated_message' ), -10 );
+		}
 
-			if ( ! in_array( 'sharedaddy', $active, true ) ) {
-				add_action( 'admin_init', array( $this->settings, 'process_update_requests_if_sharedaddy_not_loaded' ) );
-				add_action( 'sharing_global_options', array( $this->settings, 'admin_settings_showbuttonon_init' ), 19 );
-				add_action( 'sharing_admin_update', array( $this->settings, 'admin_settings_showbuttonon_callback' ), 19 );
-				add_action( 'admin_init', array( $this->settings, 'add_meta_box' ) );
-			} else {
-				add_filter( 'sharing_meta_box_title', array( $this->settings, 'add_likes_to_sharing_meta_box_title' ) );
-				add_action( 'start_sharing_meta_box_content', array( $this->settings, 'meta_box_content' ) );
-			}
-		} else { // wpcom.
-			add_action( 'wpmu_new_blog', array( $this, 'enable_comment_likes' ), 10, 1 );
+		if ( ! in_array( 'sharedaddy', $active, true ) ) {
+			add_action( 'admin_init', array( $this->settings, 'process_update_requests_if_sharedaddy_not_loaded' ) );
+			add_action( 'sharing_global_options', array( $this->settings, 'admin_settings_showbuttonon_init' ), 19 );
+			add_action( 'sharing_admin_update', array( $this->settings, 'admin_settings_showbuttonon_callback' ), 19 );
 			add_action( 'admin_init', array( $this->settings, 'add_meta_box' ) );
-			add_action( 'end_likes_meta_box_content', array( $this->settings, 'sharing_meta_box_content' ) );
-			add_filter( 'likes_meta_box_title', array( $this->settings, 'add_likes_to_sharing_meta_box_title' ) );
+		} else {
+			add_filter( 'sharing_meta_box_title', array( $this->settings, 'add_likes_to_sharing_meta_box_title' ) );
+			add_action( 'start_sharing_meta_box_content', array( $this->settings, 'meta_box_content' ) );
 		}
 
 		add_action( 'admin_init', array( $this, 'admin_discussion_likes_settings_init' ) ); // Likes notifications.
@@ -152,10 +144,17 @@ class Jetpack_Likes {
 	 * Load scripts and styles for front end.
 	 */
 	public function load_styles_register_scripts() {
-		if ( $this->in_jetpack ) {
-			wp_enqueue_style( 'jetpack_likes', plugins_url( 'likes/style.css', __FILE__ ), array(), JETPACK__VERSION );
-			$this->register_scripts();
-		}
+		wp_enqueue_style( 'jetpack_likes', plugins_url( 'likes/style.css', __FILE__ ), array(), JETPACK__VERSION );
+		wp_register_script(
+			'jetpack_likes_queuehandler',
+			Assets::get_file_url_for_environment(
+				'_inc/build/likes/queuehandler.min.js',
+				'modules/likes/queuehandler.js'
+			),
+			array(),
+			JETPACK__VERSION,
+			true
+		);
 	}
 
 	/**
@@ -207,11 +206,7 @@ class Jetpack_Likes {
 	 * @param string $option - which option we're checking (social_notifications_like).
 	 */
 	public function admin_likes_get_option( $option ) {
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			$option_setting = get_blog_option( get_current_blog_id(), $option, 'on' );
-		} else {
-			$option_setting = get_option( $option, 'on' );
-		}
+		$option_setting = get_option( $option, 'on' );
 
 		return (int) ( 'on' === $option_setting );
 	}
@@ -274,33 +269,8 @@ class Jetpack_Likes {
 			return;
 		}
 
-		if ( $this->in_jetpack ) {
-			add_filter( 'the_content', array( $this, 'post_likes' ), 30, 1 );
-			add_filter( 'the_excerpt', array( $this, 'post_likes' ), 30, 1 );
-
-		} else {
-			add_filter( 'post_flair', array( $this, 'post_likes' ), 30, 1 );
-			add_filter( 'post_flair_block_css', array( $this, 'post_flair_service_enabled_like' ) );
-
-			wp_enqueue_script( 'jetpack_likes_queuehandler', plugins_url( 'queuehandler.js', __FILE__ ), array(), JETPACK__VERSION, true );
-			wp_enqueue_style( 'jetpack_likes', plugins_url( 'jetpack-likes.css', __FILE__ ), array(), JETPACK__VERSION );
-		}
-	}
-
-	/**
-	 * Register scripts.
-	 */
-	public function register_scripts() {
-		wp_register_script(
-			'jetpack_likes_queuehandler',
-			Assets::get_file_url_for_environment(
-				'_inc/build/likes/queuehandler.min.js',
-				'modules/likes/queuehandler.js'
-			),
-			array(),
-			JETPACK__VERSION,
-			true
-		);
+		add_filter( 'the_content', array( $this, 'post_likes' ), 30, 1 );
+		add_filter( 'the_excerpt', array( $this, 'post_likes' ), 30, 1 );
 	}
 
 	/**
@@ -351,32 +321,26 @@ class Jetpack_Likes {
 	 */
 	public function enqueue_admin_scripts() {
 		if ( empty( $_GET['post_type'] ) || 'post' === $_GET['post_type'] || 'page' === $_GET['post_type'] ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			if ( $this->in_jetpack ) {
-				wp_enqueue_script(
-					'likes-post-count',
-					Assets::get_file_url_for_environment(
-						'_inc/build/likes/post-count.min.js',
-						'modules/likes/post-count.js'
-					),
-					array( 'jquery' ),
-					JETPACK__VERSION,
-					$in_footer = false
-				);
-				wp_enqueue_script(
-					'likes-post-count-jetpack',
-					Assets::get_file_url_for_environment(
-						'_inc/build/likes/post-count-jetpack.min.js',
-						'modules/likes/post-count-jetpack.js'
-					),
-					array( 'likes-post-count' ),
-					JETPACK__VERSION,
-					$in_footer = false
-				);
-			} else {
-				wp_enqueue_script( 'jquery.wpcom-proxy-request', '/wp-content/js/jquery/jquery.wpcom-proxy-request.js', array( 'jquery' ), JETPACK__VERSION, true );
-				wp_enqueue_script( 'likes-post-count', plugins_url( 'likes/post-count.js', __DIR__ ), array( 'jquery' ), JETPACK__VERSION, $in_footer = false );
-				wp_enqueue_script( 'likes-post-count-wpcom', plugins_url( 'likes/post-count-wpcom.js', __DIR__ ), array( 'likes-post-count', 'jquery.wpcom-proxy-request' ), JETPACK__VERSION, $in_footer = false );
-			}
+			wp_enqueue_script(
+				'likes-post-count',
+				Assets::get_file_url_for_environment(
+					'_inc/build/likes/post-count.min.js',
+					'modules/likes/post-count.js'
+				),
+				array( 'jquery' ),
+				JETPACK__VERSION,
+				$in_footer = false
+			);
+			wp_enqueue_script(
+				'likes-post-count-jetpack',
+				Assets::get_file_url_for_environment(
+					'_inc/build/likes/post-count-jetpack.min.js',
+					'modules/likes/post-count-jetpack.js'
+				),
+				array( 'likes-post-count' ),
+				JETPACK__VERSION,
+				$in_footer = false
+			);
 		}
 	}
 
@@ -389,11 +353,7 @@ class Jetpack_Likes {
 	public function likes_edit_column( $column_name, $post_id ) {
 		if ( 'likes' === $column_name ) {
 
-			if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-				$blog_id = get_current_blog_id();
-			} else {
-				$blog_id = Jetpack_Options::get_option( 'id' );
-			}
+			$blog_id = Jetpack_Options::get_option( 'id' );
 
 			$permalink = get_permalink( get_the_ID() );
 			?>
@@ -438,16 +398,11 @@ class Jetpack_Likes {
 			return $content;
 		}
 
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			$blog_id  = get_current_blog_id();
-			$bloginfo = get_blog_details( (int) $blog_id );
-			$domain   = $bloginfo->domain;
-		} else {
-			$blog_id   = Jetpack_Options::get_option( 'id' );
-			$url       = home_url();
-			$url_parts = wp_parse_url( $url );
-			$domain    = $url_parts['host'];
-		}
+		$blog_id   = Jetpack_Options::get_option( 'id' );
+		$url       = home_url();
+		$url_parts = wp_parse_url( $url );
+		$domain    = $url_parts['host'];
+
 		// Make sure to include the scripts before the iframe otherwise weird things happen.
 		add_action( 'wp_footer', 'jetpack_likes_master_iframe', 21 );
 
@@ -536,16 +491,11 @@ class Jetpack_Likes {
 		if ( is_ssl() ) {
 			$protocol = 'https';
 		}
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			$blog_id  = get_current_blog_id();
-			$bloginfo = get_blog_details( (int) $blog_id );
-			$domain   = $bloginfo->domain;
-		} else {
-			$blog_id   = Jetpack_Options::get_option( 'id' );
-			$url       = home_url();
-			$url_parts = wp_parse_url( $url );
-			$domain    = $url_parts['host'];
-		}
+		$blog_id   = Jetpack_Options::get_option( 'id' );
+		$url       = home_url();
+		$url_parts = wp_parse_url( $url );
+		$domain    = $url_parts['host'];
+
 		// Make sure to include the scripts before the iframe otherwise weird things happen.
 		add_action( 'wp_footer', 'jetpack_likes_master_iframe', 21 );
 

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -12,6 +12,11 @@
  *
  * @package automattic/jetpack
  */
+/**
+ * NOTE: While the front-end behavior currently varies, try to keep the data
+ * model here the same as on wpcom to facilitate Simple→Atomic moves and
+ * possible future work to recombine the front-ends.
+ */
 
 use Automattic\Jetpack\Assets;
 

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -435,16 +435,6 @@ class Jetpack_Likes {
 		return $content . $html;
 	}
 
-	/**
-	 * Adds sd-like-enabled CSS class
-	 *
-	 * @param array $classes CSS class for post flair.
-	 */
-	public function post_flair_service_enabled_like( $classes ) {
-		$classes[] = 'sd-like-enabled';
-		return $classes;
-	}
-
 	/** Checks if admin bar is visible.*/
 	public function is_admin_bar_button_visible() {
 		global $wp_admin_bar;

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-master-iframe.php
@@ -9,22 +9,18 @@
  * This function needs to get loaded after the like scripts get added to the page.
  */
 function jetpack_likes_master_iframe() {
-	$version    = gmdate( 'YW' );
-	$in_jetpack = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ? false : true;
+	$version = gmdate( 'YW' );
 
 	$_locale = get_locale();
 
-	// We have to account for w.org vs WP.com locale divergence
-	if ( $in_jetpack ) {
-		if ( ! defined( 'JETPACK__GLOTPRESS_LOCALES_PATH' ) || ! file_exists( JETPACK__GLOTPRESS_LOCALES_PATH ) ) {
-			return false;
-		}
-
-		require_once JETPACK__GLOTPRESS_LOCALES_PATH;
-
-		$gp_locale = GP_Locales::by_field( 'wp_locale', $_locale );
-		$_locale   = isset( $gp_locale->slug ) ? $gp_locale->slug : '';
+	if ( ! defined( 'JETPACK__GLOTPRESS_LOCALES_PATH' ) || ! file_exists( JETPACK__GLOTPRESS_LOCALES_PATH ) ) {
+		return false;
 	}
+
+	require_once JETPACK__GLOTPRESS_LOCALES_PATH;
+
+	$gp_locale = GP_Locales::by_field( 'wp_locale', $_locale );
+	$_locale   = isset( $gp_locale->slug ) ? $gp_locale->slug : '';
 
 	$likes_locale = ( '' === $_locale || 'en' === $_locale ) ? '' : '&amp;lang=' . strtolower( $_locale );
 

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-settings.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-settings.php
@@ -540,45 +540,6 @@ class Jetpack_Likes_Settings {
 	}
 
 	/**
-	 * Returns the current state of the "WordPress.com Reblogs are" option.
-	 *
-	 * @return bool true if enabled sitewide, false if not
-	 */
-	public function reblogs_enabled_sitewide() {
-		/**
-		 * Filters whether Reblogs are enabled by default on all posts.
-		 * true if enabled sitewide, false if not.
-		 *
-		 * @module likes
-		 *
-		 * @since 3.0.0
-		 *
-		 * @param bool $option Are Reblogs enabled sitewide.
-		 */
-		return (bool) apply_filters( 'wpl_reblogging_enabled_sitewide', ! get_option( 'disabled_reblogs' ) );
-	}
-
-	/**
-	 * Used for WPCOM ONLY. Comment likes are in their own module in Jetpack.
-	 * Returns if comment likes are enabled. Defaults to 'off'
-	 *
-	 * @return boolean true if we should show comment likes, false if not
-	 */
-	public function is_comments_enabled() {
-		/**
-		 * Filters whether Comment Likes are enabled.
-		 * true if enabled, false if not.
-		 *
-		 * @module comment-likes
-		 *
-		 * @since 2.2.0
-		 *
-		 * @param bool $option Are Comment Likes enabled sitewide.
-		 */
-		return (bool) apply_filters( 'jetpack_comment_likes_enabled', get_option( 'jetpack_comment_likes_enabled', false ) );
-	}
-
-	/**
 	 * Saves the setting in the database.
 	 */
 	public function admin_settings_callback() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The module is just a mess: very different code paths in Jetpack versus wpcom, and then wpcom hides a bunch of stuff with CSS which hides more bugs.

If someone wants to try using the Jetpack code on wpcom in the future, they're welcome to start from scratch trying to reconcile the very different behaviors.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1666718643274899-slack-C032DVAHMK3

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Does the feature still work?