### PR TITLE
Protect: Add messaging for currently available firewall features for upgraded users

### DIFF
--- a/projects/plugins/protect/changelog/add-protect-waf-current-rules-messaging
+++ b/projects/plugins/protect/changelog/add-protect-waf-current-rules-messaging
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added messaging for currently enabled firewall features.

--- a/projects/plugins/protect/src/js/components/firewall-header/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-header/index.jsx
@@ -66,7 +66,24 @@ const UpgradePrompt = () => {
 	);
 };
 
-const FirewallHeader = ( { status, hasRequiredPlan } ) => {
+const CurrentlyEnabledFeatures = ( { manualRulesEnabled, status } ) => {
+	let enabledFeatures = '';
+
+	if ( status === 'on' ) {
+		if ( manualRulesEnabled ) {
+			enabledFeatures = __( 'Automatic and manual rules are currently active.', 'jetpack-protect' );
+		} else {
+			enabledFeatures = __( 'Automatic rules are currently active.', 'jetpack-protect' );
+		}
+	}
+	if ( status === 'off' ) {
+		enabledFeatures = __( 'Automatic and manual rules are available.', 'jetpack-protect' );
+	}
+
+	return <Text weight={ 600 }>{ enabledFeatures }</Text>;
+};
+
+const FirewallHeader = ( { config, status, hasRequiredPlan } ) => {
 	return (
 		<AdminSectionHero>
 			<Container
@@ -81,9 +98,18 @@ const FirewallHeader = ( { status, hasRequiredPlan } ) => {
 								{ __( 'Active', 'jetpack-protect' ) }
 							</Text>
 							<H3 className={ styles[ 'firewall-heading' ] } mb={ 1 } mt={ 2 }>
-								{ __( 'Automatic firewall is on', 'jetpack-protect' ) }
+								{ hasRequiredPlan
+									? __( 'Automatic firewall is on', 'jetpack-protect' )
+									: __( 'Jetpack firewall is on', 'jetpack-protect' ) }
 							</H3>
-							{ ! hasRequiredPlan && <UpgradePrompt /> }
+							{ hasRequiredPlan ? (
+								<CurrentlyEnabledFeatures
+									status={ status }
+									manualRulesEnabled={ config?.jetpackWafIpList }
+								/>
+							) : (
+								<UpgradePrompt />
+							) }
 						</>
 					) }
 					{ 'off' === status && (
@@ -94,7 +120,14 @@ const FirewallHeader = ( { status, hasRequiredPlan } ) => {
 							<H3 className={ styles[ 'firewall-heading' ] } mb={ 2 } mt={ 2 }>
 								{ __( 'Automatic firewall is off', 'jetpack-protect' ) }
 							</H3>
-							{ ! hasRequiredPlan && <UpgradePrompt /> }
+							{ hasRequiredPlan ? (
+								<CurrentlyEnabledFeatures
+									status={ status }
+									manualRulesEnabled={ config?.jetpackWafIpList }
+								/>
+							) : (
+								<UpgradePrompt />
+							) }
 						</>
 					) }
 					{ 'loading' === status && (
@@ -118,11 +151,17 @@ const FirewallHeader = ( { status, hasRequiredPlan } ) => {
 };
 
 const ConnectedFirewallHeader = () => {
-	const { isEnabled } = useWafData();
+	const { isEnabled, config } = useWafData();
 	const { hasRequiredPlan } = useProtectData();
 
 	// To Do: Add loading status
-	return <FirewallHeader status={ isEnabled ? 'on' : 'off' } hasRequiredPlan={ hasRequiredPlan } />;
+	return (
+		<FirewallHeader
+			status={ isEnabled ? 'on' : 'off' }
+			hasRequiredPlan={ hasRequiredPlan }
+			config={ config }
+		/>
+	);
 };
 
 export default ConnectedFirewallHeader;

--- a/projects/plugins/protect/src/js/components/firewall-header/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-header/index.jsx
@@ -70,11 +70,13 @@ const CurrentlyEnabledFeatures = ( { manualRulesEnabled, status } ) => {
 	let enabledFeatures = '';
 
 	if ( status === 'on' ) {
-		if ( manualRulesEnabled ) {
-			enabledFeatures = __( 'Automatic and manual rules are currently active.', 'jetpack-protect' );
-		} else {
-			enabledFeatures = __( 'Automatic rules are currently active.', 'jetpack-protect' );
-		}
+		enabledFeatures = manualRulesEnabled
+			? __( 'Automatic and manual rules are currently active.', 'jetpack-protect' )
+			: __(
+					'Automatic rules are currently active.',
+					'jetpack-protect',
+					/* dummy arg to avoid bad minification */ 0
+			  );
 	}
 	if ( status === 'off' ) {
 		enabledFeatures = __( 'Automatic and manual rules are available.', 'jetpack-protect' );
@@ -100,7 +102,11 @@ const FirewallHeader = ( { config, status, hasRequiredPlan } ) => {
 							<H3 className={ styles[ 'firewall-heading' ] } mb={ 1 } mt={ 2 }>
 								{ hasRequiredPlan
 									? __( 'Automatic firewall is on', 'jetpack-protect' )
-									: __( 'Jetpack firewall is on', 'jetpack-protect' ) }
+									: __(
+											'Jetpack firewall is on',
+											'jetpack-protect',
+											/* dummy arg to avoid bad minification */ 0
+									  ) }
 							</H3>
 							{ hasRequiredPlan ? (
 								<CurrentlyEnabledFeatures


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds copy to the header to explain when automatic/manual rules are available for upgraded users.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

1201069996155224-as-1203517876254351

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Validate a correct message is shown in the header in the following cases:
  * No plan, any scenario: Only manual rules will be applied message.
  * Plan, firewall off: "Automatic and manual rules are available."
  * Plan, firewall on, manual rules off: "Automatic rules are currently active."
  * Plan, firewall on, manual rules on: "Automatic and manual rules are currently active."

#### Screenshots

<img width="965" alt="Screen Shot 2022-12-08 at 2 24 45 PM" src="https://user-images.githubusercontent.com/10933065/206570668-367ac3af-b43e-4b75-ae66-739afed3b7b4.png">
