### PR TITLE
VideoPress: Remove caption field from edit page

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-remove-caption-field
+++ b/projects/packages/videopress/changelog/update-videopress-remove-caption-field
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+VideoPress: Remove caption field from edit page

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
@@ -89,16 +89,12 @@ const Infos = ( {
 	onChangeTitle,
 	description,
 	onChangeDescription,
-	caption,
-	onChangeCaption,
 	loading,
 }: {
 	title: string;
 	onChangeTitle: ( value: string ) => void;
 	description: string;
 	onChangeDescription: ( value: string ) => void;
-	caption: string;
-	onChangeCaption: ( value: string ) => void;
 	loading: boolean;
 } ) => {
 	return (
@@ -129,20 +125,6 @@ const Infos = ( {
 					size="large"
 				/>
 			) }
-			{ loading ? (
-				<Placeholder height={ 133 } className={ styles.input } />
-			) : (
-				<Input
-					value={ caption }
-					className={ styles.input }
-					label={ __( 'Caption', 'jetpack-videopress-pkg' ) }
-					name="caption"
-					onChange={ onChangeCaption }
-					onEnter={ noop }
-					type="textarea"
-					size="large"
-				/>
-			) }
 		</>
 	);
 };
@@ -157,7 +139,6 @@ const EditVideoDetails = () => {
 		url,
 		title,
 		description,
-		caption,
 		// Playback Token
 		isFetchingPlaybackToken,
 		// Page State/Actions
@@ -169,7 +150,6 @@ const EditVideoDetails = () => {
 		// Metadata
 		setTitle,
 		setDescription,
-		setCaption,
 		processing,
 		// Poster Image
 		useVideoAsThumbnail,
@@ -253,8 +233,6 @@ const EditVideoDetails = () => {
 								onChangeTitle={ setTitle }
 								description={ description ?? '' }
 								onChangeDescription={ setDescription }
-								caption={ caption ?? '' }
-								onChangeCaption={ setCaption }
 								loading={ isFetchingData }
 							/>
 						</Col>

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/use-edit-details.ts
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/use-edit-details.ts
@@ -28,9 +28,7 @@ const useMetaEdit = ( { videoId, formData, video, updateData } ) => {
 		return ! ( isEmpty( formDataField ) && isEmpty( videoField ) ) && isDifferent;
 	};
 
-	const metaChanged = [ 'title', 'description', 'caption' ].some( field =>
-		hasFieldChanged( field )
-	);
+	const metaChanged = [ 'title', 'description' ].some( field => hasFieldChanged( field ) );
 
 	const setTitle = ( title: string ) => {
 		updateData( { title } );
@@ -38,10 +36,6 @@ const useMetaEdit = ( { videoId, formData, video, updateData } ) => {
 
 	const setDescription = ( description: string ) => {
 		updateData( { description } );
-	};
-
-	const setCaption = ( caption: string ) => {
-		updateData( { caption } );
 	};
 
 	const handleMetaUpdate = () => {
@@ -57,7 +51,6 @@ const useMetaEdit = ( { videoId, formData, video, updateData } ) => {
 	return {
 		setTitle,
 		setDescription,
-		setCaption,
 		handleMetaUpdate,
 		metaChanged,
 	};
@@ -89,7 +82,6 @@ export default () => {
 	const [ formData, setFormData ] = useState( {
 		title: video?.title,
 		description: video?.description,
-		caption: video?.caption,
 	} );
 
 	const updateData = newData => {
@@ -158,10 +150,7 @@ export default () => {
 	// This moment we fetch the video data and update after fetching
 
 	const initialLoading =
-		isFetching &&
-		formData?.title === undefined &&
-		formData?.description === undefined &&
-		formData?.caption === undefined;
+		isFetching && formData?.title === undefined && formData?.description === undefined;
 
 	useEffect( () => {
 		let mounted = true;
@@ -170,7 +159,6 @@ export default () => {
 			setFormData( {
 				title: video?.title,
 				description: video?.description,
-				caption: video?.caption,
 			} );
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27715

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes the `Caption` field from the edit page only

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1669150642692999/1669147858.831309-slack-C02LT75D3

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard with at least one uploaded video
* Click on `Edit video details`
* Check that the `Caption` field is no longer there
* Check that there are no regressions on any previous VideoPress blocks

Before | After
-----------|--------
![2022-12-01_15-27-13](https://user-images.githubusercontent.com/8486249/205138849-0600f692-26f6-4ad2-abcc-20b47557f94e.png) | ![2022-12-01_15-59-24](https://user-images.githubusercontent.com/8486249/205138844-ec90052b-9671-4c53-8ed0-dc6756bcdc89.png)

