### PR TITLE
[WIP] Jetpack: Allow more blocks as children of Contact Form

### DIFF
--- a/projects/plugins/jetpack/changelog/change-form-allowed-children
+++ b/projects/plugins/jetpack/changelog/change-form-allowed-children
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Allow columns and groups nested in forms

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/child-blocks.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/child-blocks.js
@@ -1,6 +1,8 @@
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { createBlock, getBlockType } from '@wordpress/blocks';
 import { Circle, Path } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { Fragment, useEffect } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { getIconColor } from '../../shared/block-icons';
 import renderMaterialIcon from '../../shared/render-material-icon';
@@ -12,7 +14,7 @@ import JetpackFieldTextarea from './components/jetpack-field-textarea';
 
 const FieldDefaults = {
 	category: 'contact-form-fields',
-	parent: [ 'jetpack/contact-form' ],
+	// parent: [ 'jetpack/contact-form' ],
 	supports: {
 		reusable: false,
 		html: false,
@@ -126,6 +128,19 @@ const getFieldLabel = ( { attributes, name: blockName } ) => {
 };
 
 const editField = type => props => {
+	const parents = useSelect( select => {
+		return select( blockEditorStore ).getBlockParentsByBlockName(
+			props.clientId,
+			'jetpack/contact-form'
+		);
+	} );
+	useEffect( () => {
+		// eslint-disable-next-line
+		console.log( parents );
+		// eslint-disable-next-line
+		console.log( props.clientId );
+	}, [ props.clientId, parents ] );
+
 	return (
 		<JetpackField
 			type={ type }

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/edit.js
@@ -33,6 +33,8 @@ import defaultVariations from './variations';
 
 const ALLOWED_BLOCKS = [
 	'core/audio',
+	'core/columns',
+	'core/group',
 	'core/heading',
 	'core/image',
 	'core/list',

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
@@ -26,7 +26,7 @@
 		gap: var(--wp--style--block-gap, 1.5rem);
 
 		.wp-block {
-			flex: 0 0 100%;
+			flex: 0 1 100%;
 			margin: 0;
 
 			&.jetpack-field__width-25,

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/variations.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/variations.js
@@ -1,10 +1,10 @@
 import { isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import { Path } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { compact, map } from 'lodash';
+import { compact } from 'lodash';
 import { getIconColor } from '../../shared/block-icons';
 import renderMaterialIcon from '../../shared/render-material-icon';
-import { childBlocks } from './child-blocks';
+// import { childBlocks } from './child-blocks';
 
 const defaultBlockStyling = {
 	style: {
@@ -258,25 +258,25 @@ const variations = compact( [
 	// and make then visible in the Block Library.
 	// The 'hiddenFromPicker' property will prevent
 	// them to show up in the Form placeholder
-	...map( childBlocks, block => ( {
-		name: block.name,
-		title: block.settings.title,
-		description: block.settings.description,
-		icon: block.settings.icon,
-		keywords: block.settings.keywords,
-		innerBlocks: [
-			[ `jetpack/${ block.name }`, { required: true } ],
-			[
-				'jetpack/button',
-				{
-					text: __( 'Submit', 'jetpack' ),
-					element: 'button',
-					lock: { remove: true },
-				},
-			],
-		],
-		hiddenFromPicker: true,
-	} ) ),
+	// ...map( childBlocks, block => ( {
+	// 	name: block.name,
+	// 	title: block.settings.title,
+	// 	description: block.settings.description,
+	// 	icon: block.settings.icon,
+	// 	keywords: block.settings.keywords,
+	// 	innerBlocks: [
+	// 		[ `jetpack/${ block.name }`, { required: true } ],
+	// 		[
+	// 			'jetpack/button',
+	// 			{
+	// 				text: __( 'Submit', 'jetpack' ),
+	// 				element: 'button',
+	// 				lock: { remove: true },
+	// 			},
+	// 		],
+	// 	],
+	// 	hiddenFromPicker: true,
+	// } ) ),
 ] );
 
 export default variations;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #25123 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

