### PR TITLE
POC for enforcing image restrictions

### DIFF
--- a/projects/js-packages/publicize-components/changelog/add-image-restrictions-poc
+++ b/projects/js-packages/publicize-components/changelog/add-image-restrictions-poc
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Image restriction poc

--- a/projects/js-packages/publicize-components/src/components/media-section/index.js
+++ b/projects/js-packages/publicize-components/src/components/media-section/index.js
@@ -1,10 +1,22 @@
 import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
-import { Button, ResponsiveWrapper, Spinner } from '@wordpress/components';
+import { Button, ResponsiveWrapper, Spinner, Notice } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useEffect, useState } from 'react';
 import useAttachedMedia from '../../hooks/use-attached-media';
+import useSocialMediaConnections from '../../hooks/use-social-media-connections';
 import styles from './styles.module.scss';
+
+// These will come from the server
+const RESTRICTIONS = {
+	twitter: {
+		maxImageSize: 2000000,
+	},
+	facebook: {
+		maxImageSize: 1000000,
+	},
+};
 
 /**
  * Get relevant details from a WordPress media object.
@@ -42,17 +54,44 @@ const REMOVE_MEDIA_LABEL = __( 'Remove Social Image', 'jetpack' );
 
 const ALLOWED_MEDIA_TYPES = [ 'image/jpeg', 'image/png' ];
 
+const getMaxImageSize = ( restrictions, connections ) => {
+	return Math.min(
+		...connections.map( connection => restrictions[ connection.service_name ].maxImageSize )
+	);
+};
+
+const isMediaObjectValid = ( mediaObject, maxImageSize ) => {
+	if ( mediaObject?.media_details?.filesize <= maxImageSize ) {
+		return true;
+	}
+	return false;
+};
+
+const formatMaxSize = maxImageSize => ` (${ maxImageSize / Math.pow( 10, 6 ) } Mb)`;
+
 /**
  * Wrapper that handles media-related functionality.
  *
  * @returns {object} The media section.
  */
 export default function MediaSection() {
+	const [ showNotice, setShotNotice ] = useState( false );
 	const { attachedMedia, updateAttachedMedia } = useAttachedMedia();
+	const { connections } = useSocialMediaConnections();
+	const enabledConnections = connections.filter( connection => connection.enabled );
+	const maxImageSize = getMaxImageSize( RESTRICTIONS, enabledConnections );
 
 	const mediaObject = useSelect( select =>
 		select( 'core' ).getMedia( attachedMedia[ 0 ] || null, { context: 'view' } )
 	);
+
+	useEffect( () => {
+		// Removes selected media if connection change results in invalid image
+		if ( mediaObject && ! isMediaObjectValid( mediaObject, maxImageSize ) ) {
+			updateAttachedMedia( [] );
+			setShotNotice( true );
+		}
+	}, [ updateAttachedMedia, maxImageSize, mediaObject ] );
 
 	const { mediaWidth, mediaHeight, mediaSourceUrl } = getMediaDetails( mediaObject );
 
@@ -65,9 +104,17 @@ export default function MediaSection() {
 				return;
 			}
 
+			// Do not select media if criteria is not met
+			if ( media.filesizeInBytes > getMaxImageSize( RESTRICTIONS, enabledConnections ) ) {
+				updateAttachedMedia( [] );
+				setShotNotice( true );
+				return;
+			}
+
 			updateAttachedMedia( [ media.id ] );
+			setShotNotice( false );
 		},
-		[ updateAttachedMedia ]
+		[ updateAttachedMedia, enabledConnections ]
 	);
 
 	const setMediaRender = useCallback(
@@ -79,11 +126,16 @@ export default function MediaSection() {
 							<img src={ mediaSourceUrl } alt="" />
 						</ResponsiveWrapper>
 					) }
-					{ ! mediaObject && ( attachedMedia.length ? <Spinner /> : ADD_MEDIA_LABEL ) }
+					{ ! mediaObject &&
+						( attachedMedia.length ? (
+							<Spinner />
+						) : (
+							ADD_MEDIA_LABEL + formatMaxSize( maxImageSize )
+						) ) }
 				</Button>
 			</div>
 		),
-		[ mediaHeight, mediaObject, mediaSourceUrl, mediaWidth, attachedMedia ]
+		[ mediaHeight, mediaObject, mediaSourceUrl, mediaWidth, attachedMedia, maxImageSize ]
 	);
 
 	const replaceMediaRender = useCallback(
@@ -95,11 +147,13 @@ export default function MediaSection() {
 		[]
 	);
 
+	const onDismissClick = useCallback( () => setShotNotice( false ), [] );
+
 	return (
 		<div className={ styles.wrapper }>
 			<MediaUploadCheck>
 				<MediaUpload
-					title={ ADD_MEDIA_LABEL }
+					title={ ADD_MEDIA_LABEL + formatMaxSize( maxImageSize ) }
 					onSelect={ onUpdateMedia }
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
 					render={ setMediaRender }
@@ -117,6 +171,16 @@ export default function MediaSection() {
 							{ REMOVE_MEDIA_LABEL }
 						</Button>
 					</>
+				) }
+				{ showNotice && (
+					<Notice
+						className={ styles.notice }
+						isDismissible={ true }
+						onDismiss={ onDismissClick }
+						status="warning"
+					>
+						<p>{ 'The selected media it is too big for one of the selected platforms.' }</p>
+					</Notice>
 				) }
 			</MediaUploadCheck>
 		</div>

--- a/projects/js-packages/publicize-components/src/components/media-section/index.js
+++ b/projects/js-packages/publicize-components/src/components/media-section/index.js
@@ -105,7 +105,7 @@ export default function MediaSection() {
 			}
 
 			// Do not select media if criteria is not met
-			if ( media.filesizeInBytes > getMaxImageSize( RESTRICTIONS, enabledConnections ) ) {
+			if ( media.filesizeInBytes > maxImageSize ) {
 				updateAttachedMedia( [] );
 				setShotNotice( true );
 				return;
@@ -114,7 +114,7 @@ export default function MediaSection() {
 			updateAttachedMedia( [ media.id ] );
 			setShotNotice( false );
 		},
-		[ updateAttachedMedia, enabledConnections ]
+		[ updateAttachedMedia, maxImageSize ]
 	);
 
 	const setMediaRender = useCallback(

--- a/projects/js-packages/publicize-components/src/components/media-section/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/media-section/styles.module.scss
@@ -19,6 +19,12 @@
 	position: relative;
 }
 
+.notice {
+	margin: 0 0 8px 0;
+	padding-right: 8px !important;
+	padding-bottom: 0;
+}
+
 .toggle,
 .preview {
 	display: block;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This is a POC only, do not merge!

This change introduces a logic that checks for the current image restrictions and unselects the image if it does not meet the criteria of the restrictions. Currently, the restrictions are hardcoded into the UI, it should come from the server somehow in the future.

I put up a Notice, for now, we should contact design and use what they suggest, this is only for testing purposes.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.
 
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

`testimage1`: www.cloudup.com/cXrFq_uE782
`testimage2`: www.cloudup.com/cJphGqezDB1

* Create a Facebook and a Twitter Connection.
* Go to the editor, you should see the current maximum filesize in the image picker. 1Mb if both services is enabled, 2Mb if only Twitter. It's kind of a dummy calculation for now, also probably there is a better place for it, but its good for testing
* Try to upload  `testimage2`, it should not get selected and a Notice appears, which you can close. It should also close by uploading a valid image. Upload `testimage1`, it should work.
* Disable Facebook, so only Twitter is enabled. Upload `testimage2` it should work. Turn on Facebook again, it should unselect the image and bring up the notice.