### PR TITLE
Protect: Fix polling after manual scan is triggered

### DIFF
--- a/projects/plugins/protect/changelog/fix-protect-manual-scan-polling
+++ b/projects/plugins/protect/changelog/fix-protect-manual-scan-polling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed refresh of status after triggering a manual scan.

--- a/projects/plugins/protect/src/js/state/actions.js
+++ b/projects/plugins/protect/src/js/state/actions.js
@@ -310,6 +310,7 @@ const scan = ( callback = () => {} ) => async ( { dispatch } ) => {
 		} )
 			.then( () => {
 				dispatch( startScanOptimistically() );
+				setTimeout( () => dispatch( refreshStatus( true ) ), 5000 );
 			} )
 			.catch( () => {
 				return dispatch(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes an issue where status polling does not start after a manual scan is triggered. This is due to the `optimistically_scanning` status value not triggering status polling.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Dispatches `refreshStatus( true )` five seconds after optimistic scanning begins.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Get a site with a scan plan and Protect running.
* Trigger a manual scan.
* Validate that after five seconds, the app starts polling the `/status` endpoint until a result is available.
