### PR TITLE
Jetpack: convert on-the-fly video block instances for Simple sites

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-convert-to-videopress-video-block-on-the-fly
+++ b/projects/plugins/jetpack/changelog/update-jetpack-convert-to-videopress-video-block-on-the-fly
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Jetpack: convert on-the-fly video block instances on dotcom

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -506,7 +506,7 @@ const convertCoreVideoToVideoPressVideoBlock = createHigherOrderComponent( Block
 		const isSimple = isSimpleSite();
 
 		const shouldConvertToVideoPressVideoBlock = !! (
-			name === 'core/embed' && // Only auto-convert if the block is a core/video block
+			name === 'core/video' && // Only auto-convert if the block is a core/video block
 			isCoreVideoVideoPressBlock && // Only auto-convert if the block is a VideoPress block
 			isBeta && // Only auto-convert if the feature is beta
 			// Only auto-convert if the site is Simple

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -6,7 +6,7 @@ import {
 } from '@automattic/jetpack-shared-extension-utils';
 import { createBlobURL } from '@wordpress/blob';
 import { useBlockEditContext, store as blockEditorStore } from '@wordpress/block-editor';
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, getBlockType } from '@wordpress/blocks';
 import { Button } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
@@ -15,7 +15,6 @@ import { useContext, useEffect } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import { every } from 'lodash';
-import { isBetaExtension } from '../../editor';
 import { VideoPressBlockContext } from './components';
 import deprecatedV1 from './deprecated/v1';
 import deprecatedV2 from './deprecated/v2';
@@ -502,13 +501,20 @@ const convertCoreVideoToVideoPressVideoBlock = createHigherOrderComponent( Block
 		 * based on some of its attributes.
 		 */
 		const isCoreVideoVideoPressBlock = isVideoPressBlockBasedOnAttributes( attributes );
-		const isBeta = isBetaExtension( 'videopress/video' );
+
+		const isVideoPressVideoBlockRegistered = getBlockType( 'videopress/video' );
+
+		const { available: isVideoPressVideoBlockAvailable } = getJetpackExtensionAvailability(
+			'videopress/video'
+		);
+
 		const isSimple = isSimpleSite();
 
 		const shouldConvertToVideoPressVideoBlock = !! (
 			name === 'core/video' && // Only auto-convert if the block is a core/video block
+			isVideoPressVideoBlockRegistered && // Only auto-convert if the VideoPress block is registered
 			isCoreVideoVideoPressBlock && // Only auto-convert if the block is a VideoPress block
-			isBeta && // Only auto-convert if the feature is beta
+			isVideoPressVideoBlockAvailable && // Only auto-convert if the feature is available
 			// Only auto-convert if the site is Simple
 			isSimple
 		);

--- a/projects/plugins/jetpack/extensions/blocks/videopress/videopress.php
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/videopress.php
@@ -42,6 +42,14 @@ function load_assets( $attrs, $content ) {
 	return $content;
 }
 
+// Set the videopress/video feature availability.
+add_action(
+	'jetpack_register_gutenberg_extensions',
+	function () {
+		\Jetpack_Gutenberg::set_extension_available( 'videopress/video' );
+	}
+);
+
 // Set the videopress/video-chapters feature availability.
 add_action(
 	'jetpack_register_gutenberg_extensions',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/27560

This PR converts the Jetpackj VideoPress block instances to the new VideoPress video block, on the fly, for Simple sites.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack: convert on-the-fly video block instances for Simple sites

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

#### Test on Jetpack/Atomic sites

* Activate Jetpack plugin
* Go to the block editor
* Add/create a `core/video` block instance
* Confirm the block doesn't convert (it's still a `core/video` block)

* Deactivate the Jetpack plugin
* Activate the VideoPress standalone plugin
* Go back to the block editor. Same post
* hard refresh
* Confirm the core/video block is now broken
* Confirm you see the custom VideoPress video block Recovery dialog
<img width="696" alt="image" src="https://user-images.githubusercontent.com/77539/206460131-1aad16b5-b679-4afc-91f9-e472e88813a7.png">

* Confirm it converts the block to VideoPres video block by clicking on the recovery button
<img width="902" alt="image" src="https://user-images.githubusercontent.com/77539/206460169-5da2ace4-44f1-482f-8d31-c1c04cda5817.png">

#### Test on Simple sites (Sandboxed)

* Go to the block editor
* Add/create a `core/video` block instance
* Confirm that once the video is defined for the block, it converts to the new VideoPress video block `v6`
* You can test with a previous post with core/video instances. Once the post loads, the block should convert to `v6` on the fly.

before | after
------|------
<img width="1026" alt="Screen Shot 2022-12-08 at 11 04 48" src="https://user-images.githubusercontent.com/77539/206432331-d9d7536b-7883-47af-a584-faea1378a2d4.png"> | <img width="1026" alt="Screen Shot 2022-12-08 at 11 10 30" src="https://user-images.githubusercontent.com/77539/206432321-2bbe73ca-eced-439a-a071-ab1b46ee7a37.png">

* Confirm that the block preserves the settings after it converts itself.

#### Test on Simple sites (Unsandboxed)

* Confirm on-the-fly conversion should not happen

### Convert on the fly table

/ | Jetpack / Atomic | Simple
-----|----|----
beta enabled |  🍎  | 🍏
beta disabled | 🍎  | 🍎 