### PR TITLE
Shared extension utils: add new isCurrentUserConnected utility

### DIFF
--- a/projects/js-packages/shared-extension-utils/changelog/add-is-current-user-connected-package
+++ b/projects/js-packages/shared-extension-utils/changelog/add-is-current-user-connected-package
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add new isCurrentUserConnected utility.

--- a/projects/js-packages/shared-extension-utils/index.js
+++ b/projects/js-packages/shared-extension-utils/index.js
@@ -13,3 +13,4 @@ export {
 	isStillUsableWithFreePlan,
 	getUsableBlockProps,
 } from './src/plan-utils';
+export { default as isCurrentUserConnected } from './src/is-current-user-connected';

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.6.10",
+	"version": "0.7.0-alpha",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/src/is-current-user-connected.js
+++ b/projects/js-packages/shared-extension-utils/src/is-current-user-connected.js
@@ -1,0 +1,10 @@
+import getJetpackData from './get-jetpack-data';
+
+/**
+ * Return whether the current user is connected to WP.com.
+ *
+ * @returns {boolean} Whether the current user is connected.
+ */
+export default function isCurrentUserConnected() {
+	return getJetpackData()?.jetpack?.is_current_user_connected ?? false;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This exists as a shared function in the Jetpack plugin right now. Moving it to the shared package will allow us to use it in other plugins and packages as well.

This will allow us to make progress with #27591. We'll be able to move the feature out of the Jetpack plugin, so it can be used in both the Jetpack plugin and the Jetpack Social plugin.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion

* 1386-gh-dotcom-forge

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* This isn't used anywhere yet. It will come in a follow-up PR once this is merged.
* For now, we can check that the function I add behaves the same as the one in `projects/plugins/jetpack/extensions/shared/is-current-user-connected.js`.
