### PR TITLE
VideoPress: handle properly when adding or replacing new video track

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-handle-adding-replacing-new-track
+++ b/projects/packages/videopress/changelog/update-videopress-handle-adding-replacing-new-track
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: handle properly when adding or replacing new video track


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes a visual issue when uploading a new track:

<img width="380" alt="Screen Shot 2022-12-01 at 15 50 49" src="https://user-images.githubusercontent.com/77539/205135949-6d94ba1e-d804-4eb3-b971-2caa4c47d0c2.png">

The picture above shows two chapters with the same kind and language. That's not OKAY.

We need to check if the track exists in the list based on the `kind` and `srcLang`. When it exists, the app needs to replace it. Otherwise, it should be added to the list.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: handle properly when adding or replacing new video track

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to block the editor
* Add/edit a video block instance
* Upload a track
* if it didn't exist before in the list (same `kind` and `srcLang`) confirm the track is added to the list.
* You can take a look at the debug() log: `videopress:video:tracks-control new track does not exist, adding it`
* if it did exist, confirm the item is replaced. log: `videopress:video:tracks-control new track already exists, replacing it`

before uploading | When uploading | Once uploaded
------|------|------
<img width="426" alt="image" src="https://user-images.githubusercontent.com/77539/205133324-0a8ee67e-7eb1-4851-a41e-200d4444f5ee.png"> | <img width="388" alt="image" src="https://user-images.githubusercontent.com/77539/205133422-7322d5f3-c16c-4b39-9b82-8a25f5b9673e.png"> | <img width="376" alt="image" src="https://user-images.githubusercontent.com/77539/205133712-0570ebb3-cf0d-4801-9809-d115e3b5625d.png">
