### PR TITLE
Subscriptions: change 'email followers' to 'email subscribers'

### DIFF
--- a/projects/plugins/jetpack/_inc/client/discussion/subscriptions.jsx
+++ b/projects/plugins/jetpack/_inc/client/discussion/subscriptions.jsx
@@ -74,7 +74,7 @@ class SubscriptionsComponent extends React.Component {
 						site: this.props.siteRawUrl,
 					} ) }
 				>
-					{ __( 'View your Email Followers', 'jetpack' ) }
+					{ __( 'View your Email Subscribers', 'jetpack' ) }
 				</Card>
 			);
 		};

--- a/projects/plugins/jetpack/changelog/update-email-subscribers-card-text
+++ b/projects/plugins/jetpack/changelog/update-email-subscribers-card-text
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Subscriptions: change 'email followers' to 'email subscribers' to match Calypso Users page.
+
+


### PR DESCRIPTION
Fixes #27267

#### Changes proposed in this Pull Request:

On the `/wp-admin/admin.php?page=jetpack#/discussion` page, change card text `View your Email Followers` to `View your Email Subscribers`

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

More context on internal: pcmemI-Lt-p2
Looks like at least one doc could use minor updates: https://jetpack.com/support/subscriptions/

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

Proofread.