### PR TITLE
E2E tests: fix post title in disabled sync assertion

### DIFF
--- a/projects/plugins/jetpack/changelog/e2e-fix-disabled-sync-assert
+++ b/projects/plugins/jetpack/changelog/e2e-fix-disabled-sync-assert
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+

--- a/projects/plugins/jetpack/tests/e2e/specs/sync/sync.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/sync/sync.test.js
@@ -93,7 +93,7 @@ test.describe( 'Sync', () => {
 				'Previously created post should NOT be present in the synced posts'
 			).toContainEqual(
 				expect.not.objectContaining( {
-					title: 'Disabled Sync',
+					title: postTitle,
 				} )
 			);
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

In the Disabled sync e2e test we're not checking for the exact post title, and it sometimes fails, probably when the site URL was used before.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
- All e2e tests pass

