### PR TITLE
Tools: add stable tag script

### DIFF
--- a/tools/revert-release.sh
+++ b/tools/revert-release.sh
@@ -91,7 +91,9 @@ fi
 CURRENT_STABLE_VERSION=$(jq -r .version <<<"$JSON")
 
 # Get all versions, strip anything with alpha characters such as -beta or trunk.
-LAST_STABLE_TAG=$(jq -r '.versions | delpaths([paths | select(.[] | test("[A-Za-z]+"; "i"))]) | keys[-2]' <<<"$JSON")
+SVN_TMP=$(jq -r '.versions | keys[] | select( test( "^[0-9]+(\\.[0-9]+)+$" ) )' <<<"$JSON"  | sort -V )
+mapfile -t SVN_TAGS <<<"$SVN_TMP"
+LAST_STABLE_TAG=${SVN_TAGS[-2]}
 
 red CAUTION
 echo "This script does one thing, which is to revert stable tag in WordPress.org svn to the prior tag."

--- a/tools/stable-tag.sh
+++ b/tools/stable-tag.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+BASE=$(cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
+. "$BASE/tools/includes/check-osx-bash-version.sh"
+. "$BASE/tools/includes/chalk-lite.sh"
+. "$BASE/tools/includes/normalize-version.sh"
+. "$BASE/tools/includes/plugin-functions.sh"
+. "$BASE/tools/includes/proceed_p.sh"
+
+# Instructions
+function usage {
+	cat <<-EOH
+		usage: $0 [options] <plugin>
+
+		Update the stable tag for the specified plugin. The <plugin> may be
+		either the name of a directory in projects/plugins/, or a path to a plugin directory or file.
+
+		Options:
+		  --dir <dir>  Use the specified directory for the SVN checkout,
+		               instead of creating a random directory in TMPDIR.
+
+	EOH
+	exit 1
+}
+
+# Process args.
+ARGS=()
+BUILD_DIR=
+while [[ $# -gt 0 ]]; do
+	arg="$1"
+	shift
+	case $arg in
+		--dir)
+			BUILD_DIR="$1"
+			shift
+			;;
+		--dir=*)
+			BUILD_DIR="${arg#--dir=}"
+			;;
+		--help)
+			usage
+			;;
+		*)
+			ARGS+=( "$arg" )
+			;;
+	esac
+done
+if [[ ${#ARGS[@]} -ne 1 ]]; then
+	usage
+fi
+
+$INTERACTIVE || die "Input is not a terminal, aborting."
+
+# Check plugin.
+process_plugin_arg "${ARGS[0]}"
+PLUGIN_NAME=$(jq --arg n "${ARGS[0]}" -r '.name // $n' "$PLUGIN_DIR/composer.json")
+WPSLUG=$(jq -r '.extra["wp-plugin-slug"] // ""' "$PLUGIN_DIR/composer.json")
+[[ -n "$WPSLUG" ]] || die "Plugin $PLUGIN_NAME has no WordPress.org plugin slug. Cannot deploy."
+
+# Get JSON
+JSON=$(curl -s "http://api.wordpress.org/plugins/info/1.0/$WPSLUG.json")
+if ! jq -e '.' <<<"$JSON" &>/dev/null; then
+	die "Failed to retrieve JSON data from http://api.wordpress.org/plugins/info/1.0/$WPSLUG.json"
+fi
+
+# Current stable version
+CURRENT_STABLE_VERSION=$(jq -r .version <<<"$JSON")
+
+
+echo $CURRENT_STABLE_VERSION

--- a/tools/stable-tag.sh
+++ b/tools/stable-tag.sh
@@ -87,17 +87,15 @@ fi
 # Current stable version
 CURRENT_STABLE_VERSION=$(jq -r .version <<<"$JSON")
 
-# Get all versions, strip anything with alpha characters such as -beta or trunk.
-SVN_TAGS=$(jq -r '.versions | delpaths([paths | select(.[] | test("[A-Za-z]+"; "i"))]) | keys[]' <<<"$JSON")
-
-# Sort and create an array
-SVN_TAGS=( $(printf "%s\n" $SVN_TAGS | sort -V) )
-COUNT=${#SVN_TAGS[@]}
-SVN_LATEST=${SVN_TAGS[@]:$COUNT-1:1}
+# Get all versions, strip anything with alpha characters such as -beta or trunk. Sort and create an array.
+SVN_TMP=$(jq -r '.versions | keys[] | select( test( "^[0-9]+(\\.[0-9]+)+$" ) )' <<<"$JSON"  | sort -V )
+mapfile -t SVN_TAGS <<<"$SVN_TMP"
+SVN_LATEST=${SVN_TAGS[-1]}
 
 # Get mirror repo
 
 MIRROR=$(jq -r '.extra["mirror-repo"] // ""' "$PLUGIN_DIR/composer.json")
+[[ -n "$MIRROR" ]] || die "Plugin $WPSLUG has no mirror repo."
 
 # Current release on GH
 

--- a/tools/stable-tag.sh
+++ b/tools/stable-tag.sh
@@ -89,10 +89,6 @@ fi
 
 GH_LATEST=$(jq -r '. .tag_name' <<<"$GH_JSON")
 
-GH_LATEST=1.5.4
-SVN_LATEST=1.5.4
-CURRENT_STABLE_VERSION=1.5.5
-
 yellow "Current stable tag: ${CURRENT_STABLE_VERSION}"
 yellow "Latest tag in SVN: ${SVN_LATEST}"
 yellow "Latest release tag in GH: ${GH_LATEST}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Adding a tool for updating stable tag. Most of the code is adapted from the revert-relase.sh file.


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Checking for latest SVN, latest GH release and current stable tags
* Update is possible only when GH and SVN tags are the same and newer than the current stable tag

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p9dueE-6bv-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try adding something like 
GH_LATEST=xx 
SVN_LATEST=xx
CURRENT_STABLE_VERSION=xx 
after line 91 to see what happens when different versions are used
* Use tools/stable-tag.sh plugin-name to use the tool