### PR TITLE
Protect: Fix rendering of pricing page when no introductory offer is available

### DIFF
--- a/projects/plugins/protect/changelog/fix-protect-without-introductory-offer
+++ b/projects/plugins/protect/changelog/fix-protect-without-introductory-offer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed pricing table rendering when no introductory offer is present

--- a/projects/plugins/protect/src/js/components/pricing-table/index.jsx
+++ b/projects/plugins/protect/src/js/components/pricing-table/index.jsx
@@ -35,7 +35,7 @@ const ConnectedPricingTable = ( { onScanAdd, scanJustAdded } ) => {
 
 	// Compute the price per month.
 	const price = pricingForUi.cost ? Math.ceil( ( pricingForUi.cost / 12 ) * 100 ) / 100 : null;
-	const offPrice = introductoryOffer.costPerInterval
+	const offPrice = introductoryOffer?.costPerInterval
 		? Math.ceil( ( introductoryOffer.costPerInterval / 12 ) * 100 ) / 100
 		: null;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes `TypeError: can't access property "costPerInterval", g is undefined` when rendering the pricing table with no introductory offer data present.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Uses optional chaining to trigger the `null` `offPrice` when `introductoryOffer` is not an object.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Validate a fresh JN site can render the pricing table.

