### PR TITLE
cli: Update `jetpack release <plugin> version -a`

### DIFF
--- a/tools/cli/commands/release.js
+++ b/tools/cli/commands/release.js
@@ -174,7 +174,7 @@ export async function scriptRouter( argv ) {
 			argv.version = await getReleaseVersion( argv );
 			argv = await promptForVersion( argv );
 			argv.script = 'tools/project-version.sh';
-			argv.scriptArgs = [ '-u', argv.version, argv.project ];
+			argv.scriptArgs = [ '-Cu', argv.version, argv.project ];
 			argv.next = `Finished! Next, you will likely want to check the following project files to make sure versions were updated correctly:
 				 - The main php file
 				 - package.json
@@ -264,7 +264,7 @@ export async function getReleaseVersion( argv ) {
 		// Check if dev-releases is specified in project's composer.json
 		const hasDevReleases = await readComposerJson( argv.project ).extra[ 'dev-releases' ];
 		if ( hasDevReleases ) {
-			if ( devReleaseVersion ) {
+			if ( devReleaseVersion && devReleaseVersion.match( /^a\.\d+$/ ) ) {
 				devReleaseVersion = await getVersionBump( devReleaseVersion, argv.project );
 				potentialVersion = `${ stableVersion }-${ devReleaseVersion }`;
 			} else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Two bugs that came up in the recent release:

- The `-a` option was defaulting to "11.6-beta.NaN' instead of '11.7-a.0'.
- With the new prerelease branch process, the pre-push hook isn't adding the change entry file anymore. So have the script do it.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None linkable

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check out 85a669d20a46f4b5b0f897cfc79dd06559edb241
* Cherry-pick this PR
* Run `jetpack release plugins/jetpack version -a`
  * When it prompts for the version, the default should be correct.
  * After it finishes, a file `projects/plugins/jetpack/changelog/init-release-cycle` should exist with appropriate contents.