### PR TITLE
VideoPress: re-implement track control using ToolbarDropdownMenu

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-tweak=-video-control-dropdown-menus
+++ b/projects/packages/videopress/changelog/update-videopress-tweak=-video-control-dropdown-menus
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: re-implement track control using ToolbarDropdownMenu

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
@@ -1,14 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	NavigableMenu,
-	MenuItem,
-	MenuGroup,
-	ToolbarButton,
-	Dropdown,
-	Button,
-} from '@wordpress/components';
+import { MenuItem, MenuGroup, ToolbarDropdownMenu, Button } from '@wordpress/components';
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { upload } from '@wordpress/icons';
@@ -91,18 +84,14 @@ export default function TracksControl( { attributes }: VideoControlProps ): Reac
 	const [ isUploadingNewTrack, setIsUploadingNewTrack ] = useState( false );
 
 	return (
-		<Dropdown
-			renderToggle={ ( { isOpen, onToggle } ) => (
-				<ToolbarButton
-					label={ __( 'Text tracks', 'jetpack-videopress-pkg' ) }
-					showTooltip
-					aria-expanded={ isOpen }
-					aria-haspopup="true"
-					onClick={ onToggle }
-					icon={ captionIcon }
-				/>
-			) }
-			renderContent={ () => {
+		<ToolbarDropdownMenu
+			icon={ captionIcon }
+			label={ __( 'Text tracks', 'jetpack-videopress-pkg' ) }
+			popoverProps={ {
+				variant: 'toolbar',
+			} }
+		>
+			{ () => {
 				if ( isUploadingNewTrack ) {
 					return (
 						<TrackForm
@@ -114,9 +103,8 @@ export default function TracksControl( { attributes }: VideoControlProps ): Reac
 					);
 				}
 				return (
-					<NavigableMenu>
+					<>
 						<TrackList tracks={ tracks } guid={ guid } />
-
 						<MenuGroup
 							label={ __( 'Add tracks', 'jetpack-videopress-pkg' ) }
 							className="video-tracks-control"
@@ -125,9 +113,9 @@ export default function TracksControl( { attributes }: VideoControlProps ): Reac
 								{ __( 'Upload track', 'jetpack-videopress-pkg' ) }
 							</MenuItem>
 						</MenuGroup>
-					</NavigableMenu>
+					</>
 				);
 			} }
-		/>
+		</ToolbarDropdownMenu>
 	);
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/track-form.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/track-form.tsx
@@ -3,7 +3,6 @@
  */
 import { MediaUploadCheck, store as blockEditorStore } from '@wordpress/block-editor';
 import {
-	NavigableMenu,
 	FormFileUpload,
 	Button,
 	TextControl,
@@ -76,95 +75,93 @@ export default function TrackForm( { onCancel }: TrackFormProps ): React.ReactEl
 	);
 
 	return (
-		<NavigableMenu>
-			<MenuGroup
-				className="video-tracks-control__track-form"
-				label={ __( 'Upload track', 'jetpack-videopress-pkg' ) }
-			>
-				<div className="video-tracks-control__track-form-container">
-					<div className="video-tracks-control__track-form-upload-file">
-						<div className="video-tracks-control__track-form-upload-file-label">
-							<span>{ __( 'File', 'jetpack-videopress-pkg' ) }:</span>
-							{ fileName && <strong>{ fileName }</strong> }
-							<MediaUploadCheck>
-								<FormFileUpload
-									onChange={ event => {
-										const files = event.target.files;
-										if ( ! files?.length ) {
-											return;
-										}
+		<MenuGroup
+			className="video-tracks-control__track-form"
+			label={ __( 'Upload track', 'jetpack-videopress-pkg' ) }
+		>
+			<div className="video-tracks-control__track-form-container">
+				<div className="video-tracks-control__track-form-upload-file">
+					<div className="video-tracks-control__track-form-upload-file-label">
+						<span>{ __( 'File', 'jetpack-videopress-pkg' ) }:</span>
+						{ fileName && <strong>{ fileName }</strong> }
+						<MediaUploadCheck>
+							<FormFileUpload
+								onChange={ event => {
+									const files = event.target.files;
+									if ( ! files?.length ) {
+										return;
+									}
 
-										updateTrack( 'tmpFile', files[ 0 ] );
-									} }
-									accept={ ACCEPTED_FILE_TYPES }
-									render={ ( { openFileDialog } ) => {
-										return (
-											<Button
-												variant="link"
-												onClick={ () => {
-													openFileDialog();
-												} }
-											>
-												{ __( 'Select track', 'jetpack-videopress-pkg' ) }
-											</Button>
-										);
-									} }
-								/>
-							</MediaUploadCheck>
-						</div>
-						<div className="video-tracks-control__track-form-upload-file-help">{ help }</div>
+									updateTrack( 'tmpFile', files[ 0 ] );
+								} }
+								accept={ ACCEPTED_FILE_TYPES }
+								render={ ( { openFileDialog } ) => {
+									return (
+										<Button
+											variant="link"
+											onClick={ () => {
+												openFileDialog();
+											} }
+										>
+											{ __( 'Select track', 'jetpack-videopress-pkg' ) }
+										</Button>
+									);
+								} }
+							/>
+						</MediaUploadCheck>
 					</div>
-					<div className="video-tracks-control__track-form-label-language">
-						<TextControl
-							onChange={ newLabel => updateTrack( 'label', newLabel ) }
-							label={ __( 'Label', 'jetpack-videopress-pkg' ) }
-							value={ track.label }
-							help={ __( 'Title of track', 'jetpack-videopress-pkg' ) }
-							disabled={ isSavingTrack }
-						/>
-						<TextControl
-							className="video-tracks-control__track-form-language-tag"
-							label={ __( 'Source language', 'jetpack-videopress-pkg' ) }
-							value={ track.srcLang }
-							onChange={ newSrcLang => updateTrack( 'srcLang', newSrcLang ) }
-							help={ __( 'Language (en, fr, etc.)', 'jetpack-videopress-pkg' ) }
-							disabled={ isSavingTrack }
-						/>
-					</div>
-					<SelectControl
-						options={ KIND_OPTIONS }
-						value={ track.kind }
-						label={
-							/* translators: %s: The kind of video text track e.g: "Subtitles, Captions" */
-							__( 'Kind', 'jetpack-videopress-pkg' )
-						}
-						onChange={ newKind => updateTrack( 'kind', newKind ) }
+					<div className="video-tracks-control__track-form-upload-file-help">{ help }</div>
+				</div>
+				<div className="video-tracks-control__track-form-label-language">
+					<TextControl
+						onChange={ newLabel => updateTrack( 'label', newLabel ) }
+						label={ __( 'Label', 'jetpack-videopress-pkg' ) }
+						value={ track.label }
+						help={ __( 'Title of track', 'jetpack-videopress-pkg' ) }
 						disabled={ isSavingTrack }
 					/>
-					<div className="video-tracks-control__track-form-buttons-container">
-						<Button
-							isBusy={ isSavingTrack }
-							variant="secondary"
-							disabled={ ! track.tmpFile || isSavingTrack }
-							onClick={ onSaveHandler }
-						>
-							{ __( 'Save', 'jetpack-videopress-pkg' ) }
-						</Button>
-
-						<Button variant="link" onClick={ onCancel }>
-							{ __( 'Cancel', 'jetpack-videopress-pkg' ) }
-						</Button>
-					</div>
-					{ errorMessage && (
-						<div className="video-tracks-control__track-form-error">
-							{
-								/* translators: %s: An error message returned after a failed video track file upload." */
-								sprintf( __( 'Error: %s', 'jetpack-videopress-pkg' ), errorMessage )
-							}
-						</div>
-					) }
+					<TextControl
+						className="video-tracks-control__track-form-language-tag"
+						label={ __( 'Source language', 'jetpack-videopress-pkg' ) }
+						value={ track.srcLang }
+						onChange={ newSrcLang => updateTrack( 'srcLang', newSrcLang ) }
+						help={ __( 'Language (en, fr, etc.)', 'jetpack-videopress-pkg' ) }
+						disabled={ isSavingTrack }
+					/>
 				</div>
-			</MenuGroup>
-		</NavigableMenu>
+				<SelectControl
+					options={ KIND_OPTIONS }
+					value={ track.kind }
+					label={
+						/* translators: %s: The kind of video text track e.g: "Subtitles, Captions" */
+						__( 'Kind', 'jetpack-videopress-pkg' )
+					}
+					onChange={ newKind => updateTrack( 'kind', newKind ) }
+					disabled={ isSavingTrack }
+				/>
+				<div className="video-tracks-control__track-form-buttons-container">
+					<Button
+						isBusy={ isSavingTrack }
+						variant="secondary"
+						disabled={ ! track.tmpFile || isSavingTrack }
+						onClick={ onSaveHandler }
+					>
+						{ __( 'Save', 'jetpack-videopress-pkg' ) }
+					</Button>
+
+					<Button variant="link" onClick={ onCancel }>
+						{ __( 'Cancel', 'jetpack-videopress-pkg' ) }
+					</Button>
+				</div>
+				{ errorMessage && (
+					<div className="video-tracks-control__track-form-error">
+						{
+							/* translators: %s: An error message returned after a failed video track file upload." */
+							sprintf( __( 'Error: %s', 'jetpack-videopress-pkg' ), errorMessage )
+						}
+					</div>
+				) }
+			</div>
+		</MenuGroup>
 	);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We are using not propers component to implement the Tracks control. This PR replaces these components to make the implementation consistent.

Fixes https://github.com/Automattic/jetpack/issues/27634

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: re-implement track control using ToolbarDropdownMenu

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Block editor
* Add/edit a video block
* Compare the layout of the Tracks control
  * The divider line
  * The border color of the dropdown (grey vs black) 

before | after
------|------
<img width="340" alt="image" src="https://user-images.githubusercontent.com/77539/204360469-a07b60bb-4ac5-4493-914d-812aadcd328e.png"> | <img width="324" alt="image" src="https://user-images.githubusercontent.com/77539/204360256-8244cba2-af01-4892-8901-0717d3ff5acd.png">
<img width="425" alt="image" src="https://user-images.githubusercontent.com/77539/204360497-bff3f2ae-3452-43c0-ba10-376ac1b9a61b.png"> | <img width="400" alt="image" src="https://user-images.githubusercontent.com/77539/204360225-37d3f5a2-611a-4a12-9141-94eecc5707dd.png">


