### PR TITLE
Stats: Add option to enable new Stats experience

### DIFF
--- a/projects/packages/stats-admin/changelog/add-option-to-enable-modern-stats
+++ b/projects/packages/stats-admin/changelog/add-option-to-enable-modern-stats
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: add stats option `calypso_stats` to allow user get the new experience

--- a/projects/packages/stats-admin/changelog/add-option-to-enable-modern-stats
+++ b/projects/packages/stats-admin/changelog/add-option-to-enable-modern-stats
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Stats: add stats option `calypso_stats` to allow user get the new experience
+Stats: add stats option `enable_calypso_stats` to allow users to enable the new Calypso Stats experience

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -268,7 +268,7 @@ class Dashboard {
 	protected static function get_admin_path() {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		if ( ! isset( $_SERVER['PHP_SELF'] ) || ! isset( $_SERVER['QUERY_STRING'] ) ) {
-			$parsed = wp_parse_url( admin_url( 'admin.php?page=stats&calypso_stats=1' ) );
+			$parsed = wp_parse_url( admin_url( 'admin.php?page=stats' ) );
 			return $parsed['path'] . '?' . $parsed['query'];
 		}
 		// We do this because page.js requires the exactly page base to be set otherwise it will not work properly.

--- a/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
@@ -243,12 +243,13 @@ class SiteStatsComponent extends React.Component {
 								</span>
 							</CompactFormToggle>
 						</FormFieldset>
-						<FormFieldset>
+						{ /* We hide the new Stats option till we lauch it to the general public. */ }
+						<FormFieldset style={ { display: 'none' } }>
 							<CompactFormToggle
-								checked={ !! this.props.getOptionValue( 'calypso_stats' ) }
+								checked={ !! this.props.getOptionValue( 'enable_calypso_stats' ) }
 								disabled={ ! isStatsActive || unavailableInOfflineMode }
-								toggling={ this.props.isSavingAnyOption( [ 'stats', 'calypso_stats' ] ) }
-								onChange={ this.handleStatsOptionToggle( 'calypso_stats' ) }
+								toggling={ this.props.isSavingAnyOption( [ 'stats', 'enable_calypso_stats' ] ) }
+								onChange={ this.handleStatsOptionToggle( 'enable_calypso_stats' ) }
 							>
 								<span className="jp-form-toggle-explanation">
 									{ __( 'Preview new Jetpack Stats experience (Experimental)', 'jetpack' ) }

--- a/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
@@ -244,6 +244,18 @@ class SiteStatsComponent extends React.Component {
 							</CompactFormToggle>
 						</FormFieldset>
 						<FormFieldset>
+							<CompactFormToggle
+								checked={ !! this.props.getOptionValue( 'calypso_stats' ) }
+								disabled={ ! isStatsActive || unavailableInOfflineMode }
+								toggling={ this.props.isSavingAnyOption( [ 'stats', 'calypso_stats' ] ) }
+								onChange={ this.handleStatsOptionToggle( 'calypso_stats' ) }
+							>
+								<span className="jp-form-toggle-explanation">
+									{ __( 'Preview new Jetpack Stats experience (Experimental)', 'jetpack' ) }
+								</span>
+							</CompactFormToggle>
+						</FormFieldset>
+						<FormFieldset>
 							<FormLegend>{ __( 'Count logged in page views from', 'jetpack' ) }</FormLegend>
 							{ Object.keys( siteRoles ).map( key => (
 								<CompactFormToggle

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2730,7 +2730,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'stats',
 			),
-			'calypso_stats'                        => array(
+			'enable_calypso_stats'                 => array(
 				'description'       => esc_html__( 'Preview new Jetpack Stats experience (Experimental).', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2730,6 +2730,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'stats',
 			),
+			'calypso_stats'                        => array(
+				'description'       => esc_html__( 'Preview new Jetpack Stats experience (Experimental).', 'jetpack' ),
+				'type'              => 'boolean',
+				'default'           => 0,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'stats',
+			),
 			'roles'                                => array(
 				'description'       => esc_html__( 'Select the roles that will be able to view stats reports.', 'jetpack' ),
 				'type'              => 'array',

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2731,7 +2731,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'stats',
 			),
 			'enable_calypso_stats'                 => array(
-				'description'       => esc_html__( 'Preview new Jetpack Stats experience (Experimental).', 'jetpack' ),
+				'description'       => esc_html__( 'Preview the new Jetpack Stats experience (Experimental).', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -865,6 +865,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					break;
 
 				case 'admin_bar':
+				case 'calypso_stats':
 				case 'roles':
 				case 'count_roles':
 				case 'blog_id':

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -865,7 +865,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					break;
 
 				case 'admin_bar':
-				case 'calypso_stats':
+				case 'enable_calypso_stats':
 				case 'roles':
 				case 'count_roles':
 				case 'blog_id':

--- a/projects/plugins/jetpack/changelog/add-option-to-enable-modern-stats
+++ b/projects/plugins/jetpack/changelog/add-option-to-enable-modern-stats
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Stats: add stats option `calypso_stats` to allow user get the new experience
+Stats: add stats option `enable_calypso_stats` to allow user get the new experience

--- a/projects/plugins/jetpack/changelog/add-option-to-enable-modern-stats
+++ b/projects/plugins/jetpack/changelog/add-option-to-enable-modern-stats
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: add stats option `calypso_stats` to allow user get the new experience

--- a/projects/plugins/jetpack/changelog/add-option-to-enable-modern-stats
+++ b/projects/plugins/jetpack/changelog/add-option-to-enable-modern-stats
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Stats: add stats option `enable_calypso_stats` to allow user get the new experience
+Stats: add stats option `enable_calypso_stats` to allow users to enable the new Calypso Stats experience

--- a/projects/plugins/jetpack/changelog/add-option-to-enable-modern-stats
+++ b/projects/plugins/jetpack/changelog/add-option-to-enable-modern-stats
@@ -1,4 +1,4 @@
 Significance: minor
-Type: added
+Type: enhancement
 
 Stats: add stats option `calypso_stats` to allow user get the new experience

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -286,7 +286,7 @@ function stats_admin_menu() {
 	}
 
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	if ( ! isset( $_GET['calypso_stats'] ) ) {
+	if ( ! Stats_Options::get_option( 'calypso_stats' ) ) {
 		$hook = add_submenu_page( 'jetpack', __( 'Stats', 'jetpack' ), __( 'Stats', 'jetpack' ), 'view_stats', 'stats', 'jetpack_admin_ui_stats_report_page_wrapper' );
 		add_action( "load-$hook", 'stats_reports_load' );
 	} else {

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -286,7 +286,7 @@ function stats_admin_menu() {
 	}
 
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	if ( ! Stats_Options::get_option( 'calypso_stats' ) ) {
+	if ( ! Stats_Options::get_option( 'enable_calypso_stats' ) ) {
 		$hook = add_submenu_page( 'jetpack', __( 'Stats', 'jetpack' ), __( 'Stats', 'jetpack' ), 'view_stats', 'stats', 'jetpack_admin_ui_stats_report_page_wrapper' );
 		add_action( "load-$hook", 'stats_reports_load' );
 	} else {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The PR introduces an Stats options named `calypso_stats` to control the experience of Stats, which will easily allow user to preview the new experience if they want  and also would be easier for internal testing etc.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Open a site with Jetpack plugin and fully connected
- Open `/wp-admin/admin.php?page=jetpack#/settings?term=Jetpack%20Stats`
- Expand the section
- Enable 'Preview new Jetpack Stats experience (Experimental)'
- Open `/wp-admin/admin.php?page=stats`
- Ensure you get the Calypso Stats experience
- Go back and disable the option
- Ensure you get the Old Stats experience

![image](https://user-images.githubusercontent.com/1425433/202062296-fc778ad6-aa6f-4c72-8298-8551ea2ada25.png)
