### PR TITLE
Jetpack Boost E2E Fix: 6.1 Removed a default theme (twentytwenty)

### DIFF
--- a/projects/plugins/boost/changelog/boost-fix-e2e-borken-theme
+++ b/projects/plugins/boost/changelog/boost-fix-e2e-borken-theme
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed E2E Tests
+
+

--- a/projects/plugins/boost/tests/e2e/specs/critical-css.test.js
+++ b/projects/plugins/boost/tests/e2e/specs/critical-css.test.js
@@ -82,7 +82,7 @@ test.describe( 'Critical CSS module', () => {
 		await DashboardPage.visit( page );
 		await ( await Sidebar.init( page ) ).selectThemes();
 		const themesPage = await ThemesPage.init( page );
-		await themesPage.activateTheme( 'twentytwenty' );
+		await themesPage.activateTheme( 'twentytwentytwo' );
 		expect(
 			await themesPage.isElementVisible( 'text=Jetpack Boost - Action Required' )
 		).toBeTruthy();


### PR DESCRIPTION
Fixes E2E Tests

#### Changes proposed in this Pull Request:
E2E Tests were breaking because `twentytwenty` is no longer bundled by default in WordPress 6.1

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Run the E2E Tests