### PR TITLE
VideoPress: refresh video player when deleting track

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-invalidate-embed-when-deleting-tracks
+++ b/projects/packages/videopress/changelog/update-videopress-invalidate-embed-when-deleting-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: refresh video player when deleting track

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
@@ -2,12 +2,15 @@
  * External dependencies
  */
 import { MenuItem, MenuGroup, ToolbarDropdownMenu, Button } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { upload } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import { getVideoPressUrl } from '../../../../../lib/url';
 import { deleteTrackForGuid, uploadTrackForGuid } from '../../../../../lib/video-tracks';
 import { TrackProps, VideoControlProps } from '../../types';
 import { captionIcon } from '../icons';
@@ -109,6 +112,7 @@ export default function TracksControl( {
 	const { tracks, guid } = attributes;
 
 	const [ isUploadingNewTrack, setIsUploadingNewTrack ] = useState( false );
+	const invalidateResolution = useDispatch( coreStore ).invalidateResolution;
 
 	const uploadNewTrackFile = useCallback( newTrack => {
 		uploadTrackForGuid( newTrack, guid ).then( () => {
@@ -120,6 +124,8 @@ export default function TracksControl( {
 	const onUpdateTrackListHandler = useCallback(
 		( updatedTracks: TrackProps[] ) => {
 			setAttributes( { tracks: updatedTracks } );
+			const videoPressUrl = getVideoPressUrl( guid, attributes );
+			invalidateResolution( 'getEmbedPreview', [ videoPressUrl ] );
 		},
 		[ tracks ]
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We need to refresh the video player when a track is deleted since this change would affect its visual representation.
The way to do this is by invalidating the selector that provides the embed element data, in this case, `getEmbedPreview`.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: refresh video player when deleting track

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Block Editor
* Add/edit a video block
* Add a track in case the doesn't have
* Hard refresh (follow-up task)
* Once you see the track in the tracks list:
* Remove the track by clicking on the `Delete` button
* Confirm the player refreshes once the track deletes

https://user-images.githubusercontent.com/77539/204523683-3e00e67c-cdd8-441d-b61e-f706e500eddf.mov




