### PR TITLE
Social: Generate changelog and readme changes for 1.5.0-beta

### DIFF
--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2022-10-27
+### Fixed
+- Publicize Components: Fix the panel component refactor [#27095]
+
 ## [0.8.0] - 2022-10-25
 ### Added
 - Display broken connections to user in editor [#25803]
@@ -119,6 +123,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.8.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.7.4...v0.8.0
 [0.7.4]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.7.3...v0.7.4
 [0.7.3]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.7.2...v0.7.3

--- a/projects/js-packages/publicize-components/changelog/fix-broken-connection-message
+++ b/projects/js-packages/publicize-components/changelog/fix-broken-connection-message
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Publicize Components: Fix the panel component refactor

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.8.1-alpha",
+	"version": "0.8.1",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.40.2] - 2022-10-27
+### Fixed
+- Check $action_links is still array after plugin_action_links filter has been applied. [#27076]
+
 ## [1.40.1] - 2022-10-25
 ### Added
 - Added featured_image_email_enabled option for syncing [#27009]
@@ -739,6 +743,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[1.40.2]: https://github.com/Automattic/jetpack-sync/compare/v1.40.1...v1.40.2
 [1.40.1]: https://github.com/Automattic/jetpack-sync/compare/v1.40.0...v1.40.1
 [1.40.0]: https://github.com/Automattic/jetpack-sync/compare/v1.39.0...v1.40.0
 [1.39.0]: https://github.com/Automattic/jetpack-sync/compare/v1.38.4...v1.39.0

--- a/projects/packages/sync/changelog/fix-sync-check-still-an-array-after-plugin-action-links-filter-applied
+++ b/projects/packages/sync/changelog/fix-sync-check-still-an-array-after-plugin-action-links-filter-applied
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Check $action_links is still array after plugin_action_links filter has been applied.

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.40.2-alpha';
+	const PACKAGE_VERSION = '1.40.2';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/social/CHANGELOG.md
+++ b/projects/plugins/social/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.5.0-beta - 2022-10-27
+### Added
+- Display broken connections to user in editor [#25803]
+- Integrate the ConnectionError react component to the Social plugin. [#26904]
+- Reshare: Added the reshare UI to the block editor extension [#25993]
+
+### Changed
+- Updated package dependencies. [#25993, #26640, #26683, #26705, #26716, #26790, #26791, #26808, #26826, #26829, #26851, #27089]
+
+### Fixed
+- Social: Fix the connection test endpoint URL [#26892]
+- Social: Fix the path to the connections URL in the editor [#26932]
+
 ## 1.4.0 - 2022-10-06
 ### Added
 - Add ContextualUpgradeTrigger to Jetpack Social admin page [#26115]

--- a/projects/plugins/social/CHANGELOG.md
+++ b/projects/plugins/social/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Social: Fix the connection test endpoint URL [#26892]
 - Social: Fix the path to the connections URL in the editor [#26932]
 
+## 1.4.2 - 2022-10-20
+### Fixed
+- Social: Fix the path to the connections URL in the editor [#26932]
+
+## 1.4.1 - 2022-10-19
+### Fixed
+- Social: Fix the connection test endpoint URL [#26892]
 ## 1.4.0 - 2022-10-06
 ### Added
 - Add ContextualUpgradeTrigger to Jetpack Social admin page [#26115]

--- a/projects/plugins/social/changelog/add-custom-taxonomy-slugs
+++ b/projects/plugins/social/changelog/add-custom-taxonomy-slugs
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/social/changelog/add-error-for-broken-connection
+++ b/projects/plugins/social/changelog/add-error-for-broken-connection
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Display broken connections to user in editor

--- a/projects/plugins/social/changelog/add-free-search-product-support-my-jetpack
+++ b/projects/plugins/social/changelog/add-free-search-product-support-my-jetpack
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/social/changelog/add-social-plugin-connection-errors
+++ b/projects/plugins/social/changelog/add-social-plugin-connection-errors
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Integrate the ConnectionError react component to the Social plugin.

--- a/projects/plugins/social/changelog/add-sync-sl-insta-media-to-blacklist
+++ b/projects/plugins/social/changelog/add-sync-sl-insta-media-to-blacklist
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/social/changelog/add-upgraded_tooltips
+++ b/projects/plugins/social/changelog/add-upgraded_tooltips
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/social/changelog/change-social-add-notice-to-readme
+++ b/projects/plugins/social/changelog/change-social-add-notice-to-readme
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Added notice to readme.txt that's already present in the .org repo
-
-

--- a/projects/plugins/social/changelog/fix-social-connect-account-url
+++ b/projects/plugins/social/changelog/fix-social-connect-account-url
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Social: Fix the path to the connections URL in the editor

--- a/projects/plugins/social/changelog/fix-social-connections-url
+++ b/projects/plugins/social/changelog/fix-social-connections-url
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Social: Fix the connection test endpoint URL

--- a/projects/plugins/social/changelog/fix-user-token-after-restore-error
+++ b/projects/plugins/social/changelog/fix-user-token-after-restore-error
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/social/changelog/renovate-autoprefixer-10.x
+++ b/projects/plugins/social/changelog/renovate-autoprefixer-10.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/social/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/social/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/social/changelog/renovate-postcss-8.x
+++ b/projects/plugins/social/changelog/renovate-postcss-8.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/social/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/social/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/social/changelog/update-integrate-stats-pkg-in-jetpack-plugin
+++ b/projects/plugins/social/changelog/update-integrate-stats-pkg-in-jetpack-plugin
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/social/changelog/update-refactor_upgrade_tooltips
+++ b/projects/plugins/social/changelog/update-refactor_upgrade_tooltips
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/social/changelog/update-republicize-availability
+++ b/projects/plugins/social/changelog/update-republicize-availability
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Reshare: Added the reshare UI to the block editor extension

--- a/projects/plugins/social/changelog/update-republicize-availability#2
+++ b/projects/plugins/social/changelog/update-republicize-availability#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/social/changelog/update-republicize-availability#3
+++ b/projects/plugins/social/changelog/update-republicize-availability#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -78,6 +78,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_socialⓥ1_5_0_alpha"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_socialⓥ1_5_0_beta"
 	}
 }

--- a/projects/plugins/social/jetpack-social.php
+++ b/projects/plugins/social/jetpack-social.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Social
  * Plugin URI: https://wordpress.org/plugins/jetpack-social
  * Description: Share your site’s posts on several social media networks automatically when you publish a new post.
- * Version: 1.5.0-alpha
+ * Version: 1.5.0-beta
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later

--- a/projects/plugins/social/readme.txt
+++ b/projects/plugins/social/readme.txt
@@ -98,7 +98,7 @@ The easiest way is to use the Custom Message option in the publishing options bo
 - Reshare: Added the reshare UI to the block editor extension
 
 #### Changed
-- Updated package dependencies. [#25993, #26640, #26683, #26705, #26716, #26790, #26791, #26808, #26826, #26829, #26851, #27089]
+- Updated package dependencies.
 
 #### Fixed
 - Social: Fix the connection test endpoint URL

--- a/projects/plugins/social/readme.txt
+++ b/projects/plugins/social/readme.txt
@@ -1,10 +1,10 @@
 === Jetpack Social  ===
-Contributors: automattic, pabline, danielpost, siddarthan
+Contributors: automattic, pabline, danielpost, siddarthan, gmjuhasz
 Tags: social-media, publicize, social-media-manager, social-networking, social marketing, social, social share,  social media scheduling, social media automation, auto post, auto- publish, social share
 Requires at least: 5.9
 Requires PHP: 5.6
 Tested up to: 6.0
-Stable tag: 1.3.0
+Stable tag: 1.4.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -91,25 +91,16 @@ The easiest way is to use the Custom Message option in the publishing options bo
 4. Manage your Jetpack Social and other Jetpack plugins from My Jetpack.
 
 == Changelog ==
-### 1.4.0 - 2022-10-06
+### 1.5.0-beta - 2022-10-27
 #### Added
-- Add ContextualUpgradeTrigger to Jetpack Social admin page
-- Added check to not show the share metre if someone has a paid plan.
-- Added Jetpack social redirect urls.
-- Add pricing table to Jetpack Social
-- Adds ability to autotag, autorelease and autopublish releases
-- Enforce sharing limits in the Classic Editor
+- Display broken connections to user in editor
+- Integrate the ConnectionError react component to the Social plugin.
+- Reshare: Added the reshare UI to the block editor extension
 
 #### Changed
-- Changed the values on the pricing table, and fixed a redirect
-- Move share limits code to the Publicize package
-- Set version to 1.4.0-alpha
-- Social: Aligned Jetpack and Social to use the connection-test-results endpoint in the block editor
-- Updated package dependencies.
-- Updated style for Jetpack Logo icon shown in pre-publish panels for Jetpack and Jetpack Social plugins
-- Update Inspector Panel Jetpack icon color to #1E1E1E
-- Use Jetpack logo in Jetpack Social pre-publish screen for Publicize and Social Preview features
+- Updated package dependencies. [#25993, #26640, #26683, #26705, #26716, #26790, #26791, #26808, #26826, #26829, #26851, #27089]
 
 #### Fixed
-- Social: Require a user connection to use the plugin.
-- Store: Added the missing showNudge reducer
+- Social: Fix the connection test endpoint URL
+- Social: Fix the path to the connections URL in the editor
+


### PR DESCRIPTION
This updates the plugin and package versions for the 1.5.0-beta release, and updates the changelog and readme files.

#### Other information:

The readme.txt file was out of date with the version on .org, so I've changed the version and added @gmjuhasz as a contributor.

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
No,

#### Testing instructions:
Manual checks.

