### PR TITLE
VideoPress: fix issue when setting the video block video from the media library

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-ensure-picking-proper-guid
+++ b/projects/packages/videopress/changelog/update-videopress-ensure-picking-proper-guid
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: fix issue when setting the video block video from the media library

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
@@ -184,15 +184,18 @@ const VideoPressUploader = ( {
 		media = media?.[ 0 ] ? media[ 0 ] : media;
 
 		const isFileUploading = media instanceof File;
-		// Handle upload by selecting a File
+		// - Handle upload by selecting a File
 		if ( isFileUploading ) {
 			startUpload( media );
 			return;
 		}
 
-		// Handle selection of Media Library VideoPress attachment
+		// - Handle selection of Media Library VideoPress attachment
 		if ( media.videopress_guid ) {
-			const videoGuid = media.videopress_guid[ 0 ];
+			const videoGuid = Array.isArray( media.videopress_guid )
+				? media.videopress_guid[ 0 ] // <- pick the first item when it's an array
+				: media.videopress_guid;
+
 			const videoUrl = `https://videopress.com/v/${ videoGuid }`;
 			onSelectURL( videoUrl, media?.id );
 			return;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes an issue when selecting the video of the video block from the media library. In short, depending on the site type, the media library provides different data shapes for the `videopress_video` attribute: an Array or a String.

Fixes https://github.com/Automattic/jetpack/issues/27798

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: fix issue when setting the video block video from the media library

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test in Jetpack and Simple sites

* Go to Block editor
* Create a new VideoPress video block
* Select the video from the library
* Confirm the block renders the video player

before | after
------|------
<img width="644" alt="image" src="https://user-images.githubusercontent.com/77539/206194471-d3c1c1da-7f19-4053-913e-85e8ece541b6.png"> | <img width="647" alt="image" src="https://user-images.githubusercontent.com/77539/206194545-6ae3b856-432c-4e1b-a5de-01f48a1a670e.png">

