### PR TITLE
docker: Fix maildev

### DIFF
--- a/tools/docker/jetpack-docker-config-default.yml
+++ b/tools/docker/jetpack-docker-config-default.yml
@@ -34,6 +34,10 @@ dev:
         ports:
           - '${PORT_MAILDEV:-1080}:80'
           - '${PORT_SMTP:-25}:25'
+        environment:
+          # It runs in its own container, it may as well use the standard ports instead of 1080 and 1025 so we don't have to reconfigure everything trying to send mail to it.
+          MAILDEV_WEB_PORT: 80
+          MAILDEV_SMTP_PORT: 25
 
       ## SFTP server running at localhost:1022
       sftp:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
It appears that maildev changed the default internal ports in March 2022 (v1.1.1), which broke its use in our docker environment. Set the necessary options in the docker-compose config to switch it back.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start up the docker environment.
* Open the maildev UI (at http://localhost:1080 by default). Make sure that works.
* Trigger WordPress to send some mail. Make sure it shows up in maildev's UI.
