### PR TITLE
Fix error in visibility setting for WooCommerce product categories block

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-visibility-for-product-categories-block
+++ b/projects/plugins/jetpack/changelog/fix-visibility-for-product-categories-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Widget Visibility: Fix error ocurring for WooCommerce Product Categories block

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -162,6 +162,7 @@ class Jetpack_Widget_Conditions {
 			'core/tag-cloud',
 			'core/page-list',
 			'core/latest-posts',
+			'woocommerce/product-categories',
 		);
 
 		$filter_metadata_registration = function ( $settings, $metadata ) use ( $blocks_to_add_visibility_conditions ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/62337

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
In this PR, I propose to fix an error that pops out in WooCommerce Product Categories block visibility settings. 

I fixed it previously in https://github.com/woocommerce/woocommerce-blocks/pull/6875, but the issue came back again. After reviewing the code, I may think that the previous fix was incomplete. However, it worked at that time.

In this PR I'm adding a block explicitly to the other condition, so it should properly define the `conditions` attribute for the product categories block now.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Ensure Jetpack from this PR is installed on the test site (pull branch on local development environment or use [Jetpack Beta](https://jetpack.com/download-jetpack-beta/) in any environment) and that plugin is connected to Jetpack
2. Install the WooCommerce plugin
3. Install the Storefront theme or another theme that uses widgets
4. Enable "Enable widget visibility controls to display widgets only on particular posts or pages” in Jetpack settings, the Writing tab
5. Navigate to Appearance -> Widgets
6. Add Product Categories List widget
7. In the right sidebar, open the Advanced block
8. Click “Add new rule”
9. Confirm that the visibility form is shown and there is no JS error

Before th fix, JS error was thrown in the console and content of right sidebar disappeared.