### PR TITLE
VideoPress: fix issue when setting video privacy

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-fix-setting-privacy-issue
+++ b/projects/packages/videopress/changelog/update-videopress-fix-setting-privacy-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: fix issue when setting video privacy

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
@@ -164,8 +164,15 @@ export function useSyncMedia(
 			return;
 		}
 
-		// Sync (POST request) the block attributes data with the VideoPress API.
-		updateMediaHandler( dataToUpdate ).then( () => updateInitialState( dataToUpdate ) );
+		// Sync the block attributes data with the video data
+		updateMediaHandler( dataToUpdate ).then( () => {
+			// Update local state with fresh video data.
+			updateInitialState( dataToUpdate );
+
+			// Re-render video player once the data has been updated.
+			const videoPressUrl = getVideoPressUrl( guid, attributes );
+			invalidateResolution( 'getEmbedPreview', [ videoPressUrl ] );
+		} );
 
 		// | Video Chapters feature |
 		if ( attributes?.guid && dataToUpdate?.description?.length ) {


### PR DESCRIPTION
~# 🚨 DO NOT MERGE 🚨~
~Depend on https://github.com/Automattic/jetpack/pull/27419~

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/27424

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: fix issue when setting video privacy 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create/edit a VideoPress video block
* Open the block sidebar
* Change the privacy setting using all variants: `Site Default`, `Public`, `Private`
* Confirm you never get the following screen in the video player

![image](https://user-images.githubusercontent.com/77539/202141385-b8b52ac4-8136-45ef-805d-6f2fa9c78465.png)
