### PR TITLE
Change `is_running_in_jetpack_site` into a feature flag

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-is_running_in_jetpack_site
+++ b/projects/packages/stats-admin/changelog/fix-is_running_in_jetpack_site
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+See https://github.com/Automattic/wp-calypso/pull/70122

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -224,7 +224,6 @@ class Dashboard {
 			'google_maps_and_places_api_key' => '',
 			'i18n_default_locale_slug'       => 'en',
 			'i18n_locale_slug'               => static::get_site_locale(),
-			'is_running_in_jetpack_site'     => true,
 			'mc_analytics_enabled'           => false,
 			'meta'                           => array(),
 			'nonce'                          => wp_create_nonce( 'wp_rest' ),
@@ -236,6 +235,7 @@ class Dashboard {
 				'stats/new-main-chart'             => true,
 				'stats/new-stats-module-component' => true,
 				'stats/show-traffic-highlights'    => true,
+				'is_running_in_jetpack_site'       => true,
 			),
 			'intial_state'                   => array(
 				'currentUser' => array(

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -229,7 +229,7 @@ class Dashboard {
 			'nonce'                          => wp_create_nonce( 'wp_rest' ),
 			'site_name'                      => \get_bloginfo( 'name' ),
 			'sections'                       => array(),
-			// Features are inlined @see https://github.com/Automattic/wp-calypso/pull/70051
+			// Features are inlined @see https://github.com/Automattic/wp-calypso/pull/70122
 			'features'                       => array(),
 			'intial_state'                   => array(
 				'currentUser' => array(

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -229,14 +229,8 @@ class Dashboard {
 			'nonce'                          => wp_create_nonce( 'wp_rest' ),
 			'site_name'                      => \get_bloginfo( 'name' ),
 			'sections'                       => array(),
-			'features'                       => array(
-				'stats/new-all-time-highlights'    => true,
-				'stats/new-annual-highlights'      => true,
-				'stats/new-main-chart'             => true,
-				'stats/new-stats-module-component' => true,
-				'stats/show-traffic-highlights'    => true,
-				'is_running_in_jetpack_site'       => true,
-			),
+			// Features are inlined @see https://github.com/Automattic/wp-calypso/pull/70051
+			'features'                       => array(),
 			'intial_state'                   => array(
 				'currentUser' => array(
 					'id'   => 1000,

--- a/projects/packages/stats-admin/tests/php/test-stats-dashboard.php
+++ b/projects/packages/stats-admin/tests/php/test-stats-dashboard.php
@@ -65,7 +65,7 @@ class Test_Plan extends Stats_Test_Case {
 		$this->assertArrayHasKey( 'google_maps_and_places_api_key', $data );
 		$this->assertArrayHasKey( 'i18n_default_locale_slug', $data );
 		$this->assertArrayHasKey( 'nonce', $data );
-		$this->assertArrayHasKey( 'is_running_in_jetpack_site', $data );
+		$this->assertArrayHasKey( 'is_running_in_jetpack_site', $data->features );
 		$this->assertArrayHasKey( 'site_name', $data );
 		$this->assertArrayHasKey( 'intial_state', $data );
 	}

--- a/projects/packages/stats-admin/tests/php/test-stats-dashboard.php
+++ b/projects/packages/stats-admin/tests/php/test-stats-dashboard.php
@@ -65,8 +65,8 @@ class Test_Plan extends Stats_Test_Case {
 		$this->assertArrayHasKey( 'google_maps_and_places_api_key', $data );
 		$this->assertArrayHasKey( 'i18n_default_locale_slug', $data );
 		$this->assertArrayHasKey( 'nonce', $data );
-		$this->assertArrayHasKey( 'is_running_in_jetpack_site', $data->features );
 		$this->assertArrayHasKey( 'site_name', $data );
 		$this->assertArrayHasKey( 'intial_state', $data );
+		$this->assertEmpty( $data->features );
 	}
 }


### PR DESCRIPTION
All details here: https://github.com/Automattic/wp-calypso/pull/70122

It would be pretty hard for me to write testing steps. But I think @kangzj will find it a piece of cake.

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Add `x.x.x.x widgets.wp.com` to your hosts file <- please change it to your sandbox IP
* Checkout and build current branch on your local test site
* Navigate to the settings page (/wp-admin/admin.php?page=jetpack#/traffic) and locate the Jetpack Stats section.
* Manually inspect the DOM and find a .jp-form-fieldset with a manual display: none; styling. Force the field set to display and click the toggle to enable Odyssey Stats.
* Click on Jetpack -> Stats in the sidebar to see Odyssey Stats. Note that it’s currently unpolished and not fully tested!

