### PR TITLE
VideoPress: Get video title from backend after upload to avoid dirty form while processing

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-edit-processing-dirty
+++ b/projects/packages/videopress/changelog/fix-videopress-edit-processing-dirty
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Get video title from backend after upload to avoid dirty form while processing

--- a/projects/packages/videopress/src/client/state/reducers.js
+++ b/projects/packages/videopress/src/client/state/reducers.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { combineReducers } from '@wordpress/data';
+import { cleanForSlug } from '@wordpress/url';
 /**
  * Internal dependencies
  */
@@ -317,6 +318,7 @@ const videos = ( state, action ) => {
 			const { id, title } = action;
 			const currentMeta = state?._meta || {};
 			const currentMetaItems = currentMeta?.items || {};
+			const sanitizedTitle = cleanForSlug( title );
 
 			return {
 				...state,
@@ -325,7 +327,7 @@ const videos = ( state, action ) => {
 					items: {
 						...currentMetaItems,
 						[ id ]: {
-							title,
+							title: sanitizedTitle,
 							uploading: true,
 						},
 					},
@@ -341,7 +343,9 @@ const videos = ( state, action ) => {
 			const items = [ ...( state?.items ?? [] ) ];
 			const currentMeta = state?._meta || {};
 			const currentMetaItems = Object.assign( {}, currentMeta?.items || {} );
-			const title = currentMetaItems[ id ]?.title || '';
+			const title =
+				data?.src?.split( '/' )?.slice( -1 )?.[ 0 ] || currentMetaItems[ id ]?.title || '';
+			const sanitizedTitle = cleanForSlug( title );
 
 			let total = state?.uploadedVideoCount ?? 0;
 
@@ -357,7 +361,7 @@ const videos = ( state, action ) => {
 					id: data.id,
 					guid: data.guid,
 					url: data.src,
-					title,
+					title: sanitizedTitle,
 					posterImage: null,
 					finished: false,
 				} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27157

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Gets generated video title and sanitize it to match backend title
* Enhance diff detection to account for undefined fields that are empty strings at first

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard
* Upload a video
* While it is processing, go to the video's edit page
* Wait for the processing state to end without changing anything in the form
* Check that the `Save` button is disabled and leaving the page does not prompt the user for confirmation

https://user-images.githubusercontent.com/8486249/199090627-c6f40369-0d8f-4b78-b27e-9505a0caa6ac.mp4