### PR TITLE
VideoPress: Disable automatic re-focus on video quick action popover close

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-quick-action-hover-popover
+++ b/projects/packages/videopress/changelog/fix-videopress-quick-action-hover-popover
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Disable automatic re-focus on video quick action popover close

--- a/projects/packages/videopress/src/client/admin/components/video-quick-actions/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-quick-actions/index.tsx
@@ -31,17 +31,28 @@ import {
 	ConnectVideoQuickActionsProps,
 } from './types';
 
-const PopoverWithAnchor = ( { anchor, children = null }: PopoverWithAnchorProps ) => {
-	if ( ! anchor ) {
+const PopoverWithAnchor = ( {
+	showPopover = false,
+	anchor,
+	children = null,
+}: PopoverWithAnchorProps ) => {
+	if ( ! anchor || ! showPopover ) {
 		return null;
 	}
+
+	useEffect( () => {
+		if ( showPopover ) {
+			( anchor?.querySelector( '.components-popover' ) as HTMLElement | null )?.focus();
+		}
+	}, [ showPopover ] );
+
 	const popoverProps = {
 		anchor,
 		offset: 15,
 	};
 
 	return (
-		<Popover position="top center" noArrow { ...popoverProps }>
+		<Popover position="top center" noArrow focusOnMount={ false } { ...popoverProps }>
 			<Text variant="body-small" className={ styles.popover }>
 				{ children }
 			</Text>
@@ -63,7 +74,9 @@ const ActionItem = ( { icon, children, className, ...props }: ActionItemProps ) 
 				onMouseLeave={ () => setShowPopover( false ) }
 				{ ...props }
 			/>
-			{ showPopover && <PopoverWithAnchor anchor={ anchor }>{ children }</PopoverWithAnchor> }
+			<PopoverWithAnchor showPopover={ showPopover } anchor={ anchor }>
+				{ children }
+			</PopoverWithAnchor>
 		</div>
 	);
 };
@@ -81,9 +94,8 @@ const ThumbnailActionsDropdown = ( {
 			position="bottom left"
 			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 			renderToggle={ ( { isOpen, onToggle } ) => (
-				<>
+				<div ref={ setAnchor }>
 					<Button
-						ref={ setAnchor }
 						size="small"
 						variant="tertiary"
 						icon={ image }
@@ -96,10 +108,10 @@ const ThumbnailActionsDropdown = ( {
 						onMouseEnter={ () => setShowPopover( true ) }
 						onMouseLeave={ () => setShowPopover( false ) }
 					/>
-					{ showPopover && (
-						<PopoverWithAnchor anchor={ anchor }>{ description }</PopoverWithAnchor>
-					) }
-				</>
+					<PopoverWithAnchor showPopover={ showPopover } anchor={ anchor }>
+						{ description }
+					</PopoverWithAnchor>
+				</div>
 			) }
 			renderContent={ ( { onClose } ) => (
 				<VideoThumbnailDropdownButtons
@@ -134,9 +146,8 @@ const PrivacyActionsDropdown = ( {
 		<Dropdown
 			position="bottom left"
 			renderToggle={ ( { isOpen, onToggle } ) => (
-				<>
+				<div ref={ setAnchor }>
 					<Button
-						ref={ setAnchor }
 						size="small"
 						variant="tertiary"
 						icon={ currentPrivacyIcon }
@@ -149,10 +160,10 @@ const PrivacyActionsDropdown = ( {
 						onMouseLeave={ () => setShowPopover( false ) }
 						disabled={ isUpdatingPrivacy }
 					/>
-					{ showPopover && (
-						<PopoverWithAnchor anchor={ anchor }>{ description }</PopoverWithAnchor>
-					) }
-				</>
+					<PopoverWithAnchor showPopover={ showPopover } anchor={ anchor }>
+						{ description }
+					</PopoverWithAnchor>
+				</div>
 			) }
 			renderContent={ ( { onClose } ) => (
 				<div className={ styles[ 'dropdown-content' ] }>

--- a/projects/packages/videopress/src/client/admin/components/video-quick-actions/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/video-quick-actions/types.ts
@@ -17,6 +17,10 @@ export interface ActionItemProps extends React.ButtonHTMLAttributes< HTMLButtonE
 
 export interface PopoverWithAnchorProps {
 	/**
+	 * Whether the popover should be rendered or not
+	 */
+	showPopover?: boolean;
+	/**
 	 * Ref that anchors the popover
 	 */
 	anchor: HTMLElement | null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27333

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Disables `Popover`'s `focusOnMount` option on `PopoverWithAnchor`, disabling focus change on popover render
* Manually triggers focus

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard with at least one video
* Focus on an element and scroll down until it is no longer visible
* Hover over a quick action button, showing its popover
* With the cursor still hovering over the button, check that `document.activeElement` has a `components-popover` class and its `.innerText` is the popover text
* Move the cursor out
* Check that there is no jump back to the previously focused element

Before

https://user-images.githubusercontent.com/8486249/200935561-4b35be6e-b5cd-4993-a9ec-f5bc1e0c5c93.mp4

After

https://user-images.githubusercontent.com/8486249/200935587-6f245365-08f7-4693-a1d4-5b21d4199a67.mp4

![2022-11-09_17-28-59](https://user-images.githubusercontent.com/8486249/200936319-01acb12b-71dd-4c88-bc8e-af8d29998b45.png)
