### PR TITLE
Protect: Add upgrade prompt while WAF enabled with no rules access

### DIFF
--- a/projects/plugins/protect/src/js/components/firewall-header/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-header/index.jsx
@@ -11,7 +11,7 @@ import useWafData from '../../hooks/use-waf-data';
 import { JETPACK_SCAN } from '../admin-page';
 import styles from './styles.module.scss';
 
-const FirewallHeader = ( { status, hasRequiredPlan } ) => {
+const UpgradePrompt = () => {
 	const { adminUrl } = window.jetpackProtectInitialState || {};
 	const firewallUrl = adminUrl + '#/firewall';
 
@@ -34,6 +34,40 @@ const FirewallHeader = ( { status, hasRequiredPlan } ) => {
 	}, [] );
 
 	return (
+		<>
+			<div className={ styles[ 'manual-rules-notice' ] }>
+				<Text weight={ 600 }>{ __( 'Only manual rules will be applied', 'jetpack-protect' ) }</Text>
+				<div
+					className={ styles[ 'icon-popover' ] }
+					onMouseLeave={ handleOut }
+					onMouseEnter={ handleEnter }
+					onClick={ handleEnter }
+					onFocus={ handleEnter }
+					onBlur={ handleOut }
+					role="presentation"
+				>
+					<Icon icon={ help } />
+					{ showPopover && (
+						<Popover noArrow={ false } offset={ 5 }>
+							<Text className={ styles[ 'popover-text' ] } variant={ 'body-small' }>
+								{ __(
+									'The free version of the firewall only allows for use of manual rules.',
+									'jetpack-protect'
+								) }
+							</Text>
+						</Popover>
+					) }
+				</div>
+			</div>
+			<Button onClick={ getScan }>
+				{ __( 'Upgrade to enable automatic rules', 'jetpack-protect' ) }
+			</Button>
+		</>
+	);
+};
+
+const FirewallHeader = ( { status, hasRequiredPlan } ) => {
+	return (
 		<AdminSectionHero>
 			<Container
 				className={ styles[ 'firewall-header' ] }
@@ -49,39 +83,7 @@ const FirewallHeader = ( { status, hasRequiredPlan } ) => {
 							<H3 className={ styles[ 'firewall-heading' ] } mb={ 1 } mt={ 2 }>
 								{ __( 'Automatic firewall is on', 'jetpack-protect' ) }
 							</H3>
-							{ ! hasRequiredPlan && (
-								<>
-									<div className={ styles[ 'manual-rules-notice' ] }>
-										<Text weight={ 600 }>
-											{ __( 'Only manual rules will be applied', 'jetpack-protect' ) }
-										</Text>
-										<div
-											className={ styles[ 'icon-popover' ] }
-											onMouseLeave={ handleOut }
-											onMouseEnter={ handleEnter }
-											onClick={ handleEnter }
-											onFocus={ handleEnter }
-											onBlur={ handleOut }
-											role="presentation"
-										>
-											<Icon icon={ help } />
-											{ showPopover && (
-												<Popover noArrow={ false } offset={ 5 }>
-													<Text className={ styles[ 'popover-text' ] } variant={ 'body-small' }>
-														{ __(
-															'The free version of the firewall only allows for use of manual rules.',
-															'jetpack-protect'
-														) }
-													</Text>
-												</Popover>
-											) }
-										</div>
-									</div>
-									<Button onClick={ getScan }>
-										{ __( 'Upgrade to enable automatic rules', 'jetpack-protect' ) }
-									</Button>
-								</>
-							) }
+							{ ! hasRequiredPlan && <UpgradePrompt /> }
 						</>
 					) }
 					{ 'off' === status && (
@@ -92,39 +94,7 @@ const FirewallHeader = ( { status, hasRequiredPlan } ) => {
 							<H3 className={ styles[ 'firewall-heading' ] } mb={ 2 } mt={ 2 }>
 								{ __( 'Automatic firewall is off', 'jetpack-protect' ) }
 							</H3>
-							{ ! hasRequiredPlan && (
-								<>
-									<div className={ styles[ 'manual-rules-notice' ] }>
-										<Text weight={ 600 }>
-											{ __( 'Only manual rules will be applied', 'jetpack-protect' ) }
-										</Text>
-										<div
-											className={ styles[ 'icon-popover' ] }
-											onMouseLeave={ handleOut }
-											onMouseEnter={ handleEnter }
-											onClick={ handleEnter }
-											onFocus={ handleEnter }
-											onBlur={ handleOut }
-											role="presentation"
-										>
-											<Icon icon={ help } />
-											{ showPopover && (
-												<Popover noArrow={ false } offset={ 5 }>
-													<Text className={ styles[ 'popover-text' ] } variant={ 'body-small' }>
-														{ __(
-															'The free version of the firewall only allows for use of manual rules.',
-															'jetpack-protect'
-														) }
-													</Text>
-												</Popover>
-											) }
-										</div>
-									</div>
-									<Button onClick={ getScan }>
-										{ __( 'Upgrade to enable automatic rules', 'jetpack-protect' ) }
-									</Button>
-								</>
-							) }
+							{ ! hasRequiredPlan && <UpgradePrompt /> }
 						</>
 					) }
 					{ 'loading' === status && (

--- a/projects/plugins/protect/src/js/components/firewall-header/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-header/index.jsx
@@ -49,6 +49,39 @@ const FirewallHeader = ( { status, hasRequiredPlan } ) => {
 							<H3 className={ styles[ 'firewall-heading' ] } mb={ 1 } mt={ 2 }>
 								{ __( 'Automatic firewall is on', 'jetpack-protect' ) }
 							</H3>
+							{ ! hasRequiredPlan && (
+								<>
+									<div className={ styles[ 'manual-rules-notice' ] }>
+										<Text weight={ 600 }>
+											{ __( 'Only manual rules will be applied', 'jetpack-protect' ) }
+										</Text>
+										<div
+											className={ styles[ 'icon-popover' ] }
+											onMouseLeave={ handleOut }
+											onMouseEnter={ handleEnter }
+											onClick={ handleEnter }
+											onFocus={ handleEnter }
+											onBlur={ handleOut }
+											role="presentation"
+										>
+											<Icon icon={ help } />
+											{ showPopover && (
+												<Popover noArrow={ false } offset={ 5 }>
+													<Text className={ styles[ 'popover-text' ] } variant={ 'body-small' }>
+														{ __(
+															'The free version of the firewall only allows for use of manual rules.',
+															'jetpack-protect'
+														) }
+													</Text>
+												</Popover>
+											) }
+										</div>
+									</div>
+									<Button onClick={ getScan }>
+										{ __( 'Upgrade to enable automatic rules', 'jetpack-protect' ) }
+									</Button>
+								</>
+							) }
 						</>
 					) }
 					{ 'off' === status && (

--- a/projects/plugins/protect/src/js/components/firewall-header/stories/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-header/stories/index.jsx
@@ -7,6 +7,10 @@ export default {
 };
 
 export const FirewallOn = () => {
+	return <FirewallHeader status={ 'on' } hasRequiredPlan={ false } />;
+};
+
+export const FirewallOnPaid = () => {
 	return <FirewallHeader status={ 'on' } hasRequiredPlan={ true } />;
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Description
This PR introduces an upgrade prompt when the WAF is enabled, but there is no rules access.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds an UpgradePrompt component
* Applies the prompt conditionally to both the `on` and `off` states

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- 1201069996155224-as-1203430506224966

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Start Jurassic Tube instance using this Protect branch
* Load the Firewall page and verify the FirewallHeader component displays as expected in all applicable situations (in both desktop and mobile and viewports in between):
* Note: At the moment, this can be achieved by manually setting the following component variables:
   * status ={ 'on' }, hasRequiredPlan ={ 'true' }
   * status ={ 'on' }, hasRequiredPlan ={ 'false' }
      * Hover over the help icon and ensure the Popover displays as expected
      * Ensure the upgrade button provides for a smooth checkout flow
   * status ={ 'off' }, hasRequiredPlan ={ 'true' }
   * status ={ 'off' }, hasRequiredPlan ={ 'false' }
      * Hover over the help icon and ensure the Popover displays as expected
      * Ensure the upgrade button provides for a smooth checkout flow
   * status ={ 'loading' }

