### PR TITLE
VideoPress: register and sync isPrivate block attribute

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-add-and-sync-is-private-prop
+++ b/projects/packages/videopress/changelog/update-videopress-add-and-sync-is-private-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: register and sync isPrivate block attribute

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
@@ -98,6 +98,9 @@
 		},
 		"rating": {
 			"type": "string"
+		},
+		"isPrivate": {
+			"type": "boolean"
 		}
 	},
 	"textdomain": "jetpack-videopress",

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
@@ -65,6 +65,7 @@ const videoFieldsToUpdate = [
 	'privacy_setting',
 	'rating',
 	'allow_download',
+	'isPrivate',
 ];
 
 /*

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
@@ -65,7 +65,7 @@ const videoFieldsToUpdate = [
 	'privacy_setting',
 	'rating',
 	'allow_download',
-	'isPrivate',
+	'is_private',
 ];
 
 /*
@@ -75,6 +75,7 @@ const videoFieldsToUpdate = [
 const mapFieldsToAttributes = {
 	privacy_setting: 'privacySetting',
 	allow_download: 'allowDownload',
+	is_private: 'isPrivate',
 };
 
 /**

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/index.ts
@@ -38,7 +38,7 @@ export default function useVideoData( id: VideoId ): UseVideoDataProps {
 				// Pick filename from the source_url.
 				const filename = response?.source_url?.split( '/' )?.at( -1 );
 
-				// Pick isProvate
+				// Pick isPrivate
 				const is_private = response?.media_details?.videopress?.is_private;
 
 				setVideoData( { ...response.jetpack_videopress, filename, is_private } );

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/index.ts
@@ -35,10 +35,13 @@ export default function useVideoData( id: VideoId ): UseVideoDataProps {
 					return;
 				}
 
-				// pick filename from the source_url
+				// Pick filename from the source_url.
 				const filename = response?.source_url?.split( '/' )?.at( -1 );
 
-				setVideoData( { ...response.jetpack_videopress, filename } );
+				// Pick isProvate
+				const is_private = response?.media_details?.videopress?.is_private;
+
+				setVideoData( { ...response.jetpack_videopress, filename, is_private } );
 			} catch ( error ) {
 				setIsRequestingVideoData( false );
 				throw new Error( error );

--- a/projects/packages/videopress/src/client/types.ts
+++ b/projects/packages/videopress/src/client/types.ts
@@ -33,4 +33,9 @@ export type WPV2mediaGetEndpointResponseProps = {
 		privacy_setting: PrivacySettingProp;
 		rating: string;
 	};
+	media_details: {
+		videopress?: {
+			is_private: boolean;
+		};
+	};
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR register the `isPrivate` block attribute and also keeps it in sync with the video data. This idea is to know the video's privacy state to define the best way to pull the data.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: register and sync isPrivate block attribute

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Block Editor
* Add/edit a video block
* Confirm there is a new `isPrivate` attribute in the `VideoPressEdit` component
<img width="999" alt="Screen Shot 2022-11-18 at 09 46 49" src="https://user-images.githubusercontent.com/77539/202708360-d803d9de-77a4-4e7d-98a8-0d2a4c8b773e.png">


