### PR TITLE
[Super Cache] Exclude .phpcs.dir.xml from builds

### DIFF
--- a/projects/plugins/super-cache/.gitattributes
+++ b/projects/plugins/super-cache/.gitattributes
@@ -10,6 +10,7 @@ package.json      export-ignore
 # Files to exclude from the mirror repo, but included in the monorepo.
 # Remember to end all directories with `/**` to properly tag every file.
 .gitignore        production-exclude
+.phpcs.dir.xml    production-exclude
 changelog/**      production-exclude
 phpunit.xml.dist  production-exclude
 tests/**          production-exclude

--- a/projects/plugins/super-cache/changelog/super-cache-exclude-phpcs-file
+++ b/projects/plugins/super-cache/changelog/super-cache-exclude-phpcs-file
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Added .phpcs.dir.xml git attributes to exclude it from production builds
+
+


### PR DESCRIPTION
Related: https://github.com/Automattic/jetpack/pull/26757

Adds a git-attribute for `.phpcs.dir.xml` to exclude it from production builds.

#### Changes proposed in this Pull Request:
* Exclude `phpcs.dir.xml` from prod builds

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Just look at the change.

