### PR TITLE
E2E Tests: Wait for API response in PayPal block test

### DIFF
--- a/projects/plugins/jetpack/changelog/try-e2e-paypal-wait-for-response
+++ b/projects/plugins/jetpack/changelog/try-e2e-paypal-wait-for-response
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Improve stability of Pay with Paypal test

--- a/projects/plugins/jetpack/tests/e2e/specs/blocks/pro-blocks.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/blocks/pro-blocks.test.js
@@ -73,7 +73,13 @@ test.describe( 'Paid blocks', () => {
 			'Publish a post and assert that Pay with PayPal block is rendered',
 			async () => {
 				await blockEditor.setTitle( 'Pay with PayPal block' );
-				await blockEditor.publishPost();
+
+				const testUrl = /^https?:\/\/.*%2Fwp%2Fv2%2Fjp_pay_product/;
+
+				await Promise.all( [
+					page.waitForResponse( resp => testUrl.test( resp.url() ) ),
+					blockEditor.publishPost(),
+				] );
 				await blockEditor.viewPost();
 				const frontend = await PostFrontendPage.init( page );
 				expect(

--- a/projects/plugins/jetpack/tests/e2e/specs/blocks/pro-blocks.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/blocks/pro-blocks.test.js
@@ -73,6 +73,7 @@ test.describe( 'Paid blocks', () => {
 			'Publish a post and assert that Pay with PayPal block is rendered',
 			async () => {
 				await blockEditor.setTitle( 'Pay with PayPal block' );
+				await blockEditor.publishPost();
 				await blockEditor.viewPost();
 				const frontend = await PostFrontendPage.init( page );
 				expect(

--- a/projects/plugins/jetpack/tests/e2e/specs/blocks/pro-blocks.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/blocks/pro-blocks.test.js
@@ -73,13 +73,6 @@ test.describe( 'Paid blocks', () => {
 			'Publish a post and assert that Pay with PayPal block is rendered',
 			async () => {
 				await blockEditor.setTitle( 'Pay with PayPal block' );
-
-				const testUrl = /^https?:\/\/.*%2Fwp%2Fv2%2Fjp_pay_product/;
-
-				await Promise.all( [
-					page.waitForResponse( resp => testUrl.test( resp.url() ) ),
-					blockEditor.publishPost(),
-				] );
 				await blockEditor.viewPost();
 				const frontend = await PostFrontendPage.init( page );
 				expect(

--- a/tools/e2e-commons/pages/wp-admin/blocks/simple-payments.js
+++ b/tools/e2e-commons/pages/wp-admin/blocks/simple-payments.js
@@ -31,6 +31,13 @@ export default class SimplePaymentBlock extends PageActions {
 		await this.fill( descriptionSelector, description );
 		await this.fill( priceSelector, price );
 		await this.fill( emailSelector, email );
+		await this.waitForResponse();
+	}
+
+	async waitForResponse() {
+		const testUrl = /^https?:\/\/.*%2Fwp%2Fv2%2Fjp_pay_product/;
+
+		this.page.waitForResponse( resp => testUrl.test( resp.url() ) );
 	}
 
 	getSelector( selector ) {


### PR DESCRIPTION
PayPal block test is often failing when verifying that the block is rendered on the frontend. It seems that this happening because we filling the block and publishing too fast, so POST API requests can't complete. Below is the chunk from logs that highlights the issue: the request is aborted due to navigation.

```
2022-12-14 19:44:55 action: Waiting for element '.post-publish-panel__postpublish-buttons a' to be visible [timeout: 20000 ms]
2022-12-14 19:44:55 step: View post
2022-12-14 19:44:55 action: Clicking element '.post-publish-panel__postpublish-buttons a'
2022-12-14 19:44:56 debug: Request failed: /index.php?rest_route=%2Fwp%2Fv2%2Fjp_pay_product%2F15&_locale=user  net::ERR_ABORTED
2022-12-14 19:44:56 action: Waiting for PostFrontendPage
```



#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

