### PR TITLE
Search: change Calypso search menu link to Search Dashboard in WP Admin

### DIFF
--- a/projects/plugins/jetpack/changelog/update-change-search-menu-link-to-wp-admin-for-jp-sits
+++ b/projects/plugins/jetpack/changelog/update-change-search-menu-link-to-wp-admin-for-jp-sits
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Search: Changed Search menu in Calypso menu link to Search Dashboard in WP Admin

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
@@ -177,7 +177,7 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	public function add_jetpack_menu() {
 		parent::add_jetpack_menu();
 		/* translators: Jetpack sidebar menu item. */
-		add_submenu_page( 'jetpack', esc_attr__( 'Search', 'jetpack' ), __( 'Search', 'jetpack' ), 'manage_options', 'https://wordpress.com/jetpack-search/' . $this->domain, null, 4 );
+		add_submenu_page( 'jetpack', esc_attr__( 'Search', 'jetpack' ), __( 'Search', 'jetpack' ), 'manage_options', admin_url( 'admin.php?page=jetpack-header' ), null, 4 );
 
 		// Place "Scan" submenu after Backup.
 		$position = 0;

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
@@ -177,7 +177,7 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	public function add_jetpack_menu() {
 		parent::add_jetpack_menu();
 		/* translators: Jetpack sidebar menu item. */
-		add_submenu_page( 'jetpack', esc_attr__( 'Search', 'jetpack' ), __( 'Search', 'jetpack' ), 'manage_options', admin_url( 'admin.php?page=jetpack-header' ), null, 4 );
+		add_submenu_page( 'jetpack', esc_attr__( 'Search', 'jetpack' ), __( 'Search', 'jetpack' ), 'manage_options', 'jetpack-search', admin_url( 'admin.php?page=jetpack-search' ), 4 );
 
 		// Place "Scan" submenu after Backup.
 		$position = 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The PR replaces the Search from the Calypso page to a link to Search Dashboard in WP Admin. The API affected is `wpcom/v2/admin-menu` which is forwarded and run on Jetpack sites.

The reason the Search menu isn't showing like Atomic sites is that, [all menus are cleared](https://github.com/Automattic/jetpack/blob/475bada72a037811b86529703ada73d2dc290dfe/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php#L34) before adding any.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
panfyZ-1pv#comment-3467-p2

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Prepare a connected site with current branch - a JN site works fine
* Open `https://wordpress.com/stats/day/site-slug`
* Ensure Jetpack -> Search in sidebar menu is linked to the Search Dashboard in WP Admin like `https://xxx.com/wp-admin/admin.php?page=jetpack-search`

Please note: The PR doesn't affect sites with only the Search plugin.

![image](https://user-images.githubusercontent.com/1425433/204681589-dd394dae-153e-44cc-917b-9f02fbe96d85.png)
