### PR TITLE
VideoPress: Add videopress embed shortcode

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-embed-shortcode
+++ b/projects/packages/videopress/changelog/add-videopress-embed-shortcode
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-VideoPress: Add jetpack_videopress shortcode
+VideoPress: Add videopress shortcode

--- a/projects/packages/videopress/changelog/add-videopress-embed-shortcode
+++ b/projects/packages/videopress/changelog/add-videopress-embed-shortcode
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+VideoPress: Add jetpack_videopress shortcode

--- a/projects/packages/videopress/composer.json
+++ b/projects/packages/videopress/composer.json
@@ -64,7 +64,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.9.x-dev"
+			"dev-trunk": "0.10.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-package-version.php"

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.9.3-alpha",
+	"version": "0.10.0-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-block-editor-content.php
+++ b/projects/packages/videopress/src/class-block-editor-content.php
@@ -133,10 +133,10 @@ class Block_Editor_Content {
 
 			$base_url     = 'https://videopress.com/v/' . $guid;
 			$query_params = array(
-				'resizeToParent'  => true,
-				'cover'           => true,
+				'resizeToParent'  => 'true',
+				'cover'           => 'true',
 				'preloadContent'  => 'metadata',
-				'useAverageColor' => true,
+				'useAverageColor' => 'true',
 			);
 			$url          = esc_url( add_query_arg( $query_params, $base_url ) );
 

--- a/projects/packages/videopress/src/class-block-editor-content.php
+++ b/projects/packages/videopress/src/class-block-editor-content.php
@@ -22,7 +22,7 @@ class Block_Editor_Content {
 		}
 
 		add_shortcode( 'jetpack_videopress', array( static::class, 'videopress_block_shortcode' ) );
-		add_filter( 'default_content', array( static::class, 'videopress_block_by_guid' ), 10, 2 );
+		add_filter( 'default_content', array( static::class, 'videopress_video_block_by_guid' ), 10, 2 );
 	}
 
 	/**
@@ -62,13 +62,13 @@ class Block_Editor_Content {
 	}
 
 	/**
-	 * Generates a VideoPress block content with the given guid
+	 * Generates a VideoPress video block content with the given guid
 	 *
 	 * @param string  $content Post content.
 	 * @param WP_Post $post Post.
 	 * @return string
 	 */
-	public static function videopress_block_by_guid( $content, $post ) {
+	public static function videopress_video_block_by_guid( $content, $post ) {
 		if ( isset( $_GET['videopress_guid'], $_GET['_wpnonce'] )
 			&& wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'videopress-content-nonce' )
 			&& current_user_can( 'edit_post', $post->ID )

--- a/projects/packages/videopress/src/class-block-editor-content.php
+++ b/projects/packages/videopress/src/class-block-editor-content.php
@@ -21,31 +21,67 @@ class Block_Editor_Content {
 			return;
 		}
 
-		add_filter( 'default_content', array( static::class, 'video_block_by_guid' ), 10, 2 );
+		add_shortcode( 'jetpack_videopress', array( static::class, 'videopress_block_shortcode' ) );
+		add_filter( 'default_content', array( static::class, 'videopress_block_by_guid' ), 10, 2 );
 	}
 
 	/**
-	 * Generates a video block content with the given guid
+	 * VideoPress embed shortcode
+	 *
+	 * Example use:
+	 * [jetpack_videopress guid=tLvEwHYZ width=560 height=315]
+	 *
+	 * @param array $atts Shortcode attributes.
+	 *
+	 * @return string html
+	 */
+	public static function videopress_block_shortcode( $atts ) {
+		$atts = shortcode_atts(
+			array(
+				'guid'   => '', // string.
+				'width'  => 560, // int.
+				'height' => 315, // int.
+			),
+			$atts,
+			'jetpack_videopress'
+		);
+
+		$guid = sanitize_text_field( wp_unslash( $atts['guid'] ) );
+
+		if ( empty( $guid ) ) {
+			return '<!-- error: missing VideoPress video ID -->';
+		}
+
+		$width  = (int) $atts['width'];
+		$height = (int) $atts['height'];
+		$src    = esc_url( 'https://videopress.com/embed/' . $guid );
+
+		wp_enqueue_script( 'videopress-iframe', 'https://videopress.com/videopress-iframe.js', array(), Package_Version::PACKAGE_VERSION, true );
+
+		return '<iframe src="' . $src . '" frameborder="0" allowfullscreen allow="clipboard-write" width="' . $width . '" height="' . $height . '"></iframe>';
+	}
+
+	/**
+	 * Generates a VideoPress block content with the given guid
 	 *
 	 * @param string  $content Post content.
 	 * @param WP_Post $post Post.
 	 * @return string
 	 */
-	public static function video_block_by_guid( $content, $post ) {
+	public static function videopress_block_by_guid( $content, $post ) {
 		if ( isset( $_GET['videopress_guid'], $_GET['_wpnonce'] )
 			&& wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'videopress-content-nonce' )
 			&& current_user_can( 'edit_post', $post->ID )
 			&& '' === $content
 		) {
 			$guid = sanitize_text_field( wp_unslash( $_GET['videopress_guid'] ) );
+			$url  = esc_url( 'https://videopress.com/v/' . $guid . '?resizeToParent=true&cover=true&preloadContent=metadata&useAverageColor=true' );
 
 			if ( ! empty( $guid ) ) {
 				// ref /client/lib/url/index.ts
 				$content = '<!-- wp:videopress/video {"guid":"' . $guid . '"} -->
 				<figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player">
-					<div class="jetpack-videopress-player__wrapper">
-						https://videopress.com/v/' . $guid . '?resizeToParent=true&amp;cover=true&amp;preloadContent=metadata&amp;useAverageColor=true
-					</div>
+					<div class="jetpack-videopress-player__wrapper">' . $url . '</div>
 				</figure>
 				<!-- /wp:videopress/video -->';
 			}

--- a/projects/packages/videopress/src/class-block-editor-content.php
+++ b/projects/packages/videopress/src/class-block-editor-content.php
@@ -21,13 +21,11 @@ class Block_Editor_Content {
 			return;
 		}
 
-		global $shortcode_tags;
-
 		// Remove the videopress shortcodes added by the Jetpack plugin.
-		if ( array_key_exists( 'videopress', $shortcode_tags ) ) {
+		if ( shortcode_exists( 'videopress' ) ) {
 			remove_shortcode( 'videopress' );
 		}
-		if ( array_key_exists( 'wpvideo', $shortcode_tags ) ) {
+		if ( shortcode_exists( 'wpvideo' ) ) {
 			remove_shortcode( 'wpvideo' );
 		}
 

--- a/projects/packages/videopress/src/class-block-editor-content.php
+++ b/projects/packages/videopress/src/class-block-editor-content.php
@@ -69,6 +69,7 @@ class Block_Editor_Content {
 			'at'              => 0,     // How many seconds in to initially seek to
 			'loop'            => false, // Whether to loop the video repeatedly
 			'autoplay'        => false, // Whether to autoplay the video on load
+			'cover'           => true,  // Whether to scale the video to its container
 			'muted'           => false, // Whether the video should start without sound
 			'controls'        => true,  // Whether the video should display controls
 			'playsinline'     => false, // Whether the video should be allowed to play inline (for browsers that support this)
@@ -93,6 +94,12 @@ class Block_Editor_Content {
 		$width  = absint( $atts['w'] );
 		$height = absint( $atts['h'] );
 
+		// Make sure "false" will be actually false.
+		if ( is_string( $atts['cover'] ) && 'false' === strtolower( $atts['cover'] ) ) {
+			$atts['cover'] = false;
+		}
+		$cover = $atts['cover'] ? ' data-resize-to-parent="true"' : '';
+
 		$block_template =
 		'<figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player">' .
 			'<div class="jetpack-videopress-player__wrapper">' .
@@ -103,7 +110,7 @@ class Block_Editor_Content {
 					'width="%s"' .
 					'height="%s" ' .
 					'frameborder="0" ' .
-					'allowfullscreen data-resize-to-parent="true" allow="clipboard-write">' .
+					'allowfullscreen%s allow="clipboard-write">' .
 				'</iframe>' .
 			'</div>' .
 		'</figure>';
@@ -111,7 +118,7 @@ class Block_Editor_Content {
 		$version = Package_Version::PACKAGE_VERSION;
 		wp_enqueue_script( 'videopress-iframe', 'https://videopress.com/videopress-iframe.js', array(), $version, true );
 
-		return sprintf( $block_template, $src, $width, $height );
+		return sprintf( $block_template, $src, $width, $height, $cover );
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-block-editor-content.php
+++ b/projects/packages/videopress/src/class-block-editor-content.php
@@ -21,7 +21,21 @@ class Block_Editor_Content {
 			return;
 		}
 
-		add_shortcode( 'jetpack_videopress', array( static::class, 'videopress_embed_shortcode' ) );
+		global $shortcode_tags;
+
+		// Remove the videopress shortcodes added by the Jetpack plugin.
+		if ( array_key_exists( 'videopress', $shortcode_tags ) ) {
+			remove_shortcode( 'videopress' );
+		}
+		if ( array_key_exists( 'wpvideo', $shortcode_tags ) ) {
+			remove_shortcode( 'wpvideo' );
+		}
+
+		add_shortcode( 'videopress', array( static::class, 'videopress_embed_shortcode' ) );
+		add_shortcode( 'wpvideo', array( static::class, 'videopress_embed_shortcode' ) );
+
+		add_filter( 'wp_video_shortcode_override', array( static::class, 'video_shortcode_override' ), 10, 4 );
+
 		add_filter( 'default_content', array( static::class, 'videopress_video_block_by_guid' ), 10, 2 );
 	}
 
@@ -29,7 +43,7 @@ class Block_Editor_Content {
 	 * VideoPress embed shortcode
 	 *
 	 * Expected input format:
-	 * [jetpack_videopress tLvEwHYZ width=560 height=315]
+	 * [videopress tLvEwHYZ]
 	 *
 	 * @param array $atts Shortcode attributes.
 	 *
@@ -41,15 +55,6 @@ class Block_Editor_Content {
 		 */
 		$guid = isset( $atts[0] ) ? $atts[0] : null;
 
-		$atts = shortcode_atts(
-			array(
-				'width'  => 560, // int.
-				'height' => 315, // int.
-			),
-			$atts,
-			'videopress'
-		);
-
 		/**
 		 * Make sure the GUID passed in matches how actual GUIDs are formatted.
 		 */
@@ -57,11 +62,38 @@ class Block_Editor_Content {
 			return '<!-- error: missing or invalid VideoPress video ID -->';
 		}
 
-		$width  = (int) $atts['width'];
-		$height = (int) $atts['height'];
-		$src    = esc_url( 'https://videopress.com/embed/' . $guid );
+		/**
+		 * Set the defaults
+		 */
+		$defaults = array(
+			'w'               => 854,   // Width of the video player, in pixels
+			'h'               => 480,   // Height of the video player, in pixels
+			'at'              => 0,     // How many seconds in to initially seek to
+			'loop'            => false, // Whether to loop the video repeatedly
+			'autoplay'        => false, // Whether to autoplay the video on load
+			'muted'           => false, // Whether the video should start without sound
+			'controls'        => true,  // Whether the video should display controls
+			'playsinline'     => false, // Whether the video should be allowed to play inline (for browsers that support this)
+			'useaveragecolor' => false, // Whether the video should use the seekbar automatic average color
+			// 'defaultlangcode' => false, // Default language code. Currently ignored by the player.
+		);
 
-		wp_enqueue_script( 'videopress-iframe', 'https://videopress.com/videopress-iframe.js', array(), Package_Version::PACKAGE_VERSION, true );
+		$atts = shortcode_atts( $defaults, $atts, 'videopress' );
+
+		$base_url     = 'https://videopress.com/embed/' . $guid;
+		$query_params = array(
+			'at'              => $atts['at'],
+			'loop'            => $atts['loop'],
+			'autoplay'        => $atts['autoplay'],
+			'muted'           => $atts['muted'],
+			'controls'        => $atts['controls'],
+			'playsinline'     => $atts['playsinline'],
+			'useAverageColor' => $atts['useaveragecolor'], // The casing is intentional, shortcode params are lowercase, but player expects useAverageColor
+		);
+		$src          = esc_url( add_query_arg( $query_params, $base_url ) );
+
+		$width  = absint( $atts['w'] );
+		$height = absint( $atts['h'] );
 
 		$block_template =
 		'<figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player">' .
@@ -77,6 +109,9 @@ class Block_Editor_Content {
 				'</iframe>' .
 			'</div>' .
 		'</figure>';
+
+		$version = Package_Version::PACKAGE_VERSION;
+		wp_enqueue_script( 'videopress-iframe', 'https://videopress.com/videopress-iframe.js', array(), $version, true );
 
 		return sprintf( $block_template, $src, $width, $height );
 	}
@@ -95,7 +130,15 @@ class Block_Editor_Content {
 			&& '' === $content
 		) {
 			$guid = sanitize_text_field( wp_unslash( $_GET['videopress_guid'] ) );
-			$url  = esc_url( 'https://videopress.com/v/' . $guid . '?resizeToParent=true&cover=true&preloadContent=metadata&useAverageColor=true' );
+
+			$base_url     = 'https://videopress.com/v/' . $guid;
+			$query_params = array(
+				'resizeToParent'  => true,
+				'cover'           => true,
+				'preloadContent'  => 'metadata',
+				'useAverageColor' => true,
+			);
+			$url          = esc_url( add_query_arg( $query_params, $base_url ) );
 
 			if ( ! empty( $guid ) ) {
 				// ref /client/lib/url/index.ts
@@ -108,5 +151,70 @@ class Block_Editor_Content {
 		}
 
 		return $content;
+	}
+
+	/**
+	 * Override the standard video short tag to also process videopress files as well.
+	 *
+	 * This will parse the given src and, if it is a videopress file, parse as the
+	 * VideoPress shortcode instead.
+	 *
+	 * @param string $html     Empty variable to be replaced with shortcode markup.
+	 * @param array  $attr     Attributes of the video shortcode.
+	 * @param string $content  Video shortcode content.
+	 * @param int    $instance Unique numeric ID of this video shortcode instance.
+	 *
+	 * @return string
+	 */
+	public static function video_shortcode_override( $html, $attr, $content, $instance ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$videopress_guid = null;
+
+		if ( isset( $attr['videopress_guid'] ) ) {
+			$videopress_guid = $attr['videopress_guid'];
+		} else {
+			// Handle the different possible url attributes
+			$url_keys = array( 'src', 'mp4' );
+
+			foreach ( $url_keys as $key ) {
+				if ( isset( $attr[ $key ] ) ) {
+					$url = $attr[ $key ];
+					// phpcs:ignore WordPress.WP.CapitalPDangit
+					if ( preg_match( '@videos.(videopress\.com|files\.wordpress\.com)/([a-z0-9]{8})/@i', $url, $matches ) ) {
+						$videopress_guid = $matches[2];
+					}
+
+					// Also test for videopress oembed url, which is used by the Video Media Widget.
+					if ( ! $videopress_guid && preg_match( '@https://videopress.com/v/([a-z0-9]{8})@i', $url, $matches ) ) {
+						$videopress_guid = $matches[1];
+					}
+
+					// Also test for old v.wordpress.com oembed URL.
+					if ( ! $videopress_guid && preg_match( '|^https?://v\.wordpress\.com/([a-zA-Z\d]{8})(.+)?$|i', $url, $matches ) ) { // phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
+						$videopress_guid = $matches[1];
+					}
+
+					break;
+				}
+			}
+		}
+
+		if ( $videopress_guid ) {
+			$videopress_atts = array( $videopress_guid );
+
+			if ( isset( $attr['width'] ) ) {
+				$videopress_atts['w'] = (int) $attr['width'];
+			}
+			if ( isset( $attr['autoplay'] ) ) {
+				$videopress_atts['autoplay'] = $attr['autoplay'];
+			}
+			if ( isset( $attr['loop'] ) ) {
+				$videopress_atts['loop'] = $attr['loop'];
+			}
+
+			// Then display the VideoPress version of the stored GUID!
+			return self::videopress_embed_shortcode( $videopress_atts );
+		}
+
+		return '';
 	}
 }

--- a/projects/packages/videopress/src/class-block-editor-content.php
+++ b/projects/packages/videopress/src/class-block-editor-content.php
@@ -28,28 +28,33 @@ class Block_Editor_Content {
 	/**
 	 * VideoPress embed shortcode
 	 *
-	 * Example use:
-	 * [jetpack_videopress guid=tLvEwHYZ width=560 height=315]
+	 * Expected input format:
+	 * [jetpack_videopress tLvEwHYZ width=560 height=315]
 	 *
 	 * @param array $atts Shortcode attributes.
 	 *
 	 * @return string html
 	 */
 	public static function videopress_embed_shortcode( $atts ) {
+		/**
+		 * We only accept GUIDs as a first unnamed argument.
+		 */
+		$guid = isset( $atts[0] ) ? $atts[0] : null;
+
 		$atts = shortcode_atts(
 			array(
-				'guid'   => '', // string.
 				'width'  => 560, // int.
 				'height' => 315, // int.
 			),
 			$atts,
-			'jetpack_videopress'
+			'videopress'
 		);
 
-		$guid = sanitize_text_field( wp_unslash( $atts['guid'] ) );
-
-		if ( empty( $guid ) ) {
-			return '<!-- error: missing VideoPress video ID -->';
+		/**
+		 * Make sure the GUID passed in matches how actual GUIDs are formatted.
+		 */
+		if ( ! videopress_is_valid_guid( $guid ) ) {
+			return '<!-- error: missing or invalid VideoPress video ID -->';
 		}
 
 		$width  = (int) $atts['width'];

--- a/projects/packages/videopress/src/class-block-editor-content.php
+++ b/projects/packages/videopress/src/class-block-editor-content.php
@@ -21,7 +21,7 @@ class Block_Editor_Content {
 			return;
 		}
 
-		add_shortcode( 'jetpack_videopress', array( static::class, 'videopress_block_shortcode' ) );
+		add_shortcode( 'jetpack_videopress', array( static::class, 'videopress_embed_shortcode' ) );
 		add_filter( 'default_content', array( static::class, 'videopress_video_block_by_guid' ), 10, 2 );
 	}
 
@@ -35,7 +35,7 @@ class Block_Editor_Content {
 	 *
 	 * @return string html
 	 */
-	public static function videopress_block_shortcode( $atts ) {
+	public static function videopress_embed_shortcode( $atts ) {
 		$atts = shortcode_atts(
 			array(
 				'guid'   => '', // string.
@@ -58,7 +58,22 @@ class Block_Editor_Content {
 
 		wp_enqueue_script( 'videopress-iframe', 'https://videopress.com/videopress-iframe.js', array(), Package_Version::PACKAGE_VERSION, true );
 
-		return '<iframe src="' . $src . '" frameborder="0" allowfullscreen allow="clipboard-write" width="' . $width . '" height="' . $height . '"></iframe>';
+		$block_template =
+		'<figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player">' .
+			'<div class="jetpack-videopress-player__wrapper">' .
+				'<iframe ' .
+					'title="' . __( 'VideoPress Video Player', 'jetpack-videopress-pkg' ) . '" ' .
+					'aria-label="' . __( 'VideoPress Video Player', 'jetpack-videopress-pkg' ) . '" ' .
+					'src="%s" ' .
+					'width="%s"' .
+					'height="%s" ' .
+					'frameborder="0" ' .
+					'allowfullscreen data-resize-to-parent="true" allow="clipboard-write">' .
+				'</iframe>' .
+			'</div>' .
+		'</figure>';
+
+		return sprintf( $block_template, $src, $width, $height );
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -324,10 +324,10 @@ class Data {
 					'rating'             => $rating,
 					'privacySetting'     => $privacy_setting,
 					'needsPlaybackToken' => $needs_playback_token,
+					'width'              => $width,
+					'height'             => $height,
 					'poster'             => array(
-						'src'    => $poster,
-						'width'  => $width,
-						'height' => $height,
+						'src' => $poster,
 					),
 					'thumbnail'          => $thumbnail,
 					'finished'           => $finished,

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.9.3-alpha';
+	const PACKAGE_VERSION = '0.10.0-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
@@ -203,10 +203,9 @@ const EditVideoDetails = () => {
 
 	const isFetchingData = isFetching || isFetchingPlaybackToken;
 
-	const shortcode =
-		width && height
-			? `[jetpack_videopress guid=${ guid } width=${ width } height=${ height }]`
-			: null;
+	const shortcode = `[videopress ${ guid }${ width ? ` w=${ width }` : '' }${
+		height ? ` h=${ height }` : ''
+	}]`;
 
 	return (
 		<>

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
@@ -134,11 +134,14 @@ const Infos = ( {
 const EditVideoDetails = () => {
 	const {
 		// Video Data
+		guid,
 		duration,
 		posterImage,
 		filename,
 		uploadDate,
 		url,
+		width,
+		height,
 		title,
 		description,
 		// Playback Token
@@ -200,6 +203,11 @@ const EditVideoDetails = () => {
 
 	const isFetchingData = isFetching || isFetchingPlaybackToken;
 
+	const shortcode =
+		width && height
+			? `[jetpack_videopress guid=${ guid } width=${ width } height=${ height }]`
+			: null;
+
 	return (
 		<>
 			<Prompt when={ hasChanges && ! updated } message={ unsavedChangesMessage } />
@@ -251,6 +259,7 @@ const EditVideoDetails = () => {
 								filename={ filename ?? '' }
 								uploadDate={ uploadDate ?? '' }
 								src={ url ?? '' }
+								shortcode={ shortcode ?? '' }
 								loading={ isFetchingData }
 							/>
 						</Col>

--- a/projects/packages/videopress/src/client/admin/components/video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-details/index.tsx
@@ -12,14 +12,19 @@ import Placeholder from '../placeholder';
 import styles from './style.module.scss';
 import { VideoDetailsProps } from './types';
 
-const VideoDetails = ( { filename, src, uploadDate, loading }: VideoDetailsProps ) => {
+const VideoDetails = ( { filename, src, uploadDate, loading, shortcode }: VideoDetailsProps ) => {
 	const formattedDate = uploadDate?.length ? gmdateI18n( 'F j, Y', uploadDate ) : false;
 
 	return (
 		<div className={ styles.details }>
-			<div className={ styles[ 'detail-row' ] }>
+			<div>
 				<Text variant="body-small">{ __( 'Link to video', 'jetpack-videopress-pkg' ) }</Text>
 				{ loading ? <Placeholder height={ 36 } /> : <ClipboardButtonInput value={ src } /> }
+			</div>
+
+			<div>
+				<Text variant="body-small">{ __( 'WordPress shortcode', 'jetpack-videopress-pkg' ) }</Text>
+				{ loading ? <Placeholder height={ 36 } /> : <ClipboardButtonInput value={ shortcode } /> }
 			</div>
 
 			<div>

--- a/projects/packages/videopress/src/client/admin/components/video-details/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/video-details/types.ts
@@ -10,6 +10,11 @@ export type VideoDetailsProps = {
 	src: string;
 
 	/**
+	 * VideoPress embed shortcode.
+	 */
+	shortcode: string;
+
+	/**
 	 * Video uploaded date
 	 */
 	uploadDate: string;

--- a/projects/packages/videopress/src/client/admin/types/index.ts
+++ b/projects/packages/videopress/src/client/admin/types/index.ts
@@ -154,8 +154,6 @@ export type VideoPressVideo = {
 	needsPlaybackToken?: OriginalVideoPressVideo[ 'jetpack_videopress' ][ 'needs_playback_token' ];
 	poster?: {
 		src: OriginalVideoPressVideo[ 'media_details' ][ 'videopress' ][ 'poster' ];
-		width: OriginalVideoPressVideo[ 'media_details' ][ 'width' ];
-		height: OriginalVideoPressVideo[ 'media_details' ][ 'height' ];
 	};
 	finished?: OriginalVideoPressVideo[ 'media_details' ][ 'videopress' ][ 'finished' ];
 	filename?: OriginalVideoPressVideo[ 'slug' ];

--- a/projects/packages/videopress/src/client/state/utils/map-videos.ts
+++ b/projects/packages/videopress/src/client/state/utils/map-videos.ts
@@ -66,10 +66,10 @@ export const mapVideoFromWPV2MediaEndpoint = (
 		rating,
 		privacySetting,
 		needsPlaybackToken,
+		width,
+		height,
 		poster: {
 			src: poster,
-			width,
-			height,
 		},
 		thumbnail,
 		finished,

--- a/projects/plugins/jetpack/changelog/add-videopress-embed-shortcode
+++ b/projects/plugins/jetpack/changelog/add-videopress-embed-shortcode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+VideoPress: Do not register videopress shortcode if standalone VideoPress plugin already registered it

--- a/projects/plugins/jetpack/changelog/add-videopress-embed-shortcode#2
+++ b/projects/plugins/jetpack/changelog/add-videopress-embed-shortcode#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2172,7 +2172,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/videopress",
-                "reference": "f9648f4fec2e3e51fa86bbc43e5aad2cade714f2"
+                "reference": "1992b5f3e03b0f92aca27c54941afdee6e5ffae1"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -2194,7 +2194,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-package-version.php"

--- a/projects/plugins/jetpack/modules/videopress/shortcode.php
+++ b/projects/plugins/jetpack/modules/videopress/shortcode.php
@@ -17,10 +17,15 @@ class VideoPress_Shortcode {
 	 * VideoPress_Shortcode constructor.
 	 */
 	protected function __construct() {
-		add_shortcode( 'videopress', array( $this, 'shortcode_callback' ) );
-		add_shortcode( 'wpvideo', array( $this, 'shortcode_callback' ) );
+		global $shortcode_tags;
 
-		add_filter( 'wp_video_shortcode_override', array( $this, 'video_shortcode_override' ), 10, 4 );
+		// Only add the shortcode if it hasn't already been added by the standalone VideoPress plugin.
+		if ( ! array_key_exists( 'videopress', $shortcode_tags ) ) {
+			add_shortcode( 'videopress', array( $this, 'shortcode_callback' ) );
+			add_shortcode( 'wpvideo', array( $this, 'shortcode_callback' ) );
+
+			add_filter( 'wp_video_shortcode_override', array( $this, 'video_shortcode_override' ), 10, 4 );
+		}
 
 		$this->add_video_embed_hander();
 	}

--- a/projects/plugins/jetpack/modules/videopress/shortcode.php
+++ b/projects/plugins/jetpack/modules/videopress/shortcode.php
@@ -17,10 +17,8 @@ class VideoPress_Shortcode {
 	 * VideoPress_Shortcode constructor.
 	 */
 	protected function __construct() {
-		global $shortcode_tags;
-
 		// Only add the shortcode if it hasn't already been added by the standalone VideoPress plugin.
-		if ( ! array_key_exists( 'videopress', $shortcode_tags ) ) {
+		if ( ! shortcode_exists( 'videopress' ) ) {
 			add_shortcode( 'videopress', array( $this, 'shortcode_callback' ) );
 			add_shortcode( 'wpvideo', array( $this, 'shortcode_callback' ) );
 

--- a/projects/plugins/videopress/changelog/add-videopress-embed-shortcode
+++ b/projects/plugins/videopress/changelog/add-videopress-embed-shortcode
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1277,7 +1277,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/videopress",
-                "reference": "f9648f4fec2e3e51fa86bbc43e5aad2cade714f2"
+                "reference": "1992b5f3e03b0f92aca27c54941afdee6e5ffae1"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1299,7 +1299,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-package-version.php"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27841

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds `videopress` and `wpvideo` shortcodes, overriding Jetpack's shortcodes
* Adds a shortcode quick copy field to the video details page

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard without any video
* Upload one video and check that the "Add video to post" feature still works as expected by clicking on `Add video to post` and verifying that the block is rendered:

![2022-12-21_10-36-39](https://user-images.githubusercontent.com/8486249/208921406-5afbb7a5-fb89-4cad-b002-73dbda34bdca.png)

* Change the newly uploaded video's privacy to `private`:

![2022-12-21_10-37-16](https://user-images.githubusercontent.com/8486249/208921693-2613fbfc-b822-4c00-b076-7cbd48069c15.png)

* Click on `Edit video details` and copy the generated shortcode:

![2022-12-21_10-37-38](https://user-images.githubusercontent.com/8486249/208921842-70505b92-a3b3-4741-91e3-9c593b8bafac.png)

* Back on the block editor, add the generated shortcode to a `Shortcode` block:

![2022-12-21_10-38-00](https://user-images.githubusercontent.com/8486249/208922039-a1202534-7628-47be-bb8d-ada2c69fc399.png)

* Also add other variations, including the `video` shortcode, that is overriden:

![2022-12-21_10-48-30](https://user-images.githubusercontent.com/8486249/208922408-a34f9db5-9136-41e4-b305-cc2e5d25b153.png)

1 - The generated shortcode
2 - `videopress` (or `wpvideo`) shortcode with variations
3 - `video` shortcode with `videopress_guid` key
4 - `video` shortcode with `src`

* Publish and visit the post
* Check that all shortcodes are rendered correctly
* Visit the post in a new private window (incognito mode or in another browser where you are not logged in)
* Check that the videos are marked as private as expected:

![2022-12-08_16-53-45](https://user-images.githubusercontent.com/8486249/206554427-b2cd383b-0a88-4560-aed3-f94d883b3cd1.png)

* Install the Jetpack plugin
* In another tab, visit the post (VideoPress + Jetpack)
* Uninstall VideoPress
* In another tab, visit the post (Jetpack alone)
* Reinstall VideoPress
* In another tab, visit the post (Jetpack + VideoPress, installation order matters)
* Check that all four tabs were rendered without difference

![Screenshot 2022-12-21 at 11-08-20 Testing – HelloWord](https://user-images.githubusercontent.com/8486249/208925119-60a38972-1a5a-4446-a392-f262a890a5f9.png)
