### PR TITLE
VideoPress: fix visual issue in Track list component when no tracks

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-tweak-track-list-cmp
+++ b/projects/packages/videopress/changelog/update-videopress-tweak-track-list-cmp
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: fix visual issue in Track list component when no tracks

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
@@ -54,11 +54,13 @@ function TrackItem( { track, guid }: TrackItemProps ): React.ReactElement {
 function TrackList( { tracks, guid }: TrackListProps ): React.ReactElement {
 	if ( ! tracks?.length ) {
 		return (
-			<MenuGroup className="video-tracks-control__track_list__no-tracks">
-				{ __(
-					'Tracks can be subtitles, captions, chapters, or descriptions. They help make your content more accessible to a wider range of users.',
-					'jetpack-videopress-pkg'
-				) }
+			<MenuGroup>
+				<div className="video-tracks-control__track_list__no-tracks">
+					{ __(
+						'Tracks can be subtitles, captions, chapters, or descriptions. They help make your content more accessible to a wider range of users.',
+						'jetpack-videopress-pkg'
+					) }
+				</div>
 			</MenuGroup>
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: fix visual issue in Track list component when no tracks

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Block editor
* Add/edit a video block
* Ensure video doesn't have tracks

before | after
------|------
<img width="276" alt="image" src="https://user-images.githubusercontent.com/77539/204521306-6f3836b1-f45b-47d2-95fa-0bfb95211629.png"> | <img width="260" alt="image" src="https://user-images.githubusercontent.com/77539/204521205-427268c7-fede-43e1-9bd9-f6ea61dcc083.png">


