### PR TITLE
jetpack rsync: Config: remove "clear all" option and add an "add" option

### DIFF
--- a/tools/cli/commands/rsync.js
+++ b/tools/cli/commands/rsync.js
@@ -92,14 +92,11 @@ async function promptToManageConfig() {
 		type: 'list',
 		name: 'manageConfig',
 		message: 'Manage saved destination paths.',
-		choices: [ 'list', 'clear all', 'remove' ],
+		choices: [ 'list', 'remove' ],
 	} );
 	if ( configManage.manageConfig === 'list' ) {
 		console.log( "Here's what you have saved:" );
 		console.log( rsyncConfigStore.all );
-	}
-	if ( configManage.manageConfig === 'clear' ) {
-		await promptClearAll();
 	}
 	if ( configManage.manageConfig === 'remove' ) {
 		const configKeys = Object.keys( rsyncConfigStore.all );

--- a/tools/cli/commands/rsync.js
+++ b/tools/cli/commands/rsync.js
@@ -92,11 +92,17 @@ async function promptToManageConfig() {
 		type: 'list',
 		name: 'manageConfig',
 		message: 'Manage saved destination paths.',
-		choices: [ 'list', 'remove' ],
+		choices: [ 'list', 'add', 'remove' ],
 	} );
 	if ( configManage.manageConfig === 'list' ) {
 		console.log( "Here's what you have saved:" );
 		console.log( rsyncConfigStore.all );
+	}
+	if ( configManage.manageConfig === 'add' ) {
+		const aliasDest = await promptNewDest();
+		if ( aliasDest ) {
+			await promptForSetAlias( aliasDest );
+		}
 	}
 	if ( configManage.manageConfig === 'remove' ) {
 		const configKeys = Object.keys( rsyncConfigStore.all );
@@ -280,7 +286,21 @@ async function promptForSetAlias( pluginDestPath ) {
 		message: 'Enter an alias for easier reference? (Press enter to skip.)',
 	} );
 	const alias = aliasSetPrompt.alias || pluginDestPath;
-	setRsyncDest( pluginDestPath, alias );
+	if ( rsyncConfigStore.has( escapeKey( alias ) ) ) {
+		const alreadyFound = await inquirer.prompt( {
+			name: 'overwrite',
+			type: 'confirm',
+			message: `This alias already exists for dest: ${ rsyncConfigStore.get(
+				escapeKey( alias )
+			) }. Overwrite it?`,
+		} );
+		if ( ! alreadyFound.overwrite ) {
+			console.log( 'Okay!' );
+			return;
+		}
+	}
+	await setRsyncDest( pluginDestPath, alias );
+	console.log( `Alias '${ alias }' saved for ${ pluginDestPath }` );
 }
 
 /**
@@ -300,25 +320,33 @@ async function maybePromptForDest( argv ) {
 	}
 	const savedDests = Object.keys( rsyncConfigStore.all );
 	savedDests.unshift( 'Create new' );
-	let response = await inquirer.prompt( {
+	const response = await inquirer.prompt( {
 		name: 'dest',
 		type: 'list',
 		message: 'Choose destination:',
 		choices: savedDests,
 	} );
 	if ( 'Create new' === response.dest ) {
-		response = await inquirer.prompt( {
-			name: 'dest',
-			type: 'input',
-			message:
-				"Input destination host:path to the plugin's dir or the /plugins or /mu-plugins dir: ",
-			validate: v => ( v === '' ? 'Please enter a host:path' : true ),
-		} );
-		argv.dest = response.dest;
+		argv.dest = await promptNewDest();
 	} else {
 		argv.dest = rsyncConfigStore.get( escapeKey( response.dest ) );
 	}
 	return argv;
+}
+
+/**
+ * Prompts for the destination.
+ *
+ * @returns {Promise<*|string>} - Destination path
+ */
+async function promptNewDest() {
+	const response = await inquirer.prompt( {
+		name: 'dest',
+		type: 'input',
+		message: "Input destination host:path to the plugin's dir or the /plugins or /mu-plugins dir: ",
+		validate: v => ( v === '' ? 'Please enter a host:path' : true ),
+	} );
+	return response.dest;
 }
 
 /**
@@ -384,7 +412,7 @@ export function rsyncDefine( yargs ) {
 					type: 'string',
 				} )
 				.option( 'config', {
-					describe: 'Remove or list saved destinations in the config.',
+					describe: 'List, add, or remove saved destinations in the config.',
 					type: 'boolean',
 				} );
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Updates to `jetpack rsync --config` options: 
- Removes "clear all" option. It didn't work. And the functionality already exists within the `remove` option. 
- New `add` option that allows someone to add an alias any time. Previously it was only prompted after a successful rsync. 

#### Other information:
N/A

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Bug with `clear all` was reported here: p1667486776654079/1667486016.639459-slack-C0299DMPG

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
Test the new `add` functionality:
- `jetpack rsync --config`
- Choose the `add` 
- Write a dest (pro tip: just use a local path like `/tmp/plugins` or something if you don't wanna bother with a live server)
- Write an alias 
- Then check if it was stored via the `list` option. 
- Then try saving a different destination with the same alias, it will ask you if you want to overwrite it or not. 
- Then use `remove` to remove it. 

Also make sure the regular rsync functionality works with aliases. There was a little bit of refactor. 