### PR TITLE
Writing prompts: adds a filter for whether prompts are enabled

### DIFF
--- a/projects/plugins/jetpack/_inc/blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/blogging-prompts.php
@@ -57,7 +57,16 @@ add_action( 'wp_insert_post', 'jetpack_setup_blogging_prompt_response' );
  * @return boolean
  */
 function jetpack_are_blogging_prompts_enabled() {
-	return (bool) get_option( 'jetpack_blogging_prompts_enabled', jetpack_has_write_intent() || jetpack_has_posts_page() );
+	$prompts_enabled = (bool) get_option( 'jetpack_blogging_prompts_enabled', jetpack_has_write_intent() || jetpack_has_posts_page() );
+
+	/**
+	 * Filters whether blogging prompts are enabled.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param bool $prompts_enabled Whether blogging prompts are enabled.
+	 */
+	return apply_filters( 'jetpack_are_blogging_prompts_enabled', $prompts_enabled );
 }
 
 /**

--- a/projects/plugins/jetpack/changelog/add-blogging-prompts-enabled-filter
+++ b/projects/plugins/jetpack/changelog/add-blogging-prompts-enabled-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Writing prompts: add filter for whether prompts are enabled or not

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompts/settings.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompts/settings.php
@@ -29,6 +29,12 @@ function enabled_field_callback() {
  * @return void
  */
 function init() {
+	// If editor extensions are not loaded, don't show the settings.
+	if ( ! \Jetpack_Gutenberg::should_load() ) {
+		return;
+	}
+
+	// Blogging prompts is an expermental extension: if expermental blocks are not enabled, don't show the settings.
 	if ( ! Constants::is_true( 'JETPACK_EXPERIMENTAL_BLOCKS' ) && ! Constants::is_true( 'JETPACK_BETA_BLOCKS' ) ) {
 		return;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Adds a filter for whether writing prompts appear as a placeholder in the editor when starting a new post.

This allows blanket disabling the prompts, such as P2 sites on WordPress.com

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

See previous PRs (e.g. https://github.com/Automattic/jetpack/pull/26680 and https://github.com/Automattic/jetpack/pull/27746)

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

- Set up your site to display blogging prompts, by setting posts to show in the front page, or enabling the setting from Settings > Writing
- Verify you can see the placeholder prompts when starting a new post
- Add the following code (such as an mu-plugin) to disable the prompts and setting
- Verify the placeholder prompt and setting no longer show

```
add_filter( 'jetpack_are_blogging_prompts_enabled', '__return_false' );

add_action( 'admin_init', function() {
	remove_action( 'admin_init', 'Automattic\Jetpack\Extensions\BloggingPrompts\Settings\init' );
}, 0 );

