### PR TITLE
VideoPress: Fix and return with select thumbnail from frame

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-thumbnail
+++ b/projects/packages/videopress/changelog/fix-videopress-thumbnail
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fix bug and return with select thumbnail from frame

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
@@ -497,6 +497,11 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 					$should_update_meta            = true;
 				}
 
+				if ( isset( $json_params['poster'] ) ) {
+					$meta['videopress']['poster'] = $json_params['poster'];
+					$should_update_meta           = true;
+				}
+
 				if ( isset( $json_params['allow_download'] ) ) {
 					$allow_download = (bool) $json_params['allow_download'];
 					if ( ! isset( $meta['videopress']['allow_download'] ) || $meta['videopress']['allow_download'] !== $allow_download ) {

--- a/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-card/index.tsx
@@ -97,8 +97,8 @@ export const VideoCard = ( {
 				<VideoThumbnail
 					className={ styles[ 'video-card__thumbnail' ] }
 					thumbnail={ thumbnail }
-					loading={ loading }
-					uploading={ uploading || isUpdatingPoster }
+					loading={ loading || isUpdatingPoster }
+					uploading={ uploading }
 					processing={ processing }
 					duration={ loading ? null : duration }
 					editable={ loading ? false : editable }

--- a/projects/packages/videopress/src/client/admin/components/video-row/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-row/index.tsx
@@ -253,8 +253,8 @@ export const VideoRow = ( {
 						<div className={ styles.poster }>
 							<VideoThumbnail
 								thumbnail={ thumbnail }
-								loading={ loading }
-								uploading={ uploading || isUpdatingPoster }
+								loading={ loading || isUpdatingPoster }
+								uploading={ uploading }
 								processing={ processing }
 								blankIconSize={ 28 }
 								uploadProgress={ uploadProgress }

--- a/projects/packages/videopress/src/client/admin/components/video-thumbnail/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-thumbnail/index.tsx
@@ -28,7 +28,9 @@ export const VideoThumbnailDropdownButtons = ( {
 } ) => {
 	return (
 		<>
+			{ /* TODO: Implement use default and remove disabled class */ }
 			<Button
+				className={ styles.disabled }
 				weight="regular"
 				fullWidth
 				variant="tertiary"
@@ -84,7 +86,7 @@ export const VideoThumbnailDropdown = ( {
 						variant="secondary"
 						className={ styles[ 'thumbnail__edit-button' ] }
 						icon={ edit }
-						onClick={ onUploadImage }
+						onClick={ onToggle }
 						aria-expanded={ isOpen }
 					/>
 				) }

--- a/projects/packages/videopress/src/client/admin/components/video-thumbnail/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/video-thumbnail/style.module.scss
@@ -112,3 +112,8 @@
 .upload-text {
 	margin-top: calc( var( --spacing-base ) * 3 );
 }
+
+// TODO: Remove when implement use default thumbnail
+.disabled {
+	display: none;
+}

--- a/projects/packages/videopress/src/client/state/actions.js
+++ b/projects/packages/videopress/src/client/state/actions.js
@@ -295,7 +295,16 @@ const updateVideoPoster = ( id, guid, data ) => async ( { dispatch } ) => {
 				if ( resp?.data?.generating ) {
 					pollPoster();
 				} else {
-					dispatch( { type: UPDATE_VIDEO_POSTER, id, poster: resp?.data?.poster } );
+					const poster = resp?.data?.poster;
+					dispatch( { type: UPDATE_VIDEO_POSTER, id, poster } );
+					apiFetch( {
+						path: WP_REST_API_VIDEOPRESS_META_ENDPOINT,
+						method: 'POST',
+						data: {
+							id,
+							poster,
+						},
+					} );
 				}
 			} catch ( error ) {
 				// @todo implement error handling / UI


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26626 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add new `poster` support in `meta` endpoint.
* Include a call for meta endpoint at upload video poster action.
* Use `loading` mode instead `uploading` when updating poster.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `VideoPress` dashboard.
* Click to edit video details.
* Change the thumbnail selecting a frame.
* Waits for loading (thumbnail being generated). 
* Refresh the page.
* You should keep seeing the new poster. 

