### PR TITLE
VideoPress: Add backend verification on update endpoints when user is disconnected

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-add-verification-on-update-endpoints
+++ b/projects/packages/videopress/changelog/update-videopress-add-verification-on-update-endpoints
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Add backend verification on update routes when user is disconnected

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -193,6 +193,19 @@ class Data {
 	}
 
 	/**
+	 * Checks if the user is able to perform actions that modify data
+	 */
+	public static function can_perform_action() {
+		$connection = new Connection_Manager();
+
+		return (
+			$connection->is_connected() &&
+			self::has_connected_owner() &&
+			$connection->is_user_connected()
+		);
+	}
+
+	/**
 	 * Return the initial state of the VideoPress app,
 	 * used to render initially the app in the frontend.
 	 *

--- a/projects/packages/videopress/src/class-videopress-rest-api-v1-settings.php
+++ b/projects/packages/videopress/src/class-videopress-rest-api-v1-settings.php
@@ -45,7 +45,7 @@ class VideoPress_Rest_Api_V1_Settings {
 					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => array( static::class, 'update_settings' ),
 					'permission_callback' => function () {
-						return current_user_can( 'manage_options' );
+						return Data::can_perform_action() && current_user_can( 'manage_options' );
 					},
 					'args'                => array(
 						'videopress_videos_private_for_site' => array(

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
@@ -96,7 +96,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'videopress_block_update_meta' ),
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					return Data::can_perform_action() && current_user_can( 'edit_posts' );
 				},
 			)
 		);
@@ -141,7 +141,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => array( $this, 'videopress_block_update_poster' ),
 					'permission_callback' => function () {
-						return current_user_can( 'upload_files' );
+						return Data::can_perform_action() && current_user_can( 'upload_files' );
 					},
 				),
 			)
@@ -155,7 +155,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'videopress_upload_jwt' ),
 				'permission_callback' => function () {
-					return current_user_can( 'upload_files' );
+					return Data::can_perform_action() && current_user_can( 'upload_files' );
 				},
 			)
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #27405

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Duplicates the verifications made on the frontend to the backend
* Does not add verification for video deletion in this PR

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Testing locally, upload at least one video, then disconnect Jetpack
* Connect Jetpack, but do not approve the user connection
* Comment out [this check](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/videopress/src/client/admin/hooks/use-permission/index.ts#L9), returning `true` instead to allow for testing
* Try updating a video's metadata or the site settings
* The responses should have a `403` status code

https://user-images.githubusercontent.com/8486249/202293506-13d3cedc-d124-4e69-956d-1311f9d86b38.mp4
