### PR TITLE
VideoPress: fix video block conversion issue

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-fix-converting-video-block-issue
+++ b/projects/packages/videopress/changelog/update-videopress-fix-converting-video-block-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: fix video block conversion issue

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
@@ -105,6 +105,9 @@
 		},
 		"isPrivate": {
 			"type": "boolean"
+		},
+		"isExample": {
+			"type": "boolean"
 		}
 	},
 	"textdomain": "jetpack-videopress",

--- a/projects/packages/videopress/src/client/block-editor/extend/core-video/index.js
+++ b/projects/packages/videopress/src/client/block-editor/extend/core-video/index.js
@@ -54,10 +54,34 @@ addFilter(
 	extendCoreVideoBlock
 );
 
+/**
+ * Organize the block attributes for the new videopress/video block
+ *
+ * @param {object} attributes        - core/video block attributes
+ * @param {object} defaultAttributes - default core/video block attributes
+ * @returns {object}                   The new attributes
+ */
+function getVideoPressVideoBlockAttributes( attributes, defaultAttributes ) {
+	const attrs = attributes || defaultAttributes;
+
+	// Upadte attributes names to match the new VideoPress Video block.
+	if ( attrs?.videoPressTracks ) {
+		attrs.tracks = attrs.videoPressTracks || [];
+		delete attrs.videoPressTracks;
+	}
+
+	if ( attrs?.isVideoPressExample ) {
+		attrs.isExample = attrs.isVideoPressExample || [];
+		delete attrs.isVideoPressExample;
+	}
+
+	return attrs;
+}
+
 const handleJetpackCoreVideoDeprecation = createHigherOrderComponent( BlockListBlock => {
 	return props => {
 		const { block, isValid } = props;
-		const { name, attributes, clientId } = block;
+		const { name, attributes, clientId, __unstableBlockSource } = block;
 		const { guid, videoPressTracks, poster } = attributes;
 
 		const { replaceBlock } = useDispatch( blockEditorStore );
@@ -85,8 +109,20 @@ const handleJetpackCoreVideoDeprecation = createHigherOrderComponent( BlockListB
 				return;
 			}
 
-			replaceBlock( clientId, createBlock( 'videopress/video', attributes ) );
-		}, [ clientId, shouldHandleConvertion, ignoreBlockRecovery, attributes ] );
+			replaceBlock(
+				clientId,
+				createBlock(
+					'videopress/video',
+					getVideoPressVideoBlockAttributes( __unstableBlockSource?.attrs, attributes )
+				)
+			);
+		}, [
+			clientId,
+			shouldHandleConvertion,
+			ignoreBlockRecovery,
+			attributes,
+			__unstableBlockSource,
+		] );
 
 		if ( ! shouldHandleConvertion ) {
 			return <BlockListBlock { ...props } />;

--- a/projects/packages/videopress/src/client/block-editor/extend/core-video/index.js
+++ b/projects/packages/videopress/src/client/block-editor/extend/core-video/index.js
@@ -64,7 +64,7 @@ addFilter(
 function getVideoPressVideoBlockAttributes( attributes, defaultAttributes ) {
 	const attrs = attributes || defaultAttributes;
 
-	// Upadte attributes names to match the new VideoPress Video block.
+	// Update attributes names to match the new VideoPress Video block.
 	if ( attrs?.videoPressTracks ) {
 		attrs.tracks = attrs.videoPressTracks || [];
 		delete attrs.videoPressTracks;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR issue when converting the core/video block to the `videopress/video` block. The issue [reported here](https://wordpress.org/support/topic/problem-with-videopress-blocks/) is that the new block loses all previous attributes.

Fixes https://github.com/Automattic/jetpack/issues/27630

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: fix video block conversion issue

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate Jetpack and VideoPress plugin
* Create a `core/video` block
* Set the video for the block
* Change block settings, for instance:

<img width="964" alt="Screen Shot 2022-11-30 at 11 48 18" src="https://user-images.githubusercontent.com/77539/204827174-c49cbbe4-dc4a-4abe-95e6-454b6b491e7f.png">

* Save the post
* Deactivate the Jetpack plugin
* Go back to the block editor
* Hard-refresh
* Confirm you see the dialog to convert the block to `v6`
<img width="680" alt="image" src="https://user-images.githubusercontent.com/77539/204827649-4ebeba63-8c09-4c03-8eab-3c06668159d2.png">
* Confirm the app converts the block to video by clicking on the Attempt... button
* Confirm the new block preserves the same settings that the previous block

<img width="962" alt="Screen Shot 2022-11-30 at 11 51 46" src="https://user-images.githubusercontent.com/77539/204828277-aa95cf61-a2d1-4e1b-b8d5-ca73f521ed48.png">



