### PR TITLE
Boost: Fix console error on getting started

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/elements/ReRouter.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/ReRouter.svelte
@@ -1,0 +1,23 @@
+<!--
+	Handle rerouting away from this page when a condition is met.
+	Prevents child elements from ever being rendered if the condition has been met,
+	which can be important when dealing with things like child-routes.
+-->
+<script lang="ts">
+	import { useNavigate } from 'svelte-navigator';
+
+	export let when: boolean;
+	export let to: string;
+
+	// This ain't React.
+	// eslint-disable-next-line react-hooks/rules-of-hooks
+	const navigate = useNavigate();
+
+	if ( when ) {
+		navigate( to );
+	}
+</script>
+
+{#if ! when}
+	<slot />
+{/if}

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/Settings.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/Settings.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import ReRouter from '../../elements/ReRouter.svelte';
 	import Footer from '../../sections/Footer.svelte';
 	import Header from '../../sections/Header.svelte';
 	import config from '../../stores/config';
@@ -9,39 +9,29 @@
 	import Score from './sections/Score.svelte';
 	import Support from './sections/Support.svelte';
 	import Tips from './sections/Tips.svelte';
-
-	// svelte-ignore unused-export-let - Ignored values supplied by svelte-navigator.
-	export let location, navigate;
-
-	onMount( () => {
-		if ( $config.site.getStarted ) {
-			// Use a timeout, because it's not ok to navigate during page setup. Svelte-navigator doesn't like that.
-			setTimeout( () => {
-				navigate( '/getting-started' );
-			}, 0 );
-		}
-	} );
 </script>
 
-<div id="jb-settings" class="jb-settings jb-settings--main">
-	<div class="jb-container">
-		<Header />
-	</div>
-
-	<div class="jb-section jb-section--alt jb-section--scores">
-		<Score />
-	</div>
-
-	<Router>
-		<div class="jb-section jb-section--main">
-			<Route path="critical-css-advanced" component={AdvancedCriticalCss} />
-			<Route path="/" component={Modules} />
+<ReRouter to="/getting-started" when={$config.site.getStarted}>
+	<div id="jb-settings" class="jb-settings jb-settings--main">
+		<div class="jb-container">
+			<Header />
 		</div>
-	</Router>
 
-	<Tips />
+		<div class="jb-section jb-section--alt jb-section--scores">
+			<Score />
+		</div>
 
-	<Support />
+		<Router>
+			<div class="jb-section jb-section--main">
+				<Route path="critical-css-advanced" component={AdvancedCriticalCss} />
+				<Route path="/" component={Modules} />
+			</div>
+		</Router>
 
-	<Footer />
-</div>
+		<Tips />
+
+		<Support />
+
+		<Footer />
+	</div>
+</ReRouter>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/Settings.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/Settings.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import Footer from '../../sections/Footer.svelte';
 	import Header from '../../sections/Header.svelte';
 	import config from '../../stores/config';
@@ -12,13 +13,14 @@
 	// svelte-ignore unused-export-let - Ignored values supplied by svelte-navigator.
 	export let location, navigate;
 
-	$: {
-		// If the user has Cloud CSS, assume they already got started.
+	onMount( () => {
 		if ( $config.site.getStarted ) {
 			// Use a timeout, because it's not ok to navigate during page setup. Svelte-navigator doesn't like that.
-			setTimeout( () => navigate( '/getting-started' ), 1 );
+			setTimeout( () => {
+				navigate( '/getting-started' );
+			}, 0 );
 		}
-	}
+	} );
 </script>
 
 <div id="jb-settings" class="jb-settings jb-settings--main">

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/Settings.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/Settings.svelte
@@ -15,7 +15,8 @@
 	$: {
 		// If the user has Cloud CSS, assume they already got started.
 		if ( $config.site.getStarted ) {
-			navigate( '/getting-started' );
+			// Use a timeout, because it's not ok to navigate during page setup. Svelte-navigator doesn't like that.
+			setTimeout( () => navigate( '/getting-started' ), 1 );
 		}
 	}
 </script>

--- a/projects/plugins/boost/changelog/fix-error-on-getting-started
+++ b/projects/plugins/boost/changelog/fix-error-on-getting-started
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix error log on navigating to the getting-started page


### PR DESCRIPTION
Don't navigate during the init script in a svelte component; it can break svelte-navigator.

#### Changes proposed in this Pull Request:
* Don't navigate during the init script in a svelte component; it can break svelte-navigator.

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Go to the dashboard without "getting started", and get navigated to the getting-started page
* Ensure no error appears in the console.