### PR TITLE
E2E tests: fix plugin slug for social

### DIFF
--- a/projects/plugins/social/changelog/e2e-fix-social-plugin-slug
+++ b/projects/plugins/social/changelog/e2e-fix-social-plugin-slug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+E2E tests: fix plugin slug

--- a/projects/plugins/social/tests/e2e/package.json
+++ b/projects/plugins/social/tests/e2e/package.json
@@ -49,7 +49,7 @@
 			"js-packages/publicize-components",
 			"tools/e2e-commons"
 		],
-		"pluginSlug": "social-plugin",
+		"pluginSlug": "social",
 		"mirrorName": "jetpack-social-plugin"
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Social e2e tests `package.json` had a wrong `pluginSlug` value leading to an incorrect volume mapping when setting up the test environment.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* The effect of the incorrect mapping is only when running tests for `workflow_run` trigger, using the build artefacts. After merge, make sure the Social tests pass for `workflow_run` e2e tests run.

