### PR TITLE
VideoPress: Add initial layout for Video Chapters block

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-chapter-initial-layout
+++ b/projects/packages/videopress/changelog/add-videopress-chapter-initial-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Introduce initial layout for chapters

--- a/projects/packages/videopress/src/client/block-editor/blocks/video-chapters/edit.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video-chapters/edit.js
@@ -4,14 +4,12 @@
 /**
  * WordPress dependencies
  */
-import { BlockIcon, useBlockProps } from '@wordpress/block-editor';
-import { Placeholder } from '@wordpress/components';
-import { formatListNumbered as ChaptersIcon } from '@wordpress/icons';
+import { useBlockProps } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
-import { description, title } from '.';
-
+import classNames from 'classnames';
+import useChapters from './hooks/use-chapters';
 import './editor.scss';
 
 /**
@@ -30,19 +28,30 @@ export default function VideoPressChaptersEdit( {
 	isSelected,
 	clientId,
 } ) {
+	const chapters = useChapters();
+
 	const blockProps = useBlockProps( {
-		className: 'wp-block-jetpack-videopress-chapters',
+		className: 'wp-block-jetpack-video-chapters',
 	} );
 
 	return (
 		<div { ...blockProps }>
-			<Placeholder
-				icon={ <BlockIcon icon={ ChaptersIcon } /> }
-				instructions={ description }
-				label={ title }
-			>
-				<div />
-			</Placeholder>
+			<ul className="video-chapters_list">
+				{ chapters.map( ( { chapter, time }, index ) => (
+					<li
+						className={ classNames( 'video-chapters__item', {
+							// At block we just provide an way of user see the three states, not interact with them.
+							// - Not selected
+							// - Selected
+							// - Hover
+							selected: 0 === index,
+						} ) }
+					>
+						<span>{ chapter }</span>
+						<span>{ time }</span>
+					</li>
+				) ) }
+			</ul>
 		</div>
 	);
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video-chapters/editor.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video-chapters/editor.scss
@@ -1,1 +1,31 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
+
+.wp-block-jetpack-video-chapters {
+    .video-chapters_list {
+        list-style: none;
+        padding: 8px;
+
+        .video-chapters__item {
+            cursor: pointer;
+            width: 100%;
+            padding: 8px 12px;
+            font-weight: 400;
+            font-size: 14px;
+            line-height: 17px;
+            border-radius: 4px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+
+            &:hover {
+                color: #f6f7f7;
+                background-color: #787c82;
+            }
+
+            &.selected {
+                color: #f6f7f7;
+                background-color: #101517;
+            }
+        }
+    }
+}

--- a/projects/packages/videopress/src/client/block-editor/blocks/video-chapters/hooks/use-chapters.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video-chapters/hooks/use-chapters.js
@@ -1,0 +1,16 @@
+export default () => {
+	return [
+		{
+			chapter: 'Chapter 1',
+			time: '00:00',
+		},
+		{
+			chapter: 'Chapter 2',
+			time: '02:00',
+		},
+		{
+			chapter: 'Chapter 3',
+			time: '04:00',
+		},
+	];
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Introduce initial layout for `Video Chapters` block.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate `VideoPress` block.
* Create a new post.
* Insert the `Video Chapters` block.
* You should see the mocked list.

