### PR TITLE
Add a link + message for subscription excerpts.

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -95,8 +95,8 @@ function render_block( $attributes, $content ) {
 /**
  * Filter excerpts looking for subscription data.
  *
- * @param $excerpt  string
- * @param $raw_text WP_Post
+ * @param string  $excerpt The extrapolated excerpt string.
+ * @param WP_Post $post    The current post being processed (in `get_the_excerpt`).
  *
  * @return mixed
  */

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -95,15 +95,15 @@ function render_block( $attributes, $content ) {
 /**
  * Filter excerpts looking for subscription data.
  *
- * @param string  $excerpt The extrapolated excerpt string.
- * @param WP_Post $post    The current post being processed (in `get_the_excerpt`).
+ * @param string   $excerpt The extrapolated excerpt string.
+ * @param \WP_Post $post    The current post being processed (in `get_the_excerpt`).
  *
  * @return mixed
  */
 function jetpack_filter_excerpt_for_newsletter( $excerpt, $post ) {
 	if ( false !== strpos( $post->post_content, '<!-- wp:jetpack/subscriptions -->' ) ) {
 		$excerpt .= sprintf(
-			"<p><a href='%s'>%s</a> %s.",
+			"<p><a href='%s'>%s</a> %s.</p>",
 			get_post_permalink(),
 			__( 'View post', 'jetpack' ),
 			__( 'to subscribe to site newsletter', 'jetpack' )

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -62,6 +62,7 @@ function register_block() {
 		10
 	);
 
+	add_filter( 'get_the_excerpt', __NAMESPACE__ . '\jetpack_filter_excerpt_for_newsletter', 10, 2 );
 }
 add_action( 'init', __NAMESPACE__ . '\register_block', 9 );
 
@@ -89,4 +90,24 @@ function render_block( $attributes, $content ) {
 	}
 
 	return $content;
+}
+
+/**
+ * Filter excerpts looking for subscription data.
+ *
+ * @param $excerpt  string
+ * @param $raw_text WP_Post
+ *
+ * @return mixed
+ */
+function jetpack_filter_excerpt_for_newsletter( $excerpt, $post ) {
+	if ( false !== strpos( $post->post_content, '<!-- wp:jetpack/subscriptions -->' ) ) {
+		$excerpt .= sprintf(
+			"<p><a href='%s'>%s</a> %s.",
+			get_post_permalink(),
+			__( 'View post', 'jetpack' ),
+			__( 'to subscribe to site newsletter', 'jetpack' )
+		);
+	}
+	return $excerpt;
 }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -103,10 +103,8 @@ function render_block( $attributes, $content ) {
 function jetpack_filter_excerpt_for_newsletter( $excerpt, $post ) {
 	if ( false !== strpos( $post->post_content, '<!-- wp:jetpack/subscriptions -->' ) ) {
 		$excerpt .= sprintf(
-			"<p><a href='%s'>%s</a> %s.</p>",
-			get_post_permalink(),
-			__( 'View post', 'jetpack' ),
-			__( 'to subscribe to site newsletter', 'jetpack' )
+			__( "<p><a href='%s'>View post</a> to subscribe to site newsletter.</p>", 'jetpack' ),
+			get_post_permalink()
 		);
 	}
 	return $excerpt;

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -103,6 +103,7 @@ function render_block( $attributes, $content ) {
 function jetpack_filter_excerpt_for_newsletter( $excerpt, $post ) {
 	if ( false !== strpos( $post->post_content, '<!-- wp:jetpack/subscriptions -->' ) ) {
 		$excerpt .= sprintf(
+			// translators: %s is the permalink url to the current post.
 			__( "<p><a href='%s'>View post</a> to subscribe to site newsletter.</p>", 'jetpack' ),
 			get_post_permalink()
 		);


### PR DESCRIPTION
FIxes 972-gh-Automattic/multiwoo.

## Testing instructions

Add this to your branch and view a post or page that has the jetpack subscription block enabled.  You should see a blurb in the excerpt now that resembles:

![image](https://user-images.githubusercontent.com/6354169/199134977-d65ce216-e737-4195-89fc-a6f706b0c6f6.png)

