### PR TITLE
VideoPress: render VideoChapters block on the backend

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-render-chapters
+++ b/projects/packages/videopress/changelog/add-videopress-render-chapters
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added rendering to VideoPress chapters block.

--- a/projects/packages/videopress/src/class-chapters.php
+++ b/projects/packages/videopress/src/class-chapters.php
@@ -29,7 +29,7 @@ class Chapters {
 		);
 
 		if ( is_wp_error( $result ) || 200 !== wp_remote_retrieve_response_code( $result ) ) {
-			wp_send_json_error( array( 'message' => __( 'Could not fetch VideoPress chapters. Please try again later.', 'jetpack-videopress-pkg' ) ) );
+			l( 'Error when fetching chapters for GUID ' . $video_guid );
 
 			return array();
 		}
@@ -51,16 +51,32 @@ class Chapters {
 			return '';
 		}
 
-		$html = '<ul>';
+		$html = '<div class="video-chapters_list" data-guid="' . $video_guid . '"><ul>';
 		foreach ( $chapters['chapters']['en'] as $chapter ) {
 			$html .= sprintf(
-				'<li><a href="#">%s</a> %s</li>',
-				esc_html( $chapter['start'] ),
-				esc_html( $chapter['description'] )
+				'<li><div class="video-chapters__item"><a class="video-chapters__text" href="#" data-time="%s">%s</a> %s</div></li>',
+				esc_attr( $chapter['start'] ),
+				esc_html( $chapter['description'] ),
+				esc_html( self::format_time_from_ms( $chapter['start'] ) )
 			);
 		}
-		$html .= '</ul>';
+		$html .= '</ul></div>';
 
 		return $html;
+	}
+
+	/**
+	 * Convert time in milliseconds to mm:ss or hh:mm:ss format.
+	 *
+	 * @param int $timestamp Timestamp in milliseconds. Must be shorter than 24h.
+	 *
+	 * @return string Time in mm:ss or hh:mm:ss
+	 */
+	protected static function format_time_from_ms( $timestamp ) {
+		$utc     = new \DateTimeZone( 'UTC' );
+		$seconds = (int) floor( $timestamp / 1000 );
+		$date    = \DateTime::createFromFormat( 'U', $seconds, $utc );
+
+		return $date->format( $seconds > 3600 ? 'H:i:s' : 'i:s' );
 	}
 }

--- a/projects/packages/videopress/src/class-chapters.php
+++ b/projects/packages/videopress/src/class-chapters.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * This file provides the Chapters class.
+ *
+ * @package automattic/jetpack
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * The Chapters class.
+ * This class provides methods for fetching and rendering chapters.
+ */
+class Chapters {
+	/**
+	 * Fetch chapters for a given video, based on the uploaded VTT file.
+	 *
+	 * @param string $video_guid GUID of the video.
+	 *
+	 * @return array
+	 */
+	public static function fetch_chapters( $video_guid ) {
+		$result = Client::wpcom_json_api_request_as_blog(
+			'/videos/' . $video_guid . '/chapters',
+			'1.1',
+			array()
+		);
+
+		if ( is_wp_error( $result ) || 200 !== wp_remote_retrieve_response_code( $result ) ) {
+			wp_send_json_error( array( 'message' => __( 'Could not fetch VideoPress chapters. Please try again later.', 'jetpack-videopress-pkg' ) ) );
+
+			return array();
+		}
+
+		return json_decode( wp_remote_retrieve_body( $result ), true );
+	}
+
+	/**
+	 * Return HTML markup for video chapters.
+	 *
+	 * @param string $video_guid GUID of the video.
+	 *
+	 * @return string HTML markup
+	 */
+	public static function render_chapters( $video_guid ) {
+		$chapters = self::fetch_chapters( $video_guid );
+		// @todo: figure out how to choose the language
+		if ( ! $chapters || ! isset( $chapters['chapters']['en'] ) ) {
+			return '';
+		}
+
+		$html = '<ul>';
+		foreach ( $chapters['chapters']['en'] as $chapter ) {
+			$html .= sprintf(
+				'<li><a href="#">%s</a> %s</li>',
+				esc_html( $chapter['start'] ),
+				esc_html( $chapter['description'] )
+			);
+		}
+		$html .= '</ul>';
+
+		return $html;
+	}
+}

--- a/projects/packages/videopress/src/class-chapters.php
+++ b/projects/packages/videopress/src/class-chapters.php
@@ -48,7 +48,12 @@ class Chapters {
 	 * @return string HTML markup
 	 */
 	public static function render_chapters( $video_guid ) {
-		$chapters = self::fetch_chapters( $video_guid );
+		$chapters_response = self::fetch_chapters( $video_guid );
+		if ( $chapters_response['error'] ) {
+			return '';
+		}
+		$chapters = $chapters_response['chapters'];
+
 		// @todo: figure out how to choose the language
 		if ( ! $chapters || ! isset( $chapters['chapters']['en'] ) ) {
 			return '';

--- a/projects/packages/videopress/src/class-chapters.php
+++ b/projects/packages/videopress/src/class-chapters.php
@@ -31,7 +31,10 @@ class Chapters {
 		if ( is_wp_error( $result ) || 200 !== wp_remote_retrieve_response_code( $result ) ) {
 			l( 'Error when fetching chapters for GUID ' . $video_guid );
 
-			return array();
+			return array(
+				'chapters' => array(),
+				'error'    => true,
+			);
 		}
 
 		return json_decode( wp_remote_retrieve_body( $result ), true );

--- a/projects/packages/videopress/src/class-chapters.php
+++ b/projects/packages/videopress/src/class-chapters.php
@@ -49,7 +49,7 @@ class Chapters {
 	 */
 	public static function render_chapters( $video_guid ) {
 		$chapters_response = self::fetch_chapters( $video_guid );
-		if ( $chapters_response['error'] ) {
+		if ( isset( $chapters_response['error'] ) && $chapters_response['error'] ) {
 			return '';
 		}
 		$chapters = $chapters_response['chapters'];

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -230,8 +230,7 @@ class Initializer {
 			$videopress_chapters_metadata_file,
 			array(
 				'render_callback' => function ( $attributes, $content, $block ) {
-					// @todo figure out how to fetch the guid
-					$guid = 'MNCGFUQp';
+					$guid = $attributes['guid'];
 					return Chapters::render_chapters( $guid );
 				},
 			)

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -226,6 +226,15 @@ class Initializer {
 			return;
 		}
 
-		register_block_type( $videopress_chapters_metadata_file );
+		register_block_type(
+			$videopress_chapters_metadata_file,
+			array(
+				'render_callback' => function ( $attributes, $content, $block ) {
+					// @todo figure out how to fetch the guid
+					$guid = 'MNCGFUQp';
+					return Chapters::render_chapters( $guid );
+				},
+			)
+		);
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This PR adds rendering chapters block on the backend. The data is fetched from public-api, endpoint added in D91445-code

Currently, it uses a hard-coded GUID, so I'm marking it as a draft.

<img width="439" alt="image" src="https://user-images.githubusercontent.com/6437642/199633255-6644f8d1-fd4b-4b3e-9a2d-582a776c9ab4.png">

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
pe4Cmx-qW-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Have D91445-code on your sandbox and set `JETPACK__SANDBOX_DOMAIN`.
* Follow instructions from https://github.com/Automattic/jetpack/pull/27241 to create a post with the VideoChapters block.
* Check that it is rendered when viewing the post - for now in a pretty simple style.