### PR TITLE
Jetpack: Remove require of missing file in tests/php/bootstrap.php

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-remove-require-of-missing-file
+++ b/projects/plugins/jetpack/changelog/fix-remove-require-of-missing-file
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Just removing a require of a removed file, which oddly doesn't break tests.
+
+

--- a/projects/plugins/jetpack/tests/php/bootstrap.php
+++ b/projects/plugins/jetpack/tests/php/bootstrap.php
@@ -151,7 +151,6 @@ require __DIR__ . '/attachment_test_case.php';
 
 // Load WPCOM-shared helper functions.
 require __DIR__ . '/lib/class-wpcom-features.php';
-require __DIR__ . '/lib/wpcom-helper-functions.php';
 
 // Load the Tweetstorm Requests override class.
 require __DIR__ . '/_inc/lib/class-tweetstorm-requests-transport-override.php';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
PR #27407 missed removing a require of wpcom-helper-functions.php from tests/php/bootstrap.php. Remove it.

It's odd that this didn't make tests fail. It turns out that's [a bug in the Patchwork library](https://github.com/antecedent/patchwork/pull/136), it prints a warning but then treats it as an empty file.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check that the test run no longer outputs
   > PHP Warning:  file_get_contents(/tmp/wordpress-latest/src/wp-content/plugins/jetpack/tests/php/lib/wpcom-helper-functions.php): Failed to open stream: No such file or directory in /tmp/wordpress-latest/src/wp-content/plugins/jetpack/vendor/antecedent/patchwork/src/CodeManipulation.php on line 122

   (like it did in [this past test run](https://github.com/Automattic/jetpack/actions/runs/3630390268/jobs/6124240089#step:9:5420))
