### PR TITLE
VideoPress: Fix saving video meta on simple sites

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-meta-save-simple-sites
+++ b/projects/packages/videopress/changelog/fix-videopress-meta-save-simple-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixes issue where video meta could not be saved on a WP.com simple site.

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -211,6 +211,10 @@ class Data {
 	 * Checks if the user is able to perform actions that modify data
 	 */
 	public static function can_perform_action() {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			return true;
+		}
+
 		$connection = new Connection_Manager();
 
 		return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes a production issue on wp.com where simple sites are not saving video meta changes properly. A 403 is being returned because the code is erroneously checking for a connected Jetpack user.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds an early return in `can_perform_action()` if the site is on wp.com.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync build to wp.com sandbox
* Save changes to a video block (Rating, privacy, etc). The changes should save.

