### PR TITLE
Add/site editor dashboard link setting [WIP]

### DIFF
--- a/projects/plugins/jetpack/changelog/add-site-editor-dashboard-link-setting
+++ b/projects/plugins/jetpack/changelog/add-site-editor-dashboard-link-setting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Update dashboard link editor setting

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -467,7 +467,9 @@ class Jetpack_Gutenberg {
 			return false;
 		}
 
-		add_filter( 'block_editor_settings_all', array( 'Jetpack_Gutenberg', 'update_editor_dashboard_link_setting' ), 10, 2 );
+		if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || ( new Host() )->is_woa_site() ) {
+			add_filter( 'block_editor_settings_all', array( 'Jetpack_Gutenberg', 'update_editor_dashboard_link_setting' ), 10, 2 );
+		}
 
 		/**
 		 * Filter to disable Gutenberg blocks

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -467,6 +467,8 @@ class Jetpack_Gutenberg {
 			return false;
 		}
 
+		add_filter( 'block_editor_settings_all', array( 'Jetpack_Gutenberg', 'update_editor_dashboard_link_setting' ), 10, 2 );
+
 		/**
 		 * Filter to disable Gutenberg blocks
 		 *
@@ -1198,6 +1200,18 @@ class Jetpack_Gutenberg {
 
 			return null;
 		};
+	}
+
+	/**
+	 * Update __experimentalDashboardLink setting to pass to block editor.
+	 *
+	 * @param array $setting Default editor settings.
+	 * @return array
+	 */
+	public function update_editor_dashboard_link_setting( $setting ) {
+		$site_slug                              = get_blog_details( get_current_blog_id(), false )->domain;
+		$setting['__experimentalDashboardLink'] = 'https://wordpress.com/home/' . $site_slug;
+		return $setting;
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Due to changes in Gutenberg 14.5, the slot fill mechanism to override the site editor's dashboard link will no longer be available. The navigation panel will now rely on an editor setting to allow overrides to the dashboard link.

These changes will make use of the `block_editor_settings_all` filter to update the editor `__experimentalDashboardLink` setting.

<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

