### PR TITLE
Boost: Fix pricing php notices

### DIFF
--- a/projects/plugins/boost/app/lib/Premium_Pricing.php
+++ b/projects/plugins/boost/app/lib/Premium_Pricing.php
@@ -17,8 +17,11 @@ class Premium_Pricing {
 		$yearly_pricing_slug  = self::PRODUCT_SLUG_BASE . '_yearly';
 		$yearly_pricing       = Wpcom_Products::get_product_pricing( $yearly_pricing_slug );
 
-		if ( empty( $yearly_pricing ) && ! ( new Status() )->is_offline_mode() ) {
-			Analytics::record_user_event( 'upgrade_price_missing', array( 'error_message' => 'Missing pricing information on benefits interstitial page.' ) );
+		if ( empty( $yearly_pricing ) ) {
+			// In offline mode, we don't have access to the pricing data and it's not an error.
+			if ( ! ( new Status() )->is_offline_mode() ) {
+				Analytics::record_user_event( 'upgrade_price_missing', array( 'error_message' => 'Missing pricing information on benefits interstitial page.' ) );
+			}
 			return $constants;
 		}
 

--- a/projects/plugins/boost/changelog/fix-pricing-php-notices
+++ b/projects/plugins/boost/changelog/fix-pricing-php-notices
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: A minor fix of recent unreleased change
+
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix a situation where undefined indexes would be accessed and generate PHP notices in offline mode

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Go to boost settings page in offline mode
* Make sure no PHP notices are generated

