### PR TITLE
Contact Form: Update patterns modal filter query

### DIFF
--- a/projects/plugins/jetpack/changelog/update-form-patterns-filter-query
+++ b/projects/plugins/jetpack/changelog/update-form-patterns-filter-query
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Update Form patterns modal filter query

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/edit.js
@@ -224,7 +224,12 @@ export function JetpackContactFormEdit( {
 						closeLabel={ __( 'Cancel', 'jetpack' ) }
 						onRequestClose={ () => setIsPatternsModalOpen( false ) }
 					>
-						<BlockPatternSetup blockName={ 'jetpack/contact-form' } clientId={ clientId } />
+						<BlockPatternSetup
+							filterPatternsFn={ p => {
+								return p.content.indexOf( 'jetpack/contact-form' ) !== -1;
+							} }
+							clientId={ clientId }
+						/>
 					</Modal>
 				) }
 			</div>

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/edit.js
@@ -225,8 +225,8 @@ export function JetpackContactFormEdit( {
 						onRequestClose={ () => setIsPatternsModalOpen( false ) }
 					>
 						<BlockPatternSetup
-							filterPatternsFn={ p => {
-								return p.content.indexOf( 'jetpack/contact-form' ) !== -1;
+							filterPatternsFn={ pattern => {
+								return pattern.content.indexOf( 'jetpack/contact-form' ) !== -1;
 							} }
 							clientId={ clientId }
 						/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Updates the Contact Form patterns modal query to load the patterns correctly on WP.com

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Create a page/post
* Add a Form block
* Click the "Explore Form Patterns" button
* Check if the patterns load as expected

