### PR TITLE
VideoPress: expose site-type to the client side

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-expose-site-type
+++ b/projects/packages/videopress/changelog/update-videopress-expose-site-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: expose site-type to the client side

--- a/projects/packages/videopress/src/class-block-editor-extensions.php
+++ b/projects/packages/videopress/src/class-block-editor-extensions.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\VideoPress;
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Status\Host;
 
 /**
  * VideoPress Extensions class.
@@ -88,10 +89,20 @@ class Block_Editor_Extensions {
 			$videopress_extensions_data['beta']
 		);
 
+		$site_type = 'jetpack';
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$site_type = 'simple';
+		} elseif ( ( new Host() )->is_woa_site() ) {
+			$site_type = 'atomic';
+		}
+
 		wp_localize_script(
 			self::SCRIPT_HANDLE,
-			'videoPressExtensions',
-			$beta_extensions
+			'videoPressEditorState',
+			array(
+				'extensions' => $beta_extensions,
+				'siteType'   => $site_type,
+			)
 		);
 	}
 

--- a/projects/packages/videopress/src/client/block-editor/extensions/global.d.ts
+++ b/projects/packages/videopress/src/client/block-editor/extensions/global.d.ts
@@ -3,8 +3,11 @@
  */
 import { VideoPressExtensionsProps } from './types';
 
-export declare global {
+declare global {
 	interface Window {
-		videoPressExtensions: VideoPressExtensionsProps;
+		videoPressEditorState: {
+			extensions: VideoPressExtensionsProps;
+			siteType: 'simple' | 'atomic' | 'jetpack';
+		};
 	}
 }

--- a/projects/packages/videopress/src/client/block-editor/extensions/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/extensions/index.ts
@@ -9,7 +9,7 @@ import { VideoPressExtensionsProps } from './types';
 
 const debug = debugFactory( 'videopress:extensions' );
 
-const extensions = window?.videoPressExtensions || <VideoPressExtensionsProps>[];
+const extensions = window?.videoPressEditorState?.extensions || <VideoPressExtensionsProps>[];
 
 debug( 'Extensions: %o', extensions );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: expose site type

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Block Editor
* Confirm extensions are there via debug() logs

<img width="604" alt="image" src="https://user-images.githubusercontent.com/77539/199107595-b58fafa3-9fc4-4d4d-bd8a-5f7c45056414.png">

* Confirm there is a new `videoPressEditorState` object.
* Confirm it exposes the site type correctly:

<img width="429" alt="image" src="https://user-images.githubusercontent.com/77539/199107404-4171ac4b-04f0-407b-8c09-3eee49e74d71.png">

