### PR TITLE
BBE : Menus : Show menu when in a support session for an atomic site.

### DIFF
--- a/projects/plugins/jetpack/changelog/add-support-detection
+++ b/projects/plugins/jetpack/changelog/add-support-detection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: A minor fix for built by express
+
+

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/load.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/load.php
@@ -50,7 +50,7 @@ function get_admin_menu_class() {
 		// DIFM Lite In Progress Atomic Sites. Uses the same menu used for domain-only sites.
 		// Ignore this check if we are in a support session.
 		$is_difm_lite_in_progress = wpcomsh_is_site_sticker_active( 'difm-lite-in-progress' );
-		$is_support_session       = WPCOMSH_Support_Session_Detect::is_probably_support_session();
+		$is_support_session       = class_exists( 'WPCOMSH_Support_Session_Detect' ) && WPCOMSH_Support_Session_Detect::is_probably_support_session();
 		if ( $is_difm_lite_in_progress && ! $is_support_session ) {
 			require_once __DIR__ . '/class-domain-only-admin-menu.php';
 			return Domain_Only_Admin_Menu::class;

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/load.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/load.php
@@ -50,7 +50,7 @@ function get_admin_menu_class() {
 		// DIFM Lite In Progress Atomic Sites. Uses the same menu used for domain-only sites.
 		// Ignore this check if we are in a support session.
 		$is_difm_lite_in_progress = wpcomsh_is_site_sticker_active( 'difm-lite-in-progress' );
-		$is_support_session       = defined( 'WPCOM_SUPPORT_SESSION' ) && WPCOM_SUPPORT_SESSION;
+		$is_support_session       = WPCOMSH_Support_Session_Detect::is_probably_support_session();
 		if ( $is_difm_lite_in_progress && ! $is_support_session ) {
 			require_once __DIR__ . '/class-domain-only-admin-menu.php';
 			return Domain_Only_Admin_Menu::class;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/martech#1263

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* The menus for a BBE purchased site should be visible when in a support session.

#### Other information:
* Additional context : p9o2xV-2Bw-p2#comment-6699

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Is existing version working and are the menus hidden
* Create WoA site and push these plugin changes into the atomic site
* On the atomic site purchase BBE
    * Go to `/start/do-it-for-me?flags=difm/allow-woa-sites` 
    * Select `Existing WordPress.com site`
    * In the next page make sure the feature flag `flags=difm/allow-woa-sites` is there or add it if not.
    * Select the above woa site and complete the purchase
* ~You will redirected to home~ go back to the calypso home page of the atomic site and, only the following menus should be visible.
<img width="1716" alt="image" src="https://user-images.githubusercontent.com/3422709/193906009-e804ae10-4381-40a2-b179-ea39c03e8f9b.png">

### Does the support session open up the site
* Add a non automattic user to the site above
* Start a support session with the non automattic user
* Make sure the menus are all visible.