### PR TITLE
Dashboard: Fixing the Related Posts settings card link

### DIFF
--- a/projects/plugins/jetpack/_inc/client/traffic/related-posts.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/related-posts.jsx
@@ -74,7 +74,7 @@ class RelatedPostsComponent extends React.Component {
 							{
 								a: (
 									<a
-										href={ getRedirectUrl( 'jetpack-support-jetpack-blocks-related-posts-block' ) }
+										href={ getRedirectUrl( 'jetpack-support-related-posts' ) }
 										target="_blank"
 										rel="noopener noreferrer"
 									/>

--- a/projects/plugins/jetpack/changelog/fix-rp-settings-card-link
+++ b/projects/plugins/jetpack/changelog/fix-rp-settings-card-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Dashboard: Fixed the Related Posts card link to the block editor support doc.


### PR DESCRIPTION

Fixes #27107

#### Changes proposed in this Pull Request:

* Previously the main link visible in the Related Posts settings card was redirecting to `jetpack.com/support/jetpack-blocks/related-posts-block`, however that link doesn't exist anymore. The page isn't automatically redirecting because the site URL is appended to the support doc URL (`jetpack.com/support/jetpack-blocks/related-posts-block?site=site.com`)
* This PR updates the link to go to `jetpack.com/support/related-posts/`.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

n/a

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* On a Jetpack-connected site, visit Jetpack > Settings > Traffic - `/wp-admin/admin.php?page=jetpack#/traffic`.
* Click on the main link visible in the Related Posts settings card:


<img width="1015" alt="Screen Shot 2022-10-27 at 1 27 50 pm" src="https://user-images.githubusercontent.com/16754605/198284351-e9dac637-41ef-4122-8d8f-c761dcea70bc.png">

* Notice you are sent to a page that shows 'page not found'.
* Apply this PR, then try the link again - it should send you to `jetpack.com/support/related-posts/`.