### PR TITLE
Jetpack Boost: Use TypeScript in Svelte

### DIFF
--- a/projects/plugins/boost/.eslintrc.cjs
+++ b/projects/plugins/boost/.eslintrc.cjs
@@ -46,5 +46,6 @@ module.exports = {
 		],
 
 		'prettier/prettier': 0,
+		camelcase: 0,
 	},
 };

--- a/projects/plugins/boost/app/assets/src/js/Main.svelte
+++ b/projects/plugins/boost/app/assets/src/js/Main.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import BenefitsInterstitial from './pages/benefits/BenefitsInterstitial.svelte';
 	import Connection from './pages/connection/Connection.svelte';
 	import GettingStarted from './pages/getting-started/GettingStarted.svelte';

--- a/projects/plugins/boost/app/assets/src/js/api/api.ts
+++ b/projects/plugins/boost/app/assets/src/js/api/api.ts
@@ -8,7 +8,6 @@ import { ApiError } from './api-error';
 import type { JSONObject } from '../utils/json-types';
 
 function getEndpointUrl( path: string ): string {
-	// eslint-disable-next-line camelcase
 	return wpApiSettings.root + Jetpack_Boost.api.namespace + Jetpack_Boost.api.prefix + path;
 }
 

--- a/projects/plugins/boost/app/assets/src/js/api/speed-scores.ts
+++ b/projects/plugins/boost/app/assets/src/js/api/speed-scores.ts
@@ -37,7 +37,6 @@ export async function requestSpeedScores( force = false ): Promise< SpeedScoresS
 	// Request metrics
 	const response = parseResponse(
 		await api.post( force ? '/speed-scores/refresh' : '/speed-scores', {
-			// eslint-disable-next-line camelcase
 			url: Jetpack_Boost.site.url,
 		} )
 	);
@@ -116,7 +115,6 @@ async function pollRequest(): Promise< SpeedScoresSet > {
 		timeoutError: __( 'Timed out while waiting for speed-score.', 'jetpack-boost' ),
 		callback: async resolve => {
 			const response = parseResponse(
-				// eslint-disable-next-line camelcase
 				await api.post( '/speed-scores', { url: Jetpack_Boost.site.url } )
 			);
 

--- a/projects/plugins/boost/app/assets/src/js/api/speed-scores.ts
+++ b/projects/plugins/boost/app/assets/src/js/api/speed-scores.ts
@@ -204,7 +204,15 @@ export function getScoreMovementPercentage( scores: SpeedScoresSet ): number {
 	return 0;
 }
 
-export function scoreChangeModal( scores: SpeedScoresSet ) {
+export type ScoreChangeMessage = {
+	id: string;
+	title: string;
+	message: string;
+	cta: string;
+	ctaLink: string;
+};
+
+export function scoreChangeModal( scores: SpeedScoresSet ): ScoreChangeMessage {
 	const changePercentage = getScoreMovementPercentage( scores );
 	if ( changePercentage > 5 ) {
 		return {

--- a/projects/plugins/boost/app/assets/src/js/elements/BackButton.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/BackButton.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { __ } from '@wordpress/i18n';
 	import LeftArrow from '../svg/left-arrow.svg';
-	import routerHistory from '../utils/router-history.ts';
+	import routerHistory from '../utils/router-history';
 
 	const { navigate } = routerHistory;
 

--- a/projects/plugins/boost/app/assets/src/js/elements/BackButton.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/BackButton.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { __ } from '@wordpress/i18n';
 	import LeftArrow from '../svg/left-arrow.svg';
 	import routerHistory from '../utils/router-history.ts';

--- a/projects/plugins/boost/app/assets/src/js/elements/CloseButton.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/CloseButton.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { __ } from '@wordpress/i18n';
 </script>
 

--- a/projects/plugins/boost/app/assets/src/js/elements/ErrorNotice.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/ErrorNotice.svelte
@@ -3,6 +3,7 @@
 	import { ApiError } from '../api/api-error';
 	import NoticeIcon from '../svg/notice-outline.svg';
 	import actionLinkTemplateVar from '../utils/action-link-template-var';
+	import { TemplateVars } from '../utils/copy-dom-template';
 	import { standardizeError } from '../utils/standardize-error';
 	import supportLinkTemplateVar from '../utils/support-link-template-var';
 	import TemplatedString from './TemplatedString.svelte';
@@ -26,19 +27,19 @@
 	export let data = '';
 
 	/**
-	 * @member suggestion Optional suggestion to include after the error message.
+	 * Optional suggestion to include after the error message.
 	 */
 	export let suggestion = '';
 
 	/**
-	 * @member {TemplateVars} vars Optional template variables to substitute for tags in the error suggestions.
+	 * Optional template variables to substitute for tags in the error suggestions.
 	 * Note: Unless you supply a custom description slot and template it yourself,
 	 * these will not apply to the main message / description, as it may be unsafe to parse as HTML.
 	 * Note: the following template vars are automatically included in all errors:
 	 * - <support>: a link to support.
 	 * - <action name="">: A link to dispatch the named action.
 	 */
-	export let vars = {};
+	export let vars: TemplateVars = {};
 
 	// Figure out an appropriate description based on error object or message.
 	const description = standardizeError( error ).message;

--- a/projects/plugins/boost/app/assets/src/js/elements/ErrorNotice.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/ErrorNotice.svelte
@@ -8,27 +8,27 @@
 	import TemplatedString from './TemplatedString.svelte';
 
 	/**
-	 * @member {string} title Title to display above the error message.
+	 * Title to display above the error message.
 	 */
-	export let title;
+	export let title: string;
 
 	/**
-	 * @member {Error | string} error Error being displayed. Automatically populates
+	 * Error being displayed. Automatically populates
 	 * description (and if appropriate data) sections.
 	 *
 	 * Note: Description can be overridden by the default slot, if one is provided.
 	 */
-	export let error = new Error( title );
+	export let error: Error | string = new Error( title );
 
 	/**
-	 * @member {string} data Optional raw string data to include with error. Automatically pulled out of ApiErrors.
+	 * Optional raw string data to include with error. Automatically pulled out of ApiErrors.
 	 */
-	export let data;
+	export let data = '';
 
 	/**
-	 * @member {string} suggestion Optional suggestion to include after the error message.
+	 * @member suggestion Optional suggestion to include after the error message.
 	 */
-	export let suggestion;
+	export let suggestion = '';
 
 	/**
 	 * @member {TemplateVars} vars Optional template variables to substitute for tags in the error suggestions.

--- a/projects/plugins/boost/app/assets/src/js/elements/ErrorNotice.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/ErrorNotice.svelte
@@ -1,6 +1,6 @@
-<script>
+<script lang="ts">
 	import { createEventDispatcher } from 'svelte';
-	import { ApiError } from '../api/api-error.ts';
+	import { ApiError } from '../api/api-error';
 	import NoticeIcon from '../svg/notice-outline.svg';
 	import actionLinkTemplateVar from '../utils/action-link-template-var';
 	import { standardizeError } from '../utils/standardize-error';

--- a/projects/plugins/boost/app/assets/src/js/elements/FoldingElement.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/FoldingElement.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	export let showLabel;
 	export let hideLabel;
 

--- a/projects/plugins/boost/app/assets/src/js/elements/FoldingElement.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/FoldingElement.svelte
@@ -1,16 +1,14 @@
 <script lang="ts">
-	export let showLabel;
-	export let hideLabel;
-
+	export let showLabel: string;
+	export let hideLabel: string;
 	export let visible = false;
+
+	const toggle = () => ( visible = ! visible );
+	$: label = visible ? showLabel : hideLabel;
 </script>
 
-<button
-	class="components-button is-link foldable-element-control"
-	class:visible
-	on:click={() => ( visible = ! visible )}
->
-	{visible ? hideLabel : showLabel}
+<button class="components-button is-link foldable-element-control" class:visible on:click={toggle}>
+	{label}
 </button>
 
 {#if visible}

--- a/projects/plugins/boost/app/assets/src/js/elements/MoreList.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/MoreList.svelte
@@ -9,9 +9,18 @@
 	import { sprintf, __ } from '@wordpress/i18n';
 
 	/**
-	 * List of objects to pass to each copy of the slot.
+	 * Svelte doesn't support TypeScript generics,
+	 * so this is a workaround found in:
+	 * https://github.com/sveltejs/language-tools/issues/273
 	 */
-	export let entries: unknown[] = [];
+	type T = $$Generic;
+	interface $$Slots {
+		default: {
+			entry: T;
+		};
+	}
+
+	export let entries: T[] = [];
 
 	/**
 	 * The maximum number of items to show before folding extras away.
@@ -22,12 +31,14 @@
 	function toggle() {
 		expanded = ! expanded;
 	}
+
+	$: listItems = expanded ? entries : entries.slice( 0, showLimit );
 </script>
 
 <ul>
-	{#each expanded ? entries : entries.slice( 0, showLimit ) as props}
+	{#each listItems as item}
 		<li transition:slide|local>
-			<slot entry={props} />
+			<slot entry={item} />
 		</li>
 	{/each}
 

--- a/projects/plugins/boost/app/assets/src/js/elements/MoreList.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/MoreList.svelte
@@ -9,17 +9,16 @@
 	import { sprintf, __ } from '@wordpress/i18n';
 
 	/**
-	 * @member {Array} entries List of objects to pass to each copy of the slot.
+	 * List of objects to pass to each copy of the slot.
 	 */
-	export let entries = [];
+	export let entries: unknown[] = [];
 
 	/**
-	 * @member {number} showLimit The maximum number of items to show before folding extras away.
+	 * The maximum number of items to show before folding extras away.
 	 */
 	export let showLimit = 2;
 
 	let expanded = false;
-
 	function toggle() {
 		expanded = ! expanded;
 	}

--- a/projects/plugins/boost/app/assets/src/js/elements/MoreList.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/MoreList.svelte
@@ -4,7 +4,7 @@
 
 	Automatically folds away with "...and x more" when the list exceeds showLimit.
 -->
-<script>
+<script lang="ts">
 	import { slide } from 'svelte/transition';
 	import { sprintf, __ } from '@wordpress/i18n';
 

--- a/projects/plugins/boost/app/assets/src/js/elements/NumberedList.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/NumberedList.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import TemplatedString from './TemplatedString.svelte';
 
 	/**

--- a/projects/plugins/boost/app/assets/src/js/elements/NumberedList.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/NumberedList.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
+	import { TemplateVars } from '../utils/copy-dom-template';
 	import TemplatedString from './TemplatedString.svelte';
 
 	/**
 	 * List of string items to include in the list.
 	 */
-	export let items;
+	export let items: string[];
 
 	/**
 	 * Template vars to fill in <template> elements in each list item.
 	 */
-	export let vars;
+	export let vars: TemplateVars;
 </script>
 
 <ol class="numbered-list">

--- a/projects/plugins/boost/app/assets/src/js/elements/TemplatedString.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/TemplatedString.svelte
@@ -1,24 +1,20 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { copyDomTemplate } from '../utils/copy-dom-template';
+	import { copyDomTemplate, TemplateVars } from '../utils/copy-dom-template';
 	import { parsePseudoHTML } from '../utils/parse-pseudo-html';
 
 	/**
 	 * String template to display in this component. <pseudo-html/> tags will
 	 * be replaced with the relevant value specified in vars, preserving content
-	 *
-	 * @member {string} template
 	 */
-	export let template;
+	export let template: string;
 
 	/**
 	 * Template vars to replace in the template. Each key corresponds to a
 	 * <pseudo-html /> tag name to replace, each value should be an array with
 	 * two entries; the HTML tag type, and an object full of attributes.
-	 *
-	 * @member {TemplateVars} vars
 	 */
-	export let vars;
+	export let vars: TemplateVars;
 
 	let span;
 

--- a/projects/plugins/boost/app/assets/src/js/elements/TemplatedString.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/TemplatedString.svelte
@@ -16,7 +16,7 @@
 	 */
 	export let vars: TemplateVars;
 
-	let span;
+	let span: Node;
 
 	onMount( () => {
 		// Copy template to span, substituting vars.

--- a/projects/plugins/boost/app/assets/src/js/elements/TemplatedString.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/TemplatedString.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { onMount } from 'svelte';
 	import { copyDomTemplate } from '../utils/copy-dom-template';
 	import { parsePseudoHTML } from '../utils/parse-pseudo-html';

--- a/projects/plugins/boost/app/assets/src/js/elements/TimeAgo.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/TimeAgo.svelte
@@ -2,7 +2,7 @@
 	This Component shows a span with the given time (Date) as a relative time in
 	the past. Mouseover to show the exact time.
 -->
-<script>
+<script lang="ts">
 	import { readable } from 'svelte/store';
 	import describeTimeAgo from '../utils/describe-time-ago.ts';
 

--- a/projects/plugins/boost/app/assets/src/js/elements/TimeAgo.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/TimeAgo.svelte
@@ -4,7 +4,7 @@
 -->
 <script lang="ts">
 	import { readable } from 'svelte/store';
-	import describeTimeAgo from '../utils/describe-time-ago.ts';
+	import describeTimeAgo from '../utils/describe-time-ago';
 
 	export let time;
 

--- a/projects/plugins/boost/app/assets/src/js/elements/TimeAgo.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/TimeAgo.svelte
@@ -6,7 +6,7 @@
 	import { readable } from 'svelte/store';
 	import describeTimeAgo from '../utils/describe-time-ago';
 
-	export let time;
+	export let time: Date;
 
 	const label = readable( describeTimeAgo( time ), set => {
 		// Update label every 10 seconds.

--- a/projects/plugins/boost/app/assets/src/js/global.d.ts
+++ b/projects/plugins/boost/app/assets/src/js/global.d.ts
@@ -16,7 +16,6 @@ declare global {
 	};
 
 	// Constants provided by the plugin.
-	// eslint-disable-next-line camelcase
 	const Jetpack_Boost: {
 		preferences: {
 			showRatingPrompt: boolean;
@@ -66,7 +65,6 @@ declare global {
 	type TracksEventProperties = { [ key: string ]: string | number };
 
 	const jpTracksAJAX: {
-		// eslint-disable-next-line camelcase
 		record_ajax_event(
 			eventName: string,
 			eventType: string,

--- a/projects/plugins/boost/app/assets/src/js/pages/benefits/BenefitsInterstitial.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/benefits/BenefitsInterstitial.svelte
@@ -69,6 +69,7 @@
 
 			<div class="jb-card__cta px-2 my-4">
 				{#if 'yearly' in $pricing}
+					<!-- @TODO: Fix TypeScript Issue -->
 					<ReactComponent
 						this={PricingCard}
 						title={'Jetpack Boost'}

--- a/projects/plugins/boost/app/assets/src/js/pages/benefits/BenefitsInterstitial.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/benefits/BenefitsInterstitial.svelte
@@ -69,11 +69,11 @@
 
 			<div class="jb-card__cta px-2 my-4">
 				{#if 'yearly' in $pricing}
-					<!-- @TODO: Fix TypeScript Issue -->
+					<!-- svelte-ignore missing-declaration Jetpack_Boost -->
 					<ReactComponent
 						this={PricingCard}
 						title={'Jetpack Boost'}
-						icon={`${ window.Jetpack_Boost.site.assetPath }../static/images/forward.svg`}
+						icon={`${ Jetpack_Boost.site.assetPath }../static/images/forward.svg`}
 						priceBefore={$pricing.yearly.priceBefore / 12}
 						priceAfter={$pricing.yearly.priceAfter / 12}
 						priceDetails={__( '/month, paid yearly', 'jetpack-boost' )}

--- a/projects/plugins/boost/app/assets/src/js/pages/benefits/BenefitsInterstitial.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/benefits/BenefitsInterstitial.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { PricingCard } from '@automattic/jetpack-components';
 	import React from 'react';
 	import { derived } from 'svelte/store';

--- a/projects/plugins/boost/app/assets/src/js/pages/connection/Connection.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/connection/Connection.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { __ } from '@wordpress/i18n';
 	import ErrorNotice from '../../elements/ErrorNotice.svelte';
 	import TemplatedString from '../../elements/TemplatedString.svelte';

--- a/projects/plugins/boost/app/assets/src/js/pages/getting-started/GettingStarted.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/getting-started/GettingStarted.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import ReactComponent from '../../elements/ReactComponent.svelte';
-	import { BoostPricingTable } from '../../react-components/BoostPricingTable.tsx';
+	import { BoostPricingTable } from '../../react-components/BoostPricingTable';
 	import Header from '../../sections/Header.svelte';
 	import config, { markGetStartedComplete } from '../../stores/config';
 	import { updateModuleState } from '../../stores/modules';

--- a/projects/plugins/boost/app/assets/src/js/pages/getting-started/GettingStarted.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/getting-started/GettingStarted.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import ReactComponent from '../../elements/ReactComponent.svelte';
 	import { BoostPricingTable } from '../../react-components/BoostPricingTable.tsx';
 	import Header from '../../sections/Header.svelte';

--- a/projects/plugins/boost/app/assets/src/js/pages/purchase-success/PurchaseSuccess.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/purchase-success/PurchaseSuccess.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { onMount } from 'svelte';
 	import { Button } from '@wordpress/components';
 	import { __ } from '@wordpress/i18n';

--- a/projects/plugins/boost/app/assets/src/js/pages/purchase-success/PurchaseSuccess.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/purchase-success/PurchaseSuccess.svelte
@@ -46,6 +46,7 @@
 			</div>
 
 			<div class="jb-card__cta px-1 py-4">
+				<!-- @TODO: Fix TypeScript Issue -->
 				<img
 					src={`${ window.Jetpack_Boost.site.assetPath }../static/images/boost.png`}
 					alt={__( 'Optimize with Jetpack Boost', 'jetpack-boost' )}

--- a/projects/plugins/boost/app/assets/src/js/pages/purchase-success/PurchaseSuccess.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/purchase-success/PurchaseSuccess.svelte
@@ -46,9 +46,9 @@
 			</div>
 
 			<div class="jb-card__cta px-1 py-4">
-				<!-- @TODO: Fix TypeScript Issue -->
+				<!-- svelte-ignore missing-declaration Jetpack_Boost -->
 				<img
-					src={`${ window.Jetpack_Boost.site.assetPath }../static/images/boost.png`}
+					src={`${ Jetpack_Boost.site.assetPath }../static/images/boost.png`}
 					alt={__( 'Optimize with Jetpack Boost', 'jetpack-boost' )}
 				/>
 			</div>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/Settings.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/Settings.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import Footer from '../../sections/Footer.svelte';
 	import Header from '../../sections/Header.svelte';
 	import config from '../../stores/config';

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CloudCssMeta.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CloudCssMeta.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { __ } from '@wordpress/i18n';
 	import { showError } from '../../../stores/critical-css-status';
 	import { requestCloudCss, retryCloudCss } from '../../../utils/cloud-css';

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssErrorDescription.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssErrorDescription.svelte
@@ -12,7 +12,7 @@
 	import MoreList from '../../../elements/MoreList.svelte';
 	import NumberedList from '../../../elements/NumberedList.svelte';
 	import TemplatedString from '../../../elements/TemplatedString.svelte';
-	import actionLinkTemplateVar from '../../../utils/action-link-template-var.ts';
+	import actionLinkTemplateVar from '../../../utils/action-link-template-var';
 	import {
 		describeErrorSet,
 		suggestion,

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssErrorDescription.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssErrorDescription.svelte
@@ -4,7 +4,7 @@
 
 	It can include a list of failed URLs, what a user can do, and extra information.
 -->
-<script>
+<script lang="ts">
 	import { createEventDispatcher } from 'svelte';
 	import { slide } from 'svelte/transition';
 	import { __ } from '@wordpress/i18n';

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssErrorDescription.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssErrorDescription.svelte
@@ -35,6 +35,7 @@
 	// Keep a set of URLs in an easy-to-render {href:, label:} format.
 	// Each should show the URL in its label, but actually link to error.meta.url if available.
 	let displayUrls = [];
+	// @TODO: Fix TypeScript Issue
 	$: displayUrls = Object.entries( errorSet.byUrl ).map( ( [ url, error ] ) => ( {
 		href: error.meta.url ? error.meta.url : url,
 		label: url,
@@ -48,10 +49,12 @@
 
 <div class="jb-critical-css__error-description">
 	<span class="error-description">
+		<!-- @TODO: Fix TypeScript Issue -->
 		<TemplatedString template={describeErrorSet( errorSet )} vars={{ templateVars }} />
 	</span>
 
 	<MoreList let:entry entries={displayUrls}>
+		<!-- @TODO: Fix TypeScript Issue -->
 		<a href={entry.href} target="_blank">
 			{entry.label}
 		</a>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssErrorDescription.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssErrorDescription.svelte
@@ -12,7 +12,9 @@
 	import MoreList from '../../../elements/MoreList.svelte';
 	import NumberedList from '../../../elements/NumberedList.svelte';
 	import TemplatedString from '../../../elements/TemplatedString.svelte';
+	import { ErrorSet } from '../../../stores/critical-css-recommendations';
 	import actionLinkTemplateVar from '../../../utils/action-link-template-var';
+	import { TemplateVars } from '../../../utils/copy-dom-template';
 	import {
 		describeErrorSet,
 		suggestion,
@@ -28,20 +30,36 @@
 	export let showClosingParagraph = true;
 
 	/**
-	 * @member {ErrorSet} errorSet Error Set to display a description of, from a Recommendation or CriticalCssStatus.
+	 * A set of errors to display recommendations from, from a Recommendation or CriticalCssStatus.
 	 */
-	export let errorSet;
+	export let errorSet: ErrorSet;
 
+	type FormattedURL = {
+		/**
+		 * The URL to display in the list.
+		 */
+		href: string;
+		/**
+		 * The URL to link to.
+		 */
+		label: string;
+	};
 	// Keep a set of URLs in an easy-to-render {href:, label:} format.
 	// Each should show the URL in its label, but actually link to error.meta.url if available.
-	let displayUrls = [];
-	// @TODO: Fix TypeScript Issue
-	$: displayUrls = Object.entries( errorSet.byUrl ).map( ( [ url, error ] ) => ( {
-		href: error.meta.url ? error.meta.url : url,
-		label: url,
-	} ) );
+	let displayUrls: FormattedURL[] = [];
 
-	const templateVars = {
+	$: displayUrls = Object.entries( errorSet.byUrl ).map( ( [ url, error ] ) => {
+		let href = url;
+		if ( error.meta.url && typeof error.meta.url === 'string' ) {
+			href = error.meta.url;
+		}
+		return {
+			href,
+			label: url,
+		};
+	} );
+
+	const templateVars: TemplateVars = {
 		...actionLinkTemplateVar( () => dispatch( 'retry' ), 'retry' ),
 		...supportLinkTemplateVar(),
 	};
@@ -49,12 +67,10 @@
 
 <div class="jb-critical-css__error-description">
 	<span class="error-description">
-		<!-- @TODO: Fix TypeScript Issue -->
-		<TemplatedString template={describeErrorSet( errorSet )} vars={{ templateVars }} />
+		<TemplatedString template={describeErrorSet( errorSet )} vars={templateVars} />
 	</span>
 
 	<MoreList let:entry entries={displayUrls}>
-		<!-- @TODO: Fix TypeScript Issue -->
 		<a href={entry.href} target="_blank">
 			{entry.label}
 		</a>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssMeta.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssMeta.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { __ } from '@wordpress/i18n';
 	import { criticalCssStatus, showError } from '../../../stores/critical-css-status';
 	import generateCriticalCss from '../../../utils/generate-critical-css';

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssMeta.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssMeta.svelte
@@ -17,8 +17,8 @@
 		<!-- @TODO: Fix TypeScript Issue -->
 		<div
 			role="progressbar"
-			aria-valuemax="100"
-			aria-valuemin="0"
+			aria-valuemax={100}
+			aria-valuemin={0}
 			aria-valuenow={$criticalCssStatus.progress}
 			class="jb-progress-bar"
 		>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssMeta.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssMeta.svelte
@@ -14,6 +14,7 @@
 				'jetpack-boost'
 			)}
 		</span>
+		<!-- @TODO: Fix TypeScript Issue -->
 		<div
 			role="progressbar"
 			aria-valuemax="100"

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssMeta.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssMeta.svelte
@@ -14,7 +14,6 @@
 				'jetpack-boost'
 			)}
 		</span>
-		<!-- @TODO: Fix TypeScript Issue -->
 		<div
 			role="progressbar"
 			aria-valuemax={100}
@@ -32,5 +31,5 @@
 {:else if $showError}
 	<CriticalCssShowStopperError on:retry={() => generateCriticalCss( true, true )} />
 {:else}
-	<CriticalCssStatus on:retry={generateCriticalCss} />
+	<CriticalCssStatus on:retry={() => generateCriticalCss()} />
 {/if}

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssShowStopperError.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssShowStopperError.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { createEventDispatcher } from 'svelte';
 	import { slide } from 'svelte/transition';
 	import { __ } from '@wordpress/i18n';

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssStatus.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssStatus.svelte
@@ -7,7 +7,7 @@
 	import InfoIcon from '../../../svg/info.svg';
 	import RefreshIcon from '../../../svg/refresh.svg';
 	import actionLinkTemplateVar from '../../../utils/action-link-template-var';
-	import routerHistory from '../../../utils/router-history.ts';
+	import routerHistory from '../../../utils/router-history';
 
 	export let generateText = '';
 	export let generateMoreText = '';

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssStatus.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssStatus.svelte
@@ -32,8 +32,9 @@
 					),
 					$criticalCssStatus.success_count
 				)}
-
-				<TimeAgo time={new Date( $criticalCssStatus.updated * 1000 )} />.
+				{#if $criticalCssStatus.updated}
+					<TimeAgo time={new Date( $criticalCssStatus.updated * 1000 )} />.
+				{/if}
 				{#if $criticalCssStatus.progress < 100}
 					<span>{generateMoreText}</span>
 				{/if}

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssStatus.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssStatus.svelte
@@ -32,6 +32,7 @@
 					),
 					$criticalCssStatus.success_count
 				)}
+				<!-- @TODO: Fix TypeScript Issue -->
 				<TimeAgo time={new Date( $criticalCssStatus.updated * 1000 )} />.
 				{#if $criticalCssStatus.progress < 100}
 					<span>{generateMoreText}</span>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssStatus.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssStatus.svelte
@@ -32,7 +32,7 @@
 					),
 					$criticalCssStatus.success_count
 				)}
-				<!-- @TODO: Fix TypeScript Issue -->
+
 				<TimeAgo time={new Date( $criticalCssStatus.updated * 1000 )} />.
 				{#if $criticalCssStatus.progress < 100}
 					<span>{generateMoreText}</span>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssStatus.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssStatus.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { createEventDispatcher } from 'svelte';
 	import { __, _n, sprintf } from '@wordpress/i18n';
 	import TemplatedString from '../../../elements/TemplatedString.svelte';

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/Module.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/Module.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { createEventDispatcher, onMount } from 'svelte';
 	import { __ } from '@wordpress/i18n';
 	import ErrorNotice from '../../../elements/ErrorNotice.svelte';

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PopOut.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PopOut.svelte
@@ -23,7 +23,6 @@
 			action: 'set_show_score_prompt',
 			id,
 			value: false,
-			// eslint-disable-next-line camelcase
 			nonce: Jetpack_Boost.showScorePromptNonce,
 		};
 

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PopOut.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PopOut.svelte
@@ -1,7 +1,7 @@
 <!--
 	This component pops out and shows a message based on the props passed to it
 -->
-<script>
+<script lang="ts">
 	import { createEventDispatcher } from 'svelte';
 	import { __ } from '@wordpress/i18n/';
 	import CloseButton from '../../../elements/CloseButton.svelte';

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PopOut.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PopOut.svelte
@@ -22,7 +22,6 @@
 		const data = {
 			action: 'set_show_score_prompt',
 			id,
-			value: false,
 			nonce: Jetpack_Boost.showScorePromptNonce,
 		};
 

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PopOut.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PopOut.svelte
@@ -20,6 +20,7 @@
 	const dispatch = createEventDispatcher();
 
 	async function disablePrompt() {
+		// @TODO: Fix TypeScript Issue
 		// Send a request to back-end to permanently disable the rating prompt.
 		data = {
 			action: 'set_show_score_prompt',
@@ -38,6 +39,7 @@
 
 {#if ! $dismissedPopOuts.includes( id )}
 	<div class="jb-rating-card__wrapper">
+		<!-- @TODO: Fix TypeScript Issue -->
 		<div class="jb-rating-card" transition:slideRightTransition>
 			<CloseButton on:click={() => dispatch( 'dismiss' )} />
 			<h3 class="jb-rating-card__headline">

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PopOut.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PopOut.svelte
@@ -15,14 +15,11 @@
 	export let ctaLink = '';
 	export let cta = '';
 
-	let data = '';
-
 	const dispatch = createEventDispatcher();
 
 	async function disablePrompt() {
-		// @TODO: Fix TypeScript Issue
 		// Send a request to back-end to permanently disable the rating prompt.
-		data = {
+		const data = {
 			action: 'set_show_score_prompt',
 			id,
 			value: false,
@@ -39,7 +36,6 @@
 
 {#if ! $dismissedPopOuts.includes( id )}
 	<div class="jb-rating-card__wrapper">
-		<!-- @TODO: Fix TypeScript Issue -->
 		<div class="jb-rating-card" transition:slideRightTransition>
 			<CloseButton on:click={() => dispatch( 'dismiss' )} />
 			<h3 class="jb-rating-card__headline">

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PremiumCTA.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PremiumCTA.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { __ } from '@wordpress/i18n';
 	import RightArrow from '../../../svg/right-arrow.svg';
 	import { recordBoostEvent } from '../../../utils/analytics';

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/RatingCard.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/RatingCard.svelte
@@ -1,7 +1,7 @@
 <!--
 	This component shows a prompt to rate Boost if scores improved after enabling a feature.
 -->
-<script>
+<script lang="ts">
 	import { createEventDispatcher } from 'svelte';
 	import { __, sprintf } from '@wordpress/i18n';
 	import CloseButton from '../../../elements/CloseButton.svelte';

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/RatingCard.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/RatingCard.svelte
@@ -16,9 +16,7 @@
 		// Send a request to back-end to permanently disable the rating prompt.
 		await makeAdminAjaxRequest( {
 			action: 'set_show_rating_prompt',
-			// @TODO: Fix TypeScript Issue
 			value: false,
-			// eslint-disable-next-line camelcase
 			nonce: Jetpack_Boost.showRatingPromptNonce,
 		} );
 
@@ -27,7 +25,6 @@
 	}
 </script>
 
-<!-- @TODO: Fix TypeScript Issue -->
 <div class="jb-rating-card" transition:slideRightTransition>
 	<CloseButton on:click={() => dispatch( 'dismiss' )} />
 	<h3 class="jb-rating-card__headline">

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/RatingCard.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/RatingCard.svelte
@@ -16,6 +16,7 @@
 		// Send a request to back-end to permanently disable the rating prompt.
 		await makeAdminAjaxRequest( {
 			action: 'set_show_rating_prompt',
+			// @TODO: Fix TypeScript Issue
 			value: false,
 			// eslint-disable-next-line camelcase
 			nonce: Jetpack_Boost.showRatingPromptNonce,
@@ -26,6 +27,7 @@
 	}
 </script>
 
+<!-- @TODO: Fix TypeScript Issue -->
 <div class="jb-rating-card" transition:slideRightTransition>
 	<CloseButton on:click={() => dispatch( 'dismiss' )} />
 	<h3 class="jb-rating-card__headline">

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/ScoreBar.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/ScoreBar.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import Spinner from '../../../svg/spinner.svg';
 
 	export let score = 0;

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/ScoreContext.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/ScoreContext.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { __ } from '@wordpress/i18n';
 </script>
 

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/ScoreDrop.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/ScoreDrop.svelte
@@ -1,7 +1,7 @@
 <!--
 	This component shows a prompt to refresh the Page Speed scores or contact support if a score has persistently dropped.
 -->
-<script>
+<script lang="ts">
 	/**
 	 * WordPress dependencies
 	 */

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/ScoreDrop.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/ScoreDrop.svelte
@@ -20,6 +20,7 @@
 		// Send a request to back-end to permanently disable the rating prompt.
 		await makeAdminAjaxRequest( {
 			action: 'set_show_score_prompt',
+			// @TODO: Fix TypeScript Issue
 			value: false,
 			// eslint-disable-next-line camelcase
 			nonce: Jetpack_Boost.showScorePromptNonce,
@@ -30,6 +31,7 @@
 	}
 </script>
 
+<!-- @TODO: Fix TypeScript Issue -->
 <div class="jb-rating-card" transition:slideRightTransition>
 	<CloseButton on:click={() => dispatch( 'dismiss' )} />
 	<h3 class="jb-rating-card__headline">

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/ScoreDrop.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/ScoreDrop.svelte
@@ -20,9 +20,7 @@
 		// Send a request to back-end to permanently disable the rating prompt.
 		await makeAdminAjaxRequest( {
 			action: 'set_show_score_prompt',
-			// @TODO: Fix TypeScript Issue
 			value: false,
-			// eslint-disable-next-line camelcase
 			nonce: Jetpack_Boost.showScorePromptNonce,
 		} );
 
@@ -31,7 +29,6 @@
 	}
 </script>
 
-<!-- @TODO: Fix TypeScript Issue -->
 <div class="jb-rating-card" transition:slideRightTransition>
 	<CloseButton on:click={() => dispatch( 'dismiss' )} />
 	<h3 class="jb-rating-card__headline">

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/UrlComponentsExample.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/UrlComponentsExample.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { __ } from '@wordpress/i18n';
 
 	const protocol = window.location.protocol.split( ':' )[ 0 ];

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/AdvancedCriticalCss.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/AdvancedCriticalCss.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { slide } from 'svelte/transition';
 	import { __, _n, sprintf } from '@wordpress/i18n';
 	import BackButton from '../../../elements/BackButton.svelte';

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/AdvancedCriticalCss.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/AdvancedCriticalCss.svelte
@@ -11,7 +11,7 @@
 		clearDismissedRecommendations,
 		dismissalError,
 		setDismissalError,
-	} from '../../../stores/critical-css-recommendations.ts';
+	} from '../../../stores/critical-css-recommendations';
 	import { isFinished } from '../../../stores/critical-css-status';
 	import InfoIcon from '../../../svg/info.svg';
 	import generateCriticalCss from '../../../utils/generate-critical-css';

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/AdvancedCriticalCss.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/AdvancedCriticalCss.svelte
@@ -54,7 +54,7 @@
 	/**
 	 * Figure out heading based on state.
 	 */
-	let heading;
+	let heading: string;
 	$: heading =
 		$activeRecommendations.length === 0
 			? __( 'Congratulations, you have dealt with all the recommendations.', 'jetpack-boost' )

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { getRedirectUrl } from '@automattic/jetpack-components';
 	import { __ } from '@wordpress/i18n';
 	import TemplatedString from '../../../elements/TemplatedString.svelte';

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Score.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Score.svelte
@@ -19,7 +19,6 @@
 	import ScoreBar from '../elements/ScoreBar.svelte';
 	import ScoreContext from '../elements/ScoreContext.svelte';
 
-	// eslint-disable-next-line camelcase
 	const siteIsOnline = Jetpack_Boost.site.online;
 
 	let loadError;

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Score.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Score.svelte
@@ -6,6 +6,7 @@
 		requestSpeedScores,
 		didScoresChange,
 		scoreChangeModal,
+		ScoreChangeMessage,
 	} from '../../../api/speed-scores';
 	import ErrorNotice from '../../../elements/ErrorNotice.svelte';
 	import { criticalCssStatus, isGenerating } from '../../../stores/critical-css-status';
@@ -112,14 +113,15 @@
 		}
 	}, 2000 );
 
-	$: showModal = ! $isLoading && ! $scores.isStale && scoreChangeModal( $scores );
+	let modalData: ScoreChangeMessage | null = null;
+	$: modalData = ! $isLoading && ! $scores.isStale && scoreChangeModal( $scores );
 
 	$: if ( $needsRefresh ) {
 		debouncedRefreshScore( true );
 	}
 
 	function dismissModal() {
-		showModal = false;
+		modalData = null;
 	}
 </script>
 
@@ -204,13 +206,13 @@
 	</div>
 </div>
 
-{#if showModal}
+{#if modalData}
 	<PopOut
-		id={showModal.id}
-		title={showModal.title}
+		id={modalData.id}
+		title={modalData.title}
 		on:dismiss={() => dismissModal()}
-		message={showModal.message}
-		ctaLink={showModal.ctaLink}
-		cta={showModal.cta}
+		message={modalData.message}
+		ctaLink={modalData.ctaLink}
+		cta={modalData.cta}
 	/>
 {/if}

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Score.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Score.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { derived, writable } from 'svelte/store';
 	import { __ } from '@wordpress/i18n';
 	import {

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Support.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Support.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { __ } from '@wordpress/i18n';
 	import { hasPrioritySupport, openPaidSupport } from '../../../utils/paid-plan';
 </script>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Tips.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Tips.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { getRedirectUrl } from '@automattic/jetpack-components';
 	import { __ } from '@wordpress/i18n';
 	import TemplatedString from '../../../elements/TemplatedString.svelte';

--- a/projects/plugins/boost/app/assets/src/js/sections/Footer.svelte
+++ b/projects/plugins/boost/app/assets/src/js/sections/Footer.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { __ } from '@wordpress/i18n';
 	import AutomatticLogo from '../svg/automattic.svg';
 	import JetpackIcon from '../svg/jetpack.svg';

--- a/projects/plugins/boost/app/assets/src/js/sections/Header.svelte
+++ b/projects/plugins/boost/app/assets/src/js/sections/Header.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import Logo from '../svg/logo.svg';
 </script>
 

--- a/projects/plugins/boost/app/assets/src/js/stores/config.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/config.ts
@@ -2,7 +2,6 @@ import { writable } from 'svelte/store';
 import api from '../api/api';
 import { saveGetStarted } from '../api/get-started';
 
-// eslint-disable-next-line camelcase
 const { subscribe, update } = writable( Jetpack_Boost );
 
 async function refresh(): Promise< void > {
@@ -13,7 +12,6 @@ async function refresh(): Promise< void > {
 	} );
 }
 
-// eslint-disable-next-line camelcase
 const dismissedPopOutStore = writable( Jetpack_Boost.dismissedScorePrompts );
 
 export const dismissedPopOuts = {

--- a/projects/plugins/boost/app/assets/src/js/stores/connection.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/connection.ts
@@ -9,7 +9,6 @@ export type ConnectionStatus = {
 	error: null | string;
 };
 
-// eslint-disable-next-line camelcase
 const initialState = Jetpack_Boost.connection;
 const { subscribe, update } = writable< ConnectionStatus >( initialState );
 

--- a/projects/plugins/boost/app/assets/src/js/stores/critical-css-recommendations.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/critical-css-recommendations.ts
@@ -13,7 +13,6 @@ const importantProviders = [
 	'singular_post',
 ];
 
-// eslint-disable-next-line camelcase
 const initialState = Jetpack_Boost.criticalCssDismissedRecommendations || [];
 const dismissed = writable< string[] >( initialState );
 
@@ -114,7 +113,6 @@ export function setDismissalError( title: string, error: JSONObject ): void {
 export async function dismissRecommendation( key: string ): Promise< void > {
 	await api.post( '/recommendations/dismiss', {
 		providerKey: key,
-		// eslint-disable-next-line camelcase
 		nonce: Jetpack_Boost.nonces[ 'recommendations/dismiss' ],
 	} );
 	dismissed.update( keys => [ ...keys, key ] );
@@ -125,7 +123,6 @@ export async function dismissRecommendation( key: string ): Promise< void > {
  */
 export async function clearDismissedRecommendations(): Promise< void > {
 	await api.post( '/recommendations/reset', {
-		// eslint-disable-next-line camelcase
 		nonce: Jetpack_Boost.nonces[ 'recommendations/reset' ],
 	} );
 	dismissed.set( [] );

--- a/projects/plugins/boost/app/assets/src/js/stores/critical-css-status.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/critical-css-status.ts
@@ -9,7 +9,7 @@ export interface CriticalCssErrorDetails {
 	message: string;
 	type: string;
 	meta: JSONObject;
-};
+}
 
 export interface CriticalCssStatus {
 	progress: number;
@@ -20,7 +20,7 @@ export interface CriticalCssStatus {
 	pending_provider_keys?: ProviderKeyUrls;
 	provider_success_ratio?: ProvidersSuccessRatio;
 	status: string;
-	updated: number;
+	updated?: number;
 	core_providers?: string[];
 	core_providers_status?: string;
 	status_error?: Error | string;

--- a/projects/plugins/boost/app/assets/src/js/stores/critical-css-status.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/critical-css-status.ts
@@ -5,13 +5,12 @@ import type { ProviderKeyUrls, ProvidersSuccessRatio } from '../utils/generate-c
 import type { JSONObject } from '../utils/json-types';
 import type { Viewport } from '../utils/types';
 
-export type CriticalCssErrorDetails = {
+export interface CriticalCssErrorDetails {
 	message: string;
 	type: string;
 	meta: JSONObject;
 };
 
-/* eslint-disable camelcase */
 export interface CriticalCssStatus {
 	progress: number;
 	retried_show_stopper?: boolean;
@@ -21,6 +20,7 @@ export interface CriticalCssStatus {
 	pending_provider_keys?: ProviderKeyUrls;
 	provider_success_ratio?: ProvidersSuccessRatio;
 	status: string;
+	updated: number;
 	core_providers?: string[];
 	core_providers_status?: string;
 	status_error?: Error | string;
@@ -34,7 +34,6 @@ export interface CriticalCssStatus {
 	created?: number;
 	viewports?: Viewport[];
 }
-/* eslint-enable camelcase */
 
 const SUCCESS = 'success';
 const FAIL = 'fail';
@@ -52,7 +51,7 @@ const initialState = Jetpack_Boost.criticalCssStatus || resetState;
 const store = writable< CriticalCssStatus >( initialState );
 const { subscribe, update } = store;
 
-let status;
+let status: CriticalCssStatus;
 subscribe( state => ( status = state ) );
 
 export function getStatus() {

--- a/projects/plugins/boost/app/assets/src/js/stores/critical-css-status.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/critical-css-status.ts
@@ -47,7 +47,6 @@ const resetState = {
 	status: 'not_generated',
 };
 
-// eslint-disable-next-line camelcase
 const initialState = Jetpack_Boost.criticalCssStatus || resetState;
 
 const store = writable< CriticalCssStatus >( initialState );
@@ -96,7 +95,6 @@ export const isGenerating = derived( [ store, modules ], ( [ $store, $modules ] 
 type CriticalCssApiResponse = {
 	status: string;
 	code?: string;
-	// eslint-disable-next-line camelcase
 	status_update?: CriticalCssStatus;
 };
 

--- a/projects/plugins/boost/app/assets/src/js/utils/analytics.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/analytics.ts
@@ -6,9 +6,7 @@ export async function recordBoostEvent(
 	eventName: string,
 	eventProp: TracksEventProperties
 ): Promise< RecordSuccess > {
-	// eslint-disable-next-line camelcase
 	if ( ! ( 'boost_version' in eventProp ) && 'version' in Jetpack_Boost ) {
-		// eslint-disable-next-line camelcase
 		eventProp.boost_version = Jetpack_Boost.version;
 	}
 

--- a/projects/plugins/boost/app/assets/src/js/utils/load-critical-css-library.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/load-critical-css-library.ts
@@ -12,7 +12,6 @@ export async function loadCriticalCssLibrary(): Promise< void > {
 
 	loadLibraryPromise = new Promise< void >( ( resolve, reject ) => {
 		const scriptUrl =
-			// eslint-disable-next-line camelcase
 			Jetpack_Boost.site.assetPath + '/critical-css-gen.js?ver=' + Jetpack_Boost.version;
 		const scriptTag = document.createElement( 'script' );
 		scriptTag.src = scriptUrl;

--- a/projects/plugins/boost/app/assets/src/js/utils/make-admin-ajax-request.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/make-admin-ajax-request.ts
@@ -10,15 +10,13 @@ class AdminAjaxError extends Error {
 	}
 }
 
-type PayloadValue = string | number | boolean;
-
 /**
  * Prepare a wp-ajax request, returning a raw Response object.
  *
- * @param {Record< string, PayloadValue >} payload Key/value pairs to send with the request.
+ * @param {Record< string, string >} payload Key/value pairs to send with the request.
  */
 export async function prepareAdminAjaxRequest(
-	payload: Record< string, PayloadValue >
+	payload: Record< string, string >
 ): Promise< Response > {
 	const args = {
 		method: 'post',
@@ -45,10 +43,10 @@ export async function prepareAdminAjaxRequest(
 /**
  * Make a wp-ajax request, interpreting the result as a JSON object.
  *
- * @param {Record< string, PayloadValue >} payload Key/value pairs to send with the request.
+ * @param {Record< string, string >} payload Key/value pairs to send with the request.
  */
 export async function makeAdminAjaxRequest< T = JSONObject >(
-	payload: Record< string, PayloadValue >
+	payload: Record< string, string >
 ): Promise< T > {
 	const response = await prepareAdminAjaxRequest( payload );
 

--- a/projects/plugins/boost/app/assets/src/js/utils/make-admin-ajax-request.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/make-admin-ajax-request.ts
@@ -10,13 +10,15 @@ class AdminAjaxError extends Error {
 	}
 }
 
+type PayloadValue = string | number | boolean;
+
 /**
  * Prepare a wp-ajax request, returning a raw Response object.
  *
- * @param {Record< string, string >} payload Key/value pairs to send with the request.
+ * @param {Record< string, PayloadValue >} payload Key/value pairs to send with the request.
  */
 export async function prepareAdminAjaxRequest(
-	payload: Record< string, string >
+	payload: Record< string, PayloadValue >
 ): Promise< Response > {
 	const args = {
 		method: 'post',
@@ -43,10 +45,10 @@ export async function prepareAdminAjaxRequest(
 /**
  * Make a wp-ajax request, interpreting the result as a JSON object.
  *
- * @param {Record< string, string >} payload Key/value pairs to send with the request.
+ * @param {Record< string, PayloadValue >} payload Key/value pairs to send with the request.
  */
 export async function makeAdminAjaxRequest< T = JSONObject >(
-	payload: Record< string, string >
+	payload: Record< string, PayloadValue >
 ): Promise< T > {
 	const response = await prepareAdminAjaxRequest( payload );
 

--- a/projects/plugins/boost/app/assets/src/js/utils/slide-right-transition.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/slide-right-transition.ts
@@ -20,7 +20,10 @@ export type SlideRightTransition = {
 
 import { cubicInOut } from 'svelte/easing';
 
-export default function ( node: HTMLElement, params: SlideRightParams ): SlideRightTransition {
+export default function (
+	node: HTMLElement,
+	params: SlideRightParams = null
+): SlideRightTransition {
 	const existingTransform = getComputedStyle( node ).transform.replace( 'none', '' );
 
 	return {

--- a/projects/plugins/boost/app/assets/src/js/utils/slide-right-transition.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/slide-right-transition.ts
@@ -22,7 +22,7 @@ import { cubicInOut } from 'svelte/easing';
 
 export default function (
 	node: HTMLElement,
-	params: SlideRightParams = null
+	params: SlideRightParams | null = null
 ): SlideRightTransition {
 	const existingTransform = getComputedStyle( node ).transform.replace( 'none', '' );
 

--- a/projects/plugins/boost/changelog/boost-update-typescript
+++ b/projects/plugins/boost/changelog/boost-update-typescript
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: This is an internal update only, users shouldn't notice any changes.
+
+

--- a/projects/plugins/boost/compatibility/jetpack.php
+++ b/projects/plugins/boost/compatibility/jetpack.php
@@ -69,7 +69,7 @@ add_action( 'update_option_jetpack_boost_status_lazy-images', __NAMESPACE__ . '\
 /**
  * The compatibility layer uses Jetpack as the single source of truth for lazy images.
  * As a fallback, Boost still keeps track of the value in the database,
- * This ensures that the value is still present when Jetpack is dactivated.
+ * This ensures that the value is still present when Jetpack is deactivated.
  *
  * This filter is going to track changes to the Jetpack lazy-images option
  * And make sure that Jetpack Boost is in sync.

--- a/projects/plugins/boost/tsconfig.json
+++ b/projects/plugins/boost/tsconfig.json
@@ -4,6 +4,7 @@
 	"exclude": [ "node_modules/*", "app/assets/dist/*", "tests/e2e/*" ],
 	"compilerOptions": {
 		"types": [ "svelte" ],
+		"jsx": "react",
 		"typeRoots": [ "./node_modules/@types/", "./app/assets/src/js" ],
 		/**
 		 * Values from "@tsconfig/svelte/tsconfig.json"

--- a/projects/plugins/boost/tsconfig.json
+++ b/projects/plugins/boost/tsconfig.json
@@ -4,7 +4,6 @@
 	"exclude": [ "node_modules/*", "app/assets/dist/*", "tests/e2e/*" ],
 	"compilerOptions": {
 		"types": [ "svelte" ],
-		"jsx": "react",
 		"typeRoots": [ "./node_modules/@types/", "./app/assets/src/js" ],
 		/**
 		 * Values from "@tsconfig/svelte/tsconfig.json"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
So far we've been using TypeScript only partially. This PR enables TypeScript in all Svelte files and fixes any TypeScript issues that showed up afterward.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
We discussed this in the last sprint meeting.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
1. Apply the patch
2. Build the plugin
3. Run e2e tests
4. Test the plugin to ensure nothing has changed
