### PR TITLE
Jetpack VideoPress: Remove src/client files from final bundle

### DIFF
--- a/projects/packages/videopress/.gitattributes
+++ b/projects/packages/videopress/.gitattributes
@@ -14,4 +14,5 @@ build/**         production-include
 changelog/**      production-exclude
 phpunit.xml.dist  production-exclude
 .phpcs.dir.xml    production-exclude
+src/client/**     production-exclude
 tests/**          production-exclude

--- a/projects/packages/videopress/changelog/update-jetpack-videopress-gitattributes-src-files
+++ b/projects/packages/videopress/changelog/update-jetpack-videopress-gitattributes-src-files
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove src/client files from final bundle


### PR DESCRIPTION
We were shipping JavaScript source files, thus making the bundle get to about 6MB 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates `.gitattributes` in the videopress package to not include `src/client` files

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Wait for the build check to finish, click details, then summary, search for the artifacts at the bottom of the page download the plugins.zip file and confirm the src/client dir is not included inside `jetpack-videopress-dev/automattic/jetpack_vendor/jetpack-videopress/src`

