### PR TITLE
VideoPress: mitigate video re-rendering flickr

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-mitigate-player-rerendering-flickr
+++ b/projects/packages/videopress/changelog/update-videopress-mitigate-player-rerendering-flickr
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: mitigate video re-rendering flickr

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-player/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-player/index.js
@@ -94,9 +94,13 @@ export default function VideoPressPlayer( {
 			return;
 		}
 
+		// Once the video is loaded, delegate the height to the player (iFrame)
 		if ( preview ) {
-			// Once the video is loaded, delegate the height to the player (iFrame)
-			return setVideoPlayerTemporaryHeightState( 'auto' );
+			// Hack to mitigate the flickr when the player is
+			setTimeout( () => {
+				setVideoPlayerTemporaryHeightState( 'auto' );
+			}, 250 );
+			return;
 		}
 
 		if ( ! videoRatio ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: mitigate video re-rendering flickr

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Block editor
* Add a Video block
* Add other blocks around it
* Select the block
* Change the player settings
* Confirm visually that the app reduces the flicker when the player rerenders

**Before**


https://user-images.githubusercontent.com/77539/200440469-dc5e7c48-36ad-4240-b64f-232eb7404455.mov



**After**


https://user-images.githubusercontent.com/77539/200440458-140c2587-1994-4291-bf92-6fedf3e162e9.mov



