### PR TITLE
VideoPress: update tracks icon

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-update-tracks-icon
+++ b/projects/packages/videopress/changelog/update-videopress-update-tracks-icon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: update tracks icon

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/icons/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/icons/index.js
@@ -14,7 +14,7 @@ export const VideoPressIcon = (
 	</SVG>
 );
 
-export const captionIcon = (
+export const tracksIcon = (
 	<SVG width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<Path d="M7 15.5H17V17H7V15.5Z" fill="black" />
 		<Path d="M17 12.5H7V14H17V12.5Z" fill="black" />

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/icons/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/icons/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Path, SVG, Rect } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/components';
 
 export const VideoPressIcon = (
 	<SVG width="29" height="21" viewBox="0 0 29 21" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -15,18 +15,14 @@ export const VideoPressIcon = (
 );
 
 export const captionIcon = (
-	<SVG width="18" height="14" viewBox="0 0 18 14" role="img" fill="none">
-		<Rect
-			x="0.75"
-			y="0.75"
-			width="16.5"
-			height="12.5"
-			rx="1.25"
-			stroke="black"
-			strokeWidth="1.5"
-			fill="none"
+	<SVG width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<Path d="M7 15.5H17V17H7V15.5Z" fill="black" />
+		<Path d="M17 12.5H7V14H17V12.5Z" fill="black" />
+		<Path
+			fill-rule="evenodd"
+			clip-rule="evenodd"
+			d="M18.7 3H5.3C4 3 3 4 3 5.3V18.7C3 20 4 21 5.3 21H18.7C20 21 21 20 21 18.7V5.3C21 4 20 3 18.7 3ZM19.5 18.7C19.5 19.1 19.1 19.5 18.7 19.5H5.3C4.9 19.5 4.5 19.1 4.5 18.7V5.3C4.5 4.9 4.9 4.5 5.3 4.5H18.7C19.1 4.5 19.5 4.9 19.5 5.3V18.7Z"
+			fill="black"
 		/>
-		<Path d="M3 7H15" stroke="black" strokeWidth="1.5" />
-		<Path d="M3 10L15 10" stroke="black" strokeWidth="1.5" />
 	</SVG>
 );

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
@@ -10,7 +10,7 @@ import { upload } from '@wordpress/icons';
  */
 import { deleteTrackForGuid, uploadTrackForGuid } from '../../../../../lib/video-tracks';
 import { TrackProps, VideoControlProps } from '../../types';
-import { captionIcon } from '../icons';
+import { tracksIcon } from '../icons';
 import './style.scss';
 import TrackForm from './track-form';
 import { TrackItemProps, TrackListProps } from './types';
@@ -126,7 +126,7 @@ export default function TracksControl( {
 
 	return (
 		<ToolbarDropdownMenu
-			icon={ captionIcon }
+			icon={ tracksIcon }
 			label={ __( 'Text tracks', 'jetpack-videopress-pkg' ) }
 			popoverProps={ {
 				variant: 'toolbar',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/27400

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: update tracks icon

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Block Editor
* Add/edit a video block
* Open the toolback
* Confirm the track icon has been updated

Before | After
------|------
<img width="272" alt="Screen Shot 2022-11-29 at 09 03 31" src="https://user-images.githubusercontent.com/77539/204524570-5e37c289-69c0-41b7-b4d3-0d0a60303f77.png"> | <img width="262" alt="Screen Shot 2022-11-29 at 09 04 02" src="https://user-images.githubusercontent.com/77539/204524566-b6777a91-cd19-4183-be2b-42ab6ca0124b.png">




