### PR TITLE
VideoPress: Add VideoPress video block select control component

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-video-block-select-control
+++ b/projects/packages/videopress/changelog/add-videopress-video-block-select-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Add VideoPress video block select control

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.6.5",
+	"version": "0.6.6-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.6.5';
+	const PACKAGE_VERSION = '0.6.6-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/client/block-editor/components/video-block-select-control/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/components/video-block-select-control/index.tsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { SelectControl } from '@wordpress/components';
+import { select } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { useEffect } from 'react';
+
+const VideoBlockSelectControl = ( {
+	value,
+	onChange,
+}: {
+	value: string;
+	onChange: ( blockId: string ) => void;
+} ) => {
+	const blocks = select( 'core/block-editor' )
+		.getBlocks()
+		.filter( block => block.name === 'videopress/video' );
+
+	useEffect( () => {
+		// Defaults to first option
+		if ( ! value && blocks.length > 0 ) {
+			onChange( blocks[ 0 ].clientId );
+		}
+	}, [] );
+
+	const options = blocks.map( block => ( {
+		value: block.clientId,
+		label: block.attributes.title,
+	} ) );
+
+	return (
+		<SelectControl
+			label={ __( 'Video', 'jetpack-videopress-pkg' ) }
+			value={ value }
+			onChange={ onChange }
+			options={ options }
+		/>
+	);
+};
+
+export default VideoBlockSelectControl;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #27202

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a VideoPress block selector component

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

As the block is not implemented yet to use the component, a visual verification should be enough

![2022-11-01_16-44-19](https://user-images.githubusercontent.com/8486249/199324377-75cad31f-14d1-4df7-bee3-f37fca841ae6.png)
