### PR TITLE
Deprecate few fonts

### DIFF
--- a/projects/plugins/jetpack/changelog/update-fonts-deprecated
+++ b/projects/plugins/jetpack/changelog/update-fonts-deprecated
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Fonts: deprecate 5 fonts.

--- a/projects/plugins/jetpack/modules/google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts.php
@@ -25,7 +25,6 @@ const JETPACK_GOOGLE_FONTS_LIST = array(
 	'Chivo',
 	'Courier Prime',
 	'DM Sans',
-	'Domine',
 	'EB Garamond',
 	'Fira Sans',
 	'IBM Plex Sans',
@@ -38,14 +37,10 @@ const JETPACK_GOOGLE_FONTS_LIST = array(
 	'Literata',
 	'Lora',
 	'Merriweather',
-	'Montserrat',
 	'Newsreader',
 	'Nunito',
-	'Open Sans',
 	'Overpass',
 	'Playfair Display',
-	'Poppins',
-	'Raleway',
 	'Roboto',
 	'Roboto Slab',
 	'Rubik',
@@ -54,6 +49,16 @@ const JETPACK_GOOGLE_FONTS_LIST = array(
 	'Space Mono',
 	'Texturina',
 	'Work Sans',
+);
+
+// Deprecated fonts that were available before, and we don't show to customers anymore.
+// They should keep functioning for existing sites and be available for enqueueing when used.
+const JETPACK_GOOGLE_FONTS_DEPRECATED = array(
+	'Domine',
+	'Montserrat',
+	'Open Sans',
+	'Poppins',
+	'Raleway',
 );
 
 /**
@@ -68,6 +73,8 @@ function jetpack_add_google_fonts_provider() {
 
 	wp_register_webfont_provider( 'jetpack-google-fonts', '\Automattic\Jetpack\Fonts\Google_Fonts_Provider' );
 
+	$fonts = array_merge( JETPACK_GOOGLE_FONTS_LIST, JETPACK_GOOGLE_FONTS_DEPRECATED );
+
 	/**
 	 * Curated list of Google Fonts.
 	 *
@@ -77,20 +84,22 @@ function jetpack_add_google_fonts_provider() {
 	 *
 	 * @param array $fonts_to_register Array of Google Font names to register.
 	 */
-	$fonts_to_register = apply_filters( 'jetpack_google_fonts_list', JETPACK_GOOGLE_FONTS_LIST );
+	$fonts_to_register = apply_filters( 'jetpack_google_fonts_list', $fonts );
 
 	foreach ( $fonts_to_register as $font_family ) {
+		$font_family_label = in_array( $font_family, JETPACK_GOOGLE_FONTS_DEPRECATED ) ? $font_family : $font_family . ' (deprecated)';
+
 		wp_register_webfonts(
 			array(
 				array(
-					'font-family'  => $font_family,
+					'font-family'  => $font_family_label,
 					'font-weight'  => '100 900',
 					'font-style'   => 'normal',
 					'font-display' => 'fallback',
 					'provider'     => 'jetpack-google-fonts',
 				),
 				array(
-					'font-family'  => $font_family,
+					'font-family'  => $font_family_label,
 					'font-weight'  => '100 900',
 					'font-style'   => 'italic',
 					'font-display' => 'fallback',

--- a/projects/plugins/jetpack/modules/google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts.php
@@ -53,6 +53,7 @@ const JETPACK_GOOGLE_FONTS_LIST = array(
 
 // Deprecated fonts that were available before, and we don't show to customers anymore.
 // They should keep functioning for existing sites and be available for enqueueing when used.
+// See p9Jlb4-5Dj-p2#comment-6411
 const JETPACK_GOOGLE_FONTS_DEPRECATED = array(
 	'Domine',
 	'Montserrat',
@@ -87,7 +88,7 @@ function jetpack_add_google_fonts_provider() {
 	$fonts_to_register = apply_filters( 'jetpack_google_fonts_list', $fonts );
 
 	foreach ( $fonts_to_register as $font_family ) {
-		$font_family_label = in_array( $font_family, JETPACK_GOOGLE_FONTS_DEPRECATED ) ? $font_family : $font_family . ' (deprecated)';
+		$font_family_label = in_array( $font_family, JETPACK_GOOGLE_FONTS_DEPRECATED ) ? $font_family . ' (deprecated)' : $font_family;
 
 		wp_register_webfonts(
 			array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

See p9Jlb4-5Dj-p2 for design discussion.

Related to https://github.com/Automattic/jetpack/pull/27441

<img width="500" src="https://user-images.githubusercontent.com/87168/205944784-a55412dc-a7bf-4bfd-b09c-84a1a1157302.png" />


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes fonts:
    * Domine
    * Montserrat
    * Raleway
    * Open Sans
    * Poppins
* The fonts are still registered and functional if already used, but won't appear at Global styles font dropdown going forward.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

