### PR TITLE
Protect: Fix Status Polling

### DIFF
--- a/projects/plugins/protect/changelog/fix-protect-check-status
+++ b/projects/plugins/protect/changelog/fix-protect-check-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed status checking

--- a/projects/plugins/protect/changelog/fix-protect-status-polling
+++ b/projects/plugins/protect/changelog/fix-protect-status-polling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed status polling

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -18,6 +18,7 @@ import { Spinner } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
+import camelize from 'camelize';
 import classnames from 'classnames';
 import React, { useEffect } from 'react';
 import useAnalyticsTracks from '../../hooks/use-analytics-tracks';
@@ -281,43 +282,59 @@ const useRegistrationWatcher = () => {
 /**
  * Use Status Polling
  *
- * When the status is 'scheduled', re-checks the status periodically until it isn't.
+ * When the status is 'scheduled' or 'scanning', re-checks the status periodically until it isn't.
  */
 const useStatusPolling = () => {
-	const pollingDuration = 10000;
-	const { refreshStatus } = useDispatch( STORE_ID );
 	const status = useSelect( select => select( STORE_ID ).getStatus() );
+	const { setStatus, setStatusIsFetching, setScanIsUnavailable } = useDispatch( STORE_ID );
 
 	useEffect( () => {
-		let pollTimeout;
+		const statusIsInProgress = currentStatus =>
+			[ 'scheduled', 'scanning' ].indexOf( currentStatus ) >= 0;
 
 		const pollStatus = () => {
-			refreshStatus( true )
-				.then( latestStatus => {
-					if ( latestStatus.status.error ) {
-						throw latestStatus.status.errorMessage;
-					}
-					if (
-						[ 'scheduled', 'scanning' ].indexOf( latestStatus.status ) >= 0 ||
-						! latestStatus.status.lastChecked
-					) {
-						clearTimeout( pollTimeout );
-						pollTimeout = setTimeout( pollStatus, pollingDuration );
-					}
+			return new Promise( ( resolve, reject ) => {
+				apiFetch( {
+					path: 'jetpack-protect/v1/status?hard_refresh=true',
+					method: 'GET',
 				} )
-				.catch( () => {
-					// Keep trying when unable to fetch the status.
-					clearTimeout( pollTimeout );
-					pollTimeout = setTimeout( pollStatus, pollingDuration );
-				} );
+					.then( newStatus => {
+						if ( newStatus?.error ) {
+							throw newStatus?.errorMessage;
+						}
+
+						if ( statusIsInProgress( newStatus?.status ) ) {
+							setTimeout( () => {
+								pollStatus()
+									.then( result => resolve( result ) )
+									.catch( error => reject( error ) );
+							}, 10000 );
+							return;
+						}
+
+						resolve( newStatus );
+					} )
+					.catch( () => {
+						// Keep trying when unable to fetch the status.
+						setTimeout( pollStatus, 5000 );
+					} );
+			} );
 		};
 
-		if ( [ 'scheduled', 'scanning' ].indexOf( status.status ) >= 0 ) {
-			pollTimeout = setTimeout( pollStatus, pollingDuration );
+		if ( ! statusIsInProgress( status?.status ) ) {
+			return;
 		}
 
-		return () => clearTimeout( pollTimeout );
-	}, [ status.status, refreshStatus ] );
+		setStatusIsFetching( true );
+		pollStatus()
+			.then( newStatus => {
+				setScanIsUnavailable( 'unavailable' === newStatus.status );
+				setStatus( camelize( newStatus ) );
+			} )
+			.finally( () => {
+				setStatusIsFetching( false );
+			} );
+	}, [ status.status, setScanIsUnavailable, setStatus, setStatusIsFetching ] );
 };
 
 const Admin = () => {

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -118,10 +118,10 @@ const ProtectAdminPage = () => {
 
 	// retry fetching status if it is not available
 	useEffect( () => {
-		if ( ! statusIsFetching && 'unavailable' === status.status ) {
+		if ( ! statusIsFetching && 'unavailable' === status.status && ! scanIsUnavailable ) {
 			refreshStatus( true );
 		}
-	}, [ statusIsFetching, status.status, refreshStatus ] );
+	}, [ statusIsFetching, status.status, refreshStatus, scanIsUnavailable ] );
 
 	let currentScanStatus;
 	if ( 'error' === currentStatus || scanIsUnavailable ) {

--- a/projects/plugins/protect/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/admin-page/index.jsx
@@ -319,7 +319,11 @@ const useStatusPolling = () => {
 					} )
 					.catch( () => {
 						// Keep trying when unable to fetch the status.
-						setTimeout( pollStatus, 5000 );
+						setTimeout( () => {
+							pollStatus()
+								.then( result => resolve( result ) )
+								.catch( error => reject( error ) );
+						}, 5000 );
 					} );
 			} );
 		};

--- a/projects/plugins/protect/src/js/state/actions.js
+++ b/projects/plugins/protect/src/js/state/actions.js
@@ -58,10 +58,9 @@ const refreshStatus = ( hardRefresh = false ) => async ( { dispatch } ) => {
 	dispatch( setStatusIsFetching( true ) );
 	return await new Promise( ( resolve, reject ) => {
 		return fetchStatus( hardRefresh )
+			.then( checkStatus )
 			.then( status => {
-				return dispatch( checkStatus( status ) );
-			} )
-			.then( status => {
+				dispatch( setScanIsUnavailable( 'unavailable' === status.status ) );
 				dispatch( setStatus( camelize( status ) ) );
 				dispatch( setStatusIsFetching( false ) );
 				resolve( status );
@@ -79,18 +78,17 @@ const refreshStatus = ( hardRefresh = false ) => async ( { dispatch } ) => {
  * @param {number} attempts - The amount of recursive attempts that have already been made.
  * @returns {Promise} - Promise which resolves with the status once it has been checked.
  */
-const checkStatus = ( currentStatus, attempts = 0 ) => async ( { dispatch } ) => {
-	return await new Promise( ( resolve, reject ) => {
+const checkStatus = ( currentStatus, attempts = 0 ) => {
+	return new Promise( ( resolve, reject ) => {
 		if ( 'unavailable' === currentStatus.status && attempts < 3 ) {
 			fetchStatus( true )
 				.then( newStatus => {
 					setTimeout( () => {
-						dispatch( checkStatus( newStatus, attempts + 1 ) );
+						checkStatus( newStatus, attempts + 1 );
 					}, 5000 );
 				} )
 				.catch( reject );
 		} else {
-			dispatch( setScanIsUnavailable( 'unavailable' === currentStatus.status ) );
 			resolve( currentStatus );
 		}
 	} );

--- a/projects/plugins/protect/src/js/state/actions.js
+++ b/projects/plugins/protect/src/js/state/actions.js
@@ -84,7 +84,9 @@ const checkStatus = ( currentStatus, attempts = 0 ) => {
 			fetchStatus( true )
 				.then( newStatus => {
 					setTimeout( () => {
-						checkStatus( newStatus, attempts + 1 );
+						checkStatus( newStatus, attempts + 1 )
+							.then( result => resolve( result ) )
+							.catch( error => reject( error ) );
 					}, 5000 );
 				} )
 				.catch( reject );

--- a/projects/plugins/protect/src/js/state/actions.js
+++ b/projects/plugins/protect/src/js/state/actions.js
@@ -62,11 +62,13 @@ const refreshStatus = ( hardRefresh = false ) => async ( { dispatch } ) => {
 			.then( status => {
 				dispatch( setScanIsUnavailable( 'unavailable' === status.status ) );
 				dispatch( setStatus( camelize( status ) ) );
-				dispatch( setStatusIsFetching( false ) );
 				resolve( status );
 			} )
 			.catch( error => {
 				reject( error );
+			} )
+			.finally( () => {
+				dispatch( setStatusIsFetching( false ) );
 			} );
 	} );
 };
@@ -374,6 +376,7 @@ const actions = {
 	setThreatsAreFixing,
 	refreshPlan,
 	setHasRequiredPlan,
+	setScanIsUnavailable,
 };
 
 export {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Rewrites the `useStatusPolling` hook.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Validate that after returning from the scan upgrade, the status starts polling until a scan result is available, and then stops.
* Validate that triggering a manual scan starts polling until a scan result is available, and then stops.
* Validate that polling is not triggered when loading the page with a good scan result in the initial state.
* Validate that there are no duplicate/multiple status requests being fired at the same time.

