### PR TITLE
Writing prompts: modify filter and differentiate from setting

### DIFF
--- a/projects/plugins/jetpack/_inc/blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/blogging-prompts.php
@@ -57,16 +57,7 @@ add_action( 'wp_insert_post', 'jetpack_setup_blogging_prompt_response' );
  * @return boolean
  */
 function jetpack_are_blogging_prompts_enabled() {
-	$prompts_enabled = (bool) get_option( 'jetpack_blogging_prompts_enabled', jetpack_has_write_intent() || jetpack_has_posts_page() );
-
-	/**
-	 * Filters whether blogging prompts are enabled.
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @param bool $prompts_enabled Whether blogging prompts are enabled.
-	 */
-	return apply_filters( 'jetpack_are_blogging_prompts_enabled', $prompts_enabled );
+	return (bool) get_option( 'jetpack_blogging_prompts_enabled', jetpack_has_write_intent() || jetpack_has_posts_page() );
 }
 
 /**

--- a/projects/plugins/jetpack/changelog/add-blogging-prompts-enabled-filter
+++ b/projects/plugins/jetpack/changelog/add-blogging-prompts-enabled-filter
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Writing prompts: add filter for whether prompts are hidden or not
+Writing prompts: add filter for whether prompts and setting are hidden or not

--- a/projects/plugins/jetpack/changelog/add-blogging-prompts-enabled-filter
+++ b/projects/plugins/jetpack/changelog/add-blogging-prompts-enabled-filter
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Writing prompts: add filter for whether prompts are enabled or not
+Writing prompts: add filter for whether prompts are hidden or not

--- a/projects/plugins/jetpack/changelog/update-blogging-prompts-enabled-filter
+++ b/projects/plugins/jetpack/changelog/update-blogging-prompts-enabled-filter
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Handled by previous changelog entry
+
+

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompts/settings.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompts/settings.php
@@ -9,8 +9,6 @@
 
 namespace Automattic\Jetpack\Extensions\BloggingPrompts\Settings;
 
-use Automattic\Jetpack\Constants;
-
 /**
  * Renders the settings field for enabling/disabling blogging prompts in the editor.
  *
@@ -29,16 +27,6 @@ function enabled_field_callback() {
  * @return void
  */
 function init() {
-	// If editor extensions are not loaded, don't show the settings.
-	if ( ! \Jetpack_Gutenberg::should_load() ) {
-		return;
-	}
-
-	// Blogging prompts is an expermental extension: if expermental blocks are not enabled, don't show the settings.
-	if ( ! Constants::is_true( 'JETPACK_EXPERIMENTAL_BLOCKS' ) && ! Constants::is_true( 'JETPACK_BETA_BLOCKS' ) ) {
-		return;
-	}
-
 	register_setting(
 		'writing',
 		'jetpack_blogging_prompts_enabled',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Modifies the filter added in #27778 to differentiate it from the `jetpack_are_blogging_prompts_enabled` setting.

With this change, the writing prompt loading logic now looks like this
- If the `jetpack_blogging_prompts_hidden` filter is true
  - The wp-admin settings and placeholder prompt are not loaded.
- If the filter is false (the default)
  - The`jetpack_are_blogging_prompts_enabled` setting field loads in wp-admin
  - If the setting is true, show the placeholder prompt in the editor
  - If the setting is false, no placeholder prompt is shown in the editor
- If the `answer_prompt` query param is set when loading the editor, it bypasses the filter and setting, allowing answering a prompt from an external link (email, notifications, etc)

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

See previous PRs (e.g. #26680, #27746, and #27778)

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

- Set up your site to display blogging prompts, by setting posts to show in the front page, or enabling the setting from Settings > Writing
- Verify you can see the placeholder prompts when starting a new post
- Add the following code (such as an mu-plugin) to disable the prompts and setting
- Verify the placeholder prompt and setting no longer show

```
add_filter( 'jetpack_blogging_prompts_hidden', '__return_true' );
```

