### PR TITLE
Remove nonexistant FSE styles entry point

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-site-editor-styles-entry-point
+++ b/projects/plugins/jetpack/changelog/remove-site-editor-styles-entry-point
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Remove nonexistent site editor styles entry point

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -416,10 +416,6 @@ class Admin_Menu extends Base_Admin_Menu {
 			'site-editor.php'     => 'https://wordpress.com/site-editor/' . $this->domain,
 		);
 		$this->update_submenus( 'themes.php', $submenus_to_update );
-		// Gutenberg 11.9 adds an redundant site editor entry point that requires some calypso work
-		// before it can be exposed.  Note, there are also already discussions to remove this excess
-		// item in Gutenberg.
-		$this->hide_submenu_page( 'themes.php', 'gutenberg-edit-site&styles=open' );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* These changes remove the nonexistent site editor "styles" entry point under the Calypso "Appearance" sidebar menu.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Atomic Site**

- Use an existing atomic site or create a new one.
- Install and activate [Jetpack beta](https://jetpack.com/download-jetpack-beta/) (Calypso "Plugin > Add New" sidebar menu then click the `Upload` button on the top right side of the page).
- Go to `wp-admin/admin.php?page=jetpack-beta&plugin=jetpack`
- Click on Search for a Feature Branch and enter this branch name: 
- Refresh the site and ensure that the "Editor (styles)" submenu does not appear under the Calypso "Appearance" sidebar menu.

**Simple Site**

- Use an existing simple site or create a new one.
- SSH into your sandbox and make sure you’ve CD’d into `/home/wpcom/public_html/`
- Run this script: `bin/jetpack-downloader test jetpack remove/clean-up-site-editor-styles-entry-point`
- Make sure your test site is sandboxed and test things out to make sure they work/nothing breaks/etc
- Refresh the site and ensure that the "Editor (styles)" submenu does not appear under the Calypso "Appearance" sidebar menu.
- Extra: Run this script to revert the changes (clean up jetpack plugin in your sandbox): `bin/jetpack-downloader reset jetpack`


Fixes #57997
