### PR TITLE
Protect: Add singular and plural translation options

### DIFF
--- a/projects/plugins/protect/changelog/add-protect-singular-vs-plural-translations
+++ b/projects/plugins/protect/changelog/add-protect-singular-vs-plural-translations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added singular and plural translations

--- a/projects/plugins/protect/src/js/components/threats-list/empty.jsx
+++ b/projects/plugins/protect/src/js/components/threats-list/empty.jsx
@@ -1,6 +1,6 @@
 import { H3, Text } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
-import { sprintf, __ } from '@wordpress/i18n';
+import { sprintf, __, _n } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import useProtectData from '../../hooks/use-protect-data';
 import styles from './styles.module.scss';
@@ -38,7 +38,7 @@ const timeSince = date => {
 	if ( interval > 1 ) {
 		return sprintf(
 			// translators: placeholder is a number amount of years i.e. "5 years ago".
-			__( '%s years ago', 'jetpack-protect' ),
+			_n( '%s year ago', '%s years ago', 'jetpack-protect', 'jetpack-protect' ),
 			Math.floor( interval )
 		);
 	}
@@ -47,7 +47,7 @@ const timeSince = date => {
 	if ( interval > 1 ) {
 		return sprintf(
 			// translators: placeholder is a number amount of months i.e. "5 months ago".
-			__( '%s months ago', 'jetpack-protect' ),
+			_n( '%s month ago', '%s months ago', 'jetpack-protect', 'jetpack-protect' ),
 			Math.floor( interval )
 		);
 	}
@@ -56,7 +56,7 @@ const timeSince = date => {
 	if ( interval > 1 ) {
 		return sprintf(
 			// translators: placeholder is a number amount of days i.e. "5 days ago".
-			__( '%s days ago', 'jetpack-protect' ),
+			_n( '%s day ago', '%s days ago', 'jetpack-protect', 'jetpack-protect' ),
 			Math.floor( interval )
 		);
 	}
@@ -65,7 +65,7 @@ const timeSince = date => {
 	if ( interval > 1 ) {
 		return sprintf(
 			// translators: placeholder is a number amount of hours i.e. "5 hours ago".
-			__( '%s hours ago', 'jetpack-protect' ),
+			_n( '%s hour ago', '%s hours ago', 'jetpack-protect', 'jetpack-protect' ),
 			Math.floor( interval )
 		);
 	}
@@ -74,7 +74,7 @@ const timeSince = date => {
 	if ( interval > 1 ) {
 		return sprintf(
 			// translators: placeholder is a number amount of minutes i.e. "5 minutes ago".
-			__( '%s minutes ago', 'jetpack-protect' ),
+			_n( '%s minute ago', '%s minutes ago', 'jetpack-protect', 'jetpack-protect' ),
 			Math.floor( interval )
 		);
 	}

--- a/projects/plugins/protect/src/js/components/threats-list/empty.jsx
+++ b/projects/plugins/protect/src/js/components/threats-list/empty.jsx
@@ -38,7 +38,7 @@ const timeSince = date => {
 	if ( interval > 1 ) {
 		return sprintf(
 			// translators: placeholder is a number amount of years i.e. "5 years ago".
-			_n( '%s year ago', '%s years ago', 'jetpack-protect', 'jetpack-protect' ),
+			_n( '%s year ago', '%s years ago', Math.floor( interval ), 'jetpack-protect' ),
 			Math.floor( interval )
 		);
 	}
@@ -47,7 +47,7 @@ const timeSince = date => {
 	if ( interval > 1 ) {
 		return sprintf(
 			// translators: placeholder is a number amount of months i.e. "5 months ago".
-			_n( '%s month ago', '%s months ago', 'jetpack-protect', 'jetpack-protect' ),
+			_n( '%s month ago', '%s months ago', Math.floor( interval ), 'jetpack-protect' ),
 			Math.floor( interval )
 		);
 	}
@@ -56,7 +56,7 @@ const timeSince = date => {
 	if ( interval > 1 ) {
 		return sprintf(
 			// translators: placeholder is a number amount of days i.e. "5 days ago".
-			_n( '%s day ago', '%s days ago', 'jetpack-protect', 'jetpack-protect' ),
+			_n( '%s day ago', '%s days ago', Math.floor( interval ), 'jetpack-protect' ),
 			Math.floor( interval )
 		);
 	}
@@ -65,7 +65,7 @@ const timeSince = date => {
 	if ( interval > 1 ) {
 		return sprintf(
 			// translators: placeholder is a number amount of hours i.e. "5 hours ago".
-			_n( '%s hour ago', '%s hours ago', 'jetpack-protect', 'jetpack-protect' ),
+			_n( '%s hour ago', '%s hours ago', Math.floor( interval ), 'jetpack-protect' ),
 			Math.floor( interval )
 		);
 	}
@@ -74,7 +74,7 @@ const timeSince = date => {
 	if ( interval > 1 ) {
 		return sprintf(
 			// translators: placeholder is a number amount of minutes i.e. "5 minutes ago".
-			_n( '%s minute ago', '%s minutes ago', 'jetpack-protect', 'jetpack-protect' ),
+			_n( '%s minute ago', '%s minutes ago', Math.floor( interval ), 'jetpack-protect' ),
 			Math.floor( interval )
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
Adds a singular and plural translation option within the `EmptyList` component when displaying the duration of time since the last scan.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Implements the `_n` translation function

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- #26069

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch
* Start up your Jurassic Tube
* Add a scan level plan and ensure no threats are present
* Allow the initial scan to process
* In the resulting empty list, verify that text displays the correct singular or plural usage for the time increment (`1 hour ago` and `2 hours ago`)
   * To verify the alternative, manually update the applicable lines in `src/js/threats-list/empty.jsx`

