### PR TITLE
Jetpack VideoPress: Update readme.txt to reflect the real latest stable version

### DIFF
--- a/projects/plugins/videopress/changelog/update-stable-tag-jetpack-videopress
+++ b/projects/plugins/videopress/changelog/update-stable-tag-jetpack-videopress
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Updated stable tag in readme.txt
+
+

--- a/projects/plugins/videopress/readme.txt
+++ b/projects/plugins/videopress/readme.txt
@@ -4,7 +4,7 @@ Tags: video, video-hosting, video-player, cdn, vimeo, youtube, video-streaming, 
 
 Requires at least: 5.9
 Tested up to: 6.0
-Stable tag: 0.1.0-alpha
+Stable tag: 1.0.0
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
When we shipped the first release, we left this file reading `0.1.0-alpha` as latest stable release

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates readme.txt 

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

p1HpG7-iPA-p2

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:
Check this change makes sense