### PR TITLE
Site Editor: dashboard link compat for Gutenberg 14.5

### DIFF
--- a/projects/plugins/jetpack/changelog/add-site-editor-dashboard-compat
+++ b/projects/plugins/jetpack/changelog/add-site-editor-dashboard-compat
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Site Editor dashboard link points to wp.com

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -75,6 +75,20 @@ class Admin_Menu extends Base_Admin_Menu {
 	}
 
 	/**
+	 * Point the Site Editor's `< Dashboard` link to wpcom home.
+	 *
+	 * Although this isn't strictly an admin menu item, it belongs here because it's part of
+	 * changing wp-admin links to their wp.com equivalents.
+	 *
+	 * @param  array $settings Editor settings.
+	 * @return array           Updated Editor settings.
+	 */
+	public function site_editor_dashboard_link( $settings ) {
+		$settings['__experimentalDashboardLink'] = 'https://wordpress.com/home/' . $this->domain;
+		return $settings;
+	}
+
+	/**
 	 * Check if Links Manager is being used.
 	 */
 	public function should_disable_links_manager() {

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -28,6 +28,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		add_action( 'wp_ajax_sidebar_state', array( $this, 'ajax_sidebar_state' ) );
 		add_action( 'wp_ajax_jitm_dismiss', array( $this, 'wp_ajax_jitm_dismiss' ) );
 		add_action( 'wp_ajax_upsell_nudge_jitm', array( $this, 'wp_ajax_upsell_nudge_jitm' ) );
+		add_filter( 'block_editor_settings_all', array( $this, 'site_editor_dashboard_link' ) );
 
 		if ( ! $this->is_api_request ) {
 			add_filter( 'submenu_file', array( $this, 'override_the_theme_installer' ), 10, 2 );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -33,6 +33,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		add_action( 'wp_ajax_upsell_nudge_jitm', array( $this, 'wp_ajax_upsell_nudge_jitm' ) );
 		add_action( 'admin_init', array( $this, 'sync_sidebar_collapsed_state' ) );
 		add_action( 'admin_menu', array( $this, 'remove_submenus' ), 140 ); // After hookpress hook at 130.
+		add_filter( 'block_editor_settings_all', array( $this, 'site_editor_dashboard_link' ) );
 	}
 
 	/**


### PR DESCRIPTION
Gutenberg 14.5 has removed the slotfill we formerly used for the dashboard link override, instead introducing a __experimentalDashboardLink setting.

This replaces https://github.com/Automattic/wp-calypso/pull/69929

Fixes Automattic/wp-calypso#70074

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Change the Site Editor `< Dashboard` link to WP.com Home

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
<img width="313" alt="Screenshot 2022-11-24 at 14 55 16" src="https://user-images.githubusercontent.com/195089/203861656-0d3056fe-66e2-41c6-8970-3dee2b402a88.png">

##### WPCom Simple

1. On your sandbox, run `run bin/jetpack-downloader test add/site-editor-dashboard-compat`
2. Apply to a sandboxed wp.com site
3. Ensure that your Site Editor's `< Dashboard` link points to `wordpress.com/home/SITE_SLUG` rather than `SITE_SLUG.wordpress.com/wp-admin/site-editor.php`

##### WoA

1. Use your favourite method to get this branch running on an WoA Developer blog
2. In the Site Editor, same as point 3 above.
3. Disable Editing Toolkit Plugin
4. Verify dashboard link again

**NOTE**: given that this supersedes Automattic/wp-calypso#70074 it will not necessarily appear to change anything on WP.com Simple, since both filters will be simultaneously operable. We get a truer test on Atomic by disabling the ETK plugin.
