### PR TITLE
Protect: WAF share data toggle

### DIFF
--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -203,6 +203,7 @@ class Jetpack_Protect {
 				'isLoading' => false,
 				'config'    => Waf_Runner::get_config(),
 			),
+			'wafShareData'      => get_option( 'jetpack_waf_share_data' ),
 		);
 
 		$initial_state['jetpackScan']['pricingForUi'] = Plan::get_product( 'jetpack_scan' );

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -203,7 +203,6 @@ class Jetpack_Protect {
 				'isLoading' => false,
 				'config'    => Waf_Runner::get_config(),
 			),
-			'wafShareData'      => get_option( 'jetpack_waf_share_data' ),
 		);
 
 		$initial_state['jetpackScan']['pricingForUi'] = Plan::get_product( 'jetpack_scan' );

--- a/projects/plugins/protect/src/js/components/firewall-footer/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-footer/index.jsx
@@ -40,12 +40,26 @@ const StandaloneMode = () => {
 };
 
 const ShareData = () => {
+	const { wafShareData } = window.jetpackProtectInitialState || false;
+	let shareDataEnabled = false;
+	if ( '1' === wafShareData ) {
+		shareDataEnabled = true;
+	}
+
+	const onChange = checked => {
+		if ( checked ) {
+			console.log( "Set jetpack_waf_share_data option to '1' - ON" );
+		} else {
+			console.log( "Set jetpack_waf_share_data option to '' - OFF" );
+		}
+	};
+
 	return (
 		<div className={ styles[ 'share-data-section' ] }>
 			<Title mb={ 2 }>{ __( ' Share data with Jetpack', 'jetpack-protect' ) }</Title>
 			<div className={ styles[ 'footer-checkbox' ] }>
 				{ /* To-Do: Add checkbox functionality */ }
-				<CheckboxControl checked={ true } />
+				<CheckboxControl checked={ shareDataEnabled } onChange={ onChange } />
 				<Text>
 					{ __(
 						'Allow Jetpack to collect data to improve firewall protection and rules. Collected data is also used to display advanced usage metrics.',
@@ -58,6 +72,7 @@ const ShareData = () => {
 };
 
 const FirewallFooter = () => {
+	console.log( window.jetpackProtectInitialState );
 	return (
 		<AdminSectionHero>
 			<SeventyFiveLayout

--- a/projects/plugins/protect/src/js/components/firewall-footer/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-footer/index.jsx
@@ -58,8 +58,7 @@ const ShareData = () => {
 		<div className={ styles[ 'share-data-section' ] }>
 			<Title mb={ 2 }>{ __( ' Share data with Jetpack', 'jetpack-protect' ) }</Title>
 			<div className={ styles[ 'footer-checkbox' ] }>
-				{ /* To-Do: Add checkbox functionality */ }
-				<CheckboxControl checked={ shareDataEnabled } onChange={ onChange } />
+				<CheckboxControl checked={ wafShareData } onChange={ toggleShareData } />
 				<Text>
 					{ __(
 						'Allow Jetpack to collect data to improve firewall protection and rules. Collected data is also used to display advanced usage metrics.',

--- a/projects/plugins/protect/src/js/components/firewall-footer/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-footer/index.jsx
@@ -1,10 +1,9 @@
 import { AdminSectionHero, Title, Text, Button } from '@automattic/jetpack-components';
-import apiFetch from '@wordpress/api-fetch';
 import { CheckboxControl } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import camelize from 'camelize';
 import { useState, useEffect, useCallback } from 'react';
+import API from '../../api';
 import useWafData from '../../hooks/use-waf-data';
 import { STORE_ID } from '../../state/store';
 import SeventyFiveLayout from '../seventy-five-layout';
@@ -47,7 +46,7 @@ const ShareData = () => {
 	const { waf } = useWafData();
 	const { jetpackWafShareData } = waf || {};
 
-	const { setWaf } = useDispatch( STORE_ID );
+	const { refreshWaf } = useDispatch( STORE_ID );
 
 	const [ settings, setSettings ] = useState( {
 		jetpack_waf_share_data: jetpackWafShareData,
@@ -55,20 +54,11 @@ const ShareData = () => {
 	const [ settingsAreUpdating, setSettingsAreUpdating ] = useState( false );
 
 	const toggleShareData = useCallback( () => {
-		setSettings( {
-			jetpack_waf_share_data: ! jetpackWafShareData,
-		} );
 		setSettingsAreUpdating( true );
-		apiFetch( {
-			method: 'POST',
-			path: 'jetpack/v4/waf',
-			data: {
-				jetpack_waf_share_data: ! jetpackWafShareData,
-			},
-		} )
-			.then( updatedWaf => setWaf( { ...waf, ...camelize( updatedWaf ) } ) )
+		API.updateWaf( { jetpack_waf_share_data: ! jetpackWafShareData } )
+			.then( refreshWaf )
 			.finally( () => setSettingsAreUpdating( false ) );
-	}, [ jetpackWafShareData, setWaf, waf ] );
+	}, [ refreshWaf, jetpackWafShareData ] );
 
 	useEffect( () => {
 		setSettings( {

--- a/projects/plugins/protect/src/js/components/firewall-footer/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-footer/index.jsx
@@ -81,11 +81,13 @@ const ShareData = () => {
 };
 
 const FirewallFooter = () => {
+	const { isEnabled } = useWafData();
+
 	return (
 		<AdminSectionHero>
 			<SeventyFiveLayout
 				main={ <StandaloneMode /> }
-				secondary={ <ShareData /> }
+				secondary={ isEnabled && <ShareData /> }
 				preserveSecondaryOnMobile={ true }
 			/>
 		</AdminSectionHero>

--- a/projects/plugins/protect/src/js/components/firewall-footer/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-footer/index.jsx
@@ -3,7 +3,6 @@ import { CheckboxControl } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useCallback } from 'react';
-import API from '../../api';
 import useWafData from '../../hooks/use-waf-data';
 import { STORE_ID } from '../../state/store';
 import SeventyFiveLayout from '../seventy-five-layout';
@@ -43,22 +42,17 @@ const StandaloneMode = () => {
 };
 
 const ShareData = () => {
-	const { waf } = useWafData();
-	const { jetpackWafShareData } = waf || {};
-
-	const { refreshWaf } = useDispatch( STORE_ID );
+	const { config, isLoading, toggleShareData } = useWafData();
+	const { jetpackWafShareData } = config || {};
 
 	const [ settings, setSettings ] = useState( {
 		jetpack_waf_share_data: jetpackWafShareData,
 	} );
-	const [ settingsAreUpdating, setSettingsAreUpdating ] = useState( false );
 
-	const toggleShareData = useCallback( () => {
-		setSettingsAreUpdating( true );
-		API.updateWaf( { jetpack_waf_share_data: ! jetpackWafShareData } )
-			.then( refreshWaf )
-			.finally( () => setSettingsAreUpdating( false ) );
-	}, [ refreshWaf, jetpackWafShareData ] );
+	const handleShareDataChange = useCallback( () => {
+		setSettings( { ...settings, jetpack_waf_share_data: ! settings.jetpack_waf_share_data } );
+		toggleShareData();
+	}, [ settings, toggleShareData ] );
 
 	useEffect( () => {
 		setSettings( {
@@ -72,8 +66,8 @@ const ShareData = () => {
 			<div className={ styles[ 'footer-checkbox' ] }>
 				<CheckboxControl
 					checked={ Boolean( settings.jetpack_waf_share_data ) }
-					onChange={ toggleShareData }
-					disabled={ settingsAreUpdating }
+					onChange={ handleShareDataChange }
+					disabled={ isLoading }
 				/>
 				<Text>
 					{ __(

--- a/projects/plugins/protect/src/js/hooks/use-waf-data/index.jsx
+++ b/projects/plugins/protect/src/js/hooks/use-waf-data/index.jsx
@@ -51,6 +51,18 @@ const useWafData = () => {
 			.finally( () => setWafIsLoading( false ) );
 	}, [ refreshWaf, setWafIsLoading, waf.config.jetpackWafIpList ] );
 
+	/**
+	 * Toggle Share Data
+	 *
+	 * Flips the switch on the share data option, and then refreshes the data.
+	 */
+	const toggleShareData = useCallback( () => {
+		setWafIsLoading( true );
+		return API.updateWaf( { jetpack_waf_share_data: ! waf.config.jetpackWafShareData } )
+			.then( refreshWaf )
+			.finally( () => setWafIsLoading( false ) );
+	}, [ refreshWaf, setWafIsLoading, waf.config.jetpackWafShareData ] );
+
 	const updateConfig = useCallback(
 		update => {
 			setWafIsLoading( true );
@@ -75,6 +87,7 @@ const useWafData = () => {
 		refreshWaf,
 		toggleWaf,
 		toggleManualRules,
+		toggleShareData,
 		updateConfig,
 	};
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Description
Adds functionality to the `CheckboxControl` component within the `FirewallFooter`

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds the ability to toggle the `jetpack_waf_share_data` between `true` and `false`
* Updates the `CheckboxControl` display depending on the setting
* Hides the `share-data-section` when the WAF is disabled

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- 1201069996155224-as-1203282049665702

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Start up a new Jurassic Ninja site using this Protect branch
* Activate Protect and proceed to Protect admin page Firewall tab
* Verify that the WAF is currently disabled and that the `share-data-section` is missing from the footer
* Enable the WAF and verify that the section is rendered and currently set to off
* Open your browser Dev Tools and review the Network tab
* Toggle the checkbox on
* Verify that a successful request is sent to the `/waf` endpoint to update `jetpack_waf_share_data` to `true`, that a subsequent request is sent to get the settings, and that the UI renders as expected
* Refresh the page and ensure that checkbox remains on
* Proceed similarly to disable share data
