### PR TITLE
Sync: add Launchpad-related options

### DIFF
--- a/projects/packages/sync/changelog/add-launchpad-sync-options
+++ b/projects/packages/sync/changelog/add-launchpad-sync-options
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Sync Launchpad-related options: `launchpad_screen` and `launchpad_checklist_tasks_statuses`

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -104,6 +104,8 @@ class Defaults {
 		'large_size_h',
 		'large_size_w',
 		'launch-status',
+		'launchpad_checklist_tasks_statuses',
+		'launchpad_screen',
 		'mailserver_login', // Not syncing contents, only the option name.
 		'mailserver_pass', // Not syncing contents, only the option name.
 		'mailserver_port',

--- a/projects/plugins/jetpack/changelog/add-launchpad-sync-options
+++ b/projects/plugins/jetpack/changelog/add-launchpad-sync-options
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Sync Launchpad-related options: `launchpad_screen` and `launchpad_checklist_tasks_statuses`

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -230,6 +230,9 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'launch-status'                                => 'unlaunched',
 			'jetpack_blogging_prompts_enabled'             => jetpack_has_write_intent() || jetpack_has_posts_page(),
 			'wpcom_subscription_emails_use_excerpt'        => false,
+			'launchpad_checklist_tasks_statuses'           => array(),
+			'launchpad_screen'                             => 'full',
+
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of Automattic/wp-calypso#70965

#### Changes proposed in this Pull Request:
* Sync `launchpad_screen` and `launchpad_checklist_tasks_statuses` to wpcom

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
This adds data but it is related to wpcom product.

#### Testing instructions:
This will work in conjunction with the *already-landed* D94775-code and testing instructions are be there.