### PR TITLE
Assets Package: Remove src/js files from final bundle

### DIFF
--- a/projects/packages/assets/.gitattributes
+++ b/projects/packages/assets/.gitattributes
@@ -10,6 +10,7 @@ webpack.config.js export-ignore
 .phpcs.dir.xml    production-exclude
 .phpcsignore      production-exclude
 /changelog/**     production-exclude
+src/js/**         production-exclude
 
 # Files to include in the production build.
 /build/**         production-include

--- a/projects/packages/assets/changelog/update-jetpack-assets--package-gitattributes-src-files
+++ b/projects/packages/assets/changelog/update-jetpack-assets--package-gitattributes-src-files
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove src/js files from final bundle


### PR DESCRIPTION
We were shipping JavaScript source files for the Assets package, thus adding about 4k to plugins.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates `.gitattributes` in the Assets package to not include `src/js` files

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Wait for the build check to finish, click details, then summary, search for the artifacts at the bottom of the page download the plugins.zip file and confirm the src/js dir is not included inside jetpack-dev/jetpack_vendor/automattic/jetpack-assets/src
