### PR TITLE
E2E tests: disable broke search test

### DIFF
--- a/projects/plugins/search/changelog/e2e-disable-search-test
+++ b/projects/plugins/search/changelog/e2e-disable-search-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+

--- a/projects/plugins/search/tests/e2e/specs/search-dashboard.test.js
+++ b/projects/plugins/search/tests/e2e/specs/search-dashboard.test.js
@@ -34,7 +34,7 @@ test.describe( 'Search Dashboard', () => {
 		await searchDashboard.waitForNetworkIdle();
 	} );
 
-	test( 'Can manage search module and instant search.', async () => {
+	test.skip( 'Can manage search module and instant search.', async () => {
 		await test.step( 'Can display dashboard correctly', async () => {
 			expect(
 				await searchDashboard.isSearchModuleToggleVisibile(),


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

Disable a broken search e2e test

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
p1668465202849479-slack-CDLH4C1UZ

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* All e2e tests should pass. `search-dashboard` spec should be skipped.