### PR TITLE
VideoPress: improve when re-rendering the video player

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-improve-invalidation-proccess
+++ b/projects/packages/videopress/changelog/update-videopress-improve-invalidation-proccess
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: improve when re-rendering the video player

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
@@ -179,16 +179,11 @@ export function useSyncMedia(
 			// Update local state with fresh video data.
 			updateInitialState( dataToUpdate );
 
-			// Re-render video player once the data has been updated.
-			const videoPressUrl = getVideoPressUrl( guid, attributes );
-			invalidateResolution( 'getEmbedPreview', [ videoPressUrl ] );
-		} );
-
-		// | Video Chapters feature |
-		if ( attributes?.guid && dataToUpdate?.description?.length ) {
 			// Upload .vtt file if its description contains chapters
 			const chapters = extractVideoChapters( dataToUpdate.description );
-			if ( chapters?.length ) {
+
+			// | Video Chapters feature |
+			if ( attributes?.guid && dataToUpdate?.description?.length && chapters?.length ) {
 				const track: UploadTrackDataProps = {
 					label: __( 'English', 'jetpack-videopress-pkg' ),
 					srcLang: 'en',
@@ -209,12 +204,14 @@ export function useSyncMedia(
 						],
 					} );
 				} );
-			}
-		}
 
-		// Re-render video player
-		const videoPressUrl = getVideoPressUrl( guid, attributes );
-		invalidateResolution( 'getEmbedPreview', [ videoPressUrl ] );
+				const videoPressUrl = getVideoPressUrl( guid, attributes );
+				invalidateResolution( 'getEmbedPreview', [ videoPressUrl ] );
+			} else {
+				const videoPressUrl = getVideoPressUrl( guid, attributes );
+				invalidateResolution( 'getEmbedPreview', [ videoPressUrl ] );
+			}
+		} );
 	}, [
 		isSaving,
 		wasSaving,

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
@@ -203,10 +203,10 @@ export function useSyncMedia(
 							},
 						],
 					} );
-				} );
 
-				const videoPressUrl = getVideoPressUrl( guid, attributes );
-				invalidateResolution( 'getEmbedPreview', [ videoPressUrl ] );
+					const videoPressUrl = getVideoPressUrl( guid, attributes );
+					invalidateResolution( 'getEmbedPreview', [ videoPressUrl ] );
+				} );
 			} else {
 				const videoPressUrl = getVideoPressUrl( guid, attributes );
 				invalidateResolution( 'getEmbedPreview', [ videoPressUrl ] );

--- a/projects/packages/videopress/src/client/block-editor/plugins/video-chapters/utils/extract-video-chapters.ts
+++ b/projects/packages/videopress/src/client/block-editor/plugins/video-chapters/utils/extract-video-chapters.ts
@@ -50,6 +50,10 @@ function extractSingleChapter( line: string ): VideoPressChapter | null {
  * @returns {Array<VideoPressChapter>} - Title and start time of all chapters, sorted by start time
  */
 export default function extractVideoChapters( text: string ): Array< VideoPressChapter > {
+	if ( ! text ) {
+		return [];
+	}
+
 	const lines = text.split( '\n' );
 
 	const chapters = lines


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR improves how to invalidate the embedded data, meaning how to app re-renders the player of the video block.  With these changes, it re-renders the player when the video data changes (title, description, etc) but also right after the new chapters are auto-generated.


Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: improve when re-rendering the video player

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This is not easy to test. Confirm that the player re-renders when the title or other props change and after the app generates the chapters. Also, confirm it re-renders once per block edition.

<img width="717" alt="Screen Shot 2022-11-22 at 10 39 04" src="https://user-images.githubusercontent.com/77539/203328246-e0ec4216-0c9f-48a0-a137-e19ea4d7debe.png">

In the screenshot above:

* The user edits the title.
* The app detects these changes and hits the meta endpoint
* Onde post updates, the app re-renders the player

The following, the user changes the chapters list, the app auto-generates the chapters, updates the tracks, and re-renders the player.

<img width="669" alt="image" src="https://user-images.githubusercontent.com/77539/203328735-f3ad1b01-4cb3-42ce-9ce9-346594702ac9.png">

