### PR TITLE
Stats: Fix stats admin page loading indefinitely when a hashtag exists

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-stats-loading-dead-loop
+++ b/projects/plugins/jetpack/changelog/fix-stats-loading-dead-loop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Stats: stop stats loading indefinitely when a hashtag exists

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -393,7 +393,9 @@ function stats_js_load_page_via_ajax() {
 /* <![CDATA[ */
 if ( -1 == document.location.href.indexOf( 'noheader' ) ) {
 	jQuery( function( $ ) {
-		$.get( document.location.href + '&noheader', function( responseText ) {
+		const loadStatsUrl = new URL( document.location.href );
+		loadStatsUrl.searchParams.append( 'noheader', 1 );
+		$.get( loadStatsUrl.toString(), function( responseText ) {
 			$( '#stats-loading-wrap' ).replaceWith( responseText );
 			$( '#jp-stats-wrap' )[0].dispatchEvent( new Event( 'stats-loaded' ) );
 		} );


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/pull/27431#pullrequestreview-1183188651

#### Changes proposed in this Pull Request:
When a hashtag exists in the URL, the Stats dashboard loads itself indefinitely, more information could found in the [comment](https://github.com/Automattic/jetpack/pull/27431#pullrequestreview-1183188651).

The PR use `URL` to append `noheader` to URL to fix the issue.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Go to a connected site with Jetpack plugin
* Open `/wp-admin/admin.php?page=stats#whatever`
* Ensure the page loads normally

