### PR TITLE
VideoPress: Route video pagination

### DIFF
--- a/projects/packages/videopress/changelog/add-route-video-pagination
+++ b/projects/packages/videopress/changelog/add-route-video-pagination
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+VideoPress: Handle URL pagination for video list/grid so every page has it's own URL.

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -31,6 +31,7 @@ import { fileInputExtensions } from '../../../utils/video-extensions';
 import useAnalyticsTracks from '../../hooks/use-analytics-tracks';
 import { usePermission } from '../../hooks/use-permission';
 import { usePlan } from '../../hooks/use-plan';
+import useQueryStringPages from '../../hooks/use-query-string-pages';
 import { useSearchParam } from '../../hooks/use-search-params';
 import useSelectVideoFiles from '../../hooks/use-select-video-files';
 import useVideos, { useLocalVideos } from '../../hooks/use-videos';
@@ -45,17 +46,32 @@ import styles from './styles.module.scss';
 
 const useDashboardVideos = () => {
 	const { uploadVideo, uploadVideoFromLibrary, setVideosQuery } = useDispatch( STORE_ID );
-	const { items, uploading, uploadedVideoCount, isFetching, search, page } = useVideos();
+	const {
+		items,
+		uploading,
+		uploadedVideoCount,
+		isFetching,
+		search,
+		page,
+		itemsPerPage,
+		total,
+	} = useVideos();
 	const { items: localVideos, uploadedLocalVideoCount } = useLocalVideos();
 	const { hasVideoPressPurchase } = usePlan();
 
 	/** Get the page number from the search parameters and set it to the state when the state is outdated */
 	const pageFromSearchParam = parseInt( useSearchParam( 'page', '1' ) );
+	const { forceFirstPage } = useQueryStringPages();
+	const totalOfPages = Math.ceil( total / itemsPerPage );
 	useEffect( () => {
-		if ( page !== pageFromSearchParam ) {
-			setVideosQuery( { page: pageFromSearchParam } );
+		if ( 1 <= pageFromSearchParam && pageFromSearchParam <= totalOfPages ) {
+			if ( page !== pageFromSearchParam ) {
+				setVideosQuery( { page: pageFromSearchParam } );
+			}
+		} else {
+			forceFirstPage();
 		}
-	} );
+	}, [ totalOfPages, pageFromSearchParam ] );
 
 	// Do not show uploading videos if not in the first page or searching
 	let videos = page > 1 || Boolean( search ) ? items : [ ...uploading, ...items ];

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -21,7 +21,7 @@ import { FormFileUpload } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 /**
  * Internal dependencies
  */
@@ -31,6 +31,7 @@ import { fileInputExtensions } from '../../../utils/video-extensions';
 import useAnalyticsTracks from '../../hooks/use-analytics-tracks';
 import { usePermission } from '../../hooks/use-permission';
 import { usePlan } from '../../hooks/use-plan';
+import { useSearchParam } from '../../hooks/use-search-params';
 import useSelectVideoFiles from '../../hooks/use-select-video-files';
 import useVideos, { useLocalVideos } from '../../hooks/use-videos';
 import { NeedUserConnectionGlobalNotice } from '../global-notice';
@@ -43,11 +44,18 @@ import { LocalLibrary, VideoPressLibrary } from './libraries';
 import styles from './styles.module.scss';
 
 const useDashboardVideos = () => {
-	const { uploadVideo, uploadVideoFromLibrary } = useDispatch( STORE_ID );
-
+	const { uploadVideo, uploadVideoFromLibrary, setVideosQuery } = useDispatch( STORE_ID );
 	const { items, uploading, uploadedVideoCount, isFetching, search, page } = useVideos();
 	const { items: localVideos, uploadedLocalVideoCount } = useLocalVideos();
 	const { hasVideoPressPurchase } = usePlan();
+
+	/** Get the page number from the search parameters and set it to the state when the state is outdated */
+	const pageFromSearchParam = parseInt( useSearchParam( 'page', '1' ) );
+	useEffect( () => {
+		if ( page !== pageFromSearchParam ) {
+			setVideosQuery( { page: pageFromSearchParam } );
+		}
+	} );
 
 	// Do not show uploading videos if not in the first page or searching
 	let videos = page > 1 || Boolean( search ) ? items : [ ...uploading, ...items ];

--- a/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
@@ -14,6 +14,7 @@ import { useHistory } from 'react-router-dom';
 import useVideos from '../../hooks/use-videos';
 import { SearchInput } from '../input';
 import { ConnectLocalPagination, ConnectPagination } from '../pagination';
+import { useQueryStringPages } from '../pagination/use-query-string-pages';
 import { FilterButton, ConnectFilterSection } from '../video-filter';
 import VideoGrid from '../video-grid';
 import VideoList, { LocalVideoList } from '../video-list';
@@ -50,6 +51,14 @@ const VideoLibraryWrapper = ( {
 	disabled?: boolean;
 } ) => {
 	const { setSearch, search, isFetching } = useVideos();
+	const { setPageOnURL } = useQueryStringPages();
+
+	const onSearchHandler = searchQuery => {
+		// clear the pagination, setting it back to page 1
+		setPageOnURL( 1 );
+		setSearch( searchQuery );
+	};
+
 	const [ searchQuery, setSearchQuery ] = useState( search );
 	const [ isLg ] = useBreakpointMatch( 'lg' );
 
@@ -75,7 +84,7 @@ const VideoLibraryWrapper = ( {
 					<div className={ styles[ 'filter-wrapper' ] }>
 						<SearchInput
 							className={ classnames( styles[ 'search-input' ], { [ styles.small ]: ! isLg } ) }
-							onSearch={ setSearch }
+							onSearch={ onSearchHandler }
 							value={ searchQuery }
 							loading={ isFetching }
 							onChange={ setSearchQuery }

--- a/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
@@ -11,10 +11,10 @@ import { useHistory } from 'react-router-dom';
 /**
  * Internal dependencies
  */
+import useQueryStringPages from '../../hooks/use-query-string-pages';
 import useVideos from '../../hooks/use-videos';
 import { SearchInput } from '../input';
 import { ConnectLocalPagination, ConnectPagination } from '../pagination';
-import { useQueryStringPages } from '../pagination/use-query-string-pages';
 import { FilterButton, ConnectFilterSection } from '../video-filter';
 import VideoGrid from '../video-grid';
 import VideoList, { LocalVideoList } from '../video-list';

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
@@ -76,7 +76,7 @@ const GoBackLink = () => {
 
 	return (
 		<div className={ styles[ 'back-link' ] }>
-			<Link to="#" className={ styles.link } onClick={ () => history.push( '/' ) }>
+			<Link to="#" className={ styles.link } onClick={ () => history.goBack() }>
 				<Icon icon={ arrowLeft } className={ styles.icon } />
 				{ __( 'Go back', 'jetpack-videopress-pkg' ) }
 			</Link>

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
@@ -22,7 +22,7 @@ import { Link } from 'react-router-dom';
 import { VideoPlayer } from '../../../components/video-frame-selector';
 import { usePermission } from '../../hooks/use-permission';
 import useUnloadPrevent from '../../hooks/use-unload-prevent';
-import useVideos from '../../hooks/use-videos';
+import { useVideosQuery } from '../../hooks/use-videos';
 import Input from '../input';
 import Logo from '../logo';
 import Placeholder from '../placeholder';
@@ -73,7 +73,7 @@ const Header = ( {
 };
 
 const GoBackLink = () => {
-	const { page } = useVideos();
+	const { page } = useVideosQuery();
 	const to = page > 1 ? `/?page=${ page }` : '/';
 
 	return (

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
@@ -22,6 +22,7 @@ import { Link } from 'react-router-dom';
 import { VideoPlayer } from '../../../components/video-frame-selector';
 import { usePermission } from '../../hooks/use-permission';
 import useUnloadPrevent from '../../hooks/use-unload-prevent';
+import useVideos from '../../hooks/use-videos';
 import Input from '../input';
 import Logo from '../logo';
 import Placeholder from '../placeholder';
@@ -72,11 +73,12 @@ const Header = ( {
 };
 
 const GoBackLink = () => {
-	const history = useHistory();
+	const { page } = useVideos();
+	const to = page > 1 ? `/?page=${ page }` : '/';
 
 	return (
 		<div className={ styles[ 'back-link' ] }>
-			<Link to="#" className={ styles.link } onClick={ () => history.goBack() }>
+			<Link to={ to } className={ styles.link }>
 				<Icon icon={ arrowLeft } className={ styles.icon } />
 				{ __( 'Go back', 'jetpack-videopress-pkg' ) }
 			</Link>

--- a/projects/packages/videopress/src/client/admin/components/pagination/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/pagination/index.tsx
@@ -10,6 +10,7 @@ import classnames from 'classnames';
 import useVideos, { useLocalVideos } from '../../hooks/use-videos';
 import styles from './style.module.scss';
 import { PaginationProps } from './types';
+import { useQueryStringPages } from './use-query-string-pages';
 import type React from 'react';
 
 const range = ( start, count ) => {
@@ -150,14 +151,16 @@ const Pagination: React.FC< PaginationProps > = ( {
 };
 
 export const ConnectPagination = ( props: { className: string; disabled?: boolean } ) => {
-	const { setPage, page, itemsPerPage, total, isFetching } = useVideos();
+	const { setPageOnURL } = useQueryStringPages();
+
+	const { page, itemsPerPage, total, isFetching } = useVideos();
 	return total <= itemsPerPage ? (
 		<div className={ classnames( props.className, styles[ 'pagination-placeholder' ] ) } />
 	) : (
 		<Pagination
 			{ ...props }
 			perPage={ itemsPerPage }
-			onChangePage={ setPage }
+			onChangePage={ setPageOnURL }
 			currentPage={ page }
 			total={ total }
 			disabled={ isFetching || props.disabled }

--- a/projects/packages/videopress/src/client/admin/components/pagination/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/pagination/index.tsx
@@ -7,10 +7,10 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
+import useQueryStringPages from '../../hooks/use-query-string-pages';
 import useVideos, { useLocalVideos } from '../../hooks/use-videos';
 import styles from './style.module.scss';
 import { PaginationProps } from './types';
-import { useQueryStringPages } from './use-query-string-pages';
 import type React from 'react';
 
 const range = ( start, count ) => {

--- a/projects/packages/videopress/src/client/admin/components/pagination/use-query-string-pages.ts
+++ b/projects/packages/videopress/src/client/admin/components/pagination/use-query-string-pages.ts
@@ -1,21 +1,23 @@
 /**
  * External dependencies
  */
-import { useHistory, useLocation } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 
 /**
- * Uses the history and location to manipulate the URL pagination parameters.
+ * Uses the history to manipulate the URL pagination parameters.
  *
  * @returns {object} - Object containing useful handlers for URL pagination
  */
 export const useQueryStringPages = () => {
 	const history = useHistory();
-	const location = useLocation();
 	const setPageOnURL = page => {
-		history.push( {
-			pathname: location.pathname,
-			search: `?page=${ page }`,
-		} );
+		const searchFragment = page > 1 ? `?page=${ page }` : '';
+		if ( searchFragment !== history.location.search ) {
+			history.push( {
+				pathname: history.location.pathname,
+				search: searchFragment,
+			} );
+		}
 	};
 
 	return {

--- a/projects/packages/videopress/src/client/admin/components/pagination/use-query-string-pages.ts
+++ b/projects/packages/videopress/src/client/admin/components/pagination/use-query-string-pages.ts
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { useHistory, useLocation } from 'react-router-dom';
+
+/**
+ * Uses the history and location to manipulate the URL pagination parameters.
+ *
+ * @returns {object} - Object containing useful handlers for URL pagination
+ */
+export const useQueryStringPages = () => {
+	const history = useHistory();
+	const location = useLocation();
+	const setPageOnURL = page => {
+		history.push( {
+			pathname: location.pathname,
+			search: `?page=${ page }`,
+		} );
+	};
+
+	return {
+		setPageOnURL,
+	};
+};

--- a/projects/packages/videopress/src/client/admin/components/pagination/use-query-string-pages.ts
+++ b/projects/packages/videopress/src/client/admin/components/pagination/use-query-string-pages.ts
@@ -19,8 +19,18 @@ export const useQueryStringPages = () => {
 			} );
 		}
 	};
+	const forceFirstPage = () => {
+		const searchFragment = '';
+		if ( searchFragment !== history.location.search ) {
+			history.replace( {
+				pathname: history.location.pathname,
+				search: searchFragment,
+			} );
+		}
+	};
 
 	return {
 		setPageOnURL,
+		forceFirstPage,
 	};
 };

--- a/projects/packages/videopress/src/client/admin/components/video-filter/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-filter/index.tsx
@@ -23,10 +23,10 @@ import {
 	VIDEO_FILTER_RATING,
 	VIDEO_FILTER_UPLOADER,
 } from '../../../state/constants';
+import useQueryStringPages from '../../hooks/use-query-string-pages';
 import useUsers from '../../hooks/use-users';
 import useVideos from '../../hooks/use-videos';
 import Checkbox from '../checkbox';
-import { useQueryStringPages } from '../pagination/use-query-string-pages';
 import styles from './style.module.scss';
 import { FilterObject } from './types';
 

--- a/projects/packages/videopress/src/client/admin/components/video-filter/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-filter/index.tsx
@@ -26,6 +26,7 @@ import {
 import useUsers from '../../hooks/use-users';
 import useVideos from '../../hooks/use-videos';
 import Checkbox from '../checkbox';
+import { useQueryStringPages } from '../pagination/use-query-string-pages';
 import styles from './style.module.scss';
 import { FilterObject } from './types';
 
@@ -181,8 +182,21 @@ export const FilterSection = ( props: {
 
 export const ConnectFilterSection = props => {
 	const { setFilter, filter } = useVideos();
+	const { setPageOnURL } = useQueryStringPages();
+
+	const onFilterHandler = ( ...filterArgs ) => {
+		// clear the pagination, setting it back to page 1
+		setPageOnURL( 1 );
+		setFilter( ...filterArgs );
+	};
+
 	const { items: users } = useUsers();
 	return (
-		<FilterSection { ...props } onChange={ setFilter } uploaders={ users } filter={ filter } />
+		<FilterSection
+			{ ...props }
+			onChange={ onFilterHandler }
+			uploaders={ users }
+			filter={ filter }
+		/>
 	);
 };

--- a/projects/packages/videopress/src/client/admin/hooks/use-query-string-pages/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-query-string-pages/index.ts
@@ -8,7 +8,7 @@ import { useHistory } from 'react-router-dom';
  *
  * @returns {object} - Object containing useful handlers for URL pagination
  */
-export const useQueryStringPages = () => {
+const useQueryStringPages = () => {
 	const history = useHistory();
 	const setPageOnURL = page => {
 		const searchFragment = page > 1 ? `?page=${ page }` : '';
@@ -34,3 +34,5 @@ export const useQueryStringPages = () => {
 		forceFirstPage,
 	};
 };
+
+export default useQueryStringPages;

--- a/projects/packages/videopress/src/client/admin/hooks/use-search-params/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-search-params/index.ts
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import { useLocation } from 'react-router-dom';
+
+/**
+ * Gets a given parameter from the search query.
+ *
+ * @param {string} parameterName - The name of the parameter to get from the query string.
+ * @param {string} defaultValue - The default value to return if the given parameter is not set on the query string.
+ * @returns {string} - The value of the parameter if it's set. The defaultValue if the parameter is not set.
+ */
+export const useSearchParam = ( parameterName: string, defaultValue: string = null ) => {
+	const searchParams = new URLSearchParams( useLocation().search );
+	return searchParams.has( parameterName ) ? searchParams.get( parameterName ) : defaultValue;
+};

--- a/projects/packages/videopress/src/client/admin/hooks/use-videos/index.js
+++ b/projects/packages/videopress/src/client/admin/hooks/use-videos/index.js
@@ -80,3 +80,14 @@ export const useLocalVideos = () => {
 		setPage: page => dispatch( STORE_ID ).setLocalVideosQuery( { page } ),
 	};
 };
+
+/**
+ * React custom hook to get the videos query.
+ *
+ * @returns {object} search query information
+ */
+export const useVideosQuery = () => {
+	// Data
+	const query = useSelect( select => select( STORE_ID ).getVideosQuery() || {} );
+	return query;
+};

--- a/projects/packages/videopress/src/client/admin/hooks/use-videos/index.js
+++ b/projects/packages/videopress/src/client/admin/hooks/use-videos/index.js
@@ -51,8 +51,7 @@ export default function useVideos() {
 
 		// Handlers
 		setPage: page => dispatch( STORE_ID ).setVideosQuery( { page } ),
-		setSearch: querySearch =>
-			dispatch( STORE_ID ).setVideosQuery( { search: querySearch, page: 1 } ),
+		setSearch: querySearch => dispatch( STORE_ID ).setVideosQuery( { search: querySearch } ),
 		setFilter: dispatch( STORE_ID ).setVideosFilter,
 	};
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Relates #26720.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Change the `Admin` code to update the page number on the state when there is a `page` parameter on the query string, triggering the load of the new page
   * when no page is set on the query string, the default page is `1`
   * any other value for the page number needs to be set on the query string, using `page=PAGE_NUMBER`, like `page=2`; the `page` query parameter becomes the initial source of true for the page number
   * the URL for some paginated list of videos will be like `/wp-admin/admin.php?page=jetpack-videopress#/?page=4`

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure you have at least 7 videos so you can see the pagination (more is better)
* Go to `Jetpack > VideoPress`
* Click some page number on the pagination component; this should have 2 results:
   * Change the content of the video list to show the videos on the given page
   * Change the URL to set the `page` query string parameter with the proper value

<img width="1194" alt="Screen Shot 2022-12-07 at 18 53 35" src="https://user-images.githubusercontent.com/6760046/206304743-b3db2626-55b7-4b8a-8bae-3f73565ad151.png">

* Use the left and right arrows to navigate between the pages
   * They also should change the content of the list and set the `page` query string parameter on the URL

<img width="1125" alt="Screen Shot 2022-12-07 at 18 57 20" src="https://user-images.githubusercontent.com/6760046/206305367-ee236e14-ef03-452e-8ade-54933626144e.png">

* Get the link for some page of the listing (for example, the second page) and open it on a new tab
   * This should open the list of videos showing on the given page, setting the page as the current on the pagination component as well as loading the right videos on the video list
* Try changing the page number on the URL as well (changing from `page=2` to `page=3` for example)
   * This should change the content of the list as well as setting the new page as active on the page component
* Try searching for some term while you visit a page different than the first (for example, `?page=2`)
   * This should clear the page number and send you back to page 1 on the search results (changing the URL back to `/`)
* Try filtering the videos using some filter while you visit a page different than the first (for example, `?page=2`)
   * This should clear the page number and send you back to page 1 on the search results (changing the URL back to `/`)
* Try using an invalid page number, out of the range of pages (for example, `?page=8` when you have only 7 pages)
   * This should send the request back to the first page
* On any given page, click the `Edit video details` button and, on the details page, click the "Go back" link
   * This should send you back to the page you were browsing before
* Open some details page on a new tab, so your history is clear, and then click the "Go back" link
   * This should send you back to the first page of the video library