### PR TITLE
Jetpack Defusion: load wpcom specific endpoints

### DIFF
--- a/projects/plugins/jetpack/changelog/update-defusion-json-endpoints
+++ b/projects/plugins/jetpack/changelog/update-defusion-json-endpoints
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Jetpack Defusion: load wpcom specific endpoints on wpcom
+
+

--- a/projects/plugins/jetpack/json-endpoints.php
+++ b/projects/plugins/jetpack/json-endpoints.php
@@ -113,7 +113,11 @@ require_once $json_endpoints_dir . 'class.wpcom-json-api-get-site-v1-2-endpoint.
 require_once $json_endpoints_dir . 'class.wpcom-json-api-list-posts-v1-2-endpoint.php';
 
 // Jetpack Only Endpoints
-$json_jetpack_endpoints_dir = __DIR__ . '/json-endpoints/jetpack/';
+if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+	$json_jetpack_endpoints_dir = ABSPATH . 'public.api/rest/json-endpoints/jetpack/';
+} else {
+	$json_jetpack_endpoints_dir = __DIR__ . '/json-endpoints/jetpack/';
+}
 
 // This files instantiates the endpoints
 require_once $json_jetpack_endpoints_dir . 'json-api-jetpack-endpoints.php';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

On wpcom, load the wpcom specific `json-endpoints/jetpack/` directory. A final piece to #25198

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
Internal: p1668110996687899-slack-C032DVAHMK3

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

Proofread.