### PR TITLE
E2E tests: disable redundant test for plugin update

### DIFF
--- a/.github/files/e2e-tests/create-e2e-projects-matrix.sh
+++ b/.github/files/e2e-tests/create-e2e-projects-matrix.sh
@@ -4,11 +4,6 @@ set -eo pipefail
 
 PROJECTS=('{"project":"Jetpack connection","path":"projects/plugins/jetpack/tests/e2e","testArgs":["specs/connection","--retries=2"]}' '{"project":"Jetpack pre-connection","path":"projects/plugins/jetpack/tests/e2e","testArgs":["specs/pre-connection","--retries=2"]}' '{"project":"Jetpack post-connection","path":"projects/plugins/jetpack/tests/e2e","testArgs":["specs/post-connection","--retries=2"]}' '{"project":"Jetpack sync","path":"projects/plugins/jetpack/tests/e2e","testArgs":["specs/sync","--retries=2"]}' '{"project":"Jetpack blocks","path":"projects/plugins/jetpack/tests/e2e","testArgs":["specs/blocks","--retries=2"]}' '{"project":"Boost","path":"projects/plugins/boost/tests/e2e","testArgs":[]}' '{"project":"Search","path":"projects/plugins/search/tests/e2e","testArgs":[]}' '{"project":"VideoPress","path":"projects/plugins/videopress/tests/e2e","testArgs":[]}')
 
-## Update test only works with local build and workflow_run uses CI built artefacts
-if [[ "$GITHUB_EVENT_NAME" != "workflow_run" ]]; then
-	PROJECTS+=('{"project":"Jetpack update","path":"projects/plugins/jetpack/tests/e2e","testArgs":["plugin-update","--retries=2"]}')
-fi
-
 PROJECTS_MATRIX=()
 RUN_NAME=''
 

--- a/projects/plugins/jetpack/changelog/e2e-disable-update-test
+++ b/projects/plugins/jetpack/changelog/e2e-disable-update-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+E2E tests: disabled update plugin e2e test

--- a/projects/plugins/jetpack/tests/e2e/specs/update/plugin-update.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/update/plugin-update.test.js
@@ -7,7 +7,7 @@ import { PluginsPage, JetpackDashboardPage } from 'jetpack-e2e-commons/pages/wp-
 import { test, expect } from 'jetpack-e2e-commons/fixtures/base-test.js';
 import { prerequisitesBuilder } from 'jetpack-e2e-commons/env/index.js';
 
-test( 'Update Jetpack plugin', async ( { page } ) => {
+test.skip( 'Update Jetpack plugin', async ( { page } ) => {
 	const binPath = '/usr/local/src/jetpack-monorepo/projects/plugins/jetpack/tests/e2e/bin/update/';
 
 	// Prepare for update


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Disable Jetpack plugin update e2e tests. This is already tested with the Test plugin upgrades workflow in CI.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Jetpack update e2e test is not running.

