### PR TITLE
VideoPress: Enable quick actions on video card while processing

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-video-row-actions-uploading
+++ b/projects/packages/videopress/changelog/fix-videopress-video-row-actions-uploading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Remove actions and stats on VideoRow when uploading or processing and fix styles

--- a/projects/packages/videopress/changelog/fix-videopress-video-row-actions-uploading
+++ b/projects/packages/videopress/changelog/fix-videopress-video-row-actions-uploading
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-VideoPress: Remove actions and stats on VideoRow when uploading or processing and fix styles
+VideoPress: Allow actions and stats on VideoCard when processing video and fix styles

--- a/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
@@ -81,16 +81,16 @@ export const VideoCard = ( {
 		: '';
 	const [ isSm ] = useBreakpointMatch( 'sm' );
 	const [ isOpen, setIsOpen ] = useState( false );
-	const disabled = isSm || loading || uploading || processing;
+	const disabled = loading || uploading;
 
 	return (
 		<>
 			<div
 				className={ classnames( styles[ 'video-card__wrapper' ], {
 					[ styles[ 'is-blank' ] ]: isBlank,
-					[ styles.disabled ]: disabled,
+					[ styles.disabled ]: isSm && disabled,
 				} ) }
-				{ ...( isSm && { onClick: () => setIsOpen( wasOpen => ! wasOpen ) } ) }
+				{ ...( isSm && ! disabled && { onClick: () => setIsOpen( wasOpen => ! wasOpen ) } ) }
 			>
 				{ ! isSm && <div className={ styles[ 'video-card__background' ] } /> }
 
@@ -106,7 +106,7 @@ export const VideoCard = ( {
 				/>
 
 				<div className={ styles[ 'video-card__title-section' ] }>
-					{ isSm && (
+					{ isSm && ! disabled && (
 						<div className={ styles.chevron }>
 							{ isOpen && <Icon icon={ chevronUp } /> }
 							{ ! isOpen && <Icon icon={ chevronDown } /> }

--- a/projects/packages/videopress/src/client/admin/components/video-row/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-row/index.tsx
@@ -122,16 +122,14 @@ export const VideoRow = ( {
 	const uploadDateFormatted = dateI18n( 'M j, Y', uploadDate, null );
 	const isEllipsisActive = textRef?.current?.offsetWidth < textRef?.current?.scrollWidth;
 
-	const unavailable = loading || uploading || processing;
-
 	const showTitleLabel = ! isSmall && isEllipsisActive;
 	const showActions =
-		showActionsState && ( showActionButton || showQuickActions ) && ! unavailable && ! disabled;
-	const showStats = ! unavailable && ( ( ! isSmall && ! showActions ) || ( isSmall && expanded ) );
-	const showBottom = ! unavailable && ( ! isSmall || ( isSmall && expanded ) );
+		showActionsState && ( showActionButton || showQuickActions ) && ! loading && ! disabled;
+	const showStats = ! loading && ( ( ! isSmall && ! showActions ) || ( isSmall && expanded ) );
+	const showBottom = ! loading && ( ! isSmall || ( isSmall && expanded ) );
 	const canExpand =
 		isSmall &&
-		! unavailable &&
+		! loading &&
 		( showActionButton ||
 			Boolean( duration ) ||
 			Number.isFinite( plays ) ||

--- a/projects/packages/videopress/src/client/admin/components/video-row/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-row/index.tsx
@@ -122,15 +122,16 @@ export const VideoRow = ( {
 	const uploadDateFormatted = dateI18n( 'M j, Y', uploadDate, null );
 	const isEllipsisActive = textRef?.current?.offsetWidth < textRef?.current?.scrollWidth;
 
+	const unavailable = loading || uploading || processing;
+
 	const showTitleLabel = ! isSmall && isEllipsisActive;
 	const showActions =
-		showActionsState && ( showActionButton || showQuickActions ) && ! loading && ! disabled;
-	const showStats = ( ! showActions && ! isSmall ) || ( isSmall && expanded ) || loading;
-	const showBottom = ! isSmall || ( isSmall && expanded );
-
+		showActionsState && ( showActionButton || showQuickActions ) && ! unavailable && ! disabled;
+	const showStats = ! unavailable && ( ( ! isSmall && ! showActions ) || ( isSmall && expanded ) );
+	const showBottom = ! unavailable && ( ! isSmall || ( isSmall && expanded ) );
 	const canExpand =
 		isSmall &&
-		! loading &&
+		! unavailable &&
 		( showActionButton ||
 			Boolean( duration ) ||
 			Number.isFinite( plays ) ||
@@ -215,7 +216,7 @@ export const VideoRow = ( {
 				styles[ 'video-row' ],
 				{
 					[ styles.pressed ]: keyPressed,
-					[ styles.disabled ]: hoverDisabled,
+					[ styles.disabled ]: disabled,
 				},
 				className
 			) }

--- a/projects/packages/videopress/src/client/admin/components/video-row/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/video-row/style.module.scss
@@ -89,8 +89,6 @@
 		overflow: hidden;
 		white-space: nowrap;
 		text-overflow: ellipsis;
-		display: flex;
-		align-items: center;
 	}
 
 	.label {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27118

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Disables actions and stats on VideoRow when video is processing, in line with VideoCard
* Fixes title cropping
* Fixes styles on mobile

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard and set the view to Grid
* Upload a video
* Check that the actions are rendered while processing
* Repeat the process on mobile (or simulating mobile on browser)
* Check that it is possible to expand the row when processing
* Check that long titles are correctly cropped

Before:
![2022-10-27_13-07-20](https://user-images.githubusercontent.com/8486249/198342982-af501edd-9d2c-4632-8cb0-bb6b9fb5b8b9.png)
![2022-10-27_13-06-54](https://user-images.githubusercontent.com/8486249/198342985-e8cf9459-70da-416d-bb5c-9d0501055371.png)
![2022-10-27_13-06-18](https://user-images.githubusercontent.com/8486249/198342989-dcd757d0-7203-4a14-bde5-fb0f450ee73f.png)

After:
![2022-10-27_13-04-13](https://user-images.githubusercontent.com/8486249/198343086-3b33fdce-a6a8-4c00-ad30-9a35f9b7a9e0.png)
![2022-10-27_16-24-06](https://user-images.githubusercontent.com/8486249/198383625-56deb906-eaa2-4907-9c6b-1b55f3ab00b9.png)
![2022-10-27_16-22-44](https://user-images.githubusercontent.com/8486249/198383627-509fde25-5624-45f8-8b78-0e779cd71bdf.png)