### PR TITLE
Google Fonts Provider: Add filter for API url

### DIFF
--- a/projects/packages/google-fonts-provider/changelog/add-google-font-proxy
+++ b/projects/packages/google-fonts-provider/changelog/add-google-font-proxy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added a way to filter the Google Fonts API url

--- a/projects/packages/google-fonts-provider/composer.json
+++ b/projects/packages/google-fonts-provider/composer.json
@@ -43,7 +43,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-google-fonts-provider/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.3.x-dev"
+			"dev-trunk": "0.4.x-dev"
 		},
 		"textdomain": "jetpack-google-fonts-provider"
 	}

--- a/projects/packages/google-fonts-provider/package.json
+++ b/projects/packages/google-fonts-provider/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-google-fonts-provider",
-	"version": "0.3.6",
+	"version": "0.4.0-alpha",
 	"description": "WordPress Webfonts provider for Google Fonts",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/google-fonts-provider/#readme",
 	"bugs": {

--- a/projects/packages/google-fonts-provider/src/class-google-fonts-provider.php
+++ b/projects/packages/google-fonts-provider/src/class-google-fonts-provider.php
@@ -161,7 +161,7 @@ class Google_Fonts_Provider extends \WP_Webfonts_Provider {
 		 *
 		 * @param string $url The Google Fonts API URL.
 		 */
-		$root_url = apply_filters( 'jetpack_google_fonts_api_url', $this->root_url );
+		$root_url = esc_url( apply_filters( 'jetpack_google_fonts_api_url', $this->root_url ) );
 
 		/*
 		* Iterate over each font-family group to build the Google Fonts API URL

--- a/projects/packages/google-fonts-provider/src/class-google-fonts-provider.php
+++ b/projects/packages/google-fonts-provider/src/class-google-fonts-provider.php
@@ -161,7 +161,7 @@ class Google_Fonts_Provider extends \WP_Webfonts_Provider {
 		 *
 		 * @param string $url The Google Fonts API URL.
 		 */
-		$root_url = esc_url( apply_filters( 'jetpack_google_fonts_api_url', $this->root_url ) );
+		$root_url = \esc_url( apply_filters( 'jetpack_google_fonts_api_url', $this->root_url ) );
 
 		/*
 		* Iterate over each font-family group to build the Google Fonts API URL

--- a/projects/packages/google-fonts-provider/src/class-google-fonts-provider.php
+++ b/projects/packages/google-fonts-provider/src/class-google-fonts-provider.php
@@ -157,7 +157,7 @@ class Google_Fonts_Provider extends \WP_Webfonts_Provider {
 		/**
 		 * Filters the Google Fonts API URL.
 		 *
-		 * @since 0.3.6
+		 * @since 0.4.0
 		 *
 		 * @param string $url The Google Fonts API URL.
 		 */

--- a/projects/packages/google-fonts-provider/src/class-google-fonts-provider.php
+++ b/projects/packages/google-fonts-provider/src/class-google-fonts-provider.php
@@ -154,6 +154,15 @@ class Google_Fonts_Provider extends \WP_Webfonts_Provider {
 	private function build_collection_api_urls() {
 		$font_families_urls = array();
 
+		/**
+		 * Filters the Google Fonts API URL.
+		 *
+		 * @since 0.3.6
+		 *
+		 * @param string $url The Google Fonts API URL.
+		 */
+		$root_url = apply_filters( 'jetpack_google_fonts_api_url', $this->root_url );
+
 		/*
 		* Iterate over each font-family group to build the Google Fonts API URL
 		* for that specific family. Each is added to the collection of URLs to be
@@ -179,7 +188,7 @@ class Google_Fonts_Provider extends \WP_Webfonts_Provider {
 			}
 
 			// Build the URL for this font-family and add it to the collection.
-			$font_families_urls[] = $this->root_url . '?family=' . implode( '&family=', $url_parts ) . '&display=' . $font_display;
+			$font_families_urls[] = $root_url . '?family=' . implode( '&family=', $url_parts ) . '&display=' . $font_display;
 		}
 
 		return $font_families_urls;

--- a/projects/packages/google-fonts-provider/tests/php/test-google-fonts-provider.php
+++ b/projects/packages/google-fonts-provider/tests/php/test-google-fonts-provider.php
@@ -39,6 +39,7 @@ class Test_Google_Fonts_Provider extends TestCase {
 
 		Functions\stubs(
 			array(
+				'esc_url'                          => null,
 				'get_site_transient'               => false,
 				'set_site_transient'               => 'foo',
 				'wp_remote_retrieve_response_code' => 200,

--- a/projects/plugins/jetpack/changelog/update-google-fonts-provider-version
+++ b/projects/plugins/jetpack/changelog/update-google-fonts-provider-version
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Update composer with latest version of google-fonts-provider package

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -844,7 +844,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/google-fonts-provider",
-                "reference": "373aec2cb57cf906657bf586402b83a732bac0cc"
+                "reference": "a6a206ab209d51904eec185116ab1894e1f3f062"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -859,7 +859,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-google-fonts-provider/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.3.x-dev"
+                    "dev-trunk": "0.4.x-dev"
                 },
                 "textdomain": "jetpack-google-fonts-provider"
             },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a way to filter the Google Fonts API url.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pMz3w-g6E-p2#comment-103406

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate the Jetpack plugin and activate the Google Fonts module from `/wp-admin/admin.php?page=jetpack_modules`.
* Activate a block based theme, such as Twenty Twenty Two.
* Go to the Site editor and open the Global Styles > Text panel and select one of the new font choices.
* Make sure everything works.


See gh-983-Automattic/dotcom-forge