### PR TITLE
[Boost] Fix and reinstate E2E tests

### DIFF
--- a/projects/plugins/boost/changelog/fix-boost-e2e
+++ b/projects/plugins/boost/changelog/fix-boost-e2e
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix broken e2e test, and reinstate it.
+
+

--- a/projects/plugins/boost/tests/e2e/plugins/e2e-mock-speed-score-api.php
+++ b/projects/plugins/boost/tests/e2e/plugins/e2e-mock-speed-score-api.php
@@ -66,3 +66,11 @@ function e2e_mock_speed_score_api_response( $body ) {
 		'body'     => wp_json_encode( $body ),
 	);
 }
+
+/**
+ * On deactivation, purge any cached speed scores.
+ */
+register_deactivation_hook( __FILE__, 'e2e_mock_speed_score_purge' );
+function e2e_mock_speed_score_purge() {
+	\Automattic\Jetpack_Boost\Features\Speed_Score\Speed_Score_Request::clear_cache();
+}

--- a/projects/plugins/boost/tests/e2e/specs/speed-score.test.js
+++ b/projects/plugins/boost/tests/e2e/specs/speed-score.test.js
@@ -4,7 +4,7 @@ import { JetpackBoostPage } from '../lib/pages/index.js';
 
 let jetpackBoostPage;
 
-test.describe.skip( 'Speed Score feature', () => {
+test.describe( 'Speed Score feature', () => {
 	test.beforeAll( async ( { browser } ) => {
 		const page = await browser.newPage();
 		await boostPrerequisitesBuilder( page ).withSpeedScoreMocked( false ).build();


### PR DESCRIPTION
Fix and reinstate E2E tests for Boost speed scores

#### Changes proposed in this Pull Request:
* Ensure Speed Score request cache is purged when deactivating speed-score mocks
* Reinstate speed-score E2E tests

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Verify the E2E tests work.

