### PR TITLE
Stats: Fix chart in masterbar when new experience is on

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-stats-chart-in-masterbar-when-new-stats-is-on
+++ b/projects/plugins/jetpack/changelog/fix-stats-chart-in-masterbar-when-new-stats-is-on
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Stats: fix stats chart in masterbar when new experience is turned on

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -286,7 +286,7 @@ function stats_admin_menu() {
 	}
 
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	if ( ! Stats_Options::get_option( 'enable_calypso_stats' ) ) {
+	if ( ! Stats_Options::get_option( 'enable_calypso_stats' ) || isset( $_GET['noheader'] ) ) {
 		$hook = add_submenu_page( 'jetpack', __( 'Stats', 'jetpack' ), __( 'Stats', 'jetpack' ), 'view_stats', 'stats', 'jetpack_admin_ui_stats_report_page_wrapper' );
 		add_action( "load-$hook", 'stats_reports_load' );
 	} else {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The PR allows chart from `admin.php` to function even when the new experience is on by allowing request with GET param `noheader`, which means it's an API request.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Open a site with Jetpack plugin
* Open `/wp-admin/admin.php?page=jetpack#/traffic?term=jetpack%20stats`
* Expand the Jetpack Stats section
* Open browser console and run `document.querySelector('#jp-settings-site-stats').querySelectorAll('.jp-form-fieldset')[1].setAttribute('style','color:red')`
* Turn on the new Stats experience (color red toggle)
* Turn on "Include a small chart in your admin bar with a 48-hour traffic snapshot"
* Open `/wp-admin/admin.php?page=stats`
* Ensure the page looks reasonable
* Open the home page
* Ensure the little chart in masterbar is showing


![image](https://user-images.githubusercontent.com/1425433/206350070-b9d68fa5-d0a9-46b5-8c58-5a4d85831fb9.png)
