### PR TITLE
VideoPress: handle overwriting video track file

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-warn-overwriting-video-file
+++ b/projects/packages/videopress/changelog/update-videopress-warn-overwriting-video-file
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: handle overwriting video track file

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
@@ -88,8 +88,9 @@ export default function TracksControl( { attributes }: VideoControlProps ): Reac
 
 	const uploadNewTrackFile = useCallback( newTrack => {
 		uploadTrackForGuid( newTrack, guid ).then( () => {
-			setIsUploadingNewTrack( true );
+			setIsUploadingNewTrack( false );
 		} );
+		setIsUploadingNewTrack( true );
 	}, [] );
 
 	return (

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
@@ -23,7 +23,7 @@ import type React from 'react';
  * @returns {React.ReactElement}   TrackItem react component
  */
 function TrackItem( { track, guid }: TrackItemProps ): React.ReactElement {
-	const { kind, label } = track;
+	const { kind, label, srcLang } = track;
 
 	const deleteTrackHandler = useCallback( () => {
 		deleteTrackForGuid( track, guid );
@@ -32,8 +32,11 @@ function TrackItem( { track, guid }: TrackItemProps ): React.ReactElement {
 	return (
 		<div className="video-tracks-control__track-item">
 			<div className="video-tracks-control__track-item-label">
-				{ label }
-				<span className="video-tracks-control__track-item-kind"> ({ kind })</span>
+				<strong>{ label }</strong>
+				<span className="video-tracks-control__track-item-kind">
+					{ kind }
+					{ srcLang?.length ? ` [${ srcLang }]` : '' }
+				</span>
 			</div>
 			<Button variant="link" isDestructive onClick={ deleteTrackHandler }>
 				{ __( 'Delete', 'jetpack-videopress-pkg' ) }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
@@ -108,6 +108,7 @@ export default function TracksControl( { attributes }: VideoControlProps ): Reac
 								setIsUploadingNewTrack( false );
 							} }
 							onSave={ uploadNewTrackFile }
+							tracks={ tracks }
 						/>
 					);
 				}

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
@@ -87,7 +87,6 @@ export default function TracksControl( { attributes }: VideoControlProps ): Reac
 		uploadTrackForGuid( newTrack, guid ).then( () => {
 			setIsUploadingNewTrack( false );
 		} );
-		setIsUploadingNewTrack( true );
 	}, [] );
 
 	return (

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
@@ -85,7 +85,7 @@ export default function TracksControl( { attributes }: VideoControlProps ): Reac
 
 	const uploadNewTrackFile = useCallback( newTrack => {
 		uploadTrackForGuid( newTrack, guid ).then( () => {
-			setIsUploadingNewTrack( false );
+			setIsUploadingNewTrack( true );
 		} );
 	}, [] );
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/style.scss
@@ -61,6 +61,15 @@
 
 .video-tracks-control__track-form-buttons-container {
 	display: flex;
-	justify-content: flex-end;
-	gap: 16px
+	gap: 16px;
+	align-items: center;
+
+	&:not( .track-exists ) {
+		justify-content: end;
+	}
+
+	.video-tracks-control__track-form-toggle {
+		flex-grow: 2;
+		margin-bottom: 0;
+	}
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/style.scss
@@ -1,5 +1,10 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
+.video-tracks-control__track_list,
+.video-tracks-control__track-form {
+	min-width: 360px;
+}
+
 // Tracklist
 .video-tracks-control__track_list__no-tracks {
 	padding: 8px;
@@ -14,13 +19,10 @@
 
 .video-tracks-control__track-item-kind {
 	color: $gray-700;
+	margin-left: 4px;
 }
 
 // TrackFrom
-.video-tracks-control__track-form {
-	min-width: 360px;
-}
-
 .video-tracks-control__track-form-container {
 	padding: 0 8px;
 }
@@ -31,7 +33,7 @@
 }
 
 .video-tracks-control__track-form-upload-file-help {
-	margin-top: calc(8px);
+	margin-top: 8px;
 	font-size: 12px;
 	font-style: normal;
 	color: rgb(117, 117, 117);

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/types.ts
@@ -17,4 +17,5 @@ export type TrackListProps = {
 export type TrackFormProps = {
 	onCancel: () => void;
 	onSave: ( track: UploadTrackDataProps ) => void;
+	tracks: TrackProps[];
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR suggests an implementation for the video track overwriting process. In opposite to the current implementation, it prompts the user permission to overwrite the file.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: handle overwriting video track file

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Block Editor
* Add/edit a video block
* Ensure the video has a track. Take note of its kind and language, for instance, `chapters` and `en`.

<img width="425" alt="Screen Shot 2022-11-28 at 16 52 13" src="https://user-images.githubusercontent.com/77539/204368277-5ada918e-e960-4293-9f33-db322f816bcc.png">

* Click on the `Upload track` button
* Try to upload another track with the same language and kind.
* Confirm you see a toggle control:

<img width="419" alt="Screen Shot 2022-11-28 at 16 50 36" src="https://user-images.githubusercontent.com/77539/204368104-5879fd79-79f6-4a49-b606-59ff66072d73.png">

* Confirm the `Save` button is disabled when the overwrite control is inactive.
* Confirm you can upload the track when the toggle is activated.

# 🍿 

https://user-images.githubusercontent.com/77539/204345907-0fb49af1-e456-41c6-b14e-900854bc1a86.mov

