### PR TITLE
WAF: Generate ip rules when running the update rules cron

### DIFF
--- a/projects/packages/waf/changelog/fix-waf-rule-cron
+++ b/projects/packages/waf/changelog/fix-waf-rule-cron
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed a bug that caused because the cron wont regenerate ip rules

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -331,6 +331,7 @@ class Waf_Runner {
 		$version = get_option( self::VERSION_OPTION_NAME );
 		if ( self::WAF_RULES_VERSION !== $version ) {
 			update_option( self::VERSION_OPTION_NAME, self::WAF_RULES_VERSION );
+			self::generate_ip_rules();
 			self::generate_rules();
 		}
 	}

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -313,6 +313,7 @@ class Waf_Runner {
 			return;
 		}
 
+		self::generate_ip_rules();
 		self::generate_rules();
 		update_option( self::RULE_LAST_UPDATED_OPTION_NAME, time() );
 	}


### PR DESCRIPTION
Fixes #27209

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Regenerate the ip rules when running the cron that updates the waf rules

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a JN site with a Scan subscription.
* Turn on the WAF module
* SSH into the site and remove all the rules
* Run the cron via `wp cron event run jetpack_waf_rules_update_cron`
* Verify that both sets of rules were generated and that the site still works after the cron runs

