### PR TITLE
Stats Admin: Fix phpunit tests

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-stats-admin-phpunit-tests
+++ b/projects/packages/stats-admin/changelog/fix-stats-admin-phpunit-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats Admin: fixed phpunit CI tests

--- a/projects/packages/stats-admin/composer.json
+++ b/projects/packages/stats-admin/composer.json
@@ -5,7 +5,8 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"automattic/jetpack-constants": "@dev",
-		"automattic/jetpack-options": "@dev"
+		"automattic/jetpack-options": "@dev",
+		"automattic/jetpack-stats": "0.4.x-dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.0.4",
@@ -29,7 +30,8 @@
 		],
 		"build-production": "echo 'Add your build step to composer.json, please!'",
 		"build-development": "echo 'Add your build step to composer.json, please!'",
-		"post-update-cmd": "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\""
+		"post-install-cmd": "WorDBless\\Composer\\InstallDropin::copy",
+		"post-update-cmd": "WorDBless\\Composer\\InstallDropin::copy"
 	},
 	"repositories": [
 		{

--- a/projects/packages/stats-admin/composer.json
+++ b/projects/packages/stats-admin/composer.json
@@ -6,7 +6,7 @@
 	"require": {
 		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-options": "@dev",
-		"automattic/jetpack-stats": "0.4.x-dev"
+		"automattic/jetpack-stats": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.0.4",

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -9,6 +9,7 @@
 namespace Automattic\Jetpack\Stats_Admin;
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Stats\WPCOM_Stats;
 use Jetpack_Options;
 use WP_Error;
@@ -215,7 +216,7 @@ class REST_Controller {
 		$response = wp_remote_get(
 			sprintf(
 				'%s/rest/v1.2/sites/%d/posts/%d/likes?%s',
-				JETPACK__WPCOM_JSON_API_BASE,
+				Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' ),
 				Jetpack_Options::get_option( 'id' ),
 				$req->get_param( 'resource_id' ),
 				http_build_query(
@@ -310,7 +311,7 @@ class REST_Controller {
 		$response = wp_remote_get(
 			sprintf(
 				'%s/rest/v1.2/sites/%d/posts?%s',
-				JETPACK__WPCOM_JSON_API_BASE,
+				Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' ),
 				Jetpack_Options::get_option( 'id' ),
 				$req->get_param( 'resource_id' ),
 				http_build_query( $params )

--- a/projects/packages/stats-admin/tests/php/class-test-case.php
+++ b/projects/packages/stats-admin/tests/php/class-test-case.php
@@ -124,10 +124,10 @@ class Test_Case extends TestCase {
 		if ( strpos( $url, '/sites/999/' ) !== false ) {
 			return array(
 				'response' => array(
-					'code'    => 403,
-					'message' => 'forbidden',
+					'code'    => 200,
+					'message' => 'ok',
 				),
-				'body'     => '{"code"=>"forbidden"}',
+				'body'     => '{}',
 			);
 		}
 

--- a/projects/packages/stats-admin/tests/php/test-rest-controller.php
+++ b/projects/packages/stats-admin/tests/php/test-rest-controller.php
@@ -24,20 +24,25 @@ class Test_REST_Controller extends Stats_Test_Case {
 		'/jetpack/v4/stats-app/sites/999/stats/top-authors',
 		'/jetpack/v4/stats-app/sites/999/stats/video-plays',
 		'/jetpack/v4/stats-app/sites/999/posts',
+		'/jetpack/v4/stats-app/sites/999/posts/1000',
+		'/jetpack/v4/stats-app/sites/999/posts/1000/likes',
 		'/jetpack/v4/stats-app/sites/999/stats/streak',
 		'/jetpack/v4/stats-app/sites/999/stats/tags',
 		'/jetpack/v4/stats-app/sites/999/stats/followers',
+		'/jetpack/v4/stats-app/sites/999/stats/file-downloads',
+		'/jetpack/v4/stats-app/sites/999/stats/insights',
 		'/jetpack/v4/stats-app/sites/999/stats/publicize',
 		'/jetpack/v4/stats-app/sites/999/stats/comments',
-		'/jetpack/v4/stats-app/sites/999/stats/comment-follower',
+		'/jetpack/v4/stats-app/sites/999/stats/comment-followers',
+		'/jetpack/v4/stats-app/sites/999/stats/post/1',
+		'/jetpack/v4/stats-app/sites/999/stats/video/1',
+		'/jetpack/v4/stats-app/sites/999/site-has-never-published-post',
+	);
 
-		// TODO: investigate how we could remove these calls.
-		// '/jetpack/v4/stats-app/sites/999/rewind',
-		// '/jetpack/v4/stats-app/sites/999/plugins',
-		// '/jetpack/v4/stats-app/sites/999/keyrings',
-		// '/jetpack/v4/stats-app/me/connections',
-		// '/jetpack/v4/stats-app/jetpack-blogs/999/rest-api/',
-		// '/jetpack/v4/stats-app/sites/999/sharing-buttons',
+	const UNSUPPORTED_ROUTES = array(
+		'/jetpack/v4/stats-app/sites/999/stats/this-is-not-supported',
+		'/jetpack/v4/stats-app/sites/999/rewind',
+		'/jetpack/v4/stats-app/sites/999/stats/some-post-type/1',
 	);
 
 	/**
@@ -88,10 +93,20 @@ class Test_REST_Controller extends Stats_Test_Case {
 	/**
 	 * Test /stats exists.
 	 */
-	public function test_blog_stats_endpoint_exists() {
+	public function test_blog_stats_endpoints_exists() {
 		wp_set_current_user( $this->admin_id );
 		foreach ( self::SUPPORTED_ROUTES as $route ) {
 			$this->assert_route_exists( $route );
+		}
+	}
+
+	/**
+	 * Test not supported endpoints.
+	 */
+	public function test_blog_stats_endpoints_not_supported() {
+		wp_set_current_user( $this->admin_id );
+		foreach ( self::UNSUPPORTED_ROUTES as $route ) {
+			$this->assert_route_not_supported( $route );
 		}
 	}
 
@@ -105,7 +120,20 @@ class Test_REST_Controller extends Stats_Test_Case {
 		$request->set_header( 'content-type', 'application/json' );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertNotEquals( 'rest_no_route', $response->get_data()['code'] );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * Ensure required routes exists
+	 *
+	 * @param string $route The route to check.
+	 */
+	public function assert_route_not_supported( $route ) {
+		$request = new WP_REST_Request( 'GET', $route );
+		$request->set_header( 'content-type', 'application/json' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertNotEquals( 200, $response->get_status() );
 	}
 
 	/**

--- a/projects/packages/stats-admin/tests/php/test-stats-dashboard.php
+++ b/projects/packages/stats-admin/tests/php/test-stats-dashboard.php
@@ -67,6 +67,6 @@ class Test_Plan extends Stats_Test_Case {
 		$this->assertArrayHasKey( 'nonce', $data );
 		$this->assertArrayHasKey( 'site_name', $data );
 		$this->assertArrayHasKey( 'intial_state', $data );
-		$this->assertEmpty( $data->features );
+		$this->assertEmpty( $data['features'] );
 	}
 }

--- a/projects/packages/stats-admin/tests/php/test-stats-dashboard.php
+++ b/projects/packages/stats-admin/tests/php/test-stats-dashboard.php
@@ -46,7 +46,7 @@ class Test_Plan extends Stats_Test_Case {
 		$dashboard   = new Dashboard();
 		$config_data = new \ReflectionMethod( $dashboard, 'get_config_data_js' );
 		$config_data->setAccessible( true );
-		$this->assertMatchesRegularExpression( '/window\.configData/', $config_data->invoke( $dashboard ) );
+		$this->assertTrue( strpos( $config_data->invoke( $dashboard ), 'window.configData' ) === 0 );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-stats-admin-phpunit-tests
+++ b/projects/plugins/jetpack/changelog/fix-stats-admin-phpunit-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Stats Admin: update dependencies

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1989,11 +1989,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "4cd8e038dee77f90302cf854a0c3f6974a7980b6"
+                "reference": "19d34515a0201eec283a62dde17c63baddc6e47f"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
-                "automattic/jetpack-options": "@dev"
+                "automattic/jetpack-options": "@dev",
+                "automattic/jetpack-stats": "@dev"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -2033,8 +2034,11 @@
                 "build-development": [
                     "echo 'Add your build step to composer.json, please!'"
                 ],
+                "post-install-cmd": [
+                    "WorDBless\\Composer\\InstallDropin::copy"
+                ],
                 "post-update-cmd": [
-                    "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\""
+                    "WorDBless\\Composer\\InstallDropin::copy"
                 ]
             },
             "license": [


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The PR fixes the the issue where phpunit tests are not run properly for package `stats-admin` on Github actions.

Related: https://github.com/Automattic/wordbless/#make-sure-to-copy-dbphp

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
CBG1CP4EN/p1671050728180149-slack

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
- Ensure phpunit tests on Github pass - please open PHPUnit test details and look how the tests go for `stats-admin` package

` OK (8 tests, 43 assertions)`