### PR TITLE
VideoPress: Ensure video properties exists before using them

### DIFF
--- a/projects/packages/videopress/changelog/fix-ensure-video-properties-exists-before-using-them
+++ b/projects/packages/videopress/changelog/fix-ensure-video-properties-exists-before-using-them
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Make sure media details are set before using them.

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -207,9 +207,9 @@ class Data {
 				$description = $jetpack_videopress['description'];
 				$caption     = $jetpack_videopress['caption'];
 
-				$width    = isset( $media_details['width'] ) ? $media_details['width'] : 0;
-				$height   = isset( $media_details['height'] ) ? $media_details['height'] : 0;
-				$duration = isset( $media_details['length'] ) ? $media_details['length'] : 0;
+				$width    = isset( $media_details['width'] ) ? $media_details['width'] : null;
+				$height   = isset( $media_details['height'] ) ? $media_details['height'] : null;
+				$duration = isset( $media_details['length'] ) ? $media_details['length'] : null;
 
 				return array(
 					'id'                     => $id,

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -207,9 +207,9 @@ class Data {
 				$description = $jetpack_videopress['description'];
 				$caption     = $jetpack_videopress['caption'];
 
-				$width    = $media_details['width'];
-				$height   = $media_details['height'];
-				$duration = $media_details['length'];
+				$width    = isset( $media_details['width'] ) ? $media_details['width'] : 0;
+				$height   = isset( $media_details['height'] ) ? $media_details['height'] : 0;
+				$duration = isset( $media_details['length'] ) ? $media_details['length'] : 0;
 
 				return array(
 					'id'                     => $id,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Relates to #27068.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Added checks around the use of some properties to make sure they are set
* Use `0` as the default value for `width`, `height` and `length` when the file misses it (as we will not have any other source for this info)

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure your WordPress installation has the WP_DEBUG enabled (using a local installation and changing it on `wp-config.php` is the simple way to ensure it)
* Download this file [contribute.zip](https://github.com/Automattic/jetpack/files/9938948/contribute.zip) and rename it, changing the `.zip` extension to `.mpg`
* Go to `Media > Add New` and upload the file
* Go to `Jetpack > VideoPress` and see that the uploaded file is in the list of local videos
* Check there is no notices related to missing `width`, `height` or `length` (both on the page itself as well as in the Query Monitor, if you have it set)

