### PR TITLE
Boost: Fix get started rendering

### DIFF
--- a/projects/plugins/boost/app/admin/class-config.php
+++ b/projects/plugins/boost/app/admin/class-config.php
@@ -178,7 +178,7 @@ class Config {
 	 */
 	public static function is_getting_started() {
 		// Aside from the boolean flag in the database, we also assume site already got started if they have premium features.
-		return \get_option( 'jb_get_started', false ) && ! Premium_Features::has_feature( Premium_Features::CLOUD_CSS );
+		return \get_option( 'jb_get_started', false ) && ! Premium_Features::has_feature( Premium_Features::CLOUD_CSS ) && ! ( new Status() )->is_offline_mode();
 	}
 
 	/**

--- a/projects/plugins/boost/app/assets/src/js/pages/getting-started/GettingStarted.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/getting-started/GettingStarted.svelte
@@ -25,6 +25,15 @@
 		await recordBoostEvent( 'premium_cta_from_getting_started_page_in_plugin', {} );
 		window.location.href = getUpgradeURL();
 	};
+
+	$: {
+		if ( typeof pricing.yearly === 'undefined' ) {
+			// Allow opening the boost settings page.
+			markGetStartedComplete();
+
+			navigate( '/', { replace: true } );
+		}
+	}
 </script>
 
 <div id="jb-settings" class="jb-settings jb-settings--main">
@@ -32,14 +41,16 @@
 		<Header />
 	</div>
 
-	<div class="jb-section jb-section--alt">
-		<div class="jb-container">
-			<ReactComponent
-				this={BoostPricingTable}
-				{pricing}
-				onPremiumCTA={choosePaidPlan}
-				onFreeCTA={chooseFreePlan}
-			/>
+	{#if pricing.yearly}
+		<div class="jb-section jb-section--alt">
+			<div class="jb-container">
+				<ReactComponent
+					this={BoostPricingTable}
+					{pricing}
+					onPremiumCTA={choosePaidPlan}
+					onFreeCTA={chooseFreePlan}
+				/>
+			</div>
 		</div>
-	</div>
+	{/if}
 </div>

--- a/projects/plugins/boost/app/assets/src/js/pages/getting-started/GettingStarted.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/getting-started/GettingStarted.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import ReactComponent from '../../elements/ReactComponent.svelte';
 	import { BoostPricingTable } from '../../react-components/BoostPricingTable';
 	import Header from '../../sections/Header.svelte';
@@ -26,14 +27,15 @@
 		window.location.href = getUpgradeURL();
 	};
 
-	$: {
+	onMount( () => {
+		// If we don't have pricing data, we should skip the page and go directly to settings.
 		if ( typeof pricing.yearly === 'undefined' ) {
 			// Allow opening the boost settings page.
 			markGetStartedComplete();
 
 			navigate( '/', { replace: true } );
 		}
-	}
+	} );
 </script>
 
 <div id="jb-settings" class="jb-settings jb-settings--main">

--- a/projects/plugins/boost/app/lib/Premium_Pricing.php
+++ b/projects/plugins/boost/app/lib/Premium_Pricing.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack_Boost\Lib;
 
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
+use Automattic\Jetpack\Status;
 
 class Premium_Pricing {
 	const PRODUCT_SLUG_BASE = 'jetpack_boost';
@@ -16,7 +17,7 @@ class Premium_Pricing {
 		$yearly_pricing_slug  = self::PRODUCT_SLUG_BASE . '_yearly';
 		$yearly_pricing       = Wpcom_Products::get_product_pricing( $yearly_pricing_slug );
 
-		if ( empty( $yearly_pricing ) ) {
+		if ( empty( $yearly_pricing ) && ! ( new Status() )->is_offline_mode() ) {
 			Analytics::record_user_event( 'upgrade_price_missing', array( 'error_message' => 'Missing pricing information on benefits interstitial page.' ) );
 			return $constants;
 		}

--- a/projects/plugins/boost/changelog/fix-get-started-rendering
+++ b/projects/plugins/boost/changelog/fix-get-started-rendering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed an issue that caused boost to break on offline sites


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixed an issue that caused boost to break on offline sites

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
p1667843934997759-slack-C016BBAFHHS

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Enable jetpack offline `define( 'JETPACK_DEV_DEBUG', true);`
* Install Boost and open the Boost settings page
* That should take you directly to the settings page, skipping the getting-started page