### PR TITLE
Boost: Update getting started tests

### DIFF
--- a/projects/plugins/boost/changelog/update-getting-started-tests
+++ b/projects/plugins/boost/changelog/update-getting-started-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated e2e tests around the getting started page

--- a/projects/plugins/boost/tests/e2e/lib/env/prerequisites.js
+++ b/projects/plugins/boost/tests/e2e/lib/env/prerequisites.js
@@ -12,7 +12,7 @@ export function boostPrerequisitesBuilder( page ) {
 		connected: undefined,
 		jetpackDeactivated: undefined,
 		mockSpeedScore: undefined,
-		gotStarted: undefined,
+		getStarted: false,
 	};
 
 	return {
@@ -40,8 +40,8 @@ export function boostPrerequisitesBuilder( page ) {
 			state.clean = true;
 			return this;
 		},
-		withGotStarted() {
-			state.gotStarted = true;
+		withGetStarted( shouldGetStarted ) {
+			state.getStarted = shouldGetStarted;
 			return this;
 		},
 		async build() {
@@ -57,7 +57,7 @@ async function buildPrerequisites( state, page ) {
 		testPostTitles: () => ensureTestPosts( state.testPostTitles ),
 		clean: () => ensureCleanState( state.clean ),
 		mockSpeedScore: () => ensureMockSpeedScoreState( state.mockSpeedScore ),
-		gotStarted: () => ensureGotStartedState( state.gotStarted, page ),
+		getStarted: () => ensureGetStartedState( state.getStarted, page ),
 	};
 
 	logger.prerequisites( JSON.stringify( state, null, 2 ) );
@@ -99,8 +99,11 @@ export async function ensureMockSpeedScoreState( mockSpeedScore ) {
 	}
 }
 
-export async function ensureGotStartedState( shouldGetStarted ) {
+export async function ensureGetStartedState( shouldGetStarted ) {
 	if ( shouldGetStarted ) {
+		logger.prerequisites( 'Enabling getting started' );
+		await execWpCommand( 'jetpack-boost getting_started true' );
+	} else {
 		logger.prerequisites( 'Disabling getting started' );
 		await execWpCommand( 'jetpack-boost getting_started false' );
 	}

--- a/projects/plugins/boost/tests/e2e/specs/common.test.js
+++ b/projects/plugins/boost/tests/e2e/specs/common.test.js
@@ -40,7 +40,6 @@ test( 'Deactivating the plugin should clear Critical CSS and Dismissed Recommend
 	// TODO: Also should make sure that a Critical CSS recommendation is dismissed to check that the options does not exist after deactivation of the plugin.
 	await boostPrerequisitesBuilder( page )
 		.withCleanEnv( true )
-		.withGotStarted()
 		.withActiveModules( [ 'critical-css' ] )
 		.build();
 	const jetpackBoostPage = await JetpackBoostPage.visit( page );

--- a/projects/plugins/boost/tests/e2e/specs/common.test.js
+++ b/projects/plugins/boost/tests/e2e/specs/common.test.js
@@ -10,7 +10,7 @@ test.afterAll( async ( { browser } ) => {
 	const page = await browser.newPage( playwrightConfig.use );
 
 	await prerequisitesBuilder( page ).withActivePlugins( [ 'boost' ] ).build();
-	await boostPrerequisitesBuilder( page ).withConnection( true ).withGotStarted().build();
+	await boostPrerequisitesBuilder( page ).withConnection( true ).build();
 	await page.close();
 } );
 

--- a/projects/plugins/boost/tests/e2e/specs/critical-css.test.js
+++ b/projects/plugins/boost/tests/e2e/specs/critical-css.test.js
@@ -10,11 +10,7 @@ test.describe( 'Critical CSS module', () => {
 
 	test.beforeAll( async ( { browser } ) => {
 		page = await browser.newPage( playwrightConfig.use );
-		await boostPrerequisitesBuilder( page )
-			.withCleanEnv( true )
-			.withConnection( true )
-			.withGotStarted()
-			.build();
+		await boostPrerequisitesBuilder( page ).withCleanEnv( true ).withConnection( true ).build();
 	} );
 
 	test.afterAll( async ( { browser } ) => {

--- a/projects/plugins/boost/tests/e2e/specs/get-started.test.ts
+++ b/projects/plugins/boost/tests/e2e/specs/get-started.test.ts
@@ -1,0 +1,57 @@
+import { test, expect } from 'jetpack-e2e-commons/fixtures/base-test.js';
+import playwrightConfig from 'jetpack-e2e-commons/playwright.config.cjs';
+import { boostPrerequisitesBuilder } from '../lib/env/prerequisites.js';
+import { JetpackBoostPage } from '../lib/pages/index.js';
+
+let jetpackBoostPage;
+
+test.describe( 'Getting started page', () => {
+	test.beforeAll( async ( { browser } ) => {
+		const page = await browser.newPage( playwrightConfig.use );
+		await boostPrerequisitesBuilder( page )
+			.withCleanEnv()
+			.withConnection( true )
+			.withGetStarted( true )
+			.build();
+	} );
+
+	test.afterAll( async ( { browser } ) => {
+		const page = await browser.newPage();
+		await boostPrerequisitesBuilder( page )
+			.withCleanEnv()
+			.withConnection( true )
+			.withGetStarted( false )
+			.build();
+		await page.close();
+	} );
+
+	test.beforeEach( async function ( { page } ) {
+		jetpackBoostPage = await JetpackBoostPage.visit( page );
+	} );
+
+	test( 'User should see the getting started pricing table', async () => {
+		expect(
+			await jetpackBoostPage.isElementVisible( 'text="Get Boost"' ),
+			'Premium CTA should be visible'
+		).toBe( true );
+		expect(
+			await jetpackBoostPage.isElementVisible( 'text="Start for free"' ),
+			'Free CTA should be visible'
+		).toBe( true );
+	} );
+
+	test( 'User should be able to purchase the premium plan', async () => {
+		await jetpackBoostPage.click( 'text="Get Boost"' );
+		await jetpackBoostPage.page.waitForNavigation();
+		const expectedUrlPattern = /https:\/\/wordpress.com\/.*checkout.*/;
+		expect(
+			expectedUrlPattern.test( await jetpackBoostPage.page.url() ),
+			'User should be redirected to checkout page'
+		).toBeTruthy();
+	} );
+
+	test( 'User should be able to get started with the free plan', async () => {
+		await jetpackBoostPage.click( 'text="Start for free"' );
+		expect( await jetpackBoostPage.isScoreVisible(), 'Score should be visible' ).toBeTruthy();
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Disable getting started page on tests by default
* Add tests to cover the functionality of getting-started page

#### Other information:
- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
None

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Run the boost e2e tests