### PR TITLE
Status: Add WordPress.com Simple helper function

### DIFF
--- a/projects/packages/backup/changelog/add-wpcom-platform
+++ b/projects/packages/backup/changelog/add-wpcom-platform
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/backup/composer.json
+++ b/projects/packages/backup/composer.json
@@ -13,7 +13,7 @@
 		"automattic/jetpack-identity-crisis": "^0.8",
 		"automattic/jetpack-my-jetpack": "^2.3",
 		"automattic/jetpack-sync": "^1.41",
-		"automattic/jetpack-status": "^1.14"
+		"automattic/jetpack-status": "^1.15"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.2",

--- a/projects/packages/connection/changelog/add-wpcom-platform
+++ b/projects/packages/connection/changelog/add-wpcom-platform
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/connection/composer.json
+++ b/projects/packages/connection/composer.json
@@ -8,7 +8,7 @@
 		"automattic/jetpack-admin-ui": "^0.2",
 		"automattic/jetpack-constants": "^1.6",
 		"automattic/jetpack-roles": "^1.4",
-		"automattic/jetpack-status": "^1.14",
+		"automattic/jetpack-status": "^1.15",
 		"automattic/jetpack-redirect": "^1.7"
 	},
 	"require-dev": {

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.46.1';
+	const PACKAGE_VERSION = '1.46.2-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/identity-crisis/changelog/add-wpcom-platform
+++ b/projects/packages/identity-crisis/changelog/add-wpcom-platform
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/identity-crisis/composer.json
+++ b/projects/packages/identity-crisis/composer.json
@@ -6,7 +6,7 @@
 	"require": {
 		"automattic/jetpack-connection": "^1.46",
 		"automattic/jetpack-constants": "^1.6",
-		"automattic/jetpack-status": "^1.14",
+		"automattic/jetpack-status": "^1.15",
 		"automattic/jetpack-logo": "^1.5",
 		"automattic/jetpack-assets": "^1.17"
 	},

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.8.28",
+	"version": "0.8.29-alpha",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -28,7 +28,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.8.28';
+	const PACKAGE_VERSION = '0.8.29-alpha';
 
 	/**
 	 * Instance of the object.

--- a/projects/packages/jitm/changelog/add-wpcom-platform
+++ b/projects/packages/jitm/changelog/add-wpcom-platform
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/jitm/composer.json
+++ b/projects/packages/jitm/composer.json
@@ -11,7 +11,7 @@
 		"automattic/jetpack-logo": "^1.5",
 		"automattic/jetpack-partner": "^1.7",
 		"automattic/jetpack-redirect": "^1.7",
-		"automattic/jetpack-status": "^1.14"
+		"automattic/jetpack-status": "^1.15"
 	},
 	"require-dev": {
 		"brain/monkey": "2.6.1",

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '2.2.31';
+	const PACKAGE_VERSION = '2.2.32-alpha';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/partner/changelog/add-wpcom-platform
+++ b/projects/packages/partner/changelog/add-wpcom-platform
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/partner/composer.json
+++ b/projects/packages/partner/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"automattic/jetpack-connection": "^1.46",
-		"automattic/jetpack-status": "^1.14"
+		"automattic/jetpack-status": "^1.15"
 	},
 	"require-dev": {
 		"brain/monkey": "2.6.1",

--- a/projects/packages/plans/changelog/add-wpcom-platform
+++ b/projects/packages/plans/changelog/add-wpcom-platform
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/plans/composer.json
+++ b/projects/packages/plans/composer.json
@@ -9,7 +9,7 @@
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.0.3",
 		"automattic/jetpack-changelogger": "^3.2",
-		"automattic/jetpack-status": "^1.14",
+		"automattic/jetpack-status": "^1.15",
 		"automattic/wordbless": "@dev"
 	},
 	"autoload": {

--- a/projects/packages/plans/package.json
+++ b/projects/packages/plans/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-plans",
-	"version": "0.2.5",
+	"version": "0.2.6-alpha",
 	"description": "Fetch information about Jetpack Plans from wpcom",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/plans/#readme",
 	"bugs": {

--- a/projects/packages/redirect/changelog/add-wpcom-platform
+++ b/projects/packages/redirect/changelog/add-wpcom-platform
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/redirect/composer.json
+++ b/projects/packages/redirect/composer.json
@@ -4,7 +4,7 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-status": "^1.14"
+		"automattic/jetpack-status": "^1.15"
 	},
 	"require-dev": {
 		"brain/monkey": "2.6.1",

--- a/projects/packages/search/changelog/add-wpcom-platform
+++ b/projects/packages/search/changelog/add-wpcom-platform
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -7,7 +7,7 @@
 		"automattic/jetpack-connection": "^1.46",
 		"automattic/jetpack-assets": "^1.17",
 		"automattic/jetpack-constants": "^1.6",
-		"automattic/jetpack-status": "^1.14",
+		"automattic/jetpack-status": "^1.15",
 		"automattic/jetpack-config": "^1.11",
 		"automattic/jetpack-my-jetpack": "^2.3"
 	},

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.30.0",
+	"version": "0.30.1-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.30.0';
+	const VERSION = '0.30.1-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/stats/changelog/add-wpcom-platform
+++ b/projects/packages/stats/changelog/add-wpcom-platform
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/stats/composer.json
+++ b/projects/packages/stats/composer.json
@@ -6,7 +6,7 @@
 	"require": {
 		"automattic/jetpack-connection": "^1.46",
 		"automattic/jetpack-constants": "^1.6",
-		"automattic/jetpack-status": "^1.14"
+		"automattic/jetpack-status": "^1.15"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.0.3",

--- a/projects/packages/status/changelog/add-wpcom-platform
+++ b/projects/packages/status/changelog/add-wpcom-platform
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+WordPress.com: Added checks for Simple or either Simple/WoA.

--- a/projects/packages/status/composer.json
+++ b/projects/packages/status/composer.json
@@ -45,7 +45,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "1.14.x-dev"
+			"dev-trunk": "1.15.x-dev"
 		}
 	}
 }

--- a/projects/packages/status/src/class-host.php
+++ b/projects/packages/status/src/class-host.php
@@ -59,7 +59,7 @@ class Host {
 	}
 
 	/**
-	 * Determine if this is a Simple platfoxrm site.
+	 * Determine if this is a Simple platform site.
 	 *
 	 * @return bool
 	 */
@@ -70,7 +70,7 @@ class Host {
 	/**
 	 * Determine if this is a WordPress.com site.
 	 *
-	 * Includes both Simple and WoA Platforms
+	 * Includes both Simple and WoA platforms.
 	 *
 	 * @return bool
 	 */

--- a/projects/packages/status/src/class-host.php
+++ b/projects/packages/status/src/class-host.php
@@ -59,6 +59,26 @@ class Host {
 	}
 
 	/**
+	 * Determine if this is a Simple platfoxrm site.
+	 *
+	 * @return bool
+	 */
+	public function is_wpcom_simple() {
+		return Constants::is_defined( 'IS_WPCOM' ) && true === Constants::get_constant( 'IS_WPCOM' );
+	}
+
+	/**
+	 * Determine if this is a WordPress.com site.
+	 *
+	 * Includes both Simple and WoA Platforms
+	 *
+	 * @return bool
+	 */
+	public function is_wpcom_platform() {
+		return $this->is_wpcom_simple() || $this->is_woa_site();
+	}
+
+	/**
 	 * Add all wordpress.com environments to the safe redirect allowed list.
 	 *
 	 * To be used with a filter of allowed domains for a redirect.

--- a/projects/packages/status/tests/php/test-host.php
+++ b/projects/packages/status/tests/php/test-host.php
@@ -63,6 +63,7 @@ class Test_Host extends TestCase {
 		$this->setup_atomic_constants();
 		Constants::set_constant( 'WPCOMSH__PLUGIN_FILE', true );
 		$this->assertTrue( $this->host_obj->is_woa_site() );
+		$this->assertTrue( $this->host_obj->is_wpcom_platform() );
 	}
 
 	/**
@@ -90,6 +91,15 @@ class Test_Host extends TestCase {
 		Constants::set_constant( 'ATOMIC_CLIENT_ID', false );
 		Constants::set_constant( 'ATOMIC_SITE_ID', false );
 		$this->assertFalse( $this->host_obj->is_atomic_platform() );
+	}
+
+	/**
+	 * Tests if a Simple Site based on constant
+	 */
+	public function test_simple_site_based_on_constant() {
+		Constants::set_constant( 'IS_WPCOM', true );
+		$this->assertTrue( $this->host_obj->is_wpcom_simple() );
+		$this->assertTrue( $this->host_obj->is_wpcom_platform() );
 	}
 
 	/**

--- a/projects/packages/sync/changelog/add-wpcom-platform
+++ b/projects/packages/sync/changelog/add-wpcom-platform
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -9,7 +9,7 @@
 		"automattic/jetpack-identity-crisis": "^0.8",
 		"automattic/jetpack-password-checker": "^0.2",
 		"automattic/jetpack-roles": "^1.4",
-		"automattic/jetpack-status": "^1.14"
+		"automattic/jetpack-status": "^1.15"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.2",

--- a/projects/packages/tracking/changelog/add-wpcom-platform
+++ b/projects/packages/tracking/changelog/add-wpcom-platform
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/tracking/composer.json
+++ b/projects/packages/tracking/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"automattic/jetpack-assets": "^1.17",
-		"automattic/jetpack-status": "^1.14",
+		"automattic/jetpack-status": "^1.15",
 		"automattic/jetpack-connection": "^1.46"
 	},
 	"require-dev": {

--- a/projects/packages/wordads/changelog/add-wpcom-platform
+++ b/projects/packages/wordads/changelog/add-wpcom-platform
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/wordads/composer.json
+++ b/projects/packages/wordads/composer.json
@@ -7,7 +7,7 @@
 		"automattic/jetpack-connection": "^1.46",
 		"automattic/jetpack-assets": "^1.17",
 		"automattic/jetpack-constants": "^1.6",
-		"automattic/jetpack-status": "^1.14",
+		"automattic/jetpack-status": "^1.15",
 		"automattic/jetpack-config": "^1.11"
 	},
 	"require-dev": {

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.2.22",
+	"version": "0.2.23-alpha",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.2.22';
+	const VERSION = '0.2.23-alpha';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/backup/changelog/add-wpcom-platform
+++ b/projects/plugins/backup/changelog/add-wpcom-platform
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -238,7 +238,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "c499517a11c7d080d7256f43aaaec9672b17440e"
+                "reference": "f7a53aed32b05c9680f70b961dd8e5e195f87e65"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -249,7 +249,7 @@
                 "automattic/jetpack-connection": "^1.46",
                 "automattic/jetpack-identity-crisis": "^0.8",
                 "automattic/jetpack-my-jetpack": "^2.3",
-                "automattic/jetpack-status": "^1.14",
+                "automattic/jetpack-status": "^1.15",
                 "automattic/jetpack-sync": "^1.41"
             },
             "require-dev": {
@@ -410,7 +410,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "dd23e0be7903fd17711661ba226465b6b035be57"
+                "reference": "d76ee17f41bd202a7749b0431cfd38f61c5479e5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -418,7 +418,7 @@
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-redirect": "^1.7",
                 "automattic/jetpack-roles": "^1.4",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -580,14 +580,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/identity-crisis",
-                "reference": "f0374194ef5ffda95e52932270e985da1f2c9288"
+                "reference": "9d9f583a68096f3c62e99aecd38b66e333a98e1e"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
                 "automattic/jetpack-connection": "^1.46",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-logo": "^1.5",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -655,7 +655,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "e092d87a0cee08fd5386d97e12bd93318fa7ee30"
+                "reference": "f4531599eac2ae05073ab7b5d62ed7b7fcde6863"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -665,7 +665,7 @@
                 "automattic/jetpack-logo": "^1.5",
                 "automattic/jetpack-partner": "^1.7",
                 "automattic/jetpack-redirect": "^1.7",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -915,11 +915,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/partner",
-                "reference": "992548f355ba41fc6ad3de9f59a05ef69241d095"
+                "reference": "fe539d8bee66ced559d8e5278819f4c2f8422e2c"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.46",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -1080,10 +1080,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "384df449e82c6792919537add3aa543468d98893"
+                "reference": "94b165af8d09ef555bc6e8895cd8a38435dc2409"
             },
             "require": {
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -1179,7 +1179,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "1c747edbd6e497fd58eb51ddab48d836b61a5298"
+                "reference": "8c376c3bcefd4b8b4fab64505993ee3818119ca7"
             },
             "require": {
                 "automattic/jetpack-constants": "^1.6"
@@ -1197,7 +1197,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.14.x-dev"
+                    "dev-trunk": "1.15.x-dev"
                 }
             },
             "autoload": {
@@ -1230,7 +1230,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "e8e690a9e036cd581a12bf743a558b2c32965b2e"
+                "reference": "3c4b7d333d7a82d065ee999c304253e5de01d1e6"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.46",
@@ -1238,7 +1238,7 @@
                 "automattic/jetpack-identity-crisis": "^0.8",
                 "automattic/jetpack-password-checker": "^0.2",
                 "automattic/jetpack-roles": "^1.4",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",

--- a/projects/plugins/boost/changelog/add-wpcom-platform
+++ b/projects/plugins/boost/changelog/add-wpcom-platform
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -327,7 +327,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "dd23e0be7903fd17711661ba226465b6b035be57"
+                "reference": "d76ee17f41bd202a7749b0431cfd38f61c5479e5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -335,7 +335,7 @@
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-redirect": "^1.7",
                 "automattic/jetpack-roles": "^1.4",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -497,7 +497,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "e092d87a0cee08fd5386d97e12bd93318fa7ee30"
+                "reference": "f4531599eac2ae05073ab7b5d62ed7b7fcde6863"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -507,7 +507,7 @@
                 "automattic/jetpack-logo": "^1.5",
                 "automattic/jetpack-partner": "^1.7",
                 "automattic/jetpack-redirect": "^1.7",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -822,11 +822,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/partner",
-                "reference": "992548f355ba41fc6ad3de9f59a05ef69241d095"
+                "reference": "fe539d8bee66ced559d8e5278819f4c2f8422e2c"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.46",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -932,10 +932,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "384df449e82c6792919537add3aa543468d98893"
+                "reference": "94b165af8d09ef555bc6e8895cd8a38435dc2409"
             },
             "require": {
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -1031,7 +1031,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "1c747edbd6e497fd58eb51ddab48d836b61a5298"
+                "reference": "8c376c3bcefd4b8b4fab64505993ee3818119ca7"
             },
             "require": {
                 "automattic/jetpack-constants": "^1.6"
@@ -1049,7 +1049,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.14.x-dev"
+                    "dev-trunk": "1.15.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/add-wpcom-platform
+++ b/projects/plugins/jetpack/changelog/add-wpcom-platform
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -40,7 +40,7 @@
 		"automattic/jetpack-roles": "1.4.x-dev",
 		"automattic/jetpack-search": "0.30.x-dev",
 		"automattic/jetpack-stats": "0.3.x-dev",
-		"automattic/jetpack-status": "1.14.x-dev",
+		"automattic/jetpack-status": "1.15.x-dev",
 		"automattic/jetpack-sync": "1.41.x-dev",
 		"automattic/jetpack-videopress": "0.7.x-dev",
 		"automattic/jetpack-waf": "0.6.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8ebcbc7d39d0941855909134f5c3454b",
+    "content-hash": "52d3a9f09e2b1999925ee9b7af7c294d",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -361,7 +361,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "c499517a11c7d080d7256f43aaaec9672b17440e"
+                "reference": "f7a53aed32b05c9680f70b961dd8e5e195f87e65"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "^0.2",
@@ -372,7 +372,7 @@
                 "automattic/jetpack-connection": "^1.46",
                 "automattic/jetpack-identity-crisis": "^0.8",
                 "automattic/jetpack-my-jetpack": "^2.3",
-                "automattic/jetpack-status": "^1.14",
+                "automattic/jetpack-status": "^1.15",
                 "automattic/jetpack-sync": "^1.41"
             },
             "require-dev": {
@@ -627,7 +627,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "dd23e0be7903fd17711661ba226465b6b035be57"
+                "reference": "d76ee17f41bd202a7749b0431cfd38f61c5479e5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -635,7 +635,7 @@
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-redirect": "^1.7",
                 "automattic/jetpack-roles": "^1.4",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -893,14 +893,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/identity-crisis",
-                "reference": "f0374194ef5ffda95e52932270e985da1f2c9288"
+                "reference": "9d9f583a68096f3c62e99aecd38b66e333a98e1e"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
                 "automattic/jetpack-connection": "^1.46",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-logo": "^1.5",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -968,7 +968,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "e092d87a0cee08fd5386d97e12bd93318fa7ee30"
+                "reference": "f4531599eac2ae05073ab7b5d62ed7b7fcde6863"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -978,7 +978,7 @@
                 "automattic/jetpack-logo": "^1.5",
                 "automattic/jetpack-partner": "^1.7",
                 "automattic/jetpack-redirect": "^1.7",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -1293,11 +1293,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/partner",
-                "reference": "992548f355ba41fc6ad3de9f59a05ef69241d095"
+                "reference": "fe539d8bee66ced559d8e5278819f4c2f8422e2c"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.46",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -1407,14 +1407,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "b1df4ae644c0134de7bd8a4a1ece83a9b93c7830"
+                "reference": "9b6218c0359a9c0533b30f3f95c0c847d76b88f4"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.46"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
-                "automattic/jetpack-status": "^1.14",
+                "automattic/jetpack-status": "^1.15",
                 "automattic/wordbless": "@dev",
                 "yoast/phpunit-polyfills": "1.0.3"
             },
@@ -1651,10 +1651,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "384df449e82c6792919537add3aa543468d98893"
+                "reference": "94b165af8d09ef555bc6e8895cd8a38435dc2409"
             },
             "require": {
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -1750,7 +1750,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "00d167cdf3014cbabd12338de961fc1cfbaab5ee"
+                "reference": "04c0b0d095283f8428e069b43a8766f6747249ab"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -1758,7 +1758,7 @@
                 "automattic/jetpack-connection": "^1.46",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-my-jetpack": "^2.3",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -1833,12 +1833,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats",
-                "reference": "63b87d1f604ae27d245224524c242df46fdffc9f"
+                "reference": "54e4b61cba1e5f0c904594f7bde6b60a2dc1f506"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.46",
                 "automattic/jetpack-constants": "^1.6",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -1893,7 +1893,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "1c747edbd6e497fd58eb51ddab48d836b61a5298"
+                "reference": "8c376c3bcefd4b8b4fab64505993ee3818119ca7"
             },
             "require": {
                 "automattic/jetpack-constants": "^1.6"
@@ -1911,7 +1911,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.14.x-dev"
+                    "dev-trunk": "1.15.x-dev"
                 }
             },
             "autoload": {
@@ -1944,7 +1944,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "e8e690a9e036cd581a12bf743a558b2c32965b2e"
+                "reference": "3c4b7d333d7a82d065ee999c304253e5de01d1e6"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.46",
@@ -1952,7 +1952,7 @@
                 "automattic/jetpack-identity-crisis": "^0.8",
                 "automattic/jetpack-password-checker": "^0.2",
                 "automattic/jetpack-roles": "^1.4",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -2145,14 +2145,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/wordads",
-                "reference": "4d743f4c29877c9ecce75aa09868be39e7a612bc"
+                "reference": "609485b0cc155e32707de12b79b6481009659931"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
                 "automattic/jetpack-config": "^1.11",
                 "automattic/jetpack-connection": "^1.46",
                 "automattic/jetpack-constants": "^1.6",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",

--- a/projects/plugins/protect/changelog/add-wpcom-platform
+++ b/projects/plugins/protect/changelog/add-wpcom-platform
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -327,7 +327,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "dd23e0be7903fd17711661ba226465b6b035be57"
+                "reference": "d76ee17f41bd202a7749b0431cfd38f61c5479e5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -335,7 +335,7 @@
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-redirect": "^1.7",
                 "automattic/jetpack-roles": "^1.4",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -497,14 +497,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/identity-crisis",
-                "reference": "f0374194ef5ffda95e52932270e985da1f2c9288"
+                "reference": "9d9f583a68096f3c62e99aecd38b66e333a98e1e"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
                 "automattic/jetpack-connection": "^1.46",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-logo": "^1.5",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -572,7 +572,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "e092d87a0cee08fd5386d97e12bd93318fa7ee30"
+                "reference": "f4531599eac2ae05073ab7b5d62ed7b7fcde6863"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -582,7 +582,7 @@
                 "automattic/jetpack-logo": "^1.5",
                 "automattic/jetpack-partner": "^1.7",
                 "automattic/jetpack-redirect": "^1.7",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -832,11 +832,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/partner",
-                "reference": "992548f355ba41fc6ad3de9f59a05ef69241d095"
+                "reference": "fe539d8bee66ced559d8e5278819f4c2f8422e2c"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.46",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -997,10 +997,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "384df449e82c6792919537add3aa543468d98893"
+                "reference": "94b165af8d09ef555bc6e8895cd8a38435dc2409"
             },
             "require": {
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -1096,7 +1096,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "1c747edbd6e497fd58eb51ddab48d836b61a5298"
+                "reference": "8c376c3bcefd4b8b4fab64505993ee3818119ca7"
             },
             "require": {
                 "automattic/jetpack-constants": "^1.6"
@@ -1114,7 +1114,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.14.x-dev"
+                    "dev-trunk": "1.15.x-dev"
                 }
             },
             "autoload": {
@@ -1147,7 +1147,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "e8e690a9e036cd581a12bf743a558b2c32965b2e"
+                "reference": "3c4b7d333d7a82d065ee999c304253e5de01d1e6"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.46",
@@ -1155,7 +1155,7 @@
                 "automattic/jetpack-identity-crisis": "^0.8",
                 "automattic/jetpack-password-checker": "^0.2",
                 "automattic/jetpack-roles": "^1.4",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",

--- a/projects/plugins/search/changelog/add-wpcom-platform
+++ b/projects/plugins/search/changelog/add-wpcom-platform
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -12,7 +12,7 @@
 		"automattic/jetpack-my-jetpack": "2.3.x-dev",
 		"automattic/jetpack-search": "0.30.x-dev",
 		"automattic/jetpack-stats": "0.3.x-dev",
-		"automattic/jetpack-status": "1.14.x-dev",
+		"automattic/jetpack-status": "1.15.x-dev",
 		"automattic/jetpack-sync": "1.41.x-dev",
 		"automattic/jetpack-plugins-installer": "0.2.x-dev"
 	},

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "227e88420b8ee5314ce19a9d4674555d",
+    "content-hash": "2e3ca9c9fc4f9ac8e46ee7c0c29c8d0a",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -327,7 +327,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "dd23e0be7903fd17711661ba226465b6b035be57"
+                "reference": "d76ee17f41bd202a7749b0431cfd38f61c5479e5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -335,7 +335,7 @@
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-redirect": "^1.7",
                 "automattic/jetpack-roles": "^1.4",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -497,14 +497,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/identity-crisis",
-                "reference": "f0374194ef5ffda95e52932270e985da1f2c9288"
+                "reference": "9d9f583a68096f3c62e99aecd38b66e333a98e1e"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
                 "automattic/jetpack-connection": "^1.46",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-logo": "^1.5",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -572,7 +572,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "e092d87a0cee08fd5386d97e12bd93318fa7ee30"
+                "reference": "f4531599eac2ae05073ab7b5d62ed7b7fcde6863"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -582,7 +582,7 @@
                 "automattic/jetpack-logo": "^1.5",
                 "automattic/jetpack-partner": "^1.7",
                 "automattic/jetpack-redirect": "^1.7",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -832,11 +832,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/partner",
-                "reference": "992548f355ba41fc6ad3de9f59a05ef69241d095"
+                "reference": "fe539d8bee66ced559d8e5278819f4c2f8422e2c"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.46",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -997,10 +997,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "384df449e82c6792919537add3aa543468d98893"
+                "reference": "94b165af8d09ef555bc6e8895cd8a38435dc2409"
             },
             "require": {
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -1096,7 +1096,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "00d167cdf3014cbabd12338de961fc1cfbaab5ee"
+                "reference": "04c0b0d095283f8428e069b43a8766f6747249ab"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -1104,7 +1104,7 @@
                 "automattic/jetpack-connection": "^1.46",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-my-jetpack": "^2.3",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -1179,12 +1179,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats",
-                "reference": "63b87d1f604ae27d245224524c242df46fdffc9f"
+                "reference": "54e4b61cba1e5f0c904594f7bde6b60a2dc1f506"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.46",
                 "automattic/jetpack-constants": "^1.6",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -1239,7 +1239,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "1c747edbd6e497fd58eb51ddab48d836b61a5298"
+                "reference": "8c376c3bcefd4b8b4fab64505993ee3818119ca7"
             },
             "require": {
                 "automattic/jetpack-constants": "^1.6"
@@ -1257,7 +1257,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.14.x-dev"
+                    "dev-trunk": "1.15.x-dev"
                 }
             },
             "autoload": {
@@ -1290,7 +1290,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "e8e690a9e036cd581a12bf743a558b2c32965b2e"
+                "reference": "3c4b7d333d7a82d065ee999c304253e5de01d1e6"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.46",
@@ -1298,7 +1298,7 @@
                 "automattic/jetpack-identity-crisis": "^0.8",
                 "automattic/jetpack-password-checker": "^0.2",
                 "automattic/jetpack-roles": "^1.4",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",

--- a/projects/plugins/social/changelog/add-wpcom-platform
+++ b/projects/plugins/social/changelog/add-wpcom-platform
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -14,7 +14,7 @@
 		"automattic/jetpack-connection": "1.46.x-dev",
 		"automattic/jetpack-my-jetpack": "2.3.x-dev",
 		"automattic/jetpack-sync": "1.41.x-dev",
-		"automattic/jetpack-status": "1.14.x-dev",
+		"automattic/jetpack-status": "1.15.x-dev",
 		"automattic/jetpack-plans": "0.2.x-dev"
 	},
 	"require-dev": {

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8b0fa5305d3db39eeebb8b2f69a11c26",
+    "content-hash": "cf6cab0f037857503782765f70af7512",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -327,7 +327,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "dd23e0be7903fd17711661ba226465b6b035be57"
+                "reference": "d76ee17f41bd202a7749b0431cfd38f61c5479e5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -335,7 +335,7 @@
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-redirect": "^1.7",
                 "automattic/jetpack-roles": "^1.4",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -497,14 +497,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/identity-crisis",
-                "reference": "f0374194ef5ffda95e52932270e985da1f2c9288"
+                "reference": "9d9f583a68096f3c62e99aecd38b66e333a98e1e"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
                 "automattic/jetpack-connection": "^1.46",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-logo": "^1.5",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -572,7 +572,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "e092d87a0cee08fd5386d97e12bd93318fa7ee30"
+                "reference": "f4531599eac2ae05073ab7b5d62ed7b7fcde6863"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -582,7 +582,7 @@
                 "automattic/jetpack-logo": "^1.5",
                 "automattic/jetpack-partner": "^1.7",
                 "automattic/jetpack-redirect": "^1.7",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -832,11 +832,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/partner",
-                "reference": "992548f355ba41fc6ad3de9f59a05ef69241d095"
+                "reference": "fe539d8bee66ced559d8e5278819f4c2f8422e2c"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.46",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -946,14 +946,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "b1df4ae644c0134de7bd8a4a1ece83a9b93c7830"
+                "reference": "9b6218c0359a9c0533b30f3f95c0c847d76b88f4"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.46"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
-                "automattic/jetpack-status": "^1.14",
+                "automattic/jetpack-status": "^1.15",
                 "automattic/wordbless": "@dev",
                 "yoast/phpunit-polyfills": "1.0.3"
             },
@@ -1129,10 +1129,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "384df449e82c6792919537add3aa543468d98893"
+                "reference": "94b165af8d09ef555bc6e8895cd8a38435dc2409"
             },
             "require": {
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -1228,7 +1228,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "1c747edbd6e497fd58eb51ddab48d836b61a5298"
+                "reference": "8c376c3bcefd4b8b4fab64505993ee3818119ca7"
             },
             "require": {
                 "automattic/jetpack-constants": "^1.6"
@@ -1246,7 +1246,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.14.x-dev"
+                    "dev-trunk": "1.15.x-dev"
                 }
             },
             "autoload": {
@@ -1279,7 +1279,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "e8e690a9e036cd581a12bf743a558b2c32965b2e"
+                "reference": "3c4b7d333d7a82d065ee999c304253e5de01d1e6"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.46",
@@ -1287,7 +1287,7 @@
                 "automattic/jetpack-identity-crisis": "^0.8",
                 "automattic/jetpack-password-checker": "^0.2",
                 "automattic/jetpack-roles": "^1.4",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",

--- a/projects/plugins/starter-plugin/changelog/add-wpcom-platform
+++ b/projects/plugins/starter-plugin/changelog/add-wpcom-platform
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -327,7 +327,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "dd23e0be7903fd17711661ba226465b6b035be57"
+                "reference": "d76ee17f41bd202a7749b0431cfd38f61c5479e5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -335,7 +335,7 @@
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-redirect": "^1.7",
                 "automattic/jetpack-roles": "^1.4",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -497,14 +497,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/identity-crisis",
-                "reference": "f0374194ef5ffda95e52932270e985da1f2c9288"
+                "reference": "9d9f583a68096f3c62e99aecd38b66e333a98e1e"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
                 "automattic/jetpack-connection": "^1.46",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-logo": "^1.5",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -572,7 +572,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "e092d87a0cee08fd5386d97e12bd93318fa7ee30"
+                "reference": "f4531599eac2ae05073ab7b5d62ed7b7fcde6863"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -582,7 +582,7 @@
                 "automattic/jetpack-logo": "^1.5",
                 "automattic/jetpack-partner": "^1.7",
                 "automattic/jetpack-redirect": "^1.7",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -832,11 +832,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/partner",
-                "reference": "992548f355ba41fc6ad3de9f59a05ef69241d095"
+                "reference": "fe539d8bee66ced559d8e5278819f4c2f8422e2c"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.46",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -997,10 +997,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "384df449e82c6792919537add3aa543468d98893"
+                "reference": "94b165af8d09ef555bc6e8895cd8a38435dc2409"
             },
             "require": {
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -1096,7 +1096,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "1c747edbd6e497fd58eb51ddab48d836b61a5298"
+                "reference": "8c376c3bcefd4b8b4fab64505993ee3818119ca7"
             },
             "require": {
                 "automattic/jetpack-constants": "^1.6"
@@ -1114,7 +1114,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.14.x-dev"
+                    "dev-trunk": "1.15.x-dev"
                 }
             },
             "autoload": {
@@ -1147,7 +1147,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "e8e690a9e036cd581a12bf743a558b2c32965b2e"
+                "reference": "3c4b7d333d7a82d065ee999c304253e5de01d1e6"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.46",
@@ -1155,7 +1155,7 @@
                 "automattic/jetpack-identity-crisis": "^0.8",
                 "automattic/jetpack-password-checker": "^0.2",
                 "automattic/jetpack-roles": "^1.4",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",

--- a/projects/plugins/videopress/changelog/add-wpcom-platform
+++ b/projects/plugins/videopress/changelog/add-wpcom-platform
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -327,7 +327,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "dd23e0be7903fd17711661ba226465b6b035be57"
+                "reference": "d76ee17f41bd202a7749b0431cfd38f61c5479e5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -335,7 +335,7 @@
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-redirect": "^1.7",
                 "automattic/jetpack-roles": "^1.4",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -497,14 +497,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/identity-crisis",
-                "reference": "f0374194ef5ffda95e52932270e985da1f2c9288"
+                "reference": "9d9f583a68096f3c62e99aecd38b66e333a98e1e"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
                 "automattic/jetpack-connection": "^1.46",
                 "automattic/jetpack-constants": "^1.6",
                 "automattic/jetpack-logo": "^1.5",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -572,7 +572,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "e092d87a0cee08fd5386d97e12bd93318fa7ee30"
+                "reference": "f4531599eac2ae05073ab7b5d62ed7b7fcde6863"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4",
@@ -582,7 +582,7 @@
                 "automattic/jetpack-logo": "^1.5",
                 "automattic/jetpack-partner": "^1.7",
                 "automattic/jetpack-redirect": "^1.7",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -832,11 +832,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/partner",
-                "reference": "992548f355ba41fc6ad3de9f59a05ef69241d095"
+                "reference": "fe539d8bee66ced559d8e5278819f4c2f8422e2c"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.46",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -946,14 +946,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "b1df4ae644c0134de7bd8a4a1ece83a9b93c7830"
+                "reference": "9b6218c0359a9c0533b30f3f95c0c847d76b88f4"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.46"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
-                "automattic/jetpack-status": "^1.14",
+                "automattic/jetpack-status": "^1.15",
                 "automattic/wordbless": "@dev",
                 "yoast/phpunit-polyfills": "1.0.3"
             },
@@ -1061,10 +1061,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "384df449e82c6792919537add3aa543468d98893"
+                "reference": "94b165af8d09ef555bc6e8895cd8a38435dc2409"
             },
             "require": {
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",
@@ -1160,7 +1160,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "1c747edbd6e497fd58eb51ddab48d836b61a5298"
+                "reference": "8c376c3bcefd4b8b4fab64505993ee3818119ca7"
             },
             "require": {
                 "automattic/jetpack-constants": "^1.6"
@@ -1178,7 +1178,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.14.x-dev"
+                    "dev-trunk": "1.15.x-dev"
                 }
             },
             "autoload": {
@@ -1211,7 +1211,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "e8e690a9e036cd581a12bf743a558b2c32965b2e"
+                "reference": "3c4b7d333d7a82d065ee999c304253e5de01d1e6"
             },
             "require": {
                 "automattic/jetpack-connection": "^1.46",
@@ -1219,7 +1219,7 @@
                 "automattic/jetpack-identity-crisis": "^0.8",
                 "automattic/jetpack-password-checker": "^0.2",
                 "automattic/jetpack-roles": "^1.4",
-                "automattic/jetpack-status": "^1.14"
+                "automattic/jetpack-status": "^1.15"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "^3.2",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Makes it easier to check if a site is on the WordPress.com platform at all by adding checks for Simple or for Simple/WoA.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds is_wpcom_simple
* Adds is_wpcom_platform

#### Other information:

- [x ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Using WP CLI in Jetpack, run `(new \Automattic\Jetpack\Status\Host)->is_wpcom_simple` and confirm false.
* Same on Atomic and run `(new \Automattic\Jetpack\Status\Host)->is_wpcom_platform` and confirm true.
* Same on WP.com Simple and confirm the above and is_wpcom_simple returns true.

