### PR TITLE
Add placeholder editor on jetpack inputs

### DIFF
--- a/projects/plugins/jetpack/changelog/add-placeholder-editor-on-jetpack-inputs
+++ b/projects/plugins/jetpack/changelog/add-placeholder-editor-on-jetpack-inputs
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Enable placeholder edit on input blocks inspector

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-controls.js
@@ -58,7 +58,10 @@ const JetpackFieldControls = ( { setAttributes, width, id, required, placeholder
 						label={ __( 'Placeholder text', 'jetpack' ) }
 						value={ placeholder }
 						onChange={ value => setAttributes( { placeholder: value } ) }
-						help={ __( 'Show visitors an example of the type of content expected. Otherwise, leave blank.', 'jetpack' ) }
+						help={ __(
+							'Show visitors an example of the type of content expected. Otherwise, leave blank.',
+							'jetpack'
+						) }
 					/>
 
 					<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-controls.js
@@ -3,14 +3,21 @@ import {
 	InspectorControls,
 	BlockControls,
 } from '@wordpress/block-editor';
-import { PanelBody, ToggleControl, ToolbarGroup, ToolbarButton, Path } from '@wordpress/components';
+import {
+	PanelBody,
+	TextControl,
+	ToggleControl,
+	ToolbarGroup,
+	ToolbarButton,
+	Path,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import renderMaterialIcon from '../../../shared/render-material-icon';
 import JetpackFieldCss from './jetpack-field-css';
 import JetpackFieldWidth from './jetpack-field-width';
 import JetpackManageResponsesSettings from './jetpack-manage-responses-settings';
 
-const JetpackFieldControls = ( { setAttributes, width, id, required } ) => {
+const JetpackFieldControls = ( { setAttributes, width, id, required, placeholder } ) => {
 	return (
 		<>
 			<BlockControls>
@@ -45,6 +52,13 @@ const JetpackFieldControls = ( { setAttributes, width, id, required } ) => {
 							'Does this field have to be completed for the form to be submitted?',
 							'jetpack'
 						) }
+					/>
+
+					<TextControl
+						label={ __( 'Placeholder', 'jetpack' ) }
+						value={ placeholder }
+						onChange={ value => setAttributes( { placeholder: value } ) }
+						help={ __( 'Optional - show an example of the expected value', 'jetpack' ) }
 					/>
 
 					<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-controls.js
@@ -55,10 +55,10 @@ const JetpackFieldControls = ( { setAttributes, width, id, required, placeholder
 					/>
 
 					<TextControl
-						label={ __( 'Placeholder', 'jetpack' ) }
+						label={ __( 'Placeholder text', 'jetpack' ) }
 						value={ placeholder }
 						onChange={ value => setAttributes( { placeholder: value } ) }
-						help={ __( 'Optional - show an example of the expected value', 'jetpack' ) }
+						help={ __( 'Show visitors an example of the type of content expected. Otherwise, leave blank.', 'jetpack' ) }
 					/>
 
 					<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-textarea.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-textarea.js
@@ -25,6 +25,7 @@ export default function JetpackFieldTextarea( props ) {
 				required={ required }
 				setAttributes={ setAttributes }
 				width={ width }
+				placeholder={ placeholder }
 			/>
 		</>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field.js
@@ -28,6 +28,7 @@ export default function JetpackField( props ) {
 				required={ required }
 				width={ width }
 				setAttributes={ setAttributes }
+				placeholder={ placeholder }
 			/>
 		</>
 	);


### PR DESCRIPTION
This change will enable placeholder editing on Jetpack Form inputs/fields

![placeholder](https://user-images.githubusercontent.com/157240/202858462-b5a14580-1f5c-4b46-9bba-9ccb66983139.gif)

Fixes #27513

#### Changes proposed in this Pull Request:
Add a text control on input blocks inspector to change the placeholder

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?


#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Add any input, and look at the sidebar. There should be a new entry to edit its placeholder

Please, add one of each available inputs and see they all work fine in the editor and on published view