### PR TITLE
[Boost] Update dismissed modals variable names

### DIFF
--- a/projects/plugins/boost/app/admin/class-config.php
+++ b/projects/plugins/boost/app/admin/class-config.php
@@ -21,7 +21,7 @@ class Config {
 	/**
 	 * Name of option to store status of show/hide rating and score prompts
 	 */
-	const SHOW_SCORE_PROMPT_OPTION = 'jb_show_score_prompt';
+	const DISMISSED_MODALS_OPTION = 'jb_show_score_prompt';
 
 	public function init() {
 		add_action( 'wp_ajax_set_show_score_prompt', array( $this, 'handle_set_show_score_prompt' ) );
@@ -106,7 +106,7 @@ class Config {
 				array_push( $is_dismissed, $modal_to_banish );
 				$is_dismissed = array_unique( $is_dismissed );
 
-				\update_option( self::SHOW_SCORE_PROMPT_OPTION, $is_dismissed, false );
+				\update_option( self::DISMISSED_MODALS_OPTION, $is_dismissed, false );
 			}
 
 			wp_send_json( $response );
@@ -135,7 +135,7 @@ class Config {
 	 */
 	public function get_dismissed_modals() {
 		// get the option. This will be false, or an empty array
-		$score_prompts = \get_option( self::SHOW_SCORE_PROMPT_OPTION, array() );
+		$score_prompts = \get_option( self::DISMISSED_MODALS_OPTION, array() );
 		// if the value is false - "rate boost" was dismissed so the score-increase modal should not show.
 		if ( $score_prompts === false ) {
 			$score_prompts = array( 'score-increase' );
@@ -150,7 +150,7 @@ class Config {
 	 * Clear the status of show_score_prompt
 	 */
 	public static function clear_show_score_prompt() {
-		\delete_option( self::SHOW_SCORE_PROMPT_OPTION );
+		\delete_option( self::DISMISSED_MODALS_OPTION );
 	}
 
 	/**

--- a/projects/plugins/boost/app/admin/class-config.php
+++ b/projects/plugins/boost/app/admin/class-config.php
@@ -102,11 +102,11 @@ class Config {
 				}
 
 				// get the current dismissed modals
-				$is_dismissed = $this->get_dismissed_modals();
-				array_push( $is_dismissed, $modal_to_banish );
-				$is_dismissed = array_unique( $is_dismissed );
+				$dismissed_modals = $this->get_dismissed_modals();
+				array_push( $dismissed_modals, $modal_to_banish );
+				$dismissed_modals = array_unique( $dismissed_modals );
 
-				\update_option( self::DISMISSED_MODALS_OPTION, $is_dismissed, false );
+				\update_option( self::DISMISSED_MODALS_OPTION, $dismissed_modals, false );
 			}
 
 			wp_send_json( $response );
@@ -135,15 +135,15 @@ class Config {
 	 */
 	public function get_dismissed_modals() {
 		// get the option. This will be false, or an empty array
-		$score_prompts = \get_option( self::DISMISSED_MODALS_OPTION, array() );
+		$dismissed_modals = \get_option( self::DISMISSED_MODALS_OPTION, array() );
 		// if the value is false - "rate boost" was dismissed so the score-increase modal should not show.
-		if ( $score_prompts === false ) {
-			$score_prompts = array( 'score-increase' );
+		if ( $dismissed_modals === false ) {
+			$dismissed_modals = array( 'score-increase' );
 			// if an empty array then no score prompts have been dismissed yet.
-		} elseif ( $score_prompts === array( '' ) ) {
-			$score_prompts = array();
+		} elseif ( $dismissed_modals === array( '' ) ) {
+			$dismissed_modals = array();
 		}
-		return $score_prompts;
+		return $dismissed_modals;
 	}
 
 	/**

--- a/projects/plugins/boost/changelog/boost-update-change-config-dismissed-modals-option-name
+++ b/projects/plugins/boost/changelog/boost-update-change-config-dismissed-modals-option-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update variable names for dismissing modals.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/boost-cloud/issues/154.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR updates a constant name and a few variable names, to better match what they are used for.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* No testing instructions, as this is more of a maintenance update.

