### PR TITLE
Fix Jetpack Settings WAF module plan check

### DIFF
--- a/projects/packages/waf/changelog/fix-jetpack-settings-waf-module-plan-check
+++ b/projects/packages/waf/changelog/fix-jetpack-settings-waf-module-plan-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove has_rules_access plan check in favor of external alternatives

--- a/projects/packages/waf/src/class-rest-controller.php
+++ b/projects/packages/waf/src/class-rest-controller.php
@@ -51,16 +51,6 @@ class REST_Controller {
 	}
 
 	/**
-	 * Has Rules Access
-	 *
-	 * @return bool True when the current site has access to latest firewall rules.
-	 */
-	private static function has_rules_access() {
-		// any site with Jetpack Scan can download new WAF rules
-		return \Jetpack_Plan::supports( 'scan' );
-	}
-
-	/**
 	 * Update rules endpoint
 	 */
 	public static function update_rules() {
@@ -88,8 +78,7 @@ class REST_Controller {
 	public static function waf() {
 		return rest_ensure_response(
 			array(
-				'bootstrapPath'  => self::get_bootstrap_file_path(),
-				'hasRulesAccess' => self::has_rules_access(),
+				'bootstrapPath' => self::get_bootstrap_file_path(),
 			)
 		);
 	}

--- a/projects/plugins/jetpack/_inc/client/security/waf.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/waf.jsx
@@ -17,7 +17,7 @@ import {
 import { getProductDescriptionUrl } from 'product-descriptions/utils';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { getSitePlan } from 'state/site';
+import { getSitePlan, siteHasFeature } from 'state/site';
 import QueryWafSettings from '../components/data/query-waf-bootstrap-path';
 import InfoPopover from '../components/info-popover';
 import Textarea from '../components/textarea';
@@ -295,7 +295,7 @@ export const Waf = class extends Component {
 					) }
 				</SettingsGroup>
 				{ isWafActive && this.props.bootstrapPath && bootstrapInstructions }
-				{ ! this.props.hasRulesAccess && ! this.props.isFetchingWafSettings && upgradeBanner }
+				{ ! this.props.hasScan && ! this.props.isFetchingWafSettings && upgradeBanner }
 			</SettingsCard>
 		);
 	}
@@ -305,6 +305,7 @@ export default connect( state => {
 	const sitePlan = getSitePlan( state );
 
 	return {
+		hasScan: siteHasFeature( state, 'scan' ),
 		bootstrapPath: getWafBootstrapPath( state ),
 		hasRulesAccess: getWafHasRulesAccess( state ),
 		isFetchingWafSettings: isFetchingWafSettings( state ),

--- a/projects/plugins/jetpack/_inc/client/security/waf.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/waf.jsx
@@ -21,11 +21,7 @@ import { getSitePlan, siteHasFeature } from 'state/site';
 import QueryWafSettings from '../components/data/query-waf-bootstrap-path';
 import InfoPopover from '../components/info-popover';
 import Textarea from '../components/textarea';
-import {
-	getWafBootstrapPath,
-	getWafHasRulesAccess,
-	isFetchingWafSettings,
-} from '../state/waf/reducer';
+import { getWafBootstrapPath, isFetchingWafSettings } from '../state/waf/reducer';
 
 export const Waf = class extends Component {
 	/**
@@ -307,7 +303,6 @@ export default connect( state => {
 	return {
 		hasScan: siteHasFeature( state, 'scan' ),
 		bootstrapPath: getWafBootstrapPath( state ),
-		hasRulesAccess: getWafHasRulesAccess( state ),
 		isFetchingWafSettings: isFetchingWafSettings( state ),
 		scanUpgradeUrl: getProductDescriptionUrl( state, 'scan' ),
 		sitePlan,

--- a/projects/plugins/jetpack/_inc/client/state/waf/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/waf/reducer.js
@@ -11,7 +11,6 @@ export const data = ( state = {}, action ) => {
 		case WAF_SETTINGS_FETCH_RECEIVE:
 			return assign( {}, state, {
 				bootstrapPath: action.settings?.bootstrapPath,
-				hasRulesAccess: action.settings?.hasRulesAccess,
 			} );
 		default:
 			return state;
@@ -61,14 +60,4 @@ export function isFetchingWafSettings( state ) {
  */
 export function getWafBootstrapPath( state ) {
 	return get( state.jetpack.waf, [ 'data', 'bootstrapPath' ], '' );
-}
-
-/**
- * Returns whether the site has access to latest firewall rules.
- *
- * @param {object}  state - Global state tree
- * @returns {boolean}  True when the site has access to latest firewall rules.
- */
-export function getWafHasRulesAccess( state ) {
-	return get( state.jetpack.waf, [ 'data', 'hasRulesAccess' ], false );
 }

--- a/projects/plugins/jetpack/changelog/fix-jetpack-settings-waf-module-plan-check
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-settings-waf-module-plan-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix Jetpack Settings WAF module plan check


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
Currently, the plan check that is in place for the WAF module in Jetpack Settings for determining whether or not to display an upgrade badge uses a value that is only generated when the WAF is enabled. This PR introduces a plan check that is external to the package so that we can consistently verify the existence of a scan-level plan.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Makes use of the `siteHasFeature` method for determining if the current plan includes the `scan` feature
* Applies the results to the conditional check for displaying the upgrade badge

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- 1201069996155224-as-1203402927826602

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Checkout this branch
* Start up your Jurassic Tube 
* Ensure the site has no current upgrades
* Install Jetpack, connect, and proceed to the Settings tab
* Scroll to the Firewall module section and verify that you are appropriately prompted to upgrade
* Proceed to upgrade and return the Firewall module to verify that the prompt is no longer present
* Verify that there are no regressions in the functionality of the WAF
