### PR TITLE
VideoPress: add TrackForm component

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-upload-tracks
+++ b/projects/packages/videopress/changelog/update-videopress-upload-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: add TrackForm component

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
@@ -9,26 +9,25 @@ import {
 	Dropdown,
 	Button,
 } from '@wordpress/components';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { upload } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
 import { deleteTrackForGuid } from '../../../../../lib/video-tracks';
-import { TrackProps, VideoControlProps, VideoId } from '../../types';
+import { TrackProps, VideoControlProps } from '../../types';
 import { captionIcon } from '../icons';
 import './style.scss';
+import TrackForm from './track-form';
 import { TrackItemProps, TrackListProps } from './types';
 import type React from 'react';
 
 /**
  * Track Item component.
  *
- * @param {TrackItemProps} props       - Component props.
- * @param {TrackProps}     props.track - Video track
- * @param {VideoId}        props.guid  - Video guid
- * @returns {React.ReactElement}         TrackItem react component
+ * @param {TrackItemProps} props - Component props.
+ * @returns {React.ReactElement}   TrackItem react component
  */
 function TrackItem( { track, guid }: TrackItemProps ): React.ReactElement {
 	const { kind, label } = track;
@@ -38,10 +37,10 @@ function TrackItem( { track, guid }: TrackItemProps ): React.ReactElement {
 	}, [] );
 
 	return (
-		<div className="videopress-block__track-item">
-			<div className="videopress-block__track-item-label">
+		<div className="video-tracks-control__track-item">
+			<div className="video-tracks-control__track-item-label">
 				{ label }
-				<span className="videopress-block__track-item-kind"> ({ kind })</span>
+				<span className="video-tracks-control__track-item-kind"> ({ kind })</span>
 			</div>
 			<Button variant="link" isDestructive onClick={ deleteTrackHandler }>
 				{ __( 'Delete', 'jetpack-videopress-pkg' ) }
@@ -59,7 +58,7 @@ function TrackItem( { track, guid }: TrackItemProps ): React.ReactElement {
 function TrackList( { tracks, guid }: TrackListProps ): React.ReactElement {
 	if ( ! tracks?.length ) {
 		return (
-			<MenuGroup className="videopress-block-tracks-control__track_list__no-tracks">
+			<MenuGroup className="video-tracks-control__track_list__no-tracks">
 				{ __(
 					'Tracks can be subtitles, captions, chapters, or descriptions. They help make your content more accessible to a wider range of users.',
 					'jetpack-videopress-pkg'
@@ -70,7 +69,7 @@ function TrackList( { tracks, guid }: TrackListProps ): React.ReactElement {
 
 	return (
 		<MenuGroup
-			className="videopress-block-tracks-control__track_list"
+			className="video-tracks-control__track_list"
 			label={ __( 'Text tracks', 'jetpack-videopress-pkg' ) }
 		>
 			{ tracks.map( ( track: TrackProps, index ) => {
@@ -89,10 +88,7 @@ function TrackList( { tracks, guid }: TrackListProps ): React.ReactElement {
 export default function TracksControl( { attributes }: VideoControlProps ): React.ReactElement {
 	const { tracks, guid } = attributes;
 
-	// Upload new track handler. ToDo: finish
-	const addNewTrackHandler = useCallback( () => {
-		console.log( 'adding new track...' ); // eslint-disable-line no-console
-	}, [] );
+	const [ isUploadingNewTrack, setIsUploadingNewTrack ] = useState( false );
 
 	return (
 		<Dropdown
@@ -107,15 +103,25 @@ export default function TracksControl( { attributes }: VideoControlProps ): Reac
 				/>
 			) }
 			renderContent={ () => {
+				if ( isUploadingNewTrack ) {
+					return (
+						<TrackForm
+							onCancel={ () => {
+								setIsUploadingNewTrack( false );
+							} }
+							tracks={ tracks }
+						/>
+					);
+				}
 				return (
 					<NavigableMenu>
 						<TrackList tracks={ tracks } guid={ guid } />
 
 						<MenuGroup
 							label={ __( 'Add tracks', 'jetpack-videopress-pkg' ) }
-							className="videopress-block-tracks-control"
+							className="video-tracks-control"
 						>
-							<MenuItem icon={ upload } onClick={ addNewTrackHandler }>
+							<MenuItem icon={ upload } onClick={ () => setIsUploadingNewTrack( true ) }>
 								{ __( 'Upload track', 'jetpack-videopress-pkg' ) }
 							</MenuItem>
 						</MenuGroup>

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/style.scss
@@ -1,16 +1,64 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
-.videopress-block-tracks-control__track_list__no-tracks {
+// Tracklist
+.video-tracks-control__track_list__no-tracks {
 	padding: 8px;
 }
 
 // TrackItem
-.videopress-block__track-item {
+.video-tracks-control__track-item {
 	display: flex;
 	justify-content: space-between;
 	padding: 8px;
 }
 
-.videopress-block__track-item-kind {
+.video-tracks-control__track-item-kind {
 	color: $gray-700;
+}
+
+// TrackFrom
+.video-tracks-control__track-form {
+	min-width: 360px;
+}
+
+.video-tracks-control__track-form-container {
+	padding: 0 8px;
+}
+
+.video-tracks-control__track-form__description {
+	margin: 0 0 16px 0;
+	font-size: 12px;
+}
+
+.video-tracks-control__track-form-upload-file-help {
+	margin-top: calc(8px);
+	font-size: 12px;
+	font-style: normal;
+	color: rgb(117, 117, 117);
+	margin-bottom: revert;
+}
+
+.video-tracks-control__track-form-upload-file {
+	margin-bottom: 16px;
+}
+
+.video-tracks-control__track-form-upload-file-label {
+	display: flex;
+	gap: 4px;
+}
+
+.video-tracks-control__track-form-label-language {
+	display: flex;
+	margin-bottom: 16px;
+	gap: 16px;
+}
+
+.video-tracks-control__track-form-language-tag {
+	max-width: 150px;
+}
+
+.video-tracks-control__track-form-buttons-container {
+	display: flex;
+	justify-content: flex-end;
+	gap: 16px
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/track-form.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/track-form.tsx
@@ -1,0 +1,170 @@
+/**
+ * External dependencies
+ */
+import { MediaUploadCheck, store as blockEditorStore } from '@wordpress/block-editor';
+import {
+	NavigableMenu,
+	FormFileUpload,
+	Button,
+	TextControl,
+	SelectControl,
+	MenuGroup,
+} from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { useCallback, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import { UploadTrackDataProps } from '../../../../../lib/video-tracks/types';
+import { TrackFormProps } from './types';
+import type React from 'react';
+
+const DEFAULT_KIND = 'subtitles';
+
+const ACCEPTED_FILE_TYPES = '.vtt,text/vtt';
+
+const KIND_OPTIONS = [
+	{ label: __( 'Subtitles', 'jetpack-videopress-pkg' ), value: 'subtitles' },
+	{ label: __( 'Captions', 'jetpack-videopress-pkg' ), value: 'captions' },
+	{ label: __( 'Descriptions', 'jetpack-videopress-pkg' ), value: 'descriptions' },
+	{ label: __( 'Chapters', 'jetpack-videopress-pkg' ), value: 'chapters' },
+	{ label: __( 'Metadata', 'jetpack-videopress-pkg' ), value: 'metadata' },
+];
+
+/**
+ * Track From component
+ *
+ * @param {TrackFormProps} props - Component props.
+ * @returns {React.ReactElement}   Track form react component.
+ */
+export default function TrackForm( { onCancel }: TrackFormProps ): React.ReactElement {
+	const [ errorMessage ] = useState( '' );
+	const [ isSavingTrack, setIsSavingTrack ] = useState( false );
+	const [ track, setTrack ] = useState< UploadTrackDataProps >( {
+		kind: DEFAULT_KIND,
+		srcLang: '',
+		label: '',
+		tmpFile: null,
+	} );
+
+	const updateTrack = useCallback(
+		( key: 'kind' | 'srcLang' | 'label' | 'tmpFile', value: string | File ) => {
+			setTrack( { ...track, [ key ]: value } );
+		},
+		[ track ]
+	);
+
+	const fileName = track.tmpFile?.name;
+
+	const mediaUpload = useSelect( select => {
+		return select( blockEditorStore ).getSettings().mediaUpload;
+	}, [] );
+
+	const onSaveHandler = useCallback( () => {
+		setIsSavingTrack( true );
+	}, [] );
+
+	if ( ! mediaUpload ) {
+		return null;
+	}
+
+	const help = sprintf(
+		/* translators: %s: The allowed file types to be uploaded as a video text track." */
+		__( 'Add a new text track to the video. Allowed formats: %s', 'jetpack-videopress-pkg' ),
+		ACCEPTED_FILE_TYPES
+	);
+
+	return (
+		<NavigableMenu>
+			<MenuGroup
+				className="video-tracks-control__track-form"
+				label={ __( 'Upload track', 'jetpack-videopress-pkg' ) }
+			>
+				<div className="video-tracks-control__track-form-container">
+					<div className="video-tracks-control__track-form-upload-file">
+						<div className="video-tracks-control__track-form-upload-file-label">
+							<span>{ __( 'File', 'jetpack-videopress-pkg' ) }:</span>
+							{ fileName && <strong>{ fileName }</strong> }
+							<MediaUploadCheck>
+								<FormFileUpload
+									onChange={ event => {
+										const files = event.target.files;
+										if ( ! files?.length ) {
+											return;
+										}
+
+										updateTrack( 'tmpFile', files[ 0 ] );
+									} }
+									accept={ ACCEPTED_FILE_TYPES }
+									render={ ( { openFileDialog } ) => {
+										return (
+											<Button
+												variant="link"
+												onClick={ () => {
+													openFileDialog();
+												} }
+											>
+												{ __( 'Select track', 'jetpack-videopress-pkg' ) }
+											</Button>
+										);
+									} }
+								/>
+							</MediaUploadCheck>
+						</div>
+						<div className="video-tracks-control__track-form-upload-file-help">{ help }</div>
+					</div>
+					<div className="video-tracks-control__track-form-label-language">
+						<TextControl
+							onChange={ newLabel => updateTrack( 'label', newLabel ) }
+							label={ __( 'Label', 'jetpack-videopress-pkg' ) }
+							value={ track.label }
+							help={ __( 'Title of track', 'jetpack-videopress-pkg' ) }
+							disabled={ isSavingTrack }
+						/>
+						<TextControl
+							className="video-tracks-control__track-form-language-tag"
+							label={ __( 'Source language', 'jetpack-videopress-pkg' ) }
+							value={ track.srcLang }
+							onChange={ newSrcLang => updateTrack( 'srcLang', newSrcLang ) }
+							help={ __( 'Language (en, fr, etc.)', 'jetpack-videopress-pkg' ) }
+							disabled={ isSavingTrack }
+						/>
+					</div>
+					<SelectControl
+						options={ KIND_OPTIONS }
+						value={ track.kind }
+						label={
+							/* translators: %s: The kind of video text track e.g: "Subtitles, Captions" */
+							__( 'Kind', 'jetpack-videopress-pkg' )
+						}
+						onChange={ newKind => updateTrack( 'kind', newKind ) }
+						disabled={ isSavingTrack }
+					/>
+					<div className="video-tracks-control__track-form-buttons-container">
+						<Button
+							isBusy={ isSavingTrack }
+							variant="secondary"
+							disabled={ ! track.tmpFile || isSavingTrack }
+							onClick={ onSaveHandler }
+						>
+							{ __( 'Save', 'jetpack-videopress-pkg' ) }
+						</Button>
+
+						<Button variant="link" onClick={ onCancel }>
+							{ __( 'Cancel', 'jetpack-videopress-pkg' ) }
+						</Button>
+					</div>
+					{ errorMessage && (
+						<div className="video-tracks-control__track-form-error">
+							{
+								/* translators: %s: An error message returned after a failed video track file upload." */
+								sprintf( __( 'Error: %s', 'jetpack-videopress-pkg' ), errorMessage )
+							}
+						</div>
+					) }
+				</div>
+			</MenuGroup>
+		</NavigableMenu>
+	);
+}

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/types.ts
@@ -9,3 +9,8 @@ export type TrackListProps = {
 	tracks: TrackProps[];
 	guid: VideoGUID;
 };
+
+export type TrackFormProps = {
+	onCancel: () => void;
+	tracks: TrackProps[];
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds a new `TrackForm` component to upload new tracks to the video. It implements only the UI part. Functionality-wise, it's going to be addressed in follow-up tasks.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: add TrackForm component

#### Other information:

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Block Editor
* Add/edit a video block
* Open the Tracks control
<img width="398" alt="image" src="https://user-images.githubusercontent.com/77539/204276215-1f46a69a-acf7-48ef-b448-883873500967.png">

* Click on the `Upload track` button
<img width="433" alt="image" src="https://user-images.githubusercontent.com/77539/204276280-1c747fe7-c64a-4261-97be-72ae7f71b7dd.png">

* Confirm you can type the label and language fields and select the kind of tracks.
* Confirm you can upload only `.vtt` files
* Confirm `Save` button is disabled until you select the file to upload
* Confirm the `Save` button disables and gets busy once you click on the save button
<img width="588" alt="Screen Shot 2022-11-28 at 09 22 18" src="https://user-images.githubusercontent.com/77539/204276834-da90baf2-007f-423c-bd6b-bc3389fead22.png">


