### PR TITLE
Add wpcom_gifting_subscription option to settings endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/add-wpcom_gifting_subscription-option-settings-endpoint
+++ b/projects/plugins/jetpack/changelog/add-wpcom_gifting_subscription-option-settings-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Gifting subscription: Add wpcom_gifting_subscription option to the site settings endpoint

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -436,6 +436,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'rss_use_excerpt'                  => (bool) get_option( 'rss_use_excerpt' ),
 						'launchpad_screen'                 => (string) get_option( 'launchpad_screen' ),
 						'featured_image_email_enabled'     => (bool) get_option( 'featured_image_email_enabled' ),
+						'wpcom_gifting_subscription'       => (bool) get_option( 'wpcom_gifting_subscription' ),
 					);
 
 					if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -869,6 +869,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 				case 'wpcom_publish_posts_with_markdown':
 				case 'wpcom_publish_comments_with_markdown':
+				case 'wpcom_gifting_subscription':
 					$coerce_value = (bool) $value;
 					if ( update_option( $key, $coerce_value ) ) {
 						$updated[ $key ] = $coerce_value;

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -116,6 +116,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			'wpcom_publish_comments_with_markdown'    => '(bool) Whether markdown is enabled for comments',
 			'launchpad_screen'                        => '(string) Whether or not launchpad is presented and what size it will be',
 			'featured_image_email_enabled'            => '(bool) Whether the Featured image is displayed in the New Post email template or not',
+			'wpcom_gifting_subscription'              => '(bool) Whether gifting is enabled for non auto-renew sites',
 		),
 
 		'response_format' => array(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The proposed changes add `wpcom_gifting_subscription` option to the site settings endpoint. The new option is necessary in order to save the state whether the Gift Subscription should or shouldn't be displayed when plan is about to expire.

Project thread: p9Jlb4-5Ae-p2

This PR doesn't introduce any visible / functional changes. Instead, this PR is a prerequisite for the upcoming changes that will utilize the newly-added site option/setting:

This is a follow up to D90818-code, https://github.com/Automattic/wp-calypso/pull/69458

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No, it does not.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The PR doesn't introduce any visible/functional changes. We can review the code and make sure the are no regressions.

Related to https://github.com/Automattic/dotcom-forge/issues/1081