### PR TITLE
Stats: allow red team bypass crew review for stats packages

### DIFF
--- a/.github/files/required-review.yaml
+++ b/.github/files/required-review.yaml
@@ -30,6 +30,8 @@
    # Exclude packages managed by other teams, which are covered by other blocks below.
    - '!projects/packages/backup/**'
    - '!projects/packages/search/**'
+   - '!projects/packages/stats/**'
+   - '!projects/packages/stats-admin/**'
    - '!projects/packages/publicize/**'
    - '!projects/packages/waf/**'
    - '!projects/plugins/*/composer.lock'
@@ -84,6 +86,18 @@
   paths:
    - 'projects/plugins/search/**'
    - 'projects/packages/search/**'
+   - '!projects/plugins/*/composer.lock'
+   - '!projects/plugins/*/composer.json'
+   - '!projects/plugins/*/changelog/*'
+  teams:
+   - red
+   - jetpack-approvers
+
+# The Red team reviews changes to the Stats and its Admin package.
+- name: Stats
+  paths:
+   - 'projects/packages/stats/**'
+   - 'projects/packages/stats-admin/**'
    - '!projects/plugins/*/composer.lock'
    - '!projects/plugins/*/composer.json'
    - '!projects/plugins/*/changelog/*'


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Allow red team bypasses crew review for the stats packages to speed up iterations.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Ensure the changes look okay

