### PR TITLE
Search: Add blog ID filtering and `blogIdFilteringLabels` option

### DIFF
--- a/projects/packages/search/changelog/add-blog_id_filtering
+++ b/projects/packages/search/changelog/add-blog_id_filtering
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search: add blog ID filtering and `blogIdFilteringLabels` option

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -70,7 +70,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.29.x-dev"
+			"dev-trunk": "0.30.x-dev"
 		},
 		"version-constants": {
 			"::VERSION": "src/class-package.php"

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.29.3-alpha",
+	"version": "0.30.0-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-helper.php
+++ b/projects/packages/search/src/class-helper.php
@@ -239,6 +239,10 @@ class Helper {
 				$name = _x( 'Authors', 'label for filtering posts', 'jetpack-search-pkg' );
 				break;
 
+			case 'blog_id':
+				$name = _x( 'Blogs', 'label for filtering posts', 'jetpack-search-pkg' );
+				break;
+
 			case 'date_histogram':
 				$modified_fields = array(
 					'post_modified',

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.29.3-alpha';
+	const VERSION = '0.30.0-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/class-template-tags.php
+++ b/projects/packages/search/src/class-template-tags.php
@@ -185,6 +185,9 @@ class Template_Tags {
 			case 'author':
 				$data_base = 'data-filter-type="authors" ';
 				break;
+			case 'blog_id':
+				$data_base = 'data-filter-type="blog_ids" ';
+				break;
 			case 'date_histogram':
 				if ( $filter['buckets'][0]['query_vars']['monthnum'] ) {
 					$data_base = 'data-filter-type="month_post_date" ';
@@ -211,6 +214,9 @@ class Template_Tags {
 						break;
 					case 'author':
 						$data_str .= 'data-val="' . esc_attr( $item['query_vars']['author'] ) . '"';
+						break;
+					case 'blog_id':
+						$data_str .= 'data-val="' . esc_attr( $item['query_vars']['blog_id'] ) . '"';
 						break;
 					case 'date_histogram':
 						if ( $item['query_vars']['monthnum'] ) {

--- a/projects/packages/search/src/instant-search/lib/api.js
+++ b/projects/packages/search/src/instant-search/lib/api.js
@@ -89,6 +89,9 @@ function generateAggregation( filter ) {
 		case 'author': {
 			return { terms: { field: 'author_login_slash_name', size: filter.count } };
 		}
+		case 'blog_id': {
+			return { terms: { field: filter.type, size: filter.count } };
+		}
 	}
 }
 
@@ -131,6 +134,9 @@ const filterKeyToEsFilter = new Map( [
 
 	// Author
 	[ 'authors', author => ( { term: { author_login: author } } ) ],
+
+	// Blog ID
+	[ 'blog_ids', blogId => ( { term: { blog_id: blogId } } ) ],
 
 	// Built-in taxonomies
 	[ 'category', category => ( { term: { 'category.slug': category } } ) ],

--- a/projects/packages/search/src/instant-search/lib/filters.js
+++ b/projects/packages/search/src/instant-search/lib/filters.js
@@ -3,6 +3,8 @@ import { SERVER_OBJECT_NAME } from './constants';
 // NOTE: This list is missing custom taxonomy names.
 //       getFilterKeys must be used to get the conclusive list of valid filter keys.
 export const FILTER_KEYS = Object.freeze( [
+	// Blog IDs
+	'blog_ids',
 	// Authors
 	'authors',
 	// Post types
@@ -123,6 +125,8 @@ export function mapFilterToFilterKey( filter ) {
 		return 'post_types';
 	} else if ( filter.type === 'author' ) {
 		return 'authors';
+	} else if ( filter.type === 'blog_id' ) {
+		return 'blog_ids';
 	} else if ( filter.type === 'group' ) {
 		return filter.filter_id;
 	}
@@ -157,6 +161,10 @@ export function mapFilterKeyToFilter( filterKey ) {
 		return {
 			type: 'author',
 		};
+	} else if ( filterKey === 'blog_ids' ) {
+		return {
+			type: 'blog_id',
+		};
 	} else if ( filterKey === 'group' ) {
 		return {
 			type: 'group',
@@ -184,6 +192,8 @@ export function mapFilterToType( filter ) {
 		return 'postType';
 	} else if ( filter.type === 'author' ) {
 		return 'author';
+	} else if ( filter.type === 'blog_id' ) {
+		return 'blogId';
 	} else if ( filter.type === 'group' ) {
 		return 'group';
 	}

--- a/projects/packages/search/src/instant-search/lib/test/filters.test.js
+++ b/projects/packages/search/src/instant-search/lib/test/filters.test.js
@@ -23,9 +23,11 @@ describe( 'getFilterKeys', () => {
 			{ filters: [ { type: 'date_histogram', field: 'post_date', interval: 'year' } ] },
 			{ filters: [ { type: 'post_type' } ] },
 			{ filters: [ { type: 'author' } ] },
+			{ filters: [ { type: 'blog_id' } ] },
 		];
 		const widgetsOutsideOverlay = [ { filters: [ { type: 'taxonomy', taxonomy: 'post_tag' } ] } ];
 		expect( getFilterKeys( widgets, widgetsOutsideOverlay ) ).toEqual( [
+			'blog_ids',
 			'authors',
 			'post_types',
 			'category',
@@ -55,12 +57,14 @@ describe( 'getSelectableFilterKeys', () => {
 			{ filters: [ { type: 'date_histogram', field: 'post_date', interval: 'year' } ] },
 			{ filters: [ { type: 'post_type' } ] },
 			{ filters: [ { type: 'author' } ] },
+			{ filters: [ { type: 'blog_id' } ] },
 		];
 		expect( getSelectableFilterKeys( widgets ) ).toEqual( [
 			'category',
 			'year_post_date',
 			'post_types',
 			'authors',
+			'blog_ids',
 		] );
 	} );
 } );
@@ -80,6 +84,7 @@ describe( 'getUnselectableFilterKeys', () => {
 			{ filters: [ { type: 'date_histogram', field: 'post_date', interval: 'year' } ] },
 			{ filters: [ { type: 'post_type' } ] },
 			{ filters: [ { type: 'author' } ] },
+			{ filters: [ { type: 'blog_id' } ] },
 		];
 		expect( getUnselectableFilterKeys( widgets ) ).toEqual( [
 			'category',
@@ -148,6 +153,11 @@ describe( 'mapFilterKeyToFilter', () => {
 	test( 'handles author filter key', () => {
 		expect( mapFilterKeyToFilter( 'authors' ) ).toEqual( {
 			type: 'author',
+		} );
+	} );
+	test( 'handles blog IDs filter key', () => {
+		expect( mapFilterKeyToFilter( 'blog_ids' ) ).toEqual( {
+			type: 'blog_id',
 		} );
 	} );
 	test( 'handles taxonomies-related filter keys', () => {

--- a/projects/packages/search/src/widgets/class-search-widget.php
+++ b/projects/packages/search/src/widgets/class-search-widget.php
@@ -677,6 +677,13 @@ class Search_Widget extends \WP_Widget {
 							'count' => $count,
 						);
 						break;
+					case 'blog_id':
+						$filters[] = array(
+							'name'  => sanitize_text_field( $new_instance['filter_name'][ $index ] ),
+							'type'  => 'blog_id',
+							'count' => $count,
+						);
+						break;
 					case 'date_histogram':
 						$filters[] = array(
 							'name'     => sanitize_text_field( $new_instance['filter_name'][ $index ] ),
@@ -956,8 +963,8 @@ class Search_Widget extends \WP_Widget {
 
 		$args['name_placeholder'] = Helper::generate_widget_filter_name( $args );
 
-		// Hide author filter when Instant Search is turned off.
-		if ( ! $is_instant_search && 'author' === $args['type'] ) :
+		// Hide author & blog ID filters when Instant Search is turned off.
+		if ( ! $is_instant_search && ( 'author' === $args['type'] || 'blog_id' === $args['type'] ) ) :
 			return;
 		endif;
 		?>
@@ -975,6 +982,9 @@ class Search_Widget extends \WP_Widget {
 						<?php if ( $is_instant_search ) : ?>
 						<option value="author" <?php $this->render_widget_option_selected( 'type', $args['type'], 'author', $is_template ); ?>>
 							<?php esc_html_e( 'Author', 'jetpack-search-pkg' ); ?>
+						</option>
+						<option value="blog_id" <?php $this->render_widget_option_selected( 'type', $args['type'], 'blog_id', $is_template ); ?>>
+							<?php esc_html_e( 'Blog ID', 'jetpack-search-pkg' ); ?>
 						</option>
 						<?php endif; ?>
 						<option value="date_histogram" <?php $this->render_widget_option_selected( 'type', $args['type'], 'date_histogram', $is_template ); ?>>

--- a/projects/packages/search/src/widgets/class-search-widget.php
+++ b/projects/packages/search/src/widgets/class-search-widget.php
@@ -964,7 +964,7 @@ class Search_Widget extends \WP_Widget {
 		$args['name_placeholder'] = Helper::generate_widget_filter_name( $args );
 
 		// Hide author & blog ID filters when Instant Search is turned off.
-		if ( ! $is_instant_search && ( 'author' === $args['type'] || 'blog_id' === $args['type'] ) ) :
+		if ( ! $is_instant_search && in_array( $args['type'], array( 'author', 'blog_id' ) ) ) :
 			return;
 		endif;
 		?>
@@ -984,7 +984,7 @@ class Search_Widget extends \WP_Widget {
 							<?php esc_html_e( 'Author', 'jetpack-search-pkg' ); ?>
 						</option>
 						<option value="blog_id" <?php $this->render_widget_option_selected( 'type', $args['type'], 'blog_id', $is_template ); ?>>
-							<?php esc_html_e( 'Blog ID', 'jetpack-search-pkg' ); ?>
+							<?php esc_html_e( 'Blog', 'jetpack-search-pkg' ); ?>
 						</option>
 						<?php endif; ?>
 						<option value="date_histogram" <?php $this->render_widget_option_selected( 'type', $args['type'], 'date_histogram', $is_template ); ?>>

--- a/projects/packages/search/src/widgets/class-search-widget.php
+++ b/projects/packages/search/src/widgets/class-search-widget.php
@@ -964,7 +964,7 @@ class Search_Widget extends \WP_Widget {
 		$args['name_placeholder'] = Helper::generate_widget_filter_name( $args );
 
 		// Hide author & blog ID filters when Instant Search is turned off.
-		if ( ! $is_instant_search && in_array( $args['type'], array( 'author', 'blog_id' ) ) ) :
+		if ( ! $is_instant_search && in_array( $args['type'], array( 'author', 'blog_id' ), true ) ) :
 			return;
 		endif;
 		?>

--- a/projects/packages/search/src/widgets/css/search-widget-admin-ui.css
+++ b/projects/packages/search/src/widgets/css/search-widget-admin-ui.css
@@ -52,6 +52,11 @@
 	display: none;
 }
 
+/* When blog ID type is selected, remove the other controls */
+.jetpack-search-filters-widget__filter.is-blog_id .jetpack-search-filters-widget__taxonomy-select {
+	display: none;
+}
+
 /* When date is selected, remove the other controls */
 .jetpack-search-filters-widget__filter.is-date_histogram .jetpack-search-filters-widget__date-histogram-select {
 	display: inline;

--- a/projects/plugins/jetpack/changelog/add-blog_id_filtering
+++ b/projects/plugins/jetpack/changelog/add-blog_id_filtering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -38,7 +38,7 @@
 		"automattic/jetpack-publicize": "0.17.x-dev",
 		"automattic/jetpack-redirect": "1.7.x-dev",
 		"automattic/jetpack-roles": "1.4.x-dev",
-		"automattic/jetpack-search": "0.29.x-dev",
+		"automattic/jetpack-search": "0.30.x-dev",
 		"automattic/jetpack-stats": "0.3.x-dev",
 		"automattic/jetpack-status": "1.14.x-dev",
 		"automattic/jetpack-sync": "1.40.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3fa03672cbfa0a665a7a7cfdf7fe7f90",
+    "content-hash": "0e148edc221969bc71e23bc0deb89754",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1750,7 +1750,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "9565b6ecbe9dacfa83068db4523c4c2da54f77b3"
+                "reference": "00d167cdf3014cbabd12338de961fc1cfbaab5ee"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -1774,7 +1774,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.29.x-dev"
+                    "dev-trunk": "0.30.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"

--- a/projects/plugins/search/changelog/add-blog_id_filtering
+++ b/projects/plugins/search/changelog/add-blog_id_filtering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/search/changelog/add-blog_id_filtering#2
+++ b/projects/plugins/search/changelog/add-blog_id_filtering#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -10,7 +10,7 @@
 		"automattic/jetpack-connection": "1.46.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
 		"automattic/jetpack-my-jetpack": "2.3.x-dev",
-		"automattic/jetpack-search": "0.29.x-dev",
+		"automattic/jetpack-search": "0.30.x-dev",
 		"automattic/jetpack-stats": "0.3.x-dev",
 		"automattic/jetpack-status": "1.14.x-dev",
 		"automattic/jetpack-sync": "1.40.x-dev",

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b3c3c7653f3c390eca450b0d60c92afb",
+    "content-hash": "e7690f2e8f128f7f0c7eb73e17779bef",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1096,7 +1096,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "9565b6ecbe9dacfa83068db4523c4c2da54f77b3"
+                "reference": "00d167cdf3014cbabd12338de961fc1cfbaab5ee"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -1120,7 +1120,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.29.x-dev"
+                    "dev-trunk": "0.30.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"


### PR DESCRIPTION
Due to the Search Improvements (p9lV3a-595-p2) of the [wordpress.com/forums](https://wordpress.com/forums). We need the `blog_id` filtering to display the search results between the [wordpress.com/forums](https://wordpress.com/forums) and [wordpress.com/support](https://wordpress.com/support) to our users (A.K.A [multiple blogs](https://github.com/Automattic/jetpack/pull/26046)).

#### Changes proposed in this Pull Request:

* Add `blog_id` filtering
* Add the `blogIdFilteringLabels` option to display the label of the corresponding `blog_id`

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

* p9lV3a-595-p2

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

1. In your Sandbox, use `wpsh` switch to your blog

2. And then, allow the `blog_id` that you want to search as below:

```
update_option( 'jetpack_allowed_xsite_search_ids', array( BLOG_ID ) );
```

3. In `tools/docker/mu-plugins/instant-search.php`, set the `additionalBlogIds` and `blogIdFilteringLabels` options as below:

```php
function jp_instant_search_options( $options ) {
	// Add the blog_id that you want to search
	$options['additionalBlogIds'] = array( 9619154 );
	// Add the labels that you want to display for blog IDs
	$options['blogIdFilteringLabels'] = array(
		9619154 => 'Wordpress Support',
		211763838 => 'My Site'
	);

	return $options;
}
add_filter( 'jetpack_instant_search_options', 'jp_instant_search_options' );
```

4. In wp-admin, enable the `blog_id` filtering from Jetpack > search > sidebar widget:

<img width="1213" alt="blog_id_filter" src="https://user-images.githubusercontent.com/21308003/198323988-0b44f58f-e973-438c-9f0f-e646c6f817d8.png">

5. Now you should be able to do multi-sites searching and filtering:

https://user-images.githubusercontent.com/21308003/198325346-bf398224-f49e-4d3a-8454-bcae3653b141.mov



 


