### PR TITLE
Boost: only display regeneration notice to admins

### DIFF
--- a/projects/plugins/boost/app/admin/class-regenerate-admin-notice.php
+++ b/projects/plugins/boost/app/admin/class-regenerate-admin-notice.php
@@ -57,7 +57,7 @@ class Regenerate_Admin_Notice {
 	}
 
 	public static function maybe_render() {
-		if ( static::is_enabled() ) {
+		if ( static::is_enabled() && current_user_can( 'manage_options' ) ) {
 			static::render();
 		}
 	}

--- a/projects/plugins/boost/changelog/fix-boost-regenerate-notice
+++ b/projects/plugins/boost/changelog/fix-boost-regenerate-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin notices: only display regeneration notice to admins.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Let's avoid displaying an admin notice to folks who will not be able to regenerate critical CSS.

<img width="925" alt="image" src="https://user-images.githubusercontent.com/426388/207370948-34bf484e-decf-44e8-8eaa-c3d00a36b3af.png">


#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

* No

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* On a site with Boost and critical CSS enabled, do something so the regeneration notice appears.
* You should see the admin notice appear.
* Log in to the site as a subscriber role.
* You should not see the admin notice.
