### PR TITLE
Jetpack Boost: Fix image guide breaking galleries

### DIFF
--- a/projects/plugins/boost/app/features/image-guide/src/ui/Main.svelte
+++ b/projects/plugins/boost/app/features/image-guide/src/ui/Main.svelte
@@ -66,12 +66,24 @@
 {/if}
 
 <style lang="scss">
+	:global(.jetpack-boost-guide) {
+		&:not(.relative) {
+			position: absolute;
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
+			width: 100%;
+			height: 100%;
+		}
+	}
+	:global( .jetpack-boost-guide.relative ) {
+		position: relative;
+	}
 	.guide {
 		position: absolute;
 		top: 0;
 		left: 0;
-		right: 0;
-		bottom: 0;
 		width: 100%;
 		height: 100%;
 		z-index: 8000;

--- a/projects/plugins/boost/app/features/image-guide/src/ui/Popup.svelte
+++ b/projects/plugins/boost/app/features/image-guide/src/ui/Popup.svelte
@@ -145,10 +145,6 @@
 		font-weight: 600 !important;
 	}
 
-	:global( .jetpack-boost-guide.relative ) {
-		position: relative;
-	}
-
 	.preview {
 		display: flex;
 		gap: 15px;

--- a/projects/plugins/boost/changelog/boost-fix-ig-ff-position
+++ b/projects/plugins/boost/changelog/boost-fix-ig-ff-position
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed image guide in firefox
+
+


### PR DESCRIPTION
This fixes a problem where `.jetpack-boost-guide` element disrupted the layout in Gutenberg galleries.

#### Changes proposed in this Pull Request:

- Added `position: absolute` and `position: relative` styles to the `.jetpack-boost-guide` element to prevent it from disrupting the layout in Gutenberg galleries.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
pc9hqz-1pa-p2#comment-1059

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
- Create a new WordPress post and insert a Gutenberg gallery into it.
- Use the Jetpack Boost image guide feature to add a guide to the gallery.
- Observe the layout of the gallery and ensure that it is not disrupted by the .jetpack-boost-guide element.
- Repeat steps 1-3 for different types of galleries and ensure that the .jetpack-boost-guide element does not disrupt the layout in any of them.
