### PR TITLE
Slideshow: Implement pagination number

### DIFF
--- a/projects/plugins/jetpack/changelog/update-slideshow-tweak-paginator
+++ b/projects/plugins/jetpack/changelog/update-slideshow-tweak-paginator
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: switch pagination style in the slideshow block

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.js
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { isBlobURL } from '@wordpress/blob';
 import { RichText } from '@wordpress/block-editor';
 import { Spinner } from '@wordpress/components';
@@ -6,6 +9,9 @@ import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { isEqual } from 'lodash';
 import ResizeObserver from 'resize-observer-polyfill';
+/**
+ * Internal dependencies
+ */
 import createSwiper from './create-swiper';
 import {
 	swiperApplyAria,

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.js
@@ -20,6 +20,32 @@ import {
 	swiperResize,
 } from './swiper-callbacks';
 
+export function paginationCustomRender( swiper, current, total ) {
+	let markup = '';
+
+	for ( let i = 1; i <= total; i++ ) {
+		const active = i === current ? ' swiper-pagination-bullet-active' : '';
+		const cssClass = `swiper-pagination-bullet${ active }`;
+		const ariaLabel = sprintf(
+			/* translators: placeholder is the number of videos */
+			__( 'Go to slide %s', 'jetpack' ),
+			i
+		);
+
+		markup +=
+			'<button ' +
+			'class="' +
+			cssClass +
+			'" ' +
+			'tab-index="0" ' +
+			'role="button" ' +
+			'aria-label="' +
+			ariaLabel +
+			'"></button>';
+	}
+
+	return markup;
+}
 class Slideshow extends Component {
 	pendingRequestAnimationFrame = null;
 	resizeObserver = null;
@@ -222,32 +248,7 @@ class Slideshow extends Component {
 					clickable: true,
 					el: this.paginationRef.current,
 					type: 'custom',
-					renderCustom: function ( swiper, current, total ) {
-						let markup = '';
-
-						for ( let i = 1; i <= total; i++ ) {
-							const active = i === current ? ' swiper-pagination-bullet-active' : '';
-							const cssClass = `swiper-pagination-bullet${ active }`;
-							const ariaLabel = sprintf(
-								/* translators: placeholder is the number of videos */
-								__( 'Go to slide %s', 'jetpack' ),
-								i
-							);
-
-							markup +=
-								'<button ' +
-								'class="' +
-								cssClass +
-								'" ' +
-								'tab-index="0" ' +
-								'role="button" ' +
-								'aria-label="' +
-								ariaLabel +
-								'"></button>';
-						}
-
-						return markup;
-					},
+					renderCustom: paginationCustomRender,
 				},
 			},
 			{

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.js
@@ -29,7 +29,7 @@ export function paginationCustomRender( swiper, current, total ) {
 			const active = i === current ? ' swiper-pagination-bullet-active' : '';
 			const cssClass = `swiper-pagination-bullet${ active }`;
 			const ariaLabel = sprintf(
-				/* translators: placeholder is the number of videos */
+				/* translators: placeholder is the the video number to navigate to */
 				__( 'Go to slide %s', 'jetpack' ),
 				i
 			);

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.js
@@ -5,7 +5,7 @@ import { isBlobURL } from '@wordpress/blob';
 import { RichText } from '@wordpress/block-editor';
 import { Spinner } from '@wordpress/components';
 import { Component, createRef } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { isEqual } from 'lodash';
 import ResizeObserver from 'resize-observer-polyfill';
@@ -221,7 +221,33 @@ class Slideshow extends Component {
 				pagination: {
 					clickable: true,
 					el: this.paginationRef.current,
-					type: 'bullets',
+					type: 'custom',
+					renderCustom: function ( swiper, current, total ) {
+						let markup = '';
+
+						for ( let i = 1; i <= total; i++ ) {
+							const active = i === current ? ' swiper-pagination-bullet-active' : '';
+							const cssClass = `swiper-pagination-bullet${ active }`;
+							const ariaLabel = sprintf(
+								/* translators: placeholder is the number of videos */
+								__( 'Go to slide %s', 'jetpack' ),
+								i
+							);
+
+							markup +=
+								'<button ' +
+								'class="' +
+								cssClass +
+								'" ' +
+								'tab-index="0" ' +
+								'role="button" ' +
+								'aria-label="' +
+								ariaLabel +
+								'"></button>';
+						}
+
+						return markup;
+					},
 				},
 			},
 			{

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.js
@@ -23,25 +23,30 @@ import {
 export function paginationCustomRender( swiper, current, total ) {
 	let markup = '';
 
-	for ( let i = 1; i <= total; i++ ) {
-		const active = i === current ? ' swiper-pagination-bullet-active' : '';
-		const cssClass = `swiper-pagination-bullet${ active }`;
-		const ariaLabel = sprintf(
-			/* translators: placeholder is the number of videos */
-			__( 'Go to slide %s', 'jetpack' ),
-			i
-		);
+	// Print dots pagination when total slides are less than six.
+	if ( total <= 5 ) {
+		for ( let i = 1; i <= total; i++ ) {
+			const active = i === current ? ' swiper-pagination-bullet-active' : '';
+			const cssClass = `swiper-pagination-bullet${ active }`;
+			const ariaLabel = sprintf(
+				/* translators: placeholder is the number of videos */
+				__( 'Go to slide %s', 'jetpack' ),
+				i
+			);
 
-		markup +=
-			'<button ' +
-			'class="' +
-			cssClass +
-			'" ' +
-			'tab-index="0" ' +
-			'role="button" ' +
-			'aria-label="' +
-			ariaLabel +
-			'"></button>';
+			markup +=
+				'<button ' +
+				'class="' +
+				cssClass +
+				'" ' +
+				'tab-index="0" ' +
+				'role="button" ' +
+				'aria-label="' +
+				ariaLabel +
+				'"></button>';
+		}
+	} else {
+		markup += `<div class="swiper-pagination-simple">${ current } / ${ total }</div>`;
 	}
 
 	return markup;

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.php
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.php
@@ -180,7 +180,7 @@ function bullets( $ids = array(), $block_ordinal = 0 ) {
 	);
 
 	return sprintf(
-		'<amp-selector id="wp-block-jetpack-slideshow__amp-pagination__%1$d" class="wp-block-jetpack-slideshow_pagination swiper-pagination swiper-pagination-bullets amp-pagination" on="select:wp-block-jetpack-slideshow__amp-carousel__%1$d.goToSlide(index=event.targetOption)" layout="container">%2$s</amp-selector>',
+		'<amp-selector id="wp-block-jetpack-slideshow__amp-pagination__%1$d" class="wp-block-jetpack-slideshow_pagination swiper-pagination swiper-pagination-custom amp-pagination" on="select:wp-block-jetpack-slideshow__amp-carousel__%1$d.goToSlide(index=event.targetOption)" layout="container">%2$s</amp-selector>',
 		absint( $block_ordinal ),
 		implode( '', $buttons )
 	);

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.php
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.php
@@ -150,7 +150,17 @@ function slides( $ids = array(), $width = 400, $height = 300 ) {
  * @return array Array of bullets markup.
  */
 function render_paginator( $ids = array(), $block_ordinal = 0 ) {
-	return bullets( $ids, $block_ordinal );
+	$total = count( $ids );
+
+	if ( $total < 6 ) {
+		return bullets( $ids, $block_ordinal );
+	}
+
+	return sprintf(
+		'<div class="swiper-pagination-simple">%s / %s</div>',
+		absint( $block_ordinal ),
+		absint( $total )
+	);
 }
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.php
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.php
@@ -74,7 +74,7 @@ function render_amp( $attr ) {
 		absint( $wp_block_jetpack_slideshow_id ),
 		amp_carousel( $attr, $wp_block_jetpack_slideshow_id ),
 		$autoplay ? autoplay_ui( $wp_block_jetpack_slideshow_id ) : '',
-		bullets( $ids, $wp_block_jetpack_slideshow_id )
+		render_paginator( $ids, $wp_block_jetpack_slideshow_id )
 	);
 }
 
@@ -139,6 +139,18 @@ function slides( $ids = array(), $width = 400, $height = 300 ) {
 		},
 		$ids
 	);
+}
+
+/**
+ * Render blocks paginator section
+ *
+ * @param array $ids Array of image ids.
+ * @param int   $block_ordinal The ordinal number of the block, used in unique ID.
+ *
+ * @return array Array of bullets markup.
+ */
+function render_paginator( $ids = array(), $block_ordinal = 0 ) {
+	return bullets( $ids, $block_ordinal );
 }
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/style.scss
@@ -238,6 +238,13 @@
 			opacity: 1;
 			transform: scale( 1 );
 		}
+
+		.swiper-pagination-simple {
+			line-height: 16px;
+			font-size: 14px;
+			width: 100%;
+			text-align: left;
+		}
 	}
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/style.scss
@@ -200,11 +200,16 @@
 		max-height: calc( 100% - 68px );
 	}
 
+
+	.wp-block-jetpack-slideshow_pagination.swiper-pagination-custom,
 	.wp-block-jetpack-slideshow_pagination.swiper-pagination-bullets {
 		bottom: 0;
 		line-height: 24px;
 		padding: 10px 0 2px;
 		position: relative;
+		display: flex;
+		justify-content: center;
+		gap: 8px;
 
 		.swiper-pagination-bullet {
 			background: currentColor;

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/view.js
@@ -2,6 +2,7 @@ import domReady from '@wordpress/dom-ready';
 import { forEach } from 'lodash';
 import ResizeObserver from 'resize-observer-polyfill';
 import createSwiper from './create-swiper';
+import { paginationCustomRender } from './slideshow';
 import {
 	swiperApplyAria,
 	swiperInit,
@@ -38,6 +39,11 @@ if ( typeof window !== 'undefined' ) {
 					keyboard: {
 						enabled: true,
 						onlyInViewport: true,
+					},
+					pagination: {
+						clickable: true,
+						type: 'custom',
+						renderCustom: paginationCustomRender,
 					},
 				},
 				{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR implements the pagination number style when the slideshow gallery has more than five images.

Fixes https://github.com/Automattic/jetpack/issues/27709

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Slideshow: Implement pagination number

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Add a Slideshow block
* Add less than six images there
* Confirm it shows the paginations dots style
<img width="677" alt="Screen Shot 2022-12-14 at 16 02 50" src="https://user-images.githubusercontent.com/77539/207646033-e08acb7e-29a1-43e3-a61e-dc3fab7fee82.png">

* Add more than fixed images
* Confirm the shows the pagination numbers style
<img width="724" alt="Screen Shot 2022-12-14 at 16 02 19" src="https://user-images.githubusercontent.com/77539/207646222-4879a3d0-5793-452d-8307-d42c68f0475d.png">


