### PR TITLE
Boost: fix e2e plugin deactivation

### DIFF
--- a/projects/plugins/boost/changelog/fix-boost-e2e-deactivation
+++ b/projects/plugins/boost/changelog/fix-boost-e2e-deactivation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed an e2e test
+
+

--- a/projects/plugins/boost/tests/e2e/lib/setupTests.js
+++ b/projects/plugins/boost/tests/e2e/lib/setupTests.js
@@ -5,11 +5,7 @@ import { boostPrerequisitesBuilder } from './env/prerequisites.js';
 export default async function () {
 	const browser = await chromium.launch();
 	const page = await browser.newPage();
-	await prerequisitesBuilder( page )
-		.withLoggedIn( true )
-		.withActivePlugins( [ 'boost' ] )
-		.withInactivePlugins( [ 'jetpack' ] )
-		.build();
+	await prerequisitesBuilder( page ).withLoggedIn( true ).withActivePlugins( [ 'boost' ] ).build();
 	await boostPrerequisitesBuilder( page )
 		.withCleanEnv( true )
 		.withSpeedScoreMocked( true )

--- a/projects/plugins/boost/tests/e2e/lib/setupTests.js
+++ b/projects/plugins/boost/tests/e2e/lib/setupTests.js
@@ -5,7 +5,11 @@ import { boostPrerequisitesBuilder } from './env/prerequisites.js';
 export default async function () {
 	const browser = await chromium.launch();
 	const page = await browser.newPage();
-	await prerequisitesBuilder( page ).withLoggedIn( true ).withActivePlugins( [ 'boost' ] ).build();
+	await prerequisitesBuilder( page )
+		.withLoggedIn( true )
+		.withActivePlugins( [ 'boost' ] )
+		.withInactivePlugins( [ 'jetpack' ] )
+		.build();
 	await boostPrerequisitesBuilder( page )
 		.withCleanEnv( true )
 		.withSpeedScoreMocked( true )

--- a/projects/plugins/boost/tests/e2e/package.json
+++ b/projects/plugins/boost/tests/e2e/package.json
@@ -14,7 +14,7 @@
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic",
 	"scripts": {
-		"build": "pnpm jetpack build plugins/jetpack plugins/boost -v --no-pnpm-install --production",
+		"build": "pnpm jetpack build plugins/jetpack plugins/boost packages/plugin-deactivation -v --no-pnpm-install --production",
 		"clean": "rm -rf output",
 		"config:decrypt": "openssl enc -md sha1 -aes-256-cbc -d -pass env:CONFIG_KEY -in ./node_modules/jetpack-e2e-commons/config/encrypted.enc -out ./config/local.cjs",
 		"distclean": "rm -rf node_modules",

--- a/projects/plugins/boost/tests/e2e/specs/common.test.js
+++ b/projects/plugins/boost/tests/e2e/specs/common.test.js
@@ -50,7 +50,12 @@ test( 'Deactivating the plugin should clear Critical CSS and Dismissed Recommend
 	).toBeTruthy();
 	await DashboardPage.visit( page );
 	await ( await Sidebar.init( page ) ).selectInstalledPlugins();
-	await ( await PluginsPage.init( page ) ).deactivatePlugin( 'jetpack-boost' );
+
+	// Deactivate boost
+	const pluginsPage = await PluginsPage.init( page );
+	await pluginsPage.deactivatePlugin( 'jetpack-boost' );
+	await pluginsPage.click( 'text=Just Deactivate' );
+
 	let result;
 	result = await execWpCommand(
 		'db query \'SELECT ID FROM wp_posts WHERE post_type LIKE "%jb_store_%"\' --skip-column-names'


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update e2e test to properly deactivate plugin by interacting with the deactivation dialog

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
p1669629606043189-slack-C01U2KGS2PQ

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
None