### PR TITLE
VideoPress: update tracks list once new track uploads

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-refresh-tracks-list-when-uploading-new-tracks
+++ b/projects/packages/videopress/changelog/update-videopress-refresh-tracks-list-when-uploading-new-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: update tracks list once new track uploads

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
@@ -116,8 +116,14 @@ export default function TracksControl( {
 	const [ isUploadingNewTrack, setIsUploadingNewTrack ] = useState( false );
 	const invalidateResolution = useDispatch( coreStore ).invalidateResolution;
 
-	const uploadNewTrackFile = useCallback( newTrack => {
-		uploadTrackForGuid( newTrack, guid ).then( () => {
+	const uploadNewTrackFile = useCallback( newUploadedTrack => {
+		uploadTrackForGuid( newUploadedTrack, guid ).then( src => {
+			const newTrack = {
+				...newUploadedTrack,
+				src,
+			};
+			delete newTrack.tmpFile;
+
 			setAttributes( { tracks: [ ...tracks, newTrack ] } );
 			setIsUploadingNewTrack( false );
 		} );

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
@@ -118,6 +118,7 @@ export default function TracksControl( {
 
 	const uploadNewTrackFile = useCallback( newTrack => {
 		uploadTrackForGuid( newTrack, guid ).then( () => {
+			setAttributes( { tracks: [ ...tracks, newTrack ] } );
 			setIsUploadingNewTrack( false );
 		} );
 		setIsUploadingNewTrack( true );

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
@@ -155,7 +155,7 @@ export function useSyncMedia(
 	}, [] );
 
 	/*
-	 * Media data => Block attribues (update)
+	 * Media data => Block attributes (update)
 	 *
 	 * Populate block attributes with the media data,
 	 * provided by the VideoPress API (useVideoData hook),

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
@@ -155,6 +155,8 @@ export function useSyncMedia(
 	}, [] );
 
 	/*
+	 * Media data => Block attribues (update)
+	 *
 	 * Populate block attributes with the media data,
 	 * provided by the VideoPress API (useVideoData hook),
 	 * when the block is mounted.
@@ -221,16 +223,18 @@ export function useSyncMedia(
 			return;
 		}
 
-		debug( 'attributesToUpdate: ', attributesToUpdate );
+		debug( 'Updating attributes: ', attributesToUpdate );
 		setAttributes( attributesToUpdate );
 	}, [ videoData, isRequestingVideoData ] );
 
 	const updateMediaHandler = useMediaDataUpdate( id );
 
 	/*
+	 * Block attributes => Media data (sync)
+	 *
 	 * Compare the current attribute values of the block
 	 * with the initial state,
-	 * and update the media data if it detects changes on it
+	 * and sync the media data if it detects changes on it
 	 * (via the VideoPress API) when the post saves.
 	 */
 	useEffect( () => {
@@ -255,7 +259,7 @@ export function useSyncMedia(
 				const attrValue = attributes[ attrName ];
 
 				if ( initialState[ key ] !== attributes[ attrName ] ) {
-					debug( 'Syncing %o: %o => %o: %o', key, stateValue, attrName, attrValue );
+					debug( 'Field to sync %o: %o => %o: %o', key, stateValue, attrName, attrValue );
 					acc[ key ] = attributes[ attrName ];
 				}
 				return acc;
@@ -265,8 +269,10 @@ export function useSyncMedia(
 
 		// When nothing to update, bail out early.
 		if ( ! Object.keys( dataToUpdate ).length ) {
-			return debug( 'No data to update. Bail early' );
+			return debug( 'No data to sync. Bail early' );
 		}
+
+		debug( 'Syncing data: ', dataToUpdate );
 
 		// Sync the block attributes data with the video data
 		updateMediaHandler( dataToUpdate ).then( () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/27702

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: update tracks list once new track uploads

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Block editor 
* Select a video block
* Upload a new track
* Confirm the UI shows the new track once it uploads

https://user-images.githubusercontent.com/77539/205040149-d8349e82-a785-4c7a-aab3-2707ff7390b3.mov

