### PR TITLE
tools, actions: Add `prerelease` branch

### DIFF
--- a/.github/files/gh-autotagger/workflows/autotagger.yml
+++ b/.github/files/gh-autotagger/workflows/autotagger.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - trunk
+      - prerelease
       - '*/branch-*'
 
 jobs:
@@ -33,11 +34,11 @@ jobs:
           if [[ -e composer.json ]]; then
             PREFIX=$(jq -r '.extra["release-branch-prefix"] // ""' composer.json)
           fi
-          if [[ -z "$PREFIX" && "$GITHUB_REF" != "refs/heads/trunk" ]]; then
-            echo "::error::Expected to be called for \"refs/heads/trunk\", not \"$GITHUB_REF\""
+          if [[ -z "$PREFIX" && "$GITHUB_REF" != "refs/heads/trunk" && "$GITHUB_REF" != "refs/heads/prerelease" ]]; then
+            echo "::error::Expected to be called for \"refs/heads/trunk\" or \"refs/heads/prerelease\", not \"$GITHUB_REF\""
             exit 1
-          elif [[ -n "$PREFIX" && "$GITHUB_REF" == "refs/heads/trunk" ]]; then
-            echo "::notice::Ignoring push to trunk, as this project has a release branch prefix set (\"$PREFIX\")"
+          elif [[ -n "$PREFIX" && ( "$GITHUB_REF" == "refs/heads/trunk" || "$GITHUB_REF" == "refs/heads/prerelease" ) ]]; then
+            echo "::notice::Ignoring push to $GITHUB_REF, as this project has a release branch prefix set (\"$PREFIX\")"
             echo "run=false" >> "$GITHUB_OUTPUT"
           elif [[ -n "$PREFIX" && "$GITHUB_REF" != "refs/heads/$PREFIX/branch-"* ]]; then
             echo "::error::Expected to be called for \"refs/heads/$PREFIX/branch-*\", not \"$GITHUB_REF\""

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 'trunk'
+      - 'prerelease'
       # The `**/*/` works around the fact that GitHub considers a leading `**/` as meaning "zero or more path components" where we want "one or more".
       - '**/*/branch-**'
   pull_request:

--- a/.github/workflows/delete-mirror-branches.yml
+++ b/.github/workflows/delete-mirror-branches.yml
@@ -12,7 +12,8 @@ jobs:
     if: github.event_name == 'delete' && github.repository == 'Automattic/jetpack'
     steps:
       - uses: actions/checkout@v3
-        ref: trunk
+        with:
+          ref: trunk
       - name: Delete branches
         env:
           TOKEN: ${{ secrets.API_TOKEN_GITHUB }}

--- a/.github/workflows/delete-mirror-branches.yml
+++ b/.github/workflows/delete-mirror-branches.yml
@@ -1,0 +1,26 @@
+name: Delete mirror branches
+on:
+  delete:
+    branches:
+      - 'prerelease'
+
+jobs:
+  delete:
+    name: Delete `${{ github.event.ref }}`
+    runs-on: ubuntu-latest
+    timeout-minutes: 5  # 2022-11-21: Shouldn't take long.
+    if: github.event_name == 'delete' && github.repository == 'Automattic/jetpack'
+    steps:
+      - uses: actions/checkout@v3
+        ref: trunk
+      - name: Delete branches
+        env:
+          TOKEN: ${{ secrets.API_TOKEN_GITHUB }}
+          REF: heads/${{ github.event.ref }}
+        run: |
+          for repo in $(jq -r '.extra["mirror-repo"] // empty' projects/*/*/composer.json | sort -u); do
+            echo "::group::Deleting $REF on $repo"
+            RES="$(curl -v -L -X DELETE --header "Authorization: Bearer $TOKEN" "https://api.github.com/repos/$repo/git/refs/$REF")"
+            echo '::endgroup::'
+            echo "$RES"
+          done

--- a/.github/workflows/delete-mirror-branches.yml
+++ b/.github/workflows/delete-mirror-branches.yml
@@ -1,15 +1,13 @@
 name: Delete mirror branches
 on:
   delete:
-    branches:
-      - 'prerelease'
 
 jobs:
   delete:
     name: Delete `${{ github.event.ref }}`
     runs-on: ubuntu-latest
     timeout-minutes: 5  # 2022-11-21: Shouldn't take long.
-    if: github.event_name == 'delete' && github.repository == 'Automattic/jetpack'
+    if: github.event_name == 'delete' && github.repository == 'Automattic/jetpack' && github.event.ref == 'prerelease'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/slack-branch-existence-notification.yml
+++ b/.github/workflows/slack-branch-existence-notification.yml
@@ -1,16 +1,14 @@
-name: Slack prerelease branch notification
+name: Slack branch existence notification
 on:
   create:
-    branches:
-      - 'prerelease'
   delete:
-    branches:
-      - 'prerelease'
 
 jobs:
   notify:
     name: Notify
     runs-on: ubuntu-latest
+    timeout-minutes: 5  # 2022-11-22: Shouldn't take long.
+    if: github.event.ref == 'prerelease'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/slack-prerelease-branch-notification.yml
+++ b/.github/workflows/slack-prerelease-branch-notification.yml
@@ -1,0 +1,67 @@
+name: Slack prerelease branch notification
+on:
+  create:
+    branches:
+      - 'prerelease'
+  delete:
+    branches:
+      - 'prerelease'
+
+jobs:
+  notify:
+    name: Notify
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: trunk
+      - name: Generate message
+        id: message
+        run: |
+          source .github/files/gh-funcs.sh
+
+          if [[ "$GITHUB_EVENT_NAME" == 'create' ]]; then
+            gh_set_output message "$(
+              jq -nc --slurpfile event "$GITHUB_EVENT_PATH" '$event[0] as $e | {
+                icon_emoji: ":lock:",
+                text: "Incoming release! Prerelease branch was created by \( $e.sender.login ).",
+                blocks: [
+                  {
+                    type: "section",
+                    text: {
+                      type: "mrkdwn",
+                      text: ":holdontoyourbutts: Incoming release! Prerelease branch was created by \( $e.sender.login ).",
+                    },
+                  }
+                ],
+              }'
+            )"
+          elif [[ "$GITHUB_EVENT_NAME" == 'delete' ]]; then
+            gh_set_output message "$(
+              jq -nc --slurpfile event "$GITHUB_EVENT_PATH" '$event[0] as $e | {
+                icon_emoji: ":unlock:",
+                text: "Prerelease branch was deleted by \( $e.sender.login ).",
+                blocks: [
+                  {
+                    type: "section",
+                    text: {
+                      type: "mrkdwn",
+                      text: "Prerelease branch was deleted by \( $e.sender.login ).",
+                    },
+                  }
+                ],
+              }'
+            )"
+          else
+            echo "::error::Unknown event \"$GITHUB_EVENT_NAME\""
+            exit 1
+          fi
+
+      - name: Send message to releases channel
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: ${{ secrets.SLACK_RELEASES_CHANNEL }}
+          payload: ${{ steps.message.outputs.message }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/slack-workflow-failed.yml
+++ b/.github/workflows/slack-workflow-failed.yml
@@ -9,7 +9,7 @@ on:
       - Tests
       - Gardening
       - PR is up-to-date
-    branches: [ 'trunk', '*/branch-*' ]
+    branches: [ 'trunk', 'prerelease', '*/branch-*' ]
 
 jobs:
   notify:
@@ -101,7 +101,7 @@ jobs:
 
       - name: Send message to releases channel
         uses: slackapi/slack-github-action@v1.23.0
-        if: contains( github.event.workflow_run.head_branch, '/branch-' )
+        if: contains( github.event.workflow_run.head_branch, '/branch-' ) || github.event.workflow_run.head_branch == 'prerelease'
         with:
           channel-id: ${{ secrets.SLACK_RELEASES_CHANNEL }}
           payload: ${{ steps.message.outputs.message }}

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -15,7 +15,8 @@ For example, you can run: `git checkout trunk` and then `git checkout -b fix/wha
 
 The Jetpack repo uses the following "reserved" branch name conventions:
 
-* `{something}/branch-{X.Y|something}` -- Used for release branches
+* `prerelease` -- Used for the release process.
+* `{something}/branch-{X.Y|something}` -- Used for release branches.
 * `feature/{something}` -- Used for feature branches for larger feature projects when anticipated there will be multiple PRs into that feature branch.
 
 ## Mind your commits

--- a/tools/cli/commands/release.js
+++ b/tools/cli/commands/release.js
@@ -136,7 +136,7 @@ export async function scriptRouter( argv ) {
 				argv.scriptArgs.unshift( '-b' );
 			}
 			argv.addPrNum && argv.scriptArgs.unshift( '-p' );
-			argv.next = `Finished! Next: \n	- Create a new branch off trunk, review the changes, make any necessary adjustments. \n	- Commit your changes. \n	- To continue with the release process, update the readme.txt by running:\n		jetpack release ${ argv.project } readme \n`;
+			argv.next = `Finished! Next: \n	- Create the "prerelease" branch off trunk, review the changes, make any necessary adjustments. \n	- Commit your changes. \n	- To continue with the release process, update the readme.txt by running:\n		jetpack release ${ argv.project } readme \n`;
 			break;
 		case 'readme':
 			argv.script = `tools/plugin-changelog-to-readme.sh`;
@@ -145,7 +145,7 @@ export async function scriptRouter( argv ) {
 				  - If this is a beta, ensure the stable tag in readme.txt is latest stable.
 				  - Create a PR and have your changes reviewed and merged.
 				  - Wait and make sure changes are propagated to mirror repos for each updated package.
-				  - After propagation, if you need to create a release branch, stand on trunk and then run:
+				  - After propagation, if you need to create a release branch, stand on "prerelease" and then run:
 				      jetpack release ${ argv.project } release-branch \n`.replace( /^\t+/gm, '' );
 			break;
 		case 'release-branch':

--- a/tools/create-release-branch.sh
+++ b/tools/create-release-branch.sh
@@ -75,11 +75,11 @@ if [[ "$(git status --porcelain)" ]]; then
 	die "Working directory is not clean. Aborting."
 fi
 
-# Make sure we're on latest trunk, or at least that the user is fine with it.
+# Make sure we're on the prerelease branch, or at least that the user is fine with it.
 git fetch
-if [[ "$(git rev-parse --abbrev-ref HEAD)" != "trunk" ]]; then
-	if proceed_p "Current branch is $(git rev-parse --abbrev-ref HEAD)." "Check out trunk?"; then
-		git checkout trunk
+if [[ "$(git rev-parse --abbrev-ref HEAD)" != "prerelease" ]]; then
+	if proceed_p "Current branch is $(git rev-parse --abbrev-ref HEAD)." "Check out prerelease branch?"; then
+		git checkout prerelease
 	else
 		proceed_p " " "Continue anyway?"
 	fi

--- a/tools/js-tools/git-hooks/pre-push-hook.js
+++ b/tools/js-tools/git-hooks/pre-push-hook.js
@@ -34,6 +34,10 @@ function checkChangelogFiles() {
 		console.log( chalk.green( 'Release branch detected. Skipping changelog test.' ) );
 		return;
 	}
+	if ( currentBranch === 'prerelease' ) {
+		console.log( chalk.green( 'Prerelease branch detected. Skipping changelog test.' ) );
+		return;
+	}
 
 	// Check if any changelog files are needed.
 	const needChangelog = spawnSync(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The `prerelease` branch will be used during releases instead of the release lock.

* Build workflow will run on pushes to "prerelease" in addition to "trunk".
  * This includes pushes to mirror repos.
* Autotagger will now autotag from "prerelease" in addition to "trunk".
* Slack ping will ping the releases channel for failures on the prerelease branch.
* Adjusted some text for `jetpack release` subcommands.
* `create-release-branch.sh` script will now expect to be run from the prerelease branch, not trunk.
* Pre-push hook will not prompt for change entries for the prerelease branch.
* Deletion of the prerelease branch in the monorepo will trigger deletion of the branch in mirrors too.

Note this does not run tests on pushes to the prerelease branch. The intent is that the branch will be merged into trunk in the end, which will run the tests at that point.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
PT: p9dueE-6h2-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Fork the monorepo and merge this into its trunk branch.
  * Push a `prerelease` branch and see if a build is run.
  * Delete the `prerelease` branch and see if the new workflow runs. It won't do anything since it's on a fork, but it should run.
  * Create and delete some other branch, make sure the new workflow does not run.
* Merge this.
  * Push a `prerelease` branch, it should push that branch to the mirrors.
  * Delete the branch and check that the branch is deleted from the mirrors.
  * Push a `prerelease` branch that contains a release of some project (e.g. push-to-mirrors could use a release). Check that the autotagger runs and tags correctly.
  * Make a PR from the `prerelease` branch and merge it, which should automatically delete the branch too. The deletion workflow should run, deleting the `prerelease` branch from the mirror, while the tag in the mirror should remain as it was in the previous step.