### PR TITLE
Contact Form: Allow changing required field string

### DIFF
--- a/projects/plugins/jetpack/changelog/form-editable-required-text
+++ b/projects/plugins/jetpack/changelog/form-editable-required-text
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Allow Form required field text to be changed

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/child-blocks.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/child-blocks.js
@@ -27,6 +27,9 @@ const FieldDefaults = {
 			type: 'boolean',
 			default: false,
 		},
+		requiredText: {
+			type: 'string',
+		},
 		options: {
 			type: 'array',
 			default: [],
@@ -166,6 +169,7 @@ const editField = type => props => {
 			type={ type }
 			label={ getFieldLabel( props ) }
 			required={ props.attributes.required }
+			requiredText={ props.attributes.requiredText }
 			setAttributes={ props.setAttributes }
 			isSelected={ props.isSelected }
 			defaultValue={ props.attributes.defaultValue }
@@ -183,6 +187,7 @@ const editMultiField = type => props => {
 		<JetpackFieldMultiple
 			label={ getFieldLabel( props ) }
 			required={ props.attributes.required }
+			requiredText={ props.attributes.requiredText }
 			options={ props.attributes.options }
 			setAttributes={ props.setAttributes }
 			type={ type }
@@ -351,6 +356,7 @@ export const childBlocks = [
 					<JetpackFieldTextarea
 						label={ props.attributes.label }
 						required={ props.attributes.required }
+						requiredText={ props.attributes.requiredText }
 						setAttributes={ props.setAttributes }
 						isSelected={ props.isSelected }
 						defaultValue={ props.attributes.defaultValue }
@@ -389,6 +395,7 @@ export const childBlocks = [
 					<JetpackFieldCheckbox
 						label={ props.attributes.label } // label intentinally left blank
 						required={ props.attributes.required }
+						requiredText={ props.attributes.requiredText }
 						setAttributes={ props.setAttributes }
 						isSelected={ props.isSelected }
 						defaultValue={ props.attributes.defaultValue }

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-checkbox.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-checkbox.js
@@ -6,7 +6,16 @@ import JetpackFieldControls from './jetpack-field-controls';
 import JetpackFieldLabel from './jetpack-field-label';
 
 function JetpackFieldCheckbox( props ) {
-	const { id, instanceId, required, label, setAttributes, width, defaultValue } = props;
+	const {
+		id,
+		instanceId,
+		required,
+		requiredText,
+		label,
+		setAttributes,
+		width,
+		defaultValue,
+	} = props;
 
 	return (
 		<BaseControl
@@ -22,6 +31,7 @@ function JetpackFieldCheckbox( props ) {
 					/>
 					<JetpackFieldLabel
 						required={ required }
+						requiredText={ requiredText }
 						label={ label }
 						setAttributes={ setAttributes }
 					/>

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-controls.js
@@ -48,10 +48,7 @@ const JetpackFieldControls = ( { setAttributes, width, id, required, placeholder
 						className="jetpack-field-label__required"
 						checked={ required }
 						onChange={ value => setAttributes( { required: value } ) }
-						help={ __(
-							'Does this field have to be completed for the form to be submitted?',
-							'jetpack'
-						) }
+						help={ __( 'You can edit the "required" label in the editor', 'jetpack' ) }
 					/>
 
 					<TextControl

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-label.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-label.js
@@ -8,6 +8,7 @@ const JetpackFieldLabel = ( {
 	placeholder,
 	resetFocus,
 	required,
+	requiredText = __( '(required)', 'jetpack' ),
 } ) => {
 	return (
 		<div className="jetpack-field-label">
@@ -27,7 +28,19 @@ const JetpackFieldLabel = ( {
 				withoutInteractiveFormatting
 				allowedFormats={ [ 'core/bold', 'core/italic' ] }
 			/>
-			{ required && <span className="required">{ __( '(required)', 'jetpack' ) }</span> }
+			{ required && (
+				<RichText
+					tagName="span"
+					value={ requiredText }
+					className="required"
+					onChange={ value => {
+						setAttributes( { requiredText: value } );
+					} }
+					placeholder={ __( '(required)', 'jetpack' ) }
+					withoutInteractiveFormatting
+					allowedFormats={ [ 'core/bold', 'core/italic' ] }
+				/>
+			) }
 		</div>
 	);
 };

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-label.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-label.js
@@ -1,5 +1,7 @@
 import { RichText } from '@wordpress/block-editor';
+import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { isNil } from 'lodash';
 
 const JetpackFieldLabel = ( {
 	setAttributes,
@@ -8,8 +10,15 @@ const JetpackFieldLabel = ( {
 	placeholder,
 	resetFocus,
 	required,
-	requiredText = __( '(required)', 'jetpack' ),
+	requiredText,
 } ) => {
+	useEffect( () => {
+		if ( isNil( requiredText ) ) {
+			setAttributes( { requiredText: __( '(required)', 'jetpack' ) } );
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
 	return (
 		<div className="jetpack-field-label">
 			<RichText
@@ -36,7 +45,6 @@ const JetpackFieldLabel = ( {
 					onChange={ value => {
 						setAttributes( { requiredText: value } );
 					} }
-					placeholder={ __( '(required)', 'jetpack' ) }
 					withoutInteractiveFormatting
 					allowedFormats={ [ 'core/bold', 'core/italic' ] }
 				/>

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-multiple.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-multiple.js
@@ -12,6 +12,7 @@ function JetpackFieldMultiple( props ) {
 		type,
 		instanceId,
 		required,
+		requiredText,
 		label,
 		setAttributes,
 		isSelected,
@@ -62,6 +63,7 @@ function JetpackFieldMultiple( props ) {
 				label={
 					<JetpackFieldLabel
 						required={ required }
+						requiredText={ requiredText }
 						label={ label }
 						setAttributes={ setAttributes }
 						isSelected={ isSelected }

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-textarea.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-textarea.js
@@ -4,12 +4,17 @@ import JetpackFieldControls from './jetpack-field-controls';
 import JetpackFieldLabel from './jetpack-field-label';
 
 export default function JetpackFieldTextarea( props ) {
-	const { id, required, label, setAttributes, placeholder, width } = props;
+	const { id, required, requiredText, label, setAttributes, placeholder, width } = props;
 
 	return (
 		<>
 			<div className="jetpack-field">
-				<JetpackFieldLabel required={ required } label={ label } setAttributes={ setAttributes } />
+				<JetpackFieldLabel
+					required={ required }
+					requiredText={ requiredText }
+					label={ label }
+					setAttributes={ setAttributes }
+				/>
 				<Disabled>
 					<TextareaControl
 						placeholder={ placeholder }

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field.js
@@ -6,12 +6,17 @@ import JetpackFieldControls from './jetpack-field-controls';
 import JetpackFieldLabel from './jetpack-field-label';
 
 export default function JetpackField( props ) {
-	const { id, type, required, label, setAttributes, placeholder, width } = props;
+	const { id, type, required, requiredText, label, setAttributes, placeholder, width } = props;
 
 	return (
 		<>
 			<div className="jetpack-field">
-				<JetpackFieldLabel required={ required } label={ label } setAttributes={ setAttributes } />
+				<JetpackFieldLabel
+					required={ required }
+					requiredText={ requiredText }
+					label={ label }
+					setAttributes={ setAttributes }
+				/>
 				<Disabled>
 					<TextControl
 						type={ type }

--- a/projects/plugins/jetpack/modules/contact-form/css/grunion.css
+++ b/projects/plugins/jetpack/modules/contact-form/css/grunion.css
@@ -90,6 +90,7 @@
 	font-size: 85%;
 	margin-left: 0.25em;
 	font-weight: normal;
+	opacity: 0.45;
 }
 
 .contact-form-submission {

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -4537,10 +4537,6 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 
 		$shell_field_class = "class='grunion-field-wrap grunion-field-" . trim( esc_attr( $type ) . '-wrap ' . esc_attr( $wrap_classes ) ) . "' ";
 
-		if ( ! $required_field_text ) {
-			$required_field_text = __( '(required)', 'jetpack' );
-		}
-
 		/**
 		 * Filter the Contact Form required field text
 		 *

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -3910,6 +3910,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 				'label'                  => null,
 				'type'                   => 'text',
 				'required'               => false,
+				'requiredtext'           => null,
 				'options'                => array(),
 				'id'                     => null,
 				'default'                => null,
@@ -4084,13 +4085,14 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	public function render() {
 		global $current_user, $user_identity;
 
-		$field_id          = $this->get_attribute( 'id' );
-		$field_type        = $this->maybe_override_type();
-		$field_label       = $this->get_attribute( 'label' );
-		$field_required    = $this->get_attribute( 'required' );
-		$field_placeholder = $this->get_attribute( 'placeholder' );
-		$field_width       = $this->get_attribute( 'width' );
-		$class             = 'date' === $field_type ? 'jp-contact-form-date' : $this->get_attribute( 'class' );
+		$field_id            = $this->get_attribute( 'id' );
+		$field_type          = $this->maybe_override_type();
+		$field_label         = $this->get_attribute( 'label' );
+		$field_required      = $this->get_attribute( 'required' );
+		$field_required_text = $this->get_attribute( 'requiredtext' );
+		$field_placeholder   = $this->get_attribute( 'placeholder' );
+		$field_width         = $this->get_attribute( 'width' );
+		$class               = 'date' === $field_type ? 'jp-contact-form-date' : $this->get_attribute( 'class' );
 
 		if ( ! empty( $field_width ) ) {
 			$class .= ' grunion-field-width-' . $field_width;
@@ -4151,7 +4153,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 		$field_value = Grunion_Contact_Form_Plugin::strip_tags( $this->value );
 		$field_label = Grunion_Contact_Form_Plugin::strip_tags( $field_label );
 
-		$rendered_field = $this->render_field( $field_type, $field_id, $field_label, $field_value, $field_class, $field_placeholder, $field_required );
+		$rendered_field = $this->render_field( $field_type, $field_id, $field_label, $field_value, $field_class, $field_placeholder, $field_required, $field_required_text );
 
 		/**
 		 * Filter the HTML of the Contact Form.
@@ -4523,16 +4525,22 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	 * @param string $class - the field class.
 	 * @param string $placeholder - the field placeholder content.
 	 * @param bool   $required - if the field is marked as required.
+	 * @param string $required_field_text - the text for a field marked as required.
 	 *
 	 * @return string HTML
 	 */
-	public function render_field( $type, $id, $label, $value, $class, $placeholder, $required ) {
+	public function render_field( $type, $id, $label, $value, $class, $placeholder, $required, $required_field_text ) {
 
 		$field_placeholder = ( ! empty( $placeholder ) ) ? "placeholder='" . esc_attr( $placeholder ) . "'" : '';
 		$field_class       = "class='" . trim( esc_attr( $type ) . ' ' . esc_attr( $class ) ) . "' ";
 		$wrap_classes      = empty( $class ) ? '' : implode( '-wrap ', array_filter( explode( ' ', $class ) ) ) . '-wrap'; // this adds
 
 		$shell_field_class = "class='grunion-field-wrap grunion-field-" . trim( esc_attr( $type ) . '-wrap ' . esc_attr( $wrap_classes ) ) . "' ";
+
+		if ( ! $required_field_text ) {
+			$required_field_text = __( '(required)', 'jetpack' );
+		}
+
 		/**
 		 * Filter the Contact Form required field text
 		 *
@@ -4542,7 +4550,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 		 *
 		 * @param string $var Required field text. Default is "(required)".
 		 */
-		$required_field_text = esc_html( apply_filters( 'jetpack_required_field_text', __( '(required)', 'jetpack' ) ) );
+		$required_field_text = esc_html( apply_filters( 'jetpack_required_field_text', $required_field_text ) );
 
 		$field = "\n<div {$shell_field_class} >\n"; // new in Jetpack 6.8.0
 		// If they are logged in, and this is their site, don't pre-populate fields

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -3938,6 +3938,10 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 			$attributes['required'] = false;
 		}
 
+		if ( $attributes['requiredtext'] === null ) {
+			$attributes['requiredtext'] = __( '(required)', 'jetpack' );
+		}
+
 		// parse out comma-separated options list (for selects, radios, and checkbox-multiples)
 		if ( ! empty( $attributes['options'] ) && is_string( $attributes['options'] ) ) {
 			$attributes['options'] = array_map( 'trim', explode( ',', $attributes['options'] ) );


### PR DESCRIPTION
Fixes #27657

#### Changes proposed in this Pull Request:
* Allows changing required field string. More context on #27657

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Create a post and add a Form block
* Make form fields required and check if the "(required)" text can be changed
* Save the changes and check if they are applied to the live view

