### PR TITLE
VideoPress: Improve video list empty state when filters are applied

### DIFF
--- a/projects/packages/videopress/changelog/fix-add-empty-result-string-specific-for-filters
+++ b/projects/packages/videopress/changelog/fix-add-empty-result-string-specific-for-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: Use a generic filter message when there are no videos available and a search term is not present.

--- a/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
@@ -157,16 +157,18 @@ export const VideoPressLibrary = ( { videos, totalVideos, loading }: VideoLibrar
 				library
 			) : (
 				<Text>
-					{ createInterpolateElement(
-						sprintf(
-							/* translators: placeholder is the search term */
-							__( 'No videos match your search for <em>%s</em>.', 'jetpack-videopress-pkg' ),
-							search
-						),
-						{
-							em: <em className={ styles[ 'query-no-results' ] } />,
-						}
-					) }
+					{ search.trim()
+						? createInterpolateElement(
+								sprintf(
+									/* translators: placeholder is the search term */
+									__( 'No videos match your search for <em>%s</em>.', 'jetpack-videopress-pkg' ),
+									search
+								),
+								{
+									em: <em className={ styles[ 'query-no-results' ] } />,
+								}
+						  )
+						: __( 'No videos match your filtering criteria.', 'jetpack-videopress-pkg' ) }
 				</Text>
 			) }
 			<ConnectPagination className={ styles.pagination } />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27474.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Use a generic filter message when there are no videos available and a search term is not present

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a fresh site, upload one video and set the rating to some value (for example, R)
* Alternativelly, on an existing site, make sure that no video has some specific rating (for example, PG-13)
* Apply a filter on the video listing using another rating (for example, PG-13):

<img width="1125" alt="Screen Shot 2022-11-23 at 17 42 27" src="https://user-images.githubusercontent.com/6760046/203642867-610821c4-1289-4ad0-b8f9-57d7beeac0d9.png">

* This should result on an empty result list, with the empty results string showing up
* **Before the fix**, the string would look like this:

<img width="770" alt="Screen Shot 2022-11-23 at 18 05 44" src="https://user-images.githubusercontent.com/6760046/203646078-433a442b-6a2f-453e-8772-246b2d261e1a.png">

* **After the fix**, it will look like this:

<img width="1108" alt="Screen Shot 2022-11-23 at 17 46 25" src="https://user-images.githubusercontent.com/6760046/203643282-8d8fb436-2254-4267-b020-37a12aea0a5c.png">

* When we combine filters and a search term, it returns to the original behavior:

<img width="1104" alt="Screen Shot 2022-11-23 at 17 57 17" src="https://user-images.githubusercontent.com/6760046/203644825-64312190-aec5-480d-98ab-f211f04d08eb.png">

