### PR TITLE
Revert: add launch-status to synced options

### DIFF
--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -103,7 +103,6 @@ class Defaults {
 		'jetpack_blogging_prompts_enabled',
 		'large_size_h',
 		'large_size_w',
-		'launch-status',
 		'mailserver_login', // Not syncing contents, only the option name.
 		'mailserver_pass', // Not syncing contents, only the option name.
 		'mailserver_port',

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -227,7 +227,6 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'videopress_private_enabled_for_site'          => false,
 			'featured_image_email_enabled'                 => false,
 			'wpcom_gifting_subscription'                   => true,
-			'launch-status'                                => 'unlaunched',
 			'jetpack_blogging_prompts_enabled'             => jetpack_has_write_intent() || jetpack_has_posts_page(),
 		);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Revert the sync for the option `launch-status` on atomic sites because finally is not needed. 

#### Other information:
- [X] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use? No
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Related https://github.com/Automattic/jetpack/pull/27434
