### PR TITLE
E2E tests: disable runs on push to trunk in favor of runs on mirror updates

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     paths-ignore:
     - '**.md'
-  push:
-    branches: [ 'trunk' ]
-    paths-ignore:
-    - '**.md'
   repository_dispatch:
     types: ['e2e tests**']
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

With e2e tests running now on updates in mirror repos, running on every push to trunk seems redundant. 
This PR disables the push trigger for the e2e tests workflow.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
pd5faL-kN-p2, pd5faL-lS-p2

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* After merge, check that e2e tests are not running on `push` event.