### PR TITLE
Fix/sync check still an array after plugin action links filter applied

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-check-still-an-array-after-plugin-action-links-filter-applied
+++ b/projects/packages/sync/changelog/fix-sync-check-still-an-array-after-plugin-action-links-filter-applied
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Check $action_links is still array after plugin_action_links filter has been applied.

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.40.1';
+	const PACKAGE_VERSION = '1.40.2-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/sync/src/modules/class-callables.php
+++ b/projects/packages/sync/src/modules/class-callables.php
@@ -376,6 +376,10 @@ class Callables extends Module {
 			);
 			/** This filter is documented in src/wp-admin/includes/class-wp-plugins-list-table.php */
 			$action_links = apply_filters( 'plugin_action_links', $action_links, $plugin_file, null, 'all' );
+			// Verify $action_links is still an array.
+			if ( ! is_array( $action_links ) ) {
+				$action_links = array();
+			}
 			/** This filter is documented in src/wp-admin/includes/class-wp-plugins-list-table.php */
 			$action_links = apply_filters( "plugin_action_links_{$plugin_file}", $action_links, $plugin_file, null, 'all' );
 			// Verify $action_links is still an array to resolve warnings from filters not returning an array.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This fix verifies we don't fatal if $action_links is not an array after `plugin_action_links` has been applied.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->


#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Before testing the PR, please go through the instructions on trunk first to confirm the issue (a fatal). 

* Install this [plugin](https://gist.github.com/darssen/9300ecffbc251d0cfec3e7eb3a3c7d79) so that when `plugin_action_links` filter is applied a string will be returned.
* Go to `wp-admin/plugins.php`
