### PR TITLE
Add connection follower count next to the toggle in Share this post panel

### DIFF
--- a/projects/js-packages/publicize-components/changelog/add-pre-publish-counts
+++ b/projects/js-packages/publicize-components/changelog/add-pre-publish-counts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Show social media followers next to toggle in Share this post panel.

--- a/projects/js-packages/publicize-components/src/components/connection-count/index.js
+++ b/projects/js-packages/publicize-components/src/components/connection-count/index.js
@@ -1,0 +1,30 @@
+import PropTypes from 'prop-types';
+
+import './style.scss';
+
+// convert to friendly number
+const friendlyNumber = number => {
+	if ( number >= 1000000 ) {
+		return `${ ( number / 1000000 ).toFixed( 1 ) }M`;
+	}
+	if ( number >= 1000 ) {
+		return `${ ( number / 1000 ).toFixed( 1 ) }K`;
+	}
+	return number;
+};
+
+const ConnectionCount = props => {
+	const { followerCount } = props;
+
+	return (
+		<span className="jetpack-publicize-connection-label-follower-count">
+			{ followerCount ? friendlyNumber( followerCount ) : null }
+		</span>
+	);
+};
+
+ConnectionCount.propTypes = {
+	followerCount: PropTypes.number,
+};
+
+export default ConnectionCount;

--- a/projects/js-packages/publicize-components/src/components/connection-count/style.scss
+++ b/projects/js-packages/publicize-components/src/components/connection-count/style.scss
@@ -1,0 +1,6 @@
+.jetpack-publicize-connection-label-follower-count {
+    color: #757575;
+    margin-right: 10px;
+    min-width: 15%;
+    text-align: right;; 
+}

--- a/projects/js-packages/publicize-components/src/components/connection-icon/index.jsx
+++ b/projects/js-packages/publicize-components/src/components/connection-icon/index.jsx
@@ -1,26 +1,30 @@
 import { SocialServiceIcon } from '@automattic/jetpack-components';
 import { useCallback, useState } from '@wordpress/element';
 import PropTypes from 'prop-types';
+import ConnectionCount from '../connection-count';
 
 import './style.scss';
 
 const ConnectionIcon = props => {
-	const { id, serviceName, label, profilePicture } = props;
+	const { id, serviceName, label, profilePicture, followerCount } = props;
 	const [ hasDisplayPicture, setHasDisplayPicture ] = useState( !! profilePicture );
 
 	const onError = useCallback( () => setHasDisplayPicture( false ), [] );
 
 	return (
-		<label htmlFor={ id } className="jetpack-publicize-connection-label">
-			<div className={ hasDisplayPicture ? 'components-connection-icon__picture' : '' }>
-				{ hasDisplayPicture && <img src={ profilePicture } alt={ label } onError={ onError } /> }
-				<SocialServiceIcon
-					serviceName={ serviceName }
-					className="jetpack-publicize-gutenberg-social-icon"
-				/>
-			</div>
-			<span className="jetpack-publicize-connection-label-copy">{ label }</span>
-		</label>
+		<>
+			<label htmlFor={ id } className="jetpack-publicize-connection-label">
+				<div className={ hasDisplayPicture ? 'components-connection-icon__picture' : '' }>
+					{ hasDisplayPicture && <img src={ profilePicture } alt={ label } onError={ onError } /> }
+					<SocialServiceIcon
+						serviceName={ serviceName }
+						className="jetpack-publicize-gutenberg-social-icon"
+					/>
+				</div>
+				<span className="jetpack-publicize-connection-label-copy">{ label }</span>
+			</label>
+			<ConnectionCount followerCount={ followerCount } />
+		</>
 	);
 };
 

--- a/projects/js-packages/publicize-components/src/components/connection-icon/style.scss
+++ b/projects/js-packages/publicize-components/src/components/connection-icon/style.scss
@@ -10,6 +10,7 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	max-width: 60% !important;
 
 	// Icon and picture.
 	.components-connection-icon__picture {

--- a/projects/js-packages/publicize-components/src/components/connection-toggle/index.jsx
+++ b/projects/js-packages/publicize-components/src/components/connection-toggle/index.jsx
@@ -6,7 +6,17 @@ import ConnectionIcon from '../connection-icon';
 import './style.scss';
 
 const ConnectionToggle = props => {
-	const { className, checked, id, disabled, onChange, serviceName, label, profilePicture } = props;
+	const {
+		className,
+		checked,
+		id,
+		disabled,
+		onChange,
+		serviceName,
+		label,
+		profilePicture,
+		followerCount,
+	} = props;
 
 	const wrapperClasses = classnames( 'components-connection-toggle', {
 		'is-not-checked': ! checked,
@@ -20,7 +30,9 @@ const ConnectionToggle = props => {
 				serviceName={ serviceName }
 				label={ label }
 				profilePicture={ profilePicture }
+				followerCount={ followerCount }
 			/>
+
 			<FormToggle
 				id={ id }
 				className={ className }
@@ -41,6 +53,7 @@ ConnectionToggle.propTypes = {
 	serviceName: PropTypes.string,
 	label: PropTypes.string,
 	profilePicture: PropTypes.string,
+	followerCount: PropTypes.number,
 };
 
 export default ConnectionToggle;

--- a/projects/js-packages/publicize-components/src/components/connection-toggle/style.scss
+++ b/projects/js-packages/publicize-components/src/components/connection-toggle/style.scss
@@ -5,7 +5,8 @@
 	display: flex;
 	align-items: center;
 	width: 100%;
-
+	align-self: flex-end;
+	
 	// Unchecked state.
 	&.is-not-checked .jetpack-gutenberg-social-icon {
 		fill: $gray-300;

--- a/projects/js-packages/publicize-components/src/components/connection/index.js
+++ b/projects/js-packages/publicize-components/src/components/connection/index.js
@@ -59,7 +59,7 @@ class PublicizeConnection extends Component {
 	}
 
 	render() {
-		const { disabled, enabled, id, label, name, profilePicture } = this.props;
+		const { disabled, enabled, followerCount, id, label, name, profilePicture } = this.props;
 		const fieldId = 'connection-' + name + '-' + id;
 		// Genericon names are dash separated
 		const serviceName = name.replace( '_', '-' );
@@ -74,6 +74,7 @@ class PublicizeConnection extends Component {
 				serviceName={ serviceName }
 				label={ label }
 				profilePicture={ profilePicture }
+				followerCount={ followerCount }
 			/>
 		);
 

--- a/projects/js-packages/publicize-components/src/components/form/index.js
+++ b/projects/js-packages/publicize-components/src/components/form/index.js
@@ -44,10 +44,10 @@ export default function PublicizeForm( {
 		hasConnections,
 		enabledConnections,
 	} = useSocialMediaConnections();
+
 	const { message, updateMessage, maxLength } = useSocialMediaMessage();
 
 	const Wrapper = isPublicizeDisabledBySitePlan ? Disabled : Fragment;
-
 	const brokenConnections = connections.filter( connection => false === connection.is_healthy );
 
 	const outOfConnections =
@@ -111,6 +111,7 @@ export default function PublicizeForm( {
 									toggleable,
 									profile_picture,
 									is_healthy,
+									follower_count,
 								} ) => (
 									<PublicizeConnection
 										disabled={
@@ -125,6 +126,7 @@ export default function PublicizeForm( {
 										name={ service_name }
 										toggleConnection={ toggleById }
 										profilePicture={ profile_picture }
+										followerCount={ follower_count }
 									/>
 								)
 							) }

--- a/projects/js-packages/publicize-components/src/store/effects.js
+++ b/projects/js-packages/publicize-components/src/store/effects.js
@@ -26,8 +26,8 @@ export async function refreshConnectionTestResults() {
 			done: false,
 			enabled: true,
 			toggleable: true,
+			follower_count: 0,
 		};
-
 		/*
 		 * Iterate connection by connection,
 		 * in order to refresh or update current connections.
@@ -43,6 +43,7 @@ export async function refreshConnectionTestResults() {
 				done,
 				enabled,
 				toggleable,
+				follower_count: freshConnection.follower_count,
 				is_healthy: freshConnection.test_success,
 			};
 

--- a/projects/packages/publicize/changelog/add-pre-publish-counts
+++ b/projects/packages/publicize/changelog/add-pre-publish-counts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Show social media followers next to toggle in Share this post panel.

--- a/projects/packages/publicize/src/class-connections-post-field.php
+++ b/projects/packages/publicize/src/class-connections-post-field.php
@@ -122,6 +122,12 @@ class Connections_Post_Field {
 					'context'     => array( 'edit' ),
 					'readonly'    => true,
 				),
+				'follower_count'  => array(
+					'description' => __( 'Number of followers for the connected account', 'jetpack-publicize-pkg' ),
+					'type'        => 'integer',
+					'context'     => array( 'edit' ),
+					'readonly'    => true,
+				),
 			),
 		);
 	}

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -745,6 +745,7 @@ abstract class Publicize_Base {
 	 *     @type bool   'done'             Has this connection already been publicized to?
 	 *     @type bool   'toggleable'       Is the user allowed to change the value for the connection?
 	 *     @type bool   'global'           Is this connection a global one?
+	 *     @type int    'follower_count'   Follower count for the connection.
 	 * }
 	 */
 	public function get_filtered_connection_data( $selected_post_id = null ) {
@@ -872,6 +873,7 @@ abstract class Publicize_Base {
 					'enabled'         => $enabled,
 					'done'            => $done,
 					'toggleable'      => $toggleable,
+					'follower_count'  => ! empty( $connection_data['meta']['follower_count'] ) ? $connection_data['meta']['follower_count'] : 0,
 					'global'          => 0 == $connection_data['user_id'], // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual,WordPress.PHP.StrictComparisons.LooseComparison -- Other types can be used at times.
 				);
 			}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
@@ -90,6 +90,10 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections extends WP_REST_Cont
 				'description' => __( 'Is this connection available to all users?', 'jetpack' ),
 				'type'        => 'boolean',
 			),
+			'follower_count'       => array(
+				'description' => __( 'Number of followers of the connected account', 'jetpack' ),
+				'type'        => 'integer',
+			),
 		);
 	}
 
@@ -134,6 +138,8 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections extends WP_REST_Cont
 					'profile_picture'      => ! empty( $connection_meta['profile_picture'] ) ? $connection_meta['profile_picture'] : '',
 					// phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual -- We expect an integer, but do loose comparison below in case some other type is stored.
 					'global'               => 0 == $connection_data['user_id'],
+					'follower_count'       => ! empty( $connection_data['meta']['follower_count'] ) ? $connection_data['meta']['follower_count'] : 0,
+
 				);
 			}
 		}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/subscribers.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/subscribers.php
@@ -39,6 +39,18 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers extends WP_REST_Controller {
 				),
 			)
 		);
+		// GET /sites/<blog_id>/subscriber/counts - Return splitted number of subscribers for this site
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/counts',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_subscriber_counts' ),
+					'permission_callback' => array( $this, 'readable_permission_check' ),
+				),
+			)
+		);
 	}
 
 	/**
@@ -71,6 +83,23 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers extends WP_REST_Controller {
 		return array(
 			'count' => $subscriber_count,
 		);
+	}
+
+	/**
+	 * Retrieves splitted subscriber counts
+	 *
+	 * @param WP_REST_Request $request incoming API request info.
+	 * @return array data object containing subscriber counts ['email_subscribers' => 0, 'social_followers' => 0]
+	 */
+	public function get_subscriber_counts( $request ) {
+		if ( ! Constants::is_defined( 'TESTING_IN_JETPACK' ) ) {
+			delete_transient( 'wpcom_subscribers_totals' );
+		}
+
+		$subscriber_info  = Jetpack_Subscriptions_Widget::fetch_subscriber_counts();
+		$subscriber_count = $subscriber_info['value'];
+
+		return array( 'counts' => $subscriber_count );
 	}
 }
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/subscribers.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/subscribers.php
@@ -88,10 +88,9 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers extends WP_REST_Controller {
 	/**
 	 * Retrieves splitted subscriber counts
 	 *
-	 * @param WP_REST_Request $request incoming API request info.
 	 * @return array data object containing subscriber counts ['email_subscribers' => 0, 'social_followers' => 0]
 	 */
-	public function get_subscriber_counts( $request ) {
+	public function get_subscriber_counts() {
 		if ( ! Constants::is_defined( 'TESTING_IN_JETPACK' ) ) {
 			delete_transient( 'wpcom_subscribers_totals' );
 		}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
@@ -18,6 +18,7 @@
  *     enabled:         (boolean) Is this connection slated to be shared to? context=edit only
  *     done:            (boolean) Is this post (or connection) done sharing? context=edit only
  *     toggleable:      (boolean) Can the current user change the `enabled` setting for this Connection+Post? context=edit only
+ *     follower_count:  (int)     Number of followers of the user/connection on Service
  *   }
  *   ...
  *   meta: { # Not defined in this file. Handled in modules/publicize/publicize.php via `register_meta()`
@@ -144,6 +145,12 @@ class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_
 				'toggleable'      => array(
 					'description' => __( 'Whether `enable` can be changed for this post/connection', 'jetpack' ),
 					'type'        => 'boolean',
+					'context'     => array( 'edit' ),
+					'readonly'    => true,
+				),
+				'follower_count'  => array(
+					'description' => __( 'Number of followers for the connected account', 'jetpack' ),
+					'type'        => 'integer',
 					'context'     => array( 'edit' ),
 					'readonly'    => true,
 				),

--- a/projects/plugins/jetpack/changelog/add-pre-publish-panel-changes
+++ b/projects/plugins/jetpack/changelog/add-pre-publish-panel-changes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Split out the email subscribers & social followers in the pre-publish panel.

--- a/projects/plugins/jetpack/changelog/pre-publish-counts
+++ b/projects/plugins/jetpack/changelog/pre-publish-counts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Show social media followers next to toggle in Share this post panel.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/api.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/api.js
@@ -3,12 +3,12 @@ import apiFetch from '@wordpress/api-fetch';
 export function getSubscriberCount( successCallback, failureCallback ) {
 	return apiFetch( {
 		path: '/wpcom/v2/subscribers/count?include_publicize_subscribers=false',
-	} ).then( count => {
+	} ).then( ( { count } = {} ) => {
 		// Handle error condition
-		if ( ! count.hasOwnProperty( 'count' ) ) {
-			failureCallback();
+		if ( typeof count !== 'undefined' ) {
+			successCallback( count );
 		} else {
-			successCallback( count.count );
+			failureCallback();
 		}
 	} );
 }
@@ -16,12 +16,12 @@ export function getSubscriberCount( successCallback, failureCallback ) {
 export function getSubscriberCounts( successCallback, failureCallback ) {
 	return apiFetch( {
 		path: '/wpcom/v2/subscribers/counts',
-	} ).then( count => {
+	} ).then( ( { counts } = {} ) => {
 		// Handle error condition
-		if ( ! count.hasOwnProperty( 'counts' ) ) {
-			failureCallback();
+		if ( counts ) {
+			successCallback( counts );
 		} else {
-			successCallback( count.counts );
+			failureCallback();
 		}
 	} );
 }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/api.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/api.js
@@ -12,3 +12,16 @@ export function getSubscriberCount( successCallback, failureCallback ) {
 		}
 	} );
 }
+
+export function getSubscriberCounts( successCallback, failureCallback ) {
+	return apiFetch( {
+		path: '/wpcom/v2/subscribers/counts',
+	} ).then( count => {
+		// Handle error condition
+		if ( ! count.hasOwnProperty( 'counts' ) ) {
+			failureCallback();
+		} else {
+			successCallback( count.counts );
+		}
+	} );
+}

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -6,13 +6,17 @@ import { store as editorStore } from '@wordpress/editor';
 import { createInterpolateElement, useEffect, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import InspectorNotice from '../../shared/components/inspector-notice';
-import { getSubscriberCount } from './api';
+import { getSubscriberCounts } from './api';
 import './panel.scss';
 
 export default function SubscribePanels() {
 	const [ subscriberCount, setSubscriberCount ] = useState( null );
+	const [ followerCount, setFollowerCount ] = useState( null );
 	useEffect( () => {
-		getSubscriberCount( count => setSubscriberCount( count ) );
+		getSubscriberCounts( counts => {
+			setSubscriberCount( counts.email_subscribers );
+			setFollowerCount( counts.social_followers );
+		} );
 	}, [] );
 
 	// Only show this for posts for now (subscriptions are only available on posts).
@@ -39,7 +43,10 @@ export default function SubscribePanels() {
 	}
 
 	// Do not show any panels when we have no info about the subscriber count, or it is too low.
-	if ( ! Number.isFinite( subscriberCount ) || subscriberCount <= 0 ) {
+	if (
+		( ! Number.isFinite( subscriberCount ) || subscriberCount <= 0 ) &&
+		( ! Number.isFinite( followerCount ) || followerCount <= 0 )
+	) {
 		return null;
 	}
 
@@ -54,14 +61,18 @@ export default function SubscribePanels() {
 				<InspectorNotice>
 					{ createInterpolateElement(
 						sprintf(
-							/* translators: %s is the number of subscribers */
-							_n(
-								'This post will be sent to <span>%s reader</span>',
-								'This post will be sent to <span>%s readers</span>',
-								subscriberCount,
-								'jetpack'
+							/* translators: 1$s will be email subscribers, %2$s will be social followers */
+							__( 'This post will reach <span>%1$s</span> and <span>%2$s</span>.', 'jetpack' ),
+							sprintf(
+								/* translators: %s will be a number of email subscribers */
+								_n( '%s email subscriber', '%s email subscribers', subscriberCount, 'jetpack' ),
+								numberFormat( subscriberCount )
 							),
-							numberFormat( subscriberCount )
+							sprintf(
+								/* translators: %s will be a number of social followers */
+								_n( '%s social follower', '%s social followers', followerCount, 'jetpack' ),
+								numberFormat( followerCount )
+							)
 						),
 						{ span: <span className="jetpack-subscribe-reader-count" /> }
 					) }
@@ -71,14 +82,18 @@ export default function SubscribePanels() {
 				<InspectorNotice>
 					{ createInterpolateElement(
 						sprintf(
-							/* translators: %s is the number of subscribers */
-							_n(
-								'This post has been sent to <span>%s reader</span>',
-								'This post has been sent to <span>%s readers</span>',
-								subscriberCount,
-								'jetpack'
+							/* translators: 1$s will be email subscribers, %2$s will be social followers */
+							__( 'This post was shared to <span>%1$s</span> and <span>%2$s</span>.', 'jetpack' ),
+							sprintf(
+								/* translators: %s will be a number of email subscribers */
+								_n( '%s email subscriber', '%s email subscribers', subscriberCount, 'jetpack' ),
+								numberFormat( subscriberCount )
 							),
-							numberFormat( subscriberCount )
+							sprintf(
+								/* translators: %s will be a number of social followers */
+								_n( '%s social follower', '%s social followers', followerCount, 'jetpack' ),
+								numberFormat( followerCount )
+							)
 						),
 						{ span: <span className="jetpack-subscribe-reader-count" /> }
 					) }

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -593,10 +593,55 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 	}
 
 	/**
+	 * Determine the amount of folks currently subscribed to the blog, splitted out in email_subscribers & social_followers
+	 *
+	 * @return array containing ['email_subscribers' => 0, 'social_followers' => 0]
+	 */
+	public static function fetch_subscriber_counts() {
+		$subs_count = 0;
+		if ( self::is_jetpack() ) {
+			$cache_key  = 'wpcom_subscribers_totals';
+			$subs_count = get_transient( $cache_key );
+			if ( false === $subs_count || 'failed' === $subs_count['status'] ) {
+				$xml = new Jetpack_IXR_Client();
+				$xml->query( 'jetpack.fetchSubscriberCounts' );
+
+				if ( $xml->isError() ) { // If we get an error from .com, set the status to failed so that we will try again next time the data is requested.
+
+					$subs_count = array(
+						'status'  => 'failed',
+						'code'    => $xml->getErrorCode(),
+						'message' => $xml->getErrorMessage(),
+						'value'   => ( isset( $subs_count['value'] ) ) ? $subs_count['value'] : array(
+							'email_subscribers' => 0,
+							'social_followers'  => 0,
+						),
+					);
+				} else {
+					$subs_count = array(
+						'status' => 'success',
+						'value'  => $xml->getResponse(),
+					);
+				}
+				set_transient( $cache_key, $subs_count, 3600 ); // Try to cache the result for at least 1 hour.
+			}
+		}
+
+		if ( self::is_wpcom() ) {
+			$subs_count = array(
+				'email_subscribers' => wpcom_subs_total_for_blog(),
+				'social_followers'  => wpcom_social_followers_total_for_blog(),
+			);
+		}
+
+		return $subs_count;
+	}
+
+	/**
 	 * Determine the amount of folks currently subscribed to the blog.
 	 *
 	 * @param bool $include_publicize_subscribers Include followers through Publicize.
-	 * @return int|array
+	 * @return int
 	 */
 	public static function fetch_subscriber_count( $include_publicize_subscribers = true ) {
 		$subs_count = 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This PR adds social media follower counts next to the checkboxes in the Share this post panel.

<img width="272" alt="CleanShot 2022-11-17 at 16 58 12@2x" src="https://user-images.githubusercontent.com/528287/202495355-aefc01a1-e579-46df-a42f-e6b7e41cecb9.png">


#### Jetpack product discussion
pdDOJh-ZI-p2
pdDOJh-Yp-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
1. Apply this PR
2. In the pre-publish panel, the counts of each connection should be shown next to the checkbox.
