### PR TITLE
 VideoPress: Add playback token for private videos

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-sync-video-tracks-data
+++ b/projects/packages/videopress/changelog/update-videopress-sync-video-tracks-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Sync video tracks data in video block

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
@@ -47,6 +47,8 @@ export type VideoBlockAttributes = VideoBlockColorAttributesProps & {
 	privacySetting?: number;
 	allowDownload?: boolean;
 	rating?: string;
+
+	isPrivate?: boolean;
 };
 
 export type VideoBlockSetAttributesProps = ( attributes: VideoBlockAttributes ) => void;

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
@@ -91,7 +91,7 @@ export function useSyncMedia(
 	setAttributes: VideoBlockSetAttributesProps
 ): UseSyncMediaProps {
 	const { id, guid } = attributes;
-	const { videoData, isRequestingVideoData } = useVideoData( { guid } );
+	const { videoData, isRequestingVideoData } = useVideoData( { id, guid } );
 
 	const isSaving = useSelect( select => select( editorStore ).isSavingPost(), [] );
 	const wasSaving = usePrevious( isSaving );

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
@@ -90,8 +90,8 @@ export function useSyncMedia(
 	attributes: VideoBlockAttributes,
 	setAttributes: VideoBlockSetAttributesProps
 ): UseSyncMediaProps {
-	const { id, guid } = attributes;
-	const { videoData, isRequestingVideoData } = useVideoData( { id, guid } );
+	const { id, guid, isPrivate } = attributes;
+	const { videoData, isRequestingVideoData } = useVideoData( { id, guid, isPrivate } );
 
 	const isSaving = useSelect( select => select( editorStore ).isSavingPost(), [] );
 	const wasSaving = usePrevious( isSaving );

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
@@ -90,8 +90,8 @@ export function useSyncMedia(
 	attributes: VideoBlockAttributes,
 	setAttributes: VideoBlockSetAttributesProps
 ): UseSyncMediaProps {
-	const { id, guid, isPrivate } = attributes;
-	const { videoData, isRequestingVideoData } = useVideoData( { id, guid, isPrivate } );
+	const { id, guid } = attributes;
+	const { videoData, isRequestingVideoData } = useVideoData( { id, guid } );
 
 	const isSaving = useSelect( select => select( editorStore ).isSavingPost(), [] );
 	const wasSaving = usePrevious( isSaving );

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/index.ts
@@ -3,6 +3,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useState } from '@wordpress/element';
+import getMediaToken from '../../../lib/get-media-token';
 /**
  * Types
  */
@@ -32,8 +33,11 @@ export default function useVideoData( {
 		async function fetchVideoItem() {
 			if ( guid ) {
 				try {
+					const { token } = await getMediaToken( 'playback', { id, guid } );
+					const params = token ? new URLSearchParams( { metadata_token: token } ).toString() : '';
+
 					const response: WPCOMRestAPIVideosGetEndpointResponseProps = await apiFetch( {
-						url: `https://public-api.wordpress.com/rest/v1.1/videos/${ guid }`,
+						url: `https://public-api.wordpress.com/rest/v1.1/videos/${ guid }?${ params }`,
 						credentials: 'omit',
 					} );
 

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/types.ts
@@ -3,6 +3,7 @@ import { VideoGUID, VideoId } from '../../blocks/video/types';
 export type UseVideoDataArgumentsProps = {
 	id?: VideoId;
 	guid?: VideoGUID;
+	isPrivate?: boolean;
 };
 
 export type videoDataProps = {

--- a/projects/packages/videopress/src/client/lib/get-media-token/index.ts
+++ b/projects/packages/videopress/src/client/lib/get-media-token/index.ts
@@ -1,40 +1,72 @@
+import { VideoGUID, VideoId } from '../../block-editor/blocks/video/types';
 import {
 	MediaTokenScopeProps,
 	MediaTokenScopeAdminAjaxResponseBodyProps,
-	mediaTokenProps,
+	MediaTokenProps,
 	MEDIA_TOKEN_SCOPES,
-	mediaTokenUploadActionProp,
+	AdminAjaxTokenProps,
+	GetMediaTokenArgsProps,
 } from './types';
 
 /**
  * Return media token data hiting the admin-ajax endpoint.
  *
- * @param {MediaTokenScopeProps} scope - The scope of the token to request.
- * @returns {mediaTokenProps} - The media token data.
+ * @param {MediaTokenScopeProps} scope  - The scope of the token to request.
+ * @param {GetMediaTokenArgsProps} args - function arguments
+ * @returns {MediaTokenProps}            Media token data.
  */
-const getMediaToken = function ( scope: MediaTokenScopeProps ): Promise< mediaTokenProps > {
+const getMediaToken = function (
+	scope: MediaTokenScopeProps,
+	args: GetMediaTokenArgsProps = {}
+): Promise< MediaTokenProps > {
+	const { id, guid } = args;
 	return new Promise( function ( resolve, reject ) {
 		if ( ! MEDIA_TOKEN_SCOPES.includes( scope ) ) {
 			return reject( 'Invalid scope' );
 		}
 
-		let adminAjaxAction: mediaTokenUploadActionProp;
+		let adminAjaxAction: AdminAjaxTokenProps;
+
+		const data: {
+			guid?: VideoGUID;
+			id?: VideoId;
+		} = {};
+
 		switch ( scope ) {
 			case 'upload':
 				adminAjaxAction = 'videopress-get-upload-token';
+				break;
+
+			case 'playback':
+				adminAjaxAction = 'videopress-get-playback-jwt';
+				data.id = id;
+				data.guid = guid;
 				break;
 		}
 
 		window.wp.media
 			.ajax( adminAjaxAction, {
 				async: true,
+				data,
 			} )
-			.done( ( response: MediaTokenScopeAdminAjaxResponseBodyProps ) => {
-				resolve( {
-					token: response.upload_token,
-					blogId: response.upload_blog_id,
-					url: response.upload_action_url,
-				} );
+			.then( ( response: MediaTokenScopeAdminAjaxResponseBodyProps ) => {
+				switch ( scope ) {
+					case 'upload':
+						resolve( {
+							token: response.upload_token,
+							blogId: response.upload_blog_id,
+							url: response.upload_action_url,
+						} );
+						break;
+
+					case 'playback':
+						resolve( { token: response.jwt } );
+						break;
+				}
+			} )
+			.catch( err => {
+				console.warn( 'Token is not achievable: "%s"', err?.message ?? err ); // eslint-disable-line no-console
+				resolve( { token: null } );
 			} );
 	} );
 };

--- a/projects/packages/videopress/src/client/lib/get-media-token/types.ts
+++ b/projects/packages/videopress/src/client/lib/get-media-token/types.ts
@@ -1,17 +1,35 @@
-export const MEDIA_TOKEN_SCOPES = [ 'upload' ] as const;
+/**
+ * Internal dependencies
+ */
+import { VideoGUID, VideoId } from '../../block-editor/blocks/video/types';
+
+export const MEDIA_TOKEN_SCOPES = [ 'upload', 'playback' ] as const;
 type MediaTokenScopesProps = typeof MEDIA_TOKEN_SCOPES;
 export type MediaTokenScopeProps = MediaTokenScopesProps[ number ];
 
-export type mediaTokenUploadActionProp = 'videopress-get-upload-token';
+export const TOKEN_ADMIN_AJAX_TYPES = [
+	'videopress-get-upload-token',
+	'videopress-get-playback-jwt',
+] as const;
+
+type AdminAjaxTokensProps = typeof TOKEN_ADMIN_AJAX_TYPES;
+
+export type GetMediaTokenArgsProps = {
+	id?: VideoId;
+	guid?: VideoGUID;
+};
+
+export type AdminAjaxTokenProps = AdminAjaxTokensProps[ number ];
 
 export type MediaTokenScopeAdminAjaxResponseBodyProps = {
 	upload_token: string;
 	upload_blog_id: string;
 	upload_action_url: string;
+	jwt: string;
 };
 
-export type mediaTokenProps = {
+export type MediaTokenProps = {
 	token: string;
-	blogId: string;
-	url: string;
+	blogId?: string;
+	url?: string;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds a playback token to the v1.1/videos endpoint when getting data for private videos.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: Add playback token for private videos

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to block editor
* Add/edit a video block
* Set block as private
<img width="474" alt="Screen Shot 2022-11-21 at 19 10 39" src="https://user-images.githubusercontent.com/77539/203168536-68e3b9ac-8a2b-44e5-ba11-08c6ecf2f039.png">
* Save the post
* Hard refresh
* Open network tab
* filter the requests by `v1.1/videos`

* **Before**: confirm the app hits the `v1.1/videos/<guid>` getting `401` error
<img width="704" alt="image" src="https://user-images.githubusercontent.com/77539/203169150-449d953a-0851-4df8-a43d-de0b297694f2.png">

* **After**: the app performs the request adding the token to the query string


