### PR TITLE
build: Don't mirror `prerelease` branch to plugins

### DIFF
--- a/.github/files/filter-mirrors-for-release-branch.sh
+++ b/.github/files/filter-mirrors-for-release-branch.sh
@@ -22,7 +22,7 @@ else
 	exit 1
 fi
 
-if [[ ! "$BRANCH" =~ /branch- ]]; then
+if [[ "$BRANCH" != "prerelease" && ! "$BRANCH" =~ /branch- ]]; then
 	echo "::error::Not a release branch, no filtering needed."
 	exit 0
 fi
@@ -40,12 +40,21 @@ while read -r GIT_SLUG; do
 	cd "${CLONE_DIR}"
 
 	PREFIX=$(jq -r '.extra["release-branch-prefix"] // ""' composer.json)
-	if [[ -z "$PREFIX" ]]; then
-		echo "Not mirroring release branch $BRANCH to $GIT_SLUG: no .extra.release-branch-prefix is declared in composer.json"
-	elif [[ "${BRANCH%%/branch-*}" != "$PREFIX" ]]; then
-		echo "Not mirroring release branch $BRANCH to $GIT_SLUG: branch prefix \`${BRANCH%%/branch-*}\` != declared prefix \`$PREFIX\`"
+	if [[ "$BRANCH" == "prerelease" ]]; then
+		if [[ -n "$PREFIX" ]]; then
+			echo "Not mirroring prerelease branch to $GIT_SLUG: an .extra.release-branch-prefix is declared in composer.json"
+		else
+			echo "Mirroring prerelease branch to $GIT_SLUG: no .extra.release-branch-prefix is declared in composer.json"
+			echo "$GIT_SLUG" >&4
+		fi
 	else
-		echo "Mirroring release branch $BRANCH to $GIT_SLUG: branch prefix \`${BRANCH%%/branch-*}\` == declared prefix \`$PREFIX\`"
-		echo "$GIT_SLUG" >&4
+		if [[ -z "$PREFIX" ]]; then
+			echo "Not mirroring release branch $BRANCH to $GIT_SLUG: no .extra.release-branch-prefix is declared in composer.json"
+		elif [[ "${BRANCH%%/branch-*}" != "$PREFIX" ]]; then
+			echo "Not mirroring release branch $BRANCH to $GIT_SLUG: branch prefix \`${BRANCH%%/branch-*}\` != declared prefix \`$PREFIX\`"
+		else
+			echo "Mirroring release branch $BRANCH to $GIT_SLUG: branch prefix \`${BRANCH%%/branch-*}\` == declared prefix \`$PREFIX\`"
+			echo "$GIT_SLUG" >&4
+		fi
 	fi
 done < "$BUILD_BASE/mirrors.txt.orig" 4> "$BUILD_BASE/mirrors.txt"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
           fi
 
       - name: Filter mirror list for release branch
-        if: contains( github.ref, '/branch-' )
+        if: github.ref == 'refs/heads/prerelease' || contains( github.ref, '/branch-' )
         run: .github/files/filter-mirrors-for-release-branch.sh
 
       - name: Determine plugins to publish


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Plugins (and any other project specifying a release-branch-prefix) don't need the `prerelease` branch mirrored, as they get released via release branchs instead.

Plus mirroring the branch triggers some annoying monitoring notifications in Slack, which we don't need for exactly that reason.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None linkable

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Merge this (possibly in a fork) into a branch named `prerelease`. Push that branch, then see if the build runs and the artifact gets filtered to include only non-plugins.
  * [x] https://github.com/anomiex/jetpack/actions/runs/3568031549