### PR TITLE
Blogging prompts: move to experimental blocks

### DIFF
--- a/projects/plugins/jetpack/_inc/blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/blogging-prompts.php
@@ -52,31 +52,31 @@ add_action( 'wp_insert_post', 'jetpack_setup_blogging_prompt_response' );
  */
 
 /**
- * Retrieve a daily blogging prompt from the wpcom API and cache it.
+ * Retrieve daily blogging prompts from the wpcom API and cache them.
  *
  * @param int $time Unix timestamp representing the day for which to get blogging prompts.
  * @return stdClass[] Array of blogging prompt objects.
  */
 function jetpack_get_daily_blogging_prompts( $time = 0 ) {
-	// Default to the time in the site's timezone.
+	// Default to the current time in the site's timezone.
 	$timestamp   = $time ? $time : current_time( 'timestamp' ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
 	$date_format = 'Y-m-d';
-	$today       = date_i18n( $date_format, $timestamp );
+	$day         = date_i18n( $date_format, $timestamp );
 
-	// Include prompts from yesterday, just in case someone has an outdated prompt id from a previous day.
+	// Include prompts from the previous day, just in case someone has an outdated prompt id.
 	$one_day       = date_interval_create_from_date_string( '1 day' );
-	$yesterday     = date_format( date_create( $today )->sub( $one_day ), $date_format );
+	$day_before    = date_format( date_create( $day )->sub( $one_day ), $date_format );
 	$locale        = jetpack_get_mag16_locale();
-	$transient_key = 'jetpack_blogging_prompt_' . $yesterday . '_' . $locale;
-	$prompts_today = get_transient( $transient_key );
+	$transient_key = 'jetpack_blogging_prompt_' . $day_before . '_' . $locale;
+	$daily_prompts = get_transient( $transient_key );
 
 	// Return the cached prompt, if we have it. Otherwise fetch it from the API.
-	if ( false !== $prompts_today ) {
-		return $prompts_today;
+	if ( false !== $daily_prompts ) {
+		return $daily_prompts;
 	}
 
 	$blog_id = \Jetpack_Options::get_option( 'id' );
-	$path    = '/sites/' . $blog_id . '/blogging-prompts?from=' . $yesterday . '&number=10&_locale=' . $locale;
+	$path    = '/sites/' . $blog_id . '/blogging-prompts?from=' . $day_before . '&number=10&_locale=' . $locale;
 	$args    = array(
 		'headers' => array(
 			'Content-Type'    => 'application/json',

--- a/projects/plugins/jetpack/_inc/blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/blogging-prompts.php
@@ -59,13 +59,10 @@ add_action( 'wp_insert_post', 'jetpack_setup_blogging_prompt_response' );
  */
 function jetpack_get_daily_blogging_prompts( $time = 0 ) {
 	// Default to the current time in the site's timezone.
-	$timestamp   = $time ? $time : current_time( 'timestamp' ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
-	$date_format = 'Y-m-d';
-	$day         = date_i18n( $date_format, $timestamp );
+	$timestamp = $time ? $time : current_time( 'timestamp' ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
 
 	// Include prompts from the previous day, just in case someone has an outdated prompt id.
-	$one_day       = date_interval_create_from_date_string( '1 day' );
-	$day_before    = date_format( date_create( $day )->sub( $one_day ), $date_format );
+	$day_before    = date_i18n( 'Y-m-d', $timestamp - DAY_IN_SECONDS );
 	$locale        = jetpack_get_mag16_locale();
 	$transient_key = 'jetpack_blogging_prompt_' . $day_before . '_' . $locale;
 	$daily_prompts = get_transient( $transient_key );

--- a/projects/plugins/jetpack/changelog/update-blogging-prompts-experimental
+++ b/projects/plugins/jetpack/changelog/update-blogging-prompts-experimental
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Changelog entry already provided from previous PR
+
+

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -45,14 +45,19 @@
 	],
 	"beta": [
 		"amazon",
-		"blogging-prompts",
 		"contact-form/salesforce-lead-form",
 		"google-docs-embed",
 		"recipe",
 		"videopress/video",
 		"videopress/video-chapters"
 	],
-	"experimental": [ "anchor-fm", "premium-content", "conversation", "dialogue" ],
+	"experimental": [
+		"anchor-fm",
+		"blogging-prompts",
+		"premium-content",
+		"conversation",
+		"dialogue"
+	],
 	"no-post-editor": [
 		"business-hours",
 		"button",


### PR DESCRIPTION
Follow up to #26680

#### Changes proposed in this Pull Request:

* Moves the blogging prompt editor extension to experimental, to make it available on WP.com sites
* Slightly refactors `jetpack_get_daily_blogging_prompts` since a timestamp can now be specified

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

See #26680

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

- Be sure the site is connected to WP.com to load Jetpack blocks in the editor
- Enable beta blocks by adding `define( 'JETPACK_EXPERMINENTAL_BLOCKS', true )` (or Settings > Jetpack Constants if you're using jurassic.ninja)
- Set the site as "having a blog" by doing at least one of the following
    - Set the `site_intent` option to `write`
    - Set the front page to show posts in Settings > Reading
    - Set a static page for the posts page in Settings > Reading
- Create a new post, you should see a writing prompt in the placeholder for the first paragraph
- Create a new post and add the `answer_prompt` query param with the prompt id for today as the value (e.g. `/wp-admin/post-new.php?answer_prompt=2129`), and you should see a writing prompt as a pullquote block, the tag `dailyprompt` added to the post, and the `_jetpack_blogging_prompt_key` post meta set to the prompt id.
- Create a new page or custom post type, and you should _not_ see the writing prompt
- Open an existing post, and you should _not_ see the writing prompt

