### PR TITLE
Stats: explicitly allow only the designated API with blog token

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-access-apis-explicitly
+++ b/projects/packages/stats-admin/changelog/fix-access-apis-explicitly
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Stats: explicitly allow only certain API access with blog token to wpcom

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -274,7 +274,7 @@ class REST_Controller {
 			return $post;
 		}
 
-		// TODO: do we need to check if the post is public?
+		// It shouldn't be a problem because only title and ID are exposed.
 		return array(
 			'ID'    => $post->ID,
 			'title' => $post->post_title,

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -216,13 +216,17 @@ class REST_Controller {
 
 		$response_code = wp_remote_retrieve_response_code( $response );
 		$response_body = json_decode( wp_remote_retrieve_body( $response ), true );
-		if ( is_wp_error( $response ) || 200 !== $response_code || empty( $response_body ) ) {
-			return is_wp_error( $response ) ? $response : new WP_Error(
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		if ( 200 !== $response_code ) {
+			return new WP_Error(
 				isset( $response_body['error'] ) ? 'remote-error-' . $response_body['error'] : 'remote-error',
 				isset( $response_body['message'] ) ? $response_body['message'] : 'unknown remote error',
 				array( 'status' => $response_code )
 			);
-
 		}
 
 		return $response_body;

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -205,24 +205,24 @@ class REST_Controller {
 	}
 
 	/**
-	 * Sub Resource endpoint e.g. posts/121/likes.
+	 * Redirect to post likes API which is public.
 	 *
 	 * @param WP_REST_Request $req The request object.
-	 * @return array
 	 */
 	public function get_single_post_likes( $req ) {
-		return static::request_as_blog_cached(
+		// It's a fixed host, so we could use wp_redirect() here.
+		// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
+		wp_redirect(
 			sprintf(
-				'/sites/%d/posts/%d/likes?%s',
+				'https://public-api.wordpress.com/rest/v1.2/sites/%d/posts/%d/likes?%s',
 				Jetpack_Options::get_option( 'id' ),
 				$req->get_param( 'resource_id' ),
 				http_build_query(
 					$req->get_params()
 				)
-			),
-			'1.2',
-			array( 'timeout' => 30 )
+			)
 		);
+		exit;
 	}
 
 	/**

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -41,8 +41,10 @@ class REST_Controller {
 	}
 
 	/**
-
-	 * Registers the REST routes for Stats.
+	 * Registers the REST routes for Calypso Stats.
+	 *
+	 * The Calypso Stats is built from `wp-calypso`, which leverages the `public-api.wordpress.com` API.
+	 * The current Site ID is added as part of the route, so that the front end doesn't have to handle the differences.
 	 *
 	 * @access public
 	 * @static

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -1,13 +1,14 @@
 <?php
 /**
  * The Stats Rest Controller class.
- * Registers the REST routes for Stats.
+ * Registers the REST routes for Calypso Stats.
  *
  * @package automattic/jetpack-stats-admin
  */
 
 namespace Automattic\Jetpack\Stats_Admin;
 
+use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Stats\WPCOM_Stats;
 use Jetpack_Options;
 use WP_Error;
@@ -53,7 +54,7 @@ class REST_Controller {
 			sprintf( '/sites/%d/stats/(?P<resource>[\-\w]+)/(?P<resource_id>[\d]+)', Jetpack_Options::get_option( 'id' ) ),
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'get_stats_single_resource_from_wpcom' ),
+				'callback'            => array( $this, 'get_single_resource_stats' ),
 				'permission_callback' => array( $this, 'check_user_privileges_callback' ),
 			)
 		);
@@ -91,35 +92,24 @@ class REST_Controller {
 			)
 		);
 
-		// Required site endpoints for the Stats app.
+		// General stats for the site.
 		register_rest_route(
 			static::$namespace,
-			sprintf( '/sites/%d/(?P<resource>[\-\w]+)', Jetpack_Options::get_option( 'id' ) ),
+			sprintf( '/sites/%d/stats', Jetpack_Options::get_option( 'id' ) ),
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'get_site_resource_from_wpcom' ),
+				'callback'            => array( $this, 'get_site_stats' ),
 				'permission_callback' => array( $this, 'check_user_privileges_callback' ),
 			)
 		);
 
-		// TODO remove call to the endpoint from the frontend.
+		// Whether site has never published post / page.
 		register_rest_route(
 			static::$namespace,
-			sprintf( '/jetpack-blogs/%d/rest-api/', Jetpack_Options::get_option( 'id' ) ),
+			sprintf( '/sites/%d/site-has-never-published-post', Jetpack_Options::get_option( 'id' ) ),
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'empty_result' ),
-				'permission_callback' => array( $this, 'check_user_privileges_callback' ),
-			)
-		);
-
-		// TODO remove call to the endpoint from the frontend.
-		register_rest_route(
-			static::$namespace,
-			'/me/connections',
-			array(
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'empty_result' ),
+				'callback'            => array( $this, 'site_has_never_published_post' ),
 				'permission_callback' => array( $this, 'check_user_privileges_callback' ),
 			)
 		);
@@ -242,7 +232,7 @@ class REST_Controller {
 	 * @param WP_REST_Request $req The request object.
 	 * @return array
 	 */
-	public function get_stats_single_resource_from_wpcom( $req ) {
+	public function get_single_resource_stats( $req ) {
 		switch ( $req->get_param( 'resource' ) ) {
 			case 'post':
 				return $this->wpcom_stats->get_post_views(
@@ -262,7 +252,7 @@ class REST_Controller {
 	}
 
 	/**
-	 * Site Resource endpoint.
+	 * Get brief information for a single post.
 	 *
 	 * @param WP_REST_Request $req The request object.
 	 * @return array
@@ -282,77 +272,85 @@ class REST_Controller {
 	}
 
 	/**
-	 * Returns an empty object.
-	 *
-	 * @return object
-	 */
-	public function empty_result() {
-		return json_decode( '{}' );
-	}
-
-	/**
-	 * Get a resource under site.
+	 * Get site stats.
 	 *
 	 * @param WP_REST_Request $req The request object.
 	 * @return array
 	 */
-	public function get_site_resource_from_wpcom( $req ) {
-		$resource = $req->get_param( 'resource' );
-		switch ( $resource ) {
-			case 'site-has-never-published-post':
-				return $this->get_has_never_published_post( $req );
-
-			// TODO: remove the following calls from the frontend.
-			case 'posts':
-			case 'sharing-buttons':
-			case 'plugins':
-			case 'keyrings':
-			case 'rewind':
-				return $this->empty_result();
-
-			// General stats endpiont.
-			case 'stats':
-				return $this->wpcom_stats->get_stats( $req->get_params() );
-
-			default:
-				return $this->get_forbidden_error();
-		}
+	public function get_site_stats( $req ) {
+		return $this->wpcom_stats->get_stats( $req->get_params() );
 	}
 
 	/**
-	 * Stolen from `wp-content/rest-api-plugins/endpoints/sites-has-never-published-post.php`
+	 * Whether site has never published post.
 	 *
 	 * @param WP_REST_Request $req The request object.
-	 *
-	 * @return bool the value of has ever published post
+	 * @return array
 	 */
-	protected function get_has_never_published_post( $req ) {
-		$has_never_published_post = (bool) get_option( 'has_never_published_post', false );
+	public function site_has_never_published_post( $req ) {
+		return $this->request_as_blog_cached(
+			sprintf(
+				'/sites/%d/site-has-never-published-post?%s',
+				Jetpack_Options::get_option( 'id' ),
+				http_build_query(
+					$req->get_params()
+				)
+			),
+			'v2',
+			array( 'timeout' => 5 ),
+			null,
+			'wpcom'
+		);
+	}
 
-		if ( ! $has_never_published_post ) {
-			return false;
-		}
+	/**
+	 * Query the WordPress.com REST API using the blog token
+	 *
+	 * @param String $path The API endpoint relative path.
+	 * @param String $version The API version.
+	 * @param array  $args Request arguments.
+	 * @param String $body Request body.
+	 * @param String $base_api_path (optional) the API base path override, defaults to 'rest'.
+	 * @param bool   $use_cache (optional) default to true.
+	 * @return array|WP_Error $response Data.
+	 */
+	protected function request_as_blog_cached( $path, $version = '1.1', $args = array(), $body = null, $base_api_path = 'rest', $use_cache = true ) {
+		// Arrays are serialized without considering the order of objects, but it's okay atm.
+		$cache_key = 'STATS_REST_RESP_' . md5( implode( '|', array( $path, $version, wp_json_encode( $args ), wp_json_encode( $body ), $base_api_path ) ) );
 
-		$include_pages = $req->get_param( 'include_pages' );
-		if ( $include_pages ) {
-			$has_never_published_page = true;
-			$pages                    = get_pages();
-			// 20 is a threshold, We are assuming that there won't be more than 20 head start pages.
-			if ( count( $pages ) <= 20 ) {
-				foreach ( $pages as $page ) {
-					$is_headstart_post = ! empty( get_post_meta( $page->ID, '_headstart_post' ) );
-					if ( ! $is_headstart_post ) {
-						$has_never_published_page = false;
-						break;
-					}
-				}
-			} else {
-				$has_never_published_page = false;
+		if ( $use_cache ) {
+			$response_body = get_transient( $cache_key );
+			if ( false !== $response_body ) {
+				return json_decode( $response_body, true );
 			}
-			return rest_ensure_response( $has_never_published_post && $has_never_published_page );
 		}
 
-		return rest_ensure_response( $has_never_published_post );
+		$response              = Client::wpcom_json_api_request_as_blog(
+			$path,
+			$version,
+			$args,
+			$body,
+			$base_api_path
+		);
+		$response_code         = wp_remote_retrieve_response_code( $response );
+		$response_body_content = wp_remote_retrieve_body( $response );
+		$response_body         = json_decode( $response_body, true );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		if ( 200 !== $response_code ) {
+			return new WP_Error(
+				isset( $response_body['error'] ) ? 'remote-error-' . $response_body['error'] : 'remote-error',
+				isset( $response_body['message'] ) ? $response_body['message'] : 'unknown remote error',
+				array( 'status' => $response_code )
+			);
+		}
+
+		// Cache the successful JSON response for 5 minutes.
+		set_transient( $cache_key, $response_body_content, 5 * MINUTE_IN_SECONDS );
+		return $response_body;
 	}
 
 	/**

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -214,7 +214,8 @@ class REST_Controller {
 		// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
 		wp_redirect(
 			sprintf(
-				'https://public-api.wordpress.com/rest/v1.2/sites/%d/posts/%d/likes?%s',
+				'%s/rest/v1.2/sites/%d/posts/%d/likes?%s',
+				JETPACK__WPCOM_JSON_API_BASE,
 				Jetpack_Options::get_option( 'id' ),
 				$req->get_param( 'resource_id' ),
 				http_build_query(

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -126,7 +126,7 @@ class REST_Controller {
 	}
 
 	/**
-	 * Only users with capability `view_stats` can access the API.
+	 * Only administrators or users with capability `view_stats` can access the API.
 	 *
 	 * @return bool|WP_Error True if a blog token was used to sign the request, WP_Error otherwise.
 	 */

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -205,7 +205,7 @@ class REST_Controller {
 	}
 
 	/**
-	 * Redirect to post likes API which is public.
+	 * Return likes of a single post.
 	 *
 	 * @param WP_REST_Request $req The request object.
 	 */

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -374,7 +374,7 @@ class REST_Controller {
 		if ( $use_cache ) {
 			$response_body = get_transient( $cache_key );
 			if ( false !== $response_body ) {
-				return $response_body;
+				return json_decode( $response_body, true );
 			}
 		}
 
@@ -385,13 +385,14 @@ class REST_Controller {
 			$body,
 			$base_api_path = 'rest'
 		);
-		$response_code = wp_remote_retrieve_response_code( $response );
-		$response_body = json_decode( wp_remote_retrieve_body( $response ), true );
+		$response_code       = wp_remote_retrieve_response_code( $response );
+		$response_body       = wp_remote_retrieve_body( $response );
+		$response_body_array = json_decode( $response_body, true );
 
-		if ( is_wp_error( $response ) || 200 !== $response_code || empty( $response_body ) ) {
+		if ( is_wp_error( $response ) || 200 !== $response_code || empty( $response_body_array ) ) {
 			return is_wp_error( $response ) ? $response : new WP_Error(
-				isset( $response_body['error'] ) ? 'remote-error-' . $response_body['error'] : 'remote-error',
-				isset( $response_body['message'] ) ? $response_body['message'] : 'unknown remote error',
+				isset( $response_body_array['error'] ) ? 'remote-error-' . $response_body_array['error'] : 'remote-error',
+				isset( $response_body_array['message'] ) ? $response_body_array['message'] : 'unknown remote error',
 				array( 'status' => $response_code )
 			);
 

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -148,34 +148,55 @@ class REST_Controller {
 	public function get_stats_resource( $req ) {
 		switch ( $req->get_param( 'resource' ) ) {
 			case 'file-downloads':
+				return $this->stats->get_file_downloads( $req->get_params() );
+
 			case 'video-plays':
+				return $this->stats->get_video_plays( $req->get_params() );
+
 			case 'clicks':
+				return $this->stats->get_clicks( $req->get_params() );
+
 			case 'search-terms':
+				return $this->stats->get_search_terms( $req->get_params() );
+
 			case 'top-authors':
+				return $this->stats->get_top_authors( $req->get_params() );
+
 			case 'country-views':
+				return $this->stats->get_views_by_country( $req->get_params() );
+
 			case 'referrers':
+				return $this->stats->get_referrers( $req->get_params() );
+
 			case 'top-posts':
+				return $this->stats->get_top_posts( $req->get_params() );
+
 			case 'publicize':
+				return $this->stats->get_publicize_followers( $req->get_params() );
+
 			case 'followers':
+				return $this->stats->get_followers( $req->get_params() );
+
 			case 'tags':
+				return $this->stats->get_tags( $req->get_params() );
+
 			case 'visits':
+				return $this->stats->get_visits( $req->get_params() );
+
 			case 'comments':
+				return $this->stats->get_top_comments( $req->get_params() );
+
 			case 'comment-followers':
+				return $this->stats->get_comment_followers( $req->get_params() );
+
 			case 'streak':
+				return $this->stats->get_streak( $req->get_params() );
+
 			case 'insights':
+				return $this->stats->get_insights( $req->get_params() );
+
 			case 'highlights':
-				return static::request_as_blog_cached(
-					sprintf(
-						'/sites/%d/stats/%s?%s',
-						Jetpack_Options::get_option( 'id' ),
-						$req->get_param( 'resource' ),
-						http_build_query(
-							$req->get_params()
-						)
-					),
-					'1.1',
-					array( 'timeout' => 30 )
-				);
+				return $this->stats->get_highlights( $req->get_params() );
 
 			default:
 				return $this->get_forbidden_error();
@@ -278,6 +299,7 @@ class REST_Controller {
 			case 'rewind':
 				return $this->empty_result();
 
+			// General stats endpiont.
 			case 'stats':
 				return $this->wpcom_stats->get_stats( $req->get_params() );
 

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -148,55 +148,55 @@ class REST_Controller {
 	public function get_stats_resource( $req ) {
 		switch ( $req->get_param( 'resource' ) ) {
 			case 'file-downloads':
-				return $this->stats->get_file_downloads( $req->get_params() );
+				return $this->wpcom_stats->get_file_downloads( $req->get_params() );
 
 			case 'video-plays':
-				return $this->stats->get_video_plays( $req->get_params() );
+				return $this->wpcom_stats->get_video_plays( $req->get_params() );
 
 			case 'clicks':
-				return $this->stats->get_clicks( $req->get_params() );
+				return $this->wpcom_stats->get_clicks( $req->get_params() );
 
 			case 'search-terms':
-				return $this->stats->get_search_terms( $req->get_params() );
+				return $this->wpcom_stats->get_search_terms( $req->get_params() );
 
 			case 'top-authors':
-				return $this->stats->get_top_authors( $req->get_params() );
+				return $this->wpcom_stats->get_top_authors( $req->get_params() );
 
 			case 'country-views':
-				return $this->stats->get_views_by_country( $req->get_params() );
+				return $this->wpcom_stats->get_views_by_country( $req->get_params() );
 
 			case 'referrers':
-				return $this->stats->get_referrers( $req->get_params() );
+				return $this->wpcom_stats->get_referrers( $req->get_params() );
 
 			case 'top-posts':
-				return $this->stats->get_top_posts( $req->get_params() );
+				return $this->wpcom_stats->get_top_posts( $req->get_params() );
 
 			case 'publicize':
-				return $this->stats->get_publicize_followers( $req->get_params() );
+				return $this->wpcom_stats->get_publicize_followers( $req->get_params() );
 
 			case 'followers':
-				return $this->stats->get_followers( $req->get_params() );
+				return $this->wpcom_stats->get_followers( $req->get_params() );
 
 			case 'tags':
-				return $this->stats->get_tags( $req->get_params() );
+				return $this->wpcom_stats->get_tags( $req->get_params() );
 
 			case 'visits':
-				return $this->stats->get_visits( $req->get_params() );
+				return $this->wpcom_stats->get_visits( $req->get_params() );
 
 			case 'comments':
-				return $this->stats->get_top_comments( $req->get_params() );
+				return $this->wpcom_stats->get_top_comments( $req->get_params() );
 
 			case 'comment-followers':
-				return $this->stats->get_comment_followers( $req->get_params() );
+				return $this->wpcom_stats->get_comment_followers( $req->get_params() );
 
 			case 'streak':
-				return $this->stats->get_streak( $req->get_params() );
+				return $this->wpcom_stats->get_streak( $req->get_params() );
 
 			case 'insights':
-				return $this->stats->get_insights( $req->get_params() );
+				return $this->wpcom_stats->get_insights( $req->get_params() );
 
 			case 'highlights':
-				return $this->stats->get_highlights( $req->get_params() );
+				return $this->wpcom_stats->get_highlights( $req->get_params() );
 
 			default:
 				return $this->get_forbidden_error();

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -215,17 +215,13 @@ class REST_Controller {
 			case 'post':
 				return $this->wpcom_stats->get_post_views(
 					intval( $req->get_param( 'resource_id' ) ),
-					http_build_query(
-						$req->get_params()
-					)
+					$req->get_params()
 				);
 
 			case 'video':
 				return $this->wpcom_stats->get_video_details(
 					intval( $req->get_param( 'resource_id' ) ),
-					http_build_query(
-						$req->get_params()
-					)
+					$req->get_params()
 				);
 
 			default:
@@ -283,7 +279,7 @@ class REST_Controller {
 				return $this->empty_result();
 
 			case 'stats':
-				return $this->wpcom_stats->get_stats();
+				return $this->wpcom_stats->get_stats( $req->get_params() );
 
 			default:
 				return $this->get_forbidden_error();

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -280,7 +280,7 @@ class REST_Controller {
 	}
 
 	/**
-	 * Empty result.
+	 * Get a resource under site.
 	 *
 	 * @param WP_REST_Request $req The request object.
 	 * @return array

--- a/projects/packages/stats/changelog/fix-access-apis-explicitly
+++ b/projects/packages/stats/changelog/fix-access-apis-explicitly
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: added streak, highlights, insights for WPCOM_Stats

--- a/projects/packages/stats/composer.json
+++ b/projects/packages/stats/composer.json
@@ -49,7 +49,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-stats/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.3.x-dev"
+			"dev-trunk": "0.4.x-dev"
 		},
 		"textdomain": "jetpack-stats"
 	},

--- a/projects/packages/stats/src/class-wpcom-stats.php
+++ b/projects/packages/stats/src/class-wpcom-stats.php
@@ -306,6 +306,45 @@ class WPCOM_Stats {
 	}
 
 	/**
+	 * Get streaks for the site.
+	 *
+	 * @param array $args Optional query parameters.
+	 * @return array|WP_Error
+	 */
+	public function get_streak( $args = array() ) {
+
+		$this->resource = 'streak';
+
+		return $this->fetch_stats( $args );
+	}
+
+	/**
+	 * Get the highlights for the site.
+	 *
+	 * @param array $args Optional query parameters.
+	 * @return array|WP_Error
+	 */
+	public function get_highlights( $args = array() ) {
+
+		$this->resource = 'highlights';
+
+		return $this->fetch_stats( $args );
+	}
+
+	/**
+	 * Get the number of visits for the site.
+	 *
+	 * @param array $args Optional query parameters.
+	 * @return array|WP_Error
+	 */
+	public function get_insights( $args = array() ) {
+
+		$this->resource = 'insights';
+
+		return $this->fetch_stats( $args );
+	}
+
+	/**
 	 * Build WPCOM REST API endpoint.
 	 *
 	 * @return string

--- a/projects/packages/stats/src/class-wpcom-stats.php
+++ b/projects/packages/stats/src/class-wpcom-stats.php
@@ -308,6 +308,8 @@ class WPCOM_Stats {
 	/**
 	 * Get streaks for the site.
 	 *
+	 * @link https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/streak/
+	 *
 	 * @param array $args Optional query parameters.
 	 * @return array|WP_Error
 	 */
@@ -320,6 +322,8 @@ class WPCOM_Stats {
 
 	/**
 	 * Get the highlights for the site.
+	 *
+	 * @link https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/highlights/
 	 *
 	 * @param array $args Optional query parameters.
 	 * @return array|WP_Error

--- a/projects/packages/stats/src/class-wpcom-stats.php
+++ b/projects/packages/stats/src/class-wpcom-stats.php
@@ -306,45 +306,6 @@ class WPCOM_Stats {
 	}
 
 	/**
-	 * Get the streak for the site.
-	 *
-	 * @param array $args Optional query parameters.
-	 * @return array|WP_Error
-	 */
-	public function get_streak( $args = array() ) {
-
-		$this->resource = 'streak';
-
-		return $this->fetch_stats( $args );
-	}
-
-	/**
-	 * Get the insights for the site.
-	 *
-	 * @param array $args Optional query parameters.
-	 * @return array|WP_Error
-	 */
-	public function get_insights( $args = array() ) {
-
-		$this->resource = 'insights';
-
-		return $this->fetch_stats( $args );
-	}
-
-	/**
-	 * Get the highlights for the site.
-	 *
-	 * @param array $args Optional query parameters.
-	 * @return array|WP_Error
-	 */
-	public function get_highlights( $args = array() ) {
-
-		$this->resource = 'highlights';
-
-		return $this->fetch_stats( $args );
-	}
-
-	/**
 	 * Build WPCOM REST API endpoint.
 	 *
 	 * @return string

--- a/projects/packages/stats/src/class-wpcom-stats.php
+++ b/projects/packages/stats/src/class-wpcom-stats.php
@@ -306,6 +306,45 @@ class WPCOM_Stats {
 	}
 
 	/**
+	 * Get the streak for the site.
+	 *
+	 * @param array $args Optional query parameters.
+	 * @return array|WP_Error
+	 */
+	public function get_streak( $args = array() ) {
+
+		$this->resource = 'streak';
+
+		return $this->fetch_stats( $args );
+	}
+
+	/**
+	 * Get the insights for the site.
+	 *
+	 * @param array $args Optional query parameters.
+	 * @return array|WP_Error
+	 */
+	public function get_insights( $args = array() ) {
+
+		$this->resource = 'insights';
+
+		return $this->fetch_stats( $args );
+	}
+
+	/**
+	 * Get the highlights for the site.
+	 *
+	 * @param array $args Optional query parameters.
+	 * @return array|WP_Error
+	 */
+	public function get_highlights( $args = array() ) {
+
+		$this->resource = 'highlights';
+
+		return $this->fetch_stats( $args );
+	}
+
+	/**
 	 * Build WPCOM REST API endpoint.
 	 *
 	 * @return string

--- a/projects/packages/stats/tests/php/test-wpcom-stats.php
+++ b/projects/packages/stats/tests/php/test-wpcom-stats.php
@@ -575,6 +575,141 @@ class Test_WPCOM_Stats extends StatsBaseTestCase {
 	}
 
 	/**
+	 * Test get_highlights.
+	 */
+	public function test_get_highlights() {
+		$expected_stats = array(
+			'past_seven_days'                     => array(
+				'range'    => array(
+					'start' => '2022-11-21',
+					'end'   => '2022-11-27',
+				),
+				'comments' => 0,
+				'likes'    => 1,
+				'views'    => 106,
+				'visitors' => 28,
+			),
+			'between_past_eight_and_fifteen_days' => array(
+				'range'    => array(
+					'start' => '2022-11-14',
+					'end'   => '2022-11-20',
+				),
+				'comments' => 0,
+				'likes'    => 0,
+				'views'    => 23,
+				'visitors' => 17,
+			),
+		);
+
+		$this->wpcom_stats
+			->expects( $this->once() )
+			->method( 'fetch_remote_stats' )
+			->with(
+				$this->equalTo( '/sites/1234/stats/highlights' ),
+				$this->equalTo( array() )
+			)
+			->willReturn( $expected_stats );
+
+		$stats = $this->wpcom_stats->get_highlights();
+		$this->assertSame( $expected_stats, $stats );
+		$this->assertSame( wp_json_encode( $expected_stats ), self::get_stats_transient( '/sites/1234/stats/highlights' ) );
+	}
+
+	/**
+	 * Test get_insights.
+	 */
+	public function test_get_insights() {
+		$expected_stats = array(
+			'highest_hour'         => 19,
+			'highest_hour_percent' => 32,
+			'highest_day_of_week'  => 2,
+			'highest_day_percent'  => 31,
+			'days'                 =>
+			array(
+				'0' => 103,
+				'1' => 99,
+			),
+			'hours'                =>
+			array(
+				'00' => 101,
+				'01' => 43,
+			),
+			'hourly_views'         =>
+			array(
+				'2022-11-26 04:00:00' => 0,
+				'2022-11-26 05:00:00' => 0,
+				'2022-11-26 06:00:00' => 0,
+			),
+			'years'                =>
+			array(
+				array(
+					'year'           => '2022',
+					'total_posts'    => 2,
+					'total_words'    => 35,
+					'avg_words'      => 17.5,
+					'total_likes'    => 1,
+					'avg_likes'      => 0.5,
+					'total_comments' => 0,
+					'avg_comments'   => 0,
+					'total_images'   => 2,
+					'avg_images'     => 1,
+				),
+			),
+		);
+
+		$this->wpcom_stats
+			->expects( $this->once() )
+			->method( 'fetch_remote_stats' )
+			->with(
+				$this->equalTo( '/sites/1234/stats/insights' ),
+				$this->equalTo( array() )
+			)
+			->willReturn( $expected_stats );
+
+		$stats = $this->wpcom_stats->get_insights();
+		$this->assertSame( $expected_stats, $stats );
+		$this->assertSame( wp_json_encode( $expected_stats ), self::get_stats_transient( '/sites/1234/stats/insights' ) );
+	}
+
+	/**
+	 * Test get_streak.
+	 */
+	public function test_get_streak() {
+		$expected_stats = array(
+			'streak' => array(
+				'long'    => array(
+					'start'  => '',
+					'end'    => '',
+					'length' => 1,
+				),
+				'current' => array(
+					'start'  => '2022-11-21',
+					'end'    => '2022-11-21',
+					'length' => 1,
+				),
+			),
+			'data'   => array(
+				1669011611 => 1,
+				1656367289 => 1,
+				1638135559 => 1,
+			),
+		);
+
+		$this->wpcom_stats
+			->expects( $this->once() )
+			->method( 'fetch_remote_stats' )
+			->with(
+				$this->equalTo( '/sites/1234/stats/streak' ),
+				$this->equalTo( array() )
+			)
+			->willReturn( $expected_stats );
+
+		$stats = $this->wpcom_stats->get_streak();
+		$this->assertSame( $expected_stats, $stats );
+		$this->assertSame( wp_json_encode( $expected_stats ), self::get_stats_transient( '/sites/1234/stats/streak' ) );
+	}
+
+	/**
 	 * Test get_stats with cached result.
 	 */
 	public function test_get_stats_with_cached_result() {

--- a/projects/plugins/jetpack/changelog/fix-access-apis-explicitly
+++ b/projects/plugins/jetpack/changelog/fix-access-apis-explicitly
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Stats: initialize the Stats Admin package

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -904,6 +904,8 @@ class Jetpack {
 			 */
 			add_action( 'jetpack_agreed_to_terms_of_service', array( new Plugin_Tracking(), 'init' ) );
 		}
+
+		Automattic\Jetpack\Stats_Admin\Main::init();
 	}
 
 	/**

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1873,7 +1873,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats",
-                "reference": "c33d4f4c97ec0eb77ffe8aff852b16e3bf974093"
+                "reference": "921b9b08b3336103da4fc96a317a1fb7e58d5111"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1893,7 +1893,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-stats/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.3.x-dev"
+                    "dev-trunk": "0.4.x-dev"
                 },
                 "textdomain": "jetpack-stats"
             },

--- a/projects/plugins/search/changelog/fix-access-apis-explicitly
+++ b/projects/plugins/search/changelog/fix-access-apis-explicitly
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1199,7 +1199,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-stats/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.3.x-dev"
+                    "dev-trunk": "0.4.x-dev"
                 },
                 "textdomain": "jetpack-stats"
             },

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1179,7 +1179,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats",
-                "reference": "c33d4f4c97ec0eb77ffe8aff852b16e3bf974093"
+                "reference": "921b9b08b3336103da4fc96a317a1fb7e58d5111"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Explicitly allow only the designated API forwarding with blog token.
- Added functions to `WPOM_Stats` to retrieve `highlights`, `insights` and `streak` 
- Changed to use `WPCOM_Stats` to retrieve stats for the controller

The context of the backend is to fully satisfy the needs of the frontend. The frontend isn’t purposefully built for Jetpack but is actually a Calypso app requesting ‘public-api’, which is the cause of the site Ids in the route.
We want to quickly spin up the backend so that the whole application works in Jetpack and then we’ll iterate and improve from there.

So I’m happy to leave few stubs there for now as long as they don’t cause any concerns because It’ll take significantly longer to optimise the Calypso app - we’ll need to refactor several places to remove these api calls, and make the app slimmer too and I want to deal with these on the next stage.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
p1669283843924099-slack-C0438NHCLSY

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- Open a site with Jetpack plugin or simply spin up a JN site
- Open `/wp-admin/admin.php?page=jetpack#/traffic?term=jetpack%20stats`
- Expand the Jetpack Stats section
- Open browser console and run `document.querySelector('#jp-settings-site-stats').querySelectorAll('.jp-form-fieldset')[1].setAttribute('style','color:red')`
- Turn on the new Stats experience (color red toggle)
- Open `/wp-admin/admin.php?page=stats`
- Ensure there is data fill in the page

