### PR TITLE
Stats: add list posts api

### DIFF
--- a/projects/packages/stats-admin/changelog/add-stats-list-posts-api
+++ b/projects/packages/stats-admin/changelog/add-stats-list-posts-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: added list posts endpoint

--- a/projects/packages/stats-admin/composer.json
+++ b/projects/packages/stats-admin/composer.json
@@ -46,7 +46,7 @@
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-stats-admin",
 		"branch-alias": {
-			"dev-trunk": "0.1.x-dev"
+			"dev-trunk": "0.2.x-dev"
 		},
 		"textdomain": "jetpack-stats-admin",
 		"version-constants": {

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.1.2-alpha",
+	"version": "0.2.0-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -18,7 +18,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.1.2-alpha';
+	const VERSION = '0.2.0-alpha';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -115,6 +115,17 @@ class REST_Controller {
 				'permission_callback' => array( $this, 'check_user_privileges_callback' ),
 			)
 		);
+
+		// List posts.
+		register_rest_route(
+			static::$namespace,
+			sprintf( '/sites/%d/posts', Jetpack_Options::get_option( 'id' ) ),
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_site_posts' ),
+				'permission_callback' => array( $this, 'check_user_privileges_callback' ),
+			)
+		);
 	}
 
 	/**
@@ -285,6 +296,26 @@ class REST_Controller {
 	 */
 	public function get_site_stats( $req ) {
 		return $this->wpcom_stats->get_stats( $req->get_params() );
+	}
+
+	/**
+	 * List post for the site.
+	 *
+	 * @param WP_REST_Request $req The request object.
+	 * @return array
+	 */
+	public function get_site_posts( $req ) {
+		return $this->request_as_blog_cached(
+			sprintf(
+				'/sites/%d/posts?%s',
+				Jetpack_Options::get_option( 'id' ),
+				http_build_query(
+					$req->get_params()
+				)
+			),
+			'1.2',
+			array( 'timeout' => 5 )
+		);
 	}
 
 	/**

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -305,15 +305,15 @@ class REST_Controller {
 	 * @return array
 	 */
 	public function get_site_posts( $req ) {
+		// Force wpcom response.
+		$params   = array_merge( array( 'force' => 'wpcom' ), $req->get_params() );
 		$response = wp_remote_get(
 			sprintf(
 				'%s/rest/v1.2/sites/%d/posts?%s',
 				JETPACK__WPCOM_JSON_API_BASE,
 				Jetpack_Options::get_option( 'id' ),
 				$req->get_param( 'resource_id' ),
-				http_build_query(
-					$req->get_params()
-				)
+				http_build_query( $params )
 			),
 			array( 'timeout' => 5 )
 		);

--- a/projects/plugins/jetpack/changelog/add-stats-list-posts-api
+++ b/projects/plugins/jetpack/changelog/add-stats-list-posts-api
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1989,7 +1989,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "cd68679775ac75711ed13dc4718a3012e980cb39"
+                "reference": "4cd8e038dee77f90302cf854a0c3f6974a7980b6"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -2005,7 +2005,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-stats-admin",
                 "branch-alias": {
-                    "dev-trunk": "0.1.x-dev"
+                    "dev-trunk": "0.2.x-dev"
                 },
                 "textdomain": "jetpack-stats-admin",
                 "version-constants": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The PR proposes to add `sites/%d/posts` endpoint for stats, which is used by the latest posts component. 

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
pejTkB-6b-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
* Enable Odyssey Stats for your Jetpack site (`PejTkB-3E-p2`)
* Open `Insights` tab
* Ensure `Latest Post` section is working

