### PR TITLE
VideoPress: Remove storage meter on free plan

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-remove-storage-meter-free
+++ b/projects/packages/videopress/changelog/fix-videopress-remove-storage-meter-free
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Remove storage meter on free plan

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -182,10 +182,12 @@ const Admin = () => {
 									{ __( 'High quality, ad-free video', 'jetpack-videopress-pkg' ) }
 								</Text>
 
-								<ConnectVideoStorageMeter
-									className={ styles[ 'storage-meter' ] }
-									progressBarClassName={ styles[ 'storage-meter__progress-bar' ] }
-								/>
+								{ hasVideoPressPurchase && (
+									<ConnectVideoStorageMeter
+										className={ styles[ 'storage-meter' ] }
+										progressBarClassName={ styles[ 'storage-meter__progress-bar' ] }
+									/>
+								) }
 
 								<FormFileUpload
 									onChange={ evt =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27540

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Checks if user has a paid plan before rendering the storage meter

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard with a free plan
* Check that the storage meter is not present
* Upgrade to a paid plan
* Check that the storage meter is present

![2022-11-22_11-03-19](https://user-images.githubusercontent.com/8486249/203334839-a036c615-7c15-442c-8da1-aaca41775eab.png)
