### PR TITLE
[Pre-publish/post-publish panel] Split email subscribers & social followers

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/subscribers.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/subscribers.php
@@ -39,6 +39,18 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers extends WP_REST_Controller {
 				),
 			)
 		);
+		// GET /sites/<blog_id>/subscriber/counts - Return splitted number of subscribers for this site
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/counts',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_subscriber_counts' ),
+					'permission_callback' => array( $this, 'readable_permission_check' ),
+				),
+			)
+		);
 	}
 
 	/**
@@ -71,6 +83,23 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers extends WP_REST_Controller {
 		return array(
 			'count' => $subscriber_count,
 		);
+	}
+
+	/**
+	 * Retrieves splitted subscriber counts
+	 *
+	 * @param WP_REST_Request $request incoming API request info.
+	 * @return array data object containing subscriber counts ['email_subscribers' => 0, 'social_followers' => 0]
+	 */
+	public function get_subscriber_counts( $request ) {
+		if ( ! Constants::is_defined( 'TESTING_IN_JETPACK' ) ) {
+			delete_transient( 'wpcom_subscribers_totals' );
+		}
+
+		$subscriber_info  = Jetpack_Subscriptions_Widget::fetch_subscriber_counts();
+		$subscriber_count = $subscriber_info['value'];
+
+		return array( 'counts' => $subscriber_count );
 	}
 }
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/subscribers.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/subscribers.php
@@ -88,10 +88,9 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers extends WP_REST_Controller {
 	/**
 	 * Retrieves splitted subscriber counts
 	 *
-	 * @param WP_REST_Request $request incoming API request info.
 	 * @return array data object containing subscriber counts ['email_subscribers' => 0, 'social_followers' => 0]
 	 */
-	public function get_subscriber_counts( $request ) {
+	public function get_subscriber_counts() {
 		if ( ! Constants::is_defined( 'TESTING_IN_JETPACK' ) ) {
 			delete_transient( 'wpcom_subscribers_totals' );
 		}

--- a/projects/plugins/jetpack/changelog/add-pre-publish-panel-changes
+++ b/projects/plugins/jetpack/changelog/add-pre-publish-panel-changes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Split out the email subscribers & social followers in the pre-publish panel.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/api.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/api.js
@@ -5,7 +5,7 @@ export function getSubscriberCount( successCallback, failureCallback ) {
 		path: '/wpcom/v2/subscribers/count?include_publicize_subscribers=false',
 	} ).then( ( { count } = {} ) => {
 		// Handle error condition
-		if ( typeof count !== 'undefined' ) {
+		if ( Number.isFinite( count ) ) {
 			successCallback( count );
 		} else {
 			failureCallback();

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/api.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/api.js
@@ -3,12 +3,12 @@ import apiFetch from '@wordpress/api-fetch';
 export function getSubscriberCount( successCallback, failureCallback ) {
 	return apiFetch( {
 		path: '/wpcom/v2/subscribers/count?include_publicize_subscribers=false',
-	} ).then( count => {
+	} ).then( ( { count } = {} ) => {
 		// Handle error condition
-		if ( ! count.hasOwnProperty( 'count' ) ) {
-			failureCallback();
+		if ( typeof count !== 'undefined' ) {
+			successCallback( count );
 		} else {
-			successCallback( count.count );
+			failureCallback();
 		}
 	} );
 }
@@ -16,12 +16,12 @@ export function getSubscriberCount( successCallback, failureCallback ) {
 export function getSubscriberCounts( successCallback, failureCallback ) {
 	return apiFetch( {
 		path: '/wpcom/v2/subscribers/counts',
-	} ).then( count => {
+	} ).then( ( { counts } = {} ) => {
 		// Handle error condition
-		if ( ! count.hasOwnProperty( 'counts' ) ) {
-			failureCallback();
+		if ( counts ) {
+			successCallback( counts );
 		} else {
-			successCallback( count.counts );
+			failureCallback();
 		}
 	} );
 }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/api.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/api.js
@@ -12,3 +12,16 @@ export function getSubscriberCount( successCallback, failureCallback ) {
 		}
 	} );
 }
+
+export function getSubscriberCounts( successCallback, failureCallback ) {
+	return apiFetch( {
+		path: '/wpcom/v2/subscribers/counts',
+	} ).then( count => {
+		// Handle error condition
+		if ( ! count.hasOwnProperty( 'counts' ) ) {
+			failureCallback();
+		} else {
+			successCallback( count.counts );
+		}
+	} );
+}

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -6,13 +6,17 @@ import { store as editorStore } from '@wordpress/editor';
 import { createInterpolateElement, useEffect, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import InspectorNotice from '../../shared/components/inspector-notice';
-import { getSubscriberCount } from './api';
+import { getSubscriberCounts } from './api';
 import './panel.scss';
 
 export default function SubscribePanels() {
 	const [ subscriberCount, setSubscriberCount ] = useState( null );
+	const [ followerCount, setFollowerCount ] = useState( null );
 	useEffect( () => {
-		getSubscriberCount( count => setSubscriberCount( count ) );
+		getSubscriberCounts( counts => {
+			setSubscriberCount( counts.email_subscribers );
+			setFollowerCount( counts.social_followers );
+		} );
 	}, [] );
 
 	// Only show this for posts for now (subscriptions are only available on posts).
@@ -39,7 +43,10 @@ export default function SubscribePanels() {
 	}
 
 	// Do not show any panels when we have no info about the subscriber count, or it is too low.
-	if ( ! Number.isFinite( subscriberCount ) || subscriberCount <= 0 ) {
+	if (
+		( ! Number.isFinite( subscriberCount ) || subscriberCount <= 0 ) &&
+		( ! Number.isFinite( followerCount ) || followerCount <= 0 )
+	) {
 		return null;
 	}
 
@@ -54,14 +61,18 @@ export default function SubscribePanels() {
 				<InspectorNotice>
 					{ createInterpolateElement(
 						sprintf(
-							/* translators: %s is the number of subscribers */
-							_n(
-								'This post will be sent to <span>%s reader</span>',
-								'This post will be sent to <span>%s readers</span>',
-								subscriberCount,
-								'jetpack'
+							/* translators: 1$s will be email subscribers, %2$s will be social followers */
+							__( 'This post will reach <span>%1$s</span> and <span>%2$s</span>.', 'jetpack' ),
+							sprintf(
+								/* translators: %s will be a number of email subscribers */
+								_n( '%s email subscriber', '%s email subscribers', subscriberCount, 'jetpack' ),
+								numberFormat( subscriberCount )
 							),
-							numberFormat( subscriberCount )
+							sprintf(
+								/* translators: %s will be a number of social followers */
+								_n( '%s social follower', '%s social followers', followerCount, 'jetpack' ),
+								numberFormat( followerCount )
+							)
 						),
 						{ span: <span className="jetpack-subscribe-reader-count" /> }
 					) }
@@ -71,14 +82,18 @@ export default function SubscribePanels() {
 				<InspectorNotice>
 					{ createInterpolateElement(
 						sprintf(
-							/* translators: %s is the number of subscribers */
-							_n(
-								'This post has been sent to <span>%s reader</span>',
-								'This post has been sent to <span>%s readers</span>',
-								subscriberCount,
-								'jetpack'
+							/* translators: 1$s will be email subscribers, %2$s will be social followers */
+							__( 'This post was shared to <span>%1$s</span> and <span>%2$s</span>.', 'jetpack' ),
+							sprintf(
+								/* translators: %s will be a number of email subscribers */
+								_n( '%s email subscriber', '%s email subscribers', subscriberCount, 'jetpack' ),
+								numberFormat( subscriberCount )
 							),
-							numberFormat( subscriberCount )
+							sprintf(
+								/* translators: %s will be a number of social followers */
+								_n( '%s social follower', '%s social followers', followerCount, 'jetpack' ),
+								numberFormat( followerCount )
+							)
 						),
 						{ span: <span className="jetpack-subscribe-reader-count" /> }
 					) }

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -593,10 +593,55 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 	}
 
 	/**
+	 * Determine the amount of folks currently subscribed to the blog, splitted out in email_subscribers & social_followers
+	 *
+	 * @return array containing ['email_subscribers' => 0, 'social_followers' => 0]
+	 */
+	public static function fetch_subscriber_counts() {
+		$subs_count = 0;
+		if ( self::is_jetpack() ) {
+			$cache_key  = 'wpcom_subscribers_totals';
+			$subs_count = get_transient( $cache_key );
+			if ( false === $subs_count || 'failed' === $subs_count['status'] ) {
+				$xml = new Jetpack_IXR_Client();
+				$xml->query( 'jetpack.fetchSubscriberCounts' );
+
+				if ( $xml->isError() ) { // If we get an error from .com, set the status to failed so that we will try again next time the data is requested.
+
+					$subs_count = array(
+						'status'  => 'failed',
+						'code'    => $xml->getErrorCode(),
+						'message' => $xml->getErrorMessage(),
+						'value'   => ( isset( $subs_count['value'] ) ) ? $subs_count['value'] : array(
+							'email_subscribers' => 0,
+							'social_followers'  => 0,
+						),
+					);
+				} else {
+					$subs_count = array(
+						'status' => 'success',
+						'value'  => $xml->getResponse(),
+					);
+				}
+				set_transient( $cache_key, $subs_count, 3600 ); // Try to cache the result for at least 1 hour.
+			}
+		}
+
+		if ( self::is_wpcom() ) {
+			$subs_count = array(
+				'email_subscribers' => wpcom_subs_total_for_blog(),
+				'social_followers'  => wpcom_social_followers_total_for_blog(),
+			);
+		}
+
+		return $subs_count;
+	}
+
+	/**
 	 * Determine the amount of folks currently subscribed to the blog.
 	 *
 	 * @param bool $include_publicize_subscribers Include followers through Publicize.
-	 * @return int|array
+	 * @return int
 	 */
 	public static function fetch_subscriber_count( $include_publicize_subscribers = true ) {
 		$subs_count = 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This PR changes the pre-publish/post-publish panels to show the amount of email subscribers & social followers instead of just "readers".

| Before | After |
|-------|------|
| <img width="277" alt="CleanShot 2022-11-16 at 10 28 37@2x" src="https://user-images.githubusercontent.com/528287/202143127-c7cb6886-cbc7-4a8b-bbcb-7f62b7c15d18.png"> |  <img width="277" alt="CleanShot 2022-11-16 at 10 31 18@2x" src="https://user-images.githubusercontent.com/528287/202143174-2d6585da-83b8-4472-a9ed-bce99ea7eb7e.png"> |
| <img width="267" alt="CleanShot 2022-11-16 at 10 50 04@2x" src="https://user-images.githubusercontent.com/528287/202147409-3af7c51e-528a-4199-bfa5-c912bd3af849.png"> | <img width="273" alt="CleanShot 2022-11-16 at 10 40 19@2x" src="https://user-images.githubusercontent.com/528287/202145245-9c374972-9763-4f32-8cd9-88883eee34f5.png"> |

#### Jetpack product discussion
pdDOJh-ZI-p2
pdDOJh-Yp-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
1. Apply this PR to sandbox: D92430-code
2. Make sure `public-api.wordpress.com` is sandboxed 
4. Apply this PR
5. Make sure your WP installation points to your sandbox (`define( 'JETPACK__SANDBOX_DOMAIN', '' );`
6. Email subscribers & social followers should be visible in the pre- & post-publish panels

Testing instructions for simple/JT/Atomic here: D92430-code