### PR TITLE
E2E Tests: Retry connection provisioning on failure

### DIFF
--- a/tools/e2e-commons/env/prerequisites.js
+++ b/tools/e2e-commons/env/prerequisites.js
@@ -117,8 +117,16 @@ async function connect() {
 	const creds = getDotComCredentials();
 	await execWpCommand( `user update wordpress --user_email=${ creds.email }` );
 
-	provisionJetpackStartConnection( creds.userId, 'free' );
-
+	try {
+		provisionJetpackStartConnection( creds.userId, 'free' );
+	} catch ( error ) {
+		// Let's try to re-try the provisioning if it fails the first time.
+		if ( error.message.startsWith( 'Jetpack Start provision is failed' ) ) {
+			provisionJetpackStartConnection( creds.userId, 'free' );
+		} else {
+			throw error;
+		}
+	}
 	assert.ok( await isBlogTokenSet() );
 
 	// We are connected. Let's save the existing connection options just in case.


### PR DESCRIPTION
Sometimes connection provisioning API (via `partner-provision.sh` script) fails with errors such as: `{"error":-10520,"message":"Jetpack: [invalid_signature] The required &quot;url&quot; parameter is malformed."}` 

Let's retry the provisioning on API failure

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Not much to test here.
*

