### PR TITLE
E2E tests: always write report metadata

### DIFF
--- a/.github/files/e2e-tests/report-metadata.sh
+++ b/.github/files/e2e-tests/report-metadata.sh
@@ -14,5 +14,6 @@ if [[ -z "$SUITE" ]]; then
 	fi
 fi
 
+mkdir -p "$OUTPUT_PATH/output"
 jq -n --arg suite "$SUITE" '{suite:$suite}' >"$OUTPUT_PATH/output/report-metadata.json"
 cat "$OUTPUT_PATH/output/report-metadata.json"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -156,6 +156,7 @@ jobs:
         pnpm run test:run "${TEST_ARGS[@]}"
 
     - name: Write report metadata
+      if: ${{ always() }}
       env:
         SUITE: ${{ matrix.suite }}
         PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fix for report metadata not being written when tests or setup fails.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Check that `output/report-metadata.json` is written for failed tests

