### PR TITLE
Stats: Update mentions of "site stats" to "Jetpack Stats"

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
@@ -5,7 +5,6 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, _x, _n, sprintf } from '@wordpress/i18n';
 import classNames from 'classnames';
 import Button from 'components/button';
-import Card from 'components/card';
 import ConnectButton from 'components/connect-button';
 import analytics from 'lib/analytics';
 import PropTypes from 'prop-types';
@@ -97,9 +96,27 @@ class DashStatsBottom extends Component {
 				<div className="jp-at-a-glance__stats-cta">
 					<div className="jp-at-a-glance__stats-cta-description" />
 					<div className="jp-at-a-glance__stats-ctas">
+						{ createInterpolateElement( __( '<button>View detailed stats</button>', 'jetpack' ), {
+							button: (
+								<Button
+									onClick={ this.trackViewDetailedStats }
+									href={ this.props.siteAdminUrl + 'admin.php?page=stats' }
+								/>
+							),
+						} ) }
+						{ ! this.props.isLinked && this.props.userCanConnectAccount && (
+							<ConnectButton
+								connectUser={ true }
+								from="unlinked-user-connect"
+								connectLegend={ __(
+									'Connect your WordPress.com account for more metrics',
+									'jetpack'
+								) }
+							/>
+						) }
 						{ this.props.isLinked &&
 							createInterpolateElement(
-								__( '<ExternalLink>View more stats on WordPress.com</ExternalLink>', 'jetpack' ),
+								__( '<ExternalLink>View on WordPress.com</ExternalLink>', 'jetpack' ),
 								{
 									ExternalLink: (
 										<ExternalLink
@@ -117,28 +134,8 @@ class DashStatsBottom extends Component {
 									),
 								}
 							) }
-						{ createInterpolateElement( __( '<button>View detailed stats</button>', 'jetpack' ), {
-							button: (
-								<Button
-									onClick={ this.trackViewDetailedStats }
-									href={ this.props.siteAdminUrl + 'admin.php?page=stats' }
-								/>
-							),
-						} ) }
 					</div>
 				</div>
-				{ ! this.props.isLinked && this.props.userCanConnectAccount && (
-					<Card compact className="jp-settings-card__configure-link">
-						<ConnectButton
-							connectUser={ true }
-							from="unlinked-user-connect"
-							connectLegend={ __(
-								'Connect your WordPress.com account to view more stats',
-								'jetpack'
-							) }
-						/>
-					</Card>
-				) }
 			</div>
 		);
 	}

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
@@ -230,7 +230,7 @@ export class DashStats extends Component {
 						src={ imagePath + 'stats.svg' }
 						width="60"
 						height="60"
-						alt={ __( 'Line chart overlaid a bar chart', 'jetpack' ) }
+						alt={ __( 'Line chart overlaid on a bar chart', 'jetpack' ) }
 						className="jp-at-a-glance__stats-icon"
 					/>
 				</div>

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
@@ -108,7 +108,7 @@ export class DashStats extends Component {
 						),
 						className: 'tooltip class',
 					},
-					{ label: __( 'Click to view detailed stats.', 'jetpack' ) },
+					{ label: __( 'Click to view Jetpack Stats.', 'jetpack' ) },
 				],
 			} );
 		} );
@@ -158,7 +158,7 @@ export class DashStats extends Component {
 					src={ imagePath + 'stats-people.svg' }
 					width="272"
 					height="144"
-					alt={ __( 'Jetpack Stats People', 'jetpack' ) }
+					alt={ __( 'People studying site traffic charts', 'jetpack' ) }
 					className="jp-at-a-glance__stats-icon"
 				/>
 				<p>
@@ -189,7 +189,7 @@ export class DashStats extends Component {
 						<span>
 							{ createInterpolateElement(
 								__(
-									'Something happened while loading stats. Please try again later or <a>view your stats now on WordPress.com</a>',
+									'Something happened while loading Jetpack Stats. Please try again later or <a>view your stats now on WordPress.com</a>',
 									'jetpack'
 								),
 								{
@@ -230,7 +230,7 @@ export class DashStats extends Component {
 						src={ imagePath + 'stats.svg' }
 						width="60"
 						height="60"
-						alt={ __( 'Jetpack Stats Icon', 'jetpack' ) }
+						alt={ __( 'Line chart overlaid a bar chart', 'jetpack' ) }
 						className="jp-at-a-glance__stats-icon"
 					/>
 				</div>
@@ -239,11 +239,11 @@ export class DashStats extends Component {
 						? __( 'Unavailable in Offline Mode', 'jetpack' )
 						: createInterpolateElement(
 								__(
-									'<a>Activate Jetpack Stats</a> to see detailed stats, likes, followers, subscribers, and more! <a1>Learn More</a1>',
+									'<a>Activate Jetpack Stats</a> to see page views, likes, followers, subscribers, and more! <a1>Learn More</a1>',
 									'jetpack'
 								),
 								{
-									a: <a href="#" onClick={ this.activateStats } />,
+									a: <a href="javascript:void(0)" onClick={ this.activateStats } />,
 									a1: (
 										<a
 											href={ getRedirectUrl( 'jetpack-support-wordpress-com-stats' ) }
@@ -257,7 +257,7 @@ export class DashStats extends Component {
 				{ ! this.props.isOfflineMode && (
 					<div className="jp-at-a-glance__stats-inactive-button">
 						<Button onClick={ this.activateStats } primary>
-							{ __( 'Activate Jetpack Stats', 'jetpack' ) }
+							{ __( 'Activate', 'jetpack' ) }
 						</Button>
 					</div>
 				) }
@@ -343,7 +343,7 @@ export class DashStats extends Component {
 		if ( 'inactive' === this.props.getModuleOverride( 'stats' ) ) {
 			return (
 				<div>
-					<ModuleOverriddenBanner moduleName={ __( 'Site Stats', 'jetpack' ) } />
+					<ModuleOverriddenBanner moduleName={ __( 'Jetpack Stats', 'jetpack' ) } />
 				</div>
 			);
 		}

--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -400,7 +400,7 @@ class Main extends React.Component {
 					</p>
 
 					<ul>
-						<li>{ __( 'Measure your impact with beautiful stats', 'jetpack' ) }</li>
+						<li>{ __( 'Measure your impact with Jetpack Stats', 'jetpack' ) }</li>
 						<li>{ __( 'Speed up your site with optimized images', 'jetpack' ) }</li>
 						<li>{ __( 'Protect your site against bot attacks', 'jetpack' ) }</li>
 						<li>{ __( 'Get notifications if your site goes offline', 'jetpack' ) }</li>

--- a/projects/plugins/jetpack/_inc/client/traffic/google-analytics.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/google-analytics.jsx
@@ -36,7 +36,7 @@ export const GoogleAnalytics = withModuleSettingsFormHelpers(
 					>
 						{ createInterpolateElement(
 							__(
-								'Google Analytics is a free service that complements our <a>built-in stats</a> with different insights into your traffic. WordPress.com stats and Google Analytics use different methods to identify and track activity on your site, so they will normally show slightly different totals for your visits, views, etc.',
+								'Google Analytics is a free service that complements <a>Jetpack Stats</a> with different insights into your traffic. Jetpack Stats and Google Analytics use different methods to identify and track activity on your site, so they will normally show slightly different totals for your visits, views, etc.',
 								'jetpack'
 							),
 							{

--- a/projects/plugins/jetpack/_inc/client/traffic/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/index.jsx
@@ -73,7 +73,7 @@ export class Traffic extends React.Component {
 						this.props.searchTerm
 							? __( 'Traffic', 'jetpack' )
 							: __(
-									'Maximize your site’s visibility in search engines and view traffic stats in real time.',
+									'Maximize your site’s visibility in search engines and view traffic patterns in real time.',
 									'jetpack'
 							  )
 					}

--- a/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
@@ -163,7 +163,7 @@ class SiteStatsComponent extends React.Component {
 								src={ imagePath + 'stats.svg' }
 								width="60"
 								height="60"
-								alt={ __( 'Jetpack Stats Icon', 'jetpack' ) }
+								alt={ __( 'Line chart overlaid on a bar chart', 'jetpack' ) }
 								className="jp-at-a-glance__stats-icon"
 							/>
 						</div>
@@ -172,7 +172,7 @@ class SiteStatsComponent extends React.Component {
 								? __( 'Unavailable in Offline Mode', 'jetpack' )
 								: createInterpolateElement(
 										__(
-											'<a>Activate Jetpack Stats</a> to see detailed stats, likes, followers, subscribers, and more! <a1>Learn More</a1>',
+											'<a>Activate Jetpack Stats</a> to see page views, likes, followers, subscribers, and more! <a1>Learn More</a1>',
 											'jetpack'
 										),
 										{
@@ -261,7 +261,7 @@ class SiteStatsComponent extends React.Component {
 							) ) }
 						</FormFieldset>
 						<FormFieldset>
-							<FormLegend>{ __( 'Allow stats reports to be viewed by', 'jetpack' ) }</FormLegend>
+							<FormLegend>{ __( 'Allow Jetpack Stats to be viewed by', 'jetpack' ) }</FormLegend>
 							<CompactFormToggle checked={ true } disabled={ true }>
 								<span className="jp-form-toggle-explanation">{ siteRoles.administrator.name }</span>
 							</CompactFormToggle>

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -162,7 +162,7 @@ class Jetpack_Core_API_Site_Endpoint {
 		if ( $has_stats && $stats->stats->visitors > 0 ) {
 			$benefits[] = array(
 				'name'        => 'jetpack-stats',
-				'title'       => esc_html__( 'Site Stats', 'jetpack' ),
+				'title'       => esc_html__( 'Jetpack Stats', 'jetpack' ),
 				'description' => esc_html__( 'Visitors tracked by Jetpack', 'jetpack' ),
 				'value'       => absint( $stats->stats->visitors ),
 			);

--- a/projects/plugins/jetpack/changelog/update-mentions-of-site-stats-2
+++ b/projects/plugins/jetpack/changelog/update-mentions-of-site-stats-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Updated mentions of "Site Stats" with "Jetpack Stats"

--- a/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
@@ -43,7 +43,7 @@ class Jetpack_Stats_Dashboard_Widget {
 
 		if ( has_action( 'jetpack_dashboard_widget' ) ) {
 			$widget_title = sprintf(
-				__( 'Stats by Jetpack', 'jetpack' )
+				__( 'Jetpack Stats', 'jetpack' )
 			);
 
 			wp_add_dashboard_widget(
@@ -152,7 +152,7 @@ class Jetpack_Stats_Dashboard_Widget {
 				<a href="<?php echo esc_url( admin_url( 'admin.php?page=jetpack#/settings?term=' . rawurlencode( $i18n_headers['name'] ) ) ); ?>"
 					>
 						<?php
-						esc_html_e( 'Configure stats', 'jetpack' );
+						esc_html_e( 'Configure Jetpack Stats', 'jetpack' );
 						?>
 				</a>
 				|

--- a/projects/plugins/jetpack/modules/module-info.php
+++ b/projects/plugins/jetpack/modules/module-info.php
@@ -97,7 +97,7 @@ function wpme_more_info() {
 add_action( 'jetpack_module_more_info_shortlinks', 'wpme_more_info' );
 
 /**
- * Site Stats support link.
+ * Jetpack Stats support link.
  */
 function stats_load_more_link() {
 	echo esc_url( Redirect::get_url( 'jetpack-support-wordpress-com-stats' ) );
@@ -105,11 +105,11 @@ function stats_load_more_link() {
 add_filter( 'jetpack_learn_more_button_stats', 'stats_load_more_link' );
 
 /**
- * Site Stats description.
+ * Jetpack Stats description.
  */
 function stats_more_info() {
 	esc_html_e(
-		'Simple and concise statistics about your traffic. Jetpack collects data about pageviews, likes, comments,
+		'Simple and concise statistics about your traffic. Jetpack Stats collects data on page views, likes, comments,
 		locations, and top posts. View them in your dashboard or on WordPress.com.',
 		'jetpack'
 	);

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Module Name: Site Stats
+ * Module Name: Jetpack Stats
  * Module Description: Collect valuable traffic stats and insights.
  * Sort Order: 1
  * Recommendation Order: 2
  * First Introduced: 1.1
  * Requires Connection: Yes
  * Auto Activate: Yes
- * Module Tags: Site Stats, Recommended
+ * Module Tags: Jetpack Stats, Site Stats, Recommended
  * Feature: Engagement
  * Additional Search Queries: statistics, tracking, analytics, views, traffic, stats
  *
@@ -462,8 +462,8 @@ function stats_reports_page( $main_chart_only = false ) {
 		<div id="stats-loading-wrap" class="wrap">
 		<p class="hide-if-no-js"><img width="32" height="32" alt="<?php esc_attr_e( 'Loading&hellip;', 'jetpack' ); ?>" src="<?php echo esc_url( $static_url ); ?>" /></p>
 		<p style="font-size: 11pt; margin: 0;"><a href="<?php echo esc_url( $stats_url ); ?>" rel="noopener noreferrer" target="_blank"><?php esc_html_e( 'View stats on WordPress.com right now', 'jetpack' ); ?></a></p>
-		<p class="hide-if-js"><?php esc_html_e( 'Your Site Stats work better with JavaScript enabled.', 'jetpack' ); ?><br />
-		<a href="<?php echo esc_url( $nojs_url ); ?>"><?php esc_html_e( 'View Site Stats without JavaScript', 'jetpack' ); ?></a>.</p>
+		<p class="hide-if-js"><?php esc_html_e( 'Jetpack Stats work better with JavaScript enabled.', 'jetpack' ); ?><br />
+		<a href="<?php echo esc_url( $nojs_url ); ?>"><?php esc_html_e( 'View Jetpack Stats without JavaScript', 'jetpack' ); ?></a>.</p>
 		</div>
 	</div>
 		<?php
@@ -770,7 +770,7 @@ function stats_admin_bar_menu( &$wp_admin_bar ) {
 	$img_src    = esc_attr( stats_get_image_chart_src( 'admin-bar-hours-scale' ) );
 	$img_src_2x = esc_attr( stats_get_image_chart_src( 'admin-bar-hours-scale-2x' ) );
 	$alt        = esc_attr( __( 'Stats', 'jetpack' ) );
-	$title      = esc_attr( __( 'Views over 48 hours. Click for more Site Stats.', 'jetpack' ) );
+	$title      = esc_attr( __( 'Views over 48 hours. Click for more Jetpack Stats.', 'jetpack' ) );
 
 	$menu = array(
 		'id'    => 'stats',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/68728.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Updates mentions of "stats" with "Jetpack Stats" when appropriate.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Part of the rebranding project (p1HpG7-icd-p2).

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check code changes and ensure the text replacement looks reasonable.
* Navigate to the Jetpack Dashboard (`/wp-admin/admin.php?page=jetpack#/dashboard`) and ensure that the Stats section looks reasonable.
