### PR TITLE
VideoPress: do not prompt to convert core/embed to videopress/video for Simple sites

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-not-convert-embed-for-simple-sites
+++ b/projects/packages/videopress/changelog/update-videopress-not-convert-embed-for-simple-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: do not prompt to convert core/embed to videopress/video for Simple sites

--- a/projects/packages/videopress/src/client/block-editor/extend/core-embed/index.js
+++ b/projects/packages/videopress/src/client/block-editor/extend/core-embed/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import { unregisterBlockVariation } from '@wordpress/blocks';
 import domReady from '@wordpress/dom-ready';
 import { addFilter } from '@wordpress/hooks';
@@ -10,6 +11,10 @@ import { addFilter } from '@wordpress/hooks';
 import withCoreEmbedVideoPressBlock from './edit';
 
 const extendCoreEmbedVideoPressBlock = ( settings, name ) => {
+	if ( isSimpleSite() ) {
+		return settings;
+	}
+
 	if ( name !== 'core/embed' ) {
 		return settings;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR does not prompt to the user to convert the `core/embed` block to the new `videopress/video` block for Simple sites. We'll figure out how to handle this situation in follow-up issues.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: do not prompt to convert core/embed to videopress/video for Simple sites

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

#### Jetpack / Atomic sites

* Activate Jetpack plugin
* Go to block editor
* Add a new embed block

<img width="668" alt="image" src="https://user-images.githubusercontent.com/77539/206485057-c12e1466-4344-46b2-9875-09911c035d8e.png">

* Set the embed URL. Feel free to use `https://videopress.com/v/bjvmxiQS`
* Confirm the app prompts you to convert the block to the VideoPress video block
<img width="676" alt="image" src="https://user-images.githubusercontent.com/77539/206485351-12d45ce0-8111-4b46-92da-893c3a916b82.png">

* You can convert the block or ignore it. Confirm that.

#### Simple sites

* Go to block editor
* Add a new embed block

before | after
------|------
<img width="863" alt="image" src="https://user-images.githubusercontent.com/77539/206484538-1adf68f3-cc6e-4ea4-a9b2-233c382580a5.png"> | <img width="877" alt="image" src="https://user-images.githubusercontent.com/77539/206484726-73fb27f9-aaa9-42c6-a5aa-e2dedcd12b6b.png">

You can check the patterns registered by the VideoMaker theme

before| after
-----|-------
<img width="355" alt="image" src="https://user-images.githubusercontent.com/77539/206506935-05012e57-f451-4b57-9c31-c086fb1975e9.png"> | <img width="372" alt="image" src="https://user-images.githubusercontent.com/77539/206508021-f1037d7b-dfb7-40ac-a9c9-14c022d877d9.png">

