### PR TITLE
WAF: Remove has_rules_access in favour of external checks

### DIFF
--- a/projects/packages/waf/composer.json
+++ b/projects/packages/waf/composer.json
@@ -4,8 +4,7 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"wikimedia/aho-corasick": "^1.0",
-		"automattic/jetpack-plans": "@dev"
+		"wikimedia/aho-corasick": "^1.0"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.0.3",

--- a/projects/packages/waf/composer.json
+++ b/projects/packages/waf/composer.json
@@ -4,7 +4,8 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"wikimedia/aho-corasick": "^1.0"
+		"wikimedia/aho-corasick": "^1.0",
+		"automattic/jetpack-plans": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.0.3",

--- a/projects/packages/waf/src/class-rest-controller.php
+++ b/projects/packages/waf/src/class-rest-controller.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\Waf;
 
 use Automattic\Jetpack\Connection\REST_Connector;
-use Automattic\Jetpack\Current_Plan;
 use WP_Error;
 use WP_REST_Server;
 
@@ -52,16 +51,6 @@ class REST_Controller {
 	}
 
 	/**
-	 * Has Rules Access
-	 *
-	 * @return bool True when the current site has access to latest firewall rules.
-	 */
-	private static function has_rules_access() {
-		// any site with Jetpack Scan can download new WAF rules
-		return Current_Plan::supports( 'scan' );
-	}
-
-	/**
 	 * Update rules endpoint
 	 */
 	public static function update_rules() {
@@ -89,8 +78,7 @@ class REST_Controller {
 	public static function waf() {
 		return rest_ensure_response(
 			array(
-				'bootstrapPath'  => self::get_bootstrap_file_path(),
-				'hasRulesAccess' => self::has_rules_access(),
+				'bootstrapPath' => self::get_bootstrap_file_path(),
 			)
 		);
 	}

--- a/projects/packages/waf/src/class-rest-controller.php
+++ b/projects/packages/waf/src/class-rest-controller.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Waf;
 
 use Automattic\Jetpack\Connection\REST_Connector;
+use Automattic\Jetpack\Current_Plan;
 use WP_Error;
 use WP_REST_Server;
 
@@ -57,7 +58,7 @@ class REST_Controller {
 	 */
 	private static function has_rules_access() {
 		// any site with Jetpack Scan can download new WAF rules
-		return \Jetpack_Plan::supports( 'scan' );
+		return Current_Plan::supports( 'scan' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/client/security/waf.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/waf.jsx
@@ -17,7 +17,7 @@ import {
 import { getProductDescriptionUrl } from 'product-descriptions/utils';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { getSitePlan } from 'state/site';
+import { getSitePlan, siteHasFeature } from 'state/site';
 import QueryWafSettings from '../components/data/query-waf-bootstrap-path';
 import InfoPopover from '../components/info-popover';
 import Textarea from '../components/textarea';
@@ -295,7 +295,7 @@ export const Waf = class extends Component {
 					) }
 				</SettingsGroup>
 				{ isWafActive && this.props.bootstrapPath && bootstrapInstructions }
-				{ ! this.props.hasRulesAccess && ! this.props.isFetchingWafSettings && upgradeBanner }
+				{ ! this.props.hasScan && ! this.props.isFetchingWafSettings && upgradeBanner }
 			</SettingsCard>
 		);
 	}
@@ -305,6 +305,7 @@ export default connect( state => {
 	const sitePlan = getSitePlan( state );
 
 	return {
+		hasScan: siteHasFeature( state, 'scan' ),
 		bootstrapPath: getWafBootstrapPath( state ),
 		hasRulesAccess: getWafHasRulesAccess( state ),
 		isFetchingWafSettings: isFetchingWafSettings( state ),

--- a/projects/plugins/jetpack/_inc/client/security/waf.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/waf.jsx
@@ -21,11 +21,7 @@ import { getSitePlan, siteHasFeature } from 'state/site';
 import QueryWafSettings from '../components/data/query-waf-bootstrap-path';
 import InfoPopover from '../components/info-popover';
 import Textarea from '../components/textarea';
-import {
-	getWafBootstrapPath,
-	getWafHasRulesAccess,
-	isFetchingWafSettings,
-} from '../state/waf/reducer';
+import { getWafBootstrapPath, isFetchingWafSettings } from '../state/waf/reducer';
 
 export const Waf = class extends Component {
 	/**
@@ -307,7 +303,6 @@ export default connect( state => {
 	return {
 		hasScan: siteHasFeature( state, 'scan' ),
 		bootstrapPath: getWafBootstrapPath( state ),
-		hasRulesAccess: getWafHasRulesAccess( state ),
 		isFetchingWafSettings: isFetchingWafSettings( state ),
 		scanUpgradeUrl: getProductDescriptionUrl( state, 'scan' ),
 		sitePlan,

--- a/projects/plugins/jetpack/_inc/client/state/waf/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/waf/reducer.js
@@ -11,7 +11,6 @@ export const data = ( state = {}, action ) => {
 		case WAF_SETTINGS_FETCH_RECEIVE:
 			return assign( {}, state, {
 				bootstrapPath: action.settings?.bootstrapPath,
-				hasRulesAccess: action.settings?.hasRulesAccess,
 			} );
 		default:
 			return state;
@@ -61,14 +60,4 @@ export function isFetchingWafSettings( state ) {
  */
 export function getWafBootstrapPath( state ) {
 	return get( state.jetpack.waf, [ 'data', 'bootstrapPath' ], '' );
-}
-
-/**
- * Returns whether the site has access to latest firewall rules.
- *
- * @param {object}  state - Global state tree
- * @returns {boolean}  True when the site has access to latest firewall rules.
- */
-export function getWafHasRulesAccess( state ) {
-	return get( state.jetpack.waf, [ 'data', 'hasRulesAccess' ], false );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Description
The WAF package uses `Jetpack_Plan::supports( 'scan' )` which is only available when Jetpack is installed. We should remove this in favor of using external plan checks, so the WAF package can be used in the standalone Protect plugin.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes `REST_Controller::has_rules_access` and all accessory variables and methods both internally and externally
* Updates the plan check for the upgrade badge in the Firewall module settings to use `hasScan`

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- 1201069996155224-as-1203388556983403

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch
* Start up your Jurassic Tube 
* Ensure the site has no current upgrades
* Install Jetpack, connect, and proceed to the Settings tab
* Scroll to the Firewall module section and verify that you are appropriately prompted to upgrade
* Proceed to upgrade and return the Firewall module to verify that the prompt is no longer present
* Verify that there are no regressions in the functionality of the WAF

