### PR TITLE
E2E tests: setup jetpack for other plugins tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -82,6 +82,13 @@ jobs:
         run_id: ${{ github.event.workflow_run.id }}
         path: build-output
 
+    - name: Checkout jetpack-production
+      if: github.event_name == 'repository_dispatch' && github.event.client_payload.repository != 'Automattic/jetpack-production'
+      uses: actions/checkout@v3
+      with:
+        repository: Automattic/jetpack-production
+        path: build-output/build/Automattic/jetpack-production
+
     - name: Checkout mirror repo
       if: github.event_name == 'repository_dispatch'
       uses: actions/checkout@v3


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Jetpack is required in e2e tests for standalone plugins and it's missing in the current setup of e2e tests for mirror repos.
jetpack-production should also be checked out when testing other plugins.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
pd5faL-kN-p2

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* After merge, check that for tests on standalone plugins the jetpack-production repo is also checked out and the tests pass.