### PR TITLE
JITM: Prevent the activation page from displaying the JP License Activation JITM.

### DIFF
--- a/projects/packages/jitm/changelog/hide-jitm-license-key-activation
+++ b/projects/packages/jitm/changelog/hide-jitm-license-key-activation
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fixed JP License Activation JITM to not display in the activation page.
+Prevent the activation page from displaying the JP License Activation JITM.

--- a/projects/packages/jitm/changelog/hide-jitm-license-key-activation
+++ b/projects/packages/jitm/changelog/hide-jitm-license-key-activation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed JP License Activation JITM to not display in the activation page.

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '2.2.37';
+	const PACKAGE_VERSION = '2.2.38-alpha';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/jitm/src/js/jetpack-jitm.js
+++ b/projects/packages/jitm/src/js/jetpack-jitm.js
@@ -248,7 +248,20 @@ jQuery( document ).ready( function ( $ ) {
 				}
 
 				// for now, always take the first response
-				setJITMContent( $el, response[ 0 ], redirect );
+				const data = response [ 0 ];
+
+				const LICENSE_ACTIVATION_NOTICE_KEYS = [
+					'single_licensing_activation_notice',
+					'multiple_licensing_activation_notice',
+				];
+
+				const inJPLicenseActivationPage = window?.location?.href.indexOf( 'jetpack#/add-license' ) >= 0;
+				const isJPLicenseActivationNotice = LICENSE_ACTIVATION_NOTICE_KEYS.includes( data.id );
+
+				// We do not want to display License Activation JITM in the activation page
+				if ( !( isJPLicenseActivationNotice && inJPLicenseActivationPage) ) {
+					setJITMContent( $el, data, redirect );
+				}
 			} );
 		} );
 	};
@@ -256,9 +269,10 @@ jQuery( document ).ready( function ( $ ) {
 	reFetch();
 
 	$( window ).on( 'hashchange', function ( e ) {
-		var newURL = e.originalEvent.newURL;
+		const newURL = e.originalEvent.newURL;
+		const isJetpackPage = newURL.indexOf( 'jetpack#/' ) >= 0 || newURL.indexOf( 'my-jetpack' ) >= 0;
 
-		if ( newURL.indexOf( 'jetpack#/' ) >= 0 ) {
+		if ( isJetpackPage ) {
 			var jitm_card = document.querySelector( '.jitm-card' );
 			if ( jitm_card ) {
 				jitm_card.remove();

--- a/projects/packages/jitm/src/js/jetpack-jitm.js
+++ b/projects/packages/jitm/src/js/jetpack-jitm.js
@@ -223,7 +223,14 @@ jQuery( document ).ready( function ( $ ) {
 			var hash = location.hash;
 
 			hash = hash.replace( /#\//, '_' );
-			if ( '_dashboard' !== hash ) {
+
+			// We always include the hash if this is My Jetpack page
+			if ( message_path.includes( 'jetpack_page_my-jetpack' )) {
+				message_path = message_path.replace(
+					'jetpack_page_my-jetpack',
+					'jetpack_page_my-jetpack' + hash
+				);
+			} else if ( '_dashboard' !== hash ) {
 				message_path = message_path.replace(
 					'toplevel_page_jetpack',
 					'toplevel_page_jetpack' + hash
@@ -248,20 +255,7 @@ jQuery( document ).ready( function ( $ ) {
 				}
 
 				// for now, always take the first response
-				const data = response [ 0 ];
-
-				const LICENSE_ACTIVATION_NOTICE_KEYS = [
-					'single_licensing_activation_notice',
-					'multiple_licensing_activation_notice',
-				];
-
-				const inJPLicenseActivationPage = window?.location?.href.indexOf( 'jetpack#/add-license' ) >= 0;
-				const isJPLicenseActivationNotice = LICENSE_ACTIVATION_NOTICE_KEYS.includes( data.id );
-
-				// We do not want to display License Activation JITM in the activation page
-				if ( !( isJPLicenseActivationNotice && inJPLicenseActivationPage) ) {
-					setJITMContent( $el, data, redirect );
-				}
+				setJITMContent( $el, response[ 0 ], redirect );
 			} );
 		} );
 	};


### PR DESCRIPTION

Currently, the License Activation JITM is showing in the activation page(`my-jetpack#/add-license`) which should not be the case. Additionally, when page is loaded from My Jetpack page, the JITM does not load. This PR fixes both issues.

<img width="1306" alt="204287204-d76ff86b-61d5-4a80-9d5c-fd2810a8d816" src="https://user-images.githubusercontent.com/56598660/207883610-5d01d2e8-1d37-4ab1-8f47-82efaa88f062.png">

#### Changes proposed in this Pull Request:
* Update JITM to only display License activation notice when not in the activation page.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
Context: 1202858161751496-as-1203541335085007

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
1. Goto https://cloud.jetpack.com/pricing and purchase a product or two. (Make sure you do not activate the license key)
2. Launch a test site that uses a build of the Jetpack plugin based on this branch (Make sure you build the JITM package)
3. Connect your site to Jetpack, if it's not already
4. Go to Jetpack Dashboard by clicking the **Dashboard** menu and confirm JITM is displayed in the dashboard page
<img width="1728" alt="Screen Shot 2022-12-15 at 10 23 56 PM" src="https://user-images.githubusercontent.com/56598660/207885638-f726cb1d-7b65-4d85-8478-9a7736b548e8.png">
5. Go to My Jetpack page by clicking the **My Jetpack** menu and confirm the JITM is displayed in My Jetpack page
<img width="1728" alt="Screen Shot 2022-12-15 at 10 26 50 PM" src="https://user-images.githubusercontent.com/56598660/207886151-7739cfb5-e06c-4ddf-add1-e37dd4937d1c.png">
6. Go to License activation page by clicking the **Activate a License** link in My Jetpack page.
<img width="399" alt="Screen Shot 2022-11-25 at 9 48 39 PM" src="https://user-images.githubusercontent.com/56598660/203999156-74d19d0e-9d32-479b-a95e-ba235dd811a3.png">
7. Confirm that the JITM is not displayed.
<img width="1725" alt="Screen Shot 2022-12-15 at 10 29 54 PM" src="https://user-images.githubusercontent.com/56598660/207886850-cad8dbbc-ff77-4d80-82da-a6910c5a36a1.png">
8. Finally Press **Go back** link to return in My Jetpack page and confirm the JITM is displayed again.

