### PR TITLE
E2E tests: fix potential infinite page reload

### DIFF
--- a/tools/e2e-commons/pages/page-actions.js
+++ b/tools/e2e-commons/pages/page-actions.js
@@ -44,7 +44,8 @@ export default class PageActions {
 			await this.waitForDomContentLoaded();
 		} catch ( e ) {
 			logger.error( `Error waiting for domcontentloaded (1): ${ e }` );
-			await this.reload();
+			await this.page.reload();
+			await this.waitForDomContentLoaded();
 		}
 
 		if ( checkSelectors ) {

--- a/tools/e2e-commons/pages/page-actions.js
+++ b/tools/e2e-commons/pages/page-actions.js
@@ -45,7 +45,6 @@ export default class PageActions {
 		} catch ( e ) {
 			logger.error( `Error waiting for domcontentloaded (1): ${ e }` );
 			await this.reload();
-			await this.waitForDomContentLoaded();
 		}
 
 		if ( checkSelectors ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Update the reload page call to avoid an infinite loop.
#27910 added a page reload and a retry on domcontentloaded timeout, but the reload function already calls the wait for content to load.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- All e2e tests pass.

