### PR TITLE
Jetpack Live Branches: Make stable Jetpack not be installed by default

### DIFF
--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -176,9 +176,9 @@
 						${ getOptionsList(
 							[
 								{
-									label: 'Jetpack',
+									label: 'Jetpack (latest stable)',
 									name: 'nojetpack',
-									checked: true,
+									checked: false,
 									invert: true,
 								},
 								{

--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jetpack Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.24
+// @version      1.25
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @grant        GM_xmlhttpRequest
 // @connect      jurassic.ninja


### PR DESCRIPTION
Switches the stable Jetpack checkbox not to be installed by default.

With many standalone plugins now, it's more frequent to just want to not be bothered by the presence of the latest stable when testing out PRs

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates the nojetpack option to be off by default
* Updates the text to read `Jetpack (latest stable)`
* Bumps version to 1.25

#### After

<img width="761" alt="image" src="https://user-images.githubusercontent.com/746152/205314018-c525642e-4c85-41eb-a6e4-a060828c6c17.png">

#### Before

<img width="776" alt="image" src="https://user-images.githubusercontent.com/746152/205314172-23a7b8c2-adc4-4444-974e-81ff5a59be46.png">


#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
None

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* Confirm the changes make sense

