### PR TITLE
E2E tests: Disable Boost Speed Score tests

### DIFF
--- a/projects/plugins/boost/changelog/fix-e2e-boost-disable-faling-tests
+++ b/projects/plugins/boost/changelog/fix-e2e-boost-disable-faling-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Disable Speed Score E2E tests

--- a/projects/plugins/boost/tests/e2e/specs/speed-score.test.js
+++ b/projects/plugins/boost/tests/e2e/specs/speed-score.test.js
@@ -4,7 +4,7 @@ import { JetpackBoostPage } from '../lib/pages/index.js';
 
 let jetpackBoostPage;
 
-test.describe( 'Speed Score feature', () => {
+test.describe.skip( 'Speed Score feature', () => {
 	test.beforeAll( async ( { browser } ) => {
 		const page = await browser.newPage();
 		await boostPrerequisitesBuilder( page ).withSpeedScoreMocked( false ).build();


### PR DESCRIPTION
Disables Speed Score tests that are currently failing. 

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

