### PR TITLE
E2E tests: remove repo name condition for repository dispatch

### DIFF
--- a/.github/files/gh-e2e/workflows/e2e-tests.yml
+++ b/.github/files/gh-e2e/workflows/e2e-tests.yml
@@ -7,7 +7,6 @@ jobs:
   run-tests:
     name: "Trigger e2e tests in Jetpack monorepo"
     runs-on: ubuntu-latest
-    if: github.repository == 'automattic/jetpack-production'
 
     steps:
       - name: Create a repository dispatch


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

With #27527 the e2e workflow only gets pushed to mirror repos for plugins that have e2e tests, making the repository name check obsolete.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
pd5faL-kN-p2

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* After merge, all mirror repos that have the e2e workflow should trigger e2e tests in the monorepo on push.