### PR TITLE
Subscription block: revert subscriber count

### DIFF
--- a/projects/plugins/jetpack/changelog/revert-subscription-block-subscriber-count
+++ b/projects/plugins/jetpack/changelog/revert-subscription-block-subscriber-count
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Revert the subscription block subscriber count change.

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -339,7 +339,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		$source                       = 'widget';
 		$widget_id                    = ! empty( $args['widget_id'] ) ? $args['widget_id'] : self::$instance_count;
 		$subscribe_button             = ! empty( $instance['submit_button_text'] ) ? $instance['submit_button_text'] : $instance['subscribe_button'];
-		$subscribers_total            = self::fetch_subscriber_count( false );
+		$subscribers_total            = self::fetch_subscriber_count();
 		$subscribe_placeholder        = isset( $instance['subscribe_placeholder'] ) ? stripslashes( $instance['subscribe_placeholder'] ) : '';
 		$submit_button_classes        = isset( $instance['submit_button_classes'] ) ? 'wp-block-button__link ' . $instance['submit_button_classes'] : 'wp-block-button__link';
 		$submit_button_styles         = isset( $instance['submit_button_styles'] ) ? $instance['submit_button_styles'] : '';
@@ -703,7 +703,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			$subscribe_text      = esc_attr( stripslashes( $instance['subscribe_text'] ) );
 			$subscribe_logged_in = esc_attr( stripslashes( $instance['subscribe_logged_in'] ) );
 			$subscribe_button    = esc_attr( stripslashes( $instance['subscribe_button'] ) );
-			$subscribers_total   = self::fetch_subscriber_count( false );
+			$subscribers_total   = self::fetch_subscriber_count();
 		}
 
 		if ( self::is_jetpack() ) {
@@ -712,7 +712,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			$subscribe_placeholder = stripslashes( $instance['subscribe_placeholder'] );
 			$subscribe_button      = stripslashes( $instance['subscribe_button'] );
 			$success_message       = stripslashes( $instance['success_message'] );
-			$subs_fetch            = self::fetch_subscriber_count( false );
+			$subs_fetch            = self::fetch_subscriber_count();
 			if ( 'failed' === $subs_fetch['status'] ) {
 				printf( '<div class="error inline"><p>%s: %s</p></div>', esc_html( $subs_fetch['code'] ), esc_html( $subs_fetch['message'] ) );
 			}


### PR DESCRIPTION
This patch reverts https://github.com/Automattic/jetpack/pull/26751

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Subscription block's subscriber count shows Publicize counts again

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
pdDOJh-Xh-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
- Apply this PR
- Enable Jetpack Social and connect to Twitter (Jetpack > Social > Manage Connections)
- Add one e-mail follower to your Jetpack site + click the link in the confirmation mail
- Create a new page/post and add the subscription block, make sure Show subscriber count is turned on in the block settings