### PR TITLE
Fix out-of-bounds menus on the admin

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-out-of-bounds-menu
+++ b/projects/plugins/jetpack/changelog/fix-out-of-bounds-menu
@@ -1,3 +1,3 @@
 Significance: patch
 Type: bugfix
-Comment: Fix the submenus shown outside of screen
+Comment: Fix the submenu positioning for the masterbar left nav

--- a/projects/plugins/jetpack/changelog/fix-out-of-bounds-menu
+++ b/projects/plugins/jetpack/changelog/fix-out-of-bounds-menu
@@ -1,0 +1,3 @@
+Significance: patch
+Type: bugfix
+Comment: Fix the submenus shown outside of screen

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
@@ -110,24 +110,26 @@
 			);
 		}
 
-		document.querySelectorAll( 'li.wp-has-submenu.wp-not-current-submenu' ).forEach( function ( el ) {
-			const submenu = el.querySelector( '.wp-submenu' );
-			const linkElement = el.querySelector( 'a' );
+		if ( document.querySelector('body.jetpack-masterbar') ) {
+			document.querySelectorAll( 'li.wp-has-submenu.wp-not-current-submenu' ).forEach( function ( el ) {
+				const submenu = el.querySelector( '.wp-submenu' );
+				const linkElement = el.querySelector( 'a' );
 
-			el.addEventListener( 'mouseover', function() {
-				submenu.style.display = null;
-				submenu.style.top = '-1px';
-				if ( ! isElementInViewport( submenu ) ) {
-					submenu.style.top = ( 34 - submenu.clientHeight ) + 'px';
-				}
-				linkElement.focus();
-			} );
+				el.addEventListener( 'mouseover', function() {
+					submenu.style.display = null;
+					submenu.style.top = '-1px';
+					if ( ! isElementInViewport( submenu ) ) {
+						submenu.style.top = ( 34 - submenu.clientHeight ) + 'px';
+					}
+					linkElement.focus();
+				} );
 
-			el.addEventListener( 'mouseleave', function() {
-				submenu.style.display = 'none';
-				submenu.style.top = null;
+				el.addEventListener( 'mouseleave', function() {
+					submenu.style.display = 'none';
+					submenu.style.top = null;
+				} );
 			} );
-		} );
+		}
 	}
 
 	function isElementInViewport( el ) {

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
@@ -110,11 +110,11 @@
 			);
 		}
 
-		document.querySelectorAll('li.wp-has-submenu.wp-not-current-submenu').forEach( function (el) {
-			const submenu = el.querySelector('.wp-submenu');
-			const linkElement = el.querySelector('a');
+		document.querySelectorAll( 'li.wp-has-submenu.wp-not-current-submenu' ).forEach( function ( el ) {
+			const submenu = el.querySelector( '.wp-submenu' );
+			const linkElement = el.querySelector( 'a' );
 
-			el.addEventListener('mouseover', function() {
+			el.addEventListener( 'mouseover', function() {
 				submenu.style.display = null;
 				submenu.style.top = '-1px';
 				if ( ! isElementInViewport( submenu ) ) {
@@ -123,14 +123,14 @@
 				linkElement.focus();
 			} );
 
-			el.addEventListener('mouseleave', function() {
+			el.addEventListener( 'mouseleave', function() {
 				submenu.style.display = 'none';
 				submenu.style.top = null;
 			} );
 		} );
 	}
 
-	function isElementInViewport (el) {
+	function isElementInViewport( el ) {
 		var rect = el.getBoundingClientRect();
 
 		return (

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
@@ -138,6 +138,8 @@
 		return (
 			rect.top >= 0 &&
 			rect.left >= 0 &&
+			// Tries to primarily use the window viewport, but if that's not available, uses the documentElement.
+			// The innerWidth attribute must return the viewport width including the size of a rendered scroll bar (if any), or zero if there is no viewport.
 			rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
 			rect.right <= (window.innerWidth || document.documentElement.clientWidth)
 		);

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
@@ -119,8 +119,8 @@
 					submenu.style.display = null;
 					submenu.style.top = '-1px';
 					if ( ! isElementInViewport( submenu ) ) {
-						// Repoisition the submenu to the top of the menu item. 34px is the height of the menu item.
-						submenu.style.top = ( 34 - submenu.clientHeight ) + 'px';
+						// Repoisition the submenu to the top of the menu item.
+						submenu.style.top = ( linkElement.clientHeight - submenu.clientHeight ) + 'px';
 					}
 					linkElement.focus();
 				} );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
@@ -151,4 +151,32 @@
 	} else {
 		init();
 	}
+
+	function isElementInViewport (el) {
+		var rect = el.getBoundingClientRect();
+
+		return (
+			rect.top >= 0 &&
+			rect.left >= 0 &&
+			rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+			rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+		);
+	}
+
+	document.querySelectorAll('li.wp-has-submenu.wp-not-current-submenu').forEach( function (el) {
+		const submenu = el.querySelector('.wp-submenu');
+
+		el.addEventListener('mouseover', function() {
+			submenu.style.display = null;
+			submenu.style.top = '-1px';
+			if ( ! isElementInViewport( submenu ) ) {
+				submenu.style.top = ( 34 - submenu.clientHeight ) + 'px';
+			}
+		} );
+
+		el.addEventListener('mouseleave', function() {
+			submenu.style.display = 'none';
+			submenu.style.top = null;
+		} );
+	} );
 } )();

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
@@ -119,6 +119,7 @@
 					submenu.style.display = null;
 					submenu.style.top = '-1px';
 					if ( ! isElementInViewport( submenu ) ) {
+						// Repoisition the submenu to the top of the menu item. 34px is the height of the menu item.
 						submenu.style.top = ( 34 - submenu.clientHeight ) + 'px';
 					}
 					linkElement.focus();
@@ -127,6 +128,9 @@
 				el.addEventListener( 'mouseleave', function() {
 					submenu.style.display = 'none';
 					submenu.style.top = null;
+					if ( document.activeElement === linkElement ) {
+						linkElement.blur();
+					}
 				} );
 			} );
 		}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
@@ -109,6 +109,34 @@
 				}
 			);
 		}
+
+		document.querySelectorAll('li.wp-has-submenu.wp-not-current-submenu').forEach( function (el) {
+			const submenu = el.querySelector('.wp-submenu');
+
+			el.addEventListener('mouseover', function() {
+				submenu.style.display = null;
+				submenu.style.top = '-1px';
+				if ( ! isElementInViewport( submenu ) ) {
+					submenu.style.top = ( 34 - submenu.clientHeight ) + 'px';
+				}
+			} );
+
+			el.addEventListener('mouseleave', function() {
+				submenu.style.display = 'none';
+				submenu.style.top = null;
+			} );
+		} );
+	}
+
+	function isElementInViewport (el) {
+		var rect = el.getBoundingClientRect();
+
+		return (
+			rect.top >= 0 &&
+			rect.left >= 0 &&
+			rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+			rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+		);
 	}
 
 	function makeAjaxRequest( method, url, contentType, body = null, callback = null ) {
@@ -151,32 +179,4 @@
 	} else {
 		init();
 	}
-
-	function isElementInViewport (el) {
-		var rect = el.getBoundingClientRect();
-
-		return (
-			rect.top >= 0 &&
-			rect.left >= 0 &&
-			rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-			rect.right <= (window.innerWidth || document.documentElement.clientWidth)
-		);
-	}
-
-	document.querySelectorAll('li.wp-has-submenu.wp-not-current-submenu').forEach( function (el) {
-		const submenu = el.querySelector('.wp-submenu');
-
-		el.addEventListener('mouseover', function() {
-			submenu.style.display = null;
-			submenu.style.top = '-1px';
-			if ( ! isElementInViewport( submenu ) ) {
-				submenu.style.top = ( 34 - submenu.clientHeight ) + 'px';
-			}
-		} );
-
-		el.addEventListener('mouseleave', function() {
-			submenu.style.display = 'none';
-			submenu.style.top = null;
-		} );
-	} );
 } )();

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
@@ -112,6 +112,7 @@
 
 		document.querySelectorAll('li.wp-has-submenu.wp-not-current-submenu').forEach( function (el) {
 			const submenu = el.querySelector('.wp-submenu');
+			const linkElement = el.querySelector('a');
 
 			el.addEventListener('mouseover', function() {
 				submenu.style.display = null;
@@ -119,6 +120,7 @@
 				if ( ! isElementInViewport( submenu ) ) {
 					submenu.style.top = ( 34 - submenu.clientHeight ) + 'px';
 				}
+				linkElement.focus();
 			} );
 
 			el.addEventListener('mouseleave', function() {

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
@@ -110,7 +110,7 @@
 			);
 		}
 
-		if ( document.querySelector('body.jetpack-masterbar') ) {
+		if ( jetpackAdminMenu.isAtomic ) {
 			document.querySelectorAll( 'li.wp-has-submenu.wp-not-current-submenu' ).forEach( function ( el ) {
 				const submenu = el.querySelector( '.wp-submenu' );
 				const linkElement = el.querySelector( 'a' );
@@ -144,8 +144,8 @@
 			rect.left >= 0 &&
 			// Tries to primarily use the window viewport, but if that's not available, uses the documentElement.
 			// The innerWidth attribute must return the viewport width including the size of a rendered scroll bar (if any), or zero if there is no viewport.
-			rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-			rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+			rect.bottom <= ( window.innerHeight || document.documentElement.clientHeight ) &&
+			rect.right <= ( window.innerWidth || document.documentElement.clientWidth )
 		);
 	}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Dashboard_Customizations;
 
 use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Status\Host;
 
 /**
  * Class Base_Admin_Menu
@@ -277,6 +278,7 @@ abstract class Base_Admin_Menu {
 			array(
 				'upsellNudgeJitm'  => wp_create_nonce( 'upsell_nudge_jitm' ),
 				'jitmDismissNonce' => wp_create_nonce( 'jitm_dismiss' ),
+				'isAtomic'         => ( new Host() )->is_woa_site(),
 			)
 		);
 	}


### PR DESCRIPTION
The submenu could be displayed outside of the user's screen visibility. Beyond that, hovering the `Settings` menu had the potential of causing endless flickering.

#### Before
<img width="574" alt="Screen Shot 2022-12-15 at 10 02 40" src="https://user-images.githubusercontent.com/1234758/207865747-b5ef7520-2e66-4abd-a983-278f7dbffa4c.png">

#### After
<img width="569" alt="Screen Shot 2022-12-15 at 10 02 06" src="https://user-images.githubusercontent.com/1234758/207865661-163d0341-ba4b-4d84-957e-b1f3cccaa977.png">


Fixes https://github.com/Automattic/wp-calypso/issues/71198

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Display the submenu upwards when it is out of bounds

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a

#### Testing instructions:

* Visit wp-admin/site-health.php
* Adjust your screen to a size of a 13-14" Macbook
* Hover over Settings
* The submenu should show upwards
* Flickering should no longer occur
