### PR TITLE
Code quality: Add break statement to switch to avoid issues down the road

### DIFF
--- a/projects/plugins/jetpack/changelog/update-add-break-to-site-endpoint
+++ b/projects/plugins/jetpack/changelog/update-add-break-to-site-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Comment: Add a missing break statement in the site API endpoint

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -561,6 +561,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				break;
 			case 'p2_thumbnail_elements':
 				$response[ $key ] = $this->site->get_p2_thumbnail_elements();
+				break;
 		}
 
 		do_action( 'post_render_site_response_key', $key );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

When the `p2_thumbnail_elements` field was added to the sites API in #26863 I forgot to add a `break` statement in the switch statement that outputs fields. This doesn't have any observable effect because it just happens to be the last branch in the `switch` statement. But I want to tidy it up so it doesn't trip us up later down the road.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add a `break` to the `p2_thumbnail_elements` branch
* Add a "Comment" changelog entry ([described here](https://github.com/Automattic/jetpack/blob/trunk/docs/monorepo.md#using-the-jetpack-changelogger)) which should hide it from the public changelog

#### Other information:

- [ ] ~Have you written new tests for your changes, if applicable?~ code quality only, no observable effects
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to WP.com Console (https://developer.wordpress.com/docs/api/console/)
* confirm that /me/sites endpoint still works correctly

