### PR TITLE
VideoPress: Show message when there are no search results

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-search-no-results
+++ b/projects/packages/videopress/changelog/update-videopress-search-no-results
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Show message when there are no search results

--- a/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { Button, Text, useBreakpointMatch } from '@automattic/jetpack-components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { grid, formatListBullets } from '@wordpress/icons';
 import classnames from 'classnames';
@@ -104,6 +105,7 @@ const VideoLibraryWrapper = ( {
 
 export const VideoPressLibrary = ( { videos, totalVideos, loading }: VideoLibraryProps ) => {
 	const history = useHistory();
+	const { search } = useVideos();
 
 	const libraryTypeFromLocalStorage = localStorage.getItem(
 		LIBRARY_TYPE_LOCALSORAGE_KEY
@@ -127,6 +129,23 @@ export const VideoPressLibrary = ( { videos, totalVideos, loading }: VideoLibrar
 		history.push( `/video/${ video?.id }/edit` );
 	};
 
+	const library =
+		libraryType === LibraryType.Grid ? (
+			<VideoGrid
+				videos={ videos }
+				onVideoDetailsClick={ handleClickEditDetails }
+				loading={ loading }
+				count={ uploading ? videos.length : 6 }
+			/>
+		) : (
+			<VideoList
+				videos={ videos }
+				onVideoDetailsClick={ handleClickEditDetails }
+				hidePlays
+				loading={ loading }
+			/>
+		);
+
 	return (
 		<VideoLibraryWrapper
 			totalVideos={ totalVideos }
@@ -134,20 +153,21 @@ export const VideoPressLibrary = ( { videos, totalVideos, loading }: VideoLibrar
 			libraryType={ libraryType }
 			title={ __( 'Your VideoPress library', 'jetpack-videopress-pkg' ) }
 		>
-			{ libraryType === LibraryType.Grid ? (
-				<VideoGrid
-					videos={ videos }
-					onVideoDetailsClick={ handleClickEditDetails }
-					loading={ loading }
-					count={ uploading ? videos.length : 6 }
-				/>
+			{ videos.length > 0 || loading ? (
+				library
 			) : (
-				<VideoList
-					videos={ videos }
-					onVideoDetailsClick={ handleClickEditDetails }
-					hidePlays
-					loading={ loading }
-				/>
+				<Text>
+					{ createInterpolateElement(
+						sprintf(
+							/* translators: placeholder is the search term */
+							__( 'No videos match your search for <em>%s</em>.', 'jetpack-videopress-pkg' ),
+							search
+						),
+						{
+							em: <em className={ styles[ 'query-no-results' ] } />,
+						}
+					) }
+				</Text>
 			) }
 			<ConnectPagination className={ styles.pagination } />
 		</VideoLibraryWrapper>

--- a/projects/packages/videopress/src/client/admin/components/admin-page/styles.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/styles.module.scss
@@ -67,3 +67,7 @@
 .storage-meter__progress-bar {
 	background-color: var( --jp-gray );
 }
+
+.query-no-results {
+	font-style: italic;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27155

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a message when there are no search results

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Go to the VideoPress dashboard with at least one video uploaded
* Search for a term with no results
* Check that there is now a message

![2022-11-04_15-52-12](https://user-images.githubusercontent.com/8486249/200054621-ae3055c1-c00c-4e58-a4a0-18e2126c3692.png)
![2022-11-04_15-51-45](https://user-images.githubusercontent.com/8486249/200054629-64f554b4-062f-48c7-b2f9-9feaf7d05bf5.png)
