### PR TITLE
VideoPress: New Control in VideoPress Block to Add VideoChapters Block

### DIFF
--- a/projects/packages/videopress/changelog/add-video-chapter-block
+++ b/projects/packages/videopress/changelog/add-video-chapter-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Adding the new Video Chapter block.

--- a/projects/packages/videopress/composer.json
+++ b/projects/packages/videopress/composer.json
@@ -64,7 +64,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.6.x-dev"
+			"dev-trunk": "0.7.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-package-version.php"

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.6.6-alpha",
+	"version": "0.7.0-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.6.6-alpha';
+	const PACKAGE_VERSION = '0.7.0-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/client/block-editor/plugins/video-chapters/components/details-control/index.js
+++ b/projects/packages/videopress/src/client/block-editor/plugins/video-chapters/components/details-control/index.js
@@ -70,10 +70,14 @@ export default function DetailsControl( { attributes, setAttributes, isRequestin
 			/>
 
 			{ !! attributes.tracks.length && (
-				<Notice status={ 'success' } isDismissable={ true }>
-					<div>
+				<Notice
+					className={ 'jetpack-videopress-videochapters-prompt' }
+					status={ 'success' }
+					isDismissable={ true }
+				>
+					<p>
 						{ __( 'We detected chapters in your video Description', 'jetpack-videopress-pkg' ) }
-					</div>
+					</p>
 
 					<Button variant="primary">
 						{ __( 'Add chapters list to post', 'jetpack-videopress-pkg' ) }

--- a/projects/packages/videopress/src/client/block-editor/plugins/video-chapters/components/details-control/index.js
+++ b/projects/packages/videopress/src/client/block-editor/plugins/video-chapters/components/details-control/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { PanelBody, TextareaControl, TextControl } from '@wordpress/components';
+import { Button, Notice, PanelBody, TextareaControl, TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -60,10 +60,26 @@ export default function DetailsControl( { attributes, setAttributes, isRequestin
 				label={ __( 'Description', 'jetpack-videopress-pkg' ) }
 				value={ description }
 				placeholder={ __( 'Video description', 'jetpack-videopress-pkg' ) }
+				help={ __(
+					'These details are reflected wherever the video is shown.',
+					'jetpack-videopress-pkg'
+				) }
 				onChange={ setDescriptionAttribute }
 				rows={ descriptionControlRows }
 				disabled={ isRequestingVideoData }
 			/>
+
+			{ !! attributes.tracks.length && (
+				<Notice status={ 'success' } isDismissable={ true }>
+					<div>
+						{ __( 'We detected chapters in your video Description', 'jetpack-videopress-pkg' ) }
+					</div>
+
+					<Button variant="primary">
+						{ __( 'Add chapters list to post', 'jetpack-videopress-pkg' ) }
+					</Button>
+				</Notice>
+			) }
 		</PanelBody>
 	);
 }

--- a/projects/packages/videopress/src/client/block-editor/plugins/video-chapters/components/details-control/index.js
+++ b/projects/packages/videopress/src/client/block-editor/plugins/video-chapters/components/details-control/index.js
@@ -3,6 +3,7 @@
  */
 import { Button, Notice, PanelBody, TextareaControl, TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
 /**
  * Internal dependencies
  */
@@ -22,6 +23,11 @@ const CHARACTERS_PER_LINE = 31;
 export default function DetailsControl( { attributes, setAttributes, isRequestingVideoData } ) {
 	const { title, description } = attributes;
 	const isBeta = true;
+	const [ dismiss, setDismiss ] = useState( false );
+
+	const onRemove = () => {
+		setDismiss( true );
+	};
 
 	// Expands the description textarea to accommodate the description
 	const minRows = 4;
@@ -69,11 +75,12 @@ export default function DetailsControl( { attributes, setAttributes, isRequestin
 				disabled={ isRequestingVideoData }
 			/>
 
-			{ !! attributes.tracks.length && (
+			{ ! dismiss && !! attributes.tracks.length && (
 				<Notice
 					className={ 'jetpack-videopress-videochapters-prompt' }
 					status={ 'success' }
 					isDismissable={ true }
+					onRemove={ onRemove }
 				>
 					<p>
 						{ __( 'We detected chapters in your video Description', 'jetpack-videopress-pkg' ) }

--- a/projects/packages/videopress/src/client/block-editor/plugins/video-chapters/components/details-control/index.scss
+++ b/projects/packages/videopress/src/client/block-editor/plugins/video-chapters/components/details-control/index.scss
@@ -37,3 +37,7 @@
 		}
 	}
 }
+
+.jetpack-videopress-videochapters-prompt.components-notice {
+	margin: 0;
+}

--- a/projects/plugins/jetpack/changelog/add-video-chapter-block
+++ b/projects/plugins/jetpack/changelog/add-video-chapter-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -42,7 +42,7 @@
 		"automattic/jetpack-stats": "0.3.x-dev",
 		"automattic/jetpack-status": "1.14.x-dev",
 		"automattic/jetpack-sync": "1.41.x-dev",
-		"automattic/jetpack-videopress": "0.6.x-dev",
+		"automattic/jetpack-videopress": "0.7.x-dev",
 		"automattic/jetpack-waf": "0.6.x-dev",
 		"automattic/jetpack-wordads": "0.2.x-dev",
 		"nojimage/twitter-text-php": "3.1.2"

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8d3312d130608ac19b1f425dff864fb6",
+    "content-hash": "8ebcbc7d39d0941855909134f5c3454b",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -2010,7 +2010,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/videopress",
-                "reference": "bd9f416b3539b9e28fd895efbd94a0cc7807393d"
+                "reference": "640a6ba4243aac2ef59e6b411372816fea138146"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -2032,7 +2032,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.6.x-dev"
+                    "dev-trunk": "0.7.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-package-version.php"

--- a/projects/plugins/videopress/changelog/add-video-chapter-block
+++ b/projects/plugins/videopress/changelog/add-video-chapter-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/videopress/composer.json
+++ b/projects/plugins/videopress/composer.json
@@ -13,7 +13,7 @@
 		"automattic/jetpack-my-jetpack": "2.3.x-dev",
 		"automattic/jetpack-sync": "1.41.x-dev",
 		"automattic/jetpack-plugins-installer": "0.2.x-dev",
-		"automattic/jetpack-videopress": "0.6.x-dev"
+		"automattic/jetpack-videopress": "0.7.x-dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.0.3",

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3633243872fd6dcebf0caedfef12040a",
+    "content-hash": "cb8de38942a61a1a790464d72551ceb0",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1277,7 +1277,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/videopress",
-                "reference": "bd9f416b3539b9e28fd895efbd94a0cc7807393d"
+                "reference": "640a6ba4243aac2ef59e6b411372816fea138146"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -1299,7 +1299,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.6.x-dev"
+                    "dev-trunk": "0.7.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-package-version.php"


### PR DESCRIPTION
Part of: #27206

#### Changes proposed in this Pull Request:
Add a new editor block named VideoChapters. This block pairs with a VideoPress block to provide interactive chapter controls. Using a new block allows users great flexibility in how the chapters are displayed relative to the video.

The changes will affect the following:
* Jetpack
* VideoPress

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion


#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:
1. Ensure that [beta extensions](https://github.com/Automattic/jetpack/tree/trunk/projects/plugins/jetpack/extensions#beta-extensions) are enabled.
2. Modify the description of a VideoPress block to include chapters in the following format:
```00:00 description
01:35 description
04:57 description
12:10 description
```
3. Save the post/page.
4. You should see a prompt to add a VideoChapters block similar to the following image (styling is being updated):
![videochapters-prompt](https://user-images.githubusercontent.com/56307/199593267-db1dd659-b43e-4f60-b1e3-89d07d5abaf9.png)