### PR TITLE
Add global js flag to disable window.pushState

### DIFF
--- a/projects/packages/search/changelog/add-flag-to-disable-pushState-changes
+++ b/projects/packages/search/changelog/add-flag-to-disable-pushState-changes
@@ -1,4 +1,4 @@
 Significance: minor
-Type: other
+Type: added
 
 Add an optional global flag `window.instantSearchSkipPushState` that can be declared to true, that will disable instant search from modifying the url as the search query is being written or modified.

--- a/projects/packages/search/changelog/add-flag-to-disable-pushState-changes
+++ b/projects/packages/search/changelog/add-flag-to-disable-pushState-changes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add an optional global flag `window.instantSearchSkipPushState` that can be declared to true, that will disable instant search from modifying the url as the search query is being written or modified.

--- a/projects/packages/search/src/instant-search/lib/query-string.js
+++ b/projects/packages/search/src/instant-search/lib/query-string.js
@@ -19,6 +19,9 @@ export function getQuery( search = window.location.search ) {
  * @param {object|null} queryObject - a query object.
  */
 export function setQuery( queryObject ) {
+	if ( window.instantSearchSkipPushState ) {
+		return;
+	}
 	pushQueryString( encode( queryObject ) );
 }
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add an optional global flag `window.instantSearchSkipPushState` that can be declared to true, that will disable instant search from modifying the url as the search query is being written or modified.

#### Other information:

- *n/a* Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
Discussed this with @jsnmoon in slack, also with @cagrimmett -- this is to assist sites where leaking search terms to the url could result in the PII in search terms getting accidentally sent to third-party analytics providers.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Go to a site that has Jetpack Instant Search enabled and running.
* In the browser console, run `window.instantSearchSkipPushState = true`
* Searches in the Instant Search should no longer be reflected in the page url.
