### PR TITLE
Jetpack: Issue deprecation warnings for `jetpack_require_lib()`

### DIFF
--- a/projects/plugins/jetpack/changelog/update-hard-deprecate-jetpack_require_lib
+++ b/projects/plugins/jetpack/changelog/update-hard-deprecate-jetpack_require_lib
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Deprecation warnings are now issued for `jetpack_require_lib()`, `jetpack_require_lib_dir()`, and the `jetpack_require_lib_dir` filter.

--- a/projects/plugins/jetpack/load-jetpack.php
+++ b/projects/plugins/jetpack/load-jetpack.php
@@ -11,12 +11,14 @@
  *
  * @since 4.0.2
  * @deprecated since 11.3 Use `JETPACK__PLUGIN_DIR . '_inc/lib/'` instead.
+ * @todo Remove this in Jetpack 11.9 (started issuing warnings in 11.6).
  *
  * @return string Location of Jetpack library directory.
  *
  * @filter require_lib_dir
  */
 function jetpack_require_lib_dir() {
+	_deprecated_function( __FUNCTION__, 'Jetpack 11.3', '`JETPACK__PLUGIN_DIR . \'_inc/lib/\'`' );
 	return JETPACK__PLUGIN_DIR . '_inc/lib';
 }
 add_filter( 'jetpack_require_lib_dir', 'jetpack_require_lib_dir' );

--- a/projects/plugins/jetpack/require-lib.php
+++ b/projects/plugins/jetpack/require-lib.php
@@ -9,12 +9,15 @@
  * Function for loading library files.
  *
  * @deprecated since 11.3 Load libraries directly (from `JETPACK__PLUGIN_DIR . '_inc/lib/'`) instead.
+ * @todo Remove this in Jetpack 11.9 (started issuing warnings in 11.6).
  *
  * @param string $slug Library slug.
  * @return void
  */
 function jetpack_require_lib( $slug ) {
 	static $loaded = array();
+
+	_deprecated_function( __FUNCTION__, 'Jetpack 11.3', 'libraries directly (from `JETPACK__PLUGIN_DIR . \'_inc/lib/\'`)' );
 
 	if ( defined( 'ABSPATH' ) && ! defined( 'WP_CONTENT_DIR' ) ) {
 		define( 'WP_CONTENT_DIR', ABSPATH . 'wp-content' ); // no trailing slash, full paths only - WP_CONTENT_URL is defined further down
@@ -30,7 +33,7 @@ function jetpack_require_lib( $slug ) {
 	 *
 	 * @param string $lib_dir Path to the library directory.
 	 */
-	$lib_dir = apply_filters( 'jetpack_require_lib_dir', $lib_dir );
+	$lib_dir = apply_filters_deprecated( 'jetpack_require_lib_dir', array( $lib_dir ), 'Jetpack 11.3' );
 
 	$loaded_key = "{$lib_dir}{$slug}";
 	if ( ! empty( $loaded[ $loaded_key ] ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We documented this as deprecated back in 11.3. Now that all uses have been removed (both from Jetpack and wpcom, plus we've filed tasks for all external uses we could find), it's time to start issuing deprecation warnings.

We plan to remove it entirely in Jetpack 11.9 or later. That should give people 3 months to notice and update.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-5EZ-p2
#25159

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try calling these and check for deprecation warnings.
  * Yes, calling `jetpack_require_lib()` also issues the warning for `jetpack_require_lib_dir()` and the filter, since we still have to hook the filter to preserve existing behavior. I'm fine with that.