### PR TITLE
VideoPress: Expose video visibility flag on VideoPress video data

### DIFF
--- a/projects/packages/videopress/changelog/add-expose-video-visibility-flag-on-video-data
+++ b/projects/packages/videopress/changelog/add-expose-video-visibility-flag-on-video-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Exposed video_is_private flag on each video, taking into account the video privacy setting as well as the VideoPress site-wide privacy setting.

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -25,6 +25,19 @@ class Data {
 	}
 
 	/**
+	 * Gets the VideoPress site privacy configuration.
+	 *
+	 * @return boolean If all the videos are private on the site
+	 */
+	public static function get_videopress_videos_private_for_site() {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			return boolval( get_blog_option( get_current_blog_id(), 'videopress_private_enabled_for_site', false ) );
+		} else {
+			return boolval( get_option( 'videopress_private_enabled_for_site', false ) );
+		}
+	}
+
+	/**
 	 * Gets the video data
 	 *
 	 * @param boolean $is_videopress - True when getting VideoPress data.

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
@@ -202,15 +202,22 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Data {
 			$caption     = $info->caption;
 		}
 
+		$video_privacy_setting          = ! isset( $info->privacy_setting ) ? \VIDEOPRESS_PRIVACY::SITE_DEFAULT : intval( $info->privacy_setting );
+		$all_videos_are_private_on_site = Data::get_videopress_videos_private_for_site();
+
+		// decide if the video is private based on the site privacy setting as well as the video privacy setting
+		$video_is_private = $all_videos_are_private_on_site ? true : ( $video_privacy_setting === \VIDEOPRESS_PRIVACY::IS_PRIVATE );
+
 		return array(
-			'title'           => $title,
-			'description'     => $description,
-			'caption'         => $caption,
-			'guid'            => $info->guid,
-			'rating'          => $info->rating,
-			'allow_download'  =>
+			'title'            => $title,
+			'description'      => $description,
+			'caption'          => $caption,
+			'guid'             => $info->guid,
+			'rating'           => $info->rating,
+			'allow_download'   =>
 				isset( $info->allow_download ) && $info->allow_download ? 1 : 0,
-			'privacy_setting' => ! isset( $info->privacy_setting ) ? \VIDEOPRESS_PRIVACY::SITE_DEFAULT : intval( $info->privacy_setting ),
+			'privacy_setting'  => $video_privacy_setting,
+			'video_is_private' => $video_is_private,
 		);
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Relates to #27314.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Exposed `video_is_private` flag on each video, taking into account the video privacy setting as well as the VideoPress site-wide privacy setting; the site-wide setting takes precedence over the video one, so when the site setting is set to private all the videos become private, regardless of the individual settings of the videos ([reference](https://jetpack.com/support/video-privacy/))
* This field will be useful on the client side to decide if we need playback tokens to load the thumbnails, the video files and other resources associated to the video.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* The change takes place on the API response, so we need to test the request to the video details endpoint
* Make sure you uploaded a video and know the media ID for it (see tips bellow)
* Do the following `GET` request:

```
curl -X GET -u "user:pass" http://your-site.com/wp-json/wp/v2/media/{ MEDIA ID }
```

* On the response, you should see the new `video_is_private` field under the `jetpack_videopress` VideoPress data:

```
{
    "id": 5,
    // ...
    "jetpack_videopress_guid": "ZbzcyFWW",
    "jetpack_videopress": {
        "title": "putting-pepperoni-on-a-pizza-mp4",
        "description": "",
        "caption": "",
        "guid": "ZbzcyFWW",
        "rating": "G",
        "allow_download": 0,
        "privacy_setting": 1,
        "video_is_private": true <- this is the new field
    },
    // ...
}
```
 
* You can play with the value of the video privacy setting, as well as the VideoPress site-wide privacy setting, to see how the new `video_is_private` behaves. The expected truth table is this:

| Video privacy setting | VideoPress site-wide privacy setting | Expected result on `video_is_private` |
| --- | --- | --- |
| Site Default | Public (not restricted, checkbox unchecked) | `false` |
| Public | Public (not restricted, checkbox unchecked) | `false` |
| Private | Public (not restricted, checkbox unchecked) | `true` |
| Site Default | Private (restricted, checkbox checked) | `true` |
| Public | Private (restricted, checkbox checked) | `true` |
| Private | Private (restricted, checkbox checked) | `true` |

Tips:

* Make sure you have some [API authentication plugin](https://github.com/WP-API/Basic-Auth) in place to do the test
* To get the media ID for the video, go to the VideoPress library (`Jetpack > VideoPress`), click the `Edit video details` button and check the ID number on the URL:

<img width="1127" alt="Screen Shot 2022-11-10 at 15 06 43" src="https://user-images.githubusercontent.com/6760046/201173332-641b0488-72e6-403b-bc1e-251bf6ec893f.png">
