### PR TITLE
Options: Sync wpcom_gifting_subscription site option

### DIFF
--- a/projects/packages/sync/changelog/add-sync-enable-wpcom-gifting-subscription
+++ b/projects/packages/sync/changelog/add-sync-enable-wpcom-gifting-subscription
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added wpcom_gifting_subscription option for syncing

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -174,6 +174,7 @@ class Defaults {
 		'wpcom_publish_comments_with_markdown',
 		'wpcom_publish_posts_with_markdown',
 		'videopress_private_enabled_for_site',
+		'wpcom_gifting_subscription',
 	);
 
 	/**

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.40.2';
+	const PACKAGE_VERSION = '1.40.3-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/jetpack/changelog/add-sync-enable-wpcom-gifting-subscription
+++ b/projects/plugins/jetpack/changelog/add-sync-enable-wpcom-gifting-subscription
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Comment: Added wpcom_gifting_subscription for syncing

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -226,6 +226,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'wpcom_is_fse_activated'                       => '1',
 			'videopress_private_enabled_for_site'          => false,
 			'featured_image_email_enabled'                 => false,
+			'wpcom_gifting_subscription'                   => true,
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );


### PR DESCRIPTION
<img width="735" alt="image" src="https://user-images.githubusercontent.com/402286/198298157-7ea02916-df72-4c8b-a161-3fe8650265ac.png">

This is a follow up to D90818-code, https://github.com/Automattic/wp-calypso/pull/69458

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* add new `wpcom_gifting_subscription` site option for jetpack syncing

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- pdDOJh-Nu-p2
- p1666343640133449-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- no

#### Testing instructions:

* I am not aware of a proper way of testing this other than included tests. The PR is done as per the guide: PCYsg-sBM-p2

Related to https://github.com/Automattic/dotcom-forge/issues/1081
