### PR TITLE
Port Search 1.4.0 prerelease changes back to trunk

### DIFF
--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## 0.26.3 - 2022-12-12
+### Changed
+- Updated package dependencies. [#27888]
+
 ## 0.26.2 - 2022-12-12
 ### Added
 - RNA: Add props to ActionPopover related to link on action button [#27714]

--- a/projects/js-packages/components/changelog/renovate-storybook-monorepo
+++ b/projects/js-packages/components/changelog/renovate-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.26.3-alpha",
+	"version": "0.26.3",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## 0.24.1 - 2022-12-12
+### Changed
+- Updated package dependencies. [#27888]
+
 ## 0.24.0 - 2022-12-05
 ### Changed
 - Improve design of the connection error notice. [#27340]

--- a/projects/js-packages/connection/changelog/renovate-storybook-monorepo
+++ b/projects/js-packages/connection/changelog/renovate-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.24.1-alpha",
+	"version": "0.24.1",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.1] - 2022-12-12
+### Changed
+- Updated package dependencies. [#27888]
+
 ## [2.6.0] - 2022-12-05
 ### Changed
 - Improve design of the error notice. [#27340]
@@ -690,6 +694,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[2.6.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/2.6.0...2.6.1
 [2.6.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/2.5.2...2.6.0
 [2.5.2]: https://github.com/Automattic/jetpack-my-jetpack/compare/2.5.1...2.5.2
 [2.5.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/2.5.0...2.5.1

--- a/projects/packages/my-jetpack/changelog/renovate-storybook-monorepo
+++ b/projects/packages/my-jetpack/changelog/renovate-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "2.6.1-alpha",
+	"version": "2.6.1",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -30,7 +30,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '2.6.1-alpha';
+	const PACKAGE_VERSION = '2.6.1';
 
 	/**
 	 * Initialize My Jetpack

--- a/projects/plugins/search/CHANGELOG.md
+++ b/projects/plugins/search/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2022-12-12
+### Added
+- Search: port Search plugin 1.3.1 changelog and plugin description [#27399]
+
+### Changed
+- My Jetpack: Requires connection only if needed [#27615]
+- My Jetpack: Show My Jetpack even if site is disconnected [#26967]
+- Updated package dependencies. [#26069]
+
+### Fixed
+- Search: Fixed E2E testing failures after adding a checkmark icon for resolved topics [#27586]
+- Search: fixed search E2E failure after the new pricing update [#27430]
+
 ## [1.3.1] - 2022-11-13
 ### Fixed
 - Fixed readme and descriptions for Free tier support and new pricing [#27341]
@@ -102,6 +115,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [1.1.0-beta]: https://github.com/Automattic/jetpack-search-plugin/compare/1.0.0...1.1.0-beta
 [1.2.0-beta]: https://github.com/Automattic/jetpack-search-plugin/compare/1.1.0...1.2.0-beta
+[1.3.2]: https://github.com/Automattic/jetpack-search-plugin/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/Automattic/jetpack-search-plugin/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/Automattic/jetpack-search-plugin/compare/1.2.0...1.3.0
 [1.2.0]: https://github.com/Automattic/jetpack-search-plugin/compare/1.2.0-beta...1.2.0

--- a/projects/plugins/search/CHANGELOG.md
+++ b/projects/plugins/search/CHANGELOG.md
@@ -115,8 +115,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [1.1.0-beta]: https://github.com/Automattic/jetpack-search-plugin/compare/1.0.0...1.1.0-beta
 [1.2.0-beta]: https://github.com/Automattic/jetpack-search-plugin/compare/1.1.0...1.2.0-beta
-[1.3.2]: https://github.com/Automattic/jetpack-search-plugin/compare/v1.3.1...v1.3.2
-[1.3.1]: https://github.com/Automattic/jetpack-search-plugin/compare/v1.3.0...v1.3.1
+[1.4.0]: https://github.com/Automattic/jetpack-search-plugin/compare/1.3.1...1.4.0
+[1.3.1]: https://github.com/Automattic/jetpack-search-plugin/compare/1.3.0...1.3.1
 [1.3.0]: https://github.com/Automattic/jetpack-search-plugin/compare/1.2.0...1.3.0
 [1.2.0]: https://github.com/Automattic/jetpack-search-plugin/compare/1.2.0-beta...1.2.0
 [1.1.0]: https://github.com/Automattic/jetpack-search-plugin/compare/1.1.0-beta...1.1.0

--- a/projects/plugins/search/changelog/add-checkmark-for-resolved-topics
+++ b/projects/plugins/search/changelog/add-checkmark-for-resolved-topics
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Search: Fixed E2E testing failures after adding a checkmark icon for resolved topics

--- a/projects/plugins/search/changelog/add-jetpack-search-free-for-classic
+++ b/projects/plugins/search/changelog/add-jetpack-search-free-for-classic
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/search/changelog/add-jetpack-social-panel-save-attached-media
+++ b/projects/plugins/search/changelog/add-jetpack-social-panel-save-attached-media
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/search/changelog/add-scan-in-protect
+++ b/projects/plugins/search/changelog/add-scan-in-protect
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/search/changelog/add-scan-in-protect#2
+++ b/projects/plugins/search/changelog/add-scan-in-protect#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/add-scan-in-protect#3
+++ b/projects/plugins/search/changelog/add-scan-in-protect#3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/add-sync-request-full-response-logging
+++ b/projects/plugins/search/changelog/add-sync-request-full-response-logging
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/add-sync-request-full-response-logging#2
+++ b/projects/plugins/search/changelog/add-sync-request-full-response-logging#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/e2e-disable-search-test
+++ b/projects/plugins/search/changelog/e2e-disable-search-test
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-

--- a/projects/plugins/search/changelog/fix-access-apis-explicitly
+++ b/projects/plugins/search/changelog/fix-access-apis-explicitly
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/fix-search-e2e-after-new-pricing
+++ b/projects/plugins/search/changelog/fix-search-e2e-after-new-pricing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Search: fixed search E2E failure after the new pricing update

--- a/projects/plugins/search/changelog/init-release-cycle
+++ b/projects/plugins/search/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Init 1.5.0-alpha
+
+

--- a/projects/plugins/search/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/search/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/search/changelog/renovate-yoast-phpunit-polyfills-1.x
+++ b/projects/plugins/search/changelog/renovate-yoast-phpunit-polyfills-1.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/search/changelog/sync-add-reset-endpoint
+++ b/projects/plugins/search/changelog/sync-add-reset-endpoint
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/search/changelog/update-build-action-version-handling
+++ b/projects/plugins/search/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/search/changelog/update-connection-error-notice-redesign
+++ b/projects/plugins/search/changelog/update-connection-error-notice-redesign
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/search/changelog/update-connection-error-notice-redesign#2
+++ b/projects/plugins/search/changelog/update-connection-error-notice-redesign#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/search/changelog/update-connection-error-notice-redesign#3
+++ b/projects/plugins/search/changelog/update-connection-error-notice-redesign#3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/update-init-with-config-package
+++ b/projects/plugins/search/changelog/update-init-with-config-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/update-my-jetpack-show-while-disconnected
+++ b/projects/plugins/search/changelog/update-my-jetpack-show-while-disconnected
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/update-port-search-1.3.1-changelog
+++ b/projects/plugins/search/changelog/update-port-search-1.3.1-changelog
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Search: port Search plugin 1.3.1 changelog and plugin description

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -67,7 +67,7 @@
 	},
 	"config": {
 		"sort-packages": true,
-		"autoloader-suffix": "b462338fb66be23595d68a93345c9e3d_jetpack_searchⓥ1_5_0_alpha",
+		"autoloader-suffix": "b462338fb66be23595d68a93345c9e3d_jetpack_searchⓥ1_4_1_alpha",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true,

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -67,7 +67,7 @@
 	},
 	"config": {
 		"sort-packages": true,
-		"autoloader-suffix": "b462338fb66be23595d68a93345c9e3d_jetpack_searchⓥ1_3_2_alpha",
+		"autoloader-suffix": "b462338fb66be23595d68a93345c9e3d_jetpack_searchⓥ1_4_0",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true,

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -67,7 +67,7 @@
 	},
 	"config": {
 		"sort-packages": true,
-		"autoloader-suffix": "b462338fb66be23595d68a93345c9e3d_jetpack_searchⓥ1_4_0",
+		"autoloader-suffix": "b462338fb66be23595d68a93345c9e3d_jetpack_searchⓥ1_5_0_alpha",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true,

--- a/projects/plugins/search/jetpack-search.php
+++ b/projects/plugins/search/jetpack-search.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Search
  * Plugin URI: https://jetpack.com/search/
  * Description: Easily add cloud-powered instant search and filters to your website or WooCommerce store with advanced algorithms that boost your search results based on traffic to your site.
- * Version: 1.3.2
+ * Version: 1.4.0
  * Author: Automattic - Jetpack Search team
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later

--- a/projects/plugins/search/jetpack-search.php
+++ b/projects/plugins/search/jetpack-search.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Search
  * Plugin URI: https://jetpack.com/search/
  * Description: Easily add cloud-powered instant search and filters to your website or WooCommerce store with advanced algorithms that boost your search results based on traffic to your site.
- * Version: 1.3.2-alpha
+ * Version: 1.3.2
  * Author: Automattic - Jetpack Search team
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later
@@ -26,7 +26,7 @@ define( 'JETPACK_SEARCH_PLUGIN__DIR', plugin_dir_path( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__FILE', __FILE__ );
 define( 'JETPACK_SEARCH_PLUGIN__FILE_RELATIVE_PATH', plugin_basename( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__SLUG', 'jetpack-search' );
-define( 'JETPACK_SEARCH_PLUGIN__VERSION', '1.3.2-alpha' );
+define( 'JETPACK_SEARCH_PLUGIN__VERSION', '1.4.0' );
 
 defined( 'JETPACK_CLIENT__AUTH_LOCATION' ) || define( 'JETPACK_CLIENT__AUTH_LOCATION', 'header' );
 

--- a/projects/plugins/search/jetpack-search.php
+++ b/projects/plugins/search/jetpack-search.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Search
  * Plugin URI: https://jetpack.com/search/
  * Description: Easily add cloud-powered instant search and filters to your website or WooCommerce store with advanced algorithms that boost your search results based on traffic to your site.
- * Version: 1.5.0-alpha
+ * Version: 1.4.1-alpha
  * Author: Automattic - Jetpack Search team
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later
@@ -26,7 +26,7 @@ define( 'JETPACK_SEARCH_PLUGIN__DIR', plugin_dir_path( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__FILE', __FILE__ );
 define( 'JETPACK_SEARCH_PLUGIN__FILE_RELATIVE_PATH', plugin_basename( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__SLUG', 'jetpack-search' );
-define( 'JETPACK_SEARCH_PLUGIN__VERSION', '1.5.0-alpha' );
+define( 'JETPACK_SEARCH_PLUGIN__VERSION', '1.4.1-alpha' );
 
 defined( 'JETPACK_CLIENT__AUTH_LOCATION' ) || define( 'JETPACK_CLIENT__AUTH_LOCATION', 'header' );
 

--- a/projects/plugins/search/jetpack-search.php
+++ b/projects/plugins/search/jetpack-search.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Search
  * Plugin URI: https://jetpack.com/search/
  * Description: Easily add cloud-powered instant search and filters to your website or WooCommerce store with advanced algorithms that boost your search results based on traffic to your site.
- * Version: 1.4.0
+ * Version: 1.5.0-alpha
  * Author: Automattic - Jetpack Search team
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later
@@ -26,7 +26,7 @@ define( 'JETPACK_SEARCH_PLUGIN__DIR', plugin_dir_path( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__FILE', __FILE__ );
 define( 'JETPACK_SEARCH_PLUGIN__FILE_RELATIVE_PATH', plugin_basename( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__SLUG', 'jetpack-search' );
-define( 'JETPACK_SEARCH_PLUGIN__VERSION', '1.4.0' );
+define( 'JETPACK_SEARCH_PLUGIN__VERSION', '1.5.0-alpha' );
 
 defined( 'JETPACK_CLIENT__AUTH_LOCATION' ) || define( 'JETPACK_CLIENT__AUTH_LOCATION', 'header' );
 

--- a/projects/plugins/search/readme.txt
+++ b/projects/plugins/search/readme.txt
@@ -122,25 +122,14 @@ If you are using the Jetpack Search free option, and you have more than 5000 rec
 5. Manage all of your Jetpack products, including Search, in a single place.
 
 == Changelog ==
-### 1.3.1 - 2022-11-13
+### 1.4.0 - 2022-12-12
 #### Added
-- Search: support for Jetpack Search FREE tier for up to 5000 records or 500 search requests per month.
-- Search: Enable stats tracking upon establishing a site connection.
-- Search Dashboard: new record count and search request donut meters.
-- Search Dashboard: conditional CTA and notices.
-- Search: blog filtering support.
+- Search: port Search plugin 1.3.1 changelog and plugin description
 
 #### Changed
-- Compatibility: WordPress 6.1 compatibility.
-- Search: now support 38 languages.
-- Search: always add Search Dashboard page even when submenu is hidden.
+- My Jetpack: Requires connection only if needed
+- My Jetpack: Show My Jetpack even if site is disconnected
 - Updated package dependencies.
-
-### Fixed
-- Customizer: Fixes the issue where search results are not loaded in customizer.
-- Instant Search: Fix error message styling in Instant Search overlay.
-- Search: hide meters etc for Classic Search.
-- Fixed readme and descriptions for Free tier support and new pricing.
 
 == Testimonials ==
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Port Search 1.4.0 prerelease changes back to trunk

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

Please ensure the changelog and version numbers look good.