### PR TITLE
Stats: add hostname admin url to config

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-add-hostname-admin-url-to-config
+++ b/projects/packages/stats-admin/changelog/fix-add-hostname-admin-url-to-config
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: added `hostname` and `admin_url` to config

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -200,6 +200,7 @@ class Dashboard {
 			'env_id'                         => 'production',
 			'google_analytics_key'           => 'UA-10673494-15',
 			'google_maps_and_places_api_key' => '',
+			'hostname'                       => wp_parse_url( get_site_url(), PHP_URL_HOST ),
 			'i18n_default_locale_slug'       => 'en',
 			'i18n_locale_slug'               => static::get_site_locale(),
 			'mc_analytics_enabled'           => false,
@@ -225,6 +226,9 @@ class Dashboard {
 							'jetpack'      => true,
 							'visible'      => true,
 							'capabilities' => $empty_object,
+							'options'      => array(
+								'admin_url' => admin_url(),
+							),
 							'products'     => array(),
 							'plan'         => $empty_object, // we need this empty object, otherwise the front end would crash on insight page.
 						),


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/71107

#### Changes proposed in this Pull Request:
- Adds `hostname` to `configData` which is used by Calypso to determine whether a URL is external or not.
- Adds `options.admin_url` for site, which fixes the broken links on comment section

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* Enable Odyssey Stats for your Jetpack site (`PejTkB-3E-p2`)
* Open `/wp-admin/admin.php?page=stats`
* Click Insights tab
* Ensure links in Comments sections work

<img width="783" alt="image" src="https://user-images.githubusercontent.com/1425433/207497386-4cdeab93-750b-4f0b-8927-f40a78957302.png">

