### PR TITLE
Prevent submission of empty subscribe field

### DIFF
--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -410,6 +410,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 							placeholder="%3$s"
 							value=""
 							id="%4$s"
+							required
 						/>',
 						( ! empty( $email_field_classes )
 							? 'class="' . esc_attr( $email_field_classes ) . '"'


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/70373

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Do not allow the subscribe form to be submitted while being empty

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Build and sync branch to WPCOM 
2. Attempt to subscribe without entering an email
3. The step above should fail, and an error message should be displayed
4. Repeat step 2 with Jurassic tube
5.  The attempt should fail, and an error message should be displayed

<img width="823" alt="Captura de Pantalla 2022-11-24 a las 12 58 40" src="https://user-images.githubusercontent.com/7076981/203845200-f9afa400-1fbe-48a5-a3aa-06cf99381eed.png">


