### PR TITLE
VideoPress: Add "Show video sharing menu" control to VideoPress block

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-display-embed-block-option
+++ b/projects/packages/videopress/changelog/add-videopress-display-embed-block-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Add "Show video sharing menu" control to VideoPress block

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -289,6 +289,7 @@ class Data {
 				$caption              = $jetpack_videopress['caption'];
 				$rating               = $jetpack_videopress['rating'];
 				$allow_download       = $jetpack_videopress['allow_download'];
+				$display_embed        = $jetpack_videopress['display_embed'];
 				$privacy_setting      = $jetpack_videopress['privacy_setting'];
 				$needs_playback_token = $jetpack_videopress['needs_playback_token'];
 
@@ -319,6 +320,7 @@ class Data {
 					'isPrivate'          => $is_private,
 					'posterImage'        => $poster,
 					'allowDownload'      => $allow_download,
+					'displayEmbed'       => $display_embed,
 					'rating'             => $rating,
 					'privacySetting'     => $privacy_setting,
 					'needsPlaybackToken' => $needs_playback_token,

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
@@ -236,6 +236,8 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Data {
 			'rating'               => $info->rating,
 			'allow_download'       =>
 				isset( $info->allow_download ) && $info->allow_download ? 1 : 0,
+			'display_embed'        =>
+				isset( $info->display_embed ) && $info->display_embed ? 1 : 0,
 			'privacy_setting'      => $video_privacy_setting,
 			'needs_playback_token' => $video_needs_playback_token,
 		);

--- a/projects/packages/videopress/src/client/admin/types/index.ts
+++ b/projects/packages/videopress/src/client/admin/types/index.ts
@@ -99,9 +99,13 @@ export type OriginalVideoPressVideo = {
 		 */
 		rating?: 'G' | 'PG-13' | 'R-17';
 		/**
-		 * Whether is possible to download the video, or not.
+		 * Whether it is possible to download the video or not.
 		 */
 		allow_download?: boolean;
+		/**
+		 * Whether the video sharing menu is enabled or not.
+		 */
+		display_embed?: boolean;
 		/**
 		 * Video privacy setting:
 		 * - 0 `public`: anyone can view the video
@@ -144,6 +148,7 @@ export type VideoPressVideo = {
 	isPrivate?: OriginalVideoPressVideo[ 'media_details' ][ 'videopress' ][ 'is_private' ];
 	posterImage?: OriginalVideoPressVideo[ 'media_details' ][ 'videopress' ][ 'poster' ];
 	allowDownload?: OriginalVideoPressVideo[ 'jetpack_videopress' ][ 'allow_download' ];
+	displayEmbed?: OriginalVideoPressVideo[ 'jetpack_videopress' ][ 'display_embed' ];
 	rating?: OriginalVideoPressVideo[ 'jetpack_videopress' ][ 'rating' ];
 	privacySetting?: OriginalVideoPressVideo[ 'jetpack_videopress' ][ 'privacy_setting' ];
 	needsPlaybackToken?: OriginalVideoPressVideo[ 'jetpack_videopress' ][ 'needs_playback_token' ];

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
@@ -103,6 +103,10 @@
 			"type": "boolean",
 			"default": true
 		},
+		"displayEmbed": {
+			"type": "boolean",
+			"default": true
+		},
 		"rating": {
 			"type": "string"
 		},

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/privacy-and-rating-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/privacy-and-rating-panel/index.tsx
@@ -25,7 +25,7 @@ import type React from 'react';
  * @returns {React.ReactElement}    Component template
  */
 export default function PrivacyAndRatingPanel( { attributes, setAttributes }: VideoControlProps ) {
-	const { privacySetting, rating, allowDownload } = attributes;
+	const { privacySetting, rating, allowDownload, displayEmbed } = attributes;
 
 	return (
 		<PanelBody title={ __( 'Privacy and rating', 'jetpack-videopress-pkg' ) } initialOpen={ false }>
@@ -87,6 +87,18 @@ export default function PrivacyAndRatingPanel( { attributes, setAttributes }: Vi
 				onChange={ value => {
 					setAttributes( { allowDownload: value } );
 				} }
+			/>
+
+			<ToggleControl
+				label={ __( 'Show video sharing menu', 'jetpack-videopress-pkg' ) }
+				checked={ displayEmbed }
+				onChange={ value => {
+					setAttributes( { displayEmbed: value } );
+				} }
+				help={ __(
+					'Gives viewers the option to share the video link and HTML embed code',
+					'jetpack-videopress-pkg'
+				) }
 			/>
 		</PanelBody>
 	);

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
@@ -46,6 +46,7 @@ export type VideoBlockAttributes = VideoBlockColorAttributesProps & {
 	// Privacy and Rating types
 	privacySetting?: number;
 	allowDownload?: boolean;
+	displayEmbed?: boolean;
 	rating?: string;
 
 	isPrivate?: boolean;

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
@@ -69,6 +69,7 @@ const videoFieldsToUpdate = [
 	'privacy_setting',
 	'rating',
 	'allow_download',
+	'display_embed',
 	'is_private',
 ];
 
@@ -79,6 +80,7 @@ const videoFieldsToUpdate = [
 const mapFieldsToAttributes = {
 	privacy_setting: 'privacySetting',
 	allow_download: 'allowDownload',
+	display_embed: 'displayEmbed',
 	is_private: 'isPrivate',
 };
 

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/index.ts
@@ -49,6 +49,7 @@ export default function useVideoData( {
 					title: response.title,
 					description: response.description,
 					allow_download: response.allow_download,
+					display_embed: response.display_embed,
 					privacy_setting: response.privacy_setting,
 					rating: response.rating,
 					filename,

--- a/projects/packages/videopress/src/client/state/utils/map-videos.ts
+++ b/projects/packages/videopress/src/client/state/utils/map-videos.ts
@@ -22,6 +22,7 @@ export const mapVideoFromWPV2MediaEndpoint = (
 		caption,
 		rating,
 		allow_download: allowDownload,
+		display_embed: displayEmbed,
 		privacy_setting: privacySetting,
 		needs_playback_token: needsPlaybackToken,
 	} = jetpackVideoPress;
@@ -61,6 +62,7 @@ export const mapVideoFromWPV2MediaEndpoint = (
 		isPrivate,
 		posterImage: poster,
 		allowDownload,
+		displayEmbed,
 		rating,
 		privacySetting,
 		needsPlaybackToken,

--- a/projects/packages/videopress/src/client/types.ts
+++ b/projects/packages/videopress/src/client/types.ts
@@ -61,6 +61,7 @@ export type WPV2mediaGetEndpointResponseProps = {
 		description: string;
 		caption: string;
 		allow_download: 0 | 1;
+		display_embed: 0 | 1;
 		needs_playback_token: boolean;
 		privacy_setting: PrivacySettingProp;
 		rating: string;

--- a/projects/packages/videopress/src/utility-functions.php
+++ b/projects/packages/videopress/src/utility-functions.php
@@ -505,6 +505,7 @@ function video_get_info_by_blogpostid( $blog_id, $post_id ) {
 		$videopress_meta             = $meta['videopress'];
 		$video_info->rating          = isset( $videopress_meta['rating'] ) ? $videopress_meta['rating'] : null;
 		$video_info->allow_download  = isset( $videopress_meta['allow_download'] ) ? $videopress_meta['allow_download'] : 0;
+		$video_info->display_embed   = isset( $videopress_meta['display_embed'] ) ? $videopress_meta['display_embed'] : 0;
 		$video_info->privacy_setting = ! isset( $videopress_meta['privacy_setting'] ) ? VIDEOPRESS_PRIVACY::SITE_DEFAULT : $videopress_meta['privacy_setting'];
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27780

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds the `display_embed` control to the VideoPress block under `Privacy and rating` panel

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1670354783997969/1670354139.628999-slack-C03TA48NSUX

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With VideoPress installed, go to the block editor and create/select a VideoPress block
* In the `Privacy and rating`  panel, change the value of `Show video sharing menu`
* Check that, when off, the video sharing menu is not shown if downloads are disabled, or only show the download button if downloads are enabled
* Check that, when turned on, the video sharing menu is shown normally

![2022-12-06_17-44-18](https://user-images.githubusercontent.com/8486249/206019198-c85347da-167b-43d0-ba14-83f7240e6427.png)
![2022-12-06_17-44-55](https://user-images.githubusercontent.com/8486249/206019194-6f2816c6-64ff-443f-94ed-332a07c3338e.png)
