### PR TITLE
VideoPress: connect UI settings with data handling

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-connect-settings-section
+++ b/projects/packages/videopress/changelog/update-videopress-connect-settings-section
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: connect UI of settings section with the data handling.

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -36,7 +36,7 @@ import useVideos, { useLocalVideos } from '../../hooks/use-videos';
 import { NeedUserConnectionGlobalNotice } from '../global-notice';
 import Logo from '../logo';
 import PricingSection from '../pricing-section';
-import SettingsSection from '../site-settings-section';
+import { ConnectSiteSettingsSection as SettingsSection } from '../site-settings-section';
 import { ConnectVideoStorageMeter } from '../video-storage-meter';
 import VideoUploadArea from '../video-upload-area';
 import { LocalLibrary, VideoPressLibrary } from './libraries';

--- a/projects/packages/videopress/src/client/admin/components/site-settings-section/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/site-settings-section/index.tsx
@@ -18,7 +18,7 @@ import { SiteSettingsSectionProps } from './types';
  * @returns {React.ReactElement}   Component template
  */
 const SiteSettingsSection: React.FC< SiteSettingsSectionProps > = ( {
-	videosPrivateForSite,
+	videoPressVideosPrivateForSite,
 	onPrivacyChange,
 } ) => {
 	return (
@@ -36,21 +36,24 @@ const SiteSettingsSection: React.FC< SiteSettingsSectionProps > = ( {
 						'jetpack-videopress-pkg'
 					) }
 					onChange={ onPrivacyChange }
-					checked={ videosPrivateForSite }
+					checked={ videoPressVideosPrivateForSite }
 				/>
 			</Col>
 		</Container>
 	);
 };
 
-export const ConnectSiteSettingsSection: React.FC< SiteSettingsSectionProps > = ( {
-	onPrivacyChange,
-} ) => {
-	const { videoPressVideosPrivateForSite: videosPrivateForSite } = useVideoPressSettings();
+export const ConnectSiteSettingsSection: React.FC< SiteSettingsSectionProps > = () => {
+	const { settings, onUpdate } = useVideoPressSettings();
+	const { videoPressVideosPrivateForSite } = settings;
 	return (
 		<SiteSettingsSection
-			videosPrivateForSite={ videosPrivateForSite }
-			onPrivacyChange={ onPrivacyChange }
+			videoPressVideosPrivateForSite={ videoPressVideosPrivateForSite }
+			onPrivacyChange={ newPrivacyValue => {
+				onUpdate( {
+					videoPressVideosPrivateForSite: newPrivacyValue,
+				} );
+			} }
 		/>
 	);
 };

--- a/projects/packages/videopress/src/client/admin/components/site-settings-section/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/site-settings-section/index.tsx
@@ -16,9 +16,7 @@ import { SiteSettingsSectionProps } from './types';
  * @param {SiteSettingsSectionProps} props - Component props.
  * @returns {React.ReactElement}   Component template
  */
-const SiteSettingsSection: React.FC< SiteSettingsSectionProps > = ( {
-	onPrivacySettingsChange,
-} ) => {
+const SiteSettingsSection: React.FC< SiteSettingsSectionProps > = ( { onPrivacyChange } ) => {
 	return (
 		<Container horizontalSpacing={ 0 } horizontalGap={ 0 }>
 			<Col>
@@ -33,7 +31,7 @@ const SiteSettingsSection: React.FC< SiteSettingsSectionProps > = ( {
 						'Video Privacy: Restrict views to members of this site',
 						'jetpack-videopress-pkg'
 					) }
-					onChange={ onPrivacySettingsChange }
+					onChange={ onPrivacyChange }
 				/>
 			</Col>
 		</Container>

--- a/projects/packages/videopress/src/client/admin/components/site-settings-section/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/site-settings-section/index.tsx
@@ -4,6 +4,7 @@
 import { Col, Container, Text } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
 import React from 'react';
+import { useVideoPressSettings } from '../../hooks/use-videopress-settings';
 /**
  * Internal dependencies
  */
@@ -16,7 +17,10 @@ import { SiteSettingsSectionProps } from './types';
  * @param {SiteSettingsSectionProps} props - Component props.
  * @returns {React.ReactElement}   Component template
  */
-const SiteSettingsSection: React.FC< SiteSettingsSectionProps > = ( { onPrivacyChange } ) => {
+const SiteSettingsSection: React.FC< SiteSettingsSectionProps > = ( {
+	videosPrivateForSite,
+	onPrivacyChange,
+} ) => {
 	return (
 		<Container horizontalSpacing={ 0 } horizontalGap={ 0 }>
 			<Col>
@@ -32,9 +36,22 @@ const SiteSettingsSection: React.FC< SiteSettingsSectionProps > = ( { onPrivacyC
 						'jetpack-videopress-pkg'
 					) }
 					onChange={ onPrivacyChange }
+					checked={ videosPrivateForSite }
 				/>
 			</Col>
 		</Container>
+	);
+};
+
+export const ConnectSiteSettingsSection: React.FC< SiteSettingsSectionProps > = ( {
+	onPrivacyChange,
+} ) => {
+	const { videoPressVideosPrivateForSite: videosPrivateForSite } = useVideoPressSettings();
+	return (
+		<SiteSettingsSection
+			videosPrivateForSite={ videosPrivateForSite }
+			onPrivacyChange={ onPrivacyChange }
+		/>
 	);
 };
 

--- a/projects/packages/videopress/src/client/admin/components/site-settings-section/stories/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/site-settings-section/stories/index.tsx
@@ -18,5 +18,5 @@ const Template = args => <SettingsSection { ...args } />;
 
 export const _default = Template.bind( {} );
 _default.args = {
-	onPrivacySettingsChange: action( 'onPrivacySettingsChange' ),
+	onPrivacyChange: action( 'onPrivacyChange' ),
 };

--- a/projects/packages/videopress/src/client/admin/components/site-settings-section/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/site-settings-section/types.ts
@@ -7,5 +7,5 @@ export type SiteSettingsSectionProps = {
 	/**
 	 * Callback function to be invoked when the privacy settings changes.
 	 */
-	onPrivacySettingsChange?: ( isPrivate: boolean ) => void;
+	onPrivacyChange?: ( isPrivate: boolean ) => void;
 };

--- a/projects/packages/videopress/src/client/admin/components/site-settings-section/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/site-settings-section/types.ts
@@ -5,6 +5,11 @@ export type SiteSettingsSectionProps = {
 	className?: string;
 
 	/**
+	 * Define if the videos are private at the site level.
+	 */
+	videosPrivateForSite: boolean;
+
+	/**
 	 * Callback function to be invoked when the privacy settings changes.
 	 */
 	onPrivacyChange?: ( isPrivate: boolean ) => void;

--- a/projects/packages/videopress/src/client/admin/components/site-settings-section/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/site-settings-section/types.ts
@@ -7,7 +7,7 @@ export type SiteSettingsSectionProps = {
 	/**
 	 * Define if the videos are private at the site level.
 	 */
-	videosPrivateForSite: boolean;
+	videoPressVideosPrivateForSite: boolean;
 
 	/**
 	 * Callback function to be invoked when the privacy settings changes.

--- a/projects/packages/videopress/src/client/admin/components/video-filter/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-filter/index.tsx
@@ -41,11 +41,17 @@ export const FilterButton = ( props: {
 export const CheckboxCheckmark = ( props: {
 	label?: string;
 	for: string;
+	checked?: boolean;
 	onChange?: ( checked: boolean ) => void;
 } ): JSX.Element => {
 	return (
 		<label htmlFor={ props.for } className={ styles[ 'checkbox-container' ] }>
-			<Checkbox id={ props.for } className={ styles.checkbox } onChange={ props.onChange } />
+			<Checkbox
+				id={ props.for }
+				className={ styles.checkbox }
+				onChange={ props.onChange }
+				checked={ props.checked }
+			/>
 			<span className={ styles[ 'checkbox-checkmark' ] } />
 			<Text variant="body-small">{ props.label }</Text>
 		</label>

--- a/projects/packages/videopress/src/client/admin/hooks/use-videopress-settings/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-videopress-settings/index.ts
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+/*
+ * Internal dependencies
+ */
+import { STORE_ID } from '../../../state';
+/**
+ * types
+ */
+import { VideopressSelectors } from '../../types';
+import { useVideoPressSettingsProps } from './types';
+
+export const useVideoPressSettings = (): useVideoPressSettingsProps => {
+	const settings = useSelect( select => {
+		return ( select( STORE_ID ) as VideopressSelectors ).getVideoPressSettings();
+	}, [] );
+
+	return {
+		settings,
+	};
+};

--- a/projects/packages/videopress/src/client/admin/hooks/use-videopress-settings/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-videopress-settings/index.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 /*
  * Internal dependencies
  */
@@ -13,11 +13,17 @@ import { VideopressSelectors } from '../../types';
 import { useVideoPressSettingsProps } from './types';
 
 export const useVideoPressSettings = (): useVideoPressSettingsProps => {
+	const dispatch = useDispatch( STORE_ID );
+
 	const settings = useSelect( select => {
 		return ( select( STORE_ID ) as VideopressSelectors ).getVideoPressSettings();
 	}, [] );
 
 	return {
-		settings,
+		settings: {
+			videoPressVideosPrivateForSite: settings?.videoPressVideosPrivateForSite ?? false,
+		},
+
+		onUpdate: settingsToUpdate => dispatch.updateVideoPressSettings( settingsToUpdate ),
 	};
 };

--- a/projects/packages/videopress/src/client/admin/hooks/use-videopress-settings/types.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-videopress-settings/types.ts
@@ -1,0 +1,108 @@
+export type paidFeaturesProp = {
+	isVideoPress1TBSupported: boolean;
+	isVideoPressSupported: boolean;
+	isVideoPressUnlimitedSupported: boolean;
+};
+
+export type siteProductOriginalProps = {
+	title: string;
+	name: string;
+	description: string;
+	long_description?: string;
+	features: Array< string >;
+	has_required_plan: boolean;
+	is_bundle?: boolean;
+	is_upgradable_by_bundle?: boolean;
+	manage_url?: string;
+	plugin_slug: string;
+	post_activation_url?: string;
+	pricing_for_ui: {
+		available: boolean;
+		currency_code: string;
+		discount_price: number;
+		full_price: number;
+		wpcom_product_slug: string;
+	};
+	requires_user_connection: boolean;
+	slug: string;
+	status: string;
+	supported_products: Array< string >;
+	wpcom_product_slug: string;
+};
+
+export type productOriginalProps = {
+	product_id: number;
+	product_name: string;
+	product_slug: 'jetpack_videopress';
+	description: string;
+	available: boolean;
+	billing_product_slug: 'jetpack-videopress';
+	is_domain_registration: false;
+	cost_display: string;
+	combined_cost_display: string;
+	cost: number;
+	cost_smallest_unit: number;
+	currency_code: string;
+	product_term: string;
+	price_tier_slug: string;
+	introductory_offer: {
+		interval_unit: string;
+		interval_count: number;
+		cost_per_interval: number;
+		transition_after_renewal_count: number;
+		should_prorate_when_offer_ends: boolean;
+	};
+};
+
+export type siteProductProps = {
+	title: string;
+	name: string;
+	description: string;
+	longDescription?: string;
+	features: Array< string >;
+	hasRequiredPlan: boolean;
+	isBundle?: boolean;
+	isUpgradableByBundle?: boolean;
+	manageUrl?: string;
+	pluginSlug: string;
+	postActivationUrl?: string;
+	pricingForUi: {
+		available: boolean;
+		currencyCode: string;
+		discountPrice: number;
+		fullPrice: number;
+	};
+	requiresUserConnection: boolean;
+	slug: string;
+	status: string;
+	supportedProducts: Array< string >;
+	wpcomProductSlug: string;
+};
+
+export type productProps = {
+	productId: number;
+	productName: string;
+	productSlug: 'jetpack_videopress';
+	description: string;
+	available: boolean;
+	billingProductSlug: 'jetpack-videopress';
+	isDomainRegistration: false;
+	costDisplay: string;
+	combinedCostDisplay: string;
+	cost: number;
+	costSmallestUnit: number;
+	currencyCode: string;
+	productTerm: string;
+	priceTierSlug: string;
+	introductoryOffer: {
+		intervalUnit: string;
+		intervalCount: number;
+		costPerInterval: number;
+		transitionAfterRenewalCount: number;
+		shouldProrateWhenOfferEnds: boolean;
+	};
+};
+
+export type useVideoPressSettingsProps = {
+	videoPressVideosPrivateForSite: boolean;
+};

--- a/projects/packages/videopress/src/client/admin/hooks/use-videopress-settings/types.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-videopress-settings/types.ts
@@ -104,5 +104,8 @@ export type productProps = {
 };
 
 export type useVideoPressSettingsProps = {
-	videoPressVideosPrivateForSite: boolean;
+	settings: {
+		videoPressVideosPrivateForSite: boolean;
+	};
+	onUpdate: ( settings: { videoPressVideosPrivateForSite: boolean } ) => void;
 };

--- a/projects/packages/videopress/src/client/admin/types/index.ts
+++ b/projects/packages/videopress/src/client/admin/types/index.ts
@@ -207,6 +207,10 @@ export type MetadataVideo = {
 	uploadProgress?: number;
 };
 
+export type VideoPressSettings = {
+	videoPressVideosPrivateForSite: boolean;
+};
+
 export type VideopressSelectors = {
 	isFetchingPurchases: () => boolean;
 	getVideo: ( id: number | string ) => VideoPressVideo;
@@ -220,4 +224,6 @@ export type VideopressSelectors = {
 	isFetchingPlaybackToken: () => boolean;
 
 	getUploadedLocalVideoCount: () => number;
+
+	getVideoPressSettings: () => VideoPressSettings;
 };

--- a/projects/packages/videopress/src/client/state/actions.js
+++ b/projects/packages/videopress/src/client/state/actions.js
@@ -46,6 +46,7 @@ import {
 	EXPIRE_PLAYBACK_TOKEN,
 	SET_VIDEO_UPLOAD_PROGRESS,
 	SET_VIDEOPRESS_SETTINGS,
+	WP_REST_API_VIDEOPRESS_SETTINGS_ENDPOINT,
 } from './constants';
 import { mapVideoFromWPV2MediaEndpoint } from './utils/map-videos';
 
@@ -357,6 +358,41 @@ const setVideoPressSettings = videoPressSettings => {
 	return { type: SET_VIDEOPRESS_SETTINGS, videoPressSettings };
 };
 
+/**
+ * Thunk action to remove a video from the state,
+ *
+ * @param {object} settings - VideoPress settings
+ * @returns {Function}        Thunk action
+ */
+const updateVideoPressSettings = settings => async ( { dispatch } ) => {
+	if ( ! settings ) {
+		return;
+	}
+
+	const data = { force: true };
+
+	if ( settings.videoPressVideosPrivateForSite !== undefined ) {
+		data.videopress_videos_private_for_site = settings.videoPressVideosPrivateForSite;
+	}
+
+	// videopress_videos_private_for_site
+	try {
+		// 100% optimistic update
+		dispatch.setVideoPressSettings( settings );
+
+		const resp = await apiFetch( {
+			path: WP_REST_API_VIDEOPRESS_SETTINGS_ENDPOINT,
+			method: 'PUT',
+			data,
+		} );
+
+		return resp;
+	} catch ( error ) {
+		// @todo: implement error handling / UI
+		console.error( error ); // eslint-disable-line no-console
+	}
+};
+
 const actions = {
 	setIsFetchingVideos,
 	setFetchVideosError,
@@ -398,6 +434,7 @@ const actions = {
 	expirePlaybackToken,
 
 	setVideoPressSettings,
+	updateVideoPressSettings,
 };
 
 export { actions as default };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: connect the UI of the settings section with the data handling

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to VideoPress dashboard
* Set the privacy Video Privacy
* Confirm the checkbox toggles
* Confirm the changes are presistent


<img width="910" alt="Screen Shot 2022-11-10 at 14 52 11" src="https://user-images.githubusercontent.com/77539/201170476-35f04d23-1fc8-43a0-b78b-10027add9d15.png">

###  Network tab

<img width="739" alt="image" src="https://user-images.githubusercontent.com/77539/201170258-783ab82e-a919-4b51-9073-a35594a83c95.png">

<img width="739" alt="image" src="https://user-images.githubusercontent.com/77539/201170324-ec88fcea-fea7-425c-8b2f-6829cfc166d1.png">


### State tree
<img width="740" alt="image" src="https://user-images.githubusercontent.com/77539/201170413-e887eaae-7210-4f8c-b7b6-f6390026d240.png">



