### PR TITLE
VideoPress: Expose settings on initial state

### DIFF
--- a/projects/packages/videopress/changelog/add-expose-settings-on-initial-state
+++ b/projects/packages/videopress/changelog/add-expose-settings-on-initial-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Expose the array of VideoPress settings on the client initial state.

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -38,6 +38,17 @@ class Data {
 	}
 
 	/**
+	 * Gets the VideoPress Settings.
+	 *
+	 * @return array The settings as an associative array.
+	 */
+	public static function get_videopress_settings() {
+		return array(
+			'videopress_videos_private_for_site' => self::get_videopress_videos_private_for_site(),
+		);
+	}
+
+	/**
 	 * Gets the video data
 	 *
 	 * @param boolean $is_videopress - True when getting VideoPress data.

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -330,9 +330,14 @@ class Data {
 			$videopress_data['videos']
 		);
 
+		$site_settings = self::get_videopress_settings();
+
 		$initial_state = array(
-			'users'       => self::get_user_data(),
-			'videos'      => array(
+			'users'        => self::get_user_data(),
+			'siteSettings' => array(
+				'videoPressVideosPrivateForSite' => $site_settings['videopress_videos_private_for_site'],
+			),
+			'videos'       => array(
 				'uploadedVideoCount'           => $videopress_data['total'],
 				'items'                        => $videos,
 				'isFetching'                   => false,
@@ -346,7 +351,7 @@ class Data {
 					'relyOnInitialState' => true,
 				),
 			),
-			'localVideos' => array(
+			'localVideos'  => array(
 				'uploadedVideoCount'           => $local_videos_data['total'],
 				'items'                        => $local_videos,
 				'isFetching'                   => false,

--- a/projects/packages/videopress/src/class-videopress-rest-api-v1-settings.php
+++ b/projects/packages/videopress/src/class-videopress-rest-api-v1-settings.php
@@ -88,9 +88,7 @@ class VideoPress_Rest_Api_V1_Settings {
 		}
 
 		$status = 200;
-		$data   = array(
-			'videopress_videos_private_for_site' => get_option( 'videopress_private_enabled_for_site', false ) ? true : false,
-		);
+		$data   = Data::get_videopress_settings();
 
 		return rest_ensure_response(
 			new WP_REST_Response( $data, $status )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27354.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Expose the array of VideoPress settings on the client initial state
* Refactor the Settings REST Controller to get the array of settings from a centralized source, the same used to set the initial state

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open the browser console to inspect the network activity
* Go to `Jetpack > VideoPress`
* Notice that no `GET` requests are made to `videopress/v1/settings`
* Check the value of the `jetpackVideoPressInitialState.initialState` variable in the browser console; you should see something like this:

<img width="419" alt="Screen Shot 2022-11-24 at 14 30 37" src="https://user-images.githubusercontent.com/6760046/203840662-dcf6432e-9f26-4656-9ece-2ea66c1ee578.png">

* On the Redux debugger, confirm that the state for the `videopress/media` store contains the `siteSettings` as well:

<img width="558" alt="Screen Shot 2022-11-24 at 14 32 02" src="https://user-images.githubusercontent.com/6760046/203840928-c8a8404e-9a97-44cb-8ba7-de31a4534ae0.png">

* Confirm that you can change the privacy setting checkbox and it is working properly even after refreshes