### PR TITLE
[Boost] Prevent phantom discount display

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/react-components/BoostPricingTable.tsx
+++ b/projects/plugins/boost/app/assets/src/js/react-components/BoostPricingTable.tsx
@@ -57,6 +57,8 @@ export const BoostPricingTable = ( { pricing, onPremiumCTA, onFreeCTA } ) => {
 		? __( 'First Year Discount', 'jetpack-boost' )
 		: '';
 
+	const isDiscounted = pricing.yearly.priceBefore > pricing.yearly.priceAfter;
+
 	return (
 		<PricingTable
 			title={ __( 'The easiest speed optimization plugin for WordPress', 'jetpack-boost' ) }
@@ -83,7 +85,7 @@ export const BoostPricingTable = ( { pricing, onPremiumCTA, onFreeCTA } ) => {
 				<PricingTableHeader>
 					<ProductPrice
 						price={ pricing.yearly.priceBefore / 12 }
-						offPrice={ pricing.yearly.priceAfter / 12 }
+						offPrice={ isDiscounted ? pricing.yearly.priceAfter / 12 : null }
 						currency={ pricing.yearly.currencyCode }
 						hideDiscountLabel={ false }
 						promoLabel={ promoLabel }

--- a/projects/plugins/boost/changelog/fix-boost-phantom-discount
+++ b/projects/plugins/boost/changelog/fix-boost-phantom-discount
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent displaying of "discounted from" price when there is no discount


### PR DESCRIPTION
Prevent a "discounted from" price from appearing when there is no discount during the Boost first-use flow.

#### Changes proposed in this Pull Request:
* Don't send `offPrice` to the price display component if there is no discount.

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Install Boost on a new site, or nuke My Jetpack's cache in your user-meta
* Visit the getting started page, and ensure that no crossed-out price is displayed if there is no discount offered.

