### PR TITLE
Jetpack: Add form wrapper alignment control

### DIFF
--- a/projects/plugins/jetpack/changelog/add-form-wrapper-alignment-control
+++ b/projects/plugins/jetpack/changelog/add-form-wrapper-alignment-control
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add block alignment control for the form wrapper: center, wide and full

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/index.js
@@ -40,6 +40,7 @@ export const settings = {
 			padding: true,
 			margin: true,
 		},
+		align: [ 'wide', 'full' ],
 	},
 	attributes: defaultAttributes,
 	edit,

--- a/projects/plugins/jetpack/modules/contact-form/css/grunion.css
+++ b/projects/plugins/jetpack/modules/contact-form/css/grunion.css
@@ -133,7 +133,14 @@
 	flex-wrap: wrap;
 	justify-content: flex-start;
 	flex-direction: row;
+	flex-grow: 1;
 	gap: var(--wp--style--block-gap, 1.5rem);
+}
+
+/* Added circa Nov 2022: container class assigned to topmost block div */
+.wp-block-jetpack-contact-form-container.alignfull .wp-block-jetpack-contact-form {
+	padding-right: 0;
+	padding-left: 0;
 }
 
 .wp-block-jetpack-contact-form .grunion-field-wrap,

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -2592,8 +2592,12 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			wp_enqueue_style( 'grunion.css' );
 		}
 
+		$container_classes        = array( 'wp-block-jetpack-contact-form-container' );
+		$container_classes[]      = self::get_block_alignment_class( $attributes );
+		$container_classes_string = implode( ' ', $container_classes );
+
 		$r  = '';
-		$r .= "<div id='contact-form-$id'>\n";
+		$r .= "<div data-test='contact-form' id='contact-form-$id' class='{$container_classes_string}'>\n";
 
 		if ( is_wp_error( $form->errors ) && $form->errors->get_error_codes() ) {
 			// There are errors.  Display them
@@ -3861,6 +3865,24 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		return addslashes( $value );
 	}
 
+	/**
+	 * Rough implementation of Gutenberg's align-attribute-to-css-class map.
+	 * Only allowin "wide" and "full" as "center", "left" and "right" don't
+	 * make much sense for the form.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string The CSS alignment class: alignfull | alignwide.
+	 */
+	public static function get_block_alignment_class( $attributes = array() ) {
+		$align_to_class_map = array(
+			'wide' => 'alignwide',
+			'full' => 'alignfull',
+		);
+		if ( empty( $attributes['align'] ) || ! array_key_exists( $attributes['align'], $align_to_class_map ) ) {
+			return '';
+		}
+		return $align_to_class_map[ $attributes['align'] ];
+	}
 } // end class Grunion_Contact_Form
 
 // phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound -- how many times I have to disable this?


### PR DESCRIPTION
This PR adds the BlockAlignmentControl for the form to allow custom alignment.

Fixes #27149 

#### Changes proposed in this Pull Request:
- add block alignment control
- restrict to center, wide and full as right/left remains a bit buggy

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

Insert a form block. Notice the new alignment control on the toolbar. Verify the alignment works as expected