### PR TITLE
[Boost] Fix super admin speed test log detection

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/utils/add-get-parameter.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/add-get-parameter.ts
@@ -1,0 +1,12 @@
+/**
+ * Helper function to add a get parameter to the end of the supplied URL.
+ *
+ * @param {string} url   - URL to add the parameter to.
+ * @param {string} key   - Parameter key.
+ * @param {string} value - Parameter value.
+ * @return {string} - URL with the parameter added.
+ */
+export function addGetParameter( url: string, key: string, value: string ): string {
+	const separator = url.indexOf( '?' ) === -1 ? '?' : '&';
+	return url + separator + key + '=' + encodeURIComponent( value );
+}

--- a/projects/plugins/boost/app/assets/src/js/utils/add-get-parameter.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/add-get-parameter.ts
@@ -7,6 +7,8 @@
  * @return {string} - URL with the parameter added.
  */
 export function addGetParameter( url: string, key: string, value: string ): string {
-	const separator = url.indexOf( '?' ) === -1 ? '?' : '&';
-	return url + separator + key + '=' + encodeURIComponent( value );
+	const urlObject = new URL( url );
+	urlObject.searchParams.set( key, value );
+
+	return urlObject.toString();
 }

--- a/projects/plugins/boost/changelog/fix-super-admin-test
+++ b/projects/plugins/boost/changelog/fix-super-admin-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed issues in Super Cache measurement tool on some URLs


### PR DESCRIPTION
Boost was using exact URL matching to find the performance log entries for speed test results when testing Super Cache performance. However, minor differences / redirects can cause that to fail.

This PR fixes that issue by adding a unique string to each request which can be used to identify it in the browser's performance logs.

#### Changes proposed in this Pull Request:
* Fix issues identifying performance logs at some URLs.

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Try testing the speed of Super Cache from your Boost dashboard, ensure it works

