### PR TITLE
VideoPress: Include videos with "Site default" privacy setting on the search results

### DIFF
--- a/projects/packages/videopress/changelog/fix-include-videos-with-site-default-privacy-on-search
+++ b/projects/packages/videopress/changelog/fix-include-videos-with-site-default-privacy-on-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: Include videos with Site Default privacy setting on the search results, choosing between the public or private filter based on the site default privacy setting.

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
@@ -110,6 +110,26 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Data {
 			/* Allows the filtering to happens using a list of privacy settings separated by comma */
 			$videopress_privacy_setting_list = explode( ',', $videopress_privacy_setting );
 
+			$site_default_is_private = Data::get_videopress_videos_private_for_site();
+
+			if ( $site_default_is_private ) {
+				/**
+				 * If the search is looking for private videos and the site default is private,
+				 * the site default setting should be included on the search.
+				 */
+				if ( in_array( strval( \VIDEOPRESS_PRIVACY::IS_PRIVATE ), $videopress_privacy_setting_list, true ) ) {
+					$videopress_privacy_setting_list[] = \VIDEOPRESS_PRIVACY::SITE_DEFAULT;
+				}
+			} else {
+				/**
+				 * If the search is looking for public videos and the site default is public,
+				 * the site default setting should be included on the search.
+				 */
+				if ( in_array( strval( \VIDEOPRESS_PRIVACY::IS_PUBLIC ), $videopress_privacy_setting_list, true ) ) {
+					$videopress_privacy_setting_list[] = \VIDEOPRESS_PRIVACY::SITE_DEFAULT;
+				}
+			}
+
 			$args['meta_query'][] = array(
 				'key'     => 'videopress_privacy_setting',
 				'value'   => $videopress_privacy_setting_list,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27558.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Modify the privacy filters to include the site default setting when appropriate:
   * when the site default privacy setting is private, and the search is looking for private videos, the videos with site default privacy setting are included
   * the same way, when the site default privacy setting is public, and the search is looking for public videos, the videos with site default privacy setting are include

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Upload at least three videos to the VideoPress library and set one video as private, one as public and the last one as "Site default"
* Set the site default privacy setting to public, unchecking the "Video Privacy: Restrict views to members of this site" checkbox:

<img width="430" alt="Screen Shot 2022-11-24 at 19 16 59" src="https://user-images.githubusercontent.com/6760046/203869528-fcb7926b-ceb1-4658-92f5-418c12cbcf79.png">

* Use the Privacy filters next to the search to filter the videos:

<img width="1115" alt="Screen Shot 2022-11-24 at 19 18 27" src="https://user-images.githubusercontent.com/6760046/203869739-e7e75418-f3fa-44fe-8595-79cf6f5bab08.png">

* Check the "Public" checkbox
* Given that you set the site default privacy setting to public, the search will show videos with "Public" or "Site default" settings:

<img width="1124" alt="Screen Shot 2022-11-24 at 19 32 37" src="https://user-images.githubusercontent.com/6760046/203870736-64ab12df-bb29-4959-bbf6-a867fe93b613.png">

* Uncheck the "Public" checkbox and check the "Private" one
* Now the search will show only videos with "Private" privacy setting:

<img width="1105" alt="Screen Shot 2022-11-24 at 19 24 20" src="https://user-images.githubusercontent.com/6760046/203870145-fe46ec91-39b8-499e-9089-b3c78ea5bdca.png">

* Now test the reverse scenario: set the site default privacy setting to private marking the "Video Privacy: Restrict views to members of this site" checkbox:

<img width="417" alt="Screen Shot 2022-11-24 at 19 26 29" src="https://user-images.githubusercontent.com/6760046/203870237-b1e6f257-7a69-4737-bf5b-fe351391cef4.png">

* Check the "Public" checkbox on the filters
* Given that you set the site default privacy setting to private, the search will show only videos with "Public" setting:

<img width="1119" alt="Screen Shot 2022-11-24 at 19 28 34" src="https://user-images.githubusercontent.com/6760046/203870439-1e209726-a666-47da-a5e6-68d439df3c32.png">

* Uncheck the "Public" checkbox and check the "Private" one
* Now the search will show videos with "Private" or "Site default" privacy settings:

<img width="1122" alt="Screen Shot 2022-11-24 at 19 30 50" src="https://user-images.githubusercontent.com/6760046/203870563-e1bb4b96-6279-4bd7-88af-6d90fcb1925e.png">