### PR TITLE
Search: show CtA when user should upgrade from free plan

### DIFF
--- a/projects/packages/search/changelog/add-jetpack-search-free-upgrade-cta
+++ b/projects/packages/search/changelog/add-jetpack-search-free-upgrade-cta
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added prompt for Jetpack Search Free plan upgrade for users who exceed limits.

--- a/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
@@ -192,11 +192,12 @@ const upgradeMessageBoth = apiData => {
 const upgradeMessageFromAPIData = apiData => {
 	// What's the data we're working with?
 	// apiData.currentUsage.must_upgrade
+	// apiData.currentUsage.should_upgrade
 	// apiData.currentUsage.upgrade_reason.records
 	// apiData.currentUsage.upgrade_reason.requests
 	// apiData.currentUsage.months_over_plan_records_limit
 	// apiData.currentUsage.months_over_plan_requests_limit
-	if ( ! apiData.currentUsage.must_upgrade ) {
+	if ( ! apiData.currentUsage.should_upgrade && ! apiData.currentUsage.must_upgrade ) {
 		return null;
 	}
 	// Handle both case.
@@ -218,29 +219,7 @@ const upgradeMessageFromAPIData = apiData => {
 	return upgradeMessageNoOverage();
 };
 
-// TODO: Remove this if no longer needed.
-// Currently not called. Not removing yet, pending review of new CTA logic (which feels messy).
-// eslint-disable-next-line no-unused-vars
-const upgradeTypeFromAPIData = apiData => {
-	// Determine if upgrade message is needed.
-	if ( ! apiData.currentUsage.must_upgrade ) {
-		return null;
-	}
-
-	// Determine appropriate upgrade message.
-	let mustUpgradeReason = '';
-	if ( apiData.currentUsage.upgrade_reason.requests ) {
-		mustUpgradeReason = 'requests';
-	}
-	if ( apiData.currentUsage.upgrade_reason.records ) {
-		mustUpgradeReason = mustUpgradeReason === 'requests' ? 'both' : 'records';
-	}
-
-	return mustUpgradeReason;
-};
-
 const PlanUsageSection = ( { isFreePlan, planInfo, sendPaidPlanToCart, isPlanJustUpgraded } ) => {
-	// const upgradeType = upgradeTypeFromAPIData( planInfo );
 	const upgradeMessage = isFreePlan ? upgradeMessageFromAPIData( planInfo ) : null;
 	const usageInfo = usageInfoFromAPIData( planInfo );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
As part of D92332-code, we've added a new field to plan info endpoint:
`should_upgrade`. It indicates that the site exceeds limits of Jetpack Search Free plan,
and will most likely be automatically disabled after 3 months.

We still have field `must_upgrade`, and it indicates that the
plan has already been disabled, and user cannot enable search features anymore.

In this PR, I'm changing the logic of when we show the following CTA to upgrade free plan:

![image](https://user-images.githubusercontent.com/6437642/202335637-152d1844-49ae-4bab-b30d-7eab11a742cd.png)

Now, it will be shown when `should_upgrade` is true. Before this diff, we would show it only
when `must_upgrade` was true. That meant that the free plan would already be over when
user would see it for the first time. 


#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
p8oabR-Xh-p2#comment-6778

#### Does this pull request change what data or activity we track or use?
No, it doesn't.

#### Testing instructions:
1. Create a test blog with Jetpack Search Free plan, for instance using JN.
2. Exceed the limits, either by mocking number of requests count for last month (for instance using the query provided in testing instructions for D90697-code through wpsh), or by having more than 500 posts.
3. Go to search dashboard.
4. Verify that the nudge to upgrade is visible, but the "Enable Jetpack Search" toggle is still active and can be enabled.