### PR TITLE
Option: Add new 'wpcom_subscription_emails_use_excerpt' option

### DIFF
--- a/projects/packages/sync/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
+++ b/projects/packages/sync/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Adding new boolean site option of 'wpcom-subscription-emails-use-excerpt'

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -56,7 +56,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "1.44.x-dev"
+			"dev-trunk": "1.45.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -175,6 +175,7 @@ class Defaults {
 		'wpcom_is_fse_activated',
 		'wpcom_publish_comments_with_markdown',
 		'wpcom_publish_posts_with_markdown',
+		'wpcom_subscription_emails_use_excerpt',
 		'videopress_private_enabled_for_site',
 		'wpcom_gifting_subscription',
 	);

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.44.2';
+	const PACKAGE_VERSION = '1.45.0-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/backup/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
+++ b/projects/plugins/backup/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1229,7 +1229,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "fa77060ba7ac1c88363f04f02edb1207779cd3f0"
+                "reference": "49f76caad933fe811cd60fc31c4f47b29d8365b1"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1256,7 +1256,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.44.x-dev"
+                    "dev-trunk": "1.45.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
+++ b/projects/plugins/jetpack/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Options: Added new site option of 'wpcom-subscription-emails-use-excerpt'

--- a/projects/plugins/jetpack/changelog/add-new-wpcom-subscription-emails-use-excerpt-option#2
+++ b/projects/plugins/jetpack/changelog/add-new-wpcom-subscription-emails-use-excerpt-option#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2102,7 +2102,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "fa77060ba7ac1c88363f04f02edb1207779cd3f0"
+                "reference": "49f76caad933fe811cd60fc31c4f47b29d8365b1"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2129,7 +2129,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.44.x-dev"
+                    "dev-trunk": "1.45.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -438,6 +438,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'featured_image_email_enabled'     => (bool) get_option( 'featured_image_email_enabled' ),
 						'wpcom_gifting_subscription'       => (bool) get_option( 'wpcom_gifting_subscription', $this->get_wpcom_gifting_subscription_default() ),
 						'jetpack_blogging_prompts_enabled' => (bool) jetpack_are_blogging_prompts_enabled(),
+						'wpcom_subscription_emails_use_excerpt' => get_wpcom_subscription_emails_use_excerpt_option(),
 					);
 
 					if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -933,6 +934,11 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					update_option( 'rss_use_excerpt', (int) (bool) $value );
 					break;
 
+				case 'wpcom_subscription_emails_use_excerpt':
+					update_option( 'wpcom_subscription_emails_use_excerpt', (bool) $value );
+					$updated[ $key ] = (bool) $value;
+					break;
+
 				case 'instant_search_enabled':
 					update_option( 'instant_search_enabled', (bool) $value );
 					$updated[ $key ] = (bool) $value;
@@ -1030,5 +1036,22 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 			'updated' => $updated,
 		);
 
+	}
+
+	/**
+	 * Get the value of the wpcom_subscription_emails_use_excerpt option.
+	 * When the option is not set, it will return the value of the rss_use_excerpt option.
+	 *
+	 * @return bool
+	 */
+	protected function get_wpcom_subscription_emails_use_excerpt_option() {
+		$wpcom_subscription_emails_use_excerpt = get_option( 'wpcom_subscription_emails_use_excerpt', null );
+
+		if ( $wpcom_subscription_emails_use_excerpt === null ) {
+			$rss_use_excerpt                       = get_option( 'rss_use_excerpt', null );
+			$wpcom_subscription_emails_use_excerpt = $rss_use_excerpt === null ? false : $rss_use_excerpt;
+		}
+
+		return (bool) $wpcom_subscription_emails_use_excerpt;
 	}
 }

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -438,7 +438,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'featured_image_email_enabled'     => (bool) get_option( 'featured_image_email_enabled' ),
 						'wpcom_gifting_subscription'       => (bool) get_option( 'wpcom_gifting_subscription', $this->get_wpcom_gifting_subscription_default() ),
 						'jetpack_blogging_prompts_enabled' => (bool) jetpack_are_blogging_prompts_enabled(),
-						'wpcom_subscription_emails_use_excerpt' => get_wpcom_subscription_emails_use_excerpt_option(),
+						'wpcom_subscription_emails_use_excerpt' => $this->get_wpcom_subscription_emails_use_excerpt_option(),
 					);
 
 					if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -118,6 +118,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			'featured_image_email_enabled'            => '(bool) Whether the Featured image is displayed in the New Post email template or not',
 			'wpcom_gifting_subscription'              => '(bool) Whether gifting is enabled for non auto-renew sites',
 			'jetpack_blogging_prompts_enabled'        => '(bool) Whether writing prompts are shown in the editor when starting a new post.',
+			'wpcom_subscription_emails_use_excerpt'   => '(bool) Whether site subscription emails (e.g. New Post email notification) will use post excerpts',
 		),
 
 		'response_format' => array(

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -229,6 +229,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'wpcom_gifting_subscription'                   => true,
 			'launch-status'                                => 'unlaunched',
 			'jetpack_blogging_prompts_enabled'             => jetpack_has_write_intent() || jetpack_has_posts_page(),
+			'wpcom_subscription_emails_use_excerpt'        => false,
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );

--- a/projects/plugins/protect/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
+++ b/projects/plugins/protect/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1211,7 +1211,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "fa77060ba7ac1c88363f04f02edb1207779cd3f0"
+                "reference": "49f76caad933fe811cd60fc31c4f47b29d8365b1"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1238,7 +1238,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.44.x-dev"
+                    "dev-trunk": "1.45.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
+++ b/projects/plugins/search/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1290,7 +1290,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "fa77060ba7ac1c88363f04f02edb1207779cd3f0"
+                "reference": "49f76caad933fe811cd60fc31c4f47b29d8365b1"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1317,7 +1317,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.44.x-dev"
+                    "dev-trunk": "1.45.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
+++ b/projects/plugins/social/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1279,7 +1279,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "fa77060ba7ac1c88363f04f02edb1207779cd3f0"
+                "reference": "49f76caad933fe811cd60fc31c4f47b29d8365b1"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1306,7 +1306,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.44.x-dev"
+                    "dev-trunk": "1.45.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/starter-plugin/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
+++ b/projects/plugins/starter-plugin/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1147,7 +1147,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "fa77060ba7ac1c88363f04f02edb1207779cd3f0"
+                "reference": "49f76caad933fe811cd60fc31c4f47b29d8365b1"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1174,7 +1174,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.44.x-dev"
+                    "dev-trunk": "1.45.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/videopress/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
+++ b/projects/plugins/videopress/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1211,7 +1211,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "fa77060ba7ac1c88363f04f02edb1207779cd3f0"
+                "reference": "49f76caad933fe811cd60fc31c4f47b29d8365b1"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1238,7 +1238,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.44.x-dev"
+                    "dev-trunk": "1.45.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/70426

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* allowing for saving and retrieving of the new `wpcom-subscription-emails-use-excerpt` site option. It will be possible to alter the option from the new Reading Settings page that is being developed. (For more context: pdDOJh-1cy-p2)

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pdDOJh-17o-p2, pdDOJh-1cy-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Apply the PR to your sandbox (see how to: PCYsg-eg0-p2)
* Sandbox `public-api.wordpress.com`
* Use wpcom developer console to test the "get site settings" endpoint
* The new option should be included in the api response (`body.settings.wpcom_subscription_emails_use_excerpt`): 
![Screen Shot 2022-12-14 at 09 31 21](https://user-images.githubusercontent.com/2019970/207547220-b8af1ea2-ecd5-457a-80f7-83ec0a893233.png)
