### PR TITLE
VideoPress: Check user connection before deleting VideoPress files

### DIFF
--- a/projects/packages/videopress/changelog/update-check-user-connection-before-videopress-delete
+++ b/projects/packages/videopress/changelog/update-check-user-connection-before-videopress-delete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: Disable delete_posts capability for VideoPress attachments if user is disconnected.

--- a/projects/packages/videopress/src/class-attachment-handler.php
+++ b/projects/packages/videopress/src/class-attachment-handler.php
@@ -259,7 +259,7 @@ class Attachment_Handler {
 	}
 
 	/**
-	 * Filter to disable the `delete_posts` capability
+	 * Filter to disable the `delete_post` capability
 	 * for VideoPress attachments if the current user is
 	 * not connected.
 	 *
@@ -272,7 +272,7 @@ class Attachment_Handler {
 	 */
 	public static function disable_delete_if_disconnected( $allcaps, $cap, $args ) {
 
-		// Only apply this filter to `delete_posts` checks
+		// Only apply this filter to `delete_post` checks
 		if ( 'delete_post' !== $args[0] ) {
 			return $allcaps;
 		}

--- a/projects/packages/videopress/src/class-attachment-handler.php
+++ b/projects/packages/videopress/src/class-attachment-handler.php
@@ -41,6 +41,7 @@ class Attachment_Handler {
 		add_filter( 'ajax_query_attachments_args', array( __CLASS__, 'ajax_query_attachments_args' ) );
 		add_action( 'pre_get_posts', array( __CLASS__, 'media_list_table_query' ) );
 
+		add_filter( 'user_has_cap', array( __CLASS__, 'disable_delete_if_disconnected' ), 10, 3 );
 	}
 
 	/**
@@ -257,4 +258,35 @@ class Attachment_Handler {
 		}
 	}
 
+	/**
+	 * Filter to disable the `delete_posts` capability
+	 * for VideoPress attachments if the current user is
+	 * not connected.
+	 *
+	 * @param array $allcaps All the capabilities of the user.
+	 * @param array $cap     [0] Required capability.
+	 * @param array $args    [0] Requested capability.
+	 *                       [1] User ID.
+	 *                       [2] Associated object ID.
+	 * @return array the filtered array of capabilities.
+	 */
+	public static function disable_delete_if_disconnected( $allcaps, $cap, $args ) {
+
+		// Only apply this filter to `delete_posts` checks
+		if ( 'delete_post' !== $args[0] ) {
+			return $allcaps;
+		}
+
+		// Only apply this filter to VideoPress attachments
+		if ( ! is_videopress_attachment( $args[2] ) ) {
+			return $allcaps;
+		}
+
+		// Set the capability to false if the user can't perform the actions
+		if ( ! Data::can_perform_action() ) {
+			$allcaps[ $cap[0] ] = false;
+		}
+
+		return $allcaps;
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27405 and is an alternative to #27478.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add a filter on the user capabilities to disable the `delete_posts` capability for VideoPress attachments if the user is disconnected

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Testing this is similar to testing #27478 or #27455, we need a connected site but without an user connection
* Start with a connected site, upload at least one video and then disconnect Jetpack (using `Jetpack > My Jetpack`):

<img width="895" alt="Screen Shot 2022-11-29 at 19 20 14" src="https://user-images.githubusercontent.com/6760046/204661173-82f3bc33-1989-40b9-ba87-26797d357c1d.png">

* Go to `Jetpack > My Jetpack` and click "Connect your site to fix this":

<img width="828" alt="Screen Shot 2022-11-29 at 19 24 30" src="https://user-images.githubusercontent.com/6760046/204661725-562932c4-fed4-4741-b0b1-fbe64a37333e.png">

* Click "Connect your user account":

<img width="484" alt="Screen Shot 2022-11-29 at 19 25 29" src="https://user-images.githubusercontent.com/6760046/204661957-b99faab6-4464-409b-92f1-346eabc62e9a.png">

* Don't click the "Approve" button; instead, go back to the site admin; this way the site will have a site connection, but not an user connection

<img width="428" alt="Screen Shot 2022-11-29 at 19 27 01" src="https://user-images.githubusercontent.com/6760046/204662296-d060947a-1a90-4b68-95fa-84efe1ea3853.png">

* Now we can test the change

**Testing using an API request**

* Run a `DELETE` request to the `http://your-site.com/wp-json/wp/v2/media/{ID}` endpoint:

```
curl -u "username:password" -X DELETE http://your-site.com/wp-json/wp/v2/media/{ID} -H "Accept: application/json" -d '{"id": 114,"force":true}'
```

* This request is the same performed by the frontend client
* The expected response is similar to this:

```
{
    "code": "rest_cannot_delete",
    "message": "Sorry, you are not allowed to delete this post.",
    "data": {
        "status": 403
    }
}
```

**Testing using the client app**

* The client is disabling the delete button in this scenario, so we need to force enabling it again to do the test
* Comment out [this check](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/videopress/src/client/admin/hooks/use-permission/index.ts#L9), returning `true` instead (don't forget to rebuild the client):

<img width="680" alt="Screen Shot 2022-11-29 at 19 39 03" src="https://user-images.githubusercontent.com/6760046/204663933-4dd4752e-281d-4793-9792-8a128e4f509a.png">

* Open the browser console to inspect the network activity
* Go to `Jetpack > VideoPress` and try to delete one video using the delete button
* The responses should have a `403` status code:

<img width="930" alt="Screen Shot 2022-11-29 at 18 57 26" src="https://user-images.githubusercontent.com/6760046/204664330-49488149-a2c1-4f2f-8a74-9903bcbf6a61.png">

* Fix the connection and try to do the same actions again; now they should work as expected