### PR TITLE
Search: Add checkmark icon for resolved topics

### DIFF
--- a/projects/packages/search/changelog/add-checkmark-for-resolved-topics
+++ b/projects/packages/search/changelog/add-checkmark-for-resolved-topics
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search: Add checkmark icon for resolved topics

--- a/projects/packages/search/src/instant-search/components/search-result-expanded.jsx
+++ b/projects/packages/search/src/instant-search/components/search-result-expanded.jsx
@@ -39,9 +39,15 @@ export default function SearchResultExpanded( props ) {
 							className="jetpack-instant-search__search-result-title-link jetpack-instant-search__search-result-expanded__title-link"
 							href={ `//${ fields[ 'permalink.url.raw' ] }` }
 							onClick={ props.onClick }
-							//eslint-disable-next-line react/no-danger
-							dangerouslySetInnerHTML={ { __html: highlight.title } }
-						/>
+						>
+							<span
+								//eslint-disable-next-line react/no-danger
+								dangerouslySetInnerHTML={ { __html: highlight.title } }
+							/>
+							{ fields.resolved === 'yes' && (
+								<span className="jetpack-instant-search__search-result-title-checkmark" />
+							) }
+						</a>
 					</h3>
 
 					{ ! isMultiSite && (

--- a/projects/packages/search/src/instant-search/components/search-result-expanded.jsx
+++ b/projects/packages/search/src/instant-search/components/search-result-expanded.jsx
@@ -44,7 +44,7 @@ export default function SearchResultExpanded( props ) {
 								//eslint-disable-next-line react/no-danger
 								dangerouslySetInnerHTML={ { __html: highlight.title } }
 							/>
-							{ fields.resolved === 'yes' && (
+							{ fields[ 'forum.topic_resolved' ] === 'yes' && (
 								<span className="jetpack-instant-search__search-result-title-checkmark" />
 							) }
 						</a>

--- a/projects/packages/search/src/instant-search/components/search-result-minimal.jsx
+++ b/projects/packages/search/src/instant-search/components/search-result-minimal.jsx
@@ -108,7 +108,7 @@ class SearchResultMinimal extends Component {
 							//eslint-disable-next-line react/no-danger
 							dangerouslySetInnerHTML={ { __html: highlight.title } }
 						/>
-						{ fields.resolved === 'yes' && (
+						{ fields[ 'forum.topic_resolved' ] === 'yes' && (
 							<span className="jetpack-instant-search__search-result-title-checkmark" />
 						) }
 					</a>

--- a/projects/packages/search/src/instant-search/components/search-result-minimal.jsx
+++ b/projects/packages/search/src/instant-search/components/search-result-minimal.jsx
@@ -103,9 +103,15 @@ class SearchResultMinimal extends Component {
 						className="jetpack-instant-search__search-result-title-link jetpack-instant-search__search-result-minimal-title-link"
 						href={ `//${ fields[ 'permalink.url.raw' ] }` }
 						onClick={ this.props.onClick }
-						//eslint-disable-next-line react/no-danger
-						dangerouslySetInnerHTML={ { __html: highlight.title } }
-					/>
+					>
+						<span
+							//eslint-disable-next-line react/no-danger
+							dangerouslySetInnerHTML={ { __html: highlight.title } }
+						/>
+						{ fields.resolved === 'yes' && (
+							<span className="jetpack-instant-search__search-result-title-checkmark" />
+						) }
+					</a>
 				</h3>
 				{ noMatchingContent ? this.renderNoMatchingContent() : this.renderMatchingContent() }
 				<SearchResultComments comments={ highlight && highlight.comments } />

--- a/projects/packages/search/src/instant-search/components/search-result.scss
+++ b/projects/packages/search/src/instant-search/components/search-result.scss
@@ -28,7 +28,6 @@
 
 	.jetpack-instant-search__search-result-title-checkmark {
 		position: relative;
-		display: inline-block;
 		background-color: $color-checkmark-background;
 		border-radius: 50%;
 		width: 30px;

--- a/projects/packages/search/src/instant-search/components/search-result.scss
+++ b/projects/packages/search/src/instant-search/components/search-result.scss
@@ -16,11 +16,36 @@
 	overflow-wrap: break-word;
 
 	.jetpack-instant-search__search-result-title-link {
+		display: flex;
+		align-items: center;
 		text-decoration: none;
 
 		&:hover,
 		&:focus {
 			text-decoration: underline;
+		}
+	}
+
+	.jetpack-instant-search__search-result-title-checkmark {
+		position: relative;
+		display: inline-block;
+		background-color: $color-checkmark-background;
+		border-radius: 50%;
+		width: 1.2em;
+		height: 1.2em;
+		margin-left: 0.35em;
+
+		&:after {
+			content: "";
+			position: absolute;
+			top: 6px;
+			left: 11px;
+			height: 16px;
+			width: 8px;
+			border-bottom: 3px solid;
+			border-right: 3px solid;
+			border-color: $color-checkmark;
+			transform: rotate(40deg);
 		}
 	}
 }

--- a/projects/packages/search/src/instant-search/components/search-result.scss
+++ b/projects/packages/search/src/instant-search/components/search-result.scss
@@ -31,8 +31,8 @@
 		display: inline-block;
 		background-color: $color-checkmark-background;
 		border-radius: 50%;
-		width: 1.2em;
-		height: 1.2em;
+		width: 30px;
+		height: 30px;
 		margin-left: 0.35em;
 
 		&:after {

--- a/projects/packages/search/src/instant-search/lib/api.js
+++ b/projects/packages/search/src/instant-search/lib/api.js
@@ -274,6 +274,7 @@ function generateApiQueryString( {
 		'category.name.default',
 		'post_type',
 		'shortcode_types',
+		'meta.topic_resolved.value',
 	];
 	const highlightFields = [ 'title', 'content', 'comments' ];
 

--- a/projects/packages/search/src/instant-search/lib/api.js
+++ b/projects/packages/search/src/instant-search/lib/api.js
@@ -274,7 +274,7 @@ function generateApiQueryString( {
 		'category.name.default',
 		'post_type',
 		'shortcode_types',
-		'meta.topic_resolved.value',
+		'forum.topic_resolved',
 	];
 	const highlightFields = [ 'title', 'content', 'comments' ];
 

--- a/projects/packages/search/src/instant-search/lib/styles/_variables.scss
+++ b/projects/packages/search/src/instant-search/lib/styles/_variables.scss
@@ -53,3 +53,6 @@ $color-dark-link-alt: $studio-blue-40;
 $color-dark-layout-borders: $studio-gray-70;
 $color-dark-modal-background: $studio-black;
 $color-dark-modal-backdrop-background: rgba( $studio-gray-90, 0.7 );
+
+$color-checkmark-background: $studio-green-5;
+$color-checkmark: $studio-green-80;

--- a/projects/plugins/search/changelog/add-checkmark-for-resolved-topics
+++ b/projects/plugins/search/changelog/add-checkmark-for-resolved-topics
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: Fixed E2E testing failures after adding a checkmark icon for resolved topics

--- a/projects/plugins/search/tests/e2e/specs/search.test.js
+++ b/projects/plugins/search/tests/e2e/specs/search.test.js
@@ -70,7 +70,7 @@ test.describe( 'Instant Search', () => {
 			expect(
 				await homepage.getFirstResultTitle(),
 				'First result title should match the expected value'
-			).toBe( '<mark>Test1</mark> Record 1' );
+			).toBe( '<span><mark>Test1</mark> Record 1</span>' );
 		} );
 
 		await test.step( 'Can edit query in search form', async () => {
@@ -80,7 +80,7 @@ test.describe( 'Instant Search', () => {
 			expect(
 				await homepage.getFirstResultTitle(),
 				'First result title should match the expected value'
-			).toBe( '<mark>Test2</mark> Record 1' );
+			).toBe( '<span><mark>Test2</mark> Record 1</span>' );
 		} );
 
 		await test.step( 'Can change sort order', async () => {
@@ -94,7 +94,7 @@ test.describe( 'Instant Search', () => {
 			expect(
 				await homepage.getFirstResultTitle(),
 				'First result title should match the expected value'
-			).toBe( '<mark>Test2</mark> Record 3' );
+			).toBe( '<span><mark>Test2</mark> Record 3</span>' );
 
 			await homepage.chooseSortingLink( 'oldest' );
 			await homepage.waitForSearchResponse();
@@ -106,7 +106,7 @@ test.describe( 'Instant Search', () => {
 			expect(
 				await homepage.getFirstResultTitle(),
 				'First result title should match the expected value'
-			).toBe( '<mark>Test2</mark> Record 2' );
+			).toBe( '<span><mark>Test2</mark> Record 2</span>' );
 		} );
 
 		await test.step( 'Can apply filters', async () => {
@@ -116,7 +116,7 @@ test.describe( 'Instant Search', () => {
 			expect(
 				await homepage.getFirstResultTitle(),
 				'First result title should match the expected value'
-			).toBe( '<mark>Test2</mark> Record 2' );
+			).toBe( '<span><mark>Test2</mark> Record 2</span>' );
 
 			await homepage.clickFilterCategory2();
 			await homepage.clickFilterTag3();
@@ -125,7 +125,7 @@ test.describe( 'Instant Search', () => {
 			expect(
 				await homepage.getFirstResultTitle(),
 				'First result title should match the expected value'
-			).toBe( '<mark>Test2</mark> Record 3' );
+			).toBe( '<span><mark>Test2</mark> Record 3</span>' );
 		} );
 
 		await test.step( 'Can close overlay by clicking the cross', async () => {


### PR DESCRIPTION
To add a checkmark icon for resolved topics.

#### Changes proposed in this Pull Request:

* Adding a new `forum.topic_resolved` URL parameter for Elastic indexing
* Showing a checkmark beside the search result titles (based on the above response field) for resolved topics 

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

* p9lV3a-5cq-p2

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

1. Applying this PR

2. Adding the following code to `tools/docker/mu-plugins/instant-search.php` (you might need to create it)

```php
<?php

function jp_instant_search_options( $options ) {
	if ( $_GET['blog_id'] ) {
			$options['siteId'] = (int) $_GET['blog_id'];
	}
	if ( $_GET['format'] ) {
			$options['resultFormat'] = sanitize_key( $_GET['format'] );
	}
	return $options;
}
add_filter( 'jetpack_instant_search_options', 'jp_instant_search_options' );
```

3. Go to the following URL (the JA forum has been re-indexed already):
  - https://<YOUR_LOCAL_ENV>?blog_id=142382769&s=フォロワーを削除したい
  
4. You should see a checkmark icon displayed like the following:

<img width="1479" alt="topic_resolved" src="https://user-images.githubusercontent.com/21308003/203721501-4f8f5f36-fa50-4167-adae-c6e765711cfd.png">

