### PR TITLE
VideoPress: Add video chapters style control

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-video-chapters-style-control
+++ b/projects/packages/videopress/changelog/add-videopress-video-chapters-style-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Add video chapters style selector component

--- a/projects/packages/videopress/src/client/block-editor/components/video-chapters-style-control/index.jsx
+++ b/projects/packages/videopress/src/client/block-editor/components/video-chapters-style-control/index.jsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import {
+	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line wpcalypso/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption, // eslint-disable-line wpcalypso/no-unsafe-wp-apis
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const VideoChaptersStyleControl = ( { value, onChange } ) => (
+	<ToggleGroupControl
+		label={ __( 'Style', 'jetpack-videopress-pkg' ) }
+		value={ value }
+		isBlock
+		onChange={ onChange }
+	>
+		<ToggleGroupControlOption
+			value="thumbnails"
+			label={ __( 'Thumbnails', 'jetpack-videopress-pkg' ) }
+		/>
+		<ToggleGroupControlOption value="list" label={ __( 'List', 'jetpack-videopress-pkg' ) } />
+	</ToggleGroupControl>
+);
+
+export default VideoChaptersStyleControl;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #27195

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Adds a style selector to be used on the video chapters block

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

As the block is not implemented yet to use the component, a visual verification should be enough

![2022-11-02_15-53-52](https://user-images.githubusercontent.com/8486249/199577191-dcdc20a6-6a0a-47e6-a53f-dee7b7831365.png)
