### PR TITLE
VideoPress: fix trying to get token when user is disconnected bug

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-fix-bug-when-connection-is-broken
+++ b/projects/packages/videopress/changelog/update-videopress-fix-bug-when-connection-is-broken
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: fix trying to get token when user is disconnected bug

--- a/projects/packages/videopress/src/client/state/selectors.js
+++ b/projects/packages/videopress/src/client/state/selectors.js
@@ -90,8 +90,8 @@ export const getUsersPagination = state => {
 
 export const getPlaybackToken = ( state, guid ) => {
 	const tokens = state?.playbackTokens?.items || [];
-	const token = tokens.find( t => t?.guid === guid );
-	return token;
+	const tokenData = tokens.find( t => t?.guid === guid );
+	return tokenData || {};
 };
 
 export const isFetchingPlaybackToken = state => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/27063

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: fix trying to get token when user is disconnected bug

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Take a look at the issue description
* Confirm the bug is fixed, being able to reconnect the site by clicking on the 

<img width="823" alt="Screen Shot 2022-10-25 at 16 17 26" src="https://user-images.githubusercontent.com/77539/197873358-47074e3b-46d4-4b8f-9c68-52393990213f.png">
