### PR TITLE
Stats: enable ads page for Odyssey

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-ads-page
+++ b/projects/packages/stats-admin/changelog/fix-ads-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: enable Ads page

--- a/projects/packages/stats-admin/composer.json
+++ b/projects/packages/stats-admin/composer.json
@@ -49,7 +49,7 @@
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-stats-admin",
 		"branch-alias": {
-			"dev-trunk": "0.3.x-dev"
+			"dev-trunk": "0.4.x-dev"
 		},
 		"textdomain": "jetpack-stats-admin",
 		"version-constants": {

--- a/projects/packages/stats-admin/composer.json
+++ b/projects/packages/stats-admin/composer.json
@@ -6,7 +6,8 @@
 	"require": {
 		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-options": "@dev",
-		"automattic/jetpack-stats": "@dev"
+		"automattic/jetpack-stats": "@dev",
+		"automattic/jetpack-status": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.0.4",

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.3.1",
+	"version": "0.4.0-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -230,7 +230,7 @@ class Dashboard {
 						'username' => 'no-user',
 					),
 					'capabilities' => array(
-						"$blog_id" => self::get_current_user_capatibilites(),
+						"$blog_id" => self::get_current_user_capabilities(),
 					),
 				),
 				'sites'       => array(
@@ -309,7 +309,7 @@ class Dashboard {
 	 *
 	 * @return array An array of capabilities.
 	 */
-	protected function get_current_user_capatibilites() {
+	protected function get_current_user_capabilities() {
 		// Feature lock.
 		if ( ! isset( $_GET['flags'] ) || $_GET['flags'] !== 'stats/ads-page' ) {// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return array();

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -314,7 +314,6 @@ class Dashboard {
 		if ( ! isset( $_GET['flags'] ) || $_GET['flags'] !== 'stats/ads-page' ) {// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return array();
 		}
-		// TODO: `1.0.0` is just a placeholder. Add required API and then replace with the actual version.
 		if ( version_compare( Main::VERSION, '0.4.0-alpha', '<' ) ) {
 			return array();
 		}

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -314,9 +314,6 @@ class Dashboard {
 		if ( ! isset( $_GET['flags'] ) || $_GET['flags'] !== 'stats/ads-page' ) {// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return array();
 		}
-		if ( version_compare( Main::VERSION, '0.4.0-alpha', '<' ) ) {
-			return array();
-		}
 		$user = wp_get_current_user();
 		if ( ! $user || is_wp_error( $user ) ) {
 			return array();

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Stats_Admin;
 
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Modules;
 use Jetpack_Options;
 
 /**
@@ -229,10 +230,7 @@ class Dashboard {
 						'username' => 'no-user',
 					),
 					'capabilities' => array(
-						"$blog_id" => array(
-							'manage_options'   => true,
-							'activate_wordads' => true,
-						),
+						"$blog_id" => self::get_current_user_capatibilites(),
 					),
 				),
 				'sites'       => array(
@@ -243,17 +241,15 @@ class Dashboard {
 							'jetpack'      => true,
 							'visible'      => true,
 							'capabilities' => $empty_object,
-							'options'      => array(
-								'admin_url' => admin_url(),
-							),
 							'products'     => array(),
 							'plan'         => $empty_object, // we need this empty object, otherwise the front end would crash on insight page.
 							'options'      => array(
-								'wordads' => true,
+								'wordads'   => ( new Modules() )->is_active( 'wordads' ),
+								'admin_url' => admin_url(),
 							),
 						),
 					),
-					'features' => array( "$blog_id" => array( 'data' => array( 'active' => array( 'wordads' ) ) ) ),
+					'features' => array( "$blog_id" => array( 'data' => self::get_plan_features() ) ),
 				),
 			),
 		);
@@ -292,6 +288,37 @@ class Dashboard {
 			$locale = preg_replace( '/(_.*)$/i', '', $locale );
 		}
 		return $locale;
+	}
+
+	/**
+	 * Get the features of the current plan.
+	 */
+	protected function get_plan_features() {
+		if ( ! class_exists( 'Jetpack_Plan' ) ) {
+			return array();
+		}
+		$plan = \Jetpack_Plan::get();
+		if ( empty( $plan['features'] ) ) {
+			return array();
+		}
+		return $plan['features'];
+	}
+
+	/**
+	 * Get the capabilities of the current user.
+	 *
+	 * @return array An array of capabilities.
+	 */
+	protected function get_current_user_capatibilites() {
+		// TODO: `1.0.0` is just a placeholder. Add required API and then replace with the actual version.
+		if ( version_compare( Main::VERSION, '1.0.0', '<=' ) ) {
+			return array();
+		}
+		$user = wp_get_current_user();
+		if ( ! $user || is_wp_error( $user ) ) {
+			return array();
+		}
+		return $user->allcaps;
 	}
 
 }

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -315,7 +315,7 @@ class Dashboard {
 			return array();
 		}
 		// TODO: `1.0.0` is just a placeholder. Add required API and then replace with the actual version.
-		if ( version_compare( Main::VERSION, '1.0.0', '<=' ) ) {
+		if ( version_compare( Main::VERSION, '0.4.0-alpha', '<' ) ) {
 			return array();
 		}
 		$user = wp_get_current_user();

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -311,7 +311,7 @@ class Dashboard {
 	 */
 	protected function get_current_user_capatibilites() {
 		// Feature lock.
-		if ( ! isset( $_GET['flags'] ) || $_GET['flags'] !== 'stats/ads-page' ) {
+		if ( ! isset( $_GET['flags'] ) || $_GET['flags'] !== 'stats/ads-page' ) {// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return array();
 		}
 		// TODO: `1.0.0` is just a placeholder. Add required API and then replace with the actual version.

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -310,6 +310,10 @@ class Dashboard {
 	 * @return array An array of capabilities.
 	 */
 	protected function get_current_user_capatibilites() {
+		// Feature lock.
+		if ( ! isset( $_GET['flags'] ) || $_GET['flags'] !== 'stats/ads-page' ) {
+			return array();
+		}
 		// TODO: `1.0.0` is just a placeholder. Add required API and then replace with the actual version.
 		if ( version_compare( Main::VERSION, '1.0.0', '<=' ) ) {
 			return array();

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -223,14 +223,20 @@ class Dashboard {
 			'features'                       => array(),
 			'intial_state'                   => array(
 				'currentUser' => array(
-					'id'   => 1000,
-					'user' => array(
+					'id'           => 1000,
+					'user'         => array(
 						'ID'       => 1000,
 						'username' => 'no-user',
 					),
+					'capabilities' => array(
+						"$blog_id" => array(
+							'manage_options'   => true,
+							'activate_wordads' => true,
+						),
+					),
 				),
 				'sites'       => array(
-					'items' => array(
+					'items'    => array(
 						"$blog_id" => array(
 							'ID'           => $blog_id,
 							'URL'          => site_url(),
@@ -242,8 +248,12 @@ class Dashboard {
 							),
 							'products'     => array(),
 							'plan'         => $empty_object, // we need this empty object, otherwise the front end would crash on insight page.
+							'options'      => array(
+								'wordads' => true,
+							),
 						),
 					),
+					'features' => array( "$blog_id" => array( 'data' => array( 'active' => array( 'wordads' ) ) ) ),
 				),
 			),
 		);

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -18,7 +18,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.3.1';
+	const VERSION = '0.4.0-alpha';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -168,6 +168,7 @@ class REST_Controller {
 	 * Only administrators or users with capability `activate_wordads` can access the API.
 	 */
 	public function can_user_view_wordads_stats_callback() {
+		// phpcs:ignore WordPress.WP.Capabilities.Unknown
 		if ( current_user_can( 'manage_options' ) || current_user_can( 'activate_wordads' ) ) {
 			return true;
 		}

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -392,7 +392,7 @@ class REST_Controller {
 	}
 
 	/**
-	 * Get WordAds earning for the site.
+	 * Get detailed WordAds earnings information for the site.
 	 *
 	 * @param WP_REST_Request $req The request object.
 	 * @return array
@@ -407,9 +407,7 @@ class REST_Controller {
 				)
 			),
 			'v1.1',
-			array( 'timeout' => 5 ),
-			null,
-			'wpcom'
+			array( 'timeout' => 5 )
 		);
 	}
 
@@ -429,9 +427,7 @@ class REST_Controller {
 				)
 			),
 			'v1.1',
-			array( 'timeout' => 5 ),
-			null,
-			'wpcom'
+			array( 'timeout' => 5 )
 		);
 	}
 

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -58,7 +58,7 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_single_resource_stats' ),
-				'permission_callback' => array( $this, 'check_user_privileges_callback' ),
+				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
 			)
 		);
 
@@ -69,7 +69,7 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_stats_resource' ),
-				'permission_callback' => array( $this, 'check_user_privileges_callback' ),
+				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
 			)
 		);
 
@@ -80,7 +80,7 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_single_post' ),
-				'permission_callback' => array( $this, 'check_user_privileges_callback' ),
+				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
 			)
 		);
 
@@ -91,7 +91,7 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_single_post_likes' ),
-				'permission_callback' => array( $this, 'check_user_privileges_callback' ),
+				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
 			)
 		);
 
@@ -102,7 +102,7 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_site_stats' ),
-				'permission_callback' => array( $this, 'check_user_privileges_callback' ),
+				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
 			)
 		);
 
@@ -113,7 +113,7 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'site_has_never_published_post' ),
-				'permission_callback' => array( $this, 'check_user_privileges_callback' ),
+				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
 			)
 		);
 
@@ -124,7 +124,29 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_site_posts' ),
-				'permission_callback' => array( $this, 'check_user_privileges_callback' ),
+				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
+			)
+		);
+
+		// WordAds Earnings.
+		register_rest_route(
+			static::$namespace,
+			sprintf( '/sites/%d/wordads/earnings', Jetpack_Options::get_option( 'id' ) ),
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_wordads_earnings' ),
+				'permission_callback' => array( $this, 'can_user_view_wordads_stats_callback' ),
+			)
+		);
+
+		// WordAds Stats.
+		register_rest_route(
+			static::$namespace,
+			sprintf( '/sites/%d/wordads/stats', Jetpack_Options::get_option( 'id' ) ),
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_wordads_stats' ),
+				'permission_callback' => array( $this, 'can_user_view_wordads_stats_callback' ),
 			)
 		);
 	}
@@ -134,8 +156,19 @@ class REST_Controller {
 	 *
 	 * @return bool|WP_Error True if a blog token was used to sign the request, WP_Error otherwise.
 	 */
-	public function check_user_privileges_callback() {
+	public function can_user_view_general_stats_callback() {
 		if ( current_user_can( 'manage_options' ) || current_user_can( 'view_stats' ) ) {
+			return true;
+		}
+
+		return $this->get_forbidden_error();
+	}
+
+	/**
+	 * Only administrators or users with capability `activate_wordads` can access the API.
+	 */
+	public function can_user_view_wordads_stats_callback() {
+		if ( current_user_can( 'manage_options' ) || current_user_can( 'activate_wordads' ) ) {
 			return true;
 		}
 
@@ -352,6 +385,50 @@ class REST_Controller {
 				)
 			),
 			'v2',
+			array( 'timeout' => 5 ),
+			null,
+			'wpcom'
+		);
+	}
+
+	/**
+	 * Get WordAds earning for the site.
+	 *
+	 * @param WP_REST_Request $req The request object.
+	 * @return array
+	 */
+	public function get_wordads_earnings( $req ) {
+		return $this->request_as_blog_cached(
+			sprintf(
+				'/sites/%d/wordads/earnings',
+				Jetpack_Options::get_option( 'id' ),
+				http_build_query(
+					$req->get_params()
+				)
+			),
+			'v1.1',
+			array( 'timeout' => 5 ),
+			null,
+			'wpcom'
+		);
+	}
+
+	/**
+	 * Get WordAds stats for the site.
+	 *
+	 * @param WP_REST_Request $req The request object.
+	 * @return array
+	 */
+	public function get_wordads_stats( $req ) {
+		return $this->request_as_blog_cached(
+			sprintf(
+				'/sites/%d/wordads/stats',
+				Jetpack_Options::get_option( 'id' ),
+				http_build_query(
+					$req->get_params()
+				)
+			),
+			'v1.1',
 			array( 'timeout' => 5 ),
 			null,
 			'wpcom'

--- a/projects/plugins/jetpack/changelog/fix-ads-page
+++ b/projects/plugins/jetpack/changelog/fix-ads-page
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2071,12 +2071,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "219ee9c83263cb0dbdbc0ff6c2b6eeb3682bf30b"
+                "reference": "1e063258c2df95b38a9eaa4cad153e2ab9ac3792"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
                 "automattic/jetpack-options": "@dev",
-                "automattic/jetpack-stats": "@dev"
+                "automattic/jetpack-stats": "@dev",
+                "automattic/jetpack-status": "@dev"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -2088,7 +2089,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-stats-admin",
                 "branch-alias": {
-                    "dev-trunk": "0.3.x-dev"
+                    "dev-trunk": "0.4.x-dev"
                 },
                 "textdomain": "jetpack-stats-admin",
                 "version-constants": {


### PR DESCRIPTION
Fixes #28427

#### Changes proposed in this Pull Request:
- The PR enables `Ads` tab when WordAds is supported, turned on, and user has the compatibility to view.
- The PR add two forwarded endpoints under namespace `jetpack/v4/stats-app`
  - `/sites/%d/wordads/earnings`
  - `/sites/%d/wordads/stats`

It only enables Ads tab only when the backend supports it, so the newer version of Odyssey front end will be compatible with the older versions.

The Ads tab is now behind feature flag `flags=stats/ads-page` as GET params.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* ~~Apply `D98285-code` to your sandbox~~
* Sandbox your Jetpack site by adding `define( 'JETPACK__SANDBOX_DOMAIN', 'your-sandbox-domain' )`
* Enable WordAds - `/wp-admin/admin.php?page=jetpack#/traffic?term=wordads`
* Open `/wp-admin/admin.php?page=stats&flags=stats%2Fads-page`
* Ensure Ads page generally works (it is expected that some links are not working )

<img width="708" alt="image" src="https://user-images.githubusercontent.com/1425433/212799694-a13382bb-3490-4a24-b605-cbcdb04e0f06.png">


