### PR TITLE
Search: show in Jetpack menu even without plan

### DIFF
--- a/projects/packages/search/changelog/update-always-show-search-menu
+++ b/projects/packages/search/changelog/update-always-show-search-menu
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Show search in menu even without prior plan purchase
+
+

--- a/projects/packages/search/compatibility/jetpack.php
+++ b/projects/packages/search/compatibility/jetpack.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\Search\Compatibility\Jetpack;
 
-use Automattic\Jetpack\Search\Plan;
 use Jetpack;
 
 /**
@@ -23,7 +22,7 @@ function should_show_jetpack_search_submenu() {
 		return false;
 	}
 
-	return ( new Plan() )->ever_supported_search();
+	return true;
 }
 
 add_filter( 'jetpack_search_should_add_search_submenu', __NAMESPACE__ . '\should_show_jetpack_search_submenu' );


### PR DESCRIPTION
Fixes #27512

#### Changes proposed in this Pull Request:
Before this PR, we showed Search in Jetpack submenu only when user had active Search subscription, or had one at some point. This PR changes it so that it's always visible, to increase discoverability of both free and paid Search plan.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
panfyZ-1pv-p2#comment-3221

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Activate full Jetpack plugin, make sure that Search submenu is visible under Jetpack in wp-admin.