### PR TITLE
Protect: Update Tracks Events

### DIFF
--- a/projects/plugins/protect/src/js/components/firewall-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-page/index.jsx
@@ -6,6 +6,8 @@ import { __ } from '@wordpress/i18n';
 import { useCallback, useEffect, useState } from 'react';
 import API from '../../api';
 import { PLUGIN_SUPPORT_URL } from '../../constants';
+import useAnalyticsTracks from '../../hooks/use-analytics-tracks';
+import useProtectData from '../../hooks/use-protect-data';
 import useWafData from '../../hooks/use-waf-data';
 import { STORE_ID } from '../../state/store';
 import AdminPage from '../admin-page';
@@ -19,6 +21,7 @@ import styles from './styles.module.scss';
 const FirewallPage = () => {
 	const notice = useSelect( select => select( STORE_ID ).getNotice() );
 	const { config, isSeen, isEnabled, toggleWaf, toggleManualRules, updateConfig } = useWafData();
+	const { hasRequiredPlan } = useProtectData();
 	const { jetpackWafIpList, jetpackWafIpBlockList, jetpackWafIpAllowList } = config || {};
 	const { setWafIsSeen, setNotice } = useDispatch( STORE_ID );
 
@@ -29,6 +32,14 @@ const FirewallPage = () => {
 		jetpack_waf_ip_allow_list: jetpackWafIpAllowList,
 	} );
 	const [ settingsIsUpdating, setSettingsIsUpdating ] = useState( false );
+
+	// Track view for Protect WAF page.
+	useAnalyticsTracks( {
+		pageViewEventName: 'protect_waf',
+		pageViewEventProperties: {
+			has_plan: hasRequiredPlan,
+		},
+	} );
 
 	const successNoticeDuration = 5000;
 

--- a/projects/plugins/protect/src/js/components/interstitial-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/interstitial-page/index.jsx
@@ -6,6 +6,7 @@ import {
 } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
 import React from 'react';
+import useAnalyticsTracks from '../../hooks/use-analytics-tracks';
 import Logo from '../logo';
 import ConnectedPricingTable from '../pricing-table';
 
@@ -18,6 +19,11 @@ import ConnectedPricingTable from '../pricing-table';
  * @returns {React.Component}              Interstitial react component.
  */
 const InterstitialPage = ( { onScanAdd, scanJustAdded } ) => {
+	// Track view for Protect WAF page.
+	useAnalyticsTracks( {
+		pageViewEventName: 'protect_interstitial',
+	} );
+
 	return (
 		<JetpackAdminPage moduleName={ __( 'Jetpack Protect', 'jetpack-protect' ) } header={ <Logo /> }>
 			<AdminSectionHero>

--- a/projects/plugins/protect/src/js/components/scan-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/scan-page/index.jsx
@@ -21,7 +21,7 @@ import useStatusPolling from './use-status-polling';
 export const JETPACK_SCAN = 'jetpack_scan';
 
 const ScanPage = () => {
-	const { lastChecked, currentStatus, errorCode, errorMessage } = useProtectData();
+	const { lastChecked, currentStatus, errorCode, errorMessage, hasRequiredPlan } = useProtectData();
 	const { hasConnectionError } = useConnectionErrorNotice();
 	const { refreshStatus } = useDispatch( STORE_ID );
 	const { statusIsFetching, scanIsUnavailable, status } = useSelect( select => ( {
@@ -53,6 +53,7 @@ const ScanPage = () => {
 		pageViewEventName: 'protect_admin',
 		pageViewEventProperties: {
 			check_status: currentScanStatus,
+			has_plan: hasRequiredPlan,
 		},
 	} );
 

--- a/projects/plugins/protect/src/js/components/threats-list/paid-list.jsx
+++ b/projects/plugins/protect/src/js/components/threats-list/paid-list.jsx
@@ -65,7 +65,7 @@ const ThreatAccordionItem = ( {
 			fixable={ fixable }
 			severity={ severity }
 			onOpen={ useCallback( () => {
-				if ( ! [ 'core', 'plugin', 'theme' ].includes( type ) ) {
+				if ( ! [ 'core', 'plugin', 'theme', 'file', 'database' ].includes( type ) ) {
 					return;
 				}
 				recordEvent( `jetpack_protect_${ type }_threat_open` );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR updates Tracks events in the Jetpack Protect plugin.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds new pageview for the Firewall page and Interstitial page
* Adds `has_plan` property to Scan and Firewall page view events
* Adds a `jetpack_protect_scan_completed` event status polling resolves, including a `scan_status` property.
* Adds support for file and database threats to the existing `jetpack_protect_${ type }_threat_open` event.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

peb6dq-hI-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Yes - new tracks events added, described above.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Review the modified tracking event codes.
* Ensure there is no regression in application functionality.
* Ensure tracks requests are being sent appropriately.