### PR TITLE
[Boost] Target ES6 at compile-time

### DIFF
--- a/projects/plugins/boost/changelog/fix-safari
+++ b/projects/plugins/boost/changelog/fix-safari
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Compile with browser settings compatible with older versions of Safari

--- a/projects/plugins/boost/rollup.config.js
+++ b/projects/plugins/boost/rollup.config.js
@@ -114,7 +114,6 @@ export default [
 			json(),
 
 			babel( {
-				exclude: 'node_modules/**',
 				presets: [ '@babel/preset-react' ],
 				babelHelpers: 'bundled',
 				compact: true,
@@ -233,7 +232,6 @@ export default [
 			json(),
 
 			babel( {
-				exclude: 'node_modules/**',
 				presets: [ '@babel/preset-react' ],
 				babelHelpers: 'bundled',
 				compact: true,

--- a/projects/plugins/boost/tsconfig.json
+++ b/projects/plugins/boost/tsconfig.json
@@ -3,7 +3,7 @@
 	"include": [ "app/assets/src/js/**/*", "app/features/image-guide/src/**/*" ],
 	"exclude": [ "node_modules/*", "app/assets/dist/*", "tests/e2e/*" ],
 	"compilerOptions": {
-		"target": "es5",
+		"target": "es6",
 		"types": [ "svelte" ],
 		"typeRoots": [ "./node_modules/@types/", "./app/assets/src/js" ],
 		/**

--- a/projects/plugins/boost/tsconfig.json
+++ b/projects/plugins/boost/tsconfig.json
@@ -3,6 +3,7 @@
 	"include": [ "app/assets/src/js/**/*", "app/features/image-guide/src/**/*" ],
 	"exclude": [ "node_modules/*", "app/assets/dist/*", "tests/e2e/*" ],
 	"compilerOptions": {
+		"target": "es5",
 		"types": [ "svelte" ],
 		"typeRoots": [ "./node_modules/@types/", "./app/assets/src/js" ],
 		/**


### PR DESCRIPTION
When compiling Boost, target ES6 instead of ESNext; Safari 14.0 has issues with some ESNext features - specifically with initializing class variables outside the constructor.

#### Changes proposed in this Pull Request:
* Switch Boost build target to ES6
* Ensure that node_modules imports get re-compiled to ES6 compatible code.

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Ensure Boost's UI works across major browsers
* Ensure it works in Safari 14.0, too.