### PR TITLE
VideoPress: Keep filter UI state between pages

### DIFF
--- a/projects/packages/videopress/changelog/fix-keep-filter-state-between-pages
+++ b/projects/packages/videopress/changelog/fix-keep-filter-state-between-pages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Use the filter state to check/uncheck the checkboxes associated to each filter value.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.8.3",
+	"version": "0.8.4-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.8.3';
+	const PACKAGE_VERSION = '0.8.4-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/client/admin/components/video-filter/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-filter/index.tsx
@@ -16,12 +16,7 @@ import useUsers from '../../hooks/use-users';
 import useVideos from '../../hooks/use-videos';
 import Checkbox from '../checkbox';
 import styles from './style.module.scss';
-
-type FilterObject = {
-	uploader?: { [ id: string | number ]: boolean };
-	privacy?: { [ value: string | number ]: boolean };
-	rating?: { [ value: string ]: boolean };
-};
+import { FilterObject } from './types';
 
 export const FilterButton = ( props: {
 	isActive: boolean;

--- a/projects/packages/videopress/src/client/admin/components/video-filter/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-filter/index.tsx
@@ -12,6 +12,7 @@ import { MouseEvent } from 'react';
  * Internal dependencies
  */
 import filterIcon from '../../../components/icons/filter-icon';
+import { VIDEO_RATING_G, VIDEO_RATING_PG_13, VIDEO_RATING_R_17 } from '../../../state/constants';
 import useUsers from '../../hooks/use-users';
 import useVideos from '../../hooks/use-videos';
 import Checkbox from '../checkbox';
@@ -123,20 +124,20 @@ export const FilterSection = ( props: {
 					<CheckboxCheckmark
 						for="filter-g"
 						label={ __( 'G', 'jetpack-videopress-pkg' ) }
-						onChange={ checked => props.onChange?.( 'rating', 'G', checked ) }
-						checked={ filterIsChecked( 'rating', 'G' ) }
+						onChange={ checked => props.onChange?.( 'rating', VIDEO_RATING_G, checked ) }
+						checked={ filterIsChecked( 'rating', VIDEO_RATING_G ) }
 					/>
 					<CheckboxCheckmark
 						for="filter-pg-13"
 						label={ __( 'PG-13', 'jetpack-videopress-pkg' ) }
-						onChange={ checked => props.onChange?.( 'rating', 'PG-13', checked ) }
-						checked={ filterIsChecked( 'rating', 'PG-13' ) }
+						onChange={ checked => props.onChange?.( 'rating', VIDEO_RATING_PG_13, checked ) }
+						checked={ filterIsChecked( 'rating', VIDEO_RATING_PG_13 ) }
 					/>
 					<CheckboxCheckmark
 						for="filter-r"
 						label={ __( 'R', 'jetpack-videopress-pkg' ) }
-						onChange={ checked => props.onChange?.( 'rating', 'R-17', checked ) }
-						checked={ filterIsChecked( 'rating', 'R-17' ) }
+						onChange={ checked => props.onChange?.( 'rating', VIDEO_RATING_R_17, checked ) }
+						checked={ filterIsChecked( 'rating', VIDEO_RATING_R_17 ) }
 					/>
 				</Col>
 			</Container>

--- a/projects/packages/videopress/src/client/admin/components/video-filter/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-filter/index.tsx
@@ -12,7 +12,14 @@ import { MouseEvent } from 'react';
  * Internal dependencies
  */
 import filterIcon from '../../../components/icons/filter-icon';
-import { VIDEO_RATING_G, VIDEO_RATING_PG_13, VIDEO_RATING_R_17 } from '../../../state/constants';
+import {
+	VIDEO_RATING_G,
+	VIDEO_RATING_PG_13,
+	VIDEO_RATING_R_17,
+	VIDEO_FILTER_PRIVACY,
+	VIDEO_FILTER_RATING,
+	VIDEO_FILTER_UPLOADER,
+} from '../../../state/constants';
 import useUsers from '../../hooks/use-users';
 import useVideos from '../../hooks/use-videos';
 import Checkbox from '../checkbox';
@@ -93,8 +100,10 @@ export const FilterSection = ( props: {
 							key={ uploader.id }
 							label={ uploader.name }
 							for={ `uploader-${ uploader.id }` }
-							onChange={ checked => props.onChange?.( 'uploader', uploader.id, checked ) }
-							checked={ filterIsChecked( 'uploader', uploader.id ) }
+							onChange={ checked =>
+								props.onChange?.( VIDEO_FILTER_UPLOADER, uploader.id, checked )
+							}
+							checked={ filterIsChecked( VIDEO_FILTER_UPLOADER, uploader.id ) }
 						/>
 					) ) }
 				</Col>
@@ -106,14 +115,14 @@ export const FilterSection = ( props: {
 					<CheckboxCheckmark
 						for="filter-public"
 						label={ __( 'Public', 'jetpack-videopress-pkg' ) }
-						onChange={ checked => props.onChange?.( 'privacy', 0, checked ) }
-						checked={ filterIsChecked( 'privacy', 0 ) }
+						onChange={ checked => props.onChange?.( VIDEO_FILTER_PRIVACY, 0, checked ) }
+						checked={ filterIsChecked( VIDEO_FILTER_PRIVACY, 0 ) }
 					/>
 					<CheckboxCheckmark
 						for="filter-private"
 						label={ __( 'Private', 'jetpack-videopress-pkg' ) }
-						onChange={ checked => props.onChange?.( 'privacy', 1, checked ) }
-						checked={ filterIsChecked( 'privacy', 1 ) }
+						onChange={ checked => props.onChange?.( VIDEO_FILTER_PRIVACY, 1, checked ) }
+						checked={ filterIsChecked( VIDEO_FILTER_PRIVACY, 1 ) }
 					/>
 				</Col>
 
@@ -124,20 +133,24 @@ export const FilterSection = ( props: {
 					<CheckboxCheckmark
 						for="filter-g"
 						label={ __( 'G', 'jetpack-videopress-pkg' ) }
-						onChange={ checked => props.onChange?.( 'rating', VIDEO_RATING_G, checked ) }
-						checked={ filterIsChecked( 'rating', VIDEO_RATING_G ) }
+						onChange={ checked => props.onChange?.( VIDEO_FILTER_RATING, VIDEO_RATING_G, checked ) }
+						checked={ filterIsChecked( VIDEO_FILTER_RATING, VIDEO_RATING_G ) }
 					/>
 					<CheckboxCheckmark
 						for="filter-pg-13"
 						label={ __( 'PG-13', 'jetpack-videopress-pkg' ) }
-						onChange={ checked => props.onChange?.( 'rating', VIDEO_RATING_PG_13, checked ) }
-						checked={ filterIsChecked( 'rating', VIDEO_RATING_PG_13 ) }
+						onChange={ checked =>
+							props.onChange?.( VIDEO_FILTER_RATING, VIDEO_RATING_PG_13, checked )
+						}
+						checked={ filterIsChecked( VIDEO_FILTER_RATING, VIDEO_RATING_PG_13 ) }
 					/>
 					<CheckboxCheckmark
 						for="filter-r"
 						label={ __( 'R', 'jetpack-videopress-pkg' ) }
-						onChange={ checked => props.onChange?.( 'rating', VIDEO_RATING_R_17, checked ) }
-						checked={ filterIsChecked( 'rating', VIDEO_RATING_R_17 ) }
+						onChange={ checked =>
+							props.onChange?.( VIDEO_FILTER_RATING, VIDEO_RATING_R_17, checked )
+						}
+						checked={ filterIsChecked( VIDEO_FILTER_RATING, VIDEO_RATING_R_17 ) }
 					/>
 				</Col>
 			</Container>

--- a/projects/packages/videopress/src/client/admin/components/video-filter/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-filter/index.tsx
@@ -17,6 +17,12 @@ import useVideos from '../../hooks/use-videos';
 import Checkbox from '../checkbox';
 import styles from './style.module.scss';
 
+type FilterObject = {
+	uploader?: { [ id: string | number ]: boolean };
+	privacy?: { [ value: string | number ]: boolean };
+	rating?: { [ value: string ]: boolean };
+};
+
 export const FilterButton = ( props: {
 	isActive: boolean;
 	onClick?: ( event: MouseEvent< HTMLButtonElement > ) => void;
@@ -68,8 +74,16 @@ export const FilterSection = ( props: {
 		checked: boolean
 	) => void;
 	className?: string;
+	filter?: FilterObject;
 } ): JSX.Element => {
 	const [ isSm ] = useBreakpointMatch( 'sm' );
+
+	const filterIsChecked = (
+		filterName: 'uploader' | 'privacy' | 'rating',
+		value: number | string
+	) => {
+		return props?.filter?.[ filterName ]?.[ value ] === true;
+	};
 
 	return (
 		<div className={ classnames( styles[ 'filters-section' ], props.className ) }>
@@ -84,6 +98,7 @@ export const FilterSection = ( props: {
 							label={ uploader.name }
 							for={ `uploader-${ uploader.id }` }
 							onChange={ checked => props.onChange?.( 'uploader', uploader.id, checked ) }
+							checked={ filterIsChecked( 'uploader', uploader.id ) }
 						/>
 					) ) }
 				</Col>
@@ -96,11 +111,13 @@ export const FilterSection = ( props: {
 						for="filter-public"
 						label={ __( 'Public', 'jetpack-videopress-pkg' ) }
 						onChange={ checked => props.onChange?.( 'privacy', 0, checked ) }
+						checked={ filterIsChecked( 'privacy', 0 ) }
 					/>
 					<CheckboxCheckmark
 						for="filter-private"
 						label={ __( 'Private', 'jetpack-videopress-pkg' ) }
 						onChange={ checked => props.onChange?.( 'privacy', 1, checked ) }
+						checked={ filterIsChecked( 'privacy', 1 ) }
 					/>
 				</Col>
 
@@ -112,16 +129,19 @@ export const FilterSection = ( props: {
 						for="filter-g"
 						label={ __( 'G', 'jetpack-videopress-pkg' ) }
 						onChange={ checked => props.onChange?.( 'rating', 'G', checked ) }
+						checked={ filterIsChecked( 'rating', 'G' ) }
 					/>
 					<CheckboxCheckmark
 						for="filter-pg-13"
 						label={ __( 'PG-13', 'jetpack-videopress-pkg' ) }
 						onChange={ checked => props.onChange?.( 'rating', 'PG-13', checked ) }
+						checked={ filterIsChecked( 'rating', 'PG-13' ) }
 					/>
 					<CheckboxCheckmark
 						for="filter-r"
 						label={ __( 'R', 'jetpack-videopress-pkg' ) }
 						onChange={ checked => props.onChange?.( 'rating', 'R-17', checked ) }
+						checked={ filterIsChecked( 'rating', 'R-17' ) }
 					/>
 				</Col>
 			</Container>
@@ -130,7 +150,9 @@ export const FilterSection = ( props: {
 };
 
 export const ConnectFilterSection = props => {
-	const { setFilter } = useVideos();
+	const { setFilter, filter } = useVideos();
 	const { items: users } = useUsers();
-	return <FilterSection { ...props } onChange={ setFilter } uploaders={ users } />;
+	return (
+		<FilterSection { ...props } onChange={ setFilter } uploaders={ users } filter={ filter } />
+	);
 };

--- a/projects/packages/videopress/src/client/admin/components/video-filter/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-filter/index.tsx
@@ -13,6 +13,9 @@ import { MouseEvent } from 'react';
  */
 import filterIcon from '../../../components/icons/filter-icon';
 import {
+	VIDEO_PRIVACY_LEVELS,
+	VIDEO_PRIVACY_LEVEL_PRIVATE,
+	VIDEO_PRIVACY_LEVEL_PUBLIC,
 	VIDEO_RATING_G,
 	VIDEO_RATING_PG_13,
 	VIDEO_RATING_R_17,
@@ -115,14 +118,32 @@ export const FilterSection = ( props: {
 					<CheckboxCheckmark
 						for="filter-public"
 						label={ __( 'Public', 'jetpack-videopress-pkg' ) }
-						onChange={ checked => props.onChange?.( VIDEO_FILTER_PRIVACY, 0, checked ) }
-						checked={ filterIsChecked( VIDEO_FILTER_PRIVACY, 0 ) }
+						onChange={ checked =>
+							props.onChange?.(
+								VIDEO_FILTER_PRIVACY,
+								VIDEO_PRIVACY_LEVELS.indexOf( VIDEO_PRIVACY_LEVEL_PUBLIC ),
+								checked
+							)
+						}
+						checked={ filterIsChecked(
+							VIDEO_FILTER_PRIVACY,
+							VIDEO_PRIVACY_LEVELS.indexOf( VIDEO_PRIVACY_LEVEL_PUBLIC )
+						) }
 					/>
 					<CheckboxCheckmark
 						for="filter-private"
 						label={ __( 'Private', 'jetpack-videopress-pkg' ) }
-						onChange={ checked => props.onChange?.( VIDEO_FILTER_PRIVACY, 1, checked ) }
-						checked={ filterIsChecked( VIDEO_FILTER_PRIVACY, 1 ) }
+						onChange={ checked =>
+							props.onChange?.(
+								VIDEO_FILTER_PRIVACY,
+								VIDEO_PRIVACY_LEVELS.indexOf( VIDEO_PRIVACY_LEVEL_PRIVATE ),
+								checked
+							)
+						}
+						checked={ filterIsChecked(
+							VIDEO_FILTER_PRIVACY,
+							VIDEO_PRIVACY_LEVELS.indexOf( VIDEO_PRIVACY_LEVEL_PRIVATE )
+						) }
 					/>
 				</Col>
 

--- a/projects/packages/videopress/src/client/admin/components/video-filter/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/video-filter/types.ts
@@ -1,0 +1,8 @@
+/**
+ * A type to represent the filters on the state.
+ */
+export type FilterObject = {
+	uploader?: { [ id: string | number ]: boolean };
+	privacy?: { [ value: string | number ]: boolean };
+	rating?: { [ value: string ]: boolean };
+};

--- a/projects/packages/videopress/src/client/admin/hooks/use-videos/index.js
+++ b/projects/packages/videopress/src/client/admin/hooks/use-videos/index.js
@@ -26,12 +26,14 @@ export default function useVideos() {
 	const query = useSelect( select => select( STORE_ID ).getVideosQuery() || {} );
 	const pagination = useSelect( select => select( STORE_ID ).getPagination() );
 	const storageUsed = useSelect( select => select( STORE_ID ).getStorageUsed(), [] );
+	const filter = useSelect( select => select( STORE_ID ).getVideosFilter() );
 
 	return {
 		items,
 		uploading,
 		isUploading,
 		search,
+		filter,
 		uploadedVideoCount,
 		isFetching,
 		isFetchingUploadedVideoCount,

--- a/projects/packages/videopress/src/client/state/constants.js
+++ b/projects/packages/videopress/src/client/state/constants.js
@@ -86,3 +86,7 @@ export const VIDEO_PRIVACY_LEVELS = [
 export const VIDEO_RATING_G = 'G';
 export const VIDEO_RATING_PG_13 = 'PG-13';
 export const VIDEO_RATING_R_17 = 'R-17';
+
+export const VIDEO_FILTER_UPLOADER = 'uploader';
+export const VIDEO_FILTER_RATING = 'rating';
+export const VIDEO_FILTER_PRIVACY = 'privacy';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27739.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Use the filter local state to check/uncheck the checkboxes associated to each filter value

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `Jetpack > VideoPress`
* Make sure you have videos with different ratings and privacy settings, so we can filter the results on the video list
* Apply a filter (for example, filter by the "Private" privacy):

<img width="1110" alt="Screen Shot 2022-12-02 at 12 27 04" src="https://user-images.githubusercontent.com/6760046/205395601-5189cae7-3a24-4aa5-9f85-899caea6c8f5.png">

* Notice that the list of videos will be updated
* On the new list of videos, click the "Edit video details" button for some video
* On the Video Details page, click the "Go back" link at the top of the page:

<img width="893" alt="Screen Shot 2022-12-02 at 12 28 58" src="https://user-images.githubusercontent.com/6760046/205395635-8a8cfc7a-7852-446b-ae0d-54ec8252e069.png">

* This will send you back to the list of videos
* Notice that the list is still filtered
* Click the "Filters" button at the top of the page:

<img width="780" alt="Screen Shot 2022-12-02 at 18 47 17" src="https://user-images.githubusercontent.com/6760046/205395734-fae4342f-5921-47db-99ed-3083d33ec302.png">

* **Before the fix**, the checkboxes that you selected before would not be selected anymore (but the videos were still filtered)
* **After the fix**, the checkboxes that you selected will be selected, so you can know which filters are in place on the current video list:

<img width="838" alt="Screen Shot 2022-12-02 at 18 48 41" src="https://user-images.githubusercontent.com/6760046/205395951-bde42df3-9e91-4c25-96d9-e8f22fe83c86.png">

* Make sure to test using multiple filters as well, and combining it with search queries