### PR TITLE
Sync: Add full response logging for failed Sync requests

### DIFF
--- a/projects/packages/connection/changelog/add-sync-request-full-response-logging
+++ b/projects/packages/connection/changelog/add-sync-request-full-response-logging
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added full response logging for failed Sync data requests.

--- a/projects/packages/connection/composer.json
+++ b/projects/packages/connection/composer.json
@@ -65,7 +65,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "1.46.x-dev"
+			"dev-trunk": "1.47.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/connection/legacy/class-jetpack-ixr-client.php
+++ b/projects/packages/connection/legacy/class-jetpack-ixr-client.php
@@ -35,6 +35,13 @@ class Jetpack_IXR_Client extends IXR_Client {
 	public $response_headers = null;
 
 	/**
+	 * Holds the raw remote response from the latest call to query().
+	 *
+	 * @var null|array|WP_Error
+	 */
+	public $last_response = null;
+
+	/**
 	 * Constructor.
 	 * Initialize a new Jetpack IXR client instance.
 	 *
@@ -76,6 +83,13 @@ class Jetpack_IXR_Client extends IXR_Client {
 
 		// Store response headers.
 		$this->response_headers = wp_remote_retrieve_headers( $response );
+
+		$this->last_response = $response;
+		if ( is_array( $this->last_response ) && isset( $this->last_response['http_response'] ) ) {
+			// If the expected array response is received, format the data as plain arrays.
+			$this->last_response            = $this->last_response['http_response']->to_array();
+			$this->last_response['headers'] = $this->last_response['headers']->getAll();
+		}
 
 		if ( is_wp_error( $response ) ) {
 			$this->error = new IXR_Error( -10520, sprintf( 'Jetpack: [%s] %s', $response->get_error_code(), $response->get_error_message() ) );
@@ -153,5 +167,14 @@ class Jetpack_IXR_Client extends IXR_Client {
 			return $this->response_headers[ strtolower( $name ) ];
 		}
 		return false;
+	}
+
+	/**
+	 * Retrieve the raw response for the last query() call.
+	 *
+	 * @return null|array|WP_Error
+	 */
+	public function get_last_response() {
+		return $this->last_response;
 	}
 }

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.46.4';
+	const PACKAGE_VERSION = '1.47.0-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/sync/changelog/add-sync-request-full-response-logging
+++ b/projects/packages/sync/changelog/add-sync-request-full-response-logging
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added full response logging for failed Sync data requests.

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -56,7 +56,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "1.43.x-dev"
+			"dev-trunk": "1.44.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -517,7 +517,9 @@ class Actions {
 				$error_log = array_slice( $error_log, -4, null, true );
 			}
 			// Add new error indexed to time.
-			$error_log[ (string) microtime( true ) ] = $rpc->get_jetpack_error();
+			$error = $rpc->get_jetpack_error();
+			$error->add_data( $rpc->get_last_response() );
+			$error_log[ (string) microtime( true ) ] = $error;
 			// Update the error log.
 			update_option( self::ERROR_LOG_PREFIX . $queue_id, $error_log );
 

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.43.2';
+	const PACKAGE_VERSION = '1.44.0-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/backup/changelog/add-sync-request-full-response-logging
+++ b/projects/plugins/backup/changelog/add-sync-request-full-response-logging
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/changelog/add-sync-request-full-response-logging#2
+++ b/projects/plugins/backup/changelog/add-sync-request-full-response-logging#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -410,7 +410,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "806a73b868a49ab4dbca537623416f61404c2e37"
+                "reference": "45339c58395090f59b4835f113018a969fce2113"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -438,7 +438,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.46.x-dev"
+                    "dev-trunk": "1.47.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1230,7 +1230,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "a35c76fb04806440b3000bfbb77ce8c9233d3111"
+                "reference": "71b8b6f2569d3407b18d31385b2d0aa06bdea368"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1257,7 +1257,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.43.x-dev"
+                    "dev-trunk": "1.44.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/boost/changelog/add-sync-request-full-response-logging
+++ b/projects/plugins/boost/changelog/add-sync-request-full-response-logging
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -327,7 +327,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "806a73b868a49ab4dbca537623416f61404c2e37"
+                "reference": "45339c58395090f59b4835f113018a969fce2113"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -355,7 +355,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.46.x-dev"
+                    "dev-trunk": "1.47.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/add-sync-request-full-response-logging
+++ b/projects/plugins/jetpack/changelog/add-sync-request-full-response-logging
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/changelog/add-sync-request-full-response-logging#2
+++ b/projects/plugins/jetpack/changelog/add-sync-request-full-response-logging#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -627,7 +627,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "806a73b868a49ab4dbca537623416f61404c2e37"
+                "reference": "45339c58395090f59b4835f113018a969fce2113"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -655,7 +655,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.46.x-dev"
+                    "dev-trunk": "1.47.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2046,7 +2046,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "a35c76fb04806440b3000bfbb77ce8c9233d3111"
+                "reference": "71b8b6f2569d3407b18d31385b2d0aa06bdea368"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2073,7 +2073,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.43.x-dev"
+                    "dev-trunk": "1.44.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/changelog/add-sync-request-full-response-logging
+++ b/projects/plugins/protect/changelog/add-sync-request-full-response-logging
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/changelog/add-sync-request-full-response-logging#2
+++ b/projects/plugins/protect/changelog/add-sync-request-full-response-logging#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -327,7 +327,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "806a73b868a49ab4dbca537623416f61404c2e37"
+                "reference": "45339c58395090f59b4835f113018a969fce2113"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -355,7 +355,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.46.x-dev"
+                    "dev-trunk": "1.47.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1211,7 +1211,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "a35c76fb04806440b3000bfbb77ce8c9233d3111"
+                "reference": "71b8b6f2569d3407b18d31385b2d0aa06bdea368"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1238,7 +1238,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.43.x-dev"
+                    "dev-trunk": "1.44.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/changelog/add-sync-request-full-response-logging
+++ b/projects/plugins/search/changelog/add-sync-request-full-response-logging
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/changelog/add-sync-request-full-response-logging#2
+++ b/projects/plugins/search/changelog/add-sync-request-full-response-logging#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -327,7 +327,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "806a73b868a49ab4dbca537623416f61404c2e37"
+                "reference": "45339c58395090f59b4835f113018a969fce2113"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -355,7 +355,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.46.x-dev"
+                    "dev-trunk": "1.47.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1290,7 +1290,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "a35c76fb04806440b3000bfbb77ce8c9233d3111"
+                "reference": "71b8b6f2569d3407b18d31385b2d0aa06bdea368"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1317,7 +1317,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.43.x-dev"
+                    "dev-trunk": "1.44.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/add-sync-request-full-response-logging
+++ b/projects/plugins/social/changelog/add-sync-request-full-response-logging
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/changelog/add-sync-request-full-response-logging#2
+++ b/projects/plugins/social/changelog/add-sync-request-full-response-logging#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1279,7 +1279,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "a35c76fb04806440b3000bfbb77ce8c9233d3111"
+                "reference": "71b8b6f2569d3407b18d31385b2d0aa06bdea368"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1306,7 +1306,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.43.x-dev"
+                    "dev-trunk": "1.44.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -327,7 +327,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "806a73b868a49ab4dbca537623416f61404c2e37"
+                "reference": "45339c58395090f59b4835f113018a969fce2113"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -355,7 +355,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.46.x-dev"
+                    "dev-trunk": "1.47.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/starter-plugin/changelog/add-sync-request-full-response-logging
+++ b/projects/plugins/starter-plugin/changelog/add-sync-request-full-response-logging
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/changelog/add-sync-request-full-response-logging#2
+++ b/projects/plugins/starter-plugin/changelog/add-sync-request-full-response-logging#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -327,7 +327,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "806a73b868a49ab4dbca537623416f61404c2e37"
+                "reference": "45339c58395090f59b4835f113018a969fce2113"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -355,7 +355,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.46.x-dev"
+                    "dev-trunk": "1.47.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1147,7 +1147,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "a35c76fb04806440b3000bfbb77ce8c9233d3111"
+                "reference": "71b8b6f2569d3407b18d31385b2d0aa06bdea368"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1174,7 +1174,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.43.x-dev"
+                    "dev-trunk": "1.44.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/videopress/changelog/add-sync-request-full-response-logging
+++ b/projects/plugins/videopress/changelog/add-sync-request-full-response-logging
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/changelog/add-sync-request-full-response-logging#2
+++ b/projects/plugins/videopress/changelog/add-sync-request-full-response-logging#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -327,7 +327,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "806a73b868a49ab4dbca537623416f61404c2e37"
+                "reference": "45339c58395090f59b4835f113018a969fce2113"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -355,7 +355,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.46.x-dev"
+                    "dev-trunk": "1.47.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1211,7 +1211,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "a35c76fb04806440b3000bfbb77ce8c9233d3111"
+                "reference": "71b8b6f2569d3407b18d31385b2d0aa06bdea368"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1238,7 +1238,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.43.x-dev"
+                    "dev-trunk": "1.44.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Requests to jetpack.wordpress.com to Sync data that fail only have limited HTTP status code details. To aid debugging failed requests, this change logs full response details by adding these details as a data entry to the existing `WP_Error` object for the failed request. These new details are available to existing Jetpack debugging tools.

The changes will affect the following:
* Sync

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
* None

#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:
1. Ensure that your test site's Jetpack is fully connected and is actively syncing data.
2. Break requests to `jetpack.wordpress.com`. I did this by adding the following in an `mu-plugins` plugin:
```
function caj_test_filter( $url ) { 
    if ( preg_match( '|^https://jetpack.wordpress.com/|', $url ) ) { 
        $url = 'https://chrisjean.com/http-codes/403';
    }   
    
    return $url;
}
add_filter( 'jetpack_remote_request_url', 'caj_test_filter' );
```
3. Load up the site in the Jetpack Debugger and go to the Incremental Sync section.
4. You should see one or more errors listed under "Recent Sync Send Errors:" that include `error_data` details that include `headers` and `body` details as shown below.
![sync-failure-response-example-log](https://user-images.githubusercontent.com/56307/204470241-797792a6-28d7-4541-ae04-b7cd907997e5.png)
