### PR TITLE
Protect: Add notices to the Firewall screen

### DIFF
--- a/projects/plugins/protect/src/js/components/firewall-footer/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-footer/index.jsx
@@ -1,8 +1,10 @@
 import { AdminSectionHero, Title, Text, Button } from '@automattic/jetpack-components';
-import { CheckboxControl } from '@wordpress/components';
+import { CheckboxControl, ExternalLink } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useCallback } from 'react';
+import { PLUGIN_SUPPORT_URL } from '../../constants';
 import useWafData from '../../hooks/use-waf-data';
 import { STORE_ID } from '../../state/store';
 import SeventyFiveLayout from '../seventy-five-layout';
@@ -65,9 +67,14 @@ const ShareData = () => {
 				setNotice( {
 					type: 'error',
 					dismissable: true,
-					message: __(
-						'An error ocurred. Please try again or contact support.',
-						'jetpack-protect'
+					message: createInterpolateElement(
+						__(
+							'An error ocurred. Please try again or <supportLink>contact support</supportLink>.',
+							'jetpack-protect'
+						),
+						{
+							supportLink: <ExternalLink href={ PLUGIN_SUPPORT_URL } />,
+						}
 					),
 				} );
 			} );

--- a/projects/plugins/protect/src/js/components/firewall-footer/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-footer/index.jsx
@@ -44,6 +44,7 @@ const StandaloneMode = () => {
 const ShareData = () => {
 	const { config, isLoading, toggleShareData } = useWafData();
 	const { jetpackWafShareData } = config || {};
+	const { setNotice } = useDispatch( STORE_ID );
 
 	const [ settings, setSettings ] = useState( {
 		jetpack_waf_share_data: jetpackWafShareData,
@@ -51,8 +52,26 @@ const ShareData = () => {
 
 	const handleShareDataChange = useCallback( () => {
 		setSettings( { ...settings, jetpack_waf_share_data: ! settings.jetpack_waf_share_data } );
-		toggleShareData();
-	}, [ settings, toggleShareData ] );
+		toggleShareData()
+			.then( () =>
+				setNotice( {
+					type: 'success',
+					duration: 5000,
+					dismissable: true,
+					message: __( 'Changes saved.', 'jetpack-protect' ),
+				} )
+			)
+			.catch( () => {
+				setNotice( {
+					type: 'error',
+					dismissable: true,
+					message: __(
+						'An error ocurred. Please try again or contact support.',
+						'jetpack-protect'
+					),
+				} );
+			} );
+	}, [ settings, toggleShareData, setNotice ] );
 
 	useEffect( () => {
 		setSettings( {

--- a/projects/plugins/protect/src/js/components/firewall-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-page/index.jsx
@@ -80,7 +80,11 @@ const FirewallPage = () => {
 					duration: successNoticeDuration,
 					message: newWafStatus
 						? __( `Firewall is active.`, 'jetpack-protect' )
-						: __( `Firewall is disabled.`, 'jetpack-protect' ),
+						: __(
+								`Firewall is disabled.`,
+								'jetpack-protect',
+								/* dummy arg to avoid bad minification */ 0
+						  ),
 				} )
 			)
 			.catch( () => {
@@ -103,7 +107,11 @@ const FirewallPage = () => {
 					duration: successNoticeDuration,
 					message: newManualRulesStatus
 						? __( 'Manual rules are active.', 'jetpack-protect' )
-						: __( 'Manual rules are disabled.', 'jetpack-protect' ),
+						: __(
+								'Manual rules are disabled.',
+								'jetpack-protect',
+								/* dummy arg to avoid bad minification */ 0
+						  ),
 				} )
 			)
 			.catch( () => {

--- a/projects/plugins/protect/src/js/components/firewall-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-page/index.jsx
@@ -1,8 +1,11 @@
 import { Button, Col, Container, Text } from '@automattic/jetpack-components';
+import { ExternalLink } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useEffect, useState } from 'react';
 import API from '../../api';
+import { PLUGIN_SUPPORT_URL } from '../../constants';
 import useWafData from '../../hooks/use-waf-data';
 import { STORE_ID } from '../../state/store';
 import AdminPage from '../admin-page';
@@ -29,6 +32,16 @@ const FirewallPage = () => {
 
 	const successNoticeDuration = 5000;
 
+	const errorMessage = createInterpolateElement(
+		__(
+			'An error ocurred. Please try again or <supportLink>contact support</supportLink>.',
+			'jetpack-protect'
+		),
+		{
+			supportLink: <ExternalLink href={ PLUGIN_SUPPORT_URL } />,
+		}
+	);
+
 	const saveChanges = useCallback( () => {
 		setSettingsIsUpdating( true );
 		updateConfig( settings )
@@ -42,14 +55,11 @@ const FirewallPage = () => {
 			.catch( () => {
 				setNotice( {
 					type: 'error',
-					message: __(
-						'An error ocurred. Please try again or contact support.',
-						'jetpack-protect'
-					),
+					message: errorMessage,
 				} );
 			} )
 			.finally( () => setSettingsIsUpdating( false ) );
-	}, [ settings, updateConfig, setNotice ] );
+	}, [ settings, updateConfig, setNotice, errorMessage ] );
 
 	const handleChange = useCallback(
 		event => {
@@ -76,14 +86,11 @@ const FirewallPage = () => {
 			.catch( () => {
 				setNotice( {
 					type: 'error',
-					message: __(
-						'An error ocurred. Please try again or contact support.',
-						'jetpack-protect'
-					),
+					message: errorMessage,
 				} );
 			} )
 			.finally( () => setSettingsIsUpdating( false ) );
-	}, [ settings, toggleWaf, setNotice ] );
+	}, [ settings, toggleWaf, setNotice, errorMessage ] );
 
 	const handleManualRulesChange = useCallback( () => {
 		const newManualRulesStatus = ! settings.jetpack_waf_ip_list;
@@ -102,14 +109,11 @@ const FirewallPage = () => {
 			.catch( () => {
 				setNotice( {
 					type: 'error',
-					message: __(
-						'An error ocurred. Please try again or contact support.',
-						'jetpack-protect'
-					),
+					message: errorMessage,
 				} );
 			} )
 			.finally( () => setSettingsIsUpdating( false ) );
-	}, [ settings, toggleManualRules, setNotice ] );
+	}, [ settings, toggleManualRules, setNotice, errorMessage ] );
 
 	/**
 	 * Sync state.settings with application state WAF config

--- a/projects/plugins/protect/src/js/components/notice/index.jsx
+++ b/projects/plugins/protect/src/js/components/notice/index.jsx
@@ -1,7 +1,20 @@
-import { check, info, warning, Icon } from '@wordpress/icons';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { check, close, info, warning, Icon } from '@wordpress/icons';
+import { useCallback, useEffect, useState } from 'react';
+import { STORE_ID } from '../../state/store';
 import styles from './styles.module.scss';
 
-const Notice = ( { type = 'success', message } ) => {
+const Notice = ( {
+	dismissable = false,
+	duration = null,
+	floating = false,
+	message,
+	type = 'success',
+} ) => {
+	const { clearNotice } = useDispatch( STORE_ID );
+	const [ timeoutStarted, setTimeoutStarted ] = useState( false );
+
 	let icon;
 	switch ( type ) {
 		case 'success':
@@ -15,12 +28,43 @@ const Notice = ( { type = 'success', message } ) => {
 			icon = info;
 	}
 
+	const onClose = useCallback( () => {
+		clearNotice();
+	}, [ clearNotice ] );
+
+	/**
+	 * Clears the notice automatically after {duration} milliseconds.
+	 */
+	useEffect( () => {
+		let timeout;
+
+		if ( duration && ! timeoutStarted ) {
+			timeout = setTimeout( clearNotice, duration );
+			setTimeoutStarted( true );
+		}
+
+		return () => clearTimeout( timeout );
+	}, [ clearNotice, duration, timeoutStarted ] );
+
 	return (
-		<div className={ `${ styles.notice } ${ styles[ `notice--${ type }` ] }` }>
+		<div
+			className={ `${ styles.notice } ${ styles[ `notice--${ type }` ] } ${
+				floating ? styles[ 'notice--floating' ] : ''
+			}` }
+		>
 			<div className={ styles.notice__icon }>
 				<Icon icon={ icon } />
 			</div>
 			<div className={ styles.notice__message }>{ message }</div>
+			{ dismissable && (
+				<button
+					className={ styles.notice__close }
+					aria-label={ __( 'Dismiss notice.', 'jetpack-protect' ) }
+					onClick={ onClose }
+				>
+					<Icon icon={ close } />
+				</button>
+			) }
 		</div>
 	);
 };

--- a/projects/plugins/protect/src/js/components/notice/stories/index.jsx
+++ b/projects/plugins/protect/src/js/components/notice/stories/index.jsx
@@ -17,3 +17,19 @@ export default {
 };
 
 export const Default = () => <Notice type="success" message="Code is poetry." />;
+
+export const Dismissable = () => (
+	<Notice
+		type="success"
+		dismissable={ true }
+		message="Dismiss this notice by clicking the close icon."
+	/>
+);
+
+export const Duration = () => (
+	<Notice
+		type="success"
+		duration={ 5000 }
+		message="This notice will self-destruct in five seconds."
+	/>
+);

--- a/projects/plugins/protect/src/js/components/notice/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/notice/styles.module.scss
@@ -9,6 +9,17 @@
         border-left: 4px solid var( --jp-yellow-20 );
         margin-bottom: calc( var( --spacing-base ) * 3 ); // 24px
     }
+
+    &.notice--floating {
+        position: fixed;
+        top: calc( var( --spacing-base ) * 6 ); // 48px
+        right: calc( var( --spacing-base ) * 3 ); // 24px
+        margin-left: calc( var( --spacing-base ) * 3 ); // 24px
+
+        @media ( max-width: 782px ) {
+            top: calc( var( --spacing-base ) * 8 ); // 72px
+        }
+    }
 }
 
 .notice__icon {
@@ -41,4 +52,15 @@
         color: var( --jp-gray-90 );
         background-color: var( --jp-yellow-5 );
     }
+}
+
+.notice__close {
+    fill: var( --jp-gray );
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: calc( var( --spacing-base ) * 1.5 ); // 12px
+    background: transparent;
+    border: none;
 }

--- a/projects/plugins/protect/src/js/components/notice/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/notice/styles.module.scss
@@ -20,6 +20,14 @@
             top: calc( var( --spacing-base ) * 8 ); // 72px
         }
     }
+
+    a,
+    a:link,
+    a:hover,
+    a:visited,
+    a:active {
+        color: var( --jp-white );
+    }
 }
 
 .notice__icon {

--- a/projects/plugins/protect/src/js/constants.js
+++ b/projects/plugins/protect/src/js/constants.js
@@ -1,0 +1,1 @@
+export const PLUGIN_SUPPORT_URL = 'https://wordpress.org/support/plugin/jetpack-protect/';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds success and error notices to the Protect WAF forms.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a floating notice area to the top right of the Firewall page.
* Triggers success and error notices when Firewall settings are updated (module toggled, manual rules toggled/updated, share data toggled).
* Adds a `constants.js` utility file for storing constants shared across files, to store the Protect plugin's support URL included in error notices.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

1201069996155224-as-1203442252570025

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Validate that a notice is shown after updating the Firewall settings listed above.
* Validate error notices are shown, with an external link to the support forum, when a server error occurs. You can simulate this by pasting `return new WP_REST_Response( 'Error.', 500 );` at the top of an API method such as `api_toggle_waf()` in `class-jetpack-protect.php:564`.