### PR TITLE
Update/wpcom gifting subscription option

### DIFF
--- a/projects/plugins/jetpack/changelog/update-wpcom_gifting_subscription-option
+++ b/projects/plugins/jetpack/changelog/update-wpcom_gifting_subscription-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Update how wpcom_gifting_subscription is saved so an option value of false can be created

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -900,13 +900,22 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 				case 'wpcom_gifting_subscription':
 					$coerce_value = (bool) $value;
-					// get_option returns false if the option doesn't exist, otherwise it returns a string value.
+
+					/*
+					 * get_option returns a boolean false if the option doesn't exist, otherwise it always returns
+					 * a serialized value. Knowing that we can check if the option already exists.
+					 */
 					$gift_toggle = get_option( $key );
-					// If the option doesn't exist, we add it and set the value to the inverse of auto_renew.
-					if ( $gift_toggle === false ) {
-						add_option( $key, $coerce_value );
+					if ( false === $gift_toggle ) {
+						// update_option will not create a new option if the initial value is false. So use add_option.
+						if ( add_option( $key, $coerce_value ) ) {
+							$updated[ $key ] = $coerce_value;
+						}
 					} else {
-						update_option( $key, $coerce_value );
+						// If the option already exists use update_option.
+						if ( update_option( $key, $coerce_value ) ) {
+							$updated[ $key ] = $coerce_value;
+						}
 					}
 					break;
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -892,10 +892,21 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 				case 'wpcom_publish_posts_with_markdown':
 				case 'wpcom_publish_comments_with_markdown':
-				case 'wpcom_gifting_subscription':
 					$coerce_value = (bool) $value;
 					if ( update_option( $key, $coerce_value ) ) {
 						$updated[ $key ] = $coerce_value;
+					}
+					break;
+
+				case 'wpcom_gifting_subscription':
+					$coerce_value = (bool) $value;
+					// get_option returns false if the option doesn't exist, otherwise it returns a string value.
+					$gift_toggle = get_option( $key );
+					// If the option doesn't exist, we add it and set the value to the inverse of auto_renew.
+					if ( $gift_toggle === false ) {
+						add_option( $key, $coerce_value );
+					} else {
+						update_option( $key, $coerce_value );
 					}
 					break;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes # p1668722424909449/1668705874.008579-slack-CKZHG0QCR

This PR is an alternative to switching the values of `wpcom_gifting_subscription` to `on|off`. The benefit of this PR is we don't have to update any other code outside of this PR to fix the toggle bug.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* `update_option` will not create a new option if the initial value is `false`. [Reference](https://developer.wordpress.org/reference/functions/update_option/#comment-2396). To remedy this for the `wpcom_gifting_subscription` option we first check if the option exists. If it doesn't we `add_option`. If it does we `update_option`.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See Slack thread referenced above.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In `wpcom` in your sandbox run: `bin/jetpack-downloader test jetpack update/wpcom_gifting_subscription-option`
* Sandbox the API.
* Use any site with a plan > Personal.
* Turn off Auto-Renew for that site's plan.
* Make sure the `wpcom_gifting_subscription` option does not exist for that site by running `delete_blog_option(123456789, 'wpcom_gifting_subscription');` in `wp shell` in your Sandbox.
  * For Atomic sites SSH into your site and run `delete_option('wpcom_gifting_subscription');`
* Go to Settings > General
* Observe that the Gifting Toggle is ON. (Because we turned off Auto-Renew and the default value of the toggle is the inverse of auto-renew.)
* Turn the Gifting Toggle OFF and Save it.
* Refresh the page and observe the Toggle is still OFF.
* Play around this issue
* Observe that the front end Gifting Banner still works.