### PR TITLE
Unlock content based for blog Subscribers

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-subscription-service.php
@@ -41,11 +41,12 @@ interface Subscription_Service {
 	 * Given a token (this could be from a cookie, a querystring, or some other means)
 	 * can the visitor see the premium content?
 	 *
-	 * @param array $valid_plan_ids .
+	 * @param array  $valid_plan_ids .
+	 * @param string $access_level   .
 	 *
 	 * @return boolean
 	 */
-	public function visitor_can_view_content( $valid_plan_ids );
+	public function visitor_can_view_content( $valid_plan_ids, $access_level );
 
 	/**
 	 * The current visitor would like to obtain access. Where do they go?

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-unconfigured-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-unconfigured-subscription-service.php
@@ -39,9 +39,10 @@ class Unconfigured_Subscription_Service implements Subscription_Service {
 	/**
 	 * No subscription service available, no users can see this content.
 	 *
-	 * @param array $valid_plan_ids .
+	 * @param array  $valid_plan_ids .
+	 * @param string $access_level   .
 	 */
-	public function visitor_can_view_content( $valid_plan_ids ) {
+	public function visitor_can_view_content( $valid_plan_ids, $access_level ) {
 		return false;
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-offline-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-offline-subscription-service.php
@@ -36,10 +36,12 @@ class WPCOM_Offline_Subscription_Service extends WPCOM_Token_Subscription_Servic
 	/**
 	 * Lookup users subscriptions for a site and determine if the user has a valid subscription to match the plan ID
 	 *
-	 * @param array $valid_plan_ids .
+	 * @param array  $valid_plan_ids .
+	 * @param string $access_level  .
+	 *
 	 * @return bool
 	 */
-	public function visitor_can_view_content( $valid_plan_ids ) {
+	public function visitor_can_view_content( $valid_plan_ids, $access_level ) {
 		/** This filter is already documented in projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php */
 		$subscriptions = apply_filters( 'earn_get_user_subscriptions_for_site_id', array(), wp_get_current_user()->ID, $this->get_site_id() );
 		if ( empty( $subscriptions ) ) {

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-offline-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-offline-subscription-service.php
@@ -37,7 +37,7 @@ class WPCOM_Offline_Subscription_Service extends WPCOM_Token_Subscription_Servic
 	 * Lookup users subscriptions for a site and determine if the user has a valid subscription to match the plan ID
 	 *
 	 * @param array  $valid_plan_ids .
-	 * @param string $access_level  .
+	 * @param string $access_level .
 	 *
 	 * @return bool
 	 */

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -451,7 +451,7 @@ class Jetpack_Memberships {
 	 */
 	public static function user_can_view_post() {
 		$newsletter_access_level = self::get_newsletter_access_level();
-		if ( 'everybody' === $newsletter_access_level ) {
+		if ( 'everybody' === $newsletter_access_level || empty( $newsletter_access_level ) ) {
 			return true;
 		}
 

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -450,19 +450,14 @@ class Jetpack_Memberships {
 	 * @return bool Whether the post can be viewed
 	 */
 	public static function user_can_view_post() {
+		$newsletter_access_level = self::get_newsletter_access_level();
+		if ( 'everybody' === $newsletter_access_level ) {
+			return true;
+		}
+
 		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
 		$paywall = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
-
-		$newsletter_access_level = self::get_newsletter_access_level();
-		if ( 'paid_subscribers' === $newsletter_access_level ) {
-			$plan_ids = self::get_all_plans_id_jetpack_recurring_payments();
-			return $paywall->visitor_can_view_content( $plan_ids );
-		}
-
-		if ( 'subscribers' === $newsletter_access_level ) {
-			return $paywall->vistor_is_blog_subscriber();
-		}
-		return true;
+		return $paywall->visitor_can_view_content( self::get_all_plans_id_jetpack_recurring_payments(), $newsletter_access_level );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes # https://github.com/Automattic/wp-calypso/issues/69518

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add a `$access_level` param to `visitor_can_view_content` function signature
* Add logic to unlock content based on the `blog_sub` param from the JWT or cookie

#### Testing instructions:
_Note: This is a bit hard to test as the JWT or cookie is not populated correctly when a user checkouts as a blog subscriber. This should be fixed in https://github.com/Automattic/wp-calypso/issues/69664_

* Add a `var_dump( $payload )` [here](https://github.com/Automattic/jetpack/pull/27212/files#diff-a2de8fe49437410f2cef32a4b1cb8a63cbe0727afd32c4e8312fcc73c913ad8bR75) 
* Go to your NGROK or .jurassic.tube site
* Checkout as a paid subscriber
* Notice that the payload from the JWT is logged out with a `blog_sub` param
* Notice that you now have access to the content.

<img width="1770" alt="Captura de Pantalla 2022-11-01 a las 12 21 23" src="https://user-images.githubusercontent.com/7076981/199320190-67d068d7-f2bc-4531-83d0-2378f5774c80.png">


**Automated tests are pending**
