### PR TITLE
VideoPress: Update the list of video file extensions allowed on VideoPress

### DIFF
--- a/projects/packages/videopress/changelog/fix-update-allowed-videopress-file-extensions
+++ b/projects/packages/videopress/changelog/fix-update-allowed-videopress-file-extensions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Set a static list of allowed video extensions allowed on VideoPress.

--- a/projects/packages/videopress/src/class-admin-ui.php
+++ b/projects/packages/videopress/src/class-admin-ui.php
@@ -68,20 +68,21 @@ class Admin_UI {
 	 * @return array
 	 */
 	public static function get_allowed_video_extensions() {
-		$allowed_mime_types       = get_allowed_mime_types();
-		$allowed_video_extensions = array();
-
-		foreach ( $allowed_mime_types as $possible_extensions => $mime_type ) {
-			if ( strpos( $mime_type, 'video/' ) !== false ) {
-				$extensions = explode( '|', $possible_extensions );
-
-				foreach ( $extensions as $extension ) {
-					$allowed_video_extensions[ $extension ] = $mime_type;
-				}
-			}
-		}
-
-		return $allowed_video_extensions;
+		return array(
+			'3g2'  => 'video/3gpp2',
+			'3gp'  => 'video/3gpp',
+			'3gp2' => 'video/3gpp2',
+			'3gpp' => 'video/3gpp',
+			'avi'  => 'video/avi',
+			'm4v'  => 'video/mp4',
+			'mov'  => 'video/quicktime',
+			'mp4'  => 'video/mp4',
+			'mpe'  => 'video/mpeg',
+			'mpeg' => 'video/mpeg',
+			'mpg'  => 'video/mpeg',
+			'ogv'  => 'video/ogg',
+			'wmv'  => 'video/x-ms-wmv',
+		);
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27168.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Added a static list of VideoPress allowed file extensions so the not allowed formats are not easily visible on the file browser and won't trigger an upload if selected
* The list of allowed MIME types and extensions was extracted from [this support page](https://wordpress.com/support/videopress/#video-requirements-and-specifications)

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to your VideoPress library
* On the browser console, check the value of the `jetpackVideoPressInitialState.allowedVideoExtensions` var; it should show the following values:

```
{
    "3g2": "video/3gpp2",
    "3gp": "video/3gpp",
    "3gp2": "video/3gpp2",
    "3gpp": "video/3gpp",
    "avi": "video/avi",
    "m4v": "video/mp4",
    "mov": "video/quicktime",
    "mp4": "video/mp4",
    "mpe": "video/mpeg",
    "mpeg": "video/mpeg",
    "mpg": "video/mpeg",
    "ogv": "video/ogg",
    "wmv": "video/x-ms-wmv"
}
```

* Click the "Add new video" button and try to look for unsupported file formats, like MKV or FLV
* You should not be able to select this kind of files on the file browser (depending on your OS, the functionality may look diferent, like not seeing the files at all):

<img width="245" alt="Screen Shot 2022-11-16 at 18 49 34" src="https://user-images.githubusercontent.com/6760046/202302341-38df115c-6baa-4ace-8ecf-cabbd54af8da.png">

* If you change the settings of your file browser to allow everything (may change from OS to OS) and you manage to select an unsupported file format, the upload will simply not start, preventing the broken video upload to show up on the grid/list

Resources:

* You can download video files on unsupported formats [here](https://www.sample-videos.com/); look for MKV or FLV files, for example