### PR TITLE
Stats: change embedded css to separate file

### DIFF
--- a/projects/packages/stats-admin/assets/style.css
+++ b/projects/packages/stats-admin/assets/style.css
@@ -1,0 +1,15 @@
+.jp-stats-dashboard .card {
+	border: 0;
+	max-width: initial;
+	min-width: initial;
+}
+ul.wp-submenu,
+ul.wp-submenu-wrap {
+	margin-left: 0;
+}
+.jp-stats-dashboard .followers-count {
+	display: none;
+}
+.jp-stats-dashboard .layout__content {
+	padding-top: 32px;
+}

--- a/projects/packages/stats-admin/changelog/update-change-embedded-css-to-separate-file
+++ b/projects/packages/stats-admin/changelog/update-change-embedded-css-to-separate-file
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Stats: moved embedded css to a separate file

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.1.1",
+	"version": "0.1.2-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -145,28 +145,9 @@ class Dashboard {
 			'before'
 		);
 
-		add_action(
-			'admin_head',
-			function () {
-				echo '<style>
-				.jp-stats-dashboard .card {
-					border:0;
-					max-width: initial;
-					min-width: initial;
-				}
-				ul.wp-submenu, ul.wp-submenu-wrap {
-					margin-left: 0;
-				}
-				.jp-stats-dashboard .followers-count {
-					display: none;
-				}
-				.jp-stats-dashboard .layout__content {
-					padding-top: 32px;
-				}
-				</style>';
-			},
-			100
-		);
+		// Load the style sheet to customize the look of the dashboard in Jetpack.
+		wp_register_style( 'jp-stats-dashboard-style-override', plugins_url( '../assets/style.css', __FILE__ ), array(), filemtime( plugin_dir_path( __FILE__ ) . '../assets/style.css' ) );
+		wp_enqueue_style( 'jp-stats-dashboard-style-override' );
 	}
 
 	/**

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -146,7 +146,7 @@ class Dashboard {
 		);
 
 		// Load the style sheet to customize the look of the dashboard in Jetpack.
-		wp_register_style( 'jp-stats-dashboard-style-override', plugins_url( '../assets/style.css', __FILE__ ), array(), filemtime( plugin_dir_path( __FILE__ ) . '../assets/style.css' ) );
+		wp_register_style( 'jp-stats-dashboard-style-override', plugins_url( '../assets/style.css', __FILE__ ), array(), filemtime( __DIR__ . '/../assets/style.css' ) );
 		wp_enqueue_style( 'jp-stats-dashboard-style-override' );
 	}
 

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -18,7 +18,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.1.1';
+	const VERSION = '0.1.2-alpha';
 
 	/**
 	 * Singleton Main instance.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Changes the embedded css to a separate file.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Open a site with Jetpack plugin
* Open `/wp-admin/admin.php?page=jetpack#/traffic?term=jetpack%20stats`
* Expand the Jetpack Stats section
* Open browser console and run `document.querySelector('#jp-settings-site-stats').querySelectorAll('.jp-form-fieldset')[1].setAttribute('style','color:red')`
* Turn on the new Stats experience (color red toggle)
* Open `/wp-admin/admin.php?page=stats`
* Ensure the page looks reasonable
* Inspect network requests
* Ensure `assets/style.css` is loading okay

