### PR TITLE
Update/agencies module hide on atomic sites

### DIFF
--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -63,6 +63,7 @@ import {
 	getInitialRecommendationsStep,
 	getPluginBaseUrl,
 	getPartnerCoupon,
+	isAtomicSite,
 	isWoASite,
 	isWooCommerceActive,
 } from 'state/initial-state';
@@ -574,6 +575,7 @@ class Main extends React.Component {
 			this.props.userCanConnectSite &&
 			site_count >= 2 &&
 			this.props.isSiteConnected &&
+			! this.props.isAtomicSite &&
 			! this.shouldShowWooConnectionScreen() &&
 			dashboardRoutes.includes( this.props.location.pathname )
 		);
@@ -776,6 +778,7 @@ export default connect(
 			pluginBaseUrl: getPluginBaseUrl( state ),
 			connectUrl: getConnectUrl( state ),
 			connectingUserFeatureLabel: getConnectingUserFeatureLabel( state ),
+			isAtomicSite: isAtomicSite( state ),
 			isWoaSite: isWoASite( state ),
 			isWooCommerceActive: isWooCommerceActive( state ),
 			hasSeenWCConnectionModal: getHasSeenWCConnectionModal( state ),

--- a/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
@@ -327,6 +327,7 @@ export function arePromotionsActive( state ) {
  * @returns {boolean} True if this is an WoA site, false otherwise.
  */
 export function isAtomicSite( state ) {
+	console.log( state );
 	return get( state.jetpack.initialState.siteData, 'isAtomicSite', false );
 }
 

--- a/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
@@ -327,7 +327,6 @@ export function arePromotionsActive( state ) {
  * @returns {boolean} True if this is an WoA site, false otherwise.
  */
 export function isAtomicSite( state ) {
-	console.log( state );
 	return get( state.jetpack.initialState.siteData, 'isAtomicSite', false );
 }
 

--- a/projects/plugins/jetpack/changelog/update-agencies-module-hide-on-atomic-sites
+++ b/projects/plugins/jetpack/changelog/update-agencies-module-hide-on-atomic-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Hides agencies module on jetpack dashboard if site is atomic


### PR DESCRIPTION
This PR makes it so the agencies module does not show on atomic sites.

#### Changes proposed in this Pull Request:

This hides the agencies module on the dashboard if the site is atomic. This is being done because there has been some trouble adding licenses to atomic sites via the agencies dashboard: p8oabR-110-p2#comment-6874, and because most agencies self host their sites

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion

P2: p8oabR-110-p2#comment-6862

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:
 * Checkout this branch via `git switch update/agencies-module-hide-on-atomic-sites`
 * Get your local docker setup running (or whatever you use to test locally)
 * Go to `/wp-admin/admin.php?page=jetpack#/dashboard`
 * Confirm the module still shows up
![image](https://user-images.githubusercontent.com/65001528/207949539-4acd15ed-c58b-40f5-9cd9-ddaffc0c1c28.png)
I tried follow the instructions [here](https://github.com/Automattic/jetpack/pull/27966#issuecomment-1353506928) to test out the changes on wordpress.com, but I couldn't seem to get the changes to actually show up on my atomic site even when it was sandboxed. I don't believe testing this is necessary, because `isAtomicSite` was a preexisting function, and therefore has already been tested to make sure it works. 
 * Go to the file `projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js` and go to line 330.
 * Add a new line and `return true` early
 * Confirm the module doesn't show up if `isAtomicSite` returns true
![image](https://user-images.githubusercontent.com/65001528/207949388-e388ae5c-2322-461b-b5db-462df1929174.png)
