### PR TITLE
VideoPress: add Site Settings section

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-add-site-privacy-section-cmp
+++ b/projects/packages/videopress/changelog/update-videopress-add-site-privacy-section-cmp
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: add Site Settings section

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -35,6 +35,7 @@ import useVideos, { useLocalVideos } from '../../hooks/use-videos';
 import { NeedUserConnectionGlobalNotice } from '../global-notice';
 import Logo from '../logo';
 import PricingSection from '../pricing-section';
+import SettingsSection from '../site-settings-section';
 import { ConnectVideoStorageMeter } from '../video-storage-meter';
 import VideoUploadArea from '../video-upload-area';
 import { LocalLibrary, VideoPressLibrary } from './libraries';
@@ -202,6 +203,10 @@ const Admin = () => {
 					</AdminSection>
 				</>
 			) }
+
+			<AdminSection>
+				<SettingsSection />
+			</AdminSection>
 		</AdminPage>
 	);
 };

--- a/projects/packages/videopress/src/client/admin/components/site-settings-section/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/site-settings-section/index.tsx
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { Col, Container, Text } from '@automattic/jetpack-components';
+import { __ } from '@wordpress/i18n';
+import React from 'react';
+/**
+ * Internal dependencies
+ */
+import { CheckboxCheckmark } from '../video-filter';
+import { SiteSettingsSectionProps } from './types';
+
+/**
+ * VideoPress SettingsSection component
+ *
+ * @param {SiteSettingsSectionProps} props - Component props.
+ * @returns {React.ReactElement}   Component template
+ */
+const SiteSettingsSection: React.FC< SiteSettingsSectionProps > = ( {
+	onPrivacySettingsChange,
+} ) => {
+	return (
+		<Container horizontalSpacing={ 0 } horizontalGap={ 0 }>
+			<Col>
+				<Text variant="headline-small" mb={ 1 }>
+					{ __( 'Settings', 'jetpack-videopress-pkg' ) }
+				</Text>
+			</Col>
+			<Col sm={ 12 } md={ 6 } lg={ 6 }>
+				<CheckboxCheckmark
+					for={ 'settings-site-privacy' }
+					label={ __(
+						'Video Privacy: Restrict views to members of this site',
+						'jetpack-videopress-pkg'
+					) }
+					onChange={ onPrivacySettingsChange }
+				/>
+			</Col>
+		</Container>
+	);
+};
+
+export default SiteSettingsSection;

--- a/projects/packages/videopress/src/client/admin/components/site-settings-section/stories/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/site-settings-section/stories/index.tsx
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { action } from '@storybook/addon-actions';
+import React from 'react';
+/**
+ * Internal dependencies
+ */
+import SettingsSection from '..';
+
+export default {
+	title: 'Packages/VideoPress/Site Settings',
+	component: SettingsSection,
+	argTypes: {},
+};
+
+const Template = args => <SettingsSection { ...args } />;
+
+export const _default = Template.bind( {} );
+_default.args = {
+	onPrivacySettingsChange: action( 'onPrivacySettingsChange' ),
+};

--- a/projects/packages/videopress/src/client/admin/components/site-settings-section/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/site-settings-section/types.ts
@@ -1,0 +1,11 @@
+export type SiteSettingsSectionProps = {
+	/**
+	 * Optional classname to apply to the root element.
+	 */
+	className?: string;
+
+	/**
+	 * Callback function to be invoked when the privacy settings changes.
+	 */
+	onPrivacySettingsChange?: ( isPrivate: boolean ) => void;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of https://github.com/Automattic/jetpack/issues/26938

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: add Site Settings section

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### With Storybook

* Go to `Site Settings` story
* Take a look at the component
* Confirm the `onPrivacySettingsChange()` callback is called when changing the site privacy by clicking on the checkbox

<img width="983" alt="Screen Shot 2022-11-07 at 11 30 45" src="https://user-images.githubusercontent.com/77539/200376174-9e80080c-56b8-43ea-81e9-9ef73d745b2e.png">

### VideoPress dashboard

* Check visually the new section added at the bottom of the dashboard

<img width="1022" alt="Screen Shot 2022-11-07 at 11 29 25" src="https://user-images.githubusercontent.com/77539/200376005-556b0e50-254b-4bce-8955-59c72e457fe0.png">

