### PR TITLE
Image Editor: Fix image edits not persisting or restoring

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.media.php
+++ b/projects/plugins/jetpack/_inc/lib/class.media.php
@@ -69,7 +69,7 @@ class Jetpack_Media {
 
 		do {
 			$filename  = $filename_base;
-			$filename .= $number_suffix;
+			$filename .= "e{$number_suffix}";
 			$file_ext  = $new_file_ext ? $new_file_ext : $current_file_ext;
 
 			$new_filename = "{$filename}.{$file_ext}";

--- a/projects/plugins/jetpack/_inc/lib/class.media.php
+++ b/projects/plugins/jetpack/_inc/lib/class.media.php
@@ -322,9 +322,9 @@ class Jetpack_Media {
 	 *
 	 * Also, it removes the file defined in each item.
 	 *
-	 * @param int    $media_id - media post ID.
-	 * @param object $criteria - criteria to remove the items.
-	 * @param array  $revision_history - revision history array.
+	 * @param int   $media_id - media post ID.
+	 * @param array $criteria - criteria to remove the items.
+	 * @param array $revision_history - revision history array.
 	 *
 	 * @return array `revision_history` array updated.
 	 */

--- a/projects/plugins/jetpack/changelog/fix-image-editing
+++ b/projects/plugins/jetpack/changelog/fix-image-editing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Fix issue where users are not able to edit/crop and restore images.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-edit-media-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-edit-media-v1-2-endpoint.php
@@ -354,7 +354,7 @@ class WPCOM_JSON_API_Edit_Media_v1_2_Endpoint extends WPCOM_JSON_API_Update_Medi
 	 */
 	private function restore_original( $media_id, $original_media ) {
 		$revisions = (array) Jetpack_Media::get_revision_history( $media_id );
-		$criteria  = (object) array(
+		$criteria  = array(
 			'from' => 0,
 			'to'   => REVISION_HISTORY_MAXIMUM_AMOUNT,
 		);

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-edit-media-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-edit-media-v1-2-endpoint.php
@@ -354,10 +354,17 @@ class WPCOM_JSON_API_Edit_Media_v1_2_Endpoint extends WPCOM_JSON_API_Update_Medi
 	 */
 	private function restore_original( $media_id, $original_media ) {
 		$revisions = (array) Jetpack_Media::get_revision_history( $media_id );
+		$revisions = array_filter(
+			$revisions,
+			function ( $revision ) use ( $original_media ) {
+				return $revision->file !== $original_media->file;
+			}
+		);
 		$criteria  = array(
 			'from' => 0,
 			'to'   => REVISION_HISTORY_MAXIMUM_AMOUNT,
 		);
+
 		Jetpack_Media::remove_items_from_revision_history( $media_id, $criteria, $revisions );
 		$file           = get_attached_file( $media_id );
 		$file_parts     = pathinfo( $file );

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-edit-media-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-edit-media-v1-2-endpoint.php
@@ -2,7 +2,7 @@
 
 require_once JETPACK__PLUGIN_DIR . '_inc/lib/class.media.php';
 
-define( 'REVISION_HISTORY_MAXIMUM_AMOUNT', 0 );
+define( 'REVISION_HISTORY_MAXIMUM_AMOUNT', 5 );
 define( 'WP_ATTACHMENT_IMAGE_ALT', '_wp_attachment_image_alt' );
 
 new WPCOM_JSON_API_Edit_Media_v1_2_Endpoint(
@@ -346,6 +346,31 @@ class WPCOM_JSON_API_Edit_Media_v1_2_Endpoint extends WPCOM_JSON_API_Update_Medi
 	}
 
 	/**
+	 * Restore the original media file.
+	 *
+	 * @param  {Number} $media_id       - media post ID.
+	 * @param  {Object} $original_media - orginal media data.
+	 * @return {Array}                  - restore media info.
+	 */
+	private function restore_original( $media_id, $original_media ) {
+		$revisions = (array) Jetpack_Media::get_revision_history( $media_id );
+		$criteria  = (object) array(
+			'from' => 0,
+			'to'   => REVISION_HISTORY_MAXIMUM_AMOUNT,
+		);
+		Jetpack_Media::remove_items_from_revision_history( $media_id, $criteria, $revisions );
+		$file           = get_attached_file( $media_id );
+		$file_parts     = pathinfo( $file );
+		$orginal_file   = path_join( $file_parts['dirname'], $original_media->file );
+		$restored_media = array(
+			'file' => $orginal_file,
+			'type' => $original_media->mime_type,
+		);
+
+		return $restored_media;
+	}
+
+	/**
 	 * API callback.
 	 *
 	 * @param string $path - the path.
@@ -402,7 +427,12 @@ class WPCOM_JSON_API_Edit_Media_v1_2_Endpoint extends WPCOM_JSON_API_Update_Medi
 				return $temporal_file;
 			}
 
-			$uploaded_file = $this->save_temporary_file( $temporal_file, $media_id );
+			// edited media is sent as $media_file and restored media is sent as $media_url
+			$should_restore = isset( $media_url ) && ! isset( $media_file ) && $has_original_media;
+
+			$uploaded_file = $should_restore
+				? $this->restore_original( $media_id, $has_original_media )
+				: $this->save_temporary_file( $temporal_file, $media_id );
 
 			if ( is_wp_error( $uploaded_file ) ) {
 				return $uploaded_file;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


Fixes https://github.com/Automattic/wp-calypso/issues/69441

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add `e` to filename suffix in `Jetpack_Media::generate_new_filename` , this suffix is used to determine if the image is an edited image or not. 
* Add a method `restore_original` to reconstruct the file information of the original media
* Check if we should restore file or create an edit, calypso sends a `media_url` for restorations and a `media_file` for edits or new uploads

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox this provided diff D91355-code
* run `bin/jetpack-downloader test jetpack fix/image-editing`
* Verify you are able to edit and restore media files/images
