### PR TITLE
VideoPress: Add JITM container

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-jitm
+++ b/projects/packages/videopress/changelog/add-videopress-jitm
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Add JITM wrapper

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -165,6 +165,12 @@ const Admin = () => {
 			) : (
 				<>
 					<AdminSectionHero>
+						<Container horizontalSpacing={ 0 }>
+							<Col>
+								<div id="jp-admin-notices" className="jetpack-videopress-jitm-card" />
+							</Col>
+						</Container>
+
 						<Container horizontalSpacing={ 6 } horizontalGap={ 3 }>
 							{ hasConnectionError && (
 								<Col>
@@ -177,6 +183,7 @@ const Admin = () => {
 									<NeedUserConnectionGlobalNotice />
 								</Col>
 							) }
+
 							<Col sm={ 4 } md={ 4 } lg={ 8 }>
 								<Text variant="headline-small" mb={ 3 }>
 									{ __( 'High quality, ad-free video', 'jetpack-videopress-pkg' ) }

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/style.module.scss
@@ -1,3 +1,18 @@
+
+:global {
+	#wpbody-content {
+		& > .notice {
+			display: none;
+		}
+	}
+
+	.jetpack-videopress-jitm-card {
+		.jitm-card {
+			margin-right: 0;
+		}
+	}
+}
+
 .header-wrapper {
 	&:not( .small ) {
 		display: flex;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #27501

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a container for JITM on the VideoPress dashboard

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-hAU-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the instructions from https://github.com/Automattic/jetpack/pull/25945 (manual file editing required, as the patch itself is in conflict now)
* Update the path to match the Jetpack VideoPress plugin (`->message_path( '/wp:(jetpack_page_jetpack-videopress):admin_notices/' )`)
* Visit the Jetpack VideoPress admin page and confirm that the JITM is displayed as expected
* Visit the Jetpack VideoPress admin page without the JITM enabled to ensure no side effects of adding the empty container/col