### PR TITLE
VideoPress: Fetch VideoPress settings from backend using selector/resolver

### DIFF
--- a/projects/packages/videopress/changelog/add-fetch-videopress-site-privacy-setting
+++ b/projects/packages/videopress/changelog/add-fetch-videopress-site-privacy-setting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Create selector/resolver machinery to fetch VideoPress site privacy setting from the backend.

--- a/projects/packages/videopress/src/client/state/actions.js
+++ b/projects/packages/videopress/src/client/state/actions.js
@@ -45,7 +45,7 @@ import {
 	SET_PLAYBACK_TOKEN,
 	EXPIRE_PLAYBACK_TOKEN,
 	SET_VIDEO_UPLOAD_PROGRESS,
-	SET_VIDEOPRESS_SITE_PRIVACY_SETTING,
+	SET_VIDEOPRESS_SETTINGS,
 } from './constants';
 import { mapVideoFromWPV2MediaEndpoint } from './utils/map-videos';
 
@@ -353,8 +353,8 @@ const expirePlaybackToken = guid => {
 	return { type: EXPIRE_PLAYBACK_TOKEN, guid };
 };
 
-const setVideoPressSitePrivacySetting = videoPressSitePrivacySetting => {
-	return { type: SET_VIDEOPRESS_SITE_PRIVACY_SETTING, videoPressSitePrivacySetting };
+const setVideoPressSettings = videoPressSettings => {
+	return { type: SET_VIDEOPRESS_SETTINGS, videoPressSettings };
 };
 
 const actions = {
@@ -397,7 +397,7 @@ const actions = {
 	setPlaybackToken,
 	expirePlaybackToken,
 
-	setVideoPressSitePrivacySetting,
+	setVideoPressSettings,
 };
 
 export { actions as default };

--- a/projects/packages/videopress/src/client/state/actions.js
+++ b/projects/packages/videopress/src/client/state/actions.js
@@ -45,6 +45,7 @@ import {
 	SET_PLAYBACK_TOKEN,
 	EXPIRE_PLAYBACK_TOKEN,
 	SET_VIDEO_UPLOAD_PROGRESS,
+	SET_VIDEOPRESS_SITE_PRIVACY_SETTING,
 } from './constants';
 import { mapVideoFromWPV2MediaEndpoint } from './utils/map-videos';
 
@@ -352,6 +353,10 @@ const expirePlaybackToken = guid => {
 	return { type: EXPIRE_PLAYBACK_TOKEN, guid };
 };
 
+const setVideoPressSitePrivacySetting = videoPressSitePrivacySetting => {
+	return { type: SET_VIDEOPRESS_SITE_PRIVACY_SETTING, videoPressSitePrivacySetting };
+};
+
 const actions = {
 	setIsFetchingVideos,
 	setFetchVideosError,
@@ -391,6 +396,8 @@ const actions = {
 	setIsFetchingPlaybackToken,
 	setPlaybackToken,
 	expirePlaybackToken,
+
+	setVideoPressSitePrivacySetting,
 };
 
 export { actions as default };

--- a/projects/packages/videopress/src/client/state/constants.js
+++ b/projects/packages/videopress/src/client/state/constants.js
@@ -12,8 +12,7 @@ export const WP_REST_API_MEDIA_ENDPOINT = 'wp/v2/media';
 export const WP_REST_API_VIDEOPRESS_ENDPOINT = 'wpcom/v2/videopress';
 export const WP_REST_API_VIDEOPRESS_META_ENDPOINT = 'wpcom/v2/videopress/meta';
 export const WP_REST_API_VIDEOPRESS_PLAYBACK_TOKEN_ENDPOINT = 'wpcom/v2/videopress/playback-jwt';
-export const WP_REST_API_VIDEOPRESS_SITE_PRIVACY_SETTING_ENDPOINT =
-	'videopress/v1/site-privacy-setting';
+export const WP_REST_API_VIDEOPRESS_SETTINGS_ENDPOINT = 'videopress/v1/settings';
 export const REST_API_SITE_PURCHASES_ENDPOINT = 'my-jetpack/v1/site/purchases';
 export const REST_API_SITE_INFO_ENDPOINT = 'videopress/v1/site';
 
@@ -60,7 +59,7 @@ export const SET_USERS_PAGINATION = 'SET_USERS_PAGINATION';
 export const SET_UPDATING_VIDEO_POSTER = 'SET_UPDATING_VIDEO_POSTER';
 export const UPDATE_VIDEO_POSTER = 'UPDATE_VIDEO_POSTER';
 
-export const SET_VIDEOPRESS_SITE_PRIVACY_SETTING = 'SET_VIDEOPRESS_SITE_PRIVACY_SETTING';
+export const SET_VIDEOPRESS_SETTINGS = 'SET_VIDEOPRESS_SETTINGS';
 
 /*
  * Accepted file extensions

--- a/projects/packages/videopress/src/client/state/constants.js
+++ b/projects/packages/videopress/src/client/state/constants.js
@@ -12,6 +12,8 @@ export const WP_REST_API_MEDIA_ENDPOINT = 'wp/v2/media';
 export const WP_REST_API_VIDEOPRESS_ENDPOINT = 'wpcom/v2/videopress';
 export const WP_REST_API_VIDEOPRESS_META_ENDPOINT = 'wpcom/v2/videopress/meta';
 export const WP_REST_API_VIDEOPRESS_PLAYBACK_TOKEN_ENDPOINT = 'wpcom/v2/videopress/playback-jwt';
+export const WP_REST_API_VIDEOPRESS_SITE_PRIVACY_SETTING_ENDPOINT =
+	'videopress/v1/site-privacy-setting';
 export const REST_API_SITE_PURCHASES_ENDPOINT = 'my-jetpack/v1/site/purchases';
 export const REST_API_SITE_INFO_ENDPOINT = 'videopress/v1/site';
 
@@ -57,6 +59,8 @@ export const SET_USERS_PAGINATION = 'SET_USERS_PAGINATION';
 
 export const SET_UPDATING_VIDEO_POSTER = 'SET_UPDATING_VIDEO_POSTER';
 export const UPDATE_VIDEO_POSTER = 'UPDATE_VIDEO_POSTER';
+
+export const SET_VIDEOPRESS_SITE_PRIVACY_SETTING = 'SET_VIDEOPRESS_SITE_PRIVACY_SETTING';
 
 /*
  * Accepted file extensions

--- a/projects/packages/videopress/src/client/state/reducers.js
+++ b/projects/packages/videopress/src/client/state/reducers.js
@@ -39,6 +39,7 @@ import {
 	SET_PLAYBACK_TOKEN,
 	SET_VIDEO_UPLOAD_PROGRESS,
 	EXPIRE_PLAYBACK_TOKEN,
+	SET_VIDEOPRESS_SITE_PRIVACY_SETTING,
 } from './constants';
 
 /**
@@ -647,12 +648,29 @@ const playbackTokens = ( state, action ) => {
 	}
 };
 
+const siteSettings = ( state, action ) => {
+	switch ( action.type ) {
+		case SET_VIDEOPRESS_SITE_PRIVACY_SETTING: {
+			const { videoPressSitePrivacySetting } = action;
+
+			return {
+				...state,
+				videoPressSitePrivacySetting,
+			};
+		}
+
+		default:
+			return state;
+	}
+};
+
 const reducers = combineReducers( {
 	videos,
 	localVideos,
 	purchases,
 	users,
 	playbackTokens,
+	siteSettings,
 } );
 
 export default reducers;

--- a/projects/packages/videopress/src/client/state/reducers.js
+++ b/projects/packages/videopress/src/client/state/reducers.js
@@ -39,7 +39,7 @@ import {
 	SET_PLAYBACK_TOKEN,
 	SET_VIDEO_UPLOAD_PROGRESS,
 	EXPIRE_PLAYBACK_TOKEN,
-	SET_VIDEOPRESS_SITE_PRIVACY_SETTING,
+	SET_VIDEOPRESS_SETTINGS,
 } from './constants';
 
 /**
@@ -650,12 +650,12 @@ const playbackTokens = ( state, action ) => {
 
 const siteSettings = ( state, action ) => {
 	switch ( action.type ) {
-		case SET_VIDEOPRESS_SITE_PRIVACY_SETTING: {
-			const { videoPressSitePrivacySetting } = action;
+		case SET_VIDEOPRESS_SETTINGS: {
+			const { videoPressSettings } = action;
 
 			return {
 				...state,
-				videoPressSitePrivacySetting,
+				...videoPressSettings,
 			};
 		}
 

--- a/projects/packages/videopress/src/client/state/resolvers.js
+++ b/projects/packages/videopress/src/client/state/resolvers.js
@@ -427,12 +427,14 @@ const getVideoPressSettings = {
 	},
 	fulfill: () => async ( { dispatch } ) => {
 		try {
-			const { videopress_videos_private_for_site: videoPressSitePrivacySetting } = await apiFetch( {
-				path: addQueryArgs( `${ WP_REST_API_VIDEOPRESS_SETTINGS_ENDPOINT }` ),
-				method: 'GET',
-			} );
+			const { videopress_videos_private_for_site: videoPressVideosPrivateForSite } = await apiFetch(
+				{
+					path: addQueryArgs( `${ WP_REST_API_VIDEOPRESS_SETTINGS_ENDPOINT }` ),
+					method: 'GET',
+				}
+			);
 
-			const videoPressSettings = { videoPressSitePrivacySetting };
+			const videoPressSettings = { videoPressVideosPrivateForSite };
 
 			dispatch.setVideoPressSettings( videoPressSettings );
 			return videoPressSettings;

--- a/projects/packages/videopress/src/client/state/resolvers.js
+++ b/projects/packages/videopress/src/client/state/resolvers.js
@@ -21,7 +21,7 @@ import {
 	VIDEO_PRIVACY_LEVELS,
 	VIDEO_PRIVACY_LEVEL_PRIVATE,
 	EXPIRE_PLAYBACK_TOKEN,
-	WP_REST_API_VIDEOPRESS_SITE_PRIVACY_SETTING_ENDPOINT,
+	WP_REST_API_VIDEOPRESS_SETTINGS_ENDPOINT,
 } from './constants';
 import { getDefaultQuery } from './reducers';
 import {
@@ -421,20 +421,21 @@ const getPlaybackToken = {
 	},
 };
 
-const getVideoPressSitePrivacySetting = {
+const getVideoPressSettings = {
 	isFulfilled: state => {
-		const siteSettings = state?.siteSettings || {};
-		return siteSettings.videoPressSitePrivacySetting !== undefined;
+		return state?.siteSettings !== undefined;
 	},
 	fulfill: () => async ( { dispatch } ) => {
 		try {
 			const { videopress_videos_private_for_site: videoPressSitePrivacySetting } = await apiFetch( {
-				path: addQueryArgs( `${ WP_REST_API_VIDEOPRESS_SITE_PRIVACY_SETTING_ENDPOINT }` ),
+				path: addQueryArgs( `${ WP_REST_API_VIDEOPRESS_SETTINGS_ENDPOINT }` ),
 				method: 'GET',
 			} );
 
-			dispatch.setVideoPressSitePrivacySetting( videoPressSitePrivacySetting );
-			return videoPressSitePrivacySetting;
+			const videoPressSettings = { videoPressSitePrivacySetting };
+
+			dispatch.setVideoPressSettings( videoPressSettings );
+			return videoPressSettings;
 		} catch ( error ) {
 			console.error( error ); // eslint-disable-line no-console
 		}
@@ -455,5 +456,5 @@ export default {
 
 	getPlaybackToken,
 
-	getVideoPressSitePrivacySetting,
+	getVideoPressSettings,
 };

--- a/projects/packages/videopress/src/client/state/resolvers.js
+++ b/projects/packages/videopress/src/client/state/resolvers.js
@@ -21,6 +21,7 @@ import {
 	VIDEO_PRIVACY_LEVELS,
 	VIDEO_PRIVACY_LEVEL_PRIVATE,
 	EXPIRE_PLAYBACK_TOKEN,
+	WP_REST_API_VIDEOPRESS_SITE_PRIVACY_SETTING_ENDPOINT,
 } from './constants';
 import { getDefaultQuery } from './reducers';
 import {
@@ -420,6 +421,26 @@ const getPlaybackToken = {
 	},
 };
 
+const getVideoPressSitePrivacySetting = {
+	isFulfilled: state => {
+		const siteSettings = state?.siteSettings || {};
+		return siteSettings.videoPressSitePrivacySetting !== undefined;
+	},
+	fulfill: () => async ( { dispatch } ) => {
+		try {
+			const { videopress_videos_private_for_site: videoPressSitePrivacySetting } = await apiFetch( {
+				path: addQueryArgs( `${ WP_REST_API_VIDEOPRESS_SITE_PRIVACY_SETTING_ENDPOINT }` ),
+				method: 'GET',
+			} );
+
+			dispatch.setVideoPressSitePrivacySetting( videoPressSitePrivacySetting );
+			return videoPressSitePrivacySetting;
+		} catch ( error ) {
+			console.error( error ); // eslint-disable-line no-console
+		}
+	},
+};
+
 export default {
 	getStorageUsed,
 	getUploadedVideoCount,
@@ -433,4 +454,6 @@ export default {
 	getPurchases,
 
 	getPlaybackToken,
+
+	getVideoPressSitePrivacySetting,
 };

--- a/projects/packages/videopress/src/client/state/selectors.js
+++ b/projects/packages/videopress/src/client/state/selectors.js
@@ -98,6 +98,10 @@ export const isFetchingPlaybackToken = state => {
 	return state?.playbackTokens?.isFetching;
 };
 
+export const getVideoPressSitePrivacySetting = state => {
+	return state?.siteSettings?.videoPressSitePrivacySetting;
+};
+
 const selectors = {
 	// VideoPress videos
 	getVideos,
@@ -128,6 +132,8 @@ const selectors = {
 
 	getPlaybackToken,
 	isFetchingPlaybackToken,
+
+	getVideoPressSitePrivacySetting,
 };
 
 export default selectors;

--- a/projects/packages/videopress/src/client/state/selectors.js
+++ b/projects/packages/videopress/src/client/state/selectors.js
@@ -98,8 +98,8 @@ export const isFetchingPlaybackToken = state => {
 	return state?.playbackTokens?.isFetching;
 };
 
-export const getVideoPressSitePrivacySetting = state => {
-	return state?.siteSettings?.videoPressSitePrivacySetting;
+export const getVideoPressSettings = state => {
+	return state?.siteSettings;
 };
 
 const selectors = {
@@ -133,7 +133,7 @@ const selectors = {
 	getPlaybackToken,
 	isFetchingPlaybackToken,
 
-	getVideoPressSitePrivacySetting,
+	getVideoPressSettings,
 };
 
 export default selectors;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Relates to #26938 and #27314.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Create selector/resolver machinery to fetch VideoPress settings from the backend
* Exposes the `getVideoPressSettings()` selector, returning an object with the `videoPressVideosPrivateForSite` setting present 

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test on a site with VideoPress plugin
* On the browser console, run the following:

```
wp.data.select( 'videopress/media' ).getVideoPressSettings();
```

* The first time you run it, it will return `undefined` and an API request will be triggered, a `GET` to `videopress/v1/settings`
* You should see no errors after the new endpoint becames available
* Run the command again
* Now you should see it returning an object with settings (currently only the privacy setting is present):

```
{
   "videoPressVideosPrivateForSite": false
}
```