### PR TITLE
VideoPress: Add processing state to video thumbnail on edit page

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-edit-processing
+++ b/projects/packages/videopress/changelog/update-videopress-edit-processing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Add processing state to video thumbnail on edit page

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
@@ -156,6 +156,7 @@ const EditVideoDetails = () => {
 		setTitle,
 		setDescription,
 		setCaption,
+		processing,
 		// Poster Image
 		useVideoAsThumbnail,
 		selectedTime,
@@ -242,6 +243,7 @@ const EditVideoDetails = () => {
 								thumbnail={ isFetchingData ? <Placeholder height={ 200 } /> : thumbnail }
 								duration={ duration }
 								editable
+								processing={ processing }
 								onSelectFromVideo={ handleOpenSelectFrame }
 								onUploadImage={ selectPosterImageFromLibrary }
 							/>

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/use-edit-details.ts
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/use-edit-details.ts
@@ -64,7 +64,7 @@ export default () => {
 
 	const { videoId: videoIdFromParams } = useParams();
 	const videoId = Number( videoIdFromParams );
-	const { data: video, isFetching } = useVideo( Number( videoId ) );
+	const { data: video, isFetching, processing } = useVideo( Number( videoId ) );
 
 	const { playbackToken, isFetchingPlaybackToken } = usePlaybackToken( video );
 
@@ -182,6 +182,7 @@ export default () => {
 		selectPosterImageFromLibrary,
 		handleSaveChanges,
 		isFetching,
+		processing,
 		updating,
 		updated,
 		selectedTime,

--- a/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
@@ -88,7 +88,7 @@ export const VideoCard = ( {
 			<div
 				className={ classnames( styles[ 'video-card__wrapper' ], {
 					[ styles[ 'is-blank' ] ]: isBlank,
-					[ styles.disabled ]: isSm && disabled,
+					[ styles.disabled ]: isSm || disabled,
 				} ) }
 				{ ...( isSm && ! disabled && { onClick: () => setIsOpen( wasOpen => ! wasOpen ) } ) }
 			>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27143

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Exposes the `processing` state on the edit page
* Fixes the hover effect on video card when uploading

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard and upload a video
* When the video is processing, go to the edit page
* Check that the processing state is shown during polling

![2022-10-28_11-51-34](https://user-images.githubusercontent.com/8486249/198659124-cf00b1a5-22f4-4fde-86c5-11c2f605795a.png)
