### PR TITLE
E2E Tests: Pass TEST_SITE env variable explicitly

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -149,7 +149,7 @@ jobs:
           echo "TEST_SITE=${SUITE}" >> $GITHUB_ENV
 
           # Wait for the site to pick up latest tag version (DISPATCH_REF_NAME)
-          node "$GITHUB_WORKSPACE/tools/e2e-commons/bin/update-beta-version.cjs" $DISPATCH_REF_TYPE $DISPATCH_REF_NAME
+          node "TEST_SITE=${SUITE} $GITHUB_WORKSPACE/tools/e2e-commons/bin/update-beta-version.cjs" $DISPATCH_REF_TYPE $DISPATCH_REF_NAME
         fi
 
         if [ "${SUITE}" == gutenberg ]; then

--- a/tools/e2e-commons/bin/update-beta-version.cjs
+++ b/tools/e2e-commons/bin/update-beta-version.cjs
@@ -34,7 +34,7 @@ async function getJetpackVersionFromSite() {
 		// console.log(jetpackDev);
 		return jetpackDev.version;
 	} catch ( error ) {
-		console.error( `Logging environment details failed! ${ error }` );
+		console.error( `Failed to get Jetpack version from atomic site: ${ error }` );
 		return '';
 	}
 }


### PR DESCRIPTION
The atomic script in E2E workflow expects `TEST_SITE` env variable to be available in `env`. `TEST_SITE` set only in `GITHUB_ENV`, which isn't the same as shell env.


#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

