### PR TITLE
[Pre-/Post-publish panel] Change "email subscribers" to "subscribers"

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscription-count-label
+++ b/projects/plugins/jetpack/changelog/fix-subscription-count-label
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Change the label "email subscribers" to "subscribers", since it also includes followers.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -61,11 +61,11 @@ export default function SubscribePanels() {
 				<InspectorNotice>
 					{ createInterpolateElement(
 						sprintf(
-							/* translators: 1$s will be email subscribers, %2$s will be social followers */
+							/* translators: 1$s will be subscribers, %2$s will be social followers */
 							__( 'This post will reach <span>%1$s</span> and <span>%2$s</span>.', 'jetpack' ),
 							sprintf(
-								/* translators: %s will be a number of email subscribers */
-								_n( '%s email subscriber', '%s email subscribers', subscriberCount, 'jetpack' ),
+								/* translators: %s will be a number of subscribers */
+								_n( '%s subscriber', '%s subscribers', subscriberCount, 'jetpack' ),
 								numberFormat( subscriberCount )
 							),
 							sprintf(
@@ -82,11 +82,11 @@ export default function SubscribePanels() {
 				<InspectorNotice>
 					{ createInterpolateElement(
 						sprintf(
-							/* translators: 1$s will be email subscribers, %2$s will be social followers */
+							/* translators: 1$s will be subscribers, %2$s will be social followers */
 							__( 'This post was shared to <span>%1$s</span> and <span>%2$s</span>.', 'jetpack' ),
 							sprintf(
-								/* translators: %s will be a number of email subscribers */
-								_n( '%s email subscriber', '%s email subscribers', subscriberCount, 'jetpack' ),
+								/* translators: %s will be a number of subscribers */
+								_n( '%s subscriber', '%s subscribers', subscriberCount, 'jetpack' ),
 								numberFormat( subscriberCount )
 							),
 							sprintf(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR change the wording "email subscribers" to "subscribers" in the pre- and post-publish panel. Since this count also includes followers the word "subscriber" is more accurate.

| Before | After |
|--------|------|
| <img width="268" src="https://user-images.githubusercontent.com/528287/202143174-2d6585da-83b8-4472-a9ed-bce99ea7eb7e.png" /> | <img width="268" alt="CleanShot 2022-12-12 at 09 46 45@2x" src="https://user-images.githubusercontent.com/528287/207001225-d6b358f2-74e9-4116-9711-2e6b8b2b6820.png"> |


#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
pdDOJh-Yp-p2#comment-865
p1670419117573399-slack-C02TCEHP3HA

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
- Apply this PR
- Make sure Subscriptions are enabled (Jetpack Settings > Discussions), otherwise this panel doesn't shos
- Create a new post
- Click publish
- Verify that the pre-publish and post-publish panels don't mention "email subscribers", but "subscribers"