### PR TITLE
Stats: allow blog token for list posts endpoints

### DIFF
--- a/projects/plugins/jetpack/changelog/update-allow-blog-token-list-posts
+++ b/projects/plugins/jetpack/changelog/update-allow-blog-token-list-posts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Stats: allow blog token access for list posts endpoints 1.1 & 1.2

--- a/projects/plugins/jetpack/changelog/update-allow-blog-token-list-posts
+++ b/projects/plugins/jetpack/changelog/update-allow-blog-token-list-posts
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-Stats: allow blog token access for list posts endpoints 1.1 & 1.2
+Stats: allow blog token access for list posts endpoints v1.2

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
@@ -19,6 +19,7 @@ new WPCOM_JSON_API_List_Posts_v1_1_Endpoint(
 		),
 
 		'allow_fallback_to_jetpack_blog_token' => true,
+		'allow_jetpack_site_auth'              => true,
 
 		'query_parameters'                     => array(
 			'number'          => '(int=20) The number of posts to return. Limit: 100.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
@@ -19,7 +19,6 @@ new WPCOM_JSON_API_List_Posts_v1_1_Endpoint(
 		),
 
 		'allow_fallback_to_jetpack_blog_token' => true,
-		'allow_jetpack_site_auth'              => true,
 
 		'query_parameters'                     => array(
 			'number'          => '(int=20) The number of posts to return. Limit: 100.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
@@ -19,6 +19,7 @@ new WPCOM_JSON_API_List_Posts_v1_2_Endpoint(
 		),
 
 		'allow_fallback_to_jetpack_blog_token' => true,
+		'allow_jetpack_site_auth'              => true,
 
 		'query_parameters'                     => array(
 			'number'                => '(int=20) The number of posts to return. Limit: 100.',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Odyssey Stats (Calypso Stats in Jetpack) is calling `rest/1.1/sites/{blog-id}/posts` with blog token, so we want the endpoints to allow it.

Firstly, I tried to call the endpoint locally, but we'll have to load the whole JSON API module and also that'd make the `stats-admin` package rely on Jetpack plugin which we do not want.

Another solution I tried was to create an API for the purpose independently with limited functionality just for Stats, https://github.com/Automattic/jetpack/pull/27758, which works fine, but it creates more `dup` code with similar functionality. I also tried to copy the callback function in `projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php`, but it has quite a few dependencies as well, which would make the duplication quite big.

@fgiannar suggested we call the core `wp/v2/posts` API, but which is not compatible, and misses a few important data, for example, number of comment and likes.

Based on the above, I still think it's best to just call the WPCOM API with `force=wpcom` instead as proposed.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
pejTkB-6b-p2

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Open a site with Jetpack plugin
* Open `/wp-admin/admin.php?page=jetpack#/traffic?term=jetpack%20stats`
* Expand the Jetpack Stats section
* Open browser console and run `document.querySelector('#jp-settings-site-stats').querySelectorAll('.jp-form-fieldset')[1].setAttribute('style','color:red')`
* Turn on the new Stats experience (color red toggle)
* Open `/wp-admin/admin.php?page=stats`
* Ensure the page looks reasonable

* Apply the patch to your sandbox
* Sandbox the JP site
* Inspect network requests
* Ensure `rest/1.2/sites/xxx/posts` is loading okay - NOT 403