### PR TITLE
VideoPress: Improve inline explanation for block panel options

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-block-panel-help-text
+++ b/projects/packages/videopress/changelog/update-videopress-block-panel-help-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: Improve inline explanation for block panel options

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.8.1",
+	"version": "0.8.2-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.8.1';
+	const PACKAGE_VERSION = '0.8.2-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/color-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/color-panel/index.tsx
@@ -43,7 +43,7 @@ export default function ColorPanel( { attributes, setAttributes }: VideoControlP
 		<PanelBody title={ __( 'Color', 'jetpack-videopress-pkg' ) } initialOpen={ false }>
 			<ToggleControl
 				label={ __( 'Dynamic color', 'jetpack-videopress-pkg' ) }
-				help={ __( 'Colors adapt to the video as it plays', 'jetpack-videopress-pkg' ) }
+				help={ __( 'Colors adapt to the video as it plays.', 'jetpack-videopress-pkg' ) }
 				onChange={ newUseAverageColor => setAttributes( { useAverageColor: newUseAverageColor } ) }
 				checked={ useAverageColor }
 			/>

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/index.tsx
@@ -62,7 +62,7 @@ export default function PlaybackPanel( { attributes, setAttributes }: VideoContr
 				label={ __( 'Loop', 'jetpack-videopress-pkg' ) }
 				onChange={ handleAttributeChange( 'loop' ) }
 				checked={ loop }
-				help={ __( 'Restarts the video when it reaches the end', 'jetpack-videopress-pkg' ) }
+				help={ __( 'Restarts the video when it reaches the end.', 'jetpack-videopress-pkg' ) }
 			/>
 
 			<ToggleControl
@@ -75,7 +75,7 @@ export default function PlaybackPanel( { attributes, setAttributes }: VideoContr
 				label={ __( 'Show Controls', 'jetpack-videopress-pkg' ) }
 				onChange={ handleAttributeChange( 'controls' ) }
 				checked={ controls }
-				help={ __( 'Display the video playback controls', 'jetpack-videopress-pkg' ) }
+				help={ __( 'Display the video playback controls.', 'jetpack-videopress-pkg' ) }
 			/>
 
 			<ToggleControl
@@ -83,7 +83,7 @@ export default function PlaybackPanel( { attributes, setAttributes }: VideoContr
 				onChange={ handleAttributeChange( 'playsinline' ) }
 				checked={ playsinline }
 				help={ __(
-					'Play the video inline instead of full-screen on mobile devices',
+					'Play the video inline instead of full-screen on mobile devices.',
 					'jetpack-videopress-pkg'
 				) }
 			/>
@@ -109,7 +109,7 @@ export default function PlaybackPanel( { attributes, setAttributes }: VideoContr
 				help={
 					<>
 						<span className={ styles[ 'help-message' ] }>
-							{ __( 'Content to download before the video is played', 'jetpack-videopress-pkg' ) }
+							{ __( 'Content to download before the video is played.', 'jetpack-videopress-pkg' ) }
 						</span>
 						{ preload === 'auto' && (
 							<span className={ styles[ 'help-message' ] }>

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/index.tsx
@@ -1,28 +1,17 @@
 /**
  *External dependencies
  */
-import {
-	ExternalLink,
-	PanelBody,
-	SelectControl,
-	ToggleControl,
-	Tooltip,
-} from '@wordpress/components';
+import { ExternalLink, PanelBody, RadioControl, ToggleControl } from '@wordpress/components';
 import { createInterpolateElement, useCallback } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
 import { VideoControlProps } from '../../types';
+/**
+ * Types
+ */
 import type React from 'react';
-
-export const renderControlLabelWithTooltip = ( label, tooltipText ) => {
-	return (
-		<Tooltip text={ tooltipText } position="top left">
-			<span>{ label }</span>
-		</Tooltip>
-	);
-};
 
 /**
  * Sidebar Control component.
@@ -45,27 +34,34 @@ export default function PlaybackPanel( { attributes, setAttributes }: VideoContr
 	return (
 		<PanelBody title={ __( 'Playback', 'jetpack-videopress-pkg' ) }>
 			<ToggleControl
-				label={ renderControlLabelWithTooltip(
-					__( 'Autoplay', 'jetpack-videopress-pkg' ),
-					/* translators: Tooltip describing the "autoplay" option for the VideoPress player */
-					__( 'Start playing the video as soon as the page loads', 'jetpack-videopress-pkg' )
-				) }
+				label={ __( 'Autoplay', 'jetpack-videopress-pkg' ) }
 				onChange={ handleAttributeChange( 'autoplay' ) }
 				checked={ autoplay }
-				help={ __(
-					'Note: Autoplaying videos may cause usability issues for some visitors.',
-					'jetpack-videopress-pkg'
-				) }
+				help={
+					<>
+						<p>
+							{ __(
+								'Start playing the video as soon as the page loads.',
+								'jetpack-videopress-pkg'
+							) }
+						</p>
+						{ autoplay && (
+							<p>
+								{ __(
+									'Note: Autoplaying videos may cause usability issues for some visitors.',
+									'jetpack-videopress-pkg'
+								) }
+							</p>
+						) }
+					</>
+				}
 			/>
 
 			<ToggleControl
-				label={ renderControlLabelWithTooltip(
-					__( 'Loop', 'jetpack-videopress-pkg' ),
-					/* translators: Tooltip describing the "loop" option for the VideoPress player */
-					__( 'Restarts the video when it reaches the end', 'jetpack-videopress-pkg' )
-				) }
+				label={ __( 'Loop', 'jetpack-videopress-pkg' ) }
 				onChange={ handleAttributeChange( 'loop' ) }
 				checked={ loop }
+				help={ __( 'Restarts the video when it reaches the end', 'jetpack-videopress-pkg' ) }
 			/>
 
 			<ToggleControl
@@ -75,41 +71,27 @@ export default function PlaybackPanel( { attributes, setAttributes }: VideoContr
 			/>
 
 			<ToggleControl
-				label={ renderControlLabelWithTooltip(
-					__( 'Show Controls', 'jetpack-videopress-pkg' ),
-					/* translators: Tooltip describing the "controls" option for the VideoPress player */
-					__( 'Display the video playback controls', 'jetpack-videopress-pkg' )
-				) }
+				label={ __( 'Show Controls', 'jetpack-videopress-pkg' ) }
 				onChange={ handleAttributeChange( 'controls' ) }
 				checked={ controls }
+				help={ __( 'Display the video playback controls', 'jetpack-videopress-pkg' ) }
 			/>
 
 			<ToggleControl
-				label={ renderControlLabelWithTooltip(
-					__( 'Play Inline', 'jetpack-videopress-pkg' ),
-					/* translators: Tooltip describing the "playsinline" option for the VideoPress player */
-					__(
-						'Play the video inline instead of full-screen on mobile devices',
-						'jetpack-videopress-pkg'
-					)
-				) }
+				label={ __( 'Play Inline', 'jetpack-videopress-pkg' ) }
 				onChange={ handleAttributeChange( 'playsinline' ) }
 				checked={ playsinline }
+				help={ __(
+					'Play the video inline instead of full-screen on mobile devices',
+					'jetpack-videopress-pkg'
+				) }
 			/>
 
-			<SelectControl
-				label={ renderControlLabelWithTooltip(
-					__( 'Preload', 'jetpack-videopress-pkg' ),
-					/* translators: Tooltip describing the "preload" option for the VideoPress player */
-					__( 'Content to dowload before the video is played', 'jetpack-videopress-pkg' )
-				) }
-				value={ preload }
+			<RadioControl
+				label={ __( 'Preload', 'jetpack-videopress-pkg' ) }
+				selected={ preload }
 				onChange={ value => setAttributes( { preload: value } ) }
 				options={ [
-					{
-						value: 'auto',
-						label: _x( 'Auto', 'VideoPress preload setting', 'jetpack-videopress-pkg' ),
-					},
 					{
 						value: 'metadata',
 						label: _x( 'Metadata', 'VideoPress preload setting', 'jetpack-videopress-pkg' ),
@@ -118,14 +100,25 @@ export default function PlaybackPanel( { attributes, setAttributes }: VideoContr
 						value: 'none',
 						label: _x( 'None', 'VideoPress preload setting', 'jetpack-videopress-pkg' ),
 					},
+					{
+						value: 'auto',
+						label: _x( 'Auto', 'VideoPress preload setting', 'jetpack-videopress-pkg' ),
+					},
 				] }
 				help={
-					'auto' === preload
-						? __(
-								'Note: Automatically downloading videos may cause issues if there are many videos displayed on the same page.',
-								'jetpack-videopress-pkg'
-						  )
-						: null
+					<>
+						<p>
+							{ __( 'Content to download before the video is played', 'jetpack-videopress-pkg' ) }
+						</p>
+						{ preload === 'auto' && (
+							<p>
+								{ __(
+									'Note: Automatically downloading videos may cause issues if there are many videos displayed on the same page.',
+									'jetpack-videopress-pkg'
+								) }
+							</p>
+						) }
+					</>
 				}
 			/>
 			{ createInterpolateElement(

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/index.tsx
@@ -8,6 +8,7 @@ import { __, _x } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { VideoControlProps } from '../../types';
+import styles from './style.module.scss';
 /**
  * Types
  */
@@ -39,19 +40,19 @@ export default function PlaybackPanel( { attributes, setAttributes }: VideoContr
 				checked={ autoplay }
 				help={
 					<>
-						<p>
+						<span className={ styles[ 'help-message' ] }>
 							{ __(
 								'Start playing the video as soon as the page loads.',
 								'jetpack-videopress-pkg'
 							) }
-						</p>
+						</span>
 						{ autoplay && (
-							<p>
+							<span className={ styles[ 'help-message' ] }>
 								{ __(
 									'Note: Autoplaying videos may cause usability issues for some visitors.',
 									'jetpack-videopress-pkg'
 								) }
-							</p>
+							</span>
 						) }
 					</>
 				}
@@ -107,16 +108,16 @@ export default function PlaybackPanel( { attributes, setAttributes }: VideoContr
 				] }
 				help={
 					<>
-						<p>
+						<span className={ styles[ 'help-message' ] }>
 							{ __( 'Content to download before the video is played', 'jetpack-videopress-pkg' ) }
-						</p>
+						</span>
 						{ preload === 'auto' && (
-							<p>
+							<span className={ styles[ 'help-message' ] }>
 								{ __(
 									'Note: Automatically downloading videos may cause issues if there are many videos displayed on the same page.',
 									'jetpack-videopress-pkg'
 								) }
-							</p>
+							</span>
 						) }
 					</>
 				}

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/style.module.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/style.module.scss
@@ -1,0 +1,6 @@
+.help-message {
+	--spacing-base: 8px;
+
+	display: block;
+	margin-top: var( --spacing-base );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27541

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Moves tooltip information to inline text

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and create a VideoPress block
* On the Playback panel, check that the explanations are now inline and no tooltips are shown
* Check that the Preload selector is now a radio field

![2022-11-22_18-19-06](https://user-images.githubusercontent.com/8486249/203424348-65ecfbf8-3837-48f4-89bc-706872e18f0c.png)
![2022-11-22_18-18-50](https://user-images.githubusercontent.com/8486249/203424354-4ec26edc-a93d-4d4a-9809-7f8eeed02c6e.png)
