### PR TITLE
Jetpack (plugin): Dashboard unconnected site widget copy update

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-dashboard-connection-widget-copy
+++ b/projects/plugins/jetpack/changelog/update-jetpack-dashboard-connection-widget-copy
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: This change is already included in the scope of a previous changelog entry
+
+

--- a/projects/plugins/jetpack/class-jetpack-connection-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-connection-widget.php
@@ -108,7 +108,7 @@ class Jetpack_Connection_Widget {
 					src="<?php echo esc_url( plugins_url( 'images/dashboard-connection-widget-hero.png', JETPACK__PLUGIN_FILE ) ); ?>" />
 				<p class="jp-connection-widget__heading"><?php esc_html_e( 'Finish setting up your site', 'jetpack' ); ?></p>
 				<p class="jp-connection-widget__paragraph">
-					<?php esc_html_e( 'You’re missing out on great Jetpack features, sign up to set up.', 'jetpack' ); ?>
+					<?php esc_html_e( 'Complete your setup to take advantage of security and performance features already installed by Jetpack.', 'jetpack' ); ?>
 				</p>
 				<p class="jp-connection-widget__tos-blurb">
 					<?php jetpack_render_tos_blurb(); ?>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update wp-admin dashboard widget for unconnected sites according to the changes proposed in pdpAdu-Nw-p2#comment-868


#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pbtFPC-34k-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
This PR does not add data tracking.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

> You should be able to connect to WordPress.com in order to test this feature

* Pull this branch and run on your local environment.
* You might need to `jetpack docker uninstall && jetpack docker install` if you had a local running version.
* When logging in as admin, you should see the connection banner, dismiss it and refresh the page. You should get the connection widget when visiting the admin dashboard after dismissing the Jetpack connection banner.
* You should only see the Jetpack connection widget for unconnected sites.
* You should be able to click the link on the widget to start connecting your site.

### Screenshots
![image](https://user-images.githubusercontent.com/5550190/198675307-c6687fb8-86ac-4491-8a23-cecf1858b2b8.png)
