### PR TITLE
VideoPress: modify offer text in Jetpack

### DIFF
--- a/projects/plugins/jetpack/changelog/modify-videopress-offer-text-jetpack
+++ b/projects/plugins/jetpack/changelog/modify-videopress-offer-text-jetpack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: VideoPress offer text change
+
+

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -6799,7 +6799,7 @@ endif;
 			'features'          => array(
 				_x( '1TB of storage', 'VideoPress Product Feature', 'jetpack' ),
 				_x( 'Built into WordPress editor', 'VideoPress Product Feature', 'jetpack' ),
-				_x( 'Ad-free and brandable player', 'VideoPress Product Feature', 'jetpack' ),
+				_x( 'Ad-free and customizable player', 'VideoPress Product Feature', 'jetpack' ),
 				_x( 'Unlimited users', 'VideoPress Product Feature', 'jetpack' ),
 			),
 		);


### PR DESCRIPTION
This is a follow-up of https://github.com/Automattic/jetpack/pull/27730
I missed one occurrence of the text.
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Change the offer text to advertise a customizable player instead of a brandable player.



#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

*Follow test instructions of  https://github.com/Automattic/jetpack/pull/27730

