### PR TITLE
RNA: Register --jp-gray-70 color in ThemeProvider

### DIFF
--- a/projects/js-packages/components/changelog/add-gray-variant-to-themeprovider
+++ b/projects/js-packages/components/changelog/add-gray-variant-to-themeprovider
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: added color to themeprovider
+
+

--- a/projects/js-packages/components/components/theme-provider/index.tsx
+++ b/projects/js-packages/components/components/theme-provider/index.tsx
@@ -29,6 +29,7 @@ export const colors = {
 	'--jp-gray-40': '#787C82',
 	'--jp-gray-50': '#646970',
 	'--jp-gray-60': '#50575E',
+	'--jp-gray-70': '#3C434A',
 	'--jp-gray-80': '#2C3338',
 	'--jp-gray-off': '#e2e2df',
 	// Red

--- a/projects/packages/videopress/changelog/add-gray-variant-to-themeprovider
+++ b/projects/packages/videopress/changelog/add-gray-variant-to-themeprovider
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: added color to themeprovider
+
+

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/style.module.scss
@@ -42,10 +42,9 @@
 	}
 
 	.link {
-		--gray-70: #3C434A !important;
 		margin-bottom: calc( var( --spacing-base ) * 3 );
 		font-size: 14px;
-		color: var(--gray-70);
+		color: var(--jp-gray-70);
 		display: flex;
 		text-decoration: none;
 		align-items: center;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add new gray color definition to ThemeProvider
* Use it in the Go Back button in VideoPress

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1666961031765309-slack-C03TA48NSUX

#### Does this pull request change what data or activity we track or use?
No
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open the VideoPress admin section and click in 'edit video details'
* Confirm that the back button is gray:
<img width="1145" alt="Screenshot 2022-11-09 at 14 20 28" src="https://user-images.githubusercontent.com/16329583/200841121-f7044c00-b29f-4b3b-8cd8-7aabd063424d.png">


* Run and open the Storybook, and confirm that the gray variant is there:

<img width="1107" alt="Screenshot 2022-11-09 at 14 16 32" src="https://user-images.githubusercontent.com/16329583/200840251-4b34249c-d669-4d8d-aeaf-ad3dc0394dfb.png">