### PR TITLE
Make wpcom payments-intro show patterns again

### DIFF
--- a/projects/plugins/jetpack/changelog/update-payments-intro-pattern-category
+++ b/projects/plugins/jetpack/changelog/update-payments-intro-pattern-category
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Minor bugfix for wpcom
+
+

--- a/projects/plugins/jetpack/extensions/blocks/payments-intro/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/payments-intro/edit.js
@@ -10,7 +10,7 @@ import PaymentsIntroPatternPicker from './pattern-picker';
 import defaultVariations from './variations';
 
 export default function JetpackPaymentsIntroEdit( { name, clientId, className } ) {
-	const patternFilter = pattern => pattern.categories?.includes( 'earn' );
+	const patternFilter = pattern => pattern.categories?.includes( 'shop' );
 
 	const { blockType, hasInnerBlocks, hasPatterns } = useSelect( select => {
 		const { getBlocks, __experimentalGetAllowedPatterns } = select( blockEditorStore );


### PR DESCRIPTION
The payments-intro block was not showing the option to list patterns on WordPress.com, this is because the pattern category name has been changed from earn to shop on the pattern source site.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27653

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Apply patch to wpcom sandbox
2. Open up the post editor
3. Insert the payments block
4. It should display the pattern selector like in paYJgx-2ez-p2#comment-2485