### PR TITLE
Fix FAQ Question

### DIFF
--- a/projects/plugins/backup/changelog/fix-realtime-backups-faqs
+++ b/projects/plugins/backup/changelog/fix-realtime-backups-faqs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add real-time backups details in plugin FAQs

--- a/projects/plugins/backup/readme.txt
+++ b/projects/plugins/backup/readme.txt
@@ -108,7 +108,9 @@ If you don’t have Backups as part of your Jetpack plan, [visit Jetpack.com to 
 
 As soon as you purchase Jetpack VaultPress Backup, it will be activated, and the first backup will be completed. There are barely any settings to configure, and you don’t need coding experience.
 
-Daily backups will take place approximately 24 hours from the previous backup. They occur automatically – you don’t need to create a specific time for backups to run.
+For plans with daily backups, a new backup will take place approximately 24 hours from the previous backup. They occur automatically – you don’t need to create a specific time for backups to run. 
+
+For plans with real-time backups, a new backup will be performed each time a change is made to to WordPress core's database tables, WooCommerce database tables, and any associated file changes. All other changes are backed up daily.
 
 You’ll know your WordPress backup has been created if you see a **Backup complete** event in the activity log.
 

--- a/projects/plugins/backup/readme.txt
+++ b/projects/plugins/backup/readme.txt
@@ -110,7 +110,7 @@ As soon as you purchase Jetpack VaultPress Backup, it will be activated, and the
 
 For plans with daily backups, a new backup will take place approximately 24 hours from the previous backup. They occur automatically – you don’t need to create a specific time for backups to run. 
 
-For plans with real-time backups, a new backup will be performed each time a change is made to to WordPress core's database tables, WooCommerce database tables, and any associated file changes. All other changes are backed up daily.
+For plans with real-time backups, a new backup will be performed each time a change is made to WordPress core's database tables, WooCommerce database tables, and any associated file changes. All other changes are backed up daily.
 
 You’ll know your WordPress backup has been created if you see a **Backup complete** event in the activity log.
 


### PR DESCRIPTION
"How do I create a WordPress backup for my site?" FAQ only mentions daily backups, and all the currently available plans are real-time backups only.

Information for the FAQ update is taken from this page: https://jetpack.com/support/jetpack-backup-frequently-asked-questions/#when-do-real-time-backups-occur

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update to an FAQ that was confusing for a user in 5706500-zen

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

No testing needed AFAIK.

