### PR TITLE
Protect: Use null default value for un-fetched credentials

### DIFF
--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -97,7 +97,7 @@ const useCredentials = () => {
 	const credentials = useSelect( select => select( STORE_ID ).getCredentials() );
 
 	useEffect( () => {
-		if ( ! credentials.length ) {
+		if ( ! credentials ) {
 			checkCredentials();
 		}
 	}, [ checkCredentials, credentials ] );

--- a/projects/plugins/protect/src/js/state/reducers.js
+++ b/projects/plugins/protect/src/js/state/reducers.js
@@ -15,7 +15,7 @@ import {
 	SET_THREATS_ARE_FIXING,
 } from './actions';
 
-const credentials = ( state = [], action ) => {
+const credentials = ( state = null, action ) => {
 	switch ( action.type ) {
 		case SET_CREDENTIALS_STATE:
 			return action.credentials;

--- a/projects/plugins/protect/src/js/state/selectors.js
+++ b/projects/plugins/protect/src/js/state/selectors.js
@@ -1,5 +1,5 @@
 const selectors = {
-	getCredentials: state => state.credentials || [],
+	getCredentials: state => state.credentials || null,
 	getCredentialsIsFetching: state => state.credentialsIsFetching || false,
 	getInstalledPlugins: state => state.installedPlugins || {},
 	getInstalledThemes: state => state.installedThemes || {},


### PR DESCRIPTION
Using `null` will allow use to use the `credentials` value for three scenarios:
1. `null`: No credentials data present / not fetched yet
2. `[]`: Credentials fetched, no credentials available
3. `[ {...} ]`: Credentials available

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Use `null` as the default state value for `credentials`

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a new JN site with Protect, a Scan plan, and a threat
* Visit the admin page
* Validate that only a single request is sent for credentials 
* Open and then close the fix threat modal
* Monitor the network tab to ensure it requests credentials only while the modal is open

