### PR TITLE
VideoPress: remove Preload playback control from the video block sidebar

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-remove-preload-control
+++ b/projects/packages/videopress/changelog/update-videopress-remove-preload-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: remove Preload playback control from the video block sidebar

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/index.tsx
@@ -1,9 +1,9 @@
 /**
  *External dependencies
  */
-import { ExternalLink, PanelBody, RadioControl, ToggleControl } from '@wordpress/components';
+import { ExternalLink, PanelBody, ToggleControl } from '@wordpress/components';
 import { createInterpolateElement, useCallback } from '@wordpress/element';
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
@@ -21,7 +21,7 @@ import type React from 'react';
  * @returns {React.ReactElement}      Playback block sidebar panel
  */
 export default function PlaybackPanel( { attributes, setAttributes }: VideoControlProps ) {
-	const { autoplay, loop, muted, controls, playsinline, preload } = attributes;
+	const { autoplay, loop, muted, controls, playsinline } = attributes;
 
 	const handleAttributeChange = useCallback(
 		( attributeName: string ) => {
@@ -88,40 +88,6 @@ export default function PlaybackPanel( { attributes, setAttributes }: VideoContr
 				) }
 			/>
 
-			<RadioControl
-				label={ __( 'Preload', 'jetpack-videopress-pkg' ) }
-				selected={ preload }
-				onChange={ value => setAttributes( { preload: value } ) }
-				options={ [
-					{
-						value: 'metadata',
-						label: _x( 'Metadata', 'VideoPress preload setting', 'jetpack-videopress-pkg' ),
-					},
-					{
-						value: 'none',
-						label: _x( 'None', 'VideoPress preload setting', 'jetpack-videopress-pkg' ),
-					},
-					{
-						value: 'auto',
-						label: _x( 'Auto', 'VideoPress preload setting', 'jetpack-videopress-pkg' ),
-					},
-				] }
-				help={
-					<>
-						<span className={ styles[ 'help-message' ] }>
-							{ __( 'Content to download before the video is played.', 'jetpack-videopress-pkg' ) }
-						</span>
-						{ preload === 'auto' && (
-							<span className={ styles[ 'help-message' ] }>
-								{ __(
-									'Note: Automatically downloading videos may cause issues if there are many videos displayed on the same page.',
-									'jetpack-videopress-pkg'
-								) }
-							</span>
-						) }
-					</>
-				}
-			/>
 			{ createInterpolateElement(
 				__( 'Send us your <a>VideoPress feedback</a>', 'jetpack-videopress-pkg' ),
 				{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/27700

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: remove Preload playback control from the video block sidebar

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Block edito
* Select a video block instance
* Open the sidebar in case it's closed
* Confirm the `Preload` control in not in the `Playback` panel anymore

before | after
------|------
<img width="387" alt="image" src="https://user-images.githubusercontent.com/77539/205027140-048157b4-4baf-48c7-aa59-0097cab1a98f.png"> | <img width="472" alt="Screen Shot 2022-12-01 at 07 17 20" src="https://user-images.githubusercontent.com/77539/205027323-b71e3aaa-f11d-4399-a93d-149a27ee26cc.png">
