### PR TITLE
Tooling: Preventing wrong slug from being output later in changelogger release script

### DIFF
--- a/tools/changelogger-release.sh
+++ b/tools/changelogger-release.sh
@@ -198,13 +198,13 @@ mapfile -t SLUGS <<<"$TMP"
 TMPDIR="${TMPDIR:-/tmp}"
 TEMP=$(mktemp "${TMPDIR%/}/changelogger-release-XXXXXXXX")
 
-for SLUG in "${SLUGS[@]}"; do
-	if [[ -n "${RELEASED[$SLUG]}" ]]; then
-		debug "  tools/check-intra-monorepo-deps.sh $VERBOSE $HARDWAY -U $SLUG"
-		PACKAGE_VERSIONS_CACHE="$TEMP" tools/check-intra-monorepo-deps.sh $VERBOSE $HARDWAY -U "$SLUG"
+for DEPENDENCY_SLUG in "${SLUGS[@]}"; do
+	if [[ -n "${RELEASED[$DEPENDENCY_SLUG]}" ]]; then
+		debug "  tools/check-intra-monorepo-deps.sh $VERBOSE $HARDWAY -U $DEPENDENCY_SLUG"
+		PACKAGE_VERSIONS_CACHE="$TEMP" tools/check-intra-monorepo-deps.sh $VERBOSE $HARDWAY -U "$DEPENDENCY_SLUG"
 	else
-		debug "  tools/check-intra-monorepo-deps.sh $VERBOSE $HARDWAY -u $SLUG"
-		PACKAGE_VERSIONS_CACHE="$TEMP" tools/check-intra-monorepo-deps.sh $VERBOSE $HARDWAY -u "$SLUG"
+		debug "  tools/check-intra-monorepo-deps.sh $VERBOSE $HARDWAY -u $DEPENDENCY_SLUG"
+		PACKAGE_VERSIONS_CACHE="$TEMP" tools/check-intra-monorepo-deps.sh $VERBOSE $HARDWAY -u "$DEPENDENCY_SLUG"
 	fi
 done
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* This change prevents the slug used when running the `tools/changelogger-release.sh` script from being modified when the dependencies were being updated. This was resulting in the wrong slug being output toward the end of the script.
* Specifically, the slug was being changed in the for / in loop where dependencies were being updated.
* The fix was to change the slug name in that loop, though another option is to assign the slug variable to another 'original slug' variable before running that loop, and using that new variable at the end of the changelogger release script where it is being used to echo the relevant slug in the terminal.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

n/a

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* To test without this update applied within a local development environment, run `jetpack release plugins/jetpack changelog -a --add-pr-num` in the terminal from a test branch.
* Once complete, amongst the printed output in your terminal window you may see something similar to the following: `When ready, you can create the release branch with tools/create-release-branch.sh plugins/search 1.3.1`.
* Apply this PR after removing any changed files as a result of running the script previously, and run the same command. You should now see something similar to `When ready, you can create the release branch with tools/create-release-branch.sh plugins/jetpack 11.7-a.3`.

