### PR TITLE
Tooling: PR template - adding check for WordPress.com testing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,7 @@ Fixes #
 
 - [ ] Have you written new tests for your changes, if applicable?
 - [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
+- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?
 
 #### Jetpack product discussion
 <!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* This adds an extra checkbox to add extra visibility to the need to test on WordPress.com.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

* This was discussed during the 11.6 retrospective - p9dueE-6nj-p2 

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Proof-read.
