### PR TITLE
Sync: Limit next_sync_time lock to be at most 1 hour in the future. 

### DIFF
--- a/projects/packages/sync/changelog/update-sync-next-sync-time-restrictions
+++ b/projects/packages/sync/changelog/update-sync-next-sync-time-restrictions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Limit next_sync_time lock to be at most 1 hour in the future

--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -1049,8 +1049,10 @@ class Actions {
 	 * @access public
 	 * @static
 	 * @since 1.43.0
+	 *
+	 * @param bool $unlock_queues Whether to unlock Sync queues. Defaults to true.
 	 */
-	public static function reset_sync_locks() {
+	public static function reset_sync_locks( $unlock_queues = true ) {
 		// Next sync locks.
 		delete_option( Sender::NEXT_SYNC_TIME_OPTION_NAME . '_sync' );
 		delete_option( Sender::NEXT_SYNC_TIME_OPTION_NAME . '_full_sync' );
@@ -1061,9 +1063,12 @@ class Actions {
 		// Dedicated sync lock.
 		\Jetpack_Options::delete_raw_option( Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME );
 		// Queue locks.
-		$sync_queue = new Queue( 'sync' );
-		$sync_queue->unlock();
-		$full_sync_queue = new Queue( 'full_sync' );
-		$full_sync_queue->unlock();
+		// Note that we are just unlocking the queues here, not reseting them.
+		if ( $unlock_queues ) {
+			$sync_queue = new Queue( 'sync' );
+			$sync_queue->unlock();
+			$full_sync_queue = new Queue( 'full_sync' );
+			$full_sync_queue->unlock();
+		}
 	}
 }

--- a/projects/packages/sync/src/class-sender.php
+++ b/projects/packages/sync/src/class-sender.php
@@ -227,13 +227,29 @@ class Sender {
 	/**
 	 * Retrieve the next sync time.
 	 *
+	 * Update @since $$next-version%%
+	 * Sometimes when we process Sync requests in Jetpack, the server clock can be a
+	 * bit in the future and this can lock Sync to not send stuff for a while.
+	 * We are introducing an extra check, to make sure to limit the next_sync_time
+	 * to be at most one hour in the future from the current time.
+	 *
 	 * @access public
 	 *
 	 * @param string $queue_name Name of the queue.
 	 * @return float Timestamp of the next sync.
 	 */
 	public function get_next_sync_time( $queue_name ) {
-		return (float) get_option( self::NEXT_SYNC_TIME_OPTION_NAME . '_' . $queue_name, 0 );
+		$option_name    = self::NEXT_SYNC_TIME_OPTION_NAME . '_' . $queue_name;
+		$next_sync_time = (float) get_option( $option_name, 0 );
+
+		$is_more_than_one_hour = ( $next_sync_time - microtime( true ) ) >= HOUR_IN_SECONDS;
+
+		if ( $is_more_than_one_hour ) {
+			delete_option( $option_name );
+			$next_sync_time = 0;
+		}
+
+		return $next_sync_time;
 	}
 
 	/**
@@ -944,10 +960,8 @@ class Sender {
 		foreach ( Modules::get_modules() as $module ) {
 			$module->reset_data();
 		}
-
-		foreach ( array( 'sync', 'full_sync', 'full-sync-enqueue' ) as $queue_name ) {
-			delete_option( self::NEXT_SYNC_TIME_OPTION_NAME . '_' . $queue_name );
-		}
+		// Reset Sync locks without unlocking queues since we already reset those.
+		Actions::reset_sync_locks( false );
 
 		Settings::reset_data();
 	}

--- a/projects/packages/sync/src/class-sender.php
+++ b/projects/packages/sync/src/class-sender.php
@@ -227,7 +227,7 @@ class Sender {
 	/**
 	 * Retrieve the next sync time.
 	 *
-	 * Update @since $$next-version%%
+	 * Update @since $$next-version$$
 	 * Sometimes when we process Sync requests in Jetpack, the server clock can be a
 	 * bit in the future and this can lock Sync to not send stuff for a while.
 	 * We are introducing an extra check, to make sure to limit the next_sync_time

--- a/projects/plugins/jetpack/changelog/update-sync-next-sync-time-restrictions
+++ b/projects/plugins/jetpack/changelog/update-sync-next-sync-time-restrictions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sync: Add unit tests

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -337,6 +337,16 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( $next_sync_time < time() + 15 );
 	}
 
+	public function test_expires_next_sync_time_if_more_than_one_hour() {
+		$this->sender->set_next_sync_time( time() + HOUR_IN_SECONDS );
+
+		self::factory()->post->create();
+		$this->sender->do_sync();
+
+		$next_sync_time = $this->sender->get_next_sync_time( 'sync' );
+		$this->assertSame( 0, $next_sync_time );
+	}
+
 	public function serverReceiveWithTrailingError( $data, $codec, $sent_timestamp ) {
 		$processed_item_ids = $this->server->receive( $data, null, $sent_timestamp );
 

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -338,13 +338,14 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_expires_next_sync_time_if_more_than_one_hour() {
-		$this->sender->set_next_sync_time( time() + HOUR_IN_SECONDS, 'sync' );
+		$one_hour_from_now = time() + HOUR_IN_SECONDS;
+		$this->sender->set_next_sync_time( $one_hour_from_now, 'sync' );
 
 		self::factory()->post->create();
 		$this->sender->do_sync();
 
 		$next_sync_time = $this->sender->get_next_sync_time( 'sync' );
-		$this->assertSame( 0, $next_sync_time );
+		$this->assertNotSame( $next_sync_time, $one_hour_from_now );
 	}
 
 	public function serverReceiveWithTrailingError( $data, $codec, $sent_timestamp ) {

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -338,7 +338,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_expires_next_sync_time_if_more_than_one_hour() {
-		$this->sender->set_next_sync_time( time() + HOUR_IN_SECONDS );
+		$this->sender->set_next_sync_time( time() + HOUR_IN_SECONDS, 'sync' );
 
 		self::factory()->post->create();
 		$this->sender->do_sync();


### PR DESCRIPTION
Sometimes when we process Sync requests in Jetpack, the server clock can be a bit in the future and this can lock Sync to not send stuff for a while.

In this PR we limit checks for `next_sync_time` to be at most one hour in the future from the current time and consider it as expired if it is.

As a bonus, we fix a minor bug in `Sync\Sender::reset_data` to make sure all Sync locks are actually removed when calling this method.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1203356226846000-as-1203371997360099/f

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Set the `next_sync_time` to more than one hour in the future: `wp option set jetpack_next_sync_time 4099288198 `
- Attempt to trigger a Sync
- Verify successful Sync
- Verify option is now either updated (during Sync) or not present at all