### PR TITLE
VideoPress: Fix broken video uploading in Full Site Editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-fse-broken-videopress-uploads
+++ b/projects/plugins/jetpack/changelog/fix-fse-broken-videopress-uploads
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixes issue with uploading VideoPress videos in the Full Site Editor.

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
@@ -840,7 +840,7 @@ const VideoPressEdit = CoreVideoEdit =>
 				saveEditorData();
 			};
 
-			const isResumableUploading = null !== fileForUpload && fileForUpload instanceof File;
+			const isResumableUploading = null !== fileForUpload && fileForUpload.name;
 
 			if ( isResumableUploading || this.state.isEditingWhileUploading ) {
 				const title = this.state.title ?? filename;

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -74,9 +74,11 @@ const videoPressMediaPlaceholder = createHigherOrderComponent(
 			handleUpload: false,
 			disableDropZone: true,
 			onSelect: selected => {
-				if ( selected instanceof FileList ) {
+				if ( undefined !== selected.length ) {
+					// Browser file upload
 					onFilesSelected( selected );
 				} else {
+					// WP Media Library item selected
 					onMediaItemSelected( selected );
 				}
 			},


### PR DESCRIPTION
For a yet-to-be-determined reason, VideoPress uploads in the FSE are not working in Webkit-based browsers due to `instanceof` checks on `File` and `FileList` returning `false`. 

#### Changes proposed in this Pull Request:
* I've implemented a workaround here that removes the `instanceof` checks and replaces them with property checks on the objects to determine if they are files selected for upload, or a selection from the WP media library.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Run locally in Jetpack docker.
* Purchase and activate VideoPress if you don't have it on your test site.
* Install and activate a theme that uses the FSE.
* Edit your site in the FSE, and add a video block.
* Test clicking `Upload` and select a video in a webkit-based browser. It should show the uploader! Also try in Firefox just to be safe.
* Add another block and select a video from the media library. It should load up the video in the video block.
* Try dragging and dropping multiple video files into the FSE - they should all start uploading.

