### PR TITLE
Jetpack Boost: Fix unable to click permanent dismiss button when speed score has dropped

### DIFF
--- a/projects/plugins/boost/app/assets/src/css/main/dashboard.scss
+++ b/projects/plugins/boost/app/assets/src/css/main/dashboard.scss
@@ -33,6 +33,7 @@
 
 .jb-section--scores {
 	position: relative;
+	z-index: 10;
 }
 
 .jb-container {

--- a/projects/plugins/boost/changelog/fix-score-change-modal-permanent-dismiss-not-clickable
+++ b/projects/plugins/boost/changelog/fix-score-change-modal-permanent-dismiss-not-clickable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed dismiss link not clickable in some cases


### PR DESCRIPTION
Fixes #27252

#### Changes proposed in this Pull Request:
* The fix updates the scores section to have a higher `z-index` than the other sections. That way, if there's a child element (like the modal for the speed scores or the overall score info tooltip) showing above another section, users can interact properly with it.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This will test if the "**Don't show me again**" link in the "**Speed score has fallen**" pop out can be interacted with:
* Rig the speed score so that it shows 5 points less than the **no-boost** score;
* The "**Speed score has fallen**" pop out should appear;
* You should now be able to click the "**Do not show me again**" link.
![image](https://user-images.githubusercontent.com/11799079/200842911-f97912cd-a4ca-47e0-9d0c-500c334845b2.png)



This will test if the score grade tooltip box can be properly interacted with:
* Go to `WP-admin -> Jetpack -> Boost` and wait for the `Overall score` panel to show the scores;
* After the grade shows up, hover over the small `i` icon next to it to show the tooltip;
* You should be able to select the row with the C or F scores without a problem;
![image](https://user-images.githubusercontent.com/11799079/200841427-5c4d8e0c-7ead-4733-841c-55d9c5b4c676.png)
* Before the tooltip would hide once the cursor goes near the bottom, as the hover is now over the next section.