### PR TITLE
VideoPress: Fix the selection of the last frame as thumbnail

### DIFF
--- a/projects/packages/videopress/changelog/fix-select-last-frame-as-thumbnail
+++ b/projects/packages/videopress/changelog/fix-select-last-frame-as-thumbnail
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fix the thumbnail selection to allow selecting the last frame of the video.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27365.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Detect when the selected frame is too close to the end of the video and change it to safer point, so we get the thumbnail as close as possible to the end of the video while make sure the selection it will work on most of the cases

The thumb selector goes in steps of 100ms, so the last "selectable" frame is a 100 multiple, for example 9600 ms. If the video `duration` is 5312 milliseconds, for example, the last selectable frame will be the 5300ms frame. If the video `duration` is 29568 milliseconds, for example, the last selectable frame will be the 29500ms frame.

There is one thing in common to all the videos that succeed on selecting the last frame as thumb: the selected time (`at_time` parameter) is not too close to the video `duration`, there is always at least 50ms between the selected thumb and the real end of the file.

There is also one thing in common to all the videos that fails: the selected time (`at_time` parameter) is very close to the video `duration`, usually less than 50ms between the selected thumb and the real end of the file.

I used this 50ms as magic number on the fix, because it's long enough to result in a safe threshold between the `at_time` and the video `duration`, but is also short enough to not result in a different thumbnail.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `Jetpack > VideoPress`
* Upload some videos for testing 
   * the problem that got fixed will not happen on every video
   * the 1MB, mp4, 1280x720 file from https://www.sample-videos.com/ was one of the videos that would always fail
* Click the button to update the video thumbnail and then click the "Select from video" option:

<img width="445" alt="Screen Shot 2022-11-28 at 16 38 41" src="https://user-images.githubusercontent.com/6760046/204365988-d9f0cb1d-0f53-4302-968e-03f9525be8ea.png">

* Move the selector to the last possible frame and then click "Select this frame":

<img width="581" alt="Screen Shot 2022-11-28 at 16 40 04" src="https://user-images.githubusercontent.com/6760046/204366453-6ef04c8e-74de-468d-b1a8-9f0a43f165a1.png">

* Before the fix, some videos would fail and fallback to the original thumbnail from the middle of the video
* After the fix, the new thumbnail for the video should be the frame that you selected, or as close to it as possible:

<img width="523" alt="Screen Shot 2022-11-28 at 16 44 20" src="https://user-images.githubusercontent.com/6760046/204366873-862b77f3-11d5-472e-b5cf-8e5dbdda0975.png">

<img width="367" alt="Screen Shot 2022-11-28 at 16 44 35" src="https://user-images.githubusercontent.com/6760046/204366876-dc183c0b-134d-4ab7-8f0e-dafefe179ed7.png">
