### PR TITLE
Boost: Add new tracks events

### DIFF
--- a/projects/plugins/boost/.eslintrc.cjs
+++ b/projects/plugins/boost/.eslintrc.cjs
@@ -45,6 +45,9 @@ module.exports = {
 			},
 		],
 
+		// This is not a react project.
+		'react-hooks/rules-of-hooks': 0,
+
 		'no-nested-ternary': 0,
 		'prettier/prettier': 0,
 		camelcase: 0,

--- a/projects/plugins/boost/app/assets/src/js/Main.svelte
+++ b/projects/plugins/boost/app/assets/src/js/Main.svelte
@@ -6,8 +6,24 @@
 	import Settings from './pages/settings/Settings.svelte';
 	import config from './stores/config';
 	import { connection } from './stores/connection';
+	import { recordBoostEvent } from './utils/analytics';
+	import debounce from './utils/debounce';
 	import { Router, Route } from './utils/router';
 	import routerHistory from './utils/router-history';
+
+	routerHistory.listen(
+		debounce( history => {
+			// Event names must conform to the following regex: ^[a-z_][a-z0-9_]*$
+			let path = history.location.pathname.replace( /[-/]/g, '_' );
+			if ( path === '_' ) {
+				path = '_home';
+			}
+
+			recordBoostEvent( `page_view${ path }`, {
+				path: history.location.pathname,
+			} );
+		}, 10 )
+	);
 </script>
 
 {#if $connection.connected || ! $config.site.online}

--- a/projects/plugins/boost/app/assets/src/js/Main.svelte
+++ b/projects/plugins/boost/app/assets/src/js/Main.svelte
@@ -16,7 +16,7 @@
 			// Event names must conform to the following regex: ^[a-z_][a-z0-9_]*$
 			let path = history.location.pathname.replace( /[-/]/g, '_' );
 			if ( path === '_' ) {
-				path = '_home';
+				path = '_settings';
 			}
 
 			recordBoostEvent( `page_view${ path }`, {

--- a/projects/plugins/boost/app/assets/src/js/elements/BackButton.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/BackButton.svelte
@@ -3,8 +3,6 @@
 	import { __ } from '@wordpress/i18n';
 	import LeftArrow from '../svg/left-arrow.svg';
 
-	// This isn't react
-	// eslint-disable-next-line react-hooks/rules-of-hooks
 	const navigate = useNavigate();
 
 	export let route = -1;

--- a/projects/plugins/boost/app/assets/src/js/elements/BackButton.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/BackButton.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
+	import { useNavigate } from 'svelte-navigator';
 	import { __ } from '@wordpress/i18n';
 	import LeftArrow from '../svg/left-arrow.svg';
-	import routerHistory from '../utils/router-history';
 
-	const { navigate } = routerHistory;
+	// This isn't react
+	// eslint-disable-next-line react-hooks/rules-of-hooks
+	const navigate = useNavigate();
 
 	export let route = -1;
 </script>

--- a/projects/plugins/boost/app/assets/src/js/elements/ReRouter.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/ReRouter.svelte
@@ -9,8 +9,6 @@
 	export let when: boolean;
 	export let to: string;
 
-	// This ain't React.
-	// eslint-disable-next-line react-hooks/rules-of-hooks
 	const navigate = useNavigate();
 
 	if ( when ) {

--- a/projects/plugins/boost/app/assets/src/js/pages/getting-started/GettingStarted.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/getting-started/GettingStarted.svelte
@@ -18,7 +18,7 @@
 
 		// Need to await in this case because the generation request needs to go after the backend has enabled the module.
 		await updateModuleState( 'critical-css', true );
-
+		await recordBoostEvent( 'free_cta_from_getting_started_page_in_plugin', {} );
 		navigate( '/' );
 	};
 

--- a/projects/plugins/boost/app/assets/src/js/pages/getting-started/GettingStarted.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/getting-started/GettingStarted.svelte
@@ -22,11 +22,6 @@
 		navigate( '/' );
 	};
 
-	onMount( () => {
-		// Throw away promise, as we don't need to wait for it.
-		void recordBoostEvent( 'view_getting_started_page_in_plugin', {} );
-	} );
-
 	const choosePaidPlan = async () => {
 		await recordBoostEvent( 'premium_cta_from_getting_started_page_in_plugin', {} );
 		window.location.href = getUpgradeURL();

--- a/projects/plugins/boost/app/assets/src/js/utils/analytics.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/analytics.ts
@@ -6,9 +6,20 @@ export async function recordBoostEvent(
 	eventName: string,
 	eventProp: TracksEventProperties
 ): Promise< RecordSuccess > {
-	if ( ! ( 'boost_version' in eventProp ) && 'version' in Jetpack_Boost ) {
-		eventProp.boost_version = Jetpack_Boost.version;
+	const defaultProps: { [ key: string ]: string } = {};
+	if ( 'version' in Jetpack_Boost ) {
+		defaultProps.boost_version = Jetpack_Boost.version;
 	}
+	if ( 'connection' in Jetpack_Boost ) {
+		defaultProps.jetpack_connection = Jetpack_Boost.connection.connected
+			? 'connected'
+			: 'disconnected';
+	}
+	if ( 'optimizations' in Jetpack_Boost ) {
+		defaultProps.optimizations = JSON.stringify( Jetpack_Boost.optimizations );
+	}
+
+	eventProp = { ...defaultProps, ...eventProp };
 
 	return new Promise( ( resolve, reject ) => {
 		if (

--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -130,6 +130,7 @@ class Jetpack_Boost {
 	public static function activate() {
 		// Make sure user sees the "Get Started" when first time opening.
 		Config::set_getting_started( true );
+		Analytics::record_user_event( 'activate_plugin' );
 	}
 
 	/**

--- a/projects/plugins/boost/changelog/add-tracks
+++ b/projects/plugins/boost/changelog/add-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added new tracks events


### PR DESCRIPTION
Fixes 183-gh-Automattic/boost-cloud

#### Changes proposed in this Pull Request:
* Add tracks event on plugin activation
* Add tracks event on each page-view and navigation
* Add tracks event on choosing free plan

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
p1HpG7-jhl-p2#comment-58817

#### Does this pull request change what data or activity we track or use?
May be

#### Testing instructions:
Look for `%boost_page_view%` events in tracks