### PR TITLE
VideoPress: Remove resize circle on block

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-block-right-resize
+++ b/projects/packages/videopress/changelog/update-videopress-block-right-resize
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: Remove extra resize circle on block

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-player/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-player/index.js
@@ -190,12 +190,12 @@ export default function VideoPressPlayer( {
 				enable={ {
 					top: false,
 					bottom: false,
-					left: true,
+					left: false,
 					right: true,
 				} }
 				maxWidth="100%"
 				size={ { width: maxWidth } }
-				style={ { margin: 'auto' } }
+				style={ { marginRight: 'auto' } }
 				onResizeStop={ onBlockResize }
 				onResizeStart={ () => setVideoPlayerTemporaryHeightState( 'auto' ) }
 			>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27437

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes the *left* resize circle to match the image block

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Block Editor
* Add a VideoPress block
* Check that the left resize circle was removed and the video is left-aligned

https://user-images.githubusercontent.com/8486249/202731781-f7f44546-c494-4692-87d2-2f99a3b63a43.mp4
