### PR TITLE
E2E tests: use mirror repo in tests

### DIFF
--- a/.github/files/e2e-tests/create-e2e-projects-matrix.sh
+++ b/.github/files/e2e-tests/create-e2e-projects-matrix.sh
@@ -30,6 +30,8 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
 	done
 elif [[ "$GITHUB_EVENT_NAME" == "push" || "$GITHUB_EVENT_NAME" == "workflow_run" ]]; then
 	PROJECTS_MATRIX=("${PROJECTS[*]}")
+elif [[ "$GITHUB_EVENT_NAME" == "repository_dispatch" ]]; then
+	PROJECTS_MATRIX=('{"project":"Jetpack pre-connection","path":"projects/plugins/jetpack/tests/e2e","testArgs":["specs/pre-connection","--retries=2"]}')
 elif [[ "$GITHUB_EVENT_NAME" == "schedule" ]]; then
 	# gutenberg scheduled run
   	if [ "$CRON" == "0 */12 * * *" ]; then

--- a/.github/files/e2e-tests/map-plugins-for-e2e-env.sh
+++ b/.github/files/e2e-tests/map-plugins-for-e2e-env.sh
@@ -8,8 +8,6 @@ if [[ -z "$PROJECT_PATH" ]]; then
 	exit 1
 fi
 
-tar --xz -xf "$BUILD_DIR/jetpack-build/build.tar.xz" -C "$BUILD_DIR"
-
 SLUG=$(jq -r -e ".ci.pluginSlug" "$PROJECT_PATH/package.json")
 MIRROR=$(jq -r -e ".ci.mirrorName" "$PROJECT_PATH/package.json")
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -19,7 +19,7 @@ on:
     types: ['e2e tests**']
 
 concurrency:
-  group: e2e-tests-${{ github.event_name }}-${{ github.ref }}
+  group: e2e-tests-${{ github.event_name }}-${{ github.ref }}-${{ github.event.action }}
   cancel-in-progress: true
 
 jobs:
@@ -112,7 +112,7 @@ jobs:
         fi
 
         if [ "$GITHUB_EVENT_NAME" == workflow_run || "$GITHUB_EVENT_NAME" == repository_dispatch ]; then
-          echo "::group::Updating volume mapping"
+          echo "::group::Update volume mapping"
           .github/files/e2e-tests/map-plugins-for-e2e-env.sh
           echo "::endgroup::"
         else

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -92,6 +92,13 @@ jobs:
         run_id: ${{ github.event.workflow_run.id }}
         path: build-output
 
+    - name: Checkout mirror repo
+      if: github.event_name == 'repository_dispatch'
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ github.event.client_payload.repository }}
+        path: build-output/build/${{ github.event.client_payload.repository }}
+
     - name: Prepare build
       env:
         COMPOSER_ROOT_VERSION: "dev-trunk"
@@ -100,6 +107,7 @@ jobs:
       run: |
         if [ "$GITHUB_EVENT_NAME" == workflow_run ]; then
           echo "::group::Prepare build artefacts"
+          tar --xz -xf "$BUILD_DIR/jetpack-build/build.tar.xz" -C "$BUILD_DIR"
           .github/files/e2e-tests/map-plugins-for-e2e-env.sh
           echo "::endgroup::"
         else

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -108,6 +108,11 @@ jobs:
         if [ "$GITHUB_EVENT_NAME" == workflow_run ]; then
           echo "::group::Prepare build artefacts"
           tar --xz -xf "$BUILD_DIR/jetpack-build/build.tar.xz" -C "$BUILD_DIR"
+          echo "::endgroup::"
+        fi
+
+        if [ "$GITHUB_EVENT_NAME" == workflow_run || "$GITHUB_EVENT_NAME" == repository_dispatch ]; then
+          echo "::group::Updating volume mapping"
           .github/files/e2e-tests/map-plugins-for-e2e-env.sh
           echo "::endgroup::"
         else

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -16,7 +16,7 @@ on:
     workflows: ["Build"]
     branches: [ 'trunk', '*/branch-*' ]
   repository_dispatch:
-    types: ['tba'] #use a type that will not trigger anything yet. to be updated after #27288 is merged
+    types: ['e2e tests**']
 
 concurrency:
   group: e2e-tests-${{ github.event_name }}-${{ github.ref }}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Use the code in mirror repository to run the e2e tests against.

When a `repository_dispatch` event is received, the repository that sent the event will be checked out, and used in the e2e tests setup instead of doing a `pnpm build`.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
pd5faL-i5-p2

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Unfortunately, GitHub doen't support running a repository_dispatch on a workflow that is not in the default branch. After merge, when changes are pushed to `jetpack-production` repo, the action there should trigger e2e tests in the monorepo and Jetpack pre-connection tests should run.