### PR TITLE
VideoPress: Update author for Jetpack VideoPress plugin

### DIFF
--- a/projects/plugins/videopress/changelog/update-author-for-videopress-plugin
+++ b/projects/plugins/videopress/changelog/update-author-for-videopress-plugin
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Just changed author in Jetpack VideoPress plugin file
+
+

--- a/projects/plugins/videopress/jetpack-videopress.php
+++ b/projects/plugins/videopress/jetpack-videopress.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://wordpress.org/plugins/jetpack-videopress
  * Description: High quality, ad-free video.
  * Version: 1.0.1-alpha
- * Author: Automattic
+ * Author: Automattic - Jetpack Video team
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later
  * Text Domain: jetpack-videopress

--- a/projects/plugins/videopress/jetpack-videopress.php
+++ b/projects/plugins/videopress/jetpack-videopress.php
@@ -6,7 +6,7 @@
  * Description: High quality, ad-free video.
  * Version: 1.0.1-alpha
  * Author: Automattic - Jetpack Video team
- * Author URI: https://jetpack.com/
+ * Author URI: https://jetpack.com/videopress/
  * License: GPLv2 or later
  * Text Domain: jetpack-videopress
  *


### PR DESCRIPTION
Updates the author from Automattic to `Automattic - Jetpack Video team` and the link url to `https://jetpack.com/videopress/`

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates plugin file headers author field.
* Updates plugin file headers Author URI field.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

p1HpG7-iZ6-p2#comment-58363

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Just check the changes make sense