### PR TITLE
Jetpack Search: show free plan nudge to classic search users

### DIFF
--- a/projects/packages/search/changelog/link-jetpack-search-free-for-classic-search-users
+++ b/projects/packages/search/changelog/link-jetpack-search-free-for-classic-search-users
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Suggest free Jetpack Search plan instead of the paid one to classic search users

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -70,7 +70,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.30.x-dev"
+			"dev-trunk": "0.31.x-dev"
 		},
 		"version-constants": {
 			"::VERSION": "src/class-package.php"

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.30.3-alpha",
+	"version": "0.31.0-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.30.3-alpha';
+	const VERSION = '0.31.0-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/dashboard/components/module-control/index.jsx
+++ b/projects/packages/search/src/dashboard/components/module-control/index.jsx
@@ -1,5 +1,7 @@
 import analytics from '@automattic/jetpack-analytics';
-import { getRedirectUrl } from '@automattic/jetpack-components';
+import { getProductCheckoutUrl } from '@automattic/jetpack-components';
+import { useConnection } from '@automattic/jetpack-connection';
+import { useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import classNames from 'classnames';
@@ -8,6 +10,7 @@ import Card from 'components/card';
 import CompactFormToggle from 'components/form-toggle/compact';
 import InstantSearchUpsellNudge from 'components/upsell-nudge';
 import React, { Fragment, useCallback } from 'react';
+import { STORE_ID } from 'store';
 
 import 'scss/rna-styles.scss';
 import './style.scss';
@@ -30,7 +33,6 @@ const WIDGETS_EDITOR_URL = 'widgets.php';
  * @param {object} props - Component properties.
  * @param {string} props.domain - Calypso slug.
  * @param {string} props.siteAdminUrl - site admin URL.
- * @param {string} props.upgradeBillPeriod - billing cycle for upgrades.
  * @param {Function} props.updateOptions - function to update settings.
  * @param {boolean} props.isDisabledFromOverLimit - true if the subscription is invalid to manipulate controls.
  * @param {boolean} props.isSavingEitherOption - true if Saving options.
@@ -53,16 +55,23 @@ export default function SearchModuleControl( {
 	isModuleEnabled,
 	isInstantSearchEnabled,
 	isInstantSearchPromotionActive,
-	upgradeBillPeriod,
 	supportsOnlyClassicSearch,
 	supportsSearch,
 	supportsInstantSearch,
 	isTogglingModule,
 	isTogglingInstantSearch,
 } ) {
-	const upgradeUrl = getRedirectUrl(
-		upgradeBillPeriod === 'monthly' ? 'jetpack-search-monthly' : 'jetpack-search',
-		{ site: domain }
+	const adminUrl = useSelect( select => select( STORE_ID ).getSiteAdminUrl(), [] );
+	const { isUserConnected } = useConnection( {
+		redirectUri: `${ adminUrl }admin.php?page=jetpack-search`,
+		from: 'jetpack-search',
+	} );
+	const isWpcom = useSelect( select => select( STORE_ID ).isWpcom(), [] );
+	const upgradeUrl = getProductCheckoutUrl(
+		'jetpack_search_free',
+		domain,
+		`${ adminUrl }admin.php?page=jetpack-search`,
+		isUserConnected || isWpcom
 	);
 
 	const toggleSearchModule = useCallback( () => {

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -71,8 +71,6 @@ export default function DashboardPage( { isLoading = false } ) {
 		select( STORE_ID ).isInstantSearchPromotionActive()
 	);
 
-	const upgradeBillPeriod = useSelect( select => select( STORE_ID ).getUpgradeBillPeriod() );
-
 	const supportsOnlyClassicSearch = useSelect( select =>
 		select( STORE_ID ).supportsOnlyClassicSearch()
 	);
@@ -150,7 +148,6 @@ export default function DashboardPage( { isLoading = false } ) {
 							domain={ domain }
 							isDisabledFromOverLimit={ isDisabledFromOverLimitOnFreePlan }
 							isInstantSearchPromotionActive={ isInstantSearchPromotionActive }
-							upgradeBillPeriod={ upgradeBillPeriod }
 							supportsOnlyClassicSearch={ supportsOnlyClassicSearch }
 							supportsSearch={ supportsSearch }
 							supportsInstantSearch={ supportsInstantSearch }

--- a/projects/packages/search/src/dashboard/components/upsell-nudge/index.jsx
+++ b/projects/packages/search/src/dashboard/components/upsell-nudge/index.jsx
@@ -19,12 +19,7 @@ export default function InstantSearchUpsellNudge( props = { upgrade: true } ) {
 				) }
 			</span>
 			<span>
-				{ props.upgrade && (
-					<b>{ __( 'Upgrade to Jetpack Instant Search now', 'jetpack-search-pkg' ) }</b>
-				) }
-				{ ! props.upgrade && (
-					<b>{ __( 'Purchase Jetpack Instant Search now', 'jetpack-search-pkg' ) }</b>
-				) }
+				<b>{ __( 'Try Jetpack Instant Search for free now', 'jetpack-search-pkg' ) }</b>
 			</span>
 		</a>
 	);

--- a/projects/plugins/jetpack/changelog/add-jetpack-search-free-for-classic
+++ b/projects/plugins/jetpack/changelog/add-jetpack-search-free-for-classic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -38,7 +38,7 @@
 		"automattic/jetpack-publicize": "0.18.x-dev",
 		"automattic/jetpack-redirect": "1.7.x-dev",
 		"automattic/jetpack-roles": "1.4.x-dev",
-		"automattic/jetpack-search": "0.30.x-dev",
+		"automattic/jetpack-search": "0.31.x-dev",
 		"automattic/jetpack-stats": "0.3.x-dev",
 		"automattic/jetpack-stats-admin": "0.1.x-dev",
 		"automattic/jetpack-status": "1.15.x-dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7dd2972add1115388f4d462e62772b03",
+    "content-hash": "4406815f741a8a0d16ea25c1a5dcbfa7",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1790,7 +1790,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "04c0b0d095283f8428e069b43a8766f6747249ab"
+                "reference": "5cbf091cc896dddfe5cacb411471941e0e46e686"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -1814,7 +1814,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.30.x-dev"
+                    "dev-trunk": "0.31.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"

--- a/projects/plugins/search/changelog/add-jetpack-search-free-for-classic
+++ b/projects/plugins/search/changelog/add-jetpack-search-free-for-classic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -10,7 +10,7 @@
 		"automattic/jetpack-connection": "1.46.x-dev",
 		"automattic/jetpack-identity-crisis": "0.8.x-dev",
 		"automattic/jetpack-my-jetpack": "2.3.x-dev",
-		"automattic/jetpack-search": "0.30.x-dev",
+		"automattic/jetpack-search": "0.31.x-dev",
 		"automattic/jetpack-stats": "0.3.x-dev",
 		"automattic/jetpack-status": "1.15.x-dev",
 		"automattic/jetpack-sync": "1.42.x-dev",

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fb5d1efed9fb395b260db1a57dae72c9",
+    "content-hash": "bcf3baa9f0c1cbd82da02e9a683c8dc5",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1096,7 +1096,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "04c0b0d095283f8428e069b43a8766f6747249ab"
+                "reference": "5cbf091cc896dddfe5cacb411471941e0e46e686"
             },
             "require": {
                 "automattic/jetpack-assets": "^1.17",
@@ -1120,7 +1120,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.30.x-dev"
+                    "dev-trunk": "0.31.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Currently, classic search users see a CTA to Purchase Jetpack Instant Search, but there's no way for them to start using the free plan.

This PR changes that, and shows them a button to try Jetpack Search for free instead of the one for purchasing a plan.

Before:

![image](https://user-images.githubusercontent.com/6437642/201212967-2b665d9a-15d4-4332-8027-d3fd03d99e02.png)

After:

![image](https://user-images.githubusercontent.com/6437642/201212985-34d1f034-a868-4ec8-bf0d-c4b15e6187a3.png)

The link is also changed - it goes to checkout for jetpack_search_free instead of jetpack_search now.

To see this, you need to have classic search, which is provided by wp.com business plan and legacy Jetpack Professional plan.

Note that we normally only show free option when new pricing is enabled (on sandboxed store). We should merge this after we enable the free plan for everyone.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
p8oabR-Xh-p2#comment-6774

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Ideally, this should be tested on an Atomic site with business plan, but without search plan. You can then go to `/wp-admin/admin.php?page=jetpack-search` and verify the message and link on the bottom.

An easier way would be to add:

```
isDisabledFromOverLimit = false;
supportsOnlyClassicSearch = true;
supportsInstantSearch = false;
```

at the beginning of `SearchModuleControl` function definition in `projects/packages/search/src/dashboard/components/module-control/index.jsx` on a site with existing Jetpack Search plan. This should force the right message to be shown on page `/wp-admin/admin.php?page=jetpack-search`.