### PR TITLE
Remove logic (around) overriding `safecss_filter_attr` in the `custom-css` module

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-overriden-safecss-filter-attr-in-custom-css
+++ b/projects/plugins/jetpack/changelog/remove-overriden-safecss-filter-attr-in-custom-css
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Remove the logic to override `kses`'s `safecss_filter_attr` from `custom-css.php` and other unused entities. There's no real need to override the `safecss_filter_attr` in Jetpack-powered sites anymore. This function should come verbatim from core.

--- a/projects/plugins/jetpack/modules/custom-css/custom-css.php
+++ b/projects/plugins/jetpack/modules/custom-css/custom-css.php
@@ -1831,55 +1831,6 @@ class Jetpack_Custom_CSS {
 	}
 }
 
-/**
- * The Safe CSS Class.
- */
-class Jetpack_Safe_CSS { // phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound, Generic.Classes.OpeningBraceSameLine.ContentAfterBrace
-	/**
-	 * Filter attriburtes.
-	 *
-	 * @param string $css - the CSS.
-	 * @param string $element - the HTML element.
-	 *
-	 * @return string
-	 */
-	public static function filter_attr( $css, $element = 'div' ) {
-		safecss_class();
-
-		$css = $element . ' {' . $css . '}';
-
-		$csstidy           = new csstidy();
-		$csstidy->optimise = new safecss( $csstidy );
-		$csstidy->set_cfg( 'remove_bslash', false );
-		$csstidy->set_cfg( 'compress_colors', false );
-		$csstidy->set_cfg( 'compress_font-weight', false );
-		$csstidy->set_cfg( 'discard_invalid_properties', true );
-		$csstidy->set_cfg( 'merge_selectors', false );
-		$csstidy->set_cfg( 'remove_last_;', false );
-		$csstidy->set_cfg( 'css_level', 'CSS3.0' );
-
-		// Turn off css shorthands and leading zero removal as it breaks block validation.
-		$csstidy->set_cfg( 'optimise_shorthands', 0 );
-		$csstidy->set_cfg( 'preserve_leading_zeros', true );
-
-		$css = preg_replace( '/\\\\([0-9a-fA-F]{4})/', '\\\\\\\\$1', $css );
-		$css = wp_kses_split( $css, array(), array() );
-		$csstidy->parse( $css );
-
-		$css = $csstidy->print->plain();
-
-		$css = str_replace( array( "\n", "\r", "\t" ), '', $css );
-
-		preg_match( "/^{$element}\s*{(.*)}\s*$/", $css, $matches );
-
-		if ( empty( $matches[1] ) ) {
-			return '';
-		}
-
-		return $matches[1];
-	}
-}
-
 if ( ! function_exists( 'safecss_class' ) ) :
 	/**
 	 * Setup safecss class.
@@ -1937,18 +1888,5 @@ if ( ! function_exists( 'safecss_class' ) ) :
 		}
 	}
 endif;
-
-if ( ! function_exists( 'safecss_filter_attr' ) ) {
-
-	/**
-	 * Filter safecss attriburtes.
-	 *
-	 * @param string $css - the CSS.
-	 * @param string $element - the HTML element.
-	 */
-	function safecss_filter_attr( $css, $element = 'div' ) {
-		return Jetpack_Safe_CSS::filter_attr( $css, $element );
-	}
-}
 
 require_once __DIR__ . '/custom-css/preprocessors.php';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This removes all the code related to the override of `safecss_filter_attr` in the `custom-css` module. This override was mainly in place for WPCOM to use a different implementation based off CSSTidy. This is no longer desired and we instead want full parity between org and WPCOM for the `safecss_filter_attr`, hence that code is no longer needed and should be removed.

The changes have been copied from this diff: D70703-code. You can find more context and details in the diff, too.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*