### PR TITLE
Prevent grunion contact form from escaping valid URL characters in the redirect URL

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-contact-form-redirect-url-escaping
+++ b/projects/plugins/jetpack/changelog/fix-contact-form-redirect-url-escaping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Prevent grunion contact form from escaping valid URL characters in the redirect URL

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -3675,7 +3675,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		$custom_redirect = false;
 		if ( 'redirect' === $this->get_attribute( 'customThankyou' ) ) {
 			$custom_redirect = true;
-			$redirect        = esc_url( $this->get_attribute( 'customThankyouRedirect' ) );
+			$redirect        = esc_url_raw( $this->get_attribute( 'customThankyouRedirect' ) );
 		}
 
 		if ( ! $redirect ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27140

#### Changes proposed in this Pull Request:
Updated the contact form to use `esc_url_raw` instead of `esc_url` when performing the redirect in order to prevent unwanted encoding on the URL.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p2EDhh-1JR-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Create a post with a contact form block.
- Set "On Submission" in the sidebar to "perform a redirect".
- Enter a URL with a query string containing multiple keys and values.
- Publish and view the post.
- Submit the form.
- You should be redirected to the correct URL, as you entered it, including all query parameters.