### PR TITLE
E2E tests: update setup for mirrors

### DIFF
--- a/.github/files/e2e-tests/map-plugins-for-e2e-env.sh
+++ b/.github/files/e2e-tests/map-plugins-for-e2e-env.sh
@@ -9,14 +9,18 @@ if [[ -z "$PROJECT_PATH" ]]; then
 fi
 
 SLUG=$(jq -r -e ".ci.pluginSlug" "$PROJECT_PATH/package.json")
-MIRROR=$(jq -r -e ".ci.mirrorName" "$PROJECT_PATH/package.json")
+MIRROR_NAME=$(jq -r -e ".ci.mirrorName" "$PROJECT_PATH/package.json")
+
+ls -lh "$BUILD_DIR"
 
 {
 	echo "e2e:"
 	echo "  volumeMappings:"
-	echo "    $BUILD_DIR/build/Automattic/$MIRROR: /var/www/html/wp-content/plugins/$SLUG"
+	echo "    $BUILD_DIR/$MIRROR_NAME: /var/www/html/wp-content/plugins/$SLUG"
 } > ./tools/docker/jetpack-docker-config.yml
 
+cat ./tools/docker/jetpack-docker-config.yml
+
 if [[ $SLUG != 'jetpack' ]]; then
-	echo "    $BUILD_DIR/build/Automattic/jetpack-production: /var/www/html/wp-content/plugins/jetpack" >> ./tools/docker/jetpack-docker-config.yml
+	echo "    $BUILD_DIR/jetpack-production: /var/www/html/wp-content/plugins/jetpack" >> ./tools/docker/jetpack-docker-config.yml
 fi

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -97,30 +97,34 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: ${{ github.event.client_payload.repository }}
-        path: build-output/build/${{ github.event.client_payload.repository }}
+        path: build-output/${{ github.event.client_payload.repository }}
 
     - name: Prepare build
       env:
         COMPOSER_ROOT_VERSION: "dev-trunk"
-        BUILD_DIR: ./build-output
         PROJECT_PATH: ${{ matrix.path }}
       run: |
-        if [ "$GITHUB_EVENT_NAME" == workflow_run ]; then
-          echo "::group::Prepare build artefacts"
-          tar --xz -xf "$BUILD_DIR/jetpack-build/build.tar.xz" -C "$BUILD_DIR"
-          echo "::endgroup::"
-        fi
+        case "$GITHUB_EVENT_NAME" in
+          workflow_run)
+            echo "::group::Prepare build artefacts"
+            tar --xz -xf "$BUILD_DIR/jetpack-build/build.tar.xz" -C "$BUILD_DIR"
+            BUILD_DIR=./build-output/build/Automattic .github/files/e2e-tests/map-plugins-for-e2e-env.sh
+            echo "::endgroup::"
+            ;;
 
-        if [ "$GITHUB_EVENT_NAME" == workflow_run ] || [ "$GITHUB_EVENT_NAME" == repository_dispatch ]; then
-          echo "::group::Update volume mapping"
-          .github/files/e2e-tests/map-plugins-for-e2e-env.sh
-          echo "::endgroup::"
-        else
-          echo "::group::Build plugin(s)"
-          cd $PROJECT_PATH
-          pnpm run build
-          echo "::endgroup::"
-        fi
+          repository_dispatch)
+            echo "::group::Prepare build artefacts"
+            BUILD_DIR=./build-output/automattic .github/files/e2e-tests/map-plugins-for-e2e-env.sh
+            echo "::endgroup::"
+            ;;
+
+          *)
+            echo "::group::Build plugin(s)"
+            cd $PROJECT_PATH
+            pnpm run build
+            echo "::endgroup::"
+            ;;
+        esac
 
     - name: Test environment set-up
       working-directory: ${{ matrix.path }}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fix for the e2e tests setup when using mirror repos as target. 
The workflow was supposed to work using the same setup as for the existing `workflow_run` event, but there is a difference in letter casing in the paths (Automattic vs automattic) that needs to be treated.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Can only be tested after merge. I tested it on a fork, see a successful test environment setup step [here](https://github.com/adimoldovan/jetpack/actions/runs/3471946066/jobs/5802129657#step:8:77) (Jetpack plugin installed and active)

