### PR TITLE
git hooks: Improve post-checkout/post-merge hook

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-./tools/js-tools/git-hooks/post-merge-checkout-hook.sh
+./tools/js-tools/git-hooks/post-merge-checkout-hook.sh "$1"

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-./tools/js-tools/git-hooks/post-merge-checkout-hook.sh
+./tools/js-tools/git-hooks/post-merge-checkout-hook.sh ORIG_HEAD

--- a/tools/js-tools/git-hooks/post-merge-checkout-hook.sh
+++ b/tools/js-tools/git-hooks/post-merge-checkout-hook.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
 changedFiles="$(git -c core.quotepath=off diff-tree -r --name-only --no-commit-id "$1" HEAD)"
+SEP=$'---\n'
 
 runOnChange() {
-	echo "$changedFiles" | grep -q "^\($1\)" && echo -e "$2"
+	if echo "$changedFiles" | grep -q "^\($1\)"; then
+		echo -e "$SEP$2"
+		SEP=
+	fi
 }
 
 for f in $(git -c core.quotepath=off ls-files '**/composer.lock'); do

--- a/tools/js-tools/git-hooks/post-merge-checkout-hook.sh
+++ b/tools/js-tools/git-hooks/post-merge-checkout-hook.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
 
-changedFiles="$(git -c core.quotepath=off diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
+changedFiles="$(git -c core.quotepath=off diff-tree -r --name-only --no-commit-id "$1" HEAD)"
 
 runOnChange() {
-	echo "$changedFiles" | grep -q "^$1" && echo -e "$2"
+	echo "$changedFiles" | grep -q "^\($1\)" && echo -e "$2"
 }
 
-runOnChange 'pnpm-lock.yaml\|composer.lock' "A lock file has changed. Consider updating your working copy by running: jetpack install -r"
 for f in $(git -c core.quotepath=off ls-files '**/composer.lock'); do
 	slug="${f#projects/}"
 	slug="${slug%/composer.lock}"
 	runOnChange "$f" "$f has changed. Consider updating your working copy by running: jetpack install $slug"
 done
-runOnChange projects/packages/ "Files within the packages directory have changed. Consider running: jetpack install --all"
+runOnChange 'pnpm-lock.yaml\|composer.lock' "A monorepo root lock file has changed. Consider updating your working copy by running: jetpack install -r"
 
 exit 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Use correct previous ref for post-checkout, so it doesn't give spurious notifications comparing to whatever the last merge was.
* Remove "Files within the packages directory have changed" entirely. That probably made sense back in 2020 when we first added packages, but it doesn't now.
* When a monorepo root lock file changes, say that instead of just "A lockfile".
* Monorepo root message should not be printed when plugin composer.lock changes.
* List the monorepo root last, it's most important an doing it first means it tends to get lost.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Checkout tests

* `git fetch && git checkout --detach fix/post-checkout-hook && git reset --soft $(git merge-base trunk HEAD)`
  * This should get you into a state where the files changed in this PR are in the working copy, so later operations will use the changes from the PR.
* `git checkout 07f84aaa`
* `git checkout 4d27d240`
  * You should get the notification about "A monorepo root lock file has changed", but nothing about packages.
* `git checkout fe60dabd`
  * You should get the notification about "projects/plugins/super-cache/composer.lock" but nothing else.
* `git checkout 07f84aaa`
  * You should get both of the above notifications, and nothing else.

Merge test

* `git checkout --detach fix/post-checkout-hook`
* `git rebase --onto 07f84aaa trunk HEAD`
* `git merge 4d27d240`
  * You should get the notification about "A monorepo root lock file has changed", but nothing about packages.
* `git merge fe60dabd`
  * You should get the notification about "projects/plugins/super-cache/composer.lock" but nothing else.
* `git rebase --onto 07f84aaa trunk...HEAD`
* `git merge fe60dabd`
  * You should get both of the above notifications, and nothing else.
