### PR TITLE
E2E Tests: Pull latest version from Beta on every iteration

### DIFF
--- a/tools/e2e-commons/bin/update-beta-version.cjs
+++ b/tools/e2e-commons/bin/update-beta-version.cjs
@@ -63,10 +63,11 @@ async function getLatestVersion() {
 	return manifest.pr.type.version;
 }
 
-async function waitForPluginUpdate( expectedVersion ) {
+async function waitForPluginUpdate() {
 	let timesRun = 0;
 	const interval = setInterval( async () => {
 		console.log( 'Checking for update' );
+		const expectedVersion = await getLatestVersion();
 		const jpVersion = await getJetpackVersionFromSite();
 		if ( expectedVersion === jpVersion ) {
 			console.log( 'Update completed' );
@@ -103,9 +104,7 @@ function main() {
 
 			if ( latestVersion !== version ) {
 				console.log( 'Forcing plugin update' );
-				forcePluginUpdates().then( () => {
-					waitForPluginUpdate( latestVersion );
-				} );
+				forcePluginUpdates().then( () => waitForPluginUpdate() );
 			} else {
 				console.log( 'Already up to date' );
 				process.exit( 0 );


### PR DESCRIPTION
E2E workflow waits for Jetpack to be updated on the Atomic site. It pulls the version only once and uses it throughout the waiting time. The chances are that beta server wasn't fast enough to pull the latest version.
This PR makes a change that forces to pull "latest" version on every iteration

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

