### PR TITLE
Jetpack: convert embed block VP variation to v6 on the fly for Simple sites

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-convert-embed-to-videopress-video-block-on-the-fly
+++ b/projects/plugins/jetpack/changelog/update-jetpack-convert-embed-to-videopress-video-block-on-the-fly
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: convert core/embed block, videopress variation, to VideoPress video block, on the fly for Simple sites

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -490,6 +490,14 @@ const isVideoPressBlockBasedOnAttributes = attributes => {
 	return true;
 };
 
+/**
+ * Convert some video blocks to VideoPress video blocks,
+ * when the app detects that the block is a VideoPress block instance.
+ *
+ * Blocks list:
+ * - core/video
+ * - core/embed
+ */
 const convertVideoBlockToVideoPressVideoBlock = createHigherOrderComponent( BlockListBlock => {
 	return props => {
 		const { block } = props;

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -510,7 +510,7 @@ const convertVideoBlockToVideoPressVideoBlock = createHigherOrderComponent( Bloc
 
 		const isSimple = isSimpleSite();
 
-		const shouldConvertToVideoPressVideoBlock = !! (
+		const shouldConvertCoreVideoToVideoPressVideoBlock = !! (
 			name === 'core/video' && // Only auto-convert if the block is a core/video block
 			isVideoPressVideoBlockRegistered && // Only auto-convert if the VideoPress block is registered
 			isCoreVideoVideoPressBlock && // Only auto-convert if the block is a VideoPress block
@@ -518,6 +518,8 @@ const convertVideoBlockToVideoPressVideoBlock = createHigherOrderComponent( Bloc
 			// Only auto-convert if the site is Simple
 			isSimple
 		);
+
+		const shouldConvertToVideoPressVideoBlock = shouldConvertCoreVideoToVideoPressVideoBlock;
 
 		useEffect( () => {
 			if ( ! shouldConvertToVideoPressVideoBlock ) {

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -490,7 +490,7 @@ const isVideoPressBlockBasedOnAttributes = attributes => {
 	return true;
 };
 
-const convertCoreVideoToVideoPressVideoBlock = createHigherOrderComponent( BlockListBlock => {
+const convertVideoBlockToVideoPressVideoBlock = createHigherOrderComponent( BlockListBlock => {
 	return props => {
 		const { block } = props;
 		const { name, attributes, clientId, __unstableBlockSource } = block;
@@ -541,10 +541,10 @@ const convertCoreVideoToVideoPressVideoBlock = createHigherOrderComponent( Block
 
 		return <BlockListBlock { ...props } />;
 	};
-}, 'convertCoreVideoToVideoPressVideoBlock' );
+}, 'convertVideoBlockToVideoPressVideoBlock' );
 
 addFilter(
 	'editor.BlockListBlock',
 	'videopress/jetpack-convert-to-videopress-video-block',
-	convertCoreVideoToVideoPressVideoBlock
+	convertVideoBlockToVideoPressVideoBlock
 );

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -516,10 +516,12 @@ const convertVideoBlockToVideoPressVideoBlock = createHigherOrderComponent( Bloc
 			'videopress/video'
 		);
 
+		const isCoreVideoBlock = name === 'core/video';
+
 		const isSimple = isSimpleSite();
 
 		const shouldConvertCoreVideoToVideoPressVideoBlock = !! (
-			name === 'core/video' && // Only auto-convert if the block is a core/video block
+			isCoreVideoBlock && // Only auto-convert if the block is a core/video block
 			isVideoPressVideoBlockRegistered && // Only auto-convert if the VideoPress block is registered
 			isCoreVideoVideoPressBlock && // Only auto-convert if the block is a VideoPress block
 			isVideoPressVideoBlockAvailable && // Only auto-convert if the feature is available

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -504,7 +504,7 @@ const convertVideoBlockToVideoPressVideoBlock = createHigherOrderComponent( Bloc
 		const { block } = props;
 		const { name, attributes, clientId, __unstableBlockSource } = block;
 		const { replaceBlock } = useDispatch( blockEditorStore );
-		const { url, guid: guidAttr } = attributes;
+		const { url, guid: guidAttr, providerNameSlug } = attributes;
 
 		/*
 		 * We try to recognize core/video Jetpack VideoPress block,
@@ -523,6 +523,8 @@ const convertVideoBlockToVideoPressVideoBlock = createHigherOrderComponent( Bloc
 		const isCoreEmbedBlock = name === 'core/embed';
 		const guidFromUrl = pickGUIDFromUrl( url );
 
+		const isCoreEmbedVideoPressVariation = providerNameSlug === 'videopress' && !! guidFromUrl;
+
 		/*
 		 * GUID can come `guid` attribute (for core/video)
 		 * or from the `url` attribute (for core/embed)
@@ -540,7 +542,17 @@ const convertVideoBlockToVideoPressVideoBlock = createHigherOrderComponent( Bloc
 			isSimple
 		);
 
-		const shouldConvertToVideoPressVideoBlock = shouldConvertCoreVideoToVideoPressVideoBlock;
+		const shouldConvertCoreEmbedToVideoPressVideoBlock = !! (
+			isCoreEmbedBlock && // Only auto-convert if the block is a core/embed block
+			isVideoPressVideoBlockRegistered && // Only auto-convert if the VideoPress block is registered
+			isCoreEmbedVideoPressVariation && // Only auto-convert if the block is a embed VideoPress variation
+			isVideoPressVideoBlockAvailable && // Only auto-convert if the feature is available
+			// Only auto-convert if the site is Simple
+			isSimple
+		);
+
+		const shouldConvertToVideoPressVideoBlock =
+			shouldConvertCoreVideoToVideoPressVideoBlock || shouldConvertCoreEmbedToVideoPressVideoBlock;
 
 		useEffect( () => {
 			if ( ! shouldConvertToVideoPressVideoBlock ) {

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -462,11 +462,11 @@ function getVideoPressVideoBlockAttributes( attributes, defaultAttributes ) {
 }
 
 /**
- * Check whether the block is a VideoPress block istance,
+ * Check whether the block is a VideoPress block instance,
  * based on the passed attributes.
  *
  * @param {object} attributes - Block attributes.
- * @returns {boolean} 	        Whether the block is a VideoPress block istance.
+ * @returns {boolean} 	        Whether the block is a VideoPress block instance.
  */
 const isVideoPressBlockBasedOnAttributes = attributes => {
 	const { guid, videoPressTracks, isVideoPressExample } = attributes;

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -22,6 +22,7 @@ import deprecatedV3 from './deprecated/v3';
 import deprecatedV4 from './deprecated/v4';
 import withVideoPressEdit from './edit';
 import withVideoPressSave from './save';
+import { pickGUIDFromUrl } from './utils';
 import addVideoPressVideoChaptersSupport from './video-chapters';
 import videoPressBlockExampleImage from './videopress-block-example-image.jpg';
 import './editor.scss';
@@ -503,6 +504,7 @@ const convertVideoBlockToVideoPressVideoBlock = createHigherOrderComponent( Bloc
 		const { block } = props;
 		const { name, attributes, clientId, __unstableBlockSource } = block;
 		const { replaceBlock } = useDispatch( blockEditorStore );
+		const { url, guid: guidAttr } = attributes;
 
 		/*
 		 * We try to recognize core/video Jetpack VideoPress block,
@@ -517,6 +519,15 @@ const convertVideoBlockToVideoPressVideoBlock = createHigherOrderComponent( Bloc
 		);
 
 		const isCoreVideoBlock = name === 'core/video';
+
+		const isCoreEmbedBlock = name === 'core/embed';
+		const guidFromUrl = pickGUIDFromUrl( url );
+
+		/*
+		 * GUID can come `guid` attribute (for core/video)
+		 * or from the `url` attribute (for core/embed)
+		 */
+		const guid = isCoreEmbedBlock && guidFromUrl ? guidFromUrl : guidAttr;
 
 		const isSimple = isSimpleSite();
 
@@ -540,7 +551,7 @@ const convertVideoBlockToVideoPressVideoBlock = createHigherOrderComponent( Bloc
 				clientId,
 				createBlock(
 					'videopress/video',
-					getVideoPressVideoBlockAttributes( __unstableBlockSource?.attrs, attributes )
+					getVideoPressVideoBlockAttributes( __unstableBlockSource?.attrs, { ...attributes, guid } )
 				)
 			);
 		}, [
@@ -549,6 +560,7 @@ const convertVideoBlockToVideoPressVideoBlock = createHigherOrderComponent( Bloc
 			attributes,
 			__unstableBlockSource,
 			replaceBlock,
+			guid,
 		] );
 
 		return <BlockListBlock { ...props } />;

--- a/projects/plugins/jetpack/extensions/blocks/videopress/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/utils.js
@@ -63,3 +63,19 @@ export function getClassNames( html, existingClassNames = '', allowResponsive = 
 export const removeFileNameExtension = name => {
 	return name.replace( /\.[^/.]+$/, '' );
 };
+
+export const pickGUIDFromUrl = url => {
+	if ( ! url ) {
+		return null;
+	}
+
+	const urlParts = url.match(
+		/^https?:\/\/(?<host>video(?:\.word)?press\.com)\/(?:v|embed)\/(?<guid>[a-zA-Z\d]{8})/
+	);
+
+	if ( ! urlParts?.groups?.guid ) {
+		return null;
+	}
+
+	return urlParts.groups.guid;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The changes introduced by this PR convert the `core/embed` block to the new VideoPress video block, as long as it's a `videopress` variation and only for Simple sites.

Fixes https://github.com/Automattic/jetpack/issues/27856

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack: convert core/embed block, VideoPress variation, to the VideoPress video block on the fly, for Simple sites

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

#### Jetpack / Atomic sites

* Activate Jetpack plugin
* Go to block editor
* Add a new embed block

<img src="https://user-images.githubusercontent.com/77539/206485057-c12e1466-4344-46b2-9875-09911c035d8e.png" width="600px" />

* Set the embed URL. Feel free to use
```
https://videopress.com/v/bjvmxiQS
```
* Confirm the app prompts you to convert the block to the VideoPress video block
<img width="676" alt="image" src="https://user-images.githubusercontent.com/77539/206485351-12d45ce0-8111-4b46-92da-893c3a916b82.png">

* You can convert the block or ignore it. Confirm that.

#### Simple sites

* Go to block editor
* Add a new embed block

before | after
------|------
<img width="863" alt="image" src="https://user-images.githubusercontent.com/77539/206484538-1adf68f3-cc6e-4ea4-a9b2-233c382580a5.png"> | <img width="830" alt="image" src="https://user-images.githubusercontent.com/77539/206713463-1d094d6b-b7f9-4caa-9d84-805f51d811ef.png">


You can check the patterns registered by the VideoMaker theme:

before| after
-----|-------
<img width="355" alt="image" src="https://user-images.githubusercontent.com/77539/206506935-05012e57-f451-4b57-9c31-c086fb1975e9.png"> | <img width="351" alt="image" src="https://user-images.githubusercontent.com/77539/206713672-59bf2978-0472-4ef7-b50d-d0311995e45e.png">

