### PR TITLE
VideoPress: refresh UI when video track deletes

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-update-ui-when-deleting-tracks
+++ b/projects/packages/videopress/changelog/update-videopress-update-ui-when-deleting-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: refresh UI when video track deletes

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
@@ -25,9 +25,10 @@ import type React from 'react';
 function TrackItem( { track, guid, onDelete }: TrackItemProps ): React.ReactElement {
 	const { kind, label, srcLang } = track;
 
-	const deleteTrackHandler = useCallback( () => {
+	const deleteTrackHandler = () => {
 		deleteTrackForGuid( track, guid ).then( () => onDelete?.( track ) );
-	}, [] );
+		onDelete?.( track );
+	};
 
 	return (
 		<div className="video-tracks-control__track-item">
@@ -51,7 +52,7 @@ function TrackItem( { track, guid, onDelete }: TrackItemProps ): React.ReactElem
  * @param {TrackListProps} props - Component props.
  * @returns {React.ReactElement}   TracksControl block control
  */
-function TrackList( { tracks, guid, onDeleteTrack }: TrackListProps ): React.ReactElement {
+function TrackList( { tracks, guid, onTrackListUpdate }: TrackListProps ): React.ReactElement {
 	if ( ! tracks?.length ) {
 		return (
 			<MenuGroup className="video-tracks-control__track_list__no-tracks">
@@ -62,6 +63,14 @@ function TrackList( { tracks, guid, onDeleteTrack }: TrackListProps ): React.Rea
 			</MenuGroup>
 		);
 	}
+
+	const onDeleteTrackHandler = useCallback(
+		( deletedTrack: TrackProps ) => {
+			const updatedTrackList = [ ...tracks ].filter( t => t !== deletedTrack );
+			onTrackListUpdate( updatedTrackList );
+		},
+		[ tracks ]
+	);
 
 	return (
 		<MenuGroup
@@ -74,7 +83,7 @@ function TrackList( { tracks, guid, onDeleteTrack }: TrackListProps ): React.Rea
 						key={ `${ track.kind }-${ index }` }
 						track={ track }
 						guid={ guid }
-						onDelete={ onDeleteTrack }
+						onDelete={ onDeleteTrackHandler }
 					/>
 				);
 			} ) }
@@ -103,9 +112,12 @@ export default function TracksControl( {
 		setIsUploadingNewTrack( true );
 	}, [] );
 
-	const onDeleteTrackHandler = useCallback( ( track: TrackProps ) => {
-		setAttributes( { tracks: tracks.filter( t => t !== track ) } );
-	}, [] );
+	const onUpdateTrackListHandler = useCallback(
+		( updatedTracks: TrackProps[] ) => {
+			setAttributes( { tracks: updatedTracks } );
+		},
+		[ tracks ]
+	);
 
 	return (
 		<ToolbarDropdownMenu
@@ -129,7 +141,12 @@ export default function TracksControl( {
 				}
 				return (
 					<>
-						<TrackList tracks={ tracks } guid={ guid } onDeleteTrack={ onDeleteTrackHandler } />
+						<TrackList
+							tracks={ tracks }
+							guid={ guid }
+							onTrackListUpdate={ onUpdateTrackListHandler }
+						/>
+
 						<MenuGroup
 							label={ __( 'Add tracks', 'jetpack-videopress-pkg' ) }
 							className="video-tracks-control"

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
@@ -22,11 +22,11 @@ import type React from 'react';
  * @param {TrackItemProps} props - Component props.
  * @returns {React.ReactElement}   TrackItem react component
  */
-function TrackItem( { track, guid }: TrackItemProps ): React.ReactElement {
+function TrackItem( { track, guid, onDelete }: TrackItemProps ): React.ReactElement {
 	const { kind, label, srcLang } = track;
 
 	const deleteTrackHandler = useCallback( () => {
-		deleteTrackForGuid( track, guid );
+		deleteTrackForGuid( track, guid ).then( () => onDelete?.( track ) );
 	}, [] );
 
 	return (
@@ -51,7 +51,7 @@ function TrackItem( { track, guid }: TrackItemProps ): React.ReactElement {
  * @param {TrackListProps} props - Component props.
  * @returns {React.ReactElement}   TracksControl block control
  */
-function TrackList( { tracks, guid }: TrackListProps ): React.ReactElement {
+function TrackList( { tracks, guid, onDeleteTrack }: TrackListProps ): React.ReactElement {
 	if ( ! tracks?.length ) {
 		return (
 			<MenuGroup className="video-tracks-control__track_list__no-tracks">
@@ -69,7 +69,14 @@ function TrackList( { tracks, guid }: TrackListProps ): React.ReactElement {
 			label={ __( 'Text tracks', 'jetpack-videopress-pkg' ) }
 		>
 			{ tracks.map( ( track: TrackProps, index ) => {
-				return <TrackItem key={ `${ track.kind }-${ index }` } track={ track } guid={ guid } />;
+				return (
+					<TrackItem
+						key={ `${ track.kind }-${ index }` }
+						track={ track }
+						guid={ guid }
+						onDelete={ onDeleteTrack }
+					/>
+				);
 			} ) }
 		</MenuGroup>
 	);
@@ -81,7 +88,10 @@ function TrackList( { tracks, guid }: TrackListProps ): React.ReactElement {
  * @param {VideoControlProps} props - Component props.
  * @returns {React.ReactElement}      TracksControl block control
  */
-export default function TracksControl( { attributes }: VideoControlProps ): React.ReactElement {
+export default function TracksControl( {
+	attributes,
+	setAttributes,
+}: VideoControlProps ): React.ReactElement {
 	const { tracks, guid } = attributes;
 
 	const [ isUploadingNewTrack, setIsUploadingNewTrack ] = useState( false );
@@ -91,6 +101,10 @@ export default function TracksControl( { attributes }: VideoControlProps ): Reac
 			setIsUploadingNewTrack( false );
 		} );
 		setIsUploadingNewTrack( true );
+	}, [] );
+
+	const onDeleteTrackHandler = useCallback( ( track: TrackProps ) => {
+		setAttributes( { tracks: tracks.filter( t => t !== track ) } );
 	}, [] );
 
 	return (
@@ -115,7 +129,7 @@ export default function TracksControl( { attributes }: VideoControlProps ): Reac
 				}
 				return (
 					<>
-						<TrackList tracks={ tracks } guid={ guid } />
+						<TrackList tracks={ tracks } guid={ guid } onDeleteTrack={ onDeleteTrackHandler } />
 						<MenuGroup
 							label={ __( 'Add tracks', 'jetpack-videopress-pkg' ) }
 							className="video-tracks-control"

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
@@ -23,15 +23,19 @@ import type React from 'react';
  * @returns {React.ReactElement}   TrackItem react component
  */
 function TrackItem( { track, guid, onDelete }: TrackItemProps ): React.ReactElement {
+	const [ isDeleting, setIsDeleting ] = useState( false );
 	const { kind, label, srcLang } = track;
 
 	const deleteTrackHandler = () => {
-		deleteTrackForGuid( track, guid ).then( () => onDelete?.( track ) );
-		onDelete?.( track );
+		setIsDeleting( true );
+		deleteTrackForGuid( track, guid ).then( () => {
+			setIsDeleting( false );
+			onDelete?.( track );
+		} );
 	};
 
 	return (
-		<div className="video-tracks-control__track-item">
+		<div className={ `video-tracks-control__track-item ${ isDeleting ? 'is-deleting' : '' }` }>
 			<div className="video-tracks-control__track-item-label">
 				<strong>{ label }</strong>
 				<span className="video-tracks-control__track-item-kind">
@@ -39,7 +43,8 @@ function TrackItem( { track, guid, onDelete }: TrackItemProps ): React.ReactElem
 					{ srcLang?.length ? ` [${ srcLang }]` : '' }
 				</span>
 			</div>
-			<Button variant="link" isDestructive onClick={ deleteTrackHandler }>
+
+			<Button variant="link" isDestructive onClick={ deleteTrackHandler } disabled={ isDeleting }>
 				{ __( 'Delete', 'jetpack-videopress-pkg' ) }
 			</Button>
 		</div>

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/style.scss
@@ -15,6 +15,10 @@
 	display: flex;
 	justify-content: space-between;
 	padding: 8px;
+
+	&.is-deleting {
+		opacity: 0.5;
+	}
 }
 
 .video-tracks-control__track-item-kind {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/types.ts
@@ -13,7 +13,7 @@ export type TrackItemProps = {
 export type TrackListProps = {
 	tracks: TrackProps[];
 	guid: VideoGUID;
-	onDeleteTrack?: ( track: TrackProps ) => void;
+	onTrackListUpdate?: ( tracks: TrackProps[] ) => void;
 };
 
 export type TrackFormProps = {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/types.ts
@@ -7,11 +7,13 @@ import { TrackProps, VideoGUID } from '../../types';
 export type TrackItemProps = {
 	track: TrackProps;
 	guid: VideoGUID;
+	onDelete?: ( track: TrackProps ) => void;
 };
 
 export type TrackListProps = {
 	tracks: TrackProps[];
 	guid: VideoGUID;
+	onDeleteTrack?: ( track: TrackProps ) => void;
 };
 
 export type TrackFormProps = {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.js
@@ -392,7 +392,7 @@ export default function VideoPressEdit( { attributes, setAttributes, isSelected,
 					clientId={ clientId }
 				/>
 
-				<TracksControl attributes={ attributes } />
+				<TracksControl attributes={ attributes } setAttributes={ setAttributes } />
 			</BlockControls>
 
 			<InspectorControls>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR implements the process to refresh the UI (track list component) when a video track deletes.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: refresh UI when video track deletes

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Block editor
* Add/edit a video block
* Ensure the video has a track. Otherwise, upload one.
* Hard refresh in case the track list doesn't show the new track (follow-up task)
* Delete the track by clicking on the `delete` button
* You may like to take a look at the network tab to see how the client performs the request to delete the track in the VideoPress server-side

https://user-images.githubusercontent.com/77539/204509908-0de35707-201f-4626-bb4a-b10a71211f71.mov

