### PR TITLE
Fix/boost prompt to support

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/api/speed-scores.ts
+++ b/projects/plugins/boost/app/assets/src/js/api/speed-scores.ts
@@ -210,7 +210,7 @@ export type ScoreChangeMessage = {
 	ctaLink: string;
 };
 
-export function scoreChangeModal( scores: SpeedScoresSet ): ScoreChangeMessage {
+export function scoreChangeModal( scores: SpeedScoresSet ): ScoreChangeMessage | null {
 	const changePercentage = getScoreMovementPercentage( scores );
 	if ( changePercentage > 5 ) {
 		return {
@@ -220,7 +220,7 @@ export function scoreChangeModal( scores: SpeedScoresSet ): ScoreChangeMessage {
 			cta: __( 'Rate the Plugin', 'jetpack-boost' ),
 			ctaLink: 'https://wordpress.org/support/plugin/jetpack-boost/reviews/#new-post',
 		};
-	} else if ( changePercentage < -5 ) {
+	} else if ( changePercentage < -5 && Jetpack_Boost.preferences.prioritySupport ) {
 		return {
 			id: 'score-decrease',
 			title: __( 'Speed score has fallen', 'jetpack-boost' ),
@@ -232,4 +232,6 @@ export function scoreChangeModal( scores: SpeedScoresSet ): ScoreChangeMessage {
 			ctaLink: SupportUrl,
 		};
 	}
+
+	return null;
 }

--- a/projects/plugins/boost/changelog/fix-boost-prompt-to-support
+++ b/projects/plugins/boost/changelog/fix-boost-prompt-to-support
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Don't invite free users to contact premium support


### PR DESCRIPTION
Fixes p1668625699105059-slack-C016BBAFHHS

#### Changes proposed in this Pull Request:
* Remove a link to contact premium support from the ui for free users.

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Rig your site to drop your speed score.
* Verify that no popup appears when no plan purchased.
* Verify that a prompt to contact support appears when a plan has been purchased.