### PR TITLE
Contact Form: Fix "View Form Responses" link

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-form-responses-link
+++ b/projects/plugins/jetpack/changelog/fix-form-responses-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix Contact Form view responses URL

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-manage-responses-settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-manage-responses-settings.js
@@ -1,8 +1,11 @@
+import { getJetpackData } from '@automattic/jetpack-shared-extension-utils';
 import { Button, TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { get } from 'lodash';
+import React from 'react';
 import InspectorHint from '../../../shared/components/inspector-hint';
 
-const RESPONSES_PATH = '/wp-admin/edit.php?post_type=feedback';
+const RESPONSES_PATH = `${ get( getJetpackData(), 'adminUrl', false ) }edit.php?post_type=feedback`;
 
 const JetpackManageResponsesSettings = ( {
 	formTitle = '',
@@ -21,6 +24,7 @@ const JetpackManageResponsesSettings = ( {
 				style={ { marginBottom: isChildBlock ? '12px' : '24px' } }
 			>
 				{ __( 'View Form Responses', 'jetpack' ) }
+				<span className="screen-reader-text">{ __( '(opens in a new tab)', 'jetpack' ) }</span>
 			</Button>
 			{ ! isChildBlock && (
 				<TextControl

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/edit.js
@@ -1,4 +1,4 @@
-import { isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
+import { getJetpackData, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import {
 	InnerBlocks,
 	InspectorControls,
@@ -51,7 +51,7 @@ const ALLOWED_BLOCKS = [
 	'core/video',
 ];
 
-const RESPONSES_PATH = '/wp-admin/edit.php?post_type=feedback';
+const RESPONSES_PATH = `${ get( getJetpackData(), 'adminUrl', false ) }edit.php?post_type=feedback`;
 const CUSTOMIZING_FORMS_URL = 'https://jetpack.com/support/jetpack-blocks/contact-form/';
 
 export function JetpackContactFormEdit( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Fix Contact Form "View Form Responses" button to work on WP subdirectories: p8oabR-10q-p2#comment-6833

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

* Create a post/page and add a Form block
* Select the Form and click the "View Form Responses" button on the Sidebar
* It should open the form responses page
* Make sure to test it on WP subdirectories