### PR TITLE
Jetpack Slideshow: Change Transition and Image Size option's labels

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-change-slideshow-option-labels
+++ b/projects/plugins/jetpack/changelog/fix-change-slideshow-option-labels
@@ -1,4 +1,4 @@
 Significance: patch
-Type: changed
+Type: other
 
 Jetpack Slideshow: Change the labels for Image Size and Transition Effect options.

--- a/projects/plugins/jetpack/changelog/fix-change-slideshow-option-labels
+++ b/projects/plugins/jetpack/changelog/fix-change-slideshow-option-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Jetpack Slideshow: Change the labels for Image Size and Transition Effect options.

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/controls.js
@@ -71,7 +71,7 @@ export function PanelControls( {
 			{ ! isEmpty( images ) && ! isEmpty( imageSizeOptions ) && (
 				<PanelBody title={ __( 'Image Settings', 'jetpack' ) }>
 					<SelectControl
-						label={ __( 'Image Size', 'jetpack' ) }
+						label={ __( 'Size', 'jetpack' ) }
 						value={ sizeSlug }
 						options={ imageSizeOptions }
 						onChange={ size => onChangeImageSize( size ) }

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/controls.js
@@ -60,7 +60,7 @@ export function PanelControls( {
 			</PanelBody>
 			<PanelBody title={ __( 'Effects', 'jetpack' ) }>
 				<SelectControl
-					label={ __( 'Transition effect', 'jetpack' ) }
+					label={ __( 'Transition', 'jetpack' ) }
 					value={ effect }
 					onChange={ value => {
 						setAttributes( { effect: value } );

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/test/controls.js
@@ -36,8 +36,8 @@ describe( 'Panel controls', () => {
 		render( <PanelControls { ...panelProps } /> );
 
 		expect( screen.getByLabelText( 'Autoplay' ) ).toBeInTheDocument();
-		expect( screen.getByLabelText( 'Transition effect' ) ).toBeInTheDocument();
-		expect( screen.getByLabelText( 'Image Size' ) ).toBeInTheDocument();
+		expect( screen.getByLabelText( 'Transition' ) ).toBeInTheDocument();
+		expect( screen.getByLabelText( 'Size' ) ).toBeInTheDocument();
 	} );
 
 	test( 'toggles autoplay attribute', async () => {
@@ -51,7 +51,7 @@ describe( 'Panel controls', () => {
 	test( 'sets transition attribute', async () => {
 		const user = userEvent.setup();
 		render( <PanelControls { ...panelProps } /> );
-		await user.selectOptions( screen.getByLabelText( 'Transition effect' ), [ 'fade' ] );
+		await user.selectOptions( screen.getByLabelText( 'Transition' ), [ 'fade' ] );
 
 		expect( setAttributes ).toHaveBeenCalledWith( { effect: 'fade' } );
 	} );
@@ -59,7 +59,7 @@ describe( 'Panel controls', () => {
 	test( 'calls onChangeImageSize callback when new image size selected', async () => {
 		const user = userEvent.setup();
 		render( <PanelControls { ...panelProps } /> );
-		await user.selectOptions( screen.getByLabelText( 'Image Size' ), [ 'thumbnail' ] );
+		await user.selectOptions( screen.getByLabelText( 'Size' ), [ 'thumbnail' ] );
 
 		expect( onChangeImageSize ).toHaveBeenCalledWith( 'thumbnail' );
 	} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27768.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Replaced the Transition and Image Size labels
   * From "Transition effect" to "Transition"
   * From "Image size" to "Size"

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new post or edit an existing one
* Add a Jetpack Slideshow block:

<img width="385" alt="Screen Shot 2022-12-13 at 11 26 01" src="https://user-images.githubusercontent.com/6760046/207305707-d8280ebc-e31c-4285-9441-1a3136c9fb41.png">

* Check the options panel on the right side:
   * it should say "Transition" instead of "Transition effect"
   * it should say "Size" instead of "Image size"

<img width="287" alt="Screen Shot 2022-12-13 at 11 26 59" src="https://user-images.githubusercontent.com/6760046/207306438-9216927a-6cdb-4fa0-8387-9c84a6fe7ce1.png">

* The same change should also work on WPCOM:

<img width="274" alt="Screen Shot 2022-12-13 at 12 02 09" src="https://user-images.githubusercontent.com/6760046/207312736-d3420a35-cce5-4452-86d6-43d8918bb84d.png">
