### PR TITLE
Stats: take off new stats admin backend

### DIFF
--- a/projects/plugins/jetpack/changelog/update-take-off-stats-admin-backend
+++ b/projects/plugins/jetpack/changelog/update-take-off-stats-admin-backend
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Stats: take off new Stats backend for security concerns

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -30,7 +30,6 @@ use Automattic\Jetpack\Partner;
 use Automattic\Jetpack\Paths;
 use Automattic\Jetpack\Plugin\Tracking as Plugin_Tracking;
 use Automattic\Jetpack\Redirect;
-use Automattic\Jetpack\Stats_Admin\Main as StatsAdminMain;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\Status\Visitor;
@@ -824,7 +823,6 @@ class Jetpack {
 				'waf',
 				'videopress',
 				'stats',
-				'stats_admin',
 			)
 			as $feature
 		) {
@@ -906,9 +904,6 @@ class Jetpack {
 			 */
 			add_action( 'jetpack_agreed_to_terms_of_service', array( new Plugin_Tracking(), 'init' ) );
 		}
-
-		// We will change to use the config package.
-		StatsAdminMain::init();
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The PR removes the code to init the backend for new Stats.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
p1669275468581729-slack-jetpack-stats

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Go to a jetpack site
* Open `/wp-json/`
* Ensure no endpoints under `stats-app`

