### PR TITLE
VideoPress: introduce beta-extensions for Block Editor

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-add-beta-extensions-support
+++ b/projects/packages/videopress/changelog/update-videopress-add-beta-extensions-support
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: implement extensions (beta) handling

--- a/projects/packages/videopress/src/class-block-editor-extensions.php
+++ b/projects/packages/videopress/src/class-block-editor-extensions.php
@@ -54,8 +54,8 @@ class Block_Editor_Extensions {
 	 */
 	public static function get_block_editor_extensions_url() {
 		return Assets::get_file_url_for_environment(
-			'../build/block-editor/extensions.js', // <- production
-			'client/block-editor/extensions.js', // <- development
+			'../build/block-editor/extensions/index.js', // <- production
+			'client/block-editor/extensions/index.js', // <- development
 			__FILE__
 		);
 	}

--- a/projects/packages/videopress/src/class-block-editor-extensions.php
+++ b/projects/packages/videopress/src/class-block-editor-extensions.php
@@ -63,7 +63,7 @@ class Block_Editor_Extensions {
 	/**
 	 * Enqueues the jwt bridge script.
 	 */
-	public static function enqueue_extenions() {
+	public static function enqueue_extensions() {
 		self::enqueue_script();
 
 		$videopress_extensions_file        = __DIR__ . '/client/block-editor/extensions/index.json';

--- a/projects/packages/videopress/src/class-block-editor-extensions.php
+++ b/projects/packages/videopress/src/class-block-editor-extensions.php
@@ -44,7 +44,7 @@ class Block_Editor_Extensions {
 		}
 
 		// Register the script.
-		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_extenions' ), 1 );
+		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_extensions' ), 1 );
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-block-editor-extensions.php
+++ b/projects/packages/videopress/src/class-block-editor-extensions.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * VideoPress Extensions
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Constants;
+
+/**
+ * VideoPress Extensions class.
+ */
+class Block_Editor_Extensions {
+
+	/**
+	 * The handle used to enqueue the script
+	 *
+	 * @var string
+	 */
+	const SCRIPT_HANDLE = 'videopress-extensions';
+
+	/**
+	 * Initializer
+	 *
+	 * This method should be called only once by the Initializer class. Do not call this method again.
+	 */
+	public static function init() {
+		if ( ! Status::is_active() ) {
+			return;
+		}
+
+		/**
+		 * Alternative to `JETPACK_BETA_BLOCKS`, set to `true` to load Beta Blocks.
+		 *
+		 * @since 6.9.0
+		 *
+		 * @param boolean
+		 */
+		if ( apply_filters( 'jetpack_load_beta_blocks', false ) ) {
+			Constants::set_constant( 'JETPACK_BETA_BLOCKS', true );
+		}
+
+		// Register the script.
+		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_extenions' ), 1 );
+	}
+
+	/**
+	 * Gets the bridge script URL depending on the environment we are in
+	 *
+	 * @return string
+	 */
+	public static function get_block_editor_extensions_url() {
+		return Assets::get_file_url_for_environment(
+			'../build/block-editor/extensions.js', // <- production
+			'client/block-editor/extensions.js', // <- development
+			__FILE__
+		);
+	}
+
+	/**
+	 * Enqueues the jwt bridge script.
+	 */
+	public static function enqueue_extenions() {
+		self::enqueue_script();
+
+		$videopress_extensions_file        = __DIR__ . '/client/block-editor/extensions/index.json';
+		$videopress_extensions_file_exists = file_exists( $videopress_extensions_file );
+		if ( ! $videopress_extensions_file_exists ) {
+			return;
+		}
+
+		$videopress_extensions_data = (array) json_decode(
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			file_get_contents( $videopress_extensions_file )
+		);
+
+		$beta_extensions = array_map(
+			function ( $extension ) {
+				return (array) array(
+					'name'      => $extension,
+					'isBeta'    => true,
+					'isEnabled' => Constants::is_true( 'JETPACK_BETA_BLOCKS' ),
+				);
+			},
+			$videopress_extensions_data['beta']
+		);
+
+		wp_localize_script(
+			self::SCRIPT_HANDLE,
+			'videoPressExtensions',
+			$beta_extensions
+		);
+	}
+
+	/**
+	 * Enqueues only the JS script
+	 *
+	 * @param string $handle The script handle to identify the script.
+	 * @return bool True if the script was successfully localized, false otherwise.
+	 */
+	public static function enqueue_script( $handle = self::SCRIPT_HANDLE ) {
+		$enqueued = wp_enqueue_script(
+			$handle,
+			self::get_block_editor_extensions_url(),
+			array(),
+			Package_Version::PACKAGE_VERSION,
+			false
+		);
+
+		return $enqueued;
+	}
+}

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -121,6 +121,7 @@ class Initializer {
 		VideoPress_Rest_Api_V1_Stats::init();
 		VideoPress_Rest_Api_V1_Site::init();
 		XMLRPC::init();
+		Block_Editor_Extensions::init();
 		self::register_oembed_providers();
 		if ( self::should_initialize_admin_ui() ) {
 			Admin_UI::init();

--- a/projects/packages/videopress/src/client/block-editor/extensions/index.js
+++ b/projects/packages/videopress/src/client/block-editor/extensions/index.js
@@ -1,0 +1,10 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+
+const debug = debugFactory( 'videopress:extensions' );
+
+const extensions = window?.videoPressExtensions || {};
+
+debug( 'Extensions: %o', extensions );

--- a/projects/packages/videopress/src/client/block-editor/extensions/index.json
+++ b/projects/packages/videopress/src/client/block-editor/extensions/index.json
@@ -1,0 +1,3 @@
+{
+	"beta": [ "videopress-videochapters-plugin" ]
+}

--- a/projects/packages/videopress/src/client/block-editor/index.js
+++ b/projects/packages/videopress/src/client/block-editor/index.js
@@ -4,6 +4,11 @@
 import './blocks/video';
 
 /*
- * extensibility
+ * Extensibility
  */
 import './extend';
+
+/*
+ * Extensions
+ */
+import './extensions';

--- a/projects/packages/videopress/webpack.config.js
+++ b/projects/packages/videopress/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = [
 			'block-editor/view': './src/client/block-editor/view.js',
 			'lib/videopress-token-bridge': './src/client/lib/videopress-token-bridge.js',
 			'admin/index': './src/client/admin/index.js',
+			'block-editor/extensions/index': './src/client/block-editor/extensions/index.js',
 		},
 		mode: jetpackWebpackConfig.mode,
 		devtool: jetpackWebpackConfig.isDevelopment ? 'source-map' : false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR implements a simple and basic beta-extensions handling. The idea is to be able to use it to hide beta extensions as we do in the Jetpack plugin. For this:

* Add a couple of files on the client side where the extension can be defined.
* Create `dev` and `prod` versions of it
* Process the extensions defined in the `index.json` file in the backed, following [the Jetpack plugin approach](https://github.com/Automattic/jetpack/tree/trunk/projects/plugins/jetpack/extensions#beta-extensions).

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: introduce beta-extensions


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

For the testing purpose and to be used shortly, I've added only one beta extension: `videopress-videochapters-plugin`
* Go to the block editor 
* Open the dev console
* print the `videoPressExtensions` object:
<img width="368" alt="image" src="https://user-images.githubusercontent.com/77539/198403040-cbb6b7de-1883-4612-a894-6a08e73c0512.png">
Confirm the `videopress-videochapters-plugin` extension is there, `isBeta` is `true`, and `isEnabled` depends on whether you have `beta extensions` enabled.
* Test in local dev-env, JN, and dotcom site.


#### Local Dev Env
It will be enabled depending on the `JETPACK_BETA_BLOCKS` global var.

```
define( 'JETPACK_BETA_BLOCKS', false );
```

<img width="352" alt="Screen Shot 2022-10-27 at 17 47 49" src="https://user-images.githubusercontent.com/77539/198404710-1a00fa06-e459-46e9-98e8-66ef8c399272.png">

```
define( 'JETPACK_BETA_BLOCKS', true );
```
<img width="304" alt="image" src="https://user-images.githubusercontent.com/77539/198404921-7e761d47-1ccb-45f1-bb01-b809314d53f2.png">

Additionally, you can use debug with `videopress:extensions` namespace to see the extensions list:

```es6
localStorage.setItem( 'debug', 'videopress:extensions' )
```

<img width="573" alt="image" src="https://user-images.githubusercontent.com/77539/198405263-40d77eef-b1a1-40cf-8210-5ea9abd4ff43.png">



