### PR TITLE
Blocks: add a new Analytics hook

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -547,6 +547,7 @@ importers:
   projects/js-packages/shared-extension-utils:
     specifiers:
       '@automattic/jetpack-analytics': workspace:*
+      '@automattic/jetpack-connection': workspace:*
       '@babel/core': 7.20.5
       '@babel/preset-react': 7.18.6
       '@wordpress/compose': 5.20.0
@@ -558,6 +559,7 @@ importers:
       react: 17.0.2
     dependencies:
       '@automattic/jetpack-analytics': link:../analytics
+      '@automattic/jetpack-connection': link:../connection
       '@wordpress/compose': 5.20.0_react@17.0.2
       '@wordpress/element': 4.20.0
       '@wordpress/i18n': 4.22.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -546,16 +546,20 @@ importers:
 
   projects/js-packages/shared-extension-utils:
     specifiers:
+      '@automattic/jetpack-analytics': workspace:*
       '@babel/core': 7.20.5
       '@babel/preset-react': 7.18.6
       '@wordpress/compose': 5.20.0
+      '@wordpress/element': 4.20.0
       '@wordpress/i18n': 4.22.0
       '@wordpress/plugins': 4.20.0
       '@wordpress/url': 3.23.0
       lodash: 4.17.21
       react: 17.0.2
     dependencies:
+      '@automattic/jetpack-analytics': link:../analytics
       '@wordpress/compose': 5.20.0_react@17.0.2
+      '@wordpress/element': 4.20.0
       '@wordpress/i18n': 4.22.0
       '@wordpress/plugins': 4.20.0_react@17.0.2
       '@wordpress/url': 3.23.0

--- a/projects/js-packages/shared-extension-utils/changelog/add-shared-analytics-wrapper
+++ b/projects/js-packages/shared-extension-utils/changelog/add-shared-analytics-wrapper
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add new Analytics wrapper hook.

--- a/projects/js-packages/shared-extension-utils/index.js
+++ b/projects/js-packages/shared-extension-utils/index.js
@@ -14,3 +14,4 @@ export {
 	getUsableBlockProps,
 } from './src/plan-utils';
 export { default as isCurrentUserConnected } from './src/is-current-user-connected';
+export { default as useAnalytics } from './src/hooks/use-analytics';

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -15,7 +15,9 @@
 	"author": "Automattic",
 	"scripts": {},
 	"dependencies": {
+		"@automattic/jetpack-analytics": "workspace:*",
 		"@wordpress/compose": "5.20.0",
+		"@wordpress/element": "4.20.0",
 		"@wordpress/i18n": "4.22.0",
 		"@wordpress/plugins": "4.20.0",
 		"@wordpress/url": "3.23.0",

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -16,6 +16,7 @@
 	"scripts": {},
 	"dependencies": {
 		"@automattic/jetpack-analytics": "workspace:*",
+		"@automattic/jetpack-connection": "workspace:*",
 		"@wordpress/compose": "5.20.0",
 		"@wordpress/element": "4.20.0",
 		"@wordpress/i18n": "4.22.0",

--- a/projects/js-packages/shared-extension-utils/src/hooks/readme.md
+++ b/projects/js-packages/shared-extension-utils/src/hooks/readme.md
@@ -2,7 +2,13 @@
 
 This wrapper for @automattic/jetpack-analytics provides a way to use the analytics library (Tracks) in a React component inside your plugin.
 
-This library is only useful when the logged in user is connected to WordPress.com.
+This library is only useful when the logged in user is connected to WordPress.com, and when we have information about that connection passed to JavaScript via the Jetpack Connection package. Typically, this is done by enqueuing the connection package's initial state on the editor page:
+
+```php
+use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
+// Adds Connection package initial state.
+wp_add_inline_script( 'your-app-script-handle-in-editor', Connection_Initial_State::render(), 'before' );
+```
 
 ## Usage
 

--- a/projects/js-packages/shared-extension-utils/src/hooks/readme.md
+++ b/projects/js-packages/shared-extension-utils/src/hooks/readme.md
@@ -1,0 +1,17 @@
+# useAnalytics() hook
+
+This wrapper for @automattic/jetpack-analytics provides a way to use the analytics library (Tracks) in a React component inside your plugin.
+
+This library is only useful when the logged in user is connected to WordPress.com.
+
+## Usage
+
+```es6
+const { tracks } = useAnalytics();
+
+tracks.recordEvent( 'jetpack_editor_block_upgrade_click', {
+	plan,
+	block: blockName,
+	context,
+} );
+```

--- a/projects/js-packages/shared-extension-utils/src/hooks/use-analytics.js
+++ b/projects/js-packages/shared-extension-utils/src/hooks/use-analytics.js
@@ -1,0 +1,27 @@
+import jetpackAnalytics from '@automattic/jetpack-analytics';
+import { useEffect } from '@wordpress/element';
+import { getJetpackData } from './../get-jetpack-data';
+import { isCurrentUserConnected } from './../is-current-user-connected';
+
+const useAnalytics = () => {
+	const { userid, username } = getJetpackData()?.tracksUserData ?? {};
+	const blog_id = getJetpackData()?.wpcomBlogId ?? undefined;
+
+	/**
+	 * Initialize tracks with user and blog data.
+	 * This will only work if the user is connected.
+	 */
+	useEffect( () => {
+		if ( ! isCurrentUserConnected || ! userid || ! username || ! blog_id ) {
+			return;
+		}
+
+		jetpackAnalytics.initialize( userid, username, {
+			blog_id,
+		} );
+	}, [ blog_id, userid, username ] );
+
+	return jetpackAnalytics;
+};
+
+export default useAnalytics;

--- a/projects/js-packages/shared-extension-utils/src/hooks/use-analytics.js
+++ b/projects/js-packages/shared-extension-utils/src/hooks/use-analytics.js
@@ -1,7 +1,7 @@
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { useEffect } from '@wordpress/element';
-import { getJetpackData } from './../get-jetpack-data';
-import { isCurrentUserConnected } from './../is-current-user-connected';
+import getJetpackData from './../get-jetpack-data';
+import isCurrentUserConnected from './../is-current-user-connected';
 
 const useAnalytics = () => {
 	const { userid, username } = getJetpackData()?.tracksUserData ?? {};

--- a/projects/js-packages/shared-extension-utils/src/hooks/use-analytics.js
+++ b/projects/js-packages/shared-extension-utils/src/hooks/use-analytics.js
@@ -1,25 +1,24 @@
 import jetpackAnalytics from '@automattic/jetpack-analytics';
+import { useConnection } from '@automattic/jetpack-connection';
 import { useEffect } from '@wordpress/element';
-import getJetpackData from './../get-jetpack-data';
-import isCurrentUserConnected from './../is-current-user-connected';
 
 const useAnalytics = () => {
-	const { userid, username } = getJetpackData()?.tracksUserData ?? {};
-	const blog_id = getJetpackData()?.wpcomBlogId ?? undefined;
+	const { isUserConnected, userConnectionData = {} } = useConnection();
+	const { wpcomUser: { login, ID } = {}, blogId } = userConnectionData.currentUser || {};
 
 	/**
 	 * Initialize tracks with user and blog data.
 	 * This will only work if the user is connected.
 	 */
 	useEffect( () => {
-		if ( ! isCurrentUserConnected || ! userid || ! username || ! blog_id ) {
+		if ( ! isUserConnected || ! ID || ! login || ! blogId ) {
 			return;
 		}
 
-		jetpackAnalytics.initialize( userid, username, {
-			blog_id,
+		jetpackAnalytics.initialize( ID, login, {
+			blog_id: blogId,
 		} );
-	}, [ blog_id, userid, username ] );
+	}, [ blogId, ID, login, isUserConnected ] );
 
 	return jetpackAnalytics;
 };

--- a/projects/plugins/jetpack/changelog/add-shared-analytics-wrapper
+++ b/projects/plugins/jetpack/changelog/add-shared-analytics-wrapper
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Blocks: enqueue connection data in post editor, to be used by blocks.

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -8,6 +8,7 @@
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Blocks;
+use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Status;
@@ -723,6 +724,9 @@ class Jetpack_Gutenberg {
 			'Jetpack_Editor_Initial_State',
 			$initial_state
 		);
+
+		// Adds Connection package initial state.
+		wp_add_inline_script( 'jetpack-blocks-editor', Connection_Initial_State::render(), 'before' );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This should be used in the Jetpack plugin instead of the currently hardcoded analytics pulled from the React dashboard:
https://github.com/Automattic/jetpack/blob/7588402c7937ee94543d17275ac14f9c49a139d2/projects/plugins/jetpack/extensions/editor.js#L21-L32

We can then leverage it in other plugins as well.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion

This will benefit all blocks and more plugins (like Jetpack Social), but I'm building it as part of 1386-gh-dotcom-forge

#### Does this pull request change what data or activity we track or use?

* It doesn't change data we track; it will continue to be tracked all the same.

#### Testing instructions:

* This isn't used anywhere yet. I'll start using it in a follow-up PR.
* See #27940 for the PR where we will start using this.
