### PR TITLE
Jetpack: Remove include of `functions.is-mobile.php` from `class.jetpack-user-agent.php`

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-workaround-wp-super-cache-breakage
+++ b/projects/plugins/jetpack/changelog/fix-workaround-wp-super-cache-breakage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Remove include of `functions.is-mobile.php` from `class.jetpack-user-agent.php` to restore status quo.

--- a/projects/plugins/jetpack/class.jetpack-user-agent.php
+++ b/projects/plugins/jetpack/class.jetpack-user-agent.php
@@ -18,13 +18,6 @@
 
 use \Automattic\Jetpack\Device_Detection\User_Agent_Info;
 
-require_once __DIR__ . '/functions.is-mobile.php';
-
-// We may have been loaded before the autoloader, so load the necessary class manually.
-if ( defined( 'JETPACK_PLUGIN_LOADER_PATH' ) && ! class_exists( User_Agent_Info::class ) ) {
-	require_once JETPACK_PLUGIN_LOADER_PATH . '/jetpack_vendor/automattic/jetpack-device-detection/src/class-user-agent-info.php';
-}
-
 /**
  * A class providing device properties detection.
  *

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -100,7 +100,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ11_6_a_1",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ11_6_a_2",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/functions.is-mobile.php
+++ b/projects/plugins/jetpack/functions.is-mobile.php
@@ -8,11 +8,6 @@
 
 use Automattic\Jetpack\Device_Detection;
 
-// We may have been loaded before the autoloader, so load the necessary class manually.
-if ( defined( 'JETPACK_PLUGIN_LOADER_PATH' ) && ! class_exists( Device_Detection::class ) ) {
-	require_once JETPACK_PLUGIN_LOADER_PATH . '/jetpack_vendor/automattic/jetpack-device-detection/src/class-device-detection.php';
-}
-
 /**
  * Determine if the current User Agent matches the passed $kind
  *

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 11.6-a.1
+ * Version: 11.6-a.2
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -32,7 +32,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.0' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '11.6-a.1' );
+define( 'JETPACK__VERSION', '11.6-a.2' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "11.6.0-a.1",
+	"version": "11.6.0-a.2",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The definition of `jetpack_is_mobile()` was removed from `class.jetpack-user-agent.php` back around Jetpack 8.7 time. We brought it back (via a `require_once`) in 11.5 as part of de-Fusioning the file since wpcom had never gotten the removal.

Unfortunately this triggered something to break in WP Super Cache: it had been loading `class.jetpack-user-agent.php` from a code path run before Jetpack itself gets loaded so it could call `jetpack_is_mobile()`, but managed not to break when the function was removed. OTOH, now that we brought it back in a form that depends on Jetpack's autoloader being set, it's breaking.

As a quick fix we can restore the status quo in Jetpack, having `class.jetpack-user-agent.php` no longer define `jetpack_is_mobile()`. On the wpcom side, we can just make sure the de-Fusioned stub requires both files (and the necessary should-be-autoloader-but-autoloader-isn't-set-up-yet files too).

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1667333509090869-slack-C01U2KGS2PQ
Probably fixes #27213
Works around Automattic/jpop-issues#7868, but I'm not going to say "fixes" because the real fix should be in WP Super Cache.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Do this to test WP Super Cache
  * Install Jetpack (this branch) and WP Super Cache.
  * Since you probably used Jetpack Beta to install this branch, switch it to "latest stable". Then move `wp-content/plugins/jetpack-dev` to some other name, as the bug does not occur if that specific path exists.
  * In Super Cache, turn caching on in the Easy tab, then enable "Mobile device support" in the Advanced tab and "Jetpack Mobile Theme" in the Plugins tab.
  * Load the blog homepage in a private mode / incognito tab. It should break as described in the linked issues.
  * Delete `wp-content/plugins/jetpack` and move the folder that was previously at `wp-content/plugins/jetpack-dev` to `wp-content/plugins/jetpack`.
  * Load the blog homepage in a private mode / incognito tab. It should no longer be broken.
* Also load this along with D90372-code onto wpcom and make sure that works too.