### PR TITLE
phpcs: Fix new PHP 8.1 PHPCompatibility sniffs

### DIFF
--- a/projects/packages/search/changelog/fix-phpcompatibility-new-8.1-things
+++ b/projects/packages/search/changelog/fix-phpcompatibility-new-8.1-things
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Change `${var}` to the equivalent `{$var}` for PHP 8.1 compat.
+
+

--- a/projects/packages/search/src/class-cli.php
+++ b/projects/packages/search/src/class-cli.php
@@ -63,7 +63,7 @@ class CLI extends WP_CLI_Command {
 		}
 		$user_info = get_user_by( $get_user_by, (string) $user );
 		if ( ! $user_info ) {
-			return new WP_Error( 'user_not_found', "Could not find user '${user}' by ${get_user_by}." );
+			return new WP_Error( 'user_not_found', "Could not find user '{$user}' by {$get_user_by}." );
 		}
 		return wp_set_current_user( $user_info->ID );
 	}

--- a/projects/packages/waf/changelog/fix-phpcompatibility-new-8.1-things
+++ b/projects/packages/waf/changelog/fix-phpcompatibility-new-8.1-things
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+html_entity_decode filter now decodes single-quotes too, and uses a Unicode Replacement Character instead of returning empty string on invalid characters.

--- a/projects/packages/waf/src/class-waf-transforms.php
+++ b/projects/packages/waf/src/class-waf-transforms.php
@@ -118,7 +118,7 @@ class Waf_Transforms {
 	 * @return string
 	 */
 	public function html_entity_decode( $value ) {
-		return html_entity_decode( $value );
+		return html_entity_decode( $value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -54,10 +54,10 @@ class Jetpack_Redux_State_Helper {
 		// Preparing translated fields for JSON encoding by transforming all HTML entities to
 		// respective characters.
 		foreach ( $modules as $slug => $data ) {
-			$modules[ $slug ]['name']              = html_entity_decode( $data['name'] );
-			$modules[ $slug ]['description']       = html_entity_decode( $data['description'] );
-			$modules[ $slug ]['short_description'] = html_entity_decode( $data['short_description'] );
-			$modules[ $slug ]['long_description']  = html_entity_decode( $data['long_description'] );
+			$modules[ $slug ]['name']              = html_entity_decode( $data['name'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
+			$modules[ $slug ]['description']       = html_entity_decode( $data['description'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
+			$modules[ $slug ]['short_description'] = html_entity_decode( $data['short_description'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
+			$modules[ $slug ]['long_description']  = html_entity_decode( $data['long_description'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
 		}
 
 		// "mock" a block module in order to get it searchable in the settings.

--- a/projects/plugins/jetpack/_inc/lib/class.media-extractor.php
+++ b/projects/plugins/jetpack/_inc/lib/class.media-extractor.php
@@ -565,7 +565,7 @@ class Jetpack_Media_Meta_Extractor {
 	 */
 	private static function get_stripped_content( $content ) {
 		$clean_content = wp_strip_all_tags( $content );
-		$clean_content = html_entity_decode( $clean_content );
+		$clean_content = html_entity_decode( $clean_content, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
 		// completely strip shortcodes and any content they enclose.
 		$clean_content = strip_shortcodes( $clean_content );
 		return $clean_content;

--- a/projects/plugins/jetpack/_inc/lib/components.php
+++ b/projects/plugins/jetpack/_inc/lib/components.php
@@ -106,7 +106,7 @@ class Jetpack_Components {
 			? add_query_arg(
 				'redirect_to',
 				$redirect_to,
-				"https://wordpress.com/checkout/${site_slug}/${plan_path_slug}"
+				"https://wordpress.com/checkout/{$site_slug}/{$plan_path_slug}"
 			) : '';
 
 		return self::render_component(

--- a/projects/plugins/jetpack/changelog/fix-phpcompatibility-new-8.1-things
+++ b/projects/plugins/jetpack/changelog/fix-phpcompatibility-new-8.1-things
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Decode single-quote HTML entities in various places, and use a Unicode Replacement Character rather than empty string for invalid characters.

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/podcast-player.php
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/podcast-player.php
@@ -164,7 +164,7 @@ function render_player( $player_data, $attributes ) {
 	$background_colors = get_colors( 'background', $attributes, 'background-color' );
 
 	$player_classes_name  = trim( "{$secondary_colors['class']} {$background_colors['class']}" );
-	$player_inline_style  = trim( "{$secondary_colors['style']} ${background_colors['style']}" );
+	$player_inline_style  = trim( "{$secondary_colors['style']} {$background_colors['style']}" );
 	$player_inline_style .= get_css_vars( $attributes );
 	$wrapper_attributes   = \WP_Block_Supports::get_instance()->apply_block_supports();
 	$block_classname      = Blocks::classes( FEATURE_NAME, $attributes, array( 'is-default' ) );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -455,7 +455,7 @@ function render_wpcom_subscribe_form( $data, $classes, $styles ) {
 					>
 						<?php
 						echo wp_kses(
-							html_entity_decode( $data['submit_button_text'] ),
+							html_entity_decode( $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
 							Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
 						);
 						?>
@@ -546,7 +546,7 @@ function render_jetpack_subscribe_form( $data, $classes, $styles ) {
 						>
 							<?php
 							echo wp_kses(
-								html_entity_decode( $data['submit_button_text'] ),
+								html_entity_decode( $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
 								Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
 							);
 							?>

--- a/projects/plugins/jetpack/modules/calypsoify/class-jetpack-calypsoify.php
+++ b/projects/plugins/jetpack/modules/calypsoify/class-jetpack-calypsoify.php
@@ -113,14 +113,14 @@ class Jetpack_Calypsoify {
 		if ( $post_id === null ) {
 			// E.g. posts or pages have no special suffix. CPTs are in the `types/{cpt}` format.
 			$post_type_suffix = ( 'post' === $post_type || 'page' === $post_type )
-				? "/${post_type}s/"
-				: "/types/${post_type}/";
+				? "/{$post_type}s/"
+				: "/types/{$post_type}/";
 			$post_suffix      = '';
 		} else {
 			$post_type_suffix = ( 'post' === $post_type || 'page' === $post_type )
-				? "/${post_type}/"
-				: "/edit/${post_type}/";
-			$post_suffix      = "/${post_id}";
+				? "/{$post_type}/"
+				: "/edit/{$post_type}/";
+			$post_suffix      = "/{$post_id}";
 		}
 
 		return $this->get_calypso_origin() . $post_type_suffix . $site_suffix . $post_suffix;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -904,15 +904,16 @@ class Jetpack_Carousel {
 
 		$img_meta = wp_json_encode( array_map( 'strval', array_filter( $img_meta, 'is_scalar' ) ) );
 
-		$attr['data-attachment-id']     = $attachment_id;
-		$attr['data-permalink']         = esc_attr( get_permalink( $attachment_id ) );
-		$attr['data-orig-file']         = esc_attr( $orig_file );
-		$attr['data-orig-size']         = $size;
-		$attr['data-comments-opened']   = $comments_opened;
-		$attr['data-image-meta']        = esc_attr( $img_meta );
-		$attr['data-image-title']       = esc_attr( htmlspecialchars( $attachment_title ) );
-		$attr['data-image-description'] = esc_attr( htmlspecialchars( $attachment_desc ) );
-		$attr['data-image-caption']     = esc_attr( htmlspecialchars( $attachment_caption ) );
+		$attr['data-attachment-id']   = $attachment_id;
+		$attr['data-permalink']       = esc_attr( get_permalink( $attachment_id ) );
+		$attr['data-orig-file']       = esc_attr( $orig_file );
+		$attr['data-orig-size']       = $size;
+		$attr['data-comments-opened'] = $comments_opened;
+		$attr['data-image-meta']      = esc_attr( $img_meta );
+		// The lines below use `esc_attr( htmlspecialchars( ) )` because esc_attr tries to be too smart and won't double-encode, and we need that here.
+		$attr['data-image-title']       = esc_attr( htmlspecialchars( $attachment_title, ENT_COMPAT ) );
+		$attr['data-image-description'] = esc_attr( htmlspecialchars( $attachment_desc, ENT_COMPAT ) );
+		$attr['data-image-caption']     = esc_attr( htmlspecialchars( $attachment_caption, ENT_COMPAT ) );
 		$attr['data-medium-file']       = esc_attr( $medium_file );
 		$attr['data-large-file']        = esc_attr( $large_file );
 

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -577,7 +577,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 		}
 
 		if ( false !== strpos( $post_array['hc_avatar'], '.gravatar.com' ) ) {
-			$post_array['hc_avatar'] = htmlentities( $post_array['hc_avatar'] );
+			$post_array['hc_avatar'] = htmlentities( $post_array['hc_avatar'], ENT_COMPAT );
 		}
 
 		$blog_token = ( new Tokens() )->get_access_token( false, $post_array['token_key'] );

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
@@ -150,7 +150,7 @@ abstract class Sharing_Source {
 		 */
 		$title = apply_filters( 'sharing_title', $post->post_title, $post_id, $this->id );
 
-		return html_entity_decode( wp_kses( $title, null ) );
+		return html_entity_decode( wp_kses( $title, null ), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/shortcodes/class.filter-embedded-html-objects.php
+++ b/projects/plugins/jetpack/modules/shortcodes/class.filter-embedded-html-objects.php
@@ -223,7 +223,7 @@ class Filter_Embedded_HTML_Objects {
 	 */
 	private static function dispatch_entities( $matches ) {
 		$orig_html       = $matches[0];
-		$decoded_matches = array( html_entity_decode( $matches[0] ) );
+		$decoded_matches = array( html_entity_decode( $matches[0], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ) );
 
 		return self::dispatch( $decoded_matches, $orig_html );
 	}

--- a/projects/plugins/jetpack/modules/shortcodes/dailymotion.php
+++ b/projects/plugins/jetpack/modules/shortcodes/dailymotion.php
@@ -36,12 +36,12 @@ function dailymotion_embed_to_shortcode( $content ) {
 		}
 
 		foreach ( $matches as $match ) {
-			$src    = html_entity_decode( $match[3] );
+			$src    = html_entity_decode( $match[3], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
 			$params = $match[2] . $match[4];
 
 			if ( 'regexp_ent' === $reg ) {
-				$src    = html_entity_decode( $src );
-				$params = html_entity_decode( $params );
+				$src    = html_entity_decode( $src, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
+				$params = html_entity_decode( $params, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
 			}
 
 			$params = wp_kses_hair( $params, array( 'http' ) );

--- a/projects/plugins/jetpack/modules/shortcodes/getty.php
+++ b/projects/plugins/jetpack/modules/shortcodes/getty.php
@@ -132,7 +132,7 @@ function wpcom_shortcodereverse_getty( $content ) {
 			} else {
 				$params = $match[5];
 				if ( 'regexp_ent' === $reg ) {
-					$params = html_entity_decode( $params );
+					$params = html_entity_decode( $params, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
 				}
 				$params = wp_kses_hair( $params, array( 'http' ) );
 

--- a/projects/plugins/jetpack/modules/shortcodes/googleapps.php
+++ b/projects/plugins/jetpack/modules/shortcodes/googleapps.php
@@ -72,7 +72,7 @@ function googleapps_embed_to_shortcode( $content ) {
 		foreach ( $matches as $match ) {
 			$params = $match[1] . $match[5];
 			if ( in_array( $reg, array( 'regexp_ent', 'regexp_ent_squot' ), true ) ) {
-				$params = html_entity_decode( $params );
+				$params = html_entity_decode( $params, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
 			}
 
 			$params = wp_kses_hair( $params, array( 'http' ) );
@@ -171,7 +171,7 @@ function googleapps_shortcode( $atts ) {
 	if ( $attr['src'] && preg_match( '!https?://(docs|drive|spreadsheets\d*|calendar|www)*\.google\.com/([-\w\./]+)\?([^"]+)!', $attr['src'], $matches ) ) {
 		$attr['domain'] = $matches[1];
 		$attr['dir']    = $matches[2];
-		parse_str( htmlspecialchars_decode( $matches[3] ), $query_ar );
+		parse_str( htmlspecialchars_decode( $matches[3], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ), $query_ar );
 		$query_ar['chrome']   = 'false';
 		$query_ar['embedded'] = 'true';
 		$attr['query']        = http_build_query( $query_ar );

--- a/projects/plugins/jetpack/modules/shortcodes/kickstarter.php
+++ b/projects/plugins/jetpack/modules/shortcodes/kickstarter.php
@@ -64,7 +64,7 @@ function jetpack_kickstarter_embed_to_shortcode( $content ) {
 			$params = $match[1] . $match[3];
 
 			if ( 'regexp_ent' === $reg ) {
-				$params = html_entity_decode( $params );
+				$params = html_entity_decode( $params, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
 			}
 
 			$params = wp_kses_hair( $params, array( 'http' ) );

--- a/projects/plugins/jetpack/modules/shortcodes/soundcloud.php
+++ b/projects/plugins/jetpack/modules/shortcodes/soundcloud.php
@@ -62,7 +62,7 @@ function soundcloud_shortcode( $atts, $content = null ) {
 	// Turn shortcode option "param" (param=value&param2=value) into array of params.
 	$shortcode_params = array();
 	if ( isset( $shortcode_options['params'] ) ) {
-		parse_str( html_entity_decode( $shortcode_options['params'] ), $shortcode_params );
+		parse_str( html_entity_decode( $shortcode_options['params'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ), $shortcode_params );
 		$shortcode_options = array_merge(
 			$shortcode_options,
 			$shortcode_params
@@ -226,7 +226,7 @@ function jetpack_soundcloud_embed_reversal( $content ) {
 			// if pasted from the visual editor - prevent double encoding.
 			$match[1] = str_replace( '&amp;amp;', '&amp;', $match[1] );
 
-			$args = wp_parse_url( html_entity_decode( $match[1] ), PHP_URL_QUERY );
+			$args = wp_parse_url( html_entity_decode( $match[1], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ), PHP_URL_QUERY );
 			$args = wp_parse_args( $args );
 
 			if ( ! preg_match( '#^(?:https?:)?//api\.soundcloud\.com/.+$#i', $args['url'], $url_matches ) ) {

--- a/projects/plugins/jetpack/modules/shortcodes/vimeo.php
+++ b/projects/plugins/jetpack/modules/shortcodes/vimeo.php
@@ -317,7 +317,7 @@ function vimeo_embed_to_shortcode( $content ) {
 			$params = $match[3];
 
 			if ( 'regexp_ent' === $reg ) {
-				$params = html_entity_decode( $params );
+				$params = html_entity_decode( $params, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
 			}
 
 			$params = wp_kses_hair( $params, array( 'http' ) );

--- a/projects/plugins/jetpack/modules/shortcodes/youtube.php
+++ b/projects/plugins/jetpack/modules/shortcodes/youtube.php
@@ -68,7 +68,7 @@ function youtube_embed_to_short_code( $content ) {
 				$params = $match[1];
 
 				if ( in_array( $reg, array( 'ifr_regexp_ent', 'regexp_ent' ), true ) ) {
-					$params = html_entity_decode( $params );
+					$params = html_entity_decode( $params, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
 				}
 
 				$params = wp_kses_hair( $params, array( 'http' ) );
@@ -85,7 +85,7 @@ function youtube_embed_to_short_code( $content ) {
 			} else {
 				$match[1] = str_replace( '?', '&', $match[1] );
 
-				$url = esc_url_raw( 'https://www.youtube.com/watch?v=' . html_entity_decode( $match[1] ) );
+				$url = esc_url_raw( 'https://www.youtube.com/watch?v=' . html_entity_decode( $match[1], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ) );
 			}
 
 			$content = str_replace( $match[0], "[youtube $url]", $content );

--- a/projects/plugins/jetpack/modules/simple-payments/simple-payments.php
+++ b/projects/plugins/jetpack/modules/simple-payments/simple-payments.php
@@ -334,19 +334,19 @@ class Jetpack_Simple_Payments {
 					<input class="%2$s" type="number" value="1" min="1" id="%3$s" />
 				</div>
 				',
-				esc_attr( "${css_prefix}-items" ),
-				esc_attr( "${css_prefix}-items-number" ),
+				esc_attr( "{$css_prefix}-items" ),
+				esc_attr( "{$css_prefix}-items-number" ),
 				esc_attr( "{$dom_id}_number" )
 			);
 		}
 
 		return sprintf(
 			'<div class="%1$s" id="%2$s"></div><div class="%3$s">%4$s<div class="%5$s" id="%6$s"></div></div>',
-			esc_attr( "${css_prefix}-purchase-message" ),
+			esc_attr( "{$css_prefix}-purchase-message" ),
 			esc_attr( "{$dom_id}-message-container" ),
-			esc_attr( "${css_prefix}-purchase-box" ),
+			esc_attr( "{$css_prefix}-purchase-box" ),
 			$items,
-			esc_attr( "${css_prefix}-button" ),
+			esc_attr( "{$css_prefix}-button" ),
 			esc_attr( "{$dom_id}_button" )
 		);
 	}
@@ -364,8 +364,8 @@ class Jetpack_Simple_Payments {
 		if ( has_post_thumbnail( $data['id'] ) ) {
 			$image = sprintf(
 				'<div class="%1$s"><div class="%2$s">%3$s</div></div>',
-				esc_attr( "${css_prefix}-product-image" ),
-				esc_attr( "${css_prefix}-image" ),
+				esc_attr( "{$css_prefix}-product-image" ),
+				esc_attr( "{$css_prefix}-image" ),
 				get_the_post_thumbnail( $data['id'], 'full' )
 			);
 		}
@@ -384,15 +384,15 @@ class Jetpack_Simple_Payments {
 	</div>
 </div>
 ',
-			esc_attr( "{$data['class']} ${css_prefix}-wrapper" ),
-			esc_attr( "${css_prefix}-product" ),
+			esc_attr( "{$data['class']} {$css_prefix}-wrapper" ),
+			esc_attr( "{$css_prefix}-product" ),
 			$image,
-			esc_attr( "${css_prefix}-details" ),
-			esc_attr( "${css_prefix}-title" ),
+			esc_attr( "{$css_prefix}-details" ),
+			esc_attr( "{$css_prefix}-title" ),
 			esc_html( $data['title'] ),
-			esc_attr( "${css_prefix}-description" ),
+			esc_attr( "{$css_prefix}-description" ),
 			wp_kses( $data['description'], wp_kses_allowed_html( 'post' ) ),
-			esc_attr( "${css_prefix}-price" ),
+			esc_attr( "{$css_prefix}-price" ),
 			esc_html( $data['price'] ),
 			$this->output_purchase_box( $data['dom_id'], $data['multiple'] )
 		);

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-fallback.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-fallback.php
@@ -124,7 +124,7 @@ abstract class Jetpack_Sitemap_Buffer_Fallback extends Jetpack_Sitemap_Buffer {
 			} elseif ( $value === null ) {
 				$string .= "<$tag />";
 			} else {
-				$string .= "<$tag>" . htmlspecialchars( $value ) . "</$tag>";
+				$string .= "<$tag>" . htmlspecialchars( $value, ENT_COMPAT ) . "</$tag>";
 			}
 		}
 

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
@@ -1441,7 +1441,7 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 				'lastmod'   => jp_sitemap_datetime( $post->post_modified_gmt ),
 				'news:news' => array(
 					'news:publication'      => array(
-						'news:name'     => html_entity_decode( get_bloginfo( 'name' ) ),
+						'news:name'     => html_entity_decode( get_bloginfo( 'name' ), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
 						'news:language' => $language,
 					),
 					/** This filter is already documented in core/wp-includes/feed.php */

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -428,7 +428,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 					>
 						<?php
 						echo wp_kses(
-							html_entity_decode( $subscribe_button ),
+							html_entity_decode( $subscribe_button, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
 							self::$allowed_html_tags_for_submit_button
 						);
 						?>
@@ -517,7 +517,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 						>
 							<?php
 							echo wp_kses(
-								html_entity_decode( $subscribe_button ),
+								html_entity_decode( $subscribe_button, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
 								self::$allowed_html_tags_for_submit_button
 							);
 							?>

--- a/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/templates/partials/carousel-image-args.php
+++ b/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/templates/partials/carousel-image-args.php
@@ -20,7 +20,8 @@ data-orig-file="<?php echo esc_url( wp_get_attachment_url( $item->image->ID ) );
 data-orig-size="<?php echo esc_attr( $item->meta_width() ); ?>,<?php echo esc_attr( $item->meta_height() ); ?>"
 data-comments-opened="<?php echo esc_attr( comments_open( $item->image->ID ) ); ?>"
 data-image-meta="<?php echo esc_attr( $fuzzy_image_meta ); ?>"
-data-image-title="<?php echo esc_attr( htmlspecialchars( wptexturize( $item->image->post_title ) ) ); ?>"
-data-image-description="<?php echo esc_attr( htmlspecialchars( wpautop( wptexturize( $item->image->post_content ) ) ) ); ?>"
+<?php // The two lines below use `esc_attr( htmlspecialchars( ) )` because esc_attr tries to be too smart and won't double-encode, and we need that here. ?>
+data-image-title="<?php echo esc_attr( htmlspecialchars( wptexturize( $item->image->post_title ), ENT_COMPAT ) ); ?>"
+data-image-description="<?php echo esc_attr( htmlspecialchars( wpautop( wptexturize( $item->image->post_content ) ), ENT_COMPAT ) ); ?>"
 data-medium-file="<?php echo esc_url( $item->medium_file() ); ?>"
 data-large-file="<?php echo esc_url( $item->large_file() ); ?>"

--- a/projects/plugins/jetpack/modules/widgets/flickr.php
+++ b/projects/plugins/jetpack/modules/widgets/flickr.php
@@ -71,7 +71,7 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 				 * Parse the URL, and rebuild a URL that's sure to display images.
 				 * Some Flickr Feeds do not display images by default.
 				 */
-				$flickr_parameters = wp_parse_url( htmlspecialchars_decode( $instance['flickr_rss_url'] ) );
+				$flickr_parameters = wp_parse_url( htmlspecialchars_decode( $instance['flickr_rss_url'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ) );
 
 				// Is it a Flickr Feed.
 				if (

--- a/projects/plugins/jetpack/modules/widgets/migrate-to-core/gallery-widget.php
+++ b/projects/plugins/jetpack/modules/widgets/migrate-to-core/gallery-widget.php
@@ -61,7 +61,7 @@ function jetpack_migrate_gallery_widget() {
 
 		// Now un-register old widgets and register new.
 		foreach ( $widgets_to_unregister as $id => $new_id ) {
-			wp_unregister_sidebar_widget( "gallery-${id}" );
+			wp_unregister_sidebar_widget( "gallery-{$id}" );
 
 			// register new widget.
 			$media_gallery_widget = new WP_Widget_Media_Gallery();

--- a/projects/plugins/jetpack/modules/widgets/migrate-to-core/image-widget.php
+++ b/projects/plugins/jetpack/modules/widgets/migrate-to-core/image-widget.php
@@ -200,7 +200,7 @@ function jetpack_migrate_image_widget() {
 
 		// Now un-register old widgets and register new.
 		foreach ( $widgets_to_unregister as $id ) {
-			wp_unregister_sidebar_widget( "image-${id}" );
+			wp_unregister_sidebar_widget( "image-{$id}" );
 
 			// register new widget.
 			$media_image_widget = new WP_Widget_Media_Image();

--- a/projects/plugins/jetpack/sal/class.json-api-post-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-post-base.php
@@ -830,7 +830,7 @@ abstract class SAL_Post {
 			return '';
 		}
 
-		return esc_url_raw( htmlspecialchars_decode( $avatar_url[0] ) );
+		return esc_url_raw( htmlspecialchars_decode( $avatar_url[0], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/test_class.jetpack_photon.php
+++ b/projects/plugins/jetpack/tests/php/test_class.jetpack_photon.php
@@ -1180,7 +1180,7 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
 		$filtered_content = Jetpack_Photon::filter_the_content( $sample_html );
 		$attributes       = wp_kses_hair( $filtered_content, wp_allowed_protocols() );
-		$this->assertStringEndsWith( $photon_src, html_entity_decode( $attributes['src']['value'] ) );
+		$this->assertStringEndsWith( $photon_src, html_entity_decode( $attributes['src']['value'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ) );
 		$this->assertArrayHasKey( 'width', $attributes );
 		$this->assertArrayHasKey( 'height', $attributes );
 		$this->assertStringNotContainsString( 'data-recalc-dims', $filtered_content );

--- a/projects/plugins/super-cache/changelog/fix-phpcompatibility-new-8.1-things
+++ b/projects/plugins/super-cache/changelog/fix-phpcompatibility-new-8.1-things
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Update for PHP 8.1 compat. No behaviorial changes.
+
+

--- a/projects/plugins/super-cache/wp-cache-base.php
+++ b/projects/plugins/super-cache/wp-cache-base.php
@@ -4,7 +4,8 @@ global $WPSC_HTTP_HOST, $cache_enabled, $cache_path, $blogcacheid, $blog_cache_d
 // we need to backup HTTP_HOST early in the PHP process, and if running in command line set it to something useful.
 if ( ! empty( $_SERVER['HTTP_HOST'] ) ) {
 	$WPSC_HTTP_HOST = function_exists( 'mb_strtolower' ) ? mb_strtolower( $_SERVER['HTTP_HOST'] ) : strtolower( $_SERVER['HTTP_HOST'] );
-	$WPSC_HTTP_HOST = htmlentities( $WPSC_HTTP_HOST );
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$WPSC_HTTP_HOST = htmlentities( $WPSC_HTTP_HOST, ENT_COMPAT );
 } elseif ( PHP_SAPI === 'cli' && function_exists( 'get_option' ) ) {
 	$WPSC_HTTP_HOST = (string) parse_url( get_option( 'home' ), PHP_URL_HOST );
 } else {

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -3086,7 +3086,7 @@ function wp_cache_post_edit( $post_id ) {
 
 	if ( $post_id == $last_post_edited ) {
 		$action = current_filter();
-		wp_cache_debug( "wp_cache_post_edit(${action}): Already processed post $post_id.", 4 );
+		wp_cache_debug( "wp_cache_post_edit({$action}): Already processed post $post_id.", 4 );
 		return $post_id;
 	}
 
@@ -3110,7 +3110,7 @@ function wp_cache_post_edit( $post_id ) {
 		prune_super_cache( get_supercache_dir(), true );
 	} else {
 		$action = current_filter();
-		wp_cache_debug( "wp_cache_post_edit: Clearing cache for post $post_id on ${action}", 2 );
+		wp_cache_debug( "wp_cache_post_edit: Clearing cache for post $post_id on {$action}", 2 );
 		wp_cache_post_change( $post_id );
 		wpsc_delete_post_archives( $post_id ); // delete related archive pages.
 	}
@@ -3152,7 +3152,7 @@ function wp_cache_post_change( $post_id ) {
 
 	if ( $post_id == $last_processed ) {
 		$action = current_filter();
-		wp_cache_debug( "wp_cache_post_change(${action}): Already processed post $post_id.", 4 );
+		wp_cache_debug( "wp_cache_post_change({$action}): Already processed post $post_id.", 4 );
 		return $post_id;
 	}
 

--- a/tools/check-changelogger-use.php
+++ b/tools/check-changelogger-use.php
@@ -98,9 +98,9 @@ if ( $verbose ) {
 	 */
 	function debug( ...$args ) {
 		if ( getenv( 'CI' ) ) {
-			$args[0] = "\e[34m${args[0]}\e[0m\n";
+			$args[0] = "\e[34m{$args[0]}\e[0m\n";
 		} else {
-			$args[0] = "\e[1;30m${args[0]}\e[0m\n";
+			$args[0] = "\e[1;30m{$args[0]}\e[0m\n";
 		}
 		fprintf( STDERR, ...$args );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Changes here:

* PHP 8.1 is removing `${var}`, so switch everything to the equivalent `{$var}`.
* Defaults for the flags for various HTML entity functions are changing from `ENT_COMPAT` to `ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401`.
  * For `html_entity_decode` and `htmlspecialchars_decode`, I went with the latter. Probably we intended to decode everything rather than ignoring `&#39;` and the like.
  * For `htmlspecialchars` and `htmlentities`, I went with `ENT_COMPAT` on the guess that if apostrophes were going to be a problem someone would already have done something about it (and in context none looked like they had been missed).

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1670254755932589-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is the PHP Compatibility / dev branch for PHP 8.0 check passing now?