### PR TITLE
VideoPress: switch to v1.1/videos when requesting video data

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-use-wp-com-api-to-request-video-data
+++ b/projects/packages/videopress/changelog/update-videopress-use-wp-com-api-to-request-video-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: switch to v1.1/videos when requesting video data

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
@@ -1,6 +1,7 @@
 import { trackKindOptionProps } from '../../plugins/video-chapters/utils/tracks-editor/types';
 
 export type VideoId = number;
+export type VideoGUID = string;
 
 type Track = {
 	label: string;
@@ -17,7 +18,7 @@ export type VideoBlockColorAttributesProps = {
 
 export type VideoBlockAttributes = VideoBlockColorAttributesProps & {
 	id?: VideoId;
-	guid?: string;
+	guid?: VideoGUID;
 	src?: string;
 
 	title?: string;

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
@@ -133,11 +133,6 @@ export function useSyncMedia(
 		// ...and udpate the block attributes with fresh data.
 		const initialAttributesValues = mapObjectKeysToCamel( initialVideoData, true );
 
-		// Cast/tweak response body => block attributes.
-		if ( typeof initialAttributesValues.allowDownload !== 'undefined' ) {
-			initialAttributesValues.allowDownload = !! initialAttributesValues.allowDownload;
-		}
-
 		setAttributes( initialAttributesValues );
 	}, [ videoData, isRequestingVideoData ] );
 

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
@@ -91,7 +91,7 @@ export function useSyncMedia(
 	setAttributes: VideoBlockSetAttributesProps
 ): UseSyncMediaProps {
 	const { id, guid } = attributes;
-	const { videoData, isRequestingVideoData } = useVideoData( id );
+	const { videoData, isRequestingVideoData } = useVideoData( { guid } );
 
 	const isSaving = useSelect( select => select( editorStore ).isSavingPost(), [] );
 	const wasSaving = usePrevious( isSaving );

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/Readme.md
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/Readme.md
@@ -1,10 +1,11 @@
 # useVideoHook()
 
-Perform a request to the media endpoint. Pull and tweak the response to be adequately delivered to the component.
+Perform a request to the media endpoint.
+Pull and tweak the response to be adequately delivered to the component.
 
 ```jsx
-function myVideoComponent( { id } ) {
-	const [ videoData, isRequestingVideoItem ] = useVideoData( id );
+function myVideoComponent( { id, guid } ) {
+	const [ videoData, isRequestingVideoItem ] = useVideoData( { guid } );
 
 	if ( isRequestingVideoItem ) {
 		return null;

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/index.ts
@@ -6,17 +6,22 @@ import { useEffect, useState } from '@wordpress/element';
 /**
  * Types
  */
-import { WPV2mediaGetEndpointResponseProps } from '../../../types';
-import { VideoId } from '../../blocks/video/types';
-import { UseVideoDataProps } from './types';
+import {
+	WPCOMRestAPIVideosGetEndpointResponseProps,
+	WPV2mediaGetEndpointResponseProps,
+} from '../../../types';
+import { UseVideoDataProps, UseVideoDataArgumentsProps } from './types';
 
 /**
  * React hook to fetch the video data from the media library.
  *
- * @param {VideoId}             id - The video id.
- * @returns {UseVideoDataProps}      Hook API object.
+ * @param {UseVideoDataArgumentsProps} args - Hook arguments object
+ * @returns {UseVideoDataProps}               Hook API object.
  */
-export default function useVideoData( id: VideoId ): UseVideoDataProps {
+export default function useVideoData( {
+	id,
+	guid,
+}: UseVideoDataArgumentsProps ): UseVideoDataProps {
 	const [ videoData, setVideoData ] = useState( {} );
 	const [ isRequestingVideoData, setIsRequestingVideoData ] = useState( false );
 
@@ -25,34 +30,65 @@ export default function useVideoData( id: VideoId ): UseVideoDataProps {
 		 * Fetches the video videoData from the API.
 		 */
 		async function fetchVideoItem() {
-			try {
-				const response: WPV2mediaGetEndpointResponseProps = await apiFetch( {
-					path: `/wp/v2/media/${ id }`,
-				} );
+			if ( guid ) {
+				try {
+					const response: WPCOMRestAPIVideosGetEndpointResponseProps = await apiFetch( {
+						url: `https://public-api.wordpress.com/rest/v1.1/videos/${ guid }`,
+						credentials: 'omit',
+					} );
 
-				setIsRequestingVideoData( false );
-				if ( ! response?.jetpack_videopress ) {
-					return;
+					setIsRequestingVideoData( false );
+
+					// pick filename from the source_url
+					const filename = response.original?.split( '/' )?.at( -1 );
+
+					setVideoData( {
+						guid: response.guid,
+						title: response.title,
+						description: response.description,
+						allow_download: response.allow_download,
+						privacy_setting: response.privacy_setting,
+						rating: response.rating,
+						filename,
+						tracks: response.tracks,
+					} );
+				} catch ( error ) {
+					setIsRequestingVideoData( false );
+					throw new Error( error );
 				}
+			}
 
-				// Pick filename from the source_url.
-				const filename = response?.source_url?.split( '/' )?.at( -1 );
+			// Request by hitting the /wp/v2/media endpoint
+			if ( id ) {
+				try {
+					const response: WPV2mediaGetEndpointResponseProps = await apiFetch( {
+						path: `/wp/v2/media/${ id }`,
+					} );
 
-				// Pick isPrivate
-				const is_private = response?.media_details?.videopress?.is_private;
+					setIsRequestingVideoData( false );
+					if ( ! response?.jetpack_videopress ) {
+						return;
+					}
 
-				setVideoData( { ...response.jetpack_videopress, filename, is_private } );
-			} catch ( error ) {
-				setIsRequestingVideoData( false );
-				throw new Error( error );
+					// Pick filename from the source_url.
+					const filename = response?.source_url?.split( '/' )?.at( -1 );
+
+					// Pick isPrivate
+					const is_private = response?.media_details?.videopress?.is_private;
+
+					setVideoData( { ...response.jetpack_videopress, filename, is_private } );
+				} catch ( error ) {
+					setIsRequestingVideoData( false );
+					throw new Error( error );
+				}
 			}
 		}
 
-		if ( id ) {
+		if ( id || guid ) {
 			setIsRequestingVideoData( true );
 			fetchVideoItem();
 		}
-	}, [ id ] );
+	}, [ id, guid ] );
 
 	return { videoData, isRequestingVideoData };
 }

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/types.ts
@@ -1,3 +1,10 @@
+import { VideoGUID, VideoId } from '../../blocks/video/types';
+
+export type UseVideoDataArgumentsProps = {
+	id?: VideoId;
+	guid?: VideoGUID;
+};
+
 export type videoDataProps = {
 	title?: string;
 	description?: string;

--- a/projects/packages/videopress/src/client/types.ts
+++ b/projects/packages/videopress/src/client/types.ts
@@ -1,3 +1,5 @@
+import { VideoGUID } from './block-editor/blocks/video/types';
+
 /*
  * Video Privacy:
  * '0': public
@@ -5,6 +7,36 @@
  * '2': site default
  */
 type PrivacySettingProp = '0' | '1' | '2';
+
+type STDVideoFileProps = {
+	mp4: string;
+	original_img: string;
+	thumbnail_img: string;
+};
+
+type AVC240VideoFileProps = {
+	mp4: string;
+	original_img: string;
+	thumbnail_img: string;
+	hls: string;
+	dash: string;
+};
+
+type DVDVideoFileProps = {
+	mp4: string;
+	original_img: string;
+	thumbnail_img: string;
+	hls: string;
+	dash: string;
+};
+
+type HDVideoFileProps = {
+	mp4: string;
+	original_img: string;
+	thumbnail_img: string;
+	hls: string;
+	dash: string;
+};
 
 export type WPComV2VideopressGetMetaEndpointResponseProps = {
 	code: string;
@@ -19,12 +51,12 @@ export type WPComV2VideopressPostMetaEndpointBodyProps = {
 };
 
 /*
- * 'wp/v2/media/${ id }'
+ * wp/v2/media/${ id }
  */
 export type WPV2mediaGetEndpointResponseProps = {
 	source_url: string;
 	jetpack_videopress?: {
-		guid: string;
+		guid: VideoGUID;
 		title: string;
 		description: string;
 		caption: string;
@@ -38,4 +70,165 @@ export type WPV2mediaGetEndpointResponseProps = {
 			is_private: boolean;
 		};
 	};
+};
+
+/*
+ * https://public-api.wordpress.com/rest/v1.1/videos/${ guid }
+ */
+export type WPCOMRestAPIVideosGetEndpointResponseProps = {
+	// source_url: string;
+
+	guid: VideoGUID;
+	title: string;
+	description: string;
+	width: number;
+	height: number;
+	duration: number;
+	allow_download: boolean;
+	display_embed: boolean;
+	rating: string;
+
+	/*
+	 * Video Thumbnail
+	 * https://videos.files.wordpress.com/guid/video-image.ext"
+	 */
+	poster: string;
+
+	/*
+	 * Original video
+	 * https://videos.files.wordpress.com/guid/video-filename.ext"
+	 */
+	original: string;
+
+	watermark: boolean;
+
+	jetpack_videopress?: {
+		caption: string;
+		needs_playback_token: boolean;
+		privacy_setting: PrivacySettingProp;
+		rating: string;
+	};
+
+	bg_color: boolean;
+
+	files: {
+		std: STDVideoFileProps;
+		avc_240p: AVC240VideoFileProps;
+		dvd: DVDVideoFileProps;
+		hd: HDVideoFileProps;
+	};
+
+	file_url_base: {
+		http: string;
+		https: string;
+	};
+
+	blog_id: number;
+	post_id: number;
+	is_private: boolean;
+	privacy_setting: PrivacySettingProp;
+	upload_date: string;
+	finished: boolean;
+	files_status: {
+		std: {
+			mp4: 'DONE' | string;
+			ogg: 'DONE' | string;
+		};
+		avc_240p: {
+			mp4: 'DONE' | string;
+		};
+		dvd: {
+			mp4: 'DONE' | string;
+		};
+		hd: {
+			mp4: 'DONE' | string;
+		};
+
+		hd_1080p: null;
+		hd_1080p_compat: null;
+		hevc_1440p: null;
+		vp9_1440p: null;
+		hevc_2160p: null;
+		vp9_2160p: null;
+	};
+
+	subtitles: Array< string >;
+	tracks: {
+		captions?: {
+			en: {
+				src: string;
+				label: string;
+			};
+		};
+		chapters?: {
+			en: {
+				src: string;
+				label: string;
+			};
+		};
+	};
+
+	adaptive_streaming: string;
+	format_meta: {
+		std: {
+			codec: string;
+			label: string;
+			vertical_lines: number;
+		};
+		avc_240p: {
+			codec: string;
+			label: string;
+			vertical_lines: number;
+		};
+		dvd: {
+			codec: string;
+			label: string;
+			vertical_lines: number;
+		};
+		hd: {
+			codec: string;
+			label: string;
+			vertical_lines: number;
+		};
+		hd_1080p: {
+			codec: string;
+			label: string;
+			vertical_lines: number;
+		};
+		hevc_1440p: {
+			codec: string;
+			label: string;
+			vertical_lines: number;
+		};
+		vp9_1440p: {
+			codec: string;
+			label: string;
+			vertical_lines: number;
+		};
+		hevc_2160p: {
+			codec: string;
+			label: string;
+			vertical_lines: number;
+		};
+		vp9_2160p: {
+			codec: string;
+			label: string;
+			vertical_lines: number;
+		};
+	};
+
+	thumbnails_grid: {
+		grid_interval: number;
+		grid_width: number;
+		grid_height: number;
+		thumbs_height: number;
+		files: Array< {
+			file: string;
+			start_time_ms: number;
+			end_time_ms: number;
+			thumbs_count: number;
+		} >;
+	};
+
+	thumbnail_generating: boolean;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR replaces the `wp/v2/media`  endpoint to request the video data with `v1.1/videos`, because:

* Current core/video block uses this endpoint
* Some data is not available in `wp/v2/media` (tracks, for instance)
* Video endpoint seems to be more appropriate for this stuff

We are not deleting the part of the code that uses `/wp/v2/media` but switching it. It's still usable.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: switch to v1.1/videos when requesting video data

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Check the app works as expected 😅 

* Go to the Block editor
* Create/edit a video block
* Confirm data is populated correctly to the block attributes
* You may like to take a look at the endpoint that requests the data

`wp/v2/media/Mid>` | `v1.1/videos/guid`
----|-----
<img width="932" alt="Screen Shot 2022-11-18 at 06 41 12" src="https://user-images.githubusercontent.com/77539/202671038-9a985c28-987f-4494-a3a8-48752e96554c.png"> | <img width="866" alt="Screen Shot 2022-11-18 at 06 29 42" src="https://user-images.githubusercontent.com/77539/202671057-50e59f88-6b3c-4906-bd95-6643c57ab779.png">