### PR TITLE
E2E tests: run tests with the latest Gutenberg on push instead of schedule

### DIFF
--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -90,27 +90,24 @@ switch ( process.env.GITHUB_EVENT_NAME ) {
 			}
 
 			if ( repoName === 'jetpack-production' ) {
-				matrix.push( {
-					project: 'Jetpack on Atomic',
-					path: 'projects/plugins/jetpack/tests/e2e',
-					testArgs: [ 'blocks', '--retries=1' ],
-					suite: 'atomic',
-				} );
+				matrix.push(
+					{
+						project: 'Jetpack on Atomic',
+						path: 'projects/plugins/jetpack/tests/e2e',
+						testArgs: [ 'blocks', '--retries=1' ],
+						suite: 'atomic',
+					},
+					{
+						project: 'Blocks with latest Gutenberg',
+						path: 'projects/plugins/jetpack/tests/e2e',
+						testArgs: [ 'blocks', '--retries=1' ],
+						suite: 'gutenberg',
+					}
+				);
 			}
 		} else {
 			// eslint-disable-next-line no-console
 			console.error( 'Undefined DISPATCH_REPO!' );
-		}
-		break;
-	case 'schedule':
-		// gutenberg scheduled run
-		if ( process.env.CRON === '0 */12 * * *' ) {
-			matrix.push( {
-				project: 'Jetpack with Gutenberg',
-				path: 'projects/plugins/jetpack/tests/e2e',
-				testArgs: [ 'blocks', '--retries=1' ],
-				suite: 'gutenberg',
-			} );
 		}
 		break;
 	default:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,8 +8,6 @@ on:
     branches: [ 'trunk', '*/branch-*' ]
     paths-ignore:
     - '**.md'
-  schedule:
-    - cron: '0 */12 * * *' # gutenberg run, every 12 hours - if you update this, also update it in .github/files/e2e-tests/create-e2e-projects-matrix.sh
   workflow_run:
     types: [completed]
     workflows: ["Build"]


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

Switch the e2e tests with the latest Gutenberg from running on every 12 hours to running on updates in `jetpack-production` mirror repo.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
p1669112646757509-slack-C03QNBQKG73

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* "Blocks with latest Gutenberg" job runs after merge.