### PR TITLE
autoloader: Use `Composer\ClassMapGenerator\ClassMapGenerator` with composer 2.4

### DIFF
--- a/projects/packages/autoloader/changelog/update-autoloader-use-Composer-ClassMapGenerator-ClassMapGenerator
+++ b/projects/packages/autoloader/changelog/update-autoloader-use-Composer-ClassMapGenerator-ClassMapGenerator
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use `Composer\ClassMapGenerator\ClassMapGenerator` when available (i.e. with composer 2.4).

--- a/projects/packages/autoloader/src/AutoloadGenerator.php
+++ b/projects/packages/autoloader/src/AutoloadGenerator.php
@@ -23,7 +23,6 @@
 
 namespace Automattic\Jetpack\Autoloader;
 
-use Composer\Autoload\ClassMapGenerator;
 use Composer\Composer;
 use Composer\Config;
 use Composer\Installer\InstallationManager;
@@ -302,7 +301,15 @@ class AutoloadGenerator {
 				$dir = $this->filesystem->normalizePath(
 					$this->filesystem->isAbsolutePath( $path ) ? $path : $basePath . '/' . $path
 				);
-				return ClassMapGenerator::createMap(
+
+				// Composer 2.4 changed the name of the class.
+				if ( class_exists( \Composer\ClassMapGenerator\ClassMapGenerator::class ) ) {
+					$generator = new \Composer\ClassMapGenerator\ClassMapGenerator();
+					$generator->scanPaths( $dir, $excludedClasses, 'classmap', empty( $namespace ) ? null : $namespace );
+					return $generator->getClassMap()->getMap();
+				}
+
+				return \Composer\Autoload\ClassMapGenerator::createMap(
 					$dir,
 					$excludedClasses,
 					null, // Don't pass the IOInterface since the normal autoload generation will have reported already.

--- a/projects/packages/autoloader/tests/php/lib/class-test-plugin-factory.php
+++ b/projects/packages/autoloader/tests/php/lib/class-test-plugin-factory.php
@@ -339,6 +339,11 @@ class Test_Plugin_Factory {
 		$composer_config = array(
 			'name'     => 'testing/' . $this->slug,
 			'autoload' => $this->autoloads,
+			'config'   => array(
+				'allow-plugins' => array(
+					'automattic/jetpack-autoloader' => true,
+				),
+			),
 		);
 		if ( $this->is_using_local_package() ) {
 			$composer_config['require']      = array( 'automattic/jetpack-autoloader' => 'dev-trunk' );
@@ -356,7 +361,7 @@ class Test_Plugin_Factory {
 		}
 
 		if ( isset( $this->composer_options ) ) {
-			$composer_config = array_merge( $composer_config, $this->composer_options );
+			$composer_config = array_replace_recursive( $composer_config, $this->composer_options );
 		}
 
 		return $composer_config;
@@ -374,6 +379,13 @@ class Test_Plugin_Factory {
 		// the developer has installed is compatible. To address these differences we will download a
 		// composer package that is compatible based on ranges of autoloader versions.
 		$composer_versions = array(
+			// Version 2.4.0 renamed a class, we want to test with that.
+			'2.4.4'   => array(
+				'min'     => '2.6.0',
+				'url'     => 'https://getcomposer.org/download/2.4.4/composer.phar',
+				'sha256'  => 'c252c2a2219956f88089ffc242b42c8cb9300a368fd3890d63940e4fc9652345',
+				'min_php' => 70205,
+			),
 			// Version 2.1.6 of Composer is the first to support PHP 8.1.
 			'2.1.6'   => array(
 				'min'     => '2.6.0',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Composer 2.4 deprecated `Composer\Autoload\ClassMapGenerator` in favor of `Composer\ClassMapGenerator\ClassMapGenerator`. Use the latter if it's available, falling back to the former.

Then also run tests with composer 2.4.4 when possible. Older versions are still being tested in conjunction with older PHP versions.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?
* Try it out, does it do the right thing?
