### PR TITLE
Protect: Fix checkStatus

### DIFF
--- a/projects/plugins/protect/changelog/fix-protect-check-status
+++ b/projects/plugins/protect/changelog/fix-protect-check-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed status checking

--- a/projects/plugins/protect/src/js/state/actions.js
+++ b/projects/plugins/protect/src/js/state/actions.js
@@ -58,10 +58,9 @@ const refreshStatus = ( hardRefresh = false ) => async ( { dispatch } ) => {
 	dispatch( setStatusIsFetching( true ) );
 	return await new Promise( ( resolve, reject ) => {
 		return fetchStatus( hardRefresh )
+			.then( checkStatus )
 			.then( status => {
-				return dispatch( checkStatus( status ) );
-			} )
-			.then( status => {
+				dispatch( setScanIsUnavailable( 'unavailable' === status.status ) );
 				dispatch( setStatus( camelize( status ) ) );
 				dispatch( setStatusIsFetching( false ) );
 				resolve( status );
@@ -79,18 +78,17 @@ const refreshStatus = ( hardRefresh = false ) => async ( { dispatch } ) => {
  * @param {number} attempts - The amount of recursive attempts that have already been made.
  * @returns {Promise} - Promise which resolves with the status once it has been checked.
  */
-const checkStatus = ( currentStatus, attempts = 0 ) => async ( { dispatch } ) => {
-	return await new Promise( ( resolve, reject ) => {
+const checkStatus = ( currentStatus, attempts = 0 ) => {
+	return new Promise( ( resolve, reject ) => {
 		if ( 'unavailable' === currentStatus.status && attempts < 3 ) {
 			fetchStatus( true )
 				.then( newStatus => {
 					setTimeout( () => {
-						dispatch( checkStatus( newStatus, attempts + 1 ) );
+						checkStatus( newStatus, attempts + 1 );
 					}, 5000 );
 				} )
 				.catch( reject );
 		} else {
-			dispatch( setScanIsUnavailable( 'unavailable' === currentStatus.status ) );
 			resolve( currentStatus );
 		}
 	} );

--- a/projects/plugins/protect/src/js/state/actions.js
+++ b/projects/plugins/protect/src/js/state/actions.js
@@ -84,7 +84,9 @@ const checkStatus = ( currentStatus, attempts = 0 ) => {
 			fetchStatus( true )
 				.then( newStatus => {
 					setTimeout( () => {
-						checkStatus( newStatus, attempts + 1 );
+						checkStatus( newStatus, attempts + 1 )
+							.then( result => resolve( result ) )
+							.catch( error => reject( error ) );
 					}, 5000 );
 				} )
 				.catch( reject );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR converts `checkStatus` into a function that returns a `Promise` so it can be used middleware-style in the `refreshStatus` action. This change also pulls out any use of `dispatch` from the function, moving state updates also into the `refreshStatus` action.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a JN site with Protect and a scan plan
* This part is difficult, but trigger manual scans until an 'unavailable' scan status is returned by `/status` endpoint.
* Validate that the app tries at most three more times to get a good scan status, and **updates the status in state when a good status is received**.
* You can mock the unavailable status by adding it to the status in `Status::get_status()`, i.e. `self::$status->status = "unavailable"`, and then comment out that line between status polls.
