### PR TITLE
Prevent scrolling to the active menu item on page load

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-current-menu-item-prevent-scroll
+++ b/projects/plugins/jetpack/changelog/fix-current-menu-item-prevent-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Prevent scrolling to the active menu item on page load.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
@@ -143,7 +143,7 @@
 			return;
 		}
 
-		currentMenuItem.focus();
+		currentMenuItem.focus( { preventScroll: true } );
 	}
 
 	if ( document.readyState === 'loading' ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27311

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Prevent scrolling to the active menu item on page load.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to /wp-admin
* Resize your window to a 13" monitor or similar height, so that the settings menu (when expanded) is outside of your viewport
* Click on `Settings > Permalinks` (or any non calypsoified settings submenu item)
* You won't be auto-scrolled to the active menu item

Previous behavior on this screencast

https://user-images.githubusercontent.com/2484390/200532254-17bba3b3-8d50-44e3-a0c4-fe748b37fe8c.mp4

PR that introduced this issue #20262

PS - I don't know if I tagged the correct people to review this PR - Feel free to assign it to the correct ones.

I would prefer if someone else takes over and releases this PR, as I'm not familiar with Jetpack release processes