### PR TITLE
E2E tests: add new test for Form block

### DIFF
--- a/projects/plugins/jetpack/changelog/e2e-add-form-block
+++ b/projects/plugins/jetpack/changelog/e2e-add-form-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+E2E tests: add a new tests for Form block

--- a/projects/plugins/jetpack/tests/e2e/specs/blocks/free-blocks.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/blocks/free-blocks.test.js
@@ -3,6 +3,7 @@ import {
 	BlockEditorPage,
 	PinterestBlock,
 	EventbriteBlock,
+	FormBlock,
 } from 'jetpack-e2e-commons/pages/wp-admin/index.js';
 import { PostFrontendPage } from 'jetpack-e2e-commons/pages/index.js';
 import config from 'config';
@@ -82,6 +83,29 @@ test.describe.parallel( 'Free blocks', () => {
 				await frontend.isRenderedBlockPresent( EventbriteBlock, {
 					eventId,
 				} ),
+				'Block should be displayed'
+			).toBeTruthy();
+		} );
+	} );
+
+	test( 'Form block', async ( { page } ) => {
+		await test.step( 'Can visit the block editor and add a Form block', async () => {
+			const blockId = await blockEditor.insertBlock( FormBlock.name(), FormBlock.title() );
+
+			const block = new FormBlock( blockId, page );
+			await block.selectFormVariation();
+		} );
+
+		await test.step( 'Can publish a post with a Form block', async () => {
+			await blockEditor.selectPostTitle();
+			await blockEditor.publishPost();
+			await blockEditor.viewPost();
+		} );
+
+		await test.step( 'Can assert that Form block is rendered', async () => {
+			const frontend = await PostFrontendPage.init( page );
+			expect(
+				await frontend.isRenderedBlockPresent( FormBlock ),
 				'Block should be displayed'
 			).toBeTruthy();
 		} );

--- a/tools/e2e-commons/pages/wp-admin/blocks/form.js
+++ b/tools/e2e-commons/pages/wp-admin/blocks/form.js
@@ -1,0 +1,30 @@
+import PageActions from '../../page-actions.js';
+
+export default class FormBlock extends PageActions {
+	constructor( blockId, page ) {
+		super( page, 'Form block' );
+		this.blockTitle = FormBlock.title();
+		this.blockSelector = '#block-' + blockId;
+	}
+
+	static name() {
+		return 'contact-form';
+	}
+
+	static title() {
+		return 'Form';
+	}
+
+	async selectFormVariation( variationText = 'Contact Form' ) {
+		await this.click( `text=${ variationText }` );
+	}
+
+	/**
+	 * Checks whether block is rendered on frontend
+	 *
+	 * @param {page} page Playwright page instance
+	 */
+	static async isRendered( page ) {
+		await page.waitForSelector( 'form.wp-block-jetpack-contact-form' );
+	}
+}

--- a/tools/e2e-commons/pages/wp-admin/index.js
+++ b/tools/e2e-commons/pages/wp-admin/index.js
@@ -4,6 +4,7 @@ export { default as PinterestBlock } from './blocks/pinterest.js';
 export { default as MailchimpBlock } from './blocks/mailchimp.js';
 export { default as SimplePaymentBlock } from './blocks/simple-payments.js';
 export { default as WordAdsBlock } from './blocks/word-ads.js';
+export { default as FormBlock } from './blocks/form.js';
 
 export { default as DashboardPage } from './dashboard.js';
 export { default as InPlacePlansPage } from './in-place-plans.js';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
 
Add a new e2e test for Form block.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
pd5faL-i5-p2

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* All e2e tests pass. The blocks suite has a new test named 'Form block'