### PR TITLE
Revert "Jetpack Live Branches: Make stable Jetpack not be installed by default"

### DIFF
--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jetpack Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.25
+// @version      1.24
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @grant        GM_xmlhttpRequest
 // @connect      jurassic.ninja
@@ -176,9 +176,9 @@
 						${ getOptionsList(
 							[
 								{
-									label: 'Jetpack (latest stable)',
+									label: 'Jetpack',
 									name: 'nojetpack',
-									checked: false,
+									checked: true,
 									invert: true,
 								},
 								{

--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jetpack Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.24
+// @version      1.26
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @grant        GM_xmlhttpRequest
 // @connect      jurassic.ninja


### PR DESCRIPTION
Reverts Automattic/jetpack#27738 while reviewing an issue

* Bumps version to 1.26

Edit: #27738 didn't work as expected The `jetpack` flag shouldn't affect the Jetpack Beta plugin. -- @oskosk. 
#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
None

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions

...