### PR TITLE
Jetpack: Fix CSS import that breaks themes page

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-broken-themes-page
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-broken-themes-page
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: This fix will not be relevant for the next release as it is for a bug produces while developing this version
+
+

--- a/projects/plugins/jetpack/scss/jetpack-connection-widget.scss
+++ b/projects/plugins/jetpack/scss/jetpack-connection-widget.scss
@@ -1,5 +1,4 @@
 @import 'node_modules/@automattic/color-studio/dist/color-variables.scss';
-@import 'node_modules/@automattic/jetpack-base-styles/style';
 
 #jetpack_connection_widget * {
     box-sizing: border-box;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27135

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes unnecessary scss import that breaks the layout of the themes page

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pbtFPC-34k-p2
p1667235461497009/1666956871.754059-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
This does not add data tracking

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Pull this branch and run on your local environment.
- You might need to jetpack docker uninstall && jetpack docker install if you had a local running version.
- Navigating to `Appearance > Themes` should get you to the themes page that had a slightly broken layout
- Layout on the Themes page should be fine, as in the screenshot below.

#### Screenshots
![image](https://user-images.githubusercontent.com/5550190/199098172-771909e6-1c3b-4d1c-98ec-8e394d433479.png)