### PR TITLE
VideoPress: Use terabytes instead of tebibytes on the storage meter

### DIFF
--- a/projects/packages/videopress/changelog/fix-use-terabytes-instead-of-tebibytes
+++ b/projects/packages/videopress/changelog/fix-use-terabytes-instead-of-tebibytes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Change base number to 10 and total space value to 10^12 so we refer to it in terabytes instead of tebibytes, keeping consistency between marketing and product.

--- a/projects/packages/videopress/src/client/admin/components/video-storage-meter/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-storage-meter/index.tsx
@@ -33,7 +33,7 @@ const VideoStorageMeter: React.FC< VideoStorageMeterProps > = ( {
 
 	const progress = used / total;
 	const progressLabel = `${ ( progress * 100 ).toFixed() }%`;
-	const totalLabel = filesize( total, { base: 2 } );
+	const totalLabel = filesize( total, { base: 10 } );
 
 	return (
 		<div className={ classnames( className ) }>
@@ -55,7 +55,7 @@ const VideoStorageMeter: React.FC< VideoStorageMeterProps > = ( {
 
 export const ConnectVideoStorageMeter = props => {
 	const { storageUsed, uploadedVideoCount } = useVideos();
-	const total = 1024 * 1024 * 1024 * 1024;
+	const total = 1000 * 1000 * 1000 * 1000;
 
 	const { features } = usePlan();
 

--- a/projects/packages/videopress/src/client/state/resolvers.js
+++ b/projects/packages/videopress/src/client/state/resolvers.js
@@ -284,7 +284,7 @@ const getStorageUsed = {
 			 * Let's compute the value in bytes.
 			 */
 			const storageUsed = response.options.videopress_storage_used
-				? Math.round( Number( response.options.videopress_storage_used ) * 1024 * 1024 )
+				? Math.round( Number( response.options.videopress_storage_used ) * 1000 * 1000 )
 				: 0;
 
 			dispatch.setVideosStorageUsed( storageUsed );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27160.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Change the formating of the total storage space to use 10 as base and 10^12 as total space, so we refer to it in terabytes instead of tebibytes

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `Jetpack > VideoPress`
* Confirm that the total storage space is now showing `1 TB` instead of `1 TiB`
* Before:
![image](https://user-images.githubusercontent.com/6760046/200053654-51822884-cc83-4b61-b4dd-0a35e118265c.png)

* After:
![image](https://user-images.githubusercontent.com/6760046/200053426-065f9aa4-2277-4977-8afe-57ccd7b0f3f2.png)
