### PR TITLE
fixing logged in check.

### DIFF
--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -22,9 +22,6 @@ add_action( 'jetpack_modules_loaded', 'jetpack_subscriptions_load' );
  */
 function jetpack_subscriptions_load() {
 	Jetpack::enable_module_configurable( __FILE__ );
-	if ( Automattic\Jetpack\Constants::get_constant( 'JETPACK_BETA_BLOCKS' ) ) {
-		add_action( 'the_content', 'maybe_get_locked_content' );
-	}
 }
 
 /**

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -22,7 +22,7 @@ add_action( 'jetpack_modules_loaded', 'jetpack_subscriptions_load' );
  */
 function jetpack_subscriptions_load() {
 	Jetpack::enable_module_configurable( __FILE__ );
-	error_log('n3f test');
+	error_log( 'n3f test' );
 	if ( Automattic\Jetpack\Constants::get_constant( 'JETPACK_BETA_BLOCKS' ) ) {
 		add_action( 'the_content', 'maybe_get_locked_content' );
 	}
@@ -1038,53 +1038,3 @@ class Jetpack_Subscriptions {
 Jetpack_Subscriptions::init();
 
 require __DIR__ . '/subscriptions/views.php';
-
-
-
-
-
-
-
-
-// TODO: REMOVE THIS BEFORE MERGING PR...
-
-/**
- * Gate access to posts
- *
- * @param string $the_content Post content.
- *
- * @return string
- */
-function maybe_get_locked_content( $the_content ) {
-	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
-
-	if ( Jetpack_Memberships::user_can_view_post() ) {
-		return $the_content;
-	}
-	return get_locked_content_placeholder_text();
-}
-
-/**
- * Placeholder text for non-subscribers
- *
- * @return string
- */
-function get_locked_content_placeholder_text() {
-	return do_blocks(
-		'<!-- wp:group {"layout":{"type":"constrained","contentSize":"400px"},"style":{"spacing":{"padding":{"top":"var:preset|spacing|80","right":"var:preset|spacing|80","bottom":"var:preset|spacing|80","left":"var:preset|spacing|80"}}},"backgroundColor":"tertiary"} -->
-			<div class="wp-block-group has-tertiary-background-color has-background" style="padding-top:var(--wp--preset--spacing--80);padding-right:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80);padding-left:var(--wp--preset--spacing--80)"><!-- wp:heading {"textAlign":"center"} -->
-			<h2 class="has-text-align-center">' . esc_html__( 'Subscribe to get access.', 'jetpack' ) . '</h2>
-			<!-- /wp:heading -->
-
-			<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-			<p class="has-text-align-center has-small-font-size">' . esc_html__( 'Read more of this content if you subscribe today.', 'jetpack' ) . '</p>
-			<!-- /wp:paragraph -->
-
-			<!-- wp:jetpack/subscriptions {"subscribePlaceholder":' . esc_html__( 'Email address', 'jetpack' ) . ',"buttonBackgroundColor":"primary","textColor":"secondary","borderRadius":50,"borderColor":"primary","className":"is-style-compact"} -->
-				<div class="wp-block-jetpack-subscriptions wp-block-jetpack-subscriptions__supports-newline is-style-compact">
-					[jetpack_subscription_form subscribe_placeholder="Email Address" show_subscribers_total="false" button_on_newline="false" custom_font_size="16px" custom_border_radius="50" custom_border_weight="1" custom_padding="15" custom_spacing="10" submit_button_classes="has-primary-border-color has-text-color has-secondary-color has-background has-primary-background-color" email_field_classes="has-primary-border-color" show_only_email_and_button="true"]
-				</div>
-			<!-- /wp:jetpack/subscriptions --></div>
-		<!-- /wp:group -->'
-	);
-}

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -22,6 +22,7 @@ add_action( 'jetpack_modules_loaded', 'jetpack_subscriptions_load' );
  */
 function jetpack_subscriptions_load() {
 	Jetpack::enable_module_configurable( __FILE__ );
+	error_log('n3f test');
 	if ( Automattic\Jetpack\Constants::get_constant( 'JETPACK_BETA_BLOCKS' ) ) {
 		add_action( 'the_content', 'maybe_get_locked_content' );
 	}
@@ -1037,6 +1038,15 @@ class Jetpack_Subscriptions {
 Jetpack_Subscriptions::init();
 
 require __DIR__ . '/subscriptions/views.php';
+
+
+
+
+
+
+
+
+// TODO: REMOVE THIS BEFORE MERGING PR...
 
 /**
  * Gate access to posts

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -22,7 +22,6 @@ add_action( 'jetpack_modules_loaded', 'jetpack_subscriptions_load' );
  */
 function jetpack_subscriptions_load() {
 	Jetpack::enable_module_configurable( __FILE__ );
-	error_log( 'n3f test' );
 	if ( Automattic\Jetpack\Constants::get_constant( 'JETPACK_BETA_BLOCKS' ) ) {
 		add_action( 'the_content', 'maybe_get_locked_content' );
 	}


### PR DESCRIPTION
Fixes #26842.

There's a problem with the loading of the code that gates a paid-subscription post, it might have to do with the XML-RPC stuff.

On WPCOM, when you attempt to load a post that has a subscribers only post option it doesn't get triggered and the post is viewable.

After applying this PR and syncing, you should see appropriate behavior:

![image](https://user-images.githubusercontent.com/6354169/200090485-2daf154b-eb7d-4448-9c7d-e678e5a0ef07.png)

## Test instructions
1. Go to https://neffffearn.wordpress.com/2022/11/01/subscriber-only-content/. Notice that you can view the subscriber only content!
2. Sandbox neffffearn.wordpress.com, and rsync this code (building it first).
3. Refresh the page from 1. (Content is now appropriately blocked)
4. Log in using a "good" email.
5. Post should be viewable.