### PR TITLE
API: extract subscription count function from the widget file

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/subscribers.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/subscribers.php
@@ -76,6 +76,7 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers extends WP_REST_Controller {
 			delete_transient( 'wpcom_subscribers_total' );
 			delete_transient( 'wpcom_subscribers_total_no_publicize' );
 		}
+		// @todo: update this usage.
 		$subscriber_count = Jetpack_Subscriptions_Widget::fetch_subscriber_count();
 
 		return array(

--- a/projects/plugins/jetpack/changelog/fix-wporg-error-subs
+++ b/projects/plugins/jetpack/changelog/fix-wporg-error-subs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+REST API: ensure subscription count functions are always available.


### PR DESCRIPTION
Fixes #27310

Fixes PHP error discovered looking in logs:

E_ERROR
Uncaught Error: Class 'Jetpack_Subscriptions_Widget' not found in /home/public_html/wp-content/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/subscribers.php:68
URL
/wp-json/wpcom/v2/subscribers/count?include_publicize_subscribers=false&_locale=user
Referer
/wp-admin/post.php?post=3727&action=edit

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Moves the subscriber count functions to outside of the widget file.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* I wasn't able to figure out exactly how this was executed. With the widget file not available, I assume the Subscriptions module needs to be inactive.

