### PR TITLE
Dynamic title attribute for markdown footnotes

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/markdown/extra.php
+++ b/projects/plugins/jetpack/_inc/lib/markdown/extra.php
@@ -3042,7 +3042,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 				$attr .= " class=\"$class\"";
 			}
 			if ($this->fn_link_title != "") {
-				$title = $this->fn_link_title;
+				$title = trim( wp_strip_all_tags($this->footnotes[$node_id], true) );
 				$title = $this->encodeAttribute($title);
 				$attr .= " title=\"$title\"";
 			}

--- a/projects/plugins/jetpack/changelog/27388-footnote-dynamic-title
+++ b/projects/plugins/jetpack/changelog/27388-footnote-dynamic-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Footnotes now have a `title` attribute which displays their contents.


### PR DESCRIPTION
Fixes #27387 

Quick conformance test:

```
Lorem ipsum dolor sit amet[^latin]. These footnotes support Markdown[^md] and HTML[^html]. They don't choke on entities[^ent]! And quote marks are fine[^q]. What about very long footnotes[^long]? Fully multilingual[^zh] and Unicode[^🥰] compatible.

[^latin]: Other Latin texts are available
[^md]: Some Markdown *emphasis* and a [link](https://example.com)
[^html]: Using <em>HTML</em>
[^ent]: Entity support & or &amp;? < or &lt;
[^q]: "
[^long]: Sensors indicate no shuttle or other ships in this sector. According to coordinates, we have travelled 7,000 light years and are located near the system J-25. Tractor beam released, sir. Force field maintaining our hull integrity. Damage report? Sections 27, 28 and 29 on decks four, five and six destroyed. Without our shields, at this range it is probable a photon detonation could destroy the Enterprise.
[^zh]: 威廉 莎士比亚
[^🥰]: 🥰
```

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27387 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Footnotes have a title attribute which displays a tooltip. This is now set to the contents of the footnote.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Write a Markdown post with the following text:

```
Lorem ipsum dolor sit amet[^latin]. These footnotes support Markdown[^md] and HTML[^html]. They don't choke on entities[^ent]! And quote marks are fine[^q]. What about very long footnotes[^long]? Fully multilingual[^zh] and Unicode[^🥰] compatible.

[^latin]: Other Latin texts are available
[^md]: Some Markdown *emphasis* and a [link](https://example.com)
[^html]: Using <em>HTML</em>
[^ent]: Entity support & or &amp;? < or &lt;
[^q]: "
[^long]: Sensors indicate no shuttle or other ships in this sector. According to coordinates, we have travelled 7,000 light years and are located near the system J-25. Tractor beam released, sir. Force field maintaining our hull integrity. Damage report? Sections 27, 28 and 29 on decks four, five and six destroyed. Without our shields, at this range it is probable a photon detonation could destroy the Enterprise.
[^zh]: 威廉 莎士比亚
[^🥰]: 🥰
```

Publish the post and place your cursor over the footnote links.

