### PR TITLE
Hide comments based on newsletter setting

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -66,6 +66,13 @@ function register_block() {
 
 	if ( \Automattic\Jetpack\Constants::get_constant( 'JETPACK_BETA_BLOCKS' ) ) {
 		add_action( 'the_content', __NAMESPACE__ . '\maybe_get_locked_content' );
+
+		// Close comments on the front-end
+		add_filter( 'comments_open', __NAMESPACE__ . '\maybe_close_comments' );
+		add_filter( 'pings_open', __NAMESPACE__ . '\maybe_close_comments' );
+
+		// Hide existing comments
+		add_filter( 'get_comment', __NAMESPACE__ . '\maybe_gate_existing_comments' );
 	}
 }
 add_action( 'init', __NAMESPACE__ . '\register_block', 9 );
@@ -129,6 +136,35 @@ function maybe_get_locked_content( $the_content ) {
 		return $the_content;
 	}
 	return get_locked_content_placeholder_text();
+}
+
+/**
+ * Gate access to comments
+ *
+ * @return bool
+ */
+function maybe_close_comments() {
+	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
+	return Jetpack_Memberships::user_can_view_post();
+}
+
+/**
+ * Gate access to exisiting comments
+ *
+ * @param string $comment The comment.
+ *
+ * @return string
+ */
+function maybe_gate_existing_comments( $comment ) {
+	if ( empty( $comment ) ) {
+		return $comment;
+	}
+
+	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
+	if ( Jetpack_Memberships::user_can_view_post() ) {
+		return $comment;
+	}
+	return '';
 }
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -65,7 +65,7 @@ function register_block() {
 	add_filter( 'get_the_excerpt', __NAMESPACE__ . '\jetpack_filter_excerpt_for_newsletter', 10, 2 );
 
 	if ( \Automattic\Jetpack\Constants::get_constant( 'JETPACK_BETA_BLOCKS' ) ) {
-		add_action( 'the_content', __NAMESPACE__ . '\maybe_get_locked_content' );
+		add_action( 'the_content', __NAMESPACE__ . '\maybe_gate_content_and_comments' );
 	}
 }
 add_action( 'init', __NAMESPACE__ . '\register_block', 9 );
@@ -116,18 +116,26 @@ function jetpack_filter_excerpt_for_newsletter( $excerpt, $post ) {
 }
 
 /**
- * Gate access to posts
+ * Gate access to posts and comments
  *
  * @param string $the_content Post content.
  *
  * @return string
  */
-function maybe_get_locked_content( $the_content ) {
+function maybe_gate_content_and_comments( $the_content ) {
 	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
 
 	if ( Jetpack_Memberships::user_can_view_post() ) {
 		return $the_content;
 	}
+
+	// Close comments on the front-end
+	add_filter( 'comments_open', '__return_false' );
+	add_filter( 'pings_open', '__return_false' );
+
+	// Hide existing comments
+	add_filter( 'comments_array', '__return_empty_array' );
+
 	return get_locked_content_placeholder_text();
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -65,7 +65,7 @@ function register_block() {
 	add_filter( 'get_the_excerpt', __NAMESPACE__ . '\jetpack_filter_excerpt_for_newsletter', 10, 2 );
 
 	if ( \Automattic\Jetpack\Constants::get_constant( 'JETPACK_BETA_BLOCKS' ) ) {
-		add_action( 'the_content', __NAMESPACE__ . '\maybe_gate_content_and_comments' );
+		add_action( 'the_content', __NAMESPACE__ . '\maybe_get_locked_content' );
 	}
 }
 add_action( 'init', __NAMESPACE__ . '\register_block', 9 );
@@ -116,26 +116,18 @@ function jetpack_filter_excerpt_for_newsletter( $excerpt, $post ) {
 }
 
 /**
- * Gate access to posts and comments
+ * Gate access to posts
  *
  * @param string $the_content Post content.
  *
  * @return string
  */
-function maybe_gate_content_and_comments( $the_content ) {
+function maybe_get_locked_content( $the_content ) {
 	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
 
 	if ( Jetpack_Memberships::user_can_view_post() ) {
 		return $the_content;
 	}
-
-	// Close comments on the front-end
-	add_filter( 'comments_open', '__return_false' );
-	add_filter( 'pings_open', '__return_false' );
-
-	// Hide existing comments
-	add_filter( 'comments_array', '__return_empty_array' );
-
 	return get_locked_content_placeholder_text();
 }
 


### PR DESCRIPTION
Closes [#69744](https://github.com/Automattic/wp-calypso/issues/69744)

#### Testing instructions:

**Scenario 1**
1.  Mark a post as only for subscribers
2.  Open the post in incognito
3.  Notice the comment section is not shown

**Scenario 2**
1.  Mark a post for everybody
2.  Open the post in incognito
3.  Notice the comment section is visible
4. Add a comment

**Scenario 3**
1.  Mark the previous post as only for subscribers
2.  Open the post in incognito
3.  Notice the comment section is not visible
