### PR TITLE
SEO: exclude posts with meta jetpack_seo_noindex set true from news sitemap

### DIFF
--- a/projects/plugins/jetpack/changelog/update-seo-noindex-news-sitemap
+++ b/projects/plugins/jetpack/changelog/update-seo-noindex-news-sitemap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+SEO: exclude posts with meta jetpack_seo_noindex set true from Jetpack news sitemap.

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
@@ -1393,6 +1393,9 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 	 */
 	private function post_to_news_sitemap_item( $post ) {
 
+		// Exclude posts with meta 'jetpack_seo_noindex' set true from the Jetpack news sitemap.
+		add_filter( 'jetpack_sitemap_news_skip_post', array( 'Jetpack_SEO_Posts', 'exclude_noindex_posts_from_jetpack_sitemap' ), 10, 2 );
+
 		/**
 		 * Filter condition to allow skipping specific posts in news sitemap.
 		 *


### PR DESCRIPTION
Follow-up to #27409

#### Changes proposed in this Pull Request:

For posts that have meta `jetpack_seo_noindex` set true, exclude them from being added to the Jetpack news sitemap.

Note: I tried hooking into the filter where the general sitemap one is already ([link](https://github.com/Automattic/jetpack/blob/70740808a36713c359196647a8cd1a339f7df3f4/projects/plugins/jetpack/modules/seo-tools/class-jetpack-seo.php#L60)), but had trouble with load order so just put it close to where the filter is applied.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

Internal, reported in testing: p8oabR-10q-p2#comment-6838

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

**Before patching with changes in this PR, verify the issue by:**

* Make sure SEO and Sitemaps features are turned on in: /wp-admin/admin.php?page=jetpack#/traffic
* Create a _new_ post, in the Jetpack menu SEO settings check the "Hide page from search engines" checkbox, then publish this post.
* Check the _news_ sitemap at: yoursite.com/news-sitemap.xml
* You should see that new post showing in the new post even though it's marked as 'noindex'.

**After patching with changes:**

* Create another new post, check the "Hide page from search engines" checkbox, then publish it.
* Check the news sitemap at: yoursite.com/news-sitemap.xml
* That post should not show in the news sitemap (the first post you created should not show either since the news sitemap was regenerated).
* You can try toggling the "Hide page..." option for a post and updating the post. The news sitemap should reflect that change.

CC: @sdixon194 This should be a simple cherry-pick once merged.