### PR TITLE
VideoPress: Update list of plans that support VideoPress

### DIFF
--- a/projects/packages/videopress/changelog/add-update-list-of-plans-that-support-videopress
+++ b/projects/packages/videopress/changelog/add-update-list-of-plans-that-support-videopress
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Updated the list of plans that have VideoPress included.

--- a/projects/packages/videopress/src/client/admin/hooks/use-plan/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-plan/index.ts
@@ -52,7 +52,36 @@ export const usePlan = (): usePlanProps => {
 		'jetpack_videopress_monthly',
 		'jetpack_complete',
 		'jetpack_complete_monthly',
+		'jetpack_business',
+		'jetpack_business_monthly',
+		'jetpack_personal',
+		'jetpack_personal_monthly',
+		'jetpack_premium',
+		'jetpack_premium_monthly',
+		'videopress',
+		'videopress-pro',
+		'wp_p2_plus_monthly',
+
+		// WPCOM Premium plans
+		'bundle_pro',
+		'value_bundle',
+		'value_bundle_monthly',
+		'value_bundle-2y',
+
+		// WPCOM PRO plans
+		'pro-plan',
+		'pro-plan-monthly',
+		'pro-plan-2y',
+
+		// WPCOM Business plans
 		'business-bundle',
+		'business-bundle-monthly',
+		'business-bundle-2y',
+
+		// WPCOM eCommerce plans
+		'ecommerce-bundle',
+		'ecommerce-bundle-monthly',
+		'ecommerce-bundle-2y',
 	].some( plan => hasPurchase( plan ) );
 
 	return {

--- a/projects/packages/videopress/src/client/admin/hooks/use-plan/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-plan/index.ts
@@ -52,6 +52,7 @@ export const usePlan = (): usePlanProps => {
 		'jetpack_videopress_monthly',
 		'jetpack_complete',
 		'jetpack_complete_monthly',
+		'business-bundle',
 	].some( plan => hasPurchase( plan ) );
 
 	return {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27524.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updated the list of plans that supports VideoPress using the WPCOM feature class (`class-wpcom-features.php`) as reference for the list

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

N/A