### PR TITLE
RNA: Fix Button style on tertiary variant when disabled

### DIFF
--- a/projects/js-packages/components/changelog/fix-button-disabled-style
+++ b/projects/js-packages/components/changelog/fix-button-disabled-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+RNA: Add aria-disabled property to Button when disabled

--- a/projects/js-packages/components/components/button/index.tsx
+++ b/projects/js-packages/components/components/button/index.tsx
@@ -68,6 +68,7 @@ const Button = forwardRef< HTMLInputElement, ButtonProps >( ( props, ref ) => {
 			icon={ ! isExternalLink ? icon : undefined }
 			iconSize={ iconSize }
 			disabled={ disabled }
+			aria-disabled={ disabled }
 			isDestructive={ isDestructive }
 			text={ text }
 			{ ...componentProps }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27448

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds `aria-disabled` property to `WPButton` when `Button` is disabled. Some styles on `WPButton` use this selector instead of `:disabled`.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Storybook
* Components / Button / Disabled
* Select `tertiary` variant
* Click on the button
* Check that it does not change color

On VideoPress dashboard, with a connected site but no connected user, where the issue was spotted:

https://user-images.githubusercontent.com/8486249/202252676-e6919718-da1d-40f4-bee5-8b1accdeff39.mp4
