### PR TITLE
Add brief text context to blogging prompts placeholder

### DIFF
--- a/projects/plugins/jetpack/changelog/add-context-for-blogging-prompt
+++ b/projects/plugins/jetpack/changelog/add-context-for-blogging-prompt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+add context to blogging prompt placeholder

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompts/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompts/editor.js
@@ -1,5 +1,6 @@
 import { createBlock } from '@wordpress/blocks';
 import { dispatch } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
 import { waitForEditor } from '../../shared/wait-for-editor';
 
 async function insertTemplate( prompt, embedPrompt = false ) {
@@ -8,7 +9,14 @@ async function insertTemplate( prompt, embedPrompt = false ) {
 	const { insertBlocks } = dispatch( 'core/block-editor' );
 	const bloggingPromptBlocks = embedPrompt
 		? [ createBlock( 'core/pullquote', { value: prompt.text } ), createBlock( 'core/paragraph' ) ]
-		: createBlock( 'core/paragraph', { placeholder: prompt.text }, [] );
+		: createBlock(
+				'core/paragraph',
+				{
+					/* translators: %s is the daily blogging prompt. */
+					placeholder: sprintf( __( 'Daily Prompt: %s', 'jetpack' ), prompt.text ),
+				},
+				[]
+		  );
 
 	insertBlocks( bloggingPromptBlocks, 0, undefined, false );
 }


### PR DESCRIPTION
Prefixes this simple "`Daily Prompt: `" string to give context for users who may be confused by the blogging prompt. 

<img width="795" alt="Screen Shot 2022-12-13 at 3 04 16 pm" src="https://user-images.githubusercontent.com/22446385/207231981-34de4b22-f382-4173-8789-ecddd67da3be.png">

#### Jetpack product discussion
Internal slack discussion p1670886164566729-slack-C03NLNTPZ2T, p1670877978371049-slack-C025Q5RK2

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
Create a blog that is eligible for writing prompts with `site_intent=write`.
Navigate to the new post editor
