### PR TITLE
Jetpack docker: allow expanding plugin removal list

### DIFF
--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -374,6 +374,16 @@ Since everything under `mu-plugins` and `wordpress/wp-content` is git-ignored, y
 Note that any folder within the `projects/plugins` directory will be automatically linked.
 If you're starting a new monorepo plugin, you may need to `jetpack docker stop` and `jetpack docker up` to re-run the initial linking step so it can be added.
 
+You can add your plugin to the list of plugins not allowed to be deleted or updated by adding this to a new file at `tools/docker/mu-plugins`:
+
+```php
+function jetpack_docker_disable_gutenberg_deletion( $plugins ) {
+	array_push( $plugins, 'gutenberg' );
+	return $plugins;
+}
+add_filter( 'jetpack_docker_avoided_plugins', 'jetpack_docker_disable_gutenberg_deletion' );
+```
+
 ## Debugging
 
 ### Accessing logs

--- a/tools/docker/mu-plugins/avoid-plugin-deletion.php
+++ b/tools/docker/mu-plugins/avoid-plugin-deletion.php
@@ -24,7 +24,7 @@ use Jetpack\Docker\MuPlugin\Monorepo;
  * @return mixed
  */
 function jetpack_docker_disable_plugin_deletion_link( $actions, $plugin_file ) {
-	$jetpack_docker_avoided_plugins = ( new Monorepo() )->plugins();
+	$jetpack_docker_avoided_plugins = apply_filters( 'jetpack_docker_avoided_plugins', ( new Monorepo() )->plugins() );
 	if (
 		array_key_exists( 'delete', $actions ) &&
 		in_array(
@@ -45,7 +45,7 @@ add_filter( 'plugin_action_links', 'jetpack_docker_disable_plugin_deletion_link'
  * @param string $plugin_file Path to the plugin file relative to the plugins directory.
  */
 function jetpack_docker_disable_delete_plugin( $plugin_file ) {
-	$jetpack_docker_avoided_plugins = ( new Monorepo() )->plugins();
+	$jetpack_docker_avoided_plugins = apply_filters( 'jetpack_docker_avoided_plugins', ( new Monorepo() )->plugins() );
 	if ( in_array( $plugin_file, $jetpack_docker_avoided_plugins, true ) ) {
 		wp_die(
 			esc_html( 'Deleting plugin "' . $plugin_file . '" is disabled at mu-plugins/avoid-plugin-deletion.php' ),
@@ -61,7 +61,7 @@ add_action( 'delete_plugin', 'jetpack_docker_disable_delete_plugin', 10, 2 );
  * @param mixed $plugins Value of site transient.
  */
 function jetpack_docker_disable_plugin_update( $plugins ) {
-	$jetpack_docker_avoided_plugins = ( new Monorepo() )->plugins();
+	$jetpack_docker_avoided_plugins = apply_filters( 'jetpack_docker_avoided_plugins', ( new Monorepo() )->plugins() );
 	if ( ! is_array( $jetpack_docker_avoided_plugins ) ) {
 		return $plugins;
 	}


### PR DESCRIPTION
I symlinked Gutenberg development version to my Jetpack and wanted to be extra-sure it doesn't get wiped out by adding it to the list of "don't allow deleting/updating this plugin".

You'd use this by adding this to a new file at `tools/docker/mu-plugins`:

```php
function jetpack_docker_disable_gutenberg_deletion( $plugins ) {
	array_push( $plugins, 'gutenberg' );
	return $plugins;
}
add_filter( 'jetpack_docker_avoided_plugins', 'jetpack_docker_disable_gutenberg_deletion' );
```



#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds `jetpack_docker_avoided_plugins` filter at `tools/docker/mu-plugins/avoid-plugin-deletion.php`
* Add info to Docker Readme

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

To test, visit `/wp-admin/plugins.php` and see how it's impossible to delete Gutenberg now:

<img width="811" alt="Screenshot 2022-12-08 at 14 08 53" src="https://user-images.githubusercontent.com/87168/206443057-798e8de1-52ca-41c0-a3c1-76499fc1b683.png">


