### PR TITLE
My Jetpack: rename Backup and Anti-Spam

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/style.module.scss
@@ -56,7 +56,7 @@
 
 .checkout-button {
 	display: inline-block;
-	padding: 8px 60px;
+	padding: 0.5em 2em;
 	text-align: center;
 	width: 100%;
 	min-height: 42px;
@@ -65,6 +65,13 @@
 		margin: 0;
 	}
 
+	// Overwrite component default text wrapping. Label should be able to wrap
+	// on a new line to be fully visible on mobile devices.
+	&:global(.components-button.is-primary) {
+		height: auto;
+		white-space: normal;
+	}
+	
 	&:global(.is-secondary):hover:not(:disabled) {
 		background-color: var( --jp-black );
 		color: var( --jp-white );

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-product-names
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-product-names
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: rename Backup and Anti-Spam

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "2.4.1",
+	"version": "2.4.2-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -30,7 +30,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '2.4.1';
+	const PACKAGE_VERSION = '2.4.2-alpha';
 
 	/**
 	 * Initialize My Jetapack

--- a/projects/packages/my-jetpack/src/products/class-anti-spam.php
+++ b/projects/packages/my-jetpack/src/products/class-anti-spam.php
@@ -49,7 +49,7 @@ class Anti_Spam extends Product {
 	 * @return string
 	 */
 	public static function get_name() {
-		return __( 'Akismet Anti-Spam', 'jetpack-my-jetpack' );
+		return __( 'Akismet Anti-spam', 'jetpack-my-jetpack' );
 	}
 
 	/**
@@ -58,7 +58,7 @@ class Anti_Spam extends Product {
 	 * @return string
 	 */
 	public static function get_title() {
-		return __( 'Jetpack Akismet Anti-Spam', 'jetpack-my-jetpack' );
+		return __( 'Jetpack Akismet Anti-spam', 'jetpack-my-jetpack' );
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-anti-spam.php
+++ b/projects/packages/my-jetpack/src/products/class-anti-spam.php
@@ -49,7 +49,7 @@ class Anti_Spam extends Product {
 	 * @return string
 	 */
 	public static function get_name() {
-		return __( 'Anti-Spam', 'jetpack-my-jetpack' );
+		return __( 'Akismet Anti-Spam', 'jetpack-my-jetpack' );
 	}
 
 	/**
@@ -58,7 +58,7 @@ class Anti_Spam extends Product {
 	 * @return string
 	 */
 	public static function get_title() {
-		return __( 'Jetpack Anti-Spam', 'jetpack-my-jetpack' );
+		return __( 'Jetpack Akismet Anti-Spam', 'jetpack-my-jetpack' );
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-backup.php
+++ b/projects/packages/my-jetpack/src/products/class-backup.php
@@ -50,7 +50,7 @@ class Backup extends Hybrid_Product {
 	 * @return string
 	 */
 	public static function get_name() {
-		return __( 'Backup', 'jetpack-my-jetpack' );
+		return __( 'VaultPress Backup', 'jetpack-my-jetpack' );
 	}
 
 	/**
@@ -59,7 +59,7 @@ class Backup extends Hybrid_Product {
 	 * @return string
 	 */
 	public static function get_title() {
-		return __( 'Jetpack Backup', 'jetpack-my-jetpack' );
+		return __( 'Jetpack VaultPress Backup', 'jetpack-my-jetpack' );
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-security.php
+++ b/projects/packages/my-jetpack/src/products/class-security.php
@@ -56,7 +56,7 @@ class Security extends Module_Product {
 	 * @return string
 	 */
 	public static function get_description() {
-		return __( 'Comprehensive site security, including Backup, Scan, and Anti-spam.', 'jetpack-my-jetpack' );
+		return __( 'Comprehensive site security, including VaultPress Backup, Scan, and Akismet Anti-Spam.', 'jetpack-my-jetpack' );
 	}
 
 	/**
@@ -65,7 +65,7 @@ class Security extends Module_Product {
 	 * @return string
 	 */
 	public static function get_long_description() {
-		return __( 'Comprehensive site security, including Backup, Scan, and Anti-spam.', 'jetpack-my-jetpack' );
+		return __( 'Comprehensive site security, including VaultPress Backup, Scan, and Akismet Anti-Spam.', 'jetpack-my-jetpack' );
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-security.php
+++ b/projects/packages/my-jetpack/src/products/class-security.php
@@ -56,7 +56,7 @@ class Security extends Module_Product {
 	 * @return string
 	 */
 	public static function get_description() {
-		return __( 'Comprehensive site security, including VaultPress Backup, Scan, and Akismet Anti-Spam.', 'jetpack-my-jetpack' );
+		return __( 'Comprehensive site security, including VaultPress Backup, Scan, and Akismet Anti-spam.', 'jetpack-my-jetpack' );
 	}
 
 	/**
@@ -65,7 +65,7 @@ class Security extends Module_Product {
 	 * @return string
 	 */
 	public static function get_long_description() {
-		return __( 'Comprehensive site security, including VaultPress Backup, Scan, and Akismet Anti-Spam.', 'jetpack-my-jetpack' );
+		return __( 'Comprehensive site security, including VaultPress Backup, Scan, and Akismet Anti-spam.', 'jetpack-my-jetpack' );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:

This PR renames the following products in the _My Jetpack_ page of the plugins:
- `Backup` > `VaultPress Backup`
- `Anti-spam` > `Akismet Anti-spam`

#### Other information:
- [x] Have you written new tests for your changes, if applicable?
  - Not applicable
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
Context: p1HpG7-j1R-p2 

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

_Note: `Anti-spam` should have a lowercase `s`. The following screenshots haven't been updated accordingly._

- Launch a test site that uses a build of the Jetpack plugin based on this branch
- Connect your site to Jetpack, if it's not already
- Make sure the site has no subscription to Backup
- Visit the _My Jetpack_ section
- Check that both products are renamed
<img width="364" alt="Screen Shot 2022-11-10 at 4 16 45 PM" src="https://user-images.githubusercontent.com/1620183/201207843-9f7be863-79d6-4ab9-abee-6bd26fe081f6.png">
<img width="363" alt="Screen Shot 2022-11-10 at 4 16 49 PM" src="https://user-images.githubusercontent.com/1620183/201207845-303f471b-3f99-49cb-a37b-3c665282147c.png">

- Press the _Purchase_ button in the Backup card
- In the upsell page, check that products are renamed
<img width="1119" alt="Screen Shot 2022-11-10 at 4 16 37 PM" src="https://user-images.githubusercontent.com/1620183/201207833-d7329c1f-c466-4263-b158-270ac2852941.png">

- Make sure design is not broken on mobile devices
<img width="384" alt="Screen Shot 2022-11-10 at 4 16 27 PM" src="https://user-images.githubusercontent.com/1620183/201207827-0975f0aa-c8ba-494b-867d-16c87e69ea60.png">

