### PR TITLE
tests: Only update dev deps when preparing plugins

### DIFF
--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -57,6 +57,7 @@ export COMPOSER_MIRROR_PATH_REPOS=true
 
 BASE="$(pwd)"
 PKGVERSIONS="$(jq -nc 'reduce inputs as $in ({}; .[$in.name] |= ( $in.extra["branch-alias"]["dev-trunk"] // "dev-trunk" ) )' projects/packages/*/composer.json)"
+EXIT=0
 for PLUGIN in projects/plugins/*/composer.json; do
 	DIR="${PLUGIN%/composer.json}"
 	NAME="$(basename "$DIR")"
@@ -69,8 +70,19 @@ for PLUGIN in projects/plugins/*/composer.json; do
 		echo 'Platform reqs pass, running `composer install`'
 		composer install
 	else
-		echo 'Platform reqs failed, running `composer update`'
-		composer update
+		TMP=$(diff <(composer info --locked --no-dev --format=json | jq -r '.locked[].name' | sort) <(composer info --locked --format=json | jq -r '.locked[].name' | sort) | sed -n 's/^> //p' || true)
+		if [[ -n "$TMP" ]]; then
+			echo 'Platform reqs failed, running `composer update` for dev dependencies'
+			DEPS=()
+			mapfile -t DEPS <<<"$TMP"
+			if ! composer update "${DEPS[@]}"; then
+				echo "::error::plugins/$NAME: Platform reqs failed for PHP $(php -r 'echo PHP_VERSION;') and updating dev deps didn't help. The plugin is likely broken for that PHP version."
+				EXIT=1
+			fi
+		else
+			echo "::error::plugins/$NAME: Platform reqs failed for PHP $(php -r 'echo PHP_VERSION;'). The plugin is likely broken for that PHP version."
+			EXIT=1
+		fi
 	fi
 	cd "$BASE"
 
@@ -93,4 +105,4 @@ sed -i "s/yourusernamehere/root/" wp-tests-config.php
 sed -i "s/yourpasswordhere/root/" wp-tests-config.php
 sed -i "s/localhost/127.0.0.1/" wp-tests-config.php
 
-exit 0;
+exit $EXIT

--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -70,6 +70,9 @@ for PLUGIN in projects/plugins/*/composer.json; do
 		echo 'Platform reqs pass, running `composer install`'
 		composer install
 	else
+		# Composer can't directly tell us which packages are dev deps, but we can get lists of all deps and just the non-dev deps.
+		# So we use `diff` to find which aren't in the non-dev list, and `sed` to extract just the `> ` lines with the actual package names (and remove the `> ` too).
+		# Adding `|| true` makes sure the exit code stays 0 so `-eo pipefail` doesn't trigger.
 		TMP=$(diff <(composer info --locked --no-dev --format=json | jq -r '.locked[].name' | sort) <(composer info --locked --format=json | jq -r '.locked[].name' | sort) | sed -n 's/^> //p' || true)
 		if [[ -n "$TMP" ]]; then
 			echo 'Platform reqs failed, running `composer update` for dev dependencies'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Our composer.lock files are currently generated with PHP 8.0, but we run tests with earlier versions too. To make this work, we run `composer update` if `composer check-platform-reqs` indicates that the install is going to fail.

But that causes a problem when running the tests on release branches, where newer versions of the monorepo packages might exist for it to incorrectly update to. What we really want to do is only update the dev-dependencies, since if any of the non-dev deps don't work with a PHP version that probably means the plugin is broken anyway.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1670338218449569-slack-C01U2KGS2PQ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?
* Cherry-pick this onto a branch based on `jetpack/branch-11.6` and arrange for tests to run.
  * Check that it does not update monorepo packages like it did [here](https://github.com/Automattic/jetpack/actions/runs/3630390268/jobs/6124239918#step:8:450) (except maybe changelogger).
    * [x] https://github.com/Automattic/jetpack/actions/runs/3642299079/jobs/6149246817#step:8:466
  * Did the tests pass?
    * [x] https://github.com/Automattic/jetpack/actions/runs/3642299079