### PR TITLE
Update/init with config package

### DIFF
--- a/projects/packages/config/changelog/update-init-with-config-package
+++ b/projects/packages/config/changelog/update-init-with-config-package
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Config: add option to init stats-admin

--- a/projects/packages/config/composer.json
+++ b/projects/packages/config/composer.json
@@ -31,7 +31,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-config/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "1.11.x-dev"
+			"dev-trunk": "1.12.x-dev"
 		}
 	}
 }

--- a/projects/packages/config/src/class-config.php
+++ b/projects/packages/config/src/class-config.php
@@ -20,6 +20,7 @@ use Automattic\Jetpack\Post_List\Post_List as Post_List;
 use Automattic\Jetpack\Publicize\Publicize_Setup as Publicize_Setup;
 use Automattic\Jetpack\Search\Initializer as Jetpack_Search_Main;
 use Automattic\Jetpack\Stats\Main as Stats_Main;
+use Automattic\Jetpack\Stats_Admin\Main as Stats_Admin_Main;
 use Automattic\Jetpack\Sync\Main as Sync_Main;
 use Automattic\Jetpack\VideoPress\Initializer as VideoPress_Pkg_Initializer;
 use Automattic\Jetpack\Waf\Waf_Initializer as Jetpack_Waf_Main;
@@ -51,6 +52,7 @@ class Config {
 		'waf'             => false,
 		'videopress'      => false,
 		'stats'           => false,
+		'stats_admin'     => false,
 	);
 
 	/**
@@ -150,6 +152,9 @@ class Config {
 		}
 		if ( $this->config['stats'] ) {
 			$this->ensure_class( 'Automattic\Jetpack\Stats\Main' ) && $this->ensure_feature( 'stats' );
+		}
+		if ( $this->config['stats_admin'] ) {
+			$this->ensure_class( 'Automattic\Jetpack\Stats_Admin\Main' ) && $this->ensure_feature( 'stats_admin' );
 		}
 	}
 
@@ -314,6 +319,14 @@ class Config {
 	 */
 	protected function enable_stats() {
 		Stats_Main::init();
+		return true;
+	}
+
+	/**
+	 * Enables Stats Admin.
+	 */
+	protected function enable_stats_admin() {
+		Stats_Admin_Main::init();
 		return true;
 	}
 

--- a/projects/plugins/backup/changelog/update-init-with-config-package
+++ b/projects/plugins/backup/changelog/update-init-with-config-package
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -374,7 +374,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/config",
-                "reference": "ad6c987585b5b4a0f8cbdd5add6711278c4d675f"
+                "reference": "cbf1f469eb544e364568f907ecf5511abc441954"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev"
@@ -388,7 +388,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-config/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.11.x-dev"
+                    "dev-trunk": "1.12.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/boost/changelog/update-init-with-config-package
+++ b/projects/plugins/boost/changelog/update-init-with-config-package
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -291,7 +291,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/config",
-                "reference": "ad6c987585b5b4a0f8cbdd5add6711278c4d675f"
+                "reference": "cbf1f469eb544e364568f907ecf5511abc441954"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev"
@@ -305,7 +305,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-config/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.11.x-dev"
+                    "dev-trunk": "1.12.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/update-init-with-config-package
+++ b/projects/plugins/jetpack/changelog/update-init-with-config-package
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Stats: use config package to init stats admin

--- a/projects/plugins/jetpack/changelog/update-init-with-config-package#2
+++ b/projects/plugins/jetpack/changelog/update-init-with-config-package#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -823,6 +823,7 @@ class Jetpack {
 				'waf',
 				'videopress',
 				'stats',
+				'stats_admin',
 			)
 			as $feature
 		) {
@@ -905,7 +906,6 @@ class Jetpack {
 			add_action( 'jetpack_agreed_to_terms_of_service', array( new Plugin_Tracking(), 'init' ) );
 		}
 
-		Automattic\Jetpack\Stats_Admin\Main::init();
 	}
 
 	/**

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -591,7 +591,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/config",
-                "reference": "ad6c987585b5b4a0f8cbdd5add6711278c4d675f"
+                "reference": "cbf1f469eb544e364568f907ecf5511abc441954"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev"
@@ -605,7 +605,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-config/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.11.x-dev"
+                    "dev-trunk": "1.12.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/changelog/update-init-with-config-package
+++ b/projects/plugins/protect/changelog/update-init-with-config-package
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -291,7 +291,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/config",
-                "reference": "ad6c987585b5b4a0f8cbdd5add6711278c4d675f"
+                "reference": "cbf1f469eb544e364568f907ecf5511abc441954"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev"
@@ -305,7 +305,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-config/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.11.x-dev"
+                    "dev-trunk": "1.12.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/changelog/update-init-with-config-package
+++ b/projects/plugins/search/changelog/update-init-with-config-package
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -291,7 +291,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/config",
-                "reference": "ad6c987585b5b4a0f8cbdd5add6711278c4d675f"
+                "reference": "cbf1f469eb544e364568f907ecf5511abc441954"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev"
@@ -305,7 +305,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-config/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.11.x-dev"
+                    "dev-trunk": "1.12.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/update-init-with-config-package
+++ b/projects/plugins/social/changelog/update-init-with-config-package
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -291,7 +291,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/config",
-                "reference": "ad6c987585b5b4a0f8cbdd5add6711278c4d675f"
+                "reference": "cbf1f469eb544e364568f907ecf5511abc441954"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev"
@@ -305,7 +305,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-config/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.11.x-dev"
+                    "dev-trunk": "1.12.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/starter-plugin/changelog/update-init-with-config-package
+++ b/projects/plugins/starter-plugin/changelog/update-init-with-config-package
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -291,7 +291,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/config",
-                "reference": "ad6c987585b5b4a0f8cbdd5add6711278c4d675f"
+                "reference": "cbf1f469eb544e364568f907ecf5511abc441954"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev"
@@ -305,7 +305,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-config/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.11.x-dev"
+                    "dev-trunk": "1.12.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/videopress/changelog/update-init-with-config-package
+++ b/projects/plugins/videopress/changelog/update-init-with-config-package
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -291,7 +291,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/config",
-                "reference": "ad6c987585b5b4a0f8cbdd5add6711278c4d675f"
+                "reference": "cbf1f469eb544e364568f907ecf5511abc441954"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev"
@@ -305,7 +305,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-config/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.11.x-dev"
+                    "dev-trunk": "1.12.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Changed to  use `config` package to init `stats-admin` for Jetpack the plugin.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Open a site with Jetpack plugin
* Open `/wp-admin/admin.php?page=jetpack#/traffic?term=jetpack%20stats`
* Expand the Jetpack Stats section
* Open browser console and run `document.querySelector('#jp-settings-site-stats').querySelectorAll('.jp-form-fieldset')[1].setAttribute('style','color:red')`
* Turn on the new Stats experience (color red toggle)
* Open `/wp-admin/admin.php?page=stats`
* Ensure the page looks reasonable

<img width="623" alt="image" src="https://user-images.githubusercontent.com/1425433/203453009-5184f2b8-482c-4193-b603-d62a071a4dbd.png">

<img width="495" alt="image" src="https://user-images.githubusercontent.com/1425433/203453143-f067cc78-77a0-4d6b-8e16-635c9459040c.png">
