### PR TITLE
Protect: Add useWafData hook

### DIFF
--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -353,6 +353,18 @@ class Jetpack_Protect {
 
 		register_rest_route(
 			'jetpack-protect/v1',
+			'waf',
+			array(
+				'methods'             => \WP_REST_SERVER::READABLE,
+				'callback'            => __CLASS__ . '::api_get_waf',
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
+			)
+		);
+
+		register_rest_route(
+			'jetpack-protect/v1',
 			'waf-seen',
 			array(
 				'methods'             => \WP_REST_SERVER::READABLE,
@@ -505,6 +517,22 @@ class Jetpack_Protect {
 		}
 
 		return new WP_REST_Response( 'Scan enqueued.' );
+	}
+
+	/**
+	 * Get WAF data for the API endpoint
+	 *
+	 * @return bool Whether the current user has viewed the WAF screen.
+	 */
+	public static function api_get_waf() {
+		$request  = new WP_REST_Request( 'GET', '/jetpack/v4/waf' );
+		$response = rest_do_request( $request );
+
+		if ( $response->status !== 200 ) {
+			return new WP_REST_Response( 'An error occured while attempting to load Firewall settings', 500 );
+		}
+
+		return new WP_REST_Response( $response );
 	}
 
 	/**

--- a/projects/plugins/protect/src/js/hooks/use-waf-data/index.jsx
+++ b/projects/plugins/protect/src/js/hooks/use-waf-data/index.jsx
@@ -13,7 +13,7 @@ const useWafData = () => {
 	useEffect( () => {
 		if ( waf === undefined && ! wafIsFetching ) {
 			apiFetch( {
-				path: 'jetpack/v4/waf',
+				path: 'jetpack-protect/v1/waf',
 				method: 'GET',
 			} ).then( response => {
 				setWaf( response );

--- a/projects/plugins/protect/src/js/hooks/use-waf-data/index.jsx
+++ b/projects/plugins/protect/src/js/hooks/use-waf-data/index.jsx
@@ -1,0 +1,30 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from 'react';
+import { STORE_ID } from '../../state/store';
+
+const useWafData = () => {
+	const { setWaf } = useDispatch( STORE_ID );
+	const { waf, wafIsFetching } = useSelect( select => ( {
+		waf: select( STORE_ID ).getWaf(),
+		wafIsFetching: select( STORE_ID ).getWafIsFetching(),
+	} ) );
+
+	useEffect( () => {
+		if ( waf === undefined && ! wafIsFetching ) {
+			apiFetch( {
+				path: 'jetpack/v4/waf',
+				method: 'GET',
+			} ).then( response => {
+				setWaf( response );
+			} );
+		}
+	}, [ setWaf, waf, wafIsFetching ] );
+
+	return {
+		waf,
+		wafIsFetching,
+	};
+};
+
+export default useWafData;

--- a/projects/plugins/protect/src/js/state/actions.js
+++ b/projects/plugins/protect/src/js/state/actions.js
@@ -21,6 +21,8 @@ const SET_NOTICE = 'SET_NOTICE';
 const CLEAR_NOTICE = 'CLEAR_NOTICE';
 const SET_HAS_REQUIRED_PLAN = 'SET_HAS_REQUIRED_PLAN';
 const SET_WAF_SEEN = 'SET_WAF_SEEN';
+const SET_WAF_IS_FETCHING = 'SET_WAF_IS_FETCHING';
+const SET_WAF = 'SET_WAF';
 
 const setStatus = status => {
 	return { type: SET_STATUS, status };
@@ -358,6 +360,14 @@ const setWafSeen = seen => {
 	return { type: SET_WAF_SEEN, seen };
 };
 
+const setWafIsFetching = isFetching => {
+	return { type: SET_WAF_IS_FETCHING, isFetching };
+};
+
+const setWaf = waf => {
+	return { type: SET_WAF, waf };
+};
+
 const actions = {
 	checkCredentials,
 	setCredentials,
@@ -383,6 +393,8 @@ const actions = {
 	setHasRequiredPlan,
 	setScanIsUnavailable,
 	setWafSeen,
+	setWafIsFetching,
+	setWaf,
 };
 
 export {
@@ -405,5 +417,7 @@ export {
 	SET_THREATS_ARE_FIXING,
 	SET_HAS_REQUIRED_PLAN,
 	SET_WAF_SEEN,
+	SET_WAF_IS_FETCHING,
+	SET_WAF,
 	actions as default,
 };

--- a/projects/plugins/protect/src/js/state/reducers.js
+++ b/projects/plugins/protect/src/js/state/reducers.js
@@ -19,6 +19,8 @@ import {
 	SET_THREATS_ARE_FIXING,
 	SET_HAS_REQUIRED_PLAN,
 	SET_WAF_SEEN,
+	SET_WAF_IS_FETCHING,
+	SET_WAF,
 } from './actions';
 
 const credentials = ( state = null, action ) => {
@@ -161,6 +163,22 @@ const wafSeen = ( state = undefined, action ) => {
 	return state;
 };
 
+const waf = ( state = undefined, action ) => {
+	switch ( action.type ) {
+		case SET_WAF:
+			return action.waf;
+	}
+	return state;
+};
+
+const wafIsFetching = ( state = false, action ) => {
+	switch ( action.type ) {
+		case SET_WAF_IS_FETCHING:
+			return action.isFetching;
+	}
+	return state;
+};
+
 const reducers = combineReducers( {
 	credentials,
 	credentialsIsFetching,
@@ -179,6 +197,8 @@ const reducers = combineReducers( {
 	setThreatsFixing,
 	hasRequiredPlan,
 	wafSeen,
+	waf,
+	wafIsFetching,
 } );
 
 export default reducers;

--- a/projects/plugins/protect/src/js/state/selectors.js
+++ b/projects/plugins/protect/src/js/state/selectors.js
@@ -17,6 +17,8 @@ const selectors = {
 	getThreatsAreFixing: state => state.threatsAreFixing || [],
 	hasRequiredPlan: state => state.hasRequiredPlan || false,
 	getWafSeen: state => state.wafSeen,
+	getWaf: state => state.waf,
+	getWafIsFetching: state => state.wafIsFetching || false,
 };
 
 export default selectors;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a `useWafData()` hook for interacting with firewall settings and data.
* Adds related `waf` and `wafIsFetching` redux state variables.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

peb6dq-4G-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Review the code