### PR TITLE
Blocks: tiled galleries not displaying correct aspect ratio for square/circle options

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-tiled-gallery-circle-atomic
+++ b/projects/plugins/jetpack/changelog/fix-tiled-gallery-circle-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Blocks: tiled galleries not displaying correct aspect ratio for square/circle options.

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/view.scss
@@ -18,6 +18,10 @@ $tiled-gallery-max-rounded-corners: 20; // See constants.js for JS counterpart
 			flex-grow: 1;
 			width: 100%;
 
+			.tiled-gallery__item img {
+				aspect-ratio: 1/1;
+			}
+
 			@for $cols from 1 through $tiled-gallery-max-column-count {
 				&.columns-#{$cols} {
 					.tiled-gallery__col {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Force square and circle tiled galleries to have 1/1 aspect ratio

Props to @Nic-Sevic for the solution.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?


#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
See linked issue.