### PR TITLE
Jetpack Sync: Fix reseting 'Retry After' lock

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-actions-reset-retry-at-lock
+++ b/projects/packages/sync/changelog/fix-sync-actions-reset-retry-at-lock
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Jetpack Sync: Minor fix for resetting Retry After lock
+
+

--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -1056,8 +1056,8 @@ class Actions {
 		delete_option( Sender::NEXT_SYNC_TIME_OPTION_NAME . '_full_sync' );
 		delete_option( Sender::NEXT_SYNC_TIME_OPTION_NAME . '_full-sync-enqueue' );
 		// Retry after locks.
-		delete_option( self::RETRY_AFTER_PREFIX . '_sync' );
-		delete_option( self::RETRY_AFTER_PREFIX . '_full_sync' );
+		delete_option( self::RETRY_AFTER_PREFIX . 'sync' );
+		delete_option( self::RETRY_AFTER_PREFIX . 'full_sync' );
 		// Dedicated sync lock.
 		\Jetpack_Options::delete_raw_option( Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME );
 		// Queue locks.

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.43.1';
+	const PACKAGE_VERSION = '1.43.2-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/sync/tests/php/test-actions.php
+++ b/projects/packages/sync/tests/php/test-actions.php
@@ -127,8 +127,8 @@ class Test_Actions extends BaseTestCase {
 		update_option( Sender::NEXT_SYNC_TIME_OPTION_NAME . '_full_sync', 'dummy' );
 		update_option( Sender::NEXT_SYNC_TIME_OPTION_NAME . '_full-sync-enqueue', 'dummy' );
 		// Retry after locks.
-		update_option( Actions::RETRY_AFTER_PREFIX . '_sync', 'dummy' );
-		update_option( Actions::RETRY_AFTER_PREFIX . '_full_sync', 'dummy' );
+		update_option( Actions::RETRY_AFTER_PREFIX . 'sync', 'dummy' );
+		update_option( Actions::RETRY_AFTER_PREFIX . 'full_sync', 'dummy' );
 		// Dedicated sync lock.
 		\Jetpack_Options::update_raw_option( Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME, 'dummy' );
 		// Queue locks.
@@ -142,8 +142,8 @@ class Test_Actions extends BaseTestCase {
 		$this->assertFalse( get_option( Sender::NEXT_SYNC_TIME_OPTION_NAME . '_sync' ) );
 		$this->assertFalse( get_option( Sender::NEXT_SYNC_TIME_OPTION_NAME . '_full_sync' ) );
 		$this->assertFalse( get_option( Sender::NEXT_SYNC_TIME_OPTION_NAME . '_full-sync-enqueue' ) );
-		$this->assertFalse( get_option( Actions::RETRY_AFTER_PREFIX . '_sync' ) );
-		$this->assertFalse( get_option( Actions::RETRY_AFTER_PREFIX . '_full_sync' ) );
+		$this->assertFalse( get_option( Actions::RETRY_AFTER_PREFIX . 'sync' ) );
+		$this->assertFalse( get_option( Actions::RETRY_AFTER_PREFIX . 'full_sync' ) );
 		$this->assertFalse( $sync_queue->is_locked() );
 		$this->assertFalse( $full_sync_queue->is_locked() );
 	}


### PR DESCRIPTION
Fixes a typo that prevented the Sync "Retry After" lock from being properly reset.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* `Sync\Actions`: Fix typo in `reset_sync_locks`

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Try setting the Sync Retry After locks to some extreme values via eg ` wp option update  jp_sync_retry_after_sync 4099288198 ` and verify they are reset when calling the endpoint*

_* One way of testing this is to use Jetpack Debug's REST API Tester module so in case you plan to test with a JN site, make sure to include the Jetpack Debug plugin_
