### PR TITLE
Stats: Add limited compatible list posts endpoint

### DIFF
--- a/projects/packages/stats-admin/changelog/add-added-limited-compatible-list-posts-endpoint
+++ b/projects/packages/stats-admin/changelog/add-added-limited-compatible-list-posts-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: Added `posts` endpoints with limited compatibility

--- a/projects/packages/stats-admin/composer.json
+++ b/projects/packages/stats-admin/composer.json
@@ -46,7 +46,7 @@
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-stats-admin",
 		"branch-alias": {
-			"dev-trunk": "0.1.x-dev"
+			"dev-trunk": "0.2.x-dev"
 		},
 		"textdomain": "jetpack-stats-admin",
 		"version-constants": {

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.1.1-alpha",
+	"version": "0.2.0-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -18,7 +18,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.1.1-alpha';
+	const VERSION = '0.2.0-alpha';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -298,7 +298,7 @@ class REST_Controller {
 						'comment_count' => $post->comment_count,
 						'comments_open' => $post->comment_status,
 					),
-					'like_count'    => $is_jetpack_likes_enabled ? 0 : $this->get_single_post_like_count_by_post_id( $post_id ),
+					'like_count'    => ! $is_jetpack_likes_enabled ? 0 : $this->get_single_post_like_count_by_post_id( $post_id ),
 					'likes_enabled' => $is_jetpack_likes_enabled,
 				);
 			}
@@ -358,6 +358,7 @@ class REST_Controller {
 		if ( is_wp_error( $likes_response ) ) {
 			return 0;
 		}
+
 		return isset( $likes_response['found'] ) ? $likes_response['found'] : 0;
 	}
 

--- a/projects/plugins/jetpack/changelog/add-added-limited-compatible-list-posts-endpoint
+++ b/projects/plugins/jetpack/changelog/add-added-limited-compatible-list-posts-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1933,7 +1933,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "cd68679775ac75711ed13dc4718a3012e980cb39"
+                "reference": "4cd8e038dee77f90302cf854a0c3f6974a7980b6"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1949,7 +1949,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-stats-admin",
                 "branch-alias": {
-                    "dev-trunk": "0.1.x-dev"
+                    "dev-trunk": "0.2.x-dev"
                 },
                 "textdomain": "jetpack-stats-admin",
                 "version-constants": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The PR proposes to add an enpoint compatible with `sites/$siteId/posts`, which is used used for Insights page in Stats.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

