### PR TITLE
Remove references to `$include_publicize_followers`

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/subscribers.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/subscribers.php
@@ -76,8 +76,7 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers extends WP_REST_Controller {
 			delete_transient( 'wpcom_subscribers_total' );
 			delete_transient( 'wpcom_subscribers_total_no_publicize' );
 		}
-		$include_publicize_subscribers = isset( $request['include_publicize_subscribers'] ) ? rest_sanitize_boolean( $request['include_publicize_subscribers'] ) : true;
-		$subscriber_count              = Jetpack_Subscriptions_Widget::fetch_subscriber_count( $include_publicize_subscribers );
+		$subscriber_count = Jetpack_Subscriptions_Widget::fetch_subscriber_count();
 
 		return array(
 			'count' => $subscriber_count,

--- a/projects/plugins/jetpack/changelog/fix-remove-include-publicize-followers
+++ b/projects/plugins/jetpack/changelog/fix-remove-include-publicize-followers
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Remove references to obsolete $include_publicized_followers

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/api.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/api.js
@@ -2,7 +2,7 @@ import apiFetch from '@wordpress/api-fetch';
 
 export function getSubscriberCount( successCallback, failureCallback ) {
 	return apiFetch( {
-		path: '/wpcom/v2/subscribers/count?include_publicize_subscribers=false',
+		path: '/wpcom/v2/subscribers/count',
 	} ).then( ( { count } = {} ) => {
 		// Handle error condition
 		if ( Number.isFinite( count ) ) {

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -596,17 +596,16 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 	/**
 	 * Determine the amount of folks currently subscribed to the blog.
 	 *
-	 * @param bool $include_publicize_subscribers Include followers through Publicize.
 	 * @return int
 	 */
-	public static function fetch_subscriber_count( $include_publicize_subscribers = true ) {
+	public static function fetch_subscriber_count() {
 		$subs_count = 0;
 		if ( self::is_jetpack() ) {
-			$cache_key  = $include_publicize_subscribers ? 'wpcom_subscribers_total' : 'wpcom_subscribers_total_no_publicize';
+			$cache_key  = 'wpcom_subscribers_total';
 			$subs_count = get_transient( $cache_key );
 			if ( false === $subs_count || 'failed' === $subs_count['status'] ) {
 				$xml = new Jetpack_IXR_Client();
-				$xml->query( 'jetpack.fetchSubscriberCount', $include_publicize_subscribers );
+				$xml->query( 'jetpack.fetchSubscriberCount' );
 
 				if ( $xml->isError() ) { // If we get an error from .com, set the status to failed so that we will try again next time the data is requested.
 
@@ -628,11 +627,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		}
 
 		if ( self::is_wpcom() ) {
-			if ( $include_publicize_subscribers && function_exists( 'wpcom_reach_total_for_blog' ) ) {
-				$subs_count = wpcom_reach_total_for_blog();
-			} elseif ( function_exists( 'wpcom_subs_total_for_blog' ) ) {
-				$subs_count = wpcom_subs_total_for_blog();
-			}
+			$subs_count = wpcom_reach_total_for_blog();
 			return $subs_count;
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Removes the references to $include_publicize_followers

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?

No

#### Jetpack product discussion
p1670068991490749-slack-C02TCEHP3HA

#### Testing instructions:
- Apply this PR
- Add a Subscription block
- Check if subscription block works in both the editor & the frontend