### PR TITLE
Search: hide meters for Classic Search

### DIFF
--- a/projects/packages/search/changelog/fix-classic-search-hide-meters
+++ b/projects/packages/search/changelog/fix-classic-search-hide-meters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: hide meters etc for Classic Search

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.29.1",
+	"version": "0.29.2-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.29.1';
+	const VERSION = '0.29.2-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -126,7 +126,7 @@ export default function DashboardPage( { isLoading = false } ) {
 						supportsInstantSearch={ supportsInstantSearch }
 						supportsOnlyClassicSearch={ supportsOnlyClassicSearch }
 					/>
-					{ isNewPricing && (
+					{ isNewPricing && supportsInstantSearch && (
 						<PlanInfo
 							hasIndex={ postCount !== 0 }
 							recordMeterInfo={ recordMeterInfo }
@@ -134,7 +134,7 @@ export default function DashboardPage( { isLoading = false } ) {
 							sendPaidPlanToCart={ sendPaidPlanToCart }
 						/>
 					) }
-					{ ! isNewPricing && (
+					{ ! isNewPricing && supportsInstantSearch && (
 						<RecordMeter
 							postCount={ postCount }
 							postTypeBreakdown={ postTypeBreakdown }

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -112,7 +112,7 @@ export default function DashboardPage( { isLoading = false } ) {
 			{ ! isPageLoading && (
 				<div className="jp-search-dashboard-page">
 					<Header
-						isUpgradable={ isNewPricing && isFreePlan }
+						isUpgradable={ ( isNewPricing && isFreePlan ) || ! supportsInstantSearch }
 						sendPaidPlanToCart={ sendPaidPlanToCart }
 					/>
 					{ hasConnectionError && (

--- a/projects/packages/search/src/dashboard/store/selectors/site-plan.js
+++ b/projects/packages/search/src/dashboard/store/selectors/site-plan.js
@@ -3,7 +3,7 @@ const productSlugFree = 'jetpack_search_free';
 const sitePlanSelectors = {
 	getSearchPlanInfo: state => state.sitePlan,
 	hasBusinessPlan: state => state.sitePlan.supports_only_classic_search,
-	isOverLimit: state => state.sitePlan.plan_usage.must_upgrade,
+	isOverLimit: state => state.sitePlan.plan_usage?.must_upgrade,
 	supportsInstantSearch: state => state.sitePlan.supports_instant_search,
 	supportsOnlyClassicSearch: state => state.sitePlan.supports_only_classic_search,
 	getUpgradeBillPeriod: state => state.sitePlan?.default_upgrade_bill_period,
@@ -11,7 +11,7 @@ const sitePlanSelectors = {
 		state.sitePlan.supports_instant_search || state.sitePlan.supports_only_classic_search,
 	getTierMaximumRecords: state => state.sitePlan.tier_maximum_records,
 	isFreePlan: state => state.sitePlan.effective_subscription?.product_slug === productSlugFree,
-	getLatestMonthRequests: state => state.sitePlan.plan_usage.num_requests_3m[ 0 ],
+	getLatestMonthRequests: state => state.sitePlan.plan_usage?.num_requests_3m[ 0 ],
 	getCurrentPlan: state => state.sitePlan.plan_current,
 	getCurrentUsage: state => state.sitePlan.plan_usage,
 };


### PR DESCRIPTION
Fixes #27072 

#### Changes proposed in this Pull Request:
Hide Meters for Classic Search which doesn't need them, and throws errors in some places.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Open your local site
* Add the following line as `projects/packages/search/src/class-rest-controller.php:L223`:
```
		return json_decode('{"search_subscriptions":[{"ID":"123","user_id":"123","blog_id":"123","product_id":"1008","expiry":"2023-10-19","subscribed_date":"2022-10-19 00:22:41","renew":true,"auto_renew":true,"ownership_id":"123","most_recent_renew_date":"","subscription_status":"active","product_name":"WordPress.com Business","product_name_en":"WordPress.com Business","product_slug":"business-bundle","product_type":"bundle","cost":300,"currency":"USD","bill_period":"365","available":"yes","multi":false,"support_document":null,"is_instant_search":false,"tier":null}],"supports_instant_search":false,"supports_only_classic_search":true,"supports_search":true}');

```
* Open Search Dashboard `/wp-admin/admin.php?page=jetpack-search`
* Ensure there are no error related to Search in dev console

