### PR TITLE
Rework plan gifting banner option default behavior

### DIFF
--- a/projects/plugins/jetpack/changelog/update-gifting-option-default
+++ b/projects/plugins/jetpack/changelog/update-gifting-option-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update the default value of subscription gifting option.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -506,10 +506,17 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 * @return bool
 	 */
 	protected function get_wpcom_gifting_subscription_default() {
-		if ( function_exists( 'wpcom_site_has_feature' ) ) {
-			$purchase = Gifting_Banner::get_plan_purchase();
-			if ( $purchase !== null && isset( $purchase->auto_renew ) ) {
-				return ! $purchase->auto_renew;
+		if ( function_exists( 'wpcom_get_site_purchases' ) && function_exists( 'wpcom_purchase_has_feature' ) ) {
+			$purchases = wpcom_get_site_purchases();
+
+			foreach ( $purchases as $purchase ) {
+				if ( wpcom_purchase_has_feature( $purchase, \WPCOM_Features::SUBSCRIPTION_GIFTING ) ) {
+					if ( isset( $purchase->auto_renew ) ) {
+						return ! $purchase->auto_renew;
+					} elseif ( isset( $purchase->user_allows_auto_renew ) ) {
+						return ! $purchase->user_allows_auto_renew;
+					}
+				}
 			}
 		}
 		return false;

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -436,7 +436,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'rss_use_excerpt'                  => (bool) get_option( 'rss_use_excerpt' ),
 						'launchpad_screen'                 => (string) get_option( 'launchpad_screen' ),
 						'featured_image_email_enabled'     => (bool) get_option( 'featured_image_email_enabled' ),
-						'wpcom_gifting_subscription'       => (bool) get_option( 'wpcom_gifting_subscription', true ),
+						'wpcom_gifting_subscription'       => (bool) get_option( 'wpcom_gifting_subscription', $this->get_wpcom_gifting_subscription_default() ),
 					);
 
 					if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -497,6 +497,22 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 		}
 		return $response;
 
+	}
+
+	/**
+	 * Get the default value for the wpcom_gifting_subscription option.
+	 * The default value is the inverse of the plan's auto_renew setting.
+	 *
+	 * @return bool
+	 */
+	protected function get_wpcom_gifting_subscription_default() {
+		if ( function_exists( 'wpcom_site_has_feature' ) ) {
+			$purchase = Gifting_Banner::get_plan_purchase();
+			if ( $purchase !== null && isset( $purchase->auto_renew ) ) {
+				return ! $purchase->auto_renew;
+			}
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/69879

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR sets the default value of the `wpcom_gifting_subscription` option to the inverse of the auto-renew setting of the plan that has the `subscription-gifting` feature, if applicable. Otherwise, it sets the default value to `false`.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This PR should be tested on an Atomic site and a simple site.

To test on a simple site:
- Load this PR on your sandbox by running `bin/jetpack-downloader test jetpack update/gifting-option-default` in your wpcom directory. See https://github.com/Automattic/jetpack/pull/27374#issuecomment-1311063473 for more information.
- Sandbox the API in your Host file
- Now use a Simple test site with a Personal or higher plan and visit: https://wordpress.com/settings/general/YOURTESTSITE.wordpress.com?flags=subscription-gifting (note the flag in the URL)
  - Be sure to use a Simple test site where you've never set the "Accept a gift subscription" toggle before.
- If your test site has auto-renew off "Accept a gift subscription" should be toggled on. If your test site has auto-renew on "Accept a gift subscription" should be toggled off.
<img src="https://user-images.githubusercontent.com/140841/201208303-60fc4ff0-173b-4d05-b6c0-506d4c835f8b.png" />

To test on an Atomic site:
 - Load this PR on your Atomic test site using your WoA dev environment or using the [Jetpack Beta Tester plugin](https://jetpack.com/download-jetpack-beta/).
- Now use an Atomic test site with a Personal or higher plan and visit: https://wordpress.com/settings/general/YOURTESTSITE.wpcomstaging.com?flags=subscription-gifting (note the flag in the URL)
  - Be sure to use an Atomic test site where you've never set the "Accept a gift subscription" toggle before.
- If your test site has auto-renew off "Accept a gift subscription" should be toggled on. If your test site has auto-renew on "Accept a gift subscription" should be toggled off.
