### PR TITLE
Jetpack Boost: Include built image-guide files

### DIFF
--- a/projects/plugins/boost/.gitattributes
+++ b/projects/plugins/boost/.gitattributes
@@ -2,15 +2,16 @@
 # Remember to end all directories with `/**` to properly tag every file.
 # /src/js/example.min.js  production-include
 
-app/assets/dist/**            production-include
-jetpack_vendor/**             production-include
-vendor/autoload.php           production-include
-vendor/autoload_functions.php production-include
-vendor/autoload_packages.php  production-include
-vendor/automattic/**          production-include
-vendor/composer/**            production-include
-vendor/jetpack-autoloader/**  production-include
-vendor/tedivm/** 			  production-include
+app/assets/dist/**            					production-include
+app/features/image-guide/dist/**            	production-include
+jetpack_vendor/**             					production-include
+vendor/autoload.php           					production-include
+vendor/autoload_functions.php 					production-include
+vendor/autoload_packages.php  					production-include
+vendor/automattic/**          					production-include
+vendor/composer/**            					production-include
+vendor/jetpack-autoloader/**  					production-include
+vendor/tedivm/** 			  					production-include
 
 # Files to exclude from the mirror repo, but included in the monorepo.
 # Remember to end all directories with `/**` to properly tag every file.

--- a/projects/plugins/boost/.gitattributes
+++ b/projects/plugins/boost/.gitattributes
@@ -2,16 +2,16 @@
 # Remember to end all directories with `/**` to properly tag every file.
 # /src/js/example.min.js  production-include
 
-app/assets/dist/**            					production-include
-app/features/image-guide/dist/**            	production-include
-jetpack_vendor/**             					production-include
-vendor/autoload.php           					production-include
-vendor/autoload_functions.php 					production-include
-vendor/autoload_packages.php  					production-include
-vendor/automattic/**          					production-include
-vendor/composer/**            					production-include
-vendor/jetpack-autoloader/**  					production-include
-vendor/tedivm/** 			  					production-include
+app/assets/dist/**                              production-include
+app/features/image-guide/dist/**                production-include
+jetpack_vendor/**                               production-include
+vendor/autoload.php                             production-include
+vendor/autoload_functions.php                   production-include
+vendor/autoload_packages.php                    production-include
+vendor/automattic/**                            production-include
+vendor/composer/**                              production-include
+vendor/jetpack-autoloader/**                    production-include
+vendor/tedivm/**                                production-include
 
 # Files to exclude from the mirror repo, but included in the monorepo.
 # Remember to end all directories with `/**` to properly tag every file.

--- a/projects/plugins/boost/changelog/boost-fix-image-guide-dist
+++ b/projects/plugins/boost/changelog/boost-fix-image-guide-dist
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed builds
+
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Fixes image-guide dist files not being included in beta build

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
--

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
--
