### PR TITLE
Jetpack test: Mock `@wordpress/block-editor` `useSetting`

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-mock-block-editor-useSetting
+++ b/projects/plugins/jetpack/changelog/fix-mock-block-editor-useSetting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+Comment: Mock `@wordpress/block-editor` `useSetting` in a test instead of using `BlockEditorProvider`.
+

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/test/controls.js
@@ -1,8 +1,19 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { BlockEditorProvider } from '@wordpress/block-editor';
 import { DEFAULT_FONTSIZE_VALUE } from '../constants';
 import SubscriptionsInspectorControls from '../controls';
+
+// Mock `useSetting` from `@wordpress/block-editor` to override a setting.
+// This approach was recommended at p1667855007139489-slack-C45SNKV4Z
+jest.mock( '@wordpress/block-editor/build/components/use-setting', () => {
+	const { default: useSetting } = jest.requireActual(
+		'@wordpress/block-editor/build/components/use-setting'
+	);
+	const settings = {
+		'typography.customFontSize': true,
+	};
+	return path => ( settings.hasOwnProperty( path ) ? settings[ path ] : useSetting( path ) );
+} );
 
 const setButtonBackgroundColor = jest.fn();
 const setGradient = jest.fn();
@@ -93,11 +104,7 @@ describe( 'Inspector controls', () => {
 
 		test( 'set custom text', async () => {
 			const user = userEvent.setup();
-			render(
-				<BlockEditorProvider settings={ { disableCustomFontSizes: false } }>
-					<SubscriptionsInspectorControls { ...defaultProps } />
-				</BlockEditorProvider>
-			);
+			render( <SubscriptionsInspectorControls { ...defaultProps } /> );
 			await user.click( screen.getByRole( 'button', { name: 'Typography' } ) );
 			await user.click( screen.getByRole( 'button', { name: 'Set custom size' } ) );
 			await user.type( screen.getByRole( 'spinbutton', { name: 'Custom' } ), '18' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
In #27289 I added a wrapper object to try setting a setting that was now needed for a component to behave properly while testing. After some discussion at p1667855007139489-slack-C45SNKV4Z, mocking was suggested as the preferred solution. So let's do that.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1667855007139489-slack-C45SNKV4Z

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?