### PR TITLE
VideoPress: add link to go back from video details page

### DIFF
--- a/projects/packages/videopress/changelog/add-go-back-link-in-video-details-view
+++ b/projects/packages/videopress/changelog/add-go-back-link-in-video-details-view
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Add link to go back to previous page
+
+

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
@@ -11,13 +11,14 @@ import {
 	useBreakpointMatch,
 } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
-import { Icon, chevronRightSmall } from '@wordpress/icons';
+import { Icon, chevronRightSmall, arrowLeft } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useEffect } from 'react';
 import { useHistory, Prompt } from 'react-router-dom';
 /**
  * Internal dependencies
  */
+import { Link } from 'react-router-dom';
 import { VideoPlayer } from '../../../components/video-frame-selector';
 import useUnloadPrevent from '../../hooks/use-unload-prevent';
 import Input from '../input';
@@ -65,6 +66,19 @@ const Header = ( {
 					</Button>
 				</div>
 			</div>
+		</div>
+	);
+};
+
+const GoBackLink = () => {
+	const history = useHistory();
+
+	return (
+		<div className={ styles[ 'back-link' ] }>
+			<Link to="#" className={ styles.link } onClick={ () => history.push( '/' ) }>
+				<Icon icon={ arrowLeft } className={ styles.icon } />
+				{ __( 'Go back', 'jetpack-videopress-pkg' ) }
+			</Link>
 		</div>
 	);
 };
@@ -217,11 +231,14 @@ const EditVideoDetails = () => {
 			<AdminPage
 				moduleName={ __( 'Jetpack VideoPress', 'jetpack-videopress-pkg' ) }
 				header={
-					<Header
-						onSaveChanges={ handleSaveChanges }
-						saveDisabled={ ! hasChanges }
-						saveLoading={ updating }
-					/>
+					<>
+						<GoBackLink />
+						<Header
+							onSaveChanges={ handleSaveChanges }
+							saveDisabled={ ! hasChanges }
+							saveLoading={ updating }
+						/>
+					</>
 				}
 			>
 				<AdminSection>

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/style.module.scss
@@ -34,3 +34,20 @@
 .input {
 	margin-top: calc( var( --spacing-base ) * 3 ); // 24px
 }
+
+.back-link {
+	.icon {
+		width: 16px;
+		margin-right: 4px;
+	}
+
+	.link {
+		--gray-70: #3C434A !important;
+		margin-bottom:28px;
+		font-size: 14px;
+		color: var(--gray-70);
+		display: flex;
+		text-decoration: none;
+		align-items: center;
+	}
+}

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/style.module.scss
@@ -43,7 +43,7 @@
 
 	.link {
 		--gray-70: #3C434A !important;
-		margin-bottom:28px;
+		margin-bottom: calc( var( --spacing-base ) * 3 );
 		font-size: 14px;
 		color: var(--gray-70);
 		display: flex;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add a `Go Back` link on the video details page to give a clear option to go back. 

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

 p1663759141154559-slack-C03TA48NSUX
pe4Cmx-kA-p2#comment-236

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a site with the VideoPress standalone plugin, go to the Admin dashboard
* Upload a video and select the option to edit the video details
* Confirm that the go-back button appears at the top of the page and that it works