### PR TITLE
VideoPress: Fix go back link width

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-go-back-link
+++ b/projects/packages/videopress/changelog/fix-videopress-go-back-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fix go back link width

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/style.module.scss
@@ -51,6 +51,8 @@
 }
 
 .back-link {
+	display: flex;
+
 	.icon {
 		width: 16px;
 		margin-right: 4px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27581

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Changes the width of the link area

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the edit page of a video on the VideoPress dashboard
* Check that the "Go back" link clickable area is only on the text and icon, not on the whole line as indicated on the linked issue

![2022-11-24_18-38-32](https://user-images.githubusercontent.com/8486249/203866446-c7a89b0c-94ac-495e-b6e1-cd45044e56f5.png)
