### PR TITLE
Jetpack VideoPress: Prepare release 1.1.0-beta

### DIFF
--- a/projects/js-packages/analytics/CHANGELOG.md
+++ b/projects/js-packages/analytics/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Analytics package releases.
 
+## 0.1.20 - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## 0.1.19 - 2022-10-11
 ### Changed
 - Updated package dependencies. [#26726]

--- a/projects/js-packages/analytics/changelog/update-build-action-version-handling
+++ b/projects/js-packages/analytics/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/analytics/package.json
+++ b/projects/js-packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-analytics",
-	"version": "0.1.20-alpha",
+	"version": "0.1.20",
 	"description": "Jetpack Analytics Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/api/CHANGELOG.md
+++ b/projects/js-packages/api/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## 0.14.6 - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## 0.14.5 - 2022-11-08
 ### Changed
 - Updated package dependencies. [#27289]

--- a/projects/js-packages/api/changelog/update-build-action-version-handling
+++ b/projects/js-packages/api/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/api/package.json
+++ b/projects/js-packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-api",
-	"version": "0.14.6-alpha",
+	"version": "0.14.6",
 	"description": "Jetpack Api Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/babel-plugin-replace-textdomain/CHANGELOG.md
+++ b/projects/js-packages/babel-plugin-replace-textdomain/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.18] - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [1.0.17] - 2022-11-10
 ### Changed
 - Updated package dependencies. [#27319]
@@ -82,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release.
 - Replace missing domains too.
 
+[1.0.18]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.17...v1.0.18
 [1.0.17]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.16...v1.0.17
 [1.0.16]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.15...v1.0.16
 [1.0.15]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.14...v1.0.15

--- a/projects/js-packages/babel-plugin-replace-textdomain/changelog/update-build-action-version-handling
+++ b/projects/js-packages/babel-plugin-replace-textdomain/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/babel-plugin-replace-textdomain/package.json
+++ b/projects/js-packages/babel-plugin-replace-textdomain/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/babel-plugin-replace-textdomain",
-	"version": "1.0.18-alpha",
+	"version": "1.0.18",
 	"description": "A Babel plugin to replace the textdomain in gettext-style function calls.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/babel-plugin-replace-textdomain/#readme",
 	"bugs": {

--- a/projects/js-packages/base-styles/CHANGELOG.md
+++ b/projects/js-packages/base-styles/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.15] - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [0.3.14] - 2022-11-08
 ### Changed
 - Updated package dependencies. [#27289]
@@ -127,6 +131,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Node 16.7.0 in tooling. This shouldn't change the behavior of the code itself.
 
+[0.3.15]: https://github.com/Automattic/jetpack-base-styles/compare/0.3.14...0.3.15
 [0.3.14]: https://github.com/Automattic/jetpack-base-styles/compare/0.3.13...0.3.14
 [0.3.13]: https://github.com/Automattic/jetpack-base-styles/compare/0.3.12...0.3.13
 [0.3.12]: https://github.com/Automattic/jetpack-base-styles/compare/0.3.11...0.3.12

--- a/projects/js-packages/base-styles/changelog/update-build-action-version-handling
+++ b/projects/js-packages/base-styles/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/base-styles/package.json
+++ b/projects/js-packages/base-styles/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-base-styles",
-	"version": "0.3.15-alpha",
+	"version": "0.3.15",
 	"description": "Jetpack components base styles",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/base-styles/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## 0.25.1 - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## 0.25.0 - 2022-11-17
 ### Added
 - Added additional color studio colors to the ThemeProvider component for use in Jetpack Protect. [#26069]

--- a/projects/js-packages/components/changelog/update-build-action-version-handling
+++ b/projects/js-packages/components/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.25.1-alpha",
+	"version": "0.25.1",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/config/CHANGELOG.md
+++ b/projects/js-packages/config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.15 - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## 0.1.14 - 2022-09-20
 ### Changed
 - Updated package dependencies. [#26072]

--- a/projects/js-packages/config/changelog/update-build-action-version-handling
+++ b/projects/js-packages/config/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/config/package.json
+++ b/projects/js-packages/config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-config",
-	"version": "0.1.15-alpha",
+	"version": "0.1.15",
 	"description": "Handles Jetpack global configuration shared across all packages",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/config/#readme",
 	"bugs": {

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## 0.22.10 - 2022-11-22
+### Added
+- Add Manage Connection dialog to My Jetpack [#27476]
+
+### Changed
+- Updated package dependencies. [#27043]
+
 ## 0.22.9 - 2022-11-17
 ### Changed
 - Updated package dependencies. [#26736]

--- a/projects/js-packages/connection/changelog/add-manage-connection-dialog-to-mj
+++ b/projects/js-packages/connection/changelog/add-manage-connection-dialog-to-mj
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add Manage Connection dialog to My Jetpack

--- a/projects/js-packages/connection/changelog/update-build-action-version-handling
+++ b/projects/js-packages/connection/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.22.10-alpha",
+	"version": "0.22.10",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/i18n-check-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-check-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.23] - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [1.0.22] - 2022-11-10
 ### Changed
 - Updated package dependencies. [#27319]
@@ -113,6 +117,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[1.0.23]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.0.22...v1.0.23
 [1.0.22]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.0.21...v1.0.22
 [1.0.21]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.0.20...v1.0.21
 [1.0.20]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.0.19...v1.0.20

--- a/projects/js-packages/i18n-check-webpack-plugin/changelog/update-build-action-version-handling
+++ b/projects/js-packages/i18n-check-webpack-plugin/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/i18n-check-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-check-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-check-webpack-plugin",
-	"version": "1.0.23-alpha",
+	"version": "1.0.23",
 	"description": "A Webpack plugin to check that WordPress i18n hasn't been mangled by Webpack optimizations.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/i18n-check-webpack-plugin/#readme",
 	"bugs": {

--- a/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.23] - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [2.0.22] - 2022-11-08
 ### Changed
 - Updated package dependencies. [#27289]
@@ -116,6 +120,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[2.0.23]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.22...v2.0.23
 [2.0.22]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.21...v2.0.22
 [2.0.21]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.20...v2.0.21
 [2.0.20]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.19...v2.0.20

--- a/projects/js-packages/i18n-loader-webpack-plugin/changelog/update-build-action-version-handling
+++ b/projects/js-packages/i18n-loader-webpack-plugin/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/i18n-loader-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-loader-webpack-plugin",
-	"version": "2.0.23-alpha",
+	"version": "2.0.23",
 	"description": "A Webpack plugin to load WordPress i18n when Webpack lazy-loads a bundle.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/i18n-loader-webpack-plugin/#readme",
 	"bugs": {

--- a/projects/js-packages/idc/CHANGELOG.md
+++ b/projects/js-packages/idc/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ### This is a list detailing changes for the Jetpack RNA IDC package releases.
 
+## 0.10.29 - 2022-11-22
+### Changed
+- Updated package dependencies. [#26069]
+- Updated package dependencies. [#26736]
+- Updated package dependencies. [#27043]
+
 ## 0.10.28 - 2022-11-10
 ### Changed
 - Updated package dependencies. [#27319]

--- a/projects/js-packages/idc/changelog/add-scan-in-protect
+++ b/projects/js-packages/idc/changelog/add-scan-in-protect
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/idc/changelog/add-super-cache-measurement
+++ b/projects/js-packages/idc/changelog/add-super-cache-measurement
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/idc/changelog/update-build-action-version-handling
+++ b/projects/js-packages/idc/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-idc",
-	"version": "0.10.29-alpha",
+	"version": "0.10.29",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/licensing/CHANGELOG.md
+++ b/projects/js-packages/licensing/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.7 - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## 0.6.6 - 2022-11-17
 ### Changed
 - Updated package dependencies. [#26736]

--- a/projects/js-packages/licensing/changelog/update-build-action-version-handling
+++ b/projects/js-packages/licensing/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.6.7-alpha",
+	"version": "0.6.7",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.3.18 - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## 1.3.17 - 2022-11-10
 ### Changed
 - Updated package dependencies. [#27319]

--- a/projects/js-packages/webpack-config/changelog/update-build-action-version-handling
+++ b/projects/js-packages/webpack-config/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "1.3.18-alpha",
+	"version": "1.3.18",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/packages/a8c-mc-stats/CHANGELOG.md
+++ b/projects/packages/a8c-mc-stats/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.16] - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [1.4.15] - 2022-07-26
 ### Changed
 - Updated package dependencies. [#25158]
@@ -99,6 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Creates the MC Stats package
 
+[1.4.16]: https://github.com/Automattic/jetpack-a8c-mc-stats/compare/v1.4.15...v1.4.16
 [1.4.15]: https://github.com/Automattic/jetpack-a8c-mc-stats/compare/v1.4.14...v1.4.15
 [1.4.14]: https://github.com/Automattic/jetpack-a8c-mc-stats/compare/v1.4.13...v1.4.14
 [1.4.13]: https://github.com/Automattic/jetpack-a8c-mc-stats/compare/v1.4.12...v1.4.13

--- a/projects/packages/a8c-mc-stats/changelog/update-build-action-version-handling
+++ b/projects/packages/a8c-mc-stats/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/admin-ui/CHANGELOG.md
+++ b/projects/packages/admin-ui/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.13] - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [0.2.12] - 2022-09-20
 ### Changed
 - Updated package dependencies.
@@ -76,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing menu visibility issues.
 
+[0.2.13]: https://github.com/Automattic/jetpack-admin-ui/compare/0.2.12...0.2.13
 [0.2.12]: https://github.com/Automattic/jetpack-admin-ui/compare/0.2.11...0.2.12
 [0.2.11]: https://github.com/Automattic/jetpack-admin-ui/compare/0.2.10...0.2.11
 [0.2.10]: https://github.com/Automattic/jetpack-admin-ui/compare/0.2.9...0.2.10

--- a/projects/packages/admin-ui/changelog/update-build-action-version-handling
+++ b/projects/packages/admin-ui/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/admin-ui/package.json
+++ b/projects/packages/admin-ui/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-admin-ui",
-	"version": "0.2.13-alpha",
+	"version": "0.2.13",
 	"description": "Generic Jetpack wp-admin UI elements",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/admin-ui/#readme",
 	"bugs": {

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack\Admin_UI;
  */
 class Admin_Menu {
 
-	const PACKAGE_VERSION = '0.2.13-alpha';
+	const PACKAGE_VERSION = '0.2.13';
 
 	/**
 	 * Whether this class has been initialized

--- a/projects/packages/assets/CHANGELOG.md
+++ b/projects/packages/assets/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.26] - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [1.17.25] - 2022-11-08
 ### Changed
 - Updated package dependencies. [#27289]
@@ -276,6 +280,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Statically access asset tools
 
+[1.17.26]: https://github.com/Automattic/jetpack-assets/compare/v1.17.25...v1.17.26
 [1.17.25]: https://github.com/Automattic/jetpack-assets/compare/v1.17.24...v1.17.25
 [1.17.24]: https://github.com/Automattic/jetpack-assets/compare/v1.17.23...v1.17.24
 [1.17.23]: https://github.com/Automattic/jetpack-assets/compare/v1.17.22...v1.17.23

--- a/projects/packages/assets/changelog/update-build-action-version-handling
+++ b/projects/packages/assets/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/autoloader/CHANGELOG.md
+++ b/projects/packages/autoloader/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.12] - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [2.11.11] - 2022-10-25
 ### Changed
 - Sort data in generated `vendor/composer/jetpack_autoload_classmap.php` to avoid spurious diffs. [#26929]
@@ -277,6 +281,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add Custom Autoloader
 
+[2.11.12]: https://github.com/Automattic/jetpack-autoloader/compare/v2.11.11...v2.11.12
 [2.11.11]: https://github.com/Automattic/jetpack-autoloader/compare/v2.11.10...v2.11.11
 [2.11.10]: https://github.com/Automattic/jetpack-autoloader/compare/v2.11.9...v2.11.10
 [2.11.9]: https://github.com/Automattic/jetpack-autoloader/compare/v2.11.8...v2.11.9

--- a/projects/packages/autoloader/changelog/update-build-action-version-handling
+++ b/projects/packages/autoloader/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/composer-plugin/CHANGELOG.md
+++ b/projects/packages/composer-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.6] - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [1.1.5] - 2022-10-25
 ### Changed
 - Sort data in generated `i18n-map.php` file to avoid spurious diffs. [#26929]
@@ -54,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added the Jetpack Installer package.
 
+[1.1.6]: https://github.com/Automattic/jetpack-composer-plugin/compare/v1.1.5...v1.1.6
 [1.1.5]: https://github.com/Automattic/jetpack-composer-plugin/compare/v1.1.4...v1.1.5
 [1.1.4]: https://github.com/Automattic/jetpack-composer-plugin/compare/v1.1.3...v1.1.4
 [1.1.3]: https://github.com/Automattic/jetpack-composer-plugin/compare/v1.1.2...v1.1.3

--- a/projects/packages/composer-plugin/changelog/update-build-action-version-handling
+++ b/projects/packages/composer-plugin/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/config/CHANGELOG.md
+++ b/projects/packages/config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.1] - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [1.11.0] - 2022-10-11
 ### Changed
 - Integrate Stats package in Jetpack plugin [#26640]
@@ -152,6 +156,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Trying to add deterministic initialization.
 
+[1.11.1]: https://github.com/Automattic/jetpack-config/compare/v1.11.0...v1.11.1
 [1.11.0]: https://github.com/Automattic/jetpack-config/compare/v1.10.0...v1.11.0
 [1.10.0]: https://github.com/Automattic/jetpack-config/compare/v1.9.6...v1.10.0
 [1.9.6]: https://github.com/Automattic/jetpack-config/compare/v1.9.5...v1.9.6

--- a/projects/packages/config/changelog/update-build-action-version-handling
+++ b/projects/packages/config/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.46.4] - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [1.46.3] - 2022-11-08
 ### Changed
 - Updated package dependencies. [#27289]
@@ -721,6 +725,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[1.46.4]: https://github.com/Automattic/jetpack-connection/compare/v1.46.3...v1.46.4
 [1.46.3]: https://github.com/Automattic/jetpack-connection/compare/v1.46.2...v1.46.3
 [1.46.2]: https://github.com/Automattic/jetpack-connection/compare/v1.46.1...v1.46.2
 [1.46.1]: https://github.com/Automattic/jetpack-connection/compare/v1.46.0...v1.46.1

--- a/projects/packages/connection/changelog/update-build-action-version-handling
+++ b/projects/packages/connection/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.46.4-alpha';
+	const PACKAGE_VERSION = '1.46.4';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/constants/CHANGELOG.md
+++ b/projects/packages/constants/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.19] - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [1.6.18] - 2022-07-26
 ### Changed
 - Updated package dependencies. [#25158]
@@ -134,6 +138,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Finish the constants package
 
+[1.6.19]: https://github.com/Automattic/jetpack-constants/compare/v1.6.18...v1.6.19
 [1.6.18]: https://github.com/Automattic/jetpack-constants/compare/v1.6.17...v1.6.18
 [1.6.17]: https://github.com/Automattic/jetpack-constants/compare/v1.6.16...v1.6.17
 [1.6.16]: https://github.com/Automattic/jetpack-constants/compare/v1.6.15...v1.6.16

--- a/projects/packages/constants/changelog/update-build-action-version-handling
+++ b/projects/packages/constants/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/device-detection/CHANGELOG.md
+++ b/projects/packages/device-detection/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.21] - 2022-11-22
+### Added
+- Add a guard in `functions.php` against being loaded twice from different copies of the package. [#27475]
+
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [1.4.20] - 2022-11-07
 ### Fixed
 - Ensure that User_Agent is loaded in environments without autoload enabled. (e.g.: WordPress.com and Super Cache) [#27223]
@@ -132,6 +139,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Moving jetpack_is_mobile into a package
 
+[1.4.21]: https://github.com/Automattic/jetpack-device-detection/compare/v1.4.20...v1.4.21
 [1.4.20]: https://github.com/Automattic/jetpack-device-detection/compare/v1.4.19...v1.4.20
 [1.4.19]: https://github.com/Automattic/jetpack-device-detection/compare/v1.4.18...v1.4.19
 [1.4.18]: https://github.com/Automattic/jetpack-device-detection/compare/v1.4.17...v1.4.18

--- a/projects/packages/device-detection/changelog/add-guard-in-device-detection-functions.php
+++ b/projects/packages/device-detection/changelog/add-guard-in-device-detection-functions.php
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add a guard in `functions.php` against being loaded twice from different copies of the package.

--- a/projects/packages/device-detection/changelog/update-build-action-version-handling
+++ b/projects/packages/device-detection/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/identity-crisis/CHANGELOG.md
+++ b/projects/packages/identity-crisis/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.32] - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [0.8.31] - 2022-11-10
 ### Changed
 - Updated package dependencies. [#27319]
@@ -300,6 +304,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Connection/Urls for home_url and site_url functions migrated from Sync.
 
+[0.8.32]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.8.31...v0.8.32
 [0.8.31]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.8.30...v0.8.31
 [0.8.30]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.8.29...v0.8.30
 [0.8.29]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.8.28...v0.8.29

--- a/projects/packages/identity-crisis/changelog/update-build-action-version-handling
+++ b/projects/packages/identity-crisis/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.8.32-alpha",
+	"version": "0.8.32",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -28,7 +28,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.8.32-alpha';
+	const PACKAGE_VERSION = '0.8.32';
 
 	/**
 	 * Instance of the object.

--- a/projects/packages/jitm/CHANGELOG.md
+++ b/projects/packages/jitm/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.34] - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [2.2.33] - 2022-11-08
 ### Changed
 - Updated package dependencies. [#27289]
@@ -506,6 +510,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Jetpack to use new JITM package
 
+[2.2.34]: https://github.com/Automattic/jetpack-jitm/compare/v2.2.33...v2.2.34
 [2.2.33]: https://github.com/Automattic/jetpack-jitm/compare/v2.2.32...v2.2.33
 [2.2.32]: https://github.com/Automattic/jetpack-jitm/compare/v2.2.31...v2.2.32
 [2.2.31]: https://github.com/Automattic/jetpack-jitm/compare/v2.2.30...v2.2.31

--- a/projects/packages/jitm/changelog/update-build-action-version-handling
+++ b/projects/packages/jitm/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '2.2.34-alpha';
+	const PACKAGE_VERSION = '2.2.34';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/licensing/CHANGELOG.md
+++ b/projects/packages/licensing/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.12] - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [1.7.11] - 2022-10-25
 ### Changed
 - Updated package dependencies. [#26705]
@@ -218,6 +222,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Licensing: Add support for Jetpack licenses
 
+[1.7.12]: https://github.com/Automattic/jetpack-licensing/compare/v1.7.11...v1.7.12
 [1.7.11]: https://github.com/Automattic/jetpack-licensing/compare/v1.7.10...v1.7.11
 [1.7.10]: https://github.com/Automattic/jetpack-licensing/compare/v1.7.9...v1.7.10
 [1.7.9]: https://github.com/Automattic/jetpack-licensing/compare/v1.7.8...v1.7.9

--- a/projects/packages/licensing/changelog/update-build-action-version-handling
+++ b/projects/packages/licensing/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/logo/CHANGELOG.md
+++ b/projects/packages/logo/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.19] - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [1.5.18] - 2022-11-07
 ### Changed
 - Updated package dependencies.
@@ -130,6 +134,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Add a basic Jetpack Logo package
 
+[1.5.19]: https://github.com/Automattic/jetpack-logo/compare/v1.5.18...v1.5.19
 [1.5.18]: https://github.com/Automattic/jetpack-logo/compare/v1.5.17...v1.5.18
 [1.5.17]: https://github.com/Automattic/jetpack-logo/compare/v1.5.16...v1.5.17
 [1.5.16]: https://github.com/Automattic/jetpack-logo/compare/v1.5.15...v1.5.16

--- a/projects/packages/logo/changelog/update-build-action-version-handling
+++ b/projects/packages/logo/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.1] - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [2.4.0] - 2022-11-17
 ### Added
 - Added Jetpack Protect to My Jetpack. [#26069]
@@ -668,6 +672,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[2.4.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/2.4.0...2.4.1
 [2.4.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/2.3.5...2.4.0
 [2.3.5]: https://github.com/Automattic/jetpack-my-jetpack/compare/2.3.4...2.3.5
 [2.3.4]: https://github.com/Automattic/jetpack-my-jetpack/compare/2.3.3...2.3.4

--- a/projects/packages/my-jetpack/changelog/update-build-action-version-handling
+++ b/projects/packages/my-jetpack/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "2.4.1-alpha",
+	"version": "2.4.1",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -30,7 +30,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '2.4.1-alpha';
+	const PACKAGE_VERSION = '2.4.1';
 
 	/**
 	 * Initialize My Jetapack

--- a/projects/packages/partner/CHANGELOG.md
+++ b/projects/packages/partner/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.20] - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [1.7.19] - 2022-11-07
 ### Changed
 - Updated package dependencies. [#27278]
@@ -200,6 +204,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add partner subsidiary id to upgrade URLs.
 
+[1.7.20]: https://github.com/Automattic/jetpack-partner/compare/v1.7.19...v1.7.20
 [1.7.19]: https://github.com/Automattic/jetpack-partner/compare/v1.7.18...v1.7.19
 [1.7.18]: https://github.com/Automattic/jetpack-partner/compare/v1.7.17...v1.7.18
 [1.7.17]: https://github.com/Automattic/jetpack-partner/compare/v1.7.16...v1.7.17

--- a/projects/packages/partner/changelog/update-build-action-version-handling
+++ b/projects/packages/partner/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/password-checker/CHANGELOG.md
+++ b/projects/packages/password-checker/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.8] - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [0.2.7] - 2022-09-20
 ### Changed
 - Updated package dependencies.
@@ -80,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Use `composer update` rather than `install` in scripts, as composer.lock isn't checked in.
 
+[0.2.8]: https://github.com/Automattic/jetpack-password-checker/compare/v0.2.7...v0.2.8
 [0.2.7]: https://github.com/Automattic/jetpack-password-checker/compare/v0.2.6...v0.2.7
 [0.2.6]: https://github.com/Automattic/jetpack-password-checker/compare/v0.2.5...v0.2.6
 [0.2.5]: https://github.com/Automattic/jetpack-password-checker/compare/v0.2.4...v0.2.5

--- a/projects/packages/password-checker/changelog/update-build-action-version-handling
+++ b/projects/packages/password-checker/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/plans/CHANGELOG.md
+++ b/projects/packages/plans/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.7] - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [0.2.6] - 2022-11-07
 ### Changed
 - Updated package dependencies. [#27278]
@@ -58,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 - Moved the options class into Connection. [#24095]
 
+[0.2.7]: https://github.com/Automattic/jetpack-plans/compare/v0.2.6...v0.2.7
 [0.2.6]: https://github.com/Automattic/jetpack-plans/compare/v0.2.5...v0.2.6
 [0.2.5]: https://github.com/Automattic/jetpack-plans/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/Automattic/jetpack-plans/compare/v0.2.3...v0.2.4

--- a/projects/packages/plans/changelog/update-build-action-version-handling
+++ b/projects/packages/plans/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/plans/package.json
+++ b/projects/packages/plans/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-plans",
-	"version": "0.2.7-alpha",
+	"version": "0.2.7",
 	"description": "Fetch information about Jetpack Plans from wpcom",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/plans/#readme",
 	"bugs": {

--- a/projects/packages/plugins-installer/CHANGELOG.md
+++ b/projects/packages/plugins-installer/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [0.2.0] - 2022-08-23
 ### Added
 - Add method to check plugin activation context. [#25422]
@@ -36,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix method logic
 
+[0.2.1]: https://github.com/Automattic/jetpack-plugins-installer/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Automattic/jetpack-plugins-installer/compare/v0.1.4...v0.2.0
 [0.1.4]: https://github.com/Automattic/jetpack-plugins-installer/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/Automattic/jetpack-plugins-installer/compare/v0.1.2...v0.1.3

--- a/projects/packages/plugins-installer/changelog/update-build-action-version-handling
+++ b/projects/packages/plugins-installer/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/redirect/CHANGELOG.md
+++ b/projects/packages/redirect/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.20] - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [1.7.19] - 2022-11-07
 ### Changed
 - Updated package dependencies. [#27278]
@@ -156,6 +160,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Create Jetpack Redirect package
 
+[1.7.20]: https://github.com/Automattic/jetpack-redirect/compare/v1.7.19...v1.7.20
 [1.7.19]: https://github.com/Automattic/jetpack-redirect/compare/v1.7.18...v1.7.19
 [1.7.18]: https://github.com/Automattic/jetpack-redirect/compare/v1.7.17...v1.7.18
 [1.7.17]: https://github.com/Automattic/jetpack-redirect/compare/v1.7.16...v1.7.17

--- a/projects/packages/redirect/changelog/update-build-action-version-handling
+++ b/projects/packages/redirect/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/roles/CHANGELOG.md
+++ b/projects/packages/roles/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.18] - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [1.4.17] - 2022-07-26
 ### Changed
 - Updated package dependencies. [#25158]
@@ -123,6 +127,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Jetpack DNA: Introduce a Roles package
 
+[1.4.18]: https://github.com/Automattic/jetpack-roles/compare/v1.4.17...v1.4.18
 [1.4.17]: https://github.com/Automattic/jetpack-roles/compare/v1.4.16...v1.4.17
 [1.4.16]: https://github.com/Automattic/jetpack-roles/compare/v1.4.15...v1.4.16
 [1.4.15]: https://github.com/Automattic/jetpack-roles/compare/v1.4.14...v1.4.15

--- a/projects/packages/roles/changelog/update-build-action-version-handling
+++ b/projects/packages/roles/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/status/CHANGELOG.md
+++ b/projects/packages/status/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.1] - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [1.15.0] - 2022-11-07
 ### Added
 - WordPress.com: add checks for Simple or either Simple/WoA. [#27278]
@@ -212,6 +216,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Introduce a status package
 
+[1.15.1]: https://github.com/Automattic/jetpack-status/compare/v1.15.0...v1.15.1
 [1.15.0]: https://github.com/Automattic/jetpack-status/compare/v1.14.3...v1.15.0
 [1.14.3]: https://github.com/Automattic/jetpack-status/compare/v1.14.2...v1.14.3
 [1.14.2]: https://github.com/Automattic/jetpack-status/compare/v1.14.1...v1.14.2

--- a/projects/packages/status/changelog/update-build-action-version-handling
+++ b/projects/packages/status/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.43.1] - 2022-11-22
+### Changed
+- Updated package dependencies. [#27043]
+
 ## [1.43.0] - 2022-11-17
 ### Added
 - Added new sync option for launch-status [#27434]
@@ -761,6 +765,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[1.43.1]: https://github.com/Automattic/jetpack-sync/compare/v1.43.0...v1.43.1
 [1.43.0]: https://github.com/Automattic/jetpack-sync/compare/v1.42.0...v1.43.0
 [1.42.0]: https://github.com/Automattic/jetpack-sync/compare/v1.41.0...v1.42.0
 [1.41.0]: https://github.com/Automattic/jetpack-sync/compare/v1.40.3...v1.41.0

--- a/projects/packages/sync/changelog/update-build-action-version-handling
+++ b/projects/packages/sync/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.43.1-alpha';
+	const PACKAGE_VERSION = '1.43.1';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2022-11-22
+### Added
+- Added VideoPress feedback link to the VideoPress block. [#27450]
+- VideoPress: add "Details panel" to v6 [#27428]
+- VideoPress: Add "learn how" chapters modal [#27438]
+- VideoPress: add block editor dependencies [#27489]
+- VideoPress: add dimensions panel to video block [#27520]
+- VideoPress: add rating control to Details panel [#27415]
+- VideoPress: check $products data before to pick the prices [#27504]
+- VideoPress: fix issue when setting video privacy [#27435]
+- VideoPress: implement "Allow download" control to v6 [#27420]
+- VideoPress: implement Privacy control [#27401]
+- VideoPress: improve when re-rendering the video player [#27546]
+- VideoPress: register and sync isPrivate block attribute [#27493]
+- VideoPress: Sync video tracks data in video block [#27495]
+- VideoPress: Updated the list of plans that have VideoPress included. [#27536]
+
+### Changed
+- Updated package dependencies. [#26069]
+- Updated package dependencies. [#26736]
+- Updated package dependencies. [#27043]
+- VideoPress: exposed the site purchases list on the client initial state, dropping the need of a request to the My Jetpack purchases endpoint. [#27533]
+- VideoPress: Remove extra resize circle on block [#27498]
+- VideoPress: show pricing based on sale coupons [#27535]
+- VideoPress: switch to v1.1/videos when requesting video data [#27488]
+- VideoPress: TypeScriptify code [#27419]
+
+### Fixed
+- VideoPress: Add backend verification on update routes when user is disconnected [#27455]
+- VideoPress: Add Jetpack Complete plan to list of valid purchased plans [#27500]
+- VideoPress: Disable actions when user is not connected or there is no connected site owner [#27402]
+- VideoPress: fix product plan [#27502]
+- VideoPress: Fix video getter function call [#27534]
+- VideoPress: Remove storage meter on free plan [#27549]
+- VideoPress: Set a static list of allowed video extensions allowed on VideoPress. [#27457]
+- VideoPress: Set the playback token on the video URL and the new poster URL when the video needs it. [#27404]
+
 ## [0.8.0] - 2022-11-14
 ### Added
 - VideoPress: add Color Panel component [#27381]
@@ -432,6 +469,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.8.1]: https://github.com/Automattic/jetpack-videopress/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/Automattic/jetpack-videopress/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/Automattic/jetpack-videopress/compare/v0.6.5...v0.7.0
 [0.6.5]: https://github.com/Automattic/jetpack-videopress/compare/v0.6.4...v0.6.5

--- a/projects/packages/videopress/changelog/add-expose-purchases-on-client-initial-state
+++ b/projects/packages/videopress/changelog/add-expose-purchases-on-client-initial-state
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-VideoPress: exposed the site purchases list on the client initial state, dropping the need of a request to the My Jetpack purchases endpoint.

--- a/projects/packages/videopress/changelog/add-scan-in-protect
+++ b/projects/packages/videopress/changelog/add-scan-in-protect
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/changelog/add-super-cache-measurement
+++ b/projects/packages/videopress/changelog/add-super-cache-measurement
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/changelog/add-update-list-of-plans-that-support-videopress
+++ b/projects/packages/videopress/changelog/add-update-list-of-plans-that-support-videopress
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-VideoPress: Updated the list of plans that have VideoPress included.

--- a/projects/packages/videopress/changelog/add-videopress-blocks-feedback-link
+++ b/projects/packages/videopress/changelog/add-videopress-blocks-feedback-link
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added VideoPress feedback link to the VideoPress block.

--- a/projects/packages/videopress/changelog/fix-set-playback-token-on-video-file-url
+++ b/projects/packages/videopress/changelog/fix-set-playback-token-on-video-file-url
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-VideoPress: Set the playback token on the video URL and the new poster URL when the video needs it.

--- a/projects/packages/videopress/changelog/fix-update-allowed-videopress-file-extensions
+++ b/projects/packages/videopress/changelog/fix-update-allowed-videopress-file-extensions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-VideoPress: Set a static list of allowed video extensions allowed on VideoPress.

--- a/projects/packages/videopress/changelog/fix-videopress-jetpack-complete-plan-cut
+++ b/projects/packages/videopress/changelog/fix-videopress-jetpack-complete-plan-cut
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-VideoPress: Add Jetpack Complete plan to list of valid purchased plans

--- a/projects/packages/videopress/changelog/fix-videopress-remove-storage-meter-free
+++ b/projects/packages/videopress/changelog/fix-videopress-remove-storage-meter-free
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-VideoPress: Remove storage meter on free plan

--- a/projects/packages/videopress/changelog/fix-videopress-select-thumbnail
+++ b/projects/packages/videopress/changelog/fix-videopress-select-thumbnail
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-VideoPress: Fix video getter function call

--- a/projects/packages/videopress/changelog/update-build-action-version-handling
+++ b/projects/packages/videopress/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/changelog/update-videopress-add-allow-download-control
+++ b/projects/packages/videopress/changelog/update-videopress-add-allow-download-control
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-VideoPress: implement "Allow download" control to v6

--- a/projects/packages/videopress/changelog/update-videopress-add-and-sync-is-private-prop
+++ b/projects/packages/videopress/changelog/update-videopress-add-and-sync-is-private-prop
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-VideoPress: register and sync isPrivate block attribute

--- a/projects/packages/videopress/changelog/update-videopress-add-deps
+++ b/projects/packages/videopress/changelog/update-videopress-add-deps
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-VideoPress: add block editor dependencies

--- a/projects/packages/videopress/changelog/update-videopress-add-details-panel
+++ b/projects/packages/videopress/changelog/update-videopress-add-details-panel
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-VideoPress: add "Details panel" to v6

--- a/projects/packages/videopress/changelog/update-videopress-add-dimensions-support
+++ b/projects/packages/videopress/changelog/update-videopress-add-dimensions-support
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-VideoPress: add dimensions panel to video block

--- a/projects/packages/videopress/changelog/update-videopress-add-how-learn-chapters-modal
+++ b/projects/packages/videopress/changelog/update-videopress-add-how-learn-chapters-modal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-VideoPress: Add "learn how" chapters modal

--- a/projects/packages/videopress/changelog/update-videopress-add-verification-on-update-endpoints
+++ b/projects/packages/videopress/changelog/update-videopress-add-verification-on-update-endpoints
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-VideoPress: Add backend verification on update routes when user is disconnected

--- a/projects/packages/videopress/changelog/update-videopress-block-right-resize
+++ b/projects/packages/videopress/changelog/update-videopress-block-right-resize
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-VideoPress: Remove extra resize circle on block

--- a/projects/packages/videopress/changelog/update-videopress-disconnected-user-upload
+++ b/projects/packages/videopress/changelog/update-videopress-disconnected-user-upload
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-VideoPress: Disable actions when user is not connected or there is no connected site owner

--- a/projects/packages/videopress/changelog/update-videopress-ensure-getting-product-data
+++ b/projects/packages/videopress/changelog/update-videopress-ensure-getting-product-data
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-VideoPress: check $products data before to pick the prices

--- a/projects/packages/videopress/changelog/update-videopress-fix-setting-privacy-issue
+++ b/projects/packages/videopress/changelog/update-videopress-fix-setting-privacy-issue
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-VideoPress: fix issue when setting video privacy

--- a/projects/packages/videopress/changelog/update-videopress-implement-privacy-control
+++ b/projects/packages/videopress/changelog/update-videopress-implement-privacy-control
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-VideoPress: implement Privacy control

--- a/projects/packages/videopress/changelog/update-videopress-implement-rating-control
+++ b/projects/packages/videopress/changelog/update-videopress-implement-rating-control
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-VideoPress: add rating control to Details panel

--- a/projects/packages/videopress/changelog/update-videopress-improve-invalidation-proccess
+++ b/projects/packages/videopress/changelog/update-videopress-improve-invalidation-proccess
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-VideoPress: improve when re-rendering the video player

--- a/projects/packages/videopress/changelog/update-videopress-support-sales-coupons
+++ b/projects/packages/videopress/changelog/update-videopress-support-sales-coupons
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-VideoPress: show pricing based on sale coupons

--- a/projects/packages/videopress/changelog/update-videopress-sync-video-tracks-data
+++ b/projects/packages/videopress/changelog/update-videopress-sync-video-tracks-data
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-VideoPress: Sync video tracks data in video block

--- a/projects/packages/videopress/changelog/update-videopress-tscriptify-use-video-data-update-and-more
+++ b/projects/packages/videopress/changelog/update-videopress-tscriptify-use-video-data-update-and-more
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-VideoPress: TypeScriptify code

--- a/projects/packages/videopress/changelog/update-videopress-update-price
+++ b/projects/packages/videopress/changelog/update-videopress-update-price
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-VideoPress: fix product plan

--- a/projects/packages/videopress/changelog/update-videopress-use-wp-com-api-to-request-video-data
+++ b/projects/packages/videopress/changelog/update-videopress-use-wp-com-api-to-request-video-data
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-VideoPress: switch to v1.1/videos when requesting video data

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.8.1-alpha",
+	"version": "0.8.1",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.8.1-alpha';
+	const PACKAGE_VERSION = '0.8.1';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/plugins/videopress/CHANGELOG.md
+++ b/projects/plugins/videopress/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.1.0 - 2022-11-22
+## 1.1.0-beta - 2022-11-22
 
 ### Added
 - Added VideoPress feedback link to the VideoPress block.

--- a/projects/plugins/videopress/CHANGELOG.md
+++ b/projects/plugins/videopress/CHANGELOG.md
@@ -5,7 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.1.0 - 2022-11-22
+
+### Added
+- Added VideoPress feedback link to the VideoPress block.
+- Added Download, Details, Privacy, Rating and Dimensions panel to block.
+- Added rating control to the block's admin page details panel.
+- Added file drop support also after first video on admin page.
+- Added thumbnail selection from video frame on quick action and in edit details view for the admin page.
+
+### Changed
+
+- Updated Color Panel on block.
+- Allowed keyboard navigation on video quick actions.
+- Renamed "Match video title" setting for "Dynamic color" in block settings panel.
+
+### Fixed
+
+- Fixed recognition of Jetpack Complete plan.
+- Fixed issue when setting video privacy.
+- Introduced a static list of video extensions allowed on VideoPress.
+- Mitigated video re-rendering flicker.
+- Fixed an issue with private VideoPress videos timing out when script loading is delayed.
+- Added Site Settings section for controlling site-wide privacy for videos.
+
 ## 1.0.0 - 2022-10-25
+
 ### Added
 - Initial release.
 

--- a/projects/plugins/videopress/changelog/add-jetpack-social-panel-save-attached-media
+++ b/projects/plugins/videopress/changelog/add-jetpack-social-panel-save-attached-media
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/add-scan-in-protect
+++ b/projects/plugins/videopress/changelog/add-scan-in-protect
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/add-scan-in-protect#2
+++ b/projects/plugins/videopress/changelog/add-scan-in-protect#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/add-super-cache-measurement
+++ b/projects/plugins/videopress/changelog/add-super-cache-measurement
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/add-video-chapter-block
+++ b/projects/plugins/videopress/changelog/add-video-chapter-block
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/add-wpcom-platform
+++ b/projects/plugins/videopress/changelog/add-wpcom-platform
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/videopress/changelog/bump-wp6.0-to-6.1
+++ b/projects/plugins/videopress/changelog/bump-wp6.0-to-6.1
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Compatibility: WordPress 6.1 compatibility

--- a/projects/plugins/videopress/changelog/fix-videopress-contributor
+++ b/projects/plugins/videopress/changelog/fix-videopress-contributor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-VideoPress: Fix contributor username

--- a/projects/plugins/videopress/changelog/renovate-babel-monorepo
+++ b/projects/plugins/videopress/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/videopress/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-renovatebot-github-action-34.x
+++ b/projects/plugins/videopress/changelog/renovate-renovatebot-github-action-34.x
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Make "jetpack-e2e-commons" dep explicitly "workspace:*"
-
-

--- a/projects/plugins/videopress/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/videopress/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/renovate-wordpress-monorepo#2
+++ b/projects/plugins/videopress/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/sync-add-reset-endpoint
+++ b/projects/plugins/videopress/changelog/sync-add-reset-endpoint
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/update-author-for-videopress-plugin
+++ b/projects/plugins/videopress/changelog/update-author-for-videopress-plugin
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Just changed author in Jetpack VideoPress plugin file
-
-

--- a/projects/plugins/videopress/changelog/update-build-action-version-handling
+++ b/projects/plugins/videopress/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/update-stable-tag-jetpack-videopress
+++ b/projects/plugins/videopress/changelog/update-stable-tag-jetpack-videopress
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Updated stable tag in readme.txt
-
-

--- a/projects/plugins/videopress/changelog/update-sync-minimal-config-add-updates-module
+++ b/projects/plugins/videopress/changelog/update-sync-minimal-config-add-updates-module
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/changelog/update-videopress-drop-videos
+++ b/projects/plugins/videopress/changelog/update-videopress-drop-videos
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/videopress/composer.json
+++ b/projects/plugins/videopress/composer.json
@@ -56,6 +56,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_videopressⓥ1_0_1_alpha"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_videopressⓥ1_1_0_beta"
 	}
 }

--- a/projects/plugins/videopress/jetpack-videopress.php
+++ b/projects/plugins/videopress/jetpack-videopress.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack VideoPress
  * Plugin URI: https://wordpress.org/plugins/jetpack-videopress
  * Description: High quality, ad-free video.
- * Version: 1.0.1-alpha
+ * Version: 1.1.0-beta
  * Author: Automattic - Jetpack Video team
  * Author URI: https://jetpack.com/videopress/
  * License: GPLv2 or later

--- a/projects/plugins/videopress/readme.txt
+++ b/projects/plugins/videopress/readme.txt
@@ -73,7 +73,27 @@ The file size limit is 5 GB. However, on slower networks, there is a chance the 
 2. Edit your video details, cover image, and privacy from your VideoPress library.
 
 == Changelog ==
-### 1.0.0 - 2022-10-25
+### 1.1.0 - 2022-11-22
+
 #### Added
-- Initial release.
+- Added VideoPress feedback link to the VideoPress block.
+- Added Download, Details, Privacy, Rating and Dimensions panel to block.
+- Added rating control to the block's admin page details panel.
+- Added file drop support also after first video on admin page.
+- Added thumbnail selection from video frame on quick action and in edit details view for the admin page.
+
+#### Changed
+
+- Updated Color Panel on block.
+- Allowed keyboard navigation on video quick actions.
+- Renamed "Match video title" setting for "Dynamic color" in block settings panel.
+
+#### Fixed
+
+- Fixed recognition of Jetpack Complete plan.
+- Fixed issue when setting video privacy.
+- Introduced a static list of video extensions allowed on VideoPress.
+- Mitigated video re-rendering flicker.
+- Fixed an issue with private VideoPress videos timing out when script loading is delayed.
+- Added Site Settings section for controlling site-wide privacy for videos.
 

--- a/projects/plugins/videopress/readme.txt
+++ b/projects/plugins/videopress/readme.txt
@@ -73,7 +73,7 @@ The file size limit is 5 GB. However, on slower networks, there is a chance the 
 2. Edit your video details, cover image, and privacy from your VideoPress library.
 
 == Changelog ==
-### 1.1.0 - 2022-11-22
+### 1.1.0-beta - 2022-11-22
 
 #### Added
 - Added VideoPress feedback link to the VideoPress block.


### PR DESCRIPTION
Release for Jetpack VideoPress standalone plugin V1.1.0-beta

Testing instructions:

Read the changelogs and readmes.