### PR TITLE
Change gifting banner option to on/off from true/false

### DIFF
--- a/projects/plugins/jetpack/changelog/update-gifting-bool
+++ b/projects/plugins/jetpack/changelog/update-gifting-bool
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Switching option storage approach for unlaunched feature
+
+

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -436,7 +436,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'rss_use_excerpt'                  => (bool) get_option( 'rss_use_excerpt' ),
 						'launchpad_screen'                 => (string) get_option( 'launchpad_screen' ),
 						'featured_image_email_enabled'     => (bool) get_option( 'featured_image_email_enabled' ),
-						'wpcom_gifting_subscription'       => (bool) get_option( 'wpcom_gifting_subscription', $this->get_wpcom_gifting_subscription_default() ),
+						'wpcom_gifting_subscription'       => (bool) ( 'on' === get_option( 'wpcom_gifting_subscription', $this->get_wpcom_gifting_subscription_default() ) ),
 					);
 
 					if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -512,14 +512,14 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 			foreach ( $purchases as $purchase ) {
 				if ( wpcom_purchase_has_feature( $purchase, \WPCOM_Features::SUBSCRIPTION_GIFTING ) ) {
 					if ( isset( $purchase->auto_renew ) ) {
-						return ! $purchase->auto_renew;
+						return ! $purchase->auto_renew ? 'on' : 'off';
 					} elseif ( isset( $purchase->user_allows_auto_renew ) ) {
-						return ! $purchase->user_allows_auto_renew;
+						return ! $purchase->user_allows_auto_renew ? 'on' : 'off';
 					}
 				}
 			}
 		}
-		return false;
+		return 'off';
 	}
 
 	/**
@@ -888,14 +888,23 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					if ( update_option( 'verification_services_codes', $verification_codes ) ) {
 						$updated[ $key ] = $verification_codes;
 					}
+
 					break;
 
 				case 'wpcom_publish_posts_with_markdown':
 				case 'wpcom_publish_comments_with_markdown':
-				case 'wpcom_gifting_subscription':
 					$coerce_value = (bool) $value;
 					if ( update_option( $key, $coerce_value ) ) {
 						$updated[ $key ] = $coerce_value;
+					}
+					break;
+
+				case 'wpcom_gifting_subscription':
+					// settings are stored as on|off to allow both options to be set
+					// from an initial not set state.
+					$coerce_value = ( $value ) ? 'on' : 'off';
+					if ( update_option( $key, $coerce_value ) ) {
+						$updated[ $key ] = $value;
 					}
 					break;
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -116,7 +116,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			'wpcom_publish_comments_with_markdown'    => '(bool) Whether markdown is enabled for comments',
 			'launchpad_screen'                        => '(string) Whether or not launchpad is presented and what size it will be',
 			'featured_image_email_enabled'            => '(bool) Whether the Featured image is displayed in the New Post email template or not',
-			'wpcom_gifting_subscription'              => '(bool) Whether gifting is enabled for non auto-renew sites',
+			'wpcom_gifting_subscription'              => '(string) Whether gifting is enabled (on/off).',
 		),
 
 		'response_format' => array(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Change `wpcom_gifting_subscription` option from `true/false` to `on/off`.
Related to D92810-code

This PR doesn't introduce any visible / functional changes. Instead, this PR is a prerequisite for the upcoming changes that will utilize the newly-added site option/setting:

#### Does this pull request change what data or activity we track or use?
No, it does not.

#### Testing instructions:
The PR doesn't introduce any visible/functional changes. We can review the code and make sure the are no regressions.
