### PR TITLE
JS Components: Allow null offPrice values in ProductPrice

### DIFF
--- a/projects/js-packages/components/changelog/allow-null-offPrice
+++ b/projects/js-packages/components/changelog/allow-null-offPrice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Added support for falsey non-zero values for offPrice

--- a/projects/js-packages/components/components/product-price/index.tsx
+++ b/projects/js-packages/components/components/product-price/index.tsx
@@ -37,7 +37,7 @@ const ProductPrice: React.FC< ProductPriceProps > = ( {
 	showNotOffPrice = showNotOffPrice && offPrice != null;
 
 	const discount =
-		price !== undefined && offPrice !== undefined
+		! isNaN( price ) && ! isNaN( offPrice )
 			? Math.floor( ( ( price - offPrice ) / price ) * 100 )
 			: 0;
 

--- a/projects/js-packages/components/components/product-price/index.tsx
+++ b/projects/js-packages/components/components/product-price/index.tsx
@@ -37,7 +37,7 @@ const ProductPrice: React.FC< ProductPriceProps > = ( {
 	showNotOffPrice = showNotOffPrice && offPrice != null;
 
 	const discount =
-		! isNaN( price ) && ! isNaN( offPrice )
+		typeof price === 'number' && typeof offPrice === 'number'
 			? Math.floor( ( ( price - offPrice ) / price ) * 100 )
 			: 0;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR allows `null` value to be passed as `offPrice`.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Boot up a JN site with Jetpack Protect running this branch, view the initial pricing page, and validate the `ProductPrice` renders and there is no "100% off" badge displayed.

