### PR TITLE
Fix "Cannot read properties of undefined (reading '_jetpack_newsletter_access" error "in site editor

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -19,7 +19,7 @@ import { isNewsletterFeatureEnabled } from './utils';
 
 export default function SubscribePanels() {
 	const [ subscriberCount, setSubscriberCount ] = useState( null );
-	const [ postMeta, setPostMeta ] = useEntityProp( 'postType', 'post', 'meta' );
+	const [ postMeta = [], setPostMeta ] = useEntityProp( 'postType', 'post', 'meta' );
 
 	const accessLevel =
 		postMeta[ META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS ] ?? Object.keys( accessOptions )[ 0 ];


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/70181

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* `useEntityProp` can return undefined. To prevent errors add a default state


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Set up a WPCOM site with this Jetpack branch
2. Set up payments, and a newsletter plan in wordpress.com/earn
3. Activate Lettre theme: https://wordpress.com/theme/lettre/
4. Load site editor https://wordpress.com/site-editor/${site_name}
5. There should be no "Cannot read properties of undefined (reading '_jetpack_newsletter_access" in the console ( like below ).

![Zrzut ekranu 2022-11-18 o 17 18 22](https://user-images.githubusercontent.com/3775068/202752309-89bd7946-331d-435e-a946-a52245304af7.png)
