### PR TITLE
Fix syntax in wordads-ccpa.js

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-wordads-syntax
+++ b/projects/plugins/jetpack/changelog/fix-wordads-syntax
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix syntax in wordards-ccpa.js causing it to be included in all merge commits

--- a/projects/plugins/jetpack/modules/wordads/js/wordads-ccpa.js
+++ b/projects/plugins/jetpack/modules/wordads/js/wordads-ccpa.js
@@ -312,8 +312,10 @@
 					if ( 200 === this.status ) {
 						// Got a geo response. Parse out the region data.
 						var data = JSON.parse( this.response );
-						var region      = data.region ? data.region.toLowerCase() : '';
-						var ccpaApplies = ['california', 'colorado', 'connecticut', 'utah', 'virginia'].indexOf( region ) > -1;
+						var region = data.region ? data.region.toLowerCase() : '';
+						var ccpaApplies =
+							[ 'california', 'colorado', 'connecticut', 'utah', 'virginia' ].indexOf( region ) >
+							-1;
 
 						// Set CCPA applies cookie. This keeps us from having to make a geo request too frequently.
 						setCcpaAppliesCookie( ccpaApplies );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR adjusts the syntax in wordads-ccpa.js so it's compatible with with Jetpack's pre-commit hooks.  
It seems like the original commit that added this wasn't verified and now I've run into it multiple times where it'll include this file into my merge during the pre-commit hook without my knowledge which is mildly annoying. I thought I'd just fix it as it's just two lines.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The changes are purely cosmetical, so I'm not sure if testing is required.

