### PR TITLE
CSS:Removing maybe_inline_style

### DIFF
--- a/projects/plugins/jetpack/changelog/Replace custom maybe_inline_style with core wp_maybe_inline_styles
+++ b/projects/plugins/jetpack/changelog/Replace custom maybe_inline_style with core wp_maybe_inline_styles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+CSS: Removed custom maybe_inline_style() with wp_maybe_inline_styles() which is available in WP core since 5.8.0

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -706,6 +706,7 @@ class Jetpack {
 
 		add_filter( 'plugins_url', array( 'Jetpack', 'maybe_min_asset' ), 1, 3 );
 		add_action( 'style_loader_src', array( 'Jetpack', 'set_suffix_on_min' ), 10, 2 );
+		add_filter( 'style_loader_tag', array( 'Jetpack', 'maybe_inline_style' ), 10, 2 );
 
 		add_filter( 'profile_update', array( 'Jetpack', 'user_meta_cleanup' ) );
 
@@ -5740,6 +5741,22 @@ endif;
 		}
 
 		return $src;
+	}
+
+	/**
+	 * Maybe inlines a stylesheet.
+	 *
+	 * @deprecated since $$next-version$$.
+	 *
+	 * @param string $tag The tag that would link to the external asset.
+	 * @param string $handle The registered handle of the script in question.
+	 *
+	 * @return string
+	 */
+	public static function maybe_inline_style( $tag, $handle ) { //phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		_deprecated_function( __METHOD__, '$$next-version$$', 'wp_maybe_inline_styles' );
+
+		return $tag;
 	}
 
 	/**

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -706,7 +706,6 @@ class Jetpack {
 
 		add_filter( 'plugins_url', array( 'Jetpack', 'maybe_min_asset' ), 1, 3 );
 		add_action( 'style_loader_src', array( 'Jetpack', 'set_suffix_on_min' ), 10, 2 );
-		add_filter( 'style_loader_tag', array( 'Jetpack', 'maybe_inline_style' ), 10, 2 );
 
 		add_filter( 'profile_update', array( 'Jetpack', 'user_meta_cleanup' ) );
 
@@ -5741,72 +5740,6 @@ endif;
 		}
 
 		return $src;
-	}
-
-	/**
-	 * Maybe inlines a stylesheet.
-	 *
-	 * If you'd like to inline a stylesheet instead of printing a link to it,
-	 * wp_style_add_data( 'handle', 'jetpack-inline', true );
-	 *
-	 * Attached to `style_loader_tag` filter.
-	 *
-	 * @param string $tag The tag that would link to the external asset.
-	 * @param string $handle The registered handle of the script in question.
-	 *
-	 * @return string
-	 */
-	public static function maybe_inline_style( $tag, $handle ) {
-		global $wp_styles;
-		$item = $wp_styles->registered[ $handle ];
-
-		if ( ! isset( $item->extra['jetpack-inline'] ) || ! $item->extra['jetpack-inline'] ) {
-			return $tag;
-		}
-
-		if ( preg_match( '# href=\'([^\']+)\' #i', $tag, $matches ) ) {
-			$href = $matches[1];
-			// Strip off query string.
-			$pos = strpos( $href, '?' );
-			if ( $pos ) {
-				$href = substr( $href, 0, $pos );
-			}
-			// Strip off fragment.
-			$pos = strpos( $href, '#' );
-			if ( $pos ) {
-				$href = substr( $href, 0, $pos );
-			}
-		} else {
-			return $tag;
-		}
-
-		$plugins_dir = plugin_dir_url( JETPACK__PLUGIN_FILE );
-		if ( substr( $href, 0, strlen( $plugins_dir ) ) !== $plugins_dir ) {
-			return $tag;
-		}
-
-		// If this stylesheet has a RTL version, and the RTL version replaces normal...
-		if ( isset( $item->extra['rtl'] ) && 'replace' === $item->extra['rtl'] && is_rtl() ) {
-			// And this isn't the pass that actually deals with the RTL version...
-			if ( false === strpos( $tag, " id='$handle-rtl-css' " ) ) {
-				// Short out, as the RTL version will deal with it in a moment.
-				return $tag;
-			}
-		}
-
-		$file = JETPACK__PLUGIN_DIR . substr( $href, strlen( $plugins_dir ) );
-		$css  = self::absolutize_css_urls( file_get_contents( $file ), $href ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-		if ( $css ) {
-			$tag = "<!-- Inline {$item->handle} -->\r\n";
-			if ( empty( $item->extra['after'] ) ) {
-				wp_add_inline_style( $handle, $css );
-			} else {
-				array_unshift( $item->extra['after'], $css );
-				wp_style_add_data( $handle, 'after', $item->extra['after'] );
-			}
-		}
-
-		return $tag;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/post-by-email/class-jetpack-post-by-email.php
+++ b/projects/plugins/jetpack/modules/post-by-email/class-jetpack-post-by-email.php
@@ -63,7 +63,12 @@ class Jetpack_Post_By_Email {
 			)
 		);
 		wp_enqueue_style( 'post-by-email', plugins_url( 'post-by-email.css', __FILE__ ), array(), JETPACK__VERSION );
-		wp_style_add_data( 'post-by-email', 'jetpack-inline', true );
+		/** Inline styles */
+		if ( is_rtl() ) {
+			wp_style_add_data( 'post-by-email', 'path', plugin_dir_path( __FILE__ ) . 'post-by-email-rtl.min.css' );
+		} else {
+			wp_style_add_data( 'post-by-email', 'path', plugin_dir_path( __FILE__ ) . 'post-by-email.min.css' );
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/post-by-email/class-jetpack-post-by-email.php
+++ b/projects/plugins/jetpack/modules/post-by-email/class-jetpack-post-by-email.php
@@ -63,7 +63,7 @@ class Jetpack_Post_By_Email {
 			)
 		);
 		wp_enqueue_style( 'post-by-email', plugins_url( 'post-by-email.css', __FILE__ ), array(), JETPACK__VERSION );
-		/** Inline styles */
+		// Inline styles. @see wp_maybe_inline_styles()
 		if ( is_rtl() ) {
 			wp_style_add_data( 'post-by-email', 'path', plugin_dir_path( __FILE__ ) . 'post-by-email-rtl.min.css' );
 		} else {

--- a/projects/plugins/jetpack/modules/widgets/facebook-likebox.php
+++ b/projects/plugins/jetpack/modules/widgets/facebook-likebox.php
@@ -95,6 +95,7 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 			array(),
 			JETPACK__VERSION
 		);
+		// Inline styles. @see wp_maybe_inline_styles()
 		wp_style_add_data( 'jetpack_facebook_likebox', 'path', plugin_dir_path( __FILE__ ) . 'facebook-likebox/style.css' );
 	}
 

--- a/projects/plugins/jetpack/modules/widgets/facebook-likebox.php
+++ b/projects/plugins/jetpack/modules/widgets/facebook-likebox.php
@@ -95,7 +95,7 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 			array(),
 			JETPACK__VERSION
 		);
-		wp_style_add_data( 'jetpack_facebook_likebox', 'jetpack-inline', true );
+		wp_style_add_data( 'jetpack_facebook_likebox', 'path', plugin_dir_path( __FILE__ ) . 'facebook-likebox/style.css' );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We are using a custom maybe_inline_style function for adding inline CSS that may not be necessary any longer. Since WP 5.8.0 core is using wp_maybe_inline_styles() 

Our existing function is running into some compatibility problems, such as https://wordpress.org/support/topic/error-in-php-8-0-8-1/
Although Jetpack does not cause that error, removing it may be a good idea since we can use core functionality to achieve the same thing.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removed maybe_inline_style()
* Edited Facebook likebox and Post by email files to use core wp_maybe_inline_styles() instead

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try adding a Facebook page legacy widget and make sure the style is loaded inline. <style 
id="jetpack_facebook_likebox-inline-css">
* Test it on WP.com to make sure nothing is broken

