### PR TITLE
Protect: Fix checks for paid plan

### DIFF
--- a/projects/plugins/protect/composer.json
+++ b/projects/plugins/protect/composer.json
@@ -14,7 +14,8 @@
 		"automattic/jetpack-my-jetpack": "2.4.x-dev",
 		"automattic/jetpack-plugins-installer": "0.2.x-dev",
 		"automattic/jetpack-sync": "1.42.x-dev",
-		"automattic/jetpack-transport-helper": "0.1.x-dev"
+		"automattic/jetpack-transport-helper": "0.1.x-dev",
+		"automattic/jetpack-plans": "0.2.x-dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.0.3",

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "49cecbf803e8d10094a605825072258c",
+    "content-hash": "935ecebc552e5dcc21bb95c39151e24d",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -936,6 +936,70 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Password Checker.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-plans",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/plans",
+                "reference": "9b6218c0359a9c0533b30f3f95c0c847d76b88f4"
+            },
+            "require": {
+                "automattic/jetpack-connection": "^1.46"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "^3.2",
+                "automattic/jetpack-status": "^1.15",
+                "automattic/wordbless": "@dev",
+                "yoast/phpunit-polyfills": "1.0.3"
+            },
+            "type": "library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-plans",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-plans/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "post-install-cmd": [
+                    "WorDBless\\Composer\\InstallDropin::copy"
+                ],
+                "post-update-cmd": [
+                    "WorDBless\\Composer\\InstallDropin::copy"
+                ],
+                "build-production": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ],
+                "build-development": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Fetch information about Jetpack Plans from wpcom",
             "transport-options": {
                 "relative": true
             }
@@ -4149,6 +4213,7 @@
         "automattic/jetpack-plugins-installer": 20,
         "automattic/jetpack-sync": 20,
         "automattic/jetpack-transport-helper": 20,
+        "automattic/jetpack-plans": 20,
         "automattic/jetpack-changelogger": 20
     },
     "prefer-stable": true,

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -172,6 +172,7 @@ class Jetpack_Protect {
 	 */
 	public function initial_state() {
 		global $wp_version;
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		$refresh_status_from_wpcom = isset( $_GET['checkPlan'] );
 		$initial_state             = array(
 			'apiRoot'           => esc_url_raw( rest_url() ),

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -172,7 +172,7 @@ class Jetpack_Protect {
 	 */
 	public function initial_state() {
 		global $wp_version;
-		$refresh_from_wpcom = isset( $_GET['refreshPlan'] );
+		$refresh_from_wpcom = isset( $_GET['checkPlan'] );
 		$initial_state      = array(
 			'apiRoot'           => esc_url_raw( rest_url() ),
 			'apiNonce'          => wp_create_nonce( 'wp_rest' ),

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -20,7 +20,6 @@ use Automattic\Jetpack\My_Jetpack\Products as My_Jetpack_Products;
 use Automattic\Jetpack\Plugins_Installer;
 use Automattic\Jetpack\Protect\Credentials;
 use Automattic\Jetpack\Protect\Plan;
-use Automattic\Jetpack\Protect\Protect_Status;
 use Automattic\Jetpack\Protect\Scan_Status;
 use Automattic\Jetpack\Protect\Site_Health;
 use Automattic\Jetpack\Protect\Status;
@@ -356,7 +355,7 @@ class Jetpack_Protect {
 	 * @return WP_REST_Response
 	 */
 	public static function api_check_plan() {
-		$has_required_plan = Plan::has_required_plan();
+		$has_required_plan = Plan::has_required_plan( true );
 
 		return rest_ensure_response( $has_required_plan, 200 );
 	}
@@ -369,11 +368,7 @@ class Jetpack_Protect {
 	 * @return WP_REST_Response
 	 */
 	public static function api_get_status( $request ) {
-		if ( $request['hard_refresh'] ) {
-			Scan_Status::delete_option();
-			Protect_Status::delete_option();
-		}
-		$status = Status::get_status();
+		$status = Status::get_status( $request['hard_refresh'] );
 		return rest_ensure_response( $status, 200 );
 	}
 

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -38,6 +38,7 @@ class Jetpack_Protect {
 	 */
 	public function __construct() {
 		add_action( 'init', array( $this, 'init' ) );
+		add_action( '_admin_menu', array( $this, 'admin_page_init' ) );
 
 		// Init Jetpack packages
 		add_action(
@@ -91,6 +92,22 @@ class Jetpack_Protect {
 		// Set up the REST authentication hooks.
 		Connection_Rest_Authentication::init();
 
+		add_action( 'admin_bar_menu', array( $this, 'admin_bar' ), 65 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_styles' ) );
+		// Add custom WP REST API endoints.
+		add_action( 'rest_api_init', array( __CLASS__, 'register_rest_endpoints' ) );
+
+		My_Jetpack_Initializer::init();
+		Site_Health::init();
+
+		// Sets up JITMS.
+		JITM::configure();
+	}
+
+	/**
+	 * Initialize the admin page resources.
+	 */
+	public function admin_page_init() {
 		$total_threats = Status::get_total_threats();
 		$menu_label    = _x( 'Protect', 'The Jetpack Protect product name, without the Jetpack prefix', 'jetpack-protect' );
 		if ( $total_threats ) {
@@ -105,25 +122,8 @@ class Jetpack_Protect {
 			array( $this, 'plugin_settings_page' ),
 			99
 		);
-		add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );
 
-		add_action( 'admin_bar_menu', array( $this, 'admin_bar' ), 65 );
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_styles' ) );
-		// Add custom WP REST API endoints.
-		add_action( 'rest_api_init', array( __CLASS__, 'register_rest_endpoints' ) );
-
-		My_Jetpack_Initializer::init();
-		Site_Health::init();
-
-		// Sets up JITMS.
-		JITM::configure();
-	}
-
-	/**
-	 * Initialize the admin resources.
-	 */
-	public function admin_init() {
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
+		add_action( 'load-' . $page_suffix, array( $this, 'enqueue_admin_scripts' ) );
 	}
 
 	/**

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -172,11 +172,12 @@ class Jetpack_Protect {
 	 */
 	public function initial_state() {
 		global $wp_version;
-		$initial_state = array(
+		$refresh_from_wpcom = isset( $_GET['refreshPlan'] );
+		$initial_state      = array(
 			'apiRoot'           => esc_url_raw( rest_url() ),
 			'apiNonce'          => wp_create_nonce( 'wp_rest' ),
 			'registrationNonce' => wp_create_nonce( 'jetpack-registration-nonce' ),
-			'status'            => Status::get_status(),
+			'status'            => Status::get_status( $refresh_from_wpcom ),
 			'installedPlugins'  => Plugins_Installer::get_plugins(),
 			'installedThemes'   => Sync_Functions::get_themes(),
 			'wpVersion'         => $wp_version,
@@ -184,7 +185,7 @@ class Jetpack_Protect {
 			'siteSuffix'        => ( new Jetpack_Status() )->get_site_suffix(),
 			'jetpackScan'       => My_Jetpack_Products::get_product( 'scan' ),
 			'productData'       => My_Jetpack_Products::get_product( 'protect' ),
-			'hasRequiredPlan'   => Plan::has_required_plan(),
+			'hasRequiredPlan'   => Plan::has_required_plan( $refresh_from_wpcom ),
 		);
 
 		$initial_state['jetpackScan']['pricingForUi'] = Plan::get_product( 'jetpack_scan' );

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -185,6 +185,7 @@ class Jetpack_Protect {
 			'siteSuffix'        => ( new Jetpack_Status() )->get_site_suffix(),
 			'jetpackScan'       => My_Jetpack_Products::get_product( 'scan' ),
 			'productData'       => My_Jetpack_Products::get_product( 'protect' ),
+			'hasRequiredPlan'   => Plan::has_required_plan(),
 		);
 
 		$initial_state['jetpackScan']['pricingForUi'] = Plan::get_product( 'jetpack_scan' );
@@ -254,10 +255,10 @@ class Jetpack_Protect {
 	public static function register_rest_endpoints() {
 		register_rest_route(
 			'jetpack-protect/v1',
-			'plan',
+			'check-plan',
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
-				'callback'            => __CLASS__ . '::api_get_plan',
+				'callback'            => __CLASS__ . '::api_check_plan',
 				'permission_callback' => function () {
 					return current_user_can( 'manage_options' );
 				},
@@ -354,11 +355,10 @@ class Jetpack_Protect {
 	 *
 	 * @return WP_REST_Response
 	 */
-	public static function api_get_plan() {
-		$plan                 = My_Jetpack_Products::get_product( 'scan' );
-		$plan['pricingForUi'] = Plan::get_product( 'jetpack_scan' );
+	public static function api_check_plan() {
+		$has_required_plan = Plan::has_required_plan();
 
-		return rest_ensure_response( $plan, 200 );
+		return rest_ensure_response( $has_required_plan, 200 );
 	}
 
 	/**

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -172,12 +172,12 @@ class Jetpack_Protect {
 	 */
 	public function initial_state() {
 		global $wp_version;
-		$refresh_from_wpcom = isset( $_GET['checkPlan'] );
-		$initial_state      = array(
+		$refresh_status_from_wpcom = isset( $_GET['checkPlan'] );
+		$initial_state             = array(
 			'apiRoot'           => esc_url_raw( rest_url() ),
 			'apiNonce'          => wp_create_nonce( 'wp_rest' ),
 			'registrationNonce' => wp_create_nonce( 'jetpack-registration-nonce' ),
-			'status'            => Status::get_status( $refresh_from_wpcom ),
+			'status'            => Status::get_status( $refresh_status_from_wpcom ),
 			'installedPlugins'  => Plugins_Installer::get_plugins(),
 			'installedThemes'   => Sync_Functions::get_themes(),
 			'wpVersion'         => $wp_version,
@@ -185,7 +185,7 @@ class Jetpack_Protect {
 			'siteSuffix'        => ( new Jetpack_Status() )->get_site_suffix(),
 			'jetpackScan'       => My_Jetpack_Products::get_product( 'scan' ),
 			'productData'       => My_Jetpack_Products::get_product( 'protect' ),
-			'hasRequiredPlan'   => Plan::has_required_plan( $refresh_from_wpcom ),
+			'hasRequiredPlan'   => Plan::has_required_plan(),
 		);
 
 		$initial_state['jetpackScan']['pricingForUi'] = Plan::get_product( 'jetpack_scan' );
@@ -356,7 +356,7 @@ class Jetpack_Protect {
 	 * @return WP_REST_Response
 	 */
 	public static function api_check_plan() {
-		$has_required_plan = Plan::has_required_plan( true );
+		$has_required_plan = Plan::has_required_plan();
 
 		return rest_ensure_response( $has_required_plan, 200 );
 	}

--- a/projects/plugins/protect/src/class-plan.php
+++ b/projects/plugins/protect/src/class-plan.php
@@ -7,7 +7,7 @@
 
 namespace Automattic\Jetpack\Protect;
 
-use Automattic\Jetpack\Current_Plan as Jetpack_Plan;
+use Automattic\Jetpack\Current_Plan;
 
 /**
  * The Plan class.
@@ -92,17 +92,14 @@ class Plan {
 	/**
 	 * Has Required Plan
 	 *
+	 * @param bool $refresh_from_wpcom Refresh the local plan cache from wpcom.
 	 * @return bool True when the site has a plan or product that supports the paid Protect tier.
 	 */
-	public static function has_required_plan() {
-		if ( ! class_exists( 'Jetpack_Plan' ) ) {
-			return false;
-		}
-
-		$products = array_column( Jetpack_Plan::get_products(), 'product_slug' );
+	public static function has_required_plan( $refresh_from_wpcom = false ) {
+		$products = array_column( Current_Plan::get_products(), 'product_slug' );
 
 		// Check for a plan or product that enables scan.
-		$plan_supports_scan = Jetpack_Plan::supports( 'scan' );
+		$plan_supports_scan = Current_Plan::supports( 'scan', $refresh_from_wpcom );
 		$has_scan_product   = count( array_intersect( array( 'jetpack_scan', 'jetpack_scan_monthly' ), $products ) ) > 0;
 		$has_scan           = $plan_supports_scan || $has_scan_product;
 

--- a/projects/plugins/protect/src/class-plan.php
+++ b/projects/plugins/protect/src/class-plan.php
@@ -95,7 +95,7 @@ class Plan {
 	 * @param bool $refresh_from_wpcom Refresh the local plan cache from wpcom.
 	 * @return bool True when the site has a plan or product that supports the paid Protect tier.
 	 */
-	public static function has_required_plan( $refresh_from_wpcom = false ) {
+	public static function has_required_plan( $refresh_from_wpcom = true ) {
 		$products = array_column( Current_Plan::get_products(), 'product_slug' );
 
 		// Check for a plan or product that enables scan.

--- a/projects/plugins/protect/src/class-plan.php
+++ b/projects/plugins/protect/src/class-plan.php
@@ -92,16 +92,19 @@ class Plan {
 	/**
 	 * Has Required Plan
 	 *
-	 * @param bool $refresh_from_wpcom Refresh the local plan cache from wpcom.
+	 * @param bool $force_refresh Refresh the local plan cache from wpcom.
 	 * @return bool True when the site has a plan or product that supports the paid Protect tier.
 	 */
-	public static function has_required_plan( $refresh_from_wpcom = false ) {
-		$products = array_column( Current_Plan::get_products(), 'product_slug' );
+	public static function has_required_plan( $force_refresh = false ) {
+		static $has_scan = null;
+		if ( null === $has_scan || $force_refresh ) {
+			$products = array_column( Current_Plan::get_products(), 'product_slug' );
 
-		// Check for a plan or product that enables scan.
-		$plan_supports_scan = Current_Plan::supports( 'scan', $refresh_from_wpcom );
-		$has_scan_product   = count( array_intersect( array( 'jetpack_scan', 'jetpack_scan_monthly' ), $products ) ) > 0;
-		$has_scan           = $plan_supports_scan || $has_scan_product;
+			// Check for a plan or product that enables scan.
+			$plan_supports_scan = Current_Plan::supports( 'scan', true );
+			$has_scan_product   = count( array_intersect( array( 'jetpack_scan', 'jetpack_scan_monthly' ), $products ) ) > 0;
+			$has_scan           = $plan_supports_scan || $has_scan_product;
+		}
 
 		return $has_scan;
 	}

--- a/projects/plugins/protect/src/class-plan.php
+++ b/projects/plugins/protect/src/class-plan.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Protect;
 
+use Automattic\Jetpack\Current_Plan as Jetpack_Plan;
+
 /**
  * The Plan class.
  */
@@ -97,10 +99,10 @@ class Plan {
 			return false;
 		}
 
-		$products = array_column( \Jetpack_Plan::get_products(), 'product_slug' );
+		$products = array_column( Jetpack_Plan::get_products(), 'product_slug' );
 
 		// Check for a plan or product that enables scan.
-		$plan_supports_scan = \Jetpack_Plan::supports( 'scan' );
+		$plan_supports_scan = Jetpack_Plan::supports( 'scan' );
 		$has_scan_product   = count( array_intersect( array( 'jetpack_scan', 'jetpack_scan_monthly' ), $products ) ) > 0;
 		$has_scan           = $plan_supports_scan || $has_scan_product;
 

--- a/projects/plugins/protect/src/class-plan.php
+++ b/projects/plugins/protect/src/class-plan.php
@@ -86,4 +86,24 @@ class Plan {
 			)
 		);
 	}
+
+	/**
+	 * Has Required Plan
+	 *
+	 * @return bool True when the site has a plan or product that supports the paid Protect tier.
+	 */
+	public static function has_required_plan() {
+		if ( ! class_exists( 'Jetpack_Plan' ) ) {
+			return false;
+		}
+
+		$products = array_column( \Jetpack_Plan::get_products(), 'product_slug' );
+
+		// Check for a plan or product that enables scan.
+		$plan_supports_scan = \Jetpack_Plan::supports( 'scan' );
+		$has_scan_product   = count( array_intersect( array( 'jetpack_scan', 'jetpack_scan_monthly' ), $products ) ) > 0;
+		$has_scan           = $plan_supports_scan || $has_scan_product;
+
+		return $has_scan;
+	}
 }

--- a/projects/plugins/protect/src/class-plan.php
+++ b/projects/plugins/protect/src/class-plan.php
@@ -95,7 +95,7 @@ class Plan {
 	 * @param bool $refresh_from_wpcom Refresh the local plan cache from wpcom.
 	 * @return bool True when the site has a plan or product that supports the paid Protect tier.
 	 */
-	public static function has_required_plan( $refresh_from_wpcom = true ) {
+	public static function has_required_plan( $refresh_from_wpcom = false ) {
 		$products = array_column( Current_Plan::get_products(), 'product_slug' );
 
 		// Check for a plan or product that enables scan.

--- a/projects/plugins/protect/src/class-protect-status.php
+++ b/projects/plugins/protect/src/class-protect-status.php
@@ -44,14 +44,15 @@ class Protect_Status extends Status {
 	/**
 	 * Gets the current status of the Jetpack Protect checks
 	 *
+	 * @param bool $refresh_from_wpcom Refresh the local plan and status cache from wpcom.
 	 * @return Status_Model
 	 */
-	public static function get_status() {
+	public static function get_status( $refresh_from_wpcom = false ) {
 		if ( self::$status !== null ) {
 			return self::$status;
 		}
 
-		if ( ! self::should_use_cache() || self::is_cache_expired() ) {
+		if ( $refresh_from_wpcom || ! self::should_use_cache() || self::is_cache_expired() ) {
 			$status = self::fetch_from_server();
 		} else {
 			$status = self::get_from_options();

--- a/projects/plugins/protect/src/class-scan-status.php
+++ b/projects/plugins/protect/src/class-scan-status.php
@@ -50,14 +50,15 @@ class Scan_Status extends Status {
 	/**
 	 * Gets the current status of the Jetpack Protect checks
 	 *
+	 * @param bool $refresh_from_wpcom Refresh the local plan and status cache from wpcom.
 	 * @return Status_Model
 	 */
-	public static function get_status() {
+	public static function get_status( $refresh_from_wpcom = false ) {
 		if ( self::$status !== null ) {
 			return self::$status;
 		}
 
-		if ( ! self::should_use_cache() || self::is_cache_expired() ) {
+		if ( $refresh_from_wpcom || ! self::should_use_cache() || self::is_cache_expired() ) {
 			$status = self::fetch_from_api();
 		} else {
 			$status = self::get_from_options();

--- a/projects/plugins/protect/src/class-status.php
+++ b/projects/plugins/protect/src/class-status.php
@@ -7,8 +7,6 @@
 
 namespace Automattic\Jetpack\Protect;
 
-use Automattic\Jetpack\My_Jetpack\Products\Scan;
-
 /**
  * Class that handles fetching and caching the Status of vulnerabilities check from the WPCOM servers
  */
@@ -54,7 +52,7 @@ class Status {
 	 * @return Status_Model
 	 */
 	public static function get_status() {
-		$use_scan_status = Scan::has_required_plan();
+		$use_scan_status = Plan::has_required_plan();
 
 		if ( defined( 'JETPACK_PROTECT_DEV__DATA_SOURCE' ) ) {
 			if ( 'scan_api' === JETPACK_PROTECT_DEV__DATA_SOURCE ) {

--- a/projects/plugins/protect/src/class-status.php
+++ b/projects/plugins/protect/src/class-status.php
@@ -49,10 +49,11 @@ class Status {
 	/**
 	 * Gets the current status of the Jetpack Protect checks
 	 *
+	 * @param bool $refresh_from_wpcom Refresh the local plan and status cache from wpcom.
 	 * @return Status_Model
 	 */
-	public static function get_status() {
-		$use_scan_status = Plan::has_required_plan();
+	public static function get_status( $refresh_from_wpcom = false ) {
+		$use_scan_status = Plan::has_required_plan( $refresh_from_wpcom );
 
 		if ( defined( 'JETPACK_PROTECT_DEV__DATA_SOURCE' ) ) {
 			if ( 'scan_api' === JETPACK_PROTECT_DEV__DATA_SOURCE ) {
@@ -64,7 +65,7 @@ class Status {
 			}
 		}
 
-		self::$status = $use_scan_status ? Scan_Status::get_status() : Protect_Status::get_status();
+		self::$status = $use_scan_status ? Scan_Status::get_status( $refresh_from_wpcom ) : Protect_Status::get_status( $refresh_from_wpcom );
 		return self::$status;
 	}
 

--- a/projects/plugins/protect/src/class-status.php
+++ b/projects/plugins/protect/src/class-status.php
@@ -53,7 +53,7 @@ class Status {
 	 * @return Status_Model
 	 */
 	public static function get_status( $refresh_from_wpcom = false ) {
-		$use_scan_status = Plan::has_required_plan( $refresh_from_wpcom );
+		$use_scan_status = Plan::has_required_plan();
 
 		if ( defined( 'JETPACK_PROTECT_DEV__DATA_SOURCE' ) ) {
 			if ( 'scan_api' === JETPACK_PROTECT_DEV__DATA_SOURCE ) {

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -282,6 +282,9 @@ const useStatusPolling = () => {
 		const pollStatus = () => {
 			refreshStatus( true )
 				.then( latestStatus => {
+					if ( latestStatus.status.error ) {
+						throw latestStatus.status.errorMessage;
+					}
 					if (
 						[ 'scheduled', 'scanning' ].indexOf( latestStatus.status ) >= 0 ||
 						! latestStatus.status.lastChecked

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -315,7 +315,7 @@ const Admin = () => {
 			apiFetch( {
 				path: 'jetpack-protect/v1/plan',
 				method: 'GET',
-			} ).then( jetpackScan => jetpackScan?.has_required_plan ),
+			} ).then( hasRequiredPlan => hasRequiredPlan ),
 	} );
 
 	useEffect( () => {

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -169,7 +169,10 @@ const ProtectAdminPage = () => {
 	}
 
 	// When there's no information yet. Usually when the plugin was just activated
-	if ( [ 'scheduled', 'scanning' ].indexOf( status.status ) >= 0 || ! lastChecked ) {
+	if (
+		[ 'scheduled', 'scanning', 'optimistically_scanning' ].indexOf( status.status ) >= 0 ||
+		! lastChecked
+	) {
 		return (
 			<AdminPage moduleName={ __( 'Jetpack Protect', 'jetpack-protect' ) } header={ <Logo /> }>
 				<AdminSectionHero>
@@ -306,7 +309,7 @@ const Admin = () => {
 	useRegistrationWatcher();
 	useStatusPolling();
 
-	const { refreshPlan } = useDispatch( STORE_ID );
+	const { refreshPlan, startScanOptimistically, refreshStatus } = useDispatch( STORE_ID );
 	const { adminUrl } = window.jetpackProtectInitialState || {};
 	const { run, isRegistered, hasCheckoutStarted } = useProductCheckoutWorkflow( {
 		productSlug: JETPACK_SCAN,
@@ -320,9 +323,13 @@ const Admin = () => {
 
 	useEffect( () => {
 		if ( getQueryArg( window.location.search, 'checkPlan' ) ) {
-			refreshPlan();
+			startScanOptimistically();
+			setTimeout( () => {
+				refreshPlan();
+				refreshStatus( true );
+			}, 5000 );
 		}
-	}, [ refreshPlan ] );
+	}, [ refreshPlan, refreshStatus, startScanOptimistically ] );
 
 	/*
 	 * Show interstital page when

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -313,7 +313,7 @@ const Admin = () => {
 		redirectUrl: addQueryArgs( adminUrl, { checkPlan: true } ),
 		siteProductAvailabilityHandler: async () =>
 			apiFetch( {
-				path: 'jetpack-protect/v1/plan',
+				path: 'jetpack-protect/v1/check-plan',
 				method: 'GET',
 			} ).then( hasRequiredPlan => hasRequiredPlan ),
 	} );

--- a/projects/plugins/protect/src/js/components/footer/index.jsx
+++ b/projects/plugins/protect/src/js/components/footer/index.jsx
@@ -24,8 +24,7 @@ const ProductPromotion = () => {
 	const { recordEventHandler } = useAnalyticsTracks();
 	const getScan = recordEventHandler( 'jetpack_protect_footer_get_scan_link_click', run );
 
-	const { jetpackScan } = useProtectData();
-	const { hasRequiredPlan } = jetpackScan;
+	const { hasRequiredPlan } = useProtectData();
 
 	if ( hasRequiredPlan ) {
 		const goToCloudUrl = getRedirectUrl( 'jetpack-scan-dash', { site: siteSuffix } );
@@ -70,9 +69,7 @@ const ProductPromotion = () => {
 };
 
 const FooterInfo = () => {
-	// TODO: Update with new paid Protect product
-	const { jetpackScan } = useProtectData();
-	const { hasRequiredPlan } = jetpackScan;
+	const { hasRequiredPlan } = useProtectData();
 
 	if ( hasRequiredPlan ) {
 		const learnMoreScanUrl = getRedirectUrl( 'protect-footer-learn-more-scan' );

--- a/projects/plugins/protect/src/js/components/summary/index.jsx
+++ b/projects/plugins/protect/src/js/components/summary/index.jsx
@@ -9,8 +9,7 @@ import Notice from '../notice';
 import styles from './styles.module.scss';
 
 const Summary = () => {
-	const { numThreats, lastChecked, jetpackScan } = useProtectData();
-	const { hasRequiredPlan } = jetpackScan;
+	const { numThreats, lastChecked, hasRequiredPlan } = useProtectData();
 	const notice = useSelect( select => select( STORE_ID ).getNotice() );
 	const scanIsEnqueuing = useSelect( select => select( STORE_ID ).getScanIsEnqueuing() );
 	const { scan } = useDispatch( STORE_ID );

--- a/projects/plugins/protect/src/js/components/threats-list/index.jsx
+++ b/projects/plugins/protect/src/js/components/threats-list/index.jsx
@@ -12,8 +12,7 @@ import styles from './styles.module.scss';
 import useThreatsList from './use-threats-list';
 
 const ThreatsList = () => {
-	const { jetpackScan } = useProtectData();
-	const { hasRequiredPlan } = jetpackScan;
+	const { hasRequiredPlan } = useProtectData();
 	const { item, list, selected, setSelected } = useThreatsList();
 	const fixableList = list.filter( obj => obj.fixable );
 

--- a/projects/plugins/protect/src/js/components/threats-list/navigation.jsx
+++ b/projects/plugins/protect/src/js/components/threats-list/navigation.jsx
@@ -21,9 +21,8 @@ const ThreatsNavigation = ( { selected, onSelect } ) => {
 		numCoreThreats,
 		numFilesThreats,
 		numDatabaseThreats,
-		jetpackScan,
+		hasRequiredPlan,
 	} = useProtectData();
-	const { hasRequiredPlan } = jetpackScan;
 	const { recordEvent } = useAnalyticsTracks();
 	const [ isSmallOrLarge ] = useBreakpointMatch( 'lg', '<' );
 

--- a/projects/plugins/protect/src/js/hooks/use-protect-data/index.js
+++ b/projects/plugins/protect/src/js/hooks/use-protect-data/index.js
@@ -8,12 +8,15 @@ import { STORE_ID } from '../../state/store';
  * @returns {object} The information available in Protect's initial state.
  */
 export default function useProtectData() {
-	const { statusIsFetching, status, jetpackScan, productData } = useSelect( select => ( {
-		statusIsFetching: select( STORE_ID ).getStatusIsFetching(),
-		status: select( STORE_ID ).getStatus(),
-		jetpackScan: select( STORE_ID ).getJetpackScan(),
-		productData: select( STORE_ID ).getProductData(),
-	} ) );
+	const { statusIsFetching, status, jetpackScan, productData, hasRequiredPlan } = useSelect(
+		select => ( {
+			statusIsFetching: select( STORE_ID ).getStatusIsFetching(),
+			status: select( STORE_ID ).getStatus(),
+			jetpackScan: select( STORE_ID ).getJetpackScan(),
+			productData: select( STORE_ID ).getProductData(),
+			hasRequiredPlan: select( STORE_ID ).hasRequiredPlan(),
+		} )
+	);
 
 	let currentStatus = 'error';
 	if ( true === statusIsFetching ) {
@@ -66,5 +69,6 @@ export default function useProtectData() {
 		hasUncheckedItems: status.hasUncheckedItems,
 		jetpackScan,
 		productData,
+		hasRequiredPlan,
 	};
 }

--- a/projects/plugins/protect/src/js/state/actions.js
+++ b/projects/plugins/protect/src/js/state/actions.js
@@ -30,7 +30,7 @@ const startScanOptimistically = () => {
 
 const refreshPlan = () => ( { dispatch } ) => {
 	apiFetch( {
-		path: 'jetpack-protect/v1/plan',
+		path: 'jetpack-protect/v1/check-plan',
 		method: 'GET',
 	} ).then( jetpackScan => dispatch( setJetpackScan( camelize( jetpackScan ) ) ) );
 };

--- a/projects/plugins/protect/src/js/state/actions.js
+++ b/projects/plugins/protect/src/js/state/actions.js
@@ -18,6 +18,7 @@ const SET_THREATS_ARE_FIXING = 'SET_THREATS_ARE_FIXING';
 const SET_MODAL = 'SET_MODAL';
 const SET_NOTICE = 'SET_NOTICE';
 const CLEAR_NOTICE = 'CLEAR_NOTICE';
+const SET_HAS_REQUIRED_PLAN = 'SET_HAS_REQUIRED_PLAN';
 
 const setStatus = status => {
 	return { type: SET_STATUS, status };
@@ -304,6 +305,10 @@ const clearNotice = () => {
 	return { type: CLEAR_NOTICE };
 };
 
+const setHasRequiredPlan = hasRequiredPlan => {
+	return { type: SET_HAS_REQUIRED_PLAN, hasRequiredPlan };
+};
+
 const actions = {
 	checkCredentials,
 	setCredentials,
@@ -326,6 +331,7 @@ const actions = {
 	scan,
 	setThreatsAreFixing,
 	refreshPlan,
+	setHasRequiredPlan,
 };
 
 export {
@@ -345,5 +351,6 @@ export {
 	SET_NOTICE,
 	CLEAR_NOTICE,
 	SET_THREATS_ARE_FIXING,
+	SET_HAS_REQUIRED_PLAN,
 	actions as default,
 };

--- a/projects/plugins/protect/src/js/state/actions.js
+++ b/projects/plugins/protect/src/js/state/actions.js
@@ -32,7 +32,7 @@ const refreshPlan = () => ( { dispatch } ) => {
 	apiFetch( {
 		path: 'jetpack-protect/v1/check-plan',
 		method: 'GET',
-	} ).then( jetpackScan => dispatch( setJetpackScan( camelize( jetpackScan ) ) ) );
+	} ).then( hasRequiredPlan => dispatch( setHasRequiredPlan( hasRequiredPlan ) ) );
 };
 
 /**

--- a/projects/plugins/protect/src/js/state/reducers.js
+++ b/projects/plugins/protect/src/js/state/reducers.js
@@ -40,7 +40,7 @@ const status = ( state = {}, action ) => {
 		case SET_STATUS:
 			return action.status;
 		case START_SCAN_OPTIMISTICALLY:
-			return { ...state, status: 'scanning' };
+			return { ...state, status: 'optimistically_scanning' };
 	}
 	return state;
 };

--- a/projects/plugins/protect/src/js/state/reducers.js
+++ b/projects/plugins/protect/src/js/state/reducers.js
@@ -16,6 +16,7 @@ import {
 	SET_NOTICE,
 	CLEAR_NOTICE,
 	SET_THREATS_ARE_FIXING,
+	SET_HAS_REQUIRED_PLAN,
 } from './actions';
 
 const credentials = ( state = null, action ) => {
@@ -134,6 +135,14 @@ const notice = ( state = {}, action ) => {
 	return state;
 };
 
+const hasRequiredPlan = ( state = false, action ) => {
+	switch ( action.type ) {
+		case SET_HAS_REQUIRED_PLAN:
+			return action.hasRequiredPlan;
+	}
+	return state;
+};
+
 const reducers = combineReducers( {
 	credentials,
 	credentialsIsFetching,
@@ -149,6 +158,7 @@ const reducers = combineReducers( {
 	modal,
 	notice,
 	setThreatsFixing,
+	hasRequiredPlan,
 } );
 
 export default reducers;

--- a/projects/plugins/protect/src/js/state/selectors.js
+++ b/projects/plugins/protect/src/js/state/selectors.js
@@ -14,6 +14,7 @@ const selectors = {
 	getModalProps: state => state.modal?.props || {},
 	getNotice: state => state.notice || null,
 	getThreatsAreFixing: state => state.threatsAreFixing || [],
+	hasRequiredPlan: state => state.hasRequiredPlan || false,
 };
 
 export default selectors;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* We've been having reliability issues using `Scan::has_required_plan()` from `My_Jetpack` due to server timeouts, this PR introduces a new way of validating the site plan using the connection package's `Current_Plan`. While the My Jetpack method validates the plan by availability of an accessible scan status, this alternate method directly checks the site's available features. This allows us to handle scenarios where the site has the correct plan, but no available scan status (i.e. right after purchase, the scanner may still be initializing and is "unavailable" for a few moments.)
* This PR also updates what logic is ran by protect on the `init` hook, moving any code that relies on status data to `_admin_menu`, where it will be called only when necessary instead of every page load.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

1201069996155224-as-1203341574761584

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start up a JN site with Jetpack Beta running this branch for Protect, and no core Jetpack plugin installed.
* Go through the process of activating Protect as a paid and free user, validating both experiences use the proper UI and status data source.
* Manually upgrade or cancel your plan outside of wp-admin, and validate the correct plan is immediately recognized in Protect.

