### PR TITLE
Stats: enable Store page

### DIFF
--- a/projects/packages/stats-admin/changelog/2022-12-07-06-40-04-615114
+++ b/projects/packages/stats-admin/changelog/2022-12-07-06-40-04-615114
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: enable Store tab

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -248,6 +248,9 @@ class Dashboard {
 							'visible'      => true,
 							'capabilities' => $empty_object,
 							'products'     => array(),
+							'options'      => array(
+								'woocommerce_is_active' => true,
+							),
 							'plan'         => $empty_object, // we need this empty object, otherwise the front end would crash on insight page.
 						),
 					),


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request:
The PR enables Store tab for Stats if the site is a store.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
* TBC
*

