### PR TITLE
Improve post-count="3" width precision

### DIFF
--- a/projects/plugins/jetpack/changelog/try-fix-related-posts-grid-precision
+++ b/projects/plugins/jetpack/changelog/try-fix-related-posts-grid-precision
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Related Posts Block: when 3 posts are outputted, increase the width to closer to 100%

--- a/projects/plugins/jetpack/extensions/blocks/related-posts/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/related-posts/style.scss
@@ -11,7 +11,7 @@
 		}
 
 		&[data-post-count='3'] .jp-related-posts-i2__post {
-			max-width: calc( 33% - 20px );
+			max-width: calc( 33.33333333% - 20px );
 		}
 
 		&[data-post-count='2'] .jp-related-posts-i2__post,


### PR DESCRIPTION
When using the Related Post block with `3` columns the grid doesn't expand the full width of the container because the CSS math only adds up to `99%`. This PR updates the precision to include more decimal places. Although I'm not sure what the perfect number of decimal places would be, I have copied the weather-tested bootstrap's precision: `33.33333333` for this PR.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds more decimals places to get closer to `100%` (Effectively 100% in browsers)

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Nope

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add the Related Post block to a container with a visible background color
* View the front end, notice that you can see the background to the right of the last block.
* Apply this PR, you should no longer see space to the right of the last block.

### Screenshots
| Before | After |
| --- | --- |
| <img width="699" alt="Screen Shot 2022-11-02 at 8 30 01 PM" src="https://user-images.githubusercontent.com/1657336/199482392-1c3005b6-6449-407a-8154-975333f2135b.png"> | <img width="696" alt="Screen Shot 2022-11-02 at 8 30 16 PM" src="https://user-images.githubusercontent.com/1657336/199482375-bce14c78-06ce-4374-8fb6-a5cfe729a325.png"> | 

