### PR TITLE
Stats: Remove custom css for Stats

### DIFF
--- a/projects/packages/stats-admin/changelog/remove-stats-css
+++ b/projects/packages/stats-admin/changelog/remove-stats-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Stats: removed style overriding for Odyssey stats

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.1.1",
+	"version": "0.1.2-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -145,28 +145,6 @@ class Dashboard {
 			'before'
 		);
 
-		add_action(
-			'admin_head',
-			function () {
-				echo '<style>
-				.jp-stats-dashboard .card {
-					border:0;
-					max-width: initial;
-					min-width: initial;
-				}
-				ul.wp-submenu, ul.wp-submenu-wrap {
-					margin-left: 0;
-				}
-				.jp-stats-dashboard .followers-count {
-					display: none;
-				}
-				.jp-stats-dashboard .layout__content {
-					padding-top: 32px;
-				}
-				</style>';
-			},
-			100
-		);
 	}
 
 	/**

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -18,7 +18,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.1.1';
+	const VERSION = '0.1.2-alpha';
 
 	/**
 	 * Singleton Main instance.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Removes inline style overrides, which is now done in Calypso https://github.com/Automattic/wp-calypso/pull/71113

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
* Enable Odyssey Stats for your Jetpack site (`PejTkB-3E-p2`)
* Open Stats page
* The page might look odd, but mostly works