### PR TITLE
tools: Support shared prefixes in create-release-branch.sh

### DIFF
--- a/tools/create-release-branch.sh
+++ b/tools/create-release-branch.sh
@@ -1,27 +1,40 @@
 #!/usr/bin/env bash
 
 set -eo pipefail
+shopt -s inherit_errexit
 
-BASE=$(cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
+BASE=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 . "$BASE/tools/includes/check-osx-bash-version.sh"
 . "$BASE/tools/includes/chalk-lite.sh"
 . "$BASE/tools/includes/normalize-version.sh"
 . "$BASE/tools/includes/plugin-functions.sh"
 . "$BASE/tools/includes/proceed_p.sh"
+. "$BASE/tools/includes/version-compare.sh"
 
 # Instructions
 function usage {
 	cat <<-EOH
-		usage: $0 [options] <plugin> <version>
+		usage: $0 [options] <prefix|plugin> [<version>]
 
-		Create a new release branch for the specified plugin. The <plugin> may be
-		either the name of a directory in projects/plugins/, or a path to a plugin
-		directory or file.
+		Create a new release branch for the specified prefix or plugin.
+		The <prefix|plugin> should be a release branch prefix used by at least one
+		monorepo plugin, but may also be the name of a directory in projects/plugins/
+		or a path to a plugin directory or file.
+
+		If no <version> is specified (and we're not non-interactive), you will be
+		prompted. You'll also be prompted if more than one plugin matches the prefix.
 
 		Options:
 		  --non-interactive  Exit instead of prompting for questionable cases.
 	EOH
 	exit 1
+}
+
+# Run a command and check if output is empty/non-empty
+function isnotempty {
+	local TMP
+	TMP=$("$@") || exit $?
+	[[ -n "$TMP" ]]
 }
 
 # Process args.
@@ -47,47 +60,76 @@ if $INTERACTIVE && [[ ! -t 0 ]]; then
 	debug "Input is not a terminal, forcing --non-interactive."
 	INTERACTIVE=false
 fi
-if [[ ${#ARGS[@]} -ne 2 ]]; then
+if [[ ${#ARGS[@]} -ne 1 && ${#ARGS[@]} -ne 2 ]]; then
 	usage
 fi
-process_plugin_arg "${ARGS[0]}"
-normalize_version_number "${ARGS[1]}"
 
-info "Checking if the plugin is releasable..."
-PLUGIN_NAME=$(jq --arg n "${ARGS[0]}" -r '.name // $n' "$PLUGIN_DIR/composer.json")
-PREFIX=$(jq -r '.extra["release-branch-prefix"] // ""' "$PLUGIN_DIR/composer.json")
-MIRROR=$(jq -r '.extra["mirror-repo"] // ""' "$PLUGIN_DIR/composer.json")
-if [[ -z "$PREFIX" ]]; then
-	die "Plugin $PLUGIN_NAME does not have a release branch prefix defined in composer.json. Aborting."
+# Collect available prefixes
+declare -A PREFIXES
+TMP=$(jq -r '.extra["release-branch-prefix"] // empty | [ ., input_filename ] | @tsv' "$BASE"/projects/plugins/*/composer.json)
+while IFS=$'\t' read -r prefix file; do
+	PREFIXES[$prefix]="${PREFIXES[$prefix]:+${PREFIXES[$prefix]}$'\n'}${file%/composer.json}"
+done <<<"$TMP"
+
+# If <prefix|plugin> is a known prefix, use the corresponding plugins. Otherwise, process it as a plugin arg.
+if [[ -n "${PREFIXES[${ARGS[0]}]}" ]]; then
+	PREFIX=${ARGS[0]}
+	mapfile -t DIRS <<<"${PREFIXES[$PREFIX]}"
+else
+	process_plugin_arg "${ARGS[0]}"
+	PLUGIN_NAME=$(jq --arg n "${ARGS[0]}" -r '.name // $n' "$PLUGIN_DIR/composer.json")
+	PREFIX=$(jq -r '.extra["release-branch-prefix"] // ""' "$PLUGIN_DIR/composer.json")
+	if [[ -z "$PREFIX" ]]; then
+		die "Plugin $PLUGIN_NAME does not have a release branch prefix defined in composer.json. Aborting."
+	fi
+	DIRS=( "$PLUGIN_DIR" )
+
+	if [[ "${PREFIXES[$PREFIX]}" == *$'\n'* ]]; then
+		info "Plugin $PLUGIN_NAME uses prefix $PREFIX, which is used in multiple plugins:"
+		echo "   ${PREFIXES[$PREFIX]//$'\n'/$'\n   '}"
+		# shellcheck disable=SC2310
+		if proceed_p '' 'Release all these plugins?'; then
+			mapfile -t DIRS <<<"${PREFIXES[$PREFIX]}"
+		else
+			proceed_p ' ' "Release only $PLUGIN_NAME?"
+		fi
+	fi
 fi
 
-# Check the version.
-if [[ ! "$NORMALIZED_VERSION" =~ ^[0-9]+(\.[0-9]+)+(-.*)?$ ]]; then
-	die "\"$NORMALIZED_VERSION\" does not appear to be a valid version number."
-fi
-CUR_VERSION=$("$BASE/tools/plugin-version.sh" "$PLUGIN_DIR")
-if pnpm semver --range "<= $("$BASE/tools/plugin-version.sh" -n 3 -v "$CUR_VERSION")" "$("$BASE/tools/plugin-version.sh" -n 3 -v "$NORMALIZED_VERSION")" &>/dev/null; then
-	proceed_p "Version $NORMALIZED_VERSION <= $CUR_VERSION."
-fi
+NAMES=()
+MIRRORS=()
+for DIR in "${DIRS[@]}"; do
+	NAMES+=( "$(jq --arg n "${DIR##*/}" -r '.name // $n' "$DIR/composer.json")" )
+	TMP=$(jq -r '.extra["mirror-repo"] // ""' "$DIR/composer.json")
+	if [[ -n "$TMP" ]]; then
+		MIRRORS+=( "$TMP" )
+	fi
+done
+info "Releasing plugins: ${NAMES[*]}"
 
 info "Checking working directory status..."
-if [[ "$(git status --porcelain)" ]]; then
+# shellcheck disable=SC2310
+if isnotempty git status --porcelain; then
 	die "Working directory is not clean. Aborting."
 fi
 
 # Make sure we're on the prerelease branch, or at least that the user is fine with it.
 git fetch
-if [[ "$(git rev-parse --abbrev-ref HEAD)" != "prerelease" ]]; then
-	if proceed_p "Current branch is $(git rev-parse --abbrev-ref HEAD)." "Check out prerelease branch?"; then
+TMP=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$TMP" != "prerelease" ]]; then
+	# shellcheck disable=SC2310
+	if proceed_p "Current branch is $TMP." "Check out prerelease branch?"; then
 		git checkout prerelease
 	else
 		proceed_p " " "Continue anyway?"
 	fi
 fi
-COMMITS="$(git log HEAD.. --oneline)"
+COMMITS=$(git log HEAD.. --oneline)
 if [[ -n "$COMMITS" ]]; then
-	info "The current branch is behind $(git rev-parse --abbrev-ref --symbolic-full-name @{u})."
+	TMP=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}')
+	info "The current branch is behind $TMP."
 	echo "$COMMITS"
+	# shellcheck disable=SC2310
 	if proceed_p "" "Pull?"; then
 		git pull
 	else
@@ -95,11 +137,84 @@ if [[ -n "$COMMITS" ]]; then
 	fi
 fi
 
-# See if the release branch already exists.
-BRANCH="$PREFIX/branch-${NORMALIZED_VERSION%%-*}"
-if [[ "$(git ls-remote --heads origin "$BRANCH")" ]]; then
+# Figure out the version(s) to use for the plugin(s).
+function check_ver {
+	normalize_version_number "$1"
+	if [[ ! "$NORMALIZED_VERSION" =~ ^[0-9]+(\.[0-9]+)+(-.*)?$ ]]; then
+		red "\"$NORMALIZED_VERSION\" does not appear to be a valid version number."
+		return 1
+	fi
+	local CUR_VERSION
+	CUR_VERSION=$("$BASE/tools/plugin-version.sh" "${DIRS[$2]}")
+	# shellcheck disable=SC2310
+	if version_compare "$CUR_VERSION" "$NORMALIZED_VERSION"; then
+		proceed_p "Version $NORMALIZED_VERSION <= $CUR_VERSION."
+		return $?
+	fi
+	return 0
+}
+VERSIONS=()
+if [[ -n "${ARGS[1]}" && ${#DIRS[@]} -gt 1 ]]; then
+	debug "Ignoring specified version since more than one plugin matches."
+	ARGS[1]=
+fi
+if [[ -n "${ARGS[1]}" ]]; then
+	# Check the version.
+	check_ver "${ARGS[1]}" 0
+	info "Using version number $NORMALIZED_VERSION for plugin ${NAMES[0]}"
+	VERSIONS+=( "$NORMALIZED_VERSION" )
+else
+	# Prompt for versions.
+	$INTERACTIVE || die "Cannot prompt for versions when running in non-interactive mode!"
+	for ((i=0; i < ${#DIRS[@]}; i++)); do
+		PROMPT="Version to use for plugin ${NAMES[$i]}:"
+		# shellcheck disable=SC2310
+		if color_supported; then
+			PROMPT=$(FORCE_COLOR=1 prompt "$PROMPT")
+		fi
+		while [[ ${#VERSIONS[@]} -le $i ]]; do
+			IFS= read -p "$PROMPT " -r LINE || die "Aborting!"
+			# shellcheck disable=SC2310
+			if [[ -n "$LINE" ]] && check_ver "$LINE" "$i"; then
+				VERSIONS+=( "$NORMALIZED_VERSION" )
+			fi
+		done
+	done
+fi
+
+# Figure out the release branch, and see if it already exists.
+# - If there's just one plugin using this prefix, just use the version.
+# - Else if the prefix matches a plugin dir name, use that plugin's version.
+# - Else ask.
+if [[ "${PREFIXES[$PREFIX]}" != *$'\n'* ]]; then
+	BRANCH="$PREFIX/branch-${VERSIONS[0]%%-*}"
+else
+	BRANCH=
+	for ((i=0; i < ${#DIRS[@]}; i++)); do
+		if [[ "${DIRS[$i]}" == "$BASE/projects/plugins/$PREFIX" ]]; then
+			TMP="${VERSIONS[$i]}"
+			BRANCH="$PREFIX/branch-${TMP%%-*}"
+		fi
+	done
+	# If that didn't work, ask.
+	if [[ -z "$BRANCH" ]]; then
+		PROMPT="Version to use for the release branch name:"
+		# shellcheck disable=SC2310
+		if color_supported; then
+			PROMPT=$(FORCE_COLOR=1 prompt "$PROMPT")
+		fi
+		while [[ -z "$BRANCH" ]]; do
+			IFS= read -p "$PROMPT " -r LINE || die "Aborting!"
+			if [[ -n "$LINE" ]]; then
+				BRANCH="$PREFIX/branch-$LINE"
+			fi
+		done
+	fi
+fi
+# shellcheck disable=SC2310
+if isnotempty git ls-remote --heads origin "$BRANCH"; then
 	die "Release branch $BRANCH has already been pushed. Aborting."
-elif [[ "$(git branch --list "$BRANCH")" ]]; then
+elif isnotempty git branch --list "$BRANCH"; then
 	proceed_p "Release branch $BRANCH already exists locally, but has not been pushed." "Delete it?"
 	git branch -D "$BRANCH"
 fi
@@ -108,21 +223,25 @@ BASE_REF="$(git rev-parse --abbrev-ref HEAD)"
 info "Creating release branch $BRANCH based on $BASE_REF..."
 git checkout -b "$BRANCH"
 
-info "Updating version numbers..."
-"$BASE/tools/plugin-version.sh" -v "$NORMALIZED_VERSION" "$PLUGIN_DIR"
-if [[ "$(git status --porcelain)" ]]; then
-	git commit -am "Updated $PLUGIN_NAME version to $NORMALIZED_VERSION"
-else
-	debug "No version numbers needed updating."
-fi
+for ((i=0; i < ${#DIRS[@]}; i++)); do
+	info "Updating version numbers for ${NAMES[$i]}..."
+	"$BASE/tools/plugin-version.sh" -v "${VERSIONS[$i]}" "${DIRS[$i]}"
+	# shellcheck disable=SC2310
+	if isnotempty git status --porcelain; then
+		git commit -am "Updated ${NAMES[$i]} version to ${VERSIONS[$i]}"
+	else
+		debug "No version numbers needed updating."
+	fi
 
-info "Versioning packages..."
-"$BASE/tools/version-packages.sh" "$PLUGIN_DIR"
-if [[ "$(git status --porcelain)" ]]; then
-	git commit -am "Updated package versions for $PLUGIN_NAME"
-else
-	debug "No packages needed versioning."
-fi
+	info "Versioning packages for ${NAMES[$i]}..."
+	"$BASE/tools/version-packages.sh" "${DIRS[$i]}"
+	# shellcheck disable=SC2310
+	if isnotempty git status --porcelain; then
+		git commit -am "Updated package versions for ${NAMES[$i]}"
+	else
+		debug "No packages needed versioning."
+	fi
+done
 
 info <<-EOM
 Release branch $BRANCH created! When ready, push to GitHub with
@@ -133,8 +252,10 @@ EOM
 
 PUSH_MSG=" after you push"
 if $INTERACTIVE; then
+	# shellcheck disable=SC2310
 	if proceed_p "" "Check changes and push?"; then
 		git log -p "$BASE_REF".."$BRANCH" || true
+		# shellcheck disable=SC2310
 		if proceed_p "" "Push it now?"; then
 			git push -u origin "$BRANCH"
 			PUSH_MSG=
@@ -143,10 +264,18 @@ if $INTERACTIVE; then
 	echo ""
 fi
 
-if [[ "$MIRROR" ]]; then
-	MIRROR_MSG="and pushed to $MIRROR when (if) it completes successfully"
+if [[ ${#MIRRORS[@]} -eq 1 ]]; then
+	MIRROR_MSG="and pushed to ${MIRRORS[0]} when (if) it completes successfully"
+elif [[ ${#MIRRORS[@]} -eq 2 ]]; then
+	MIRROR_MSG="and pushed to ${MIRRORS[0]} and ${MIRRORS[1]} when (if) it completes successfully"
+elif [[ ${#MIRRORS[@]} -gt 2 ]]; then
+	MIRRORS[-1]="and ${MIRRORS[-1]}"
+	TMP=$( printf ", %s" "${MIRRORS[@]}" )
+	MIRROR_MSG="and pushed to ${TMP:2} when (if) it completes successfully"
+elif [[ ${#NAMES[@]} -eq 1 ]]; then
+	MIRROR_MSG="although no mirror repo is set up for ${NAMES[0]}"
 else
-	MIRROR_MSG="although no mirror repo is set up for $PLUGIN_NAME"
+	MIRROR_MSG="although no mirror repos are set up for any of these plugins"
 fi
 fold -s <<-EOM
 Remember that the build will be done by GitHub Actions$PUSH_MSG, $MIRROR_MSG. You'll probably want to watch to make sure that happens. This link should list the build jobs for the branch:

--- a/tools/includes/normalize-version.sh
+++ b/tools/includes/normalize-version.sh
@@ -2,14 +2,16 @@
 
 # Normalizes a version string to desired length.
 # First arg is input string, second is minimum number of points.
+# Version is written to NORMALIZED_VERSION.
 function normalize_version_number {
+	local TARGET_LENGTH VERSION_ARRAY VERSION_SUFFIX VERSION_RAW VERSION_PARTS i
 	TARGET_LENGTH="${2:-2}"
 	VERSION_ARRAY=()
 
 	# Break off dash content to append later.
-	if [[ $1 =~ "-" ]]; then
-		VERSION_SUFFIX=$(echo $1 | cut -d'-' -f 2)
-		VERSION_RAW=$(echo $1 | cut -d'-' -f 1)
+	if [[ "$1" =~ "-" ]]; then
+		VERSION_SUFFIX=${1#*-}
+		VERSION_RAW=${1%%-*}
 	else
 		VERSION_RAW=$1
 	fi
@@ -21,13 +23,13 @@ function normalize_version_number {
 	done
 
 	# Add additional zeros until target length is reached.
-	while [ "${#VERSION_ARRAY[@]}" -lt "$TARGET_LENGTH" ]; do
+	while [[ "${#VERSION_ARRAY[@]}" -lt "$TARGET_LENGTH" ]]; do
 		VERSION_ARRAY+=( "0" )
 	done
 
 	# Join array by dots, then append suffix.
 	NORMALIZED_VERSION=$(IFS=. ; echo "${VERSION_ARRAY[*]}")
-	if [ $VERSION_SUFFIX ]; then
+	if [[ -n "$VERSION_SUFFIX" ]]; then
 		NORMALIZED_VERSION="${NORMALIZED_VERSION}-${VERSION_SUFFIX}"
 	fi
 }

--- a/tools/includes/plugin-functions.sh
+++ b/tools/includes/plugin-functions.sh
@@ -50,9 +50,15 @@ function process_plugin_arg {
 		find_plugin_file
 	elif [[ -d "$1" ]]; then
 		PLUGIN_DIR="${1%/}"
+		if [[ "${PLUGIN_DIR:0:1}" != '/' ]]; then
+			PLUGIN_DIR="$PWD/${PLUGIN_DIR}"
+		fi
 		find_plugin_file
 	elif [[ -f "$1" ]]; then
 		PLUGIN_FILE="$1"
+		if [[ "${PLUGIN_FILE:0:1}" != '/' ]]; then
+			PLUGIN_FILE="$PWD/${PLUGIN_FILE}"
+		fi
 		PLUGIN_DIR=$(dirname "$1")
 		if ! is_wp_plugin_file "$PLUGIN_FILE"; then
 			error "File $1 does not appear to be a WordPress plugin file."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We're always going to want to release both Jetpack and jetpack-mu-wpcom together, so we may as well use just one release branch to do it. For that to work, we need to make sure that create-release-branch.sh runs plugin-version.sh and version-packages.sh on both plugins.

We might also want to add some of the other standalone plugins to that group in the future.

Also minor fixes to other scripts:
* Localize variables and update syntax in normalize-version.sh.
* Have `process_plugin_arg` always produce a full path.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
🤷

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try using the script to create a release for one of the standalone plugins.
* Try using it to create a release for "jetpack". See that it does the right thing, releasing both jetpack and jetpack-mu-wpcom.
* Try using it to create a release for "jetpack-mu-wpcom". Try different answers to the prompts and see that it does the right thing.
* Try using it to create a release for "projects/plugins/jetpack". Try different answers to the prompts and see that it does the right thing.