### PR TITLE
Protect: Compute "checked" value for extensions in Scan_Status

### DIFF
--- a/projects/plugins/protect/src/class-scan-status.php
+++ b/projects/plugins/protect/src/class-scan-status.php
@@ -144,7 +144,6 @@ class Scan_Status extends Status {
 		$status->num_threats         = 0;
 		$status->num_themes_threats  = 0;
 		$status->num_plugins_threats = 0;
-		// to do: check for unchecked items once Scan API has manifest
 		$status->has_unchecked_items = false;
 
 		if ( ! empty( $scan_data->most_recent->timestamp ) ) {
@@ -287,6 +286,13 @@ class Scan_Status extends Status {
 		$installed_themes = Sync_Functions::get_themes();
 		$status->themes   = self::merge_installed_and_checked_lists( $installed_themes, $status->themes, array( 'type' => 'themes' ), true );
 
+		foreach ( array_merge( $status->themes, $status->plugins ) as $extension ) {
+			if ( ! $extension->checked ) {
+				$status->has_unchecked_items = true;
+				break;
+			}
+		}
+
 		return $status;
 	}
 
@@ -300,28 +306,44 @@ class Scan_Status extends Status {
 	 */
 	protected static function merge_installed_and_checked_lists( $installed, $checked, $append ) {
 		$new_list = array();
+		$checked  = (object) $checked;
+
 		foreach ( array_keys( $installed ) as $slug ) {
+			/**
+			 * Extension Type Map
+			 *
+			 * @var array $extension_type_map Key value pairs of extension types and their corresponding
+			 *                                 identifier used by the Scan API data source.
+			 */
+			$extension_type_map = array(
+				'themes'  => 'r1',
+				'plugins' => 'r2',
+			);
 
-			$checked = (object) $checked;
-
-			$short_slug = str_replace( '.php', '', explode( '/', $slug )[0] );
+			$version        = $installed[ $slug ]['Version'];
+			$short_slug     = str_replace( '.php', '', explode( '/', $slug )[0] );
+			$scanifest_slug = $extension_type_map[ $append['type'] ] . ":$short_slug@$version";
 
 			$extension = new Extension_Model(
 				array_merge(
 					array(
 						'name'    => $installed[ $slug ]['Name'],
-						'version' => $installed[ $slug ]['Version'],
+						'version' => $version,
 						'slug'    => $slug,
 						'threats' => array(),
-						'checked' => true, // to do: default to false once Scan API has manifest
+						'checked' => false,
 					),
 					$append
 				)
 			);
 
-			if ( isset( $checked->{ $short_slug } ) && $checked->{ $short_slug }->version === $installed[ $slug ]['Version'] ) {
+			if ( ! isset( $checked->extensions ) // no extension data available from Scan API
+				|| is_array( $checked->extensions ) && in_array( $scanifest_slug, $checked->extensions, true ) // extension data matches Scan API
+			) {
 				$extension->checked = true;
-				$extension->threats = $checked->{ $short_slug }->threats;
+				if ( isset( $checked->{ $short_slug }->threats ) ) {
+					$extension->threats = $checked->{ $short_slug }->threats;
+				}
 			}
 
 			$new_list[] = $extension;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
This PR computes the "checked" value for extensions in `Scan_Status`, which will allow the UI do differentiate between extensions that have no threats, and extensions that have been installed/updated since the last scan.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Checks the scan data for an `extensions` array, and uses it to compute which extensions have been checked.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

1201069996155224-as-1203167996777740

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Boot a JN site with a Scan plan
* Run a scan
* Install a new non-vulnerable plugin
* Verify that the "not scanned" info icon is shown on the Protect admin page for the plugin
* Run another scan
* Verify that the "not scanned" info icon is replaced with a green checkmark for the plugin