### PR TITLE
VideoPress: re-render player after a new track uploads

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-re-render-player-when-adding-new-chapter-track
+++ b/projects/packages/videopress/changelog/update-videopress-re-render-player-when-adding-new-chapter-track
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: re-render player after a new track uploads

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/tracks-control/index.tsx
@@ -116,6 +116,8 @@ export default function TracksControl( {
 	const [ isUploadingNewTrack, setIsUploadingNewTrack ] = useState( false );
 	const invalidateResolution = useDispatch( coreStore ).invalidateResolution;
 
+	const videoPressUrl = getVideoPressUrl( guid, attributes );
+
 	const uploadNewTrackFile = useCallback( newUploadedTrack => {
 		uploadTrackForGuid( newUploadedTrack, guid ).then( src => {
 			const newTrack = {
@@ -126,6 +128,7 @@ export default function TracksControl( {
 
 			setAttributes( { tracks: [ ...tracks, newTrack ] } );
 			setIsUploadingNewTrack( false );
+			invalidateResolution( 'getEmbedPreview', [ videoPressUrl ] );
 		} );
 		setIsUploadingNewTrack( true );
 	}, [] );
@@ -133,7 +136,6 @@ export default function TracksControl( {
 	const onUpdateTrackListHandler = useCallback(
 		( updatedTracks: TrackProps[] ) => {
 			setAttributes( { tracks: updatedTracks } );
-			const videoPressUrl = getVideoPressUrl( guid, attributes );
 			invalidateResolution( 'getEmbedPreview', [ videoPressUrl ] );
 		},
 		[ tracks ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: re-render player after a new track uploads

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Add/edit a video block instance
* Upload chapters
* Confirm the player re-renders after the new track uploads, reflecting the changes at the player level


https://user-images.githubusercontent.com/77539/205093597-03044f33-9a40-4d32-b721-db03b478e65a.mov

