### PR TITLE
Jetpack: Remove redundant menu item and threat notifications for Protect users

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-jetpack-protect-redundencies
+++ b/projects/plugins/jetpack/changelog/remove-jetpack-protect-redundencies
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Improved compatibility with the Jetpack Protect standalone plugin.

--- a/projects/plugins/jetpack/modules/scan/class-admin-bar-notice.php
+++ b/projects/plugins/jetpack/modules/scan/class-admin-bar-notice.php
@@ -80,6 +80,12 @@ class Admin_Bar_Notice {
 			return false;
 		}
 
+		// Check if Protect is active.
+		// It has its own notice in the admin bar.
+		if ( class_exists( 'Jetpack_Protect' ) ) {
+			return false;
+		}
+
 		// Only show the notice to admins.
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return false;

--- a/projects/plugins/jetpack/modules/scan/class-admin-sidebar-link.php
+++ b/projects/plugins/jetpack/modules/scan/class-admin-sidebar-link.php
@@ -133,7 +133,18 @@ class Admin_Sidebar_Link {
 			return false;
 		}
 
-		return $this->has_scan() || $this->should_show_backup();
+		return $this->should_show_scan() || $this->should_show_backup();
+	}
+
+	/**
+	 * Check if we should display the Scan menu item.
+	 *
+	 * It will only be displayed if site has Scan enabled and the stand-alone Protect plugin is not active, because it will have a menu item of its own.
+	 *
+	 * @return boolean
+	 */
+	private function should_show_scan() {
+		return $this->has_scan() && ! $this->has_protect_plugin();
 	}
 
 	/**
@@ -156,6 +167,15 @@ class Admin_Sidebar_Link {
 		$this->maybe_refresh_transient_cache();
 		$scan_state = get_transient( 'jetpack_scan_state' );
 		return ! $scan_state || 'unavailable' !== $scan_state->state;
+	}
+
+	/**
+	 * Detects if Protect plugin is active.
+	 *
+	 * @return boolean
+	 */
+	private function has_protect_plugin() {
+		return class_exists( 'Jetpack_Protect' );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR removes some duplicate functionality for users with a Scan plan and Jetpack Protect installed.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds `Jetpack_Protect` check to `should_try_to_display_notice()` to prevent threat notifications being shown to Protect users.
* Adds `should_show_scan()` method to `Admin_Sidebar_Link` to prevent the Scan menu item from being shown to users with Protect.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

1201069996155224-as-1203286905507172

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a fresh Jetpack site, verify no Scan or Protect menu items are displayed.
* Add a Scan plan, verify the external Scan menu item is displayed.
* Add a threat, run a scan.
* Validate that only one threat notification area is displayed in the admin bar.
* Install Protect, verify the external Scan menu item is replaced with a Protect menu item.
* Validate that only one threat notification area is displayed in the admin bar.
* Add a Backup plan, verify the external Backup menu item is displayed alongside the Protect menu item.

#### Screenshots

![image](https://user-images.githubusercontent.com/10933065/200915224-89864776-bdb9-4a0b-a036-1a7127b3d670.png)

![image](https://user-images.githubusercontent.com/10933065/200915260-3506c952-bd56-4a6c-bd03-1460f635dba8.png)
