### PR TITLE
VideoPress: fix width of the actionable placeholder of v6

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-v6-actionable-placeholder-width
+++ b/projects/packages/videopress/changelog/update-videopress-v6-actionable-placeholder-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: fix width of the actionable placeholder of v6

--- a/projects/packages/videopress/src/client/block-editor/extend/core-video/index.js
+++ b/projects/packages/videopress/src/client/block-editor/extend/core-video/index.js
@@ -104,7 +104,7 @@ const handleJetpackCoreVideoDeprecation = createHigherOrderComponent( BlockListB
 
 		if ( ! ignoreBlockRecovery ) {
 			return (
-				<>
+				<div>
 					<Warning
 						className="extended-block-warning"
 						actions={ [
@@ -136,7 +136,7 @@ const handleJetpackCoreVideoDeprecation = createHigherOrderComponent( BlockListB
 							</p>
 						) }
 					</Warning>
-				</>
+				</div>
 			);
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/27096

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: fix width of the actionable placeholder of v6

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a VideoPress block but with Jetpack active / VideoPress reactive 
* Once uploaded save the post
* Deactivate Jetpack plugin
* Activate VideoPress
* Confirm the width to the placeholder looks as expected
before | after
------|------
<img width="929" alt="image" src="https://user-images.githubusercontent.com/77539/198134170-2174194a-cf69-48b4-8f9c-c8bb97c9cfe7.png"> | <img width="929" alt="image" src="https://user-images.githubusercontent.com/77539/198134068-d90f1e81-50c6-42d3-866e-946086153b6c.png">


