### PR TITLE
actions: Fix slack-workflow-failed workflow (again)

### DIFF
--- a/.github/workflows/slack-workflow-failed.yml
+++ b/.github/workflows/slack-workflow-failed.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           source .github/files/gh-funcs.sh
 
-          set_output message "$(
+          gh_set_output message "$(
             jq -nc --slurpfile event "$GITHUB_EVENT_PATH" '$event[0] as $e | $e.workflow_run as $run | {
               icon_emoji: ":github-rejected:",
               text: "*\( $e.workflow.name ) failed on \( $run.head_branch )*\n<\( $run.html_url )|Run #\( $run.id )>",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
In #26800 we added use of a shared function to replace the deprecated set-output command. Then in #27205 we tried to fix it, but that just revealed another problem.

Hopefully this is the last problem. It'd be nice if this weren't so hard to test.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Maybe copy this into another repo, with appropriate secrets set, then have something fail to trigger it?
  * [x] https://github.com/anomiex/jetpack/actions/runs/3379327560/jobs/5610735619