### PR TITLE
Add translation context to Security product name

### DIFF
--- a/projects/packages/my-jetpack/changelog/add-translation-context-security
+++ b/projects/packages/my-jetpack/changelog/add-translation-context-security
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add translation context to Security product name

--- a/projects/packages/my-jetpack/src/products/class-security.php
+++ b/projects/packages/my-jetpack/src/products/class-security.php
@@ -38,7 +38,7 @@ class Security extends Module_Product {
 	 * @return string
 	 */
 	public static function get_name() {
-		return __( 'Security', 'jetpack-my-jetpack' );
+		return _x( 'Security', 'Jetpack product name', 'jetpack-my-jetpack' );
 	}
 
 	/**
@@ -47,7 +47,7 @@ class Security extends Module_Product {
 	 * @return string
 	 */
 	public static function get_title() {
-		return __( 'Security', 'jetpack-my-jetpack' );
+		return _x( 'Security', 'Jetpack product name', 'jetpack-my-jetpack' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-translation-context-security
+++ b/projects/plugins/jetpack/changelog/add-translation-context-security
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Add translation context to Security product name

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -6775,7 +6775,7 @@ endif;
 		);
 
 		$products['security'] = array(
-			'title'             => __( 'Security', 'jetpack' ),
+			'title'             => _x( 'Security', 'Jetpack product name', 'jetpack' ),
 			'slug'              => 'jetpack_security_t1_yearly',
 			'description'       => __( 'Comprehensive site security, including Backup, Scan, and Anti-spam.', 'jetpack' ),
 			'show_promotion'    => true,

--- a/projects/plugins/jetpack/modules/stats/class-jetpack-stats-upgrade-nudges.php
+++ b/projects/plugins/jetpack/modules/stats/class-jetpack-stats-upgrade-nudges.php
@@ -405,7 +405,7 @@ class Jetpack_Stats_Upgrade_Nudges {
 		$link       = self::get_product_description_link( 'security' );
 		$learn_link = self::get_upgrade_link( 'stats-nudges-security-learn' );
 		$text       = __( 'Comprehensive protection for your site, including Backup, Scan, and Anti-spam.', 'jetpack' );
-		self::print_item( __( 'Security', 'jetpack' ), $text, 'product-jetpack-security-bundle.svg', $link, 'security', $learn_link );
+		self::print_item( _x( 'Security', 'Jetpack product name', 'jetpack' ), $text, 'product-jetpack-security-bundle.svg', $link, 'security', $learn_link );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Add translation context to `Security` product name so that it won't be translated literally.

Fixes 493-gh-Automattic/i18n-issues

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Change the `__( 'Security'...` translation calls to `_x( 'Security', 'Jetpack product name'...`

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Code review