### PR TITLE
Unhide customizer from block themes

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-unhide-customizer-from-block-themes
+++ b/projects/plugins/jetpack/changelog/fix-unhide-customizer-from-block-themes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Removing the Customizer link breaks other plugins that rely on it.

--- a/projects/plugins/jetpack/modules/custom-css/custom-css-4.7.php
+++ b/projects/plugins/jetpack/modules/custom-css/custom-css-4.7.php
@@ -1,7 +1,6 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
 use Automattic\Jetpack\Assets;
-use Automattic\Jetpack\Blocks;
 
 /**
  * Alternate Custom CSS source for 4.7 compat.
@@ -45,25 +44,6 @@ class Jetpack_Custom_CSS_Enhancements {
 		add_filter( 'editor_max_image_size', array( __CLASS__, 'editor_max_image_size' ), 10, 3 );
 		add_action( 'template_redirect', array( __CLASS__, 'set_content_width' ) );
 		add_action( 'admin_init', array( __CLASS__, 'set_content_width' ) );
-
-		// Remove the Customizer link from the menu to avoid additional confusion if the site is a FSE themed site.
-		if ( wp_is_block_theme() || Blocks::is_fse_theme() ) {
-			if ( isset( $_SERVER['REQUEST_URI'] ) ) {
-				add_action(
-					'admin_menu',
-					function () {
-						remove_submenu_page(
-							'themes.php',
-							add_query_arg(
-								'return',
-								rawurlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ),  // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-								'customize.php'
-							)
-						);
-					}
-				);
-			}
-		}
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/wp-calypso#60732

#### Changes proposed in this Pull Request:
* stop hiding the Customizer admin menu link for block themes, introduced in #23670 

As seen in Automattic/wp-calypso#60732, we have customers with other Customizer-reliant plugins who are poorly served by this change. If we really wanted to replicate the desired behaviour in #23670, we could check to see if there are any actions _other than Custom CSS_ on the `customize_register` hook and act accordingly. In the meantime, it was a well-intentioned change with unintended breakage for WoA customers. 


#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
1. Load this patch on a Jetpack or WoA site
2. Ensure a block theme is active, or activate one (eg Twenty Twenty Two)
3. Verify that Appearance --> Customizer exists in the admin menu