### PR TITLE
Contact Forms: Normalize fields styles to comply with WYSIWYG

### DIFF
--- a/projects/plugins/jetpack/changelog/update-form-fields-style
+++ b/projects/plugins/jetpack/changelog/update-form-fields-style
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Update Form fields styles to comply with WYSIWYG

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-checkbox.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-checkbox.js
@@ -1,5 +1,5 @@
 import { InspectorControls } from '@wordpress/block-editor';
-import { BaseControl, PanelBody, ToggleControl } from '@wordpress/components';
+import { PanelBody, ToggleControl } from '@wordpress/components';
 import { withInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import JetpackFieldControls from './jetpack-field-controls';
@@ -18,41 +18,38 @@ function JetpackFieldCheckbox( props ) {
 	} = props;
 
 	return (
-		<BaseControl
+		<div
 			id={ `jetpack-field-checkbox-${ instanceId }` }
 			className="jetpack-field jetpack-field-checkbox"
-			label={
-				<>
-					<input
-						className="jetpack-field-checkbox__checkbox"
-						type="checkbox"
-						disabled
+		>
+			<input
+				className="jetpack-field-checkbox__checkbox"
+				type="checkbox"
+				disabled
+				checked={ defaultValue }
+			/>
+			<JetpackFieldLabel
+				required={ required }
+				requiredText={ requiredText }
+				label={ label }
+				setAttributes={ setAttributes }
+			/>
+			<JetpackFieldControls
+				id={ id }
+				required={ required }
+				width={ width }
+				setAttributes={ setAttributes }
+			/>
+			<InspectorControls>
+				<PanelBody title={ __( 'Checkbox Settings', 'jetpack' ) }>
+					<ToggleControl
+						label={ __( 'Checked by default', 'jetpack' ) }
 						checked={ defaultValue }
+						onChange={ value => setAttributes( { defaultValue: value ? 'true' : '' } ) }
 					/>
-					<JetpackFieldLabel
-						required={ required }
-						requiredText={ requiredText }
-						label={ label }
-						setAttributes={ setAttributes }
-					/>
-					<JetpackFieldControls
-						id={ id }
-						required={ required }
-						width={ width }
-						setAttributes={ setAttributes }
-					/>
-					<InspectorControls>
-						<PanelBody title={ __( 'Checkbox Settings', 'jetpack' ) }>
-							<ToggleControl
-								label={ __( 'Checked by default', 'jetpack' ) }
-								checked={ defaultValue }
-								onChange={ value => setAttributes( { defaultValue: value ? 'true' : '' } ) }
-							/>
-						</PanelBody>
-					</InspectorControls>
-				</>
-			}
-		/>
+				</PanelBody>
+			</InspectorControls>
+		</div>
 	);
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-consent.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-consent.js
@@ -17,59 +17,56 @@ const JetpackFieldConsent = ( {
 	setAttributes,
 } ) => {
 	return (
-		<BaseControl
+		<div
 			id={ `jetpack-field-consent-${ instanceId }` }
 			className="jetpack-field jetpack-field-consent"
-			label={
-				<>
-					{ consentType === 'explicit' && (
-						<input className="jetpack-field-consent__checkbox" type="checkbox" disabled />
-					) }
-					<JetpackFieldLabel
-						required={ false }
-						label={
-							{
-								implicit: implicitConsentMessage,
-								explicit: explicitConsentMessage,
-							}[ consentType ] ?? ''
-						}
-						setAttributes={ setAttributes }
-						labelFieldName={ `${ consentType }ConsentMessage` }
-						placeholder={ sprintf(
-							/* translators: placeholder is a type of consent: implicit or explicit */
-							__( 'Add %s consent message…', 'jetpack' ),
-							consentType
-						) }
-					/>
-					<InspectorControls>
-						<PanelBody title={ __( 'Manage Responses', 'jetpack' ) }>
-							<JetpackManageResponsesSettings isChildBlock />
-						</PanelBody>
-						<PanelBody title={ __( 'Field Settings', 'jetpack' ) }>
-							<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />
-						</PanelBody>
-					</InspectorControls>
-					<InspectorAdvancedControls>
-						<JetpackFieldCss setAttributes={ setAttributes } id={ id } />
-					</InspectorAdvancedControls>
-					<InspectorControls>
-						<PanelBody title={ __( 'Consent Settings', 'jetpack' ) }>
-							<BaseControl>
-								<SelectControl
-									label={ __( 'Permission to email', 'jetpack' ) }
-									value={ consentType }
-									options={ [
-										{ label: __( 'Mention that you can email', 'jetpack' ), value: 'implicit' },
-										{ label: __( 'Add a privacy checkbox', 'jetpack' ), value: 'explicit' },
-									] }
-									onChange={ value => setAttributes( { consentType: value } ) }
-								/>
-							</BaseControl>
-						</PanelBody>
-					</InspectorControls>
-				</>
-			}
-		/>
+		>
+			{ consentType === 'explicit' && (
+				<input className="jetpack-field-consent__checkbox" type="checkbox" disabled />
+			) }
+			<JetpackFieldLabel
+				required={ false }
+				label={
+					{
+						implicit: implicitConsentMessage,
+						explicit: explicitConsentMessage,
+					}[ consentType ] ?? ''
+				}
+				setAttributes={ setAttributes }
+				labelFieldName={ `${ consentType }ConsentMessage` }
+				placeholder={ sprintf(
+					/* translators: placeholder is a type of consent: implicit or explicit */
+					__( 'Add %s consent message…', 'jetpack' ),
+					consentType
+				) }
+			/>
+			<InspectorControls>
+				<PanelBody title={ __( 'Manage Responses', 'jetpack' ) }>
+					<JetpackManageResponsesSettings isChildBlock />
+				</PanelBody>
+				<PanelBody title={ __( 'Field Settings', 'jetpack' ) }>
+					<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />
+				</PanelBody>
+			</InspectorControls>
+			<InspectorAdvancedControls>
+				<JetpackFieldCss setAttributes={ setAttributes } id={ id } />
+			</InspectorAdvancedControls>
+			<InspectorControls>
+				<PanelBody title={ __( 'Consent Settings', 'jetpack' ) }>
+					<BaseControl>
+						<SelectControl
+							label={ __( 'Permission to email', 'jetpack' ) }
+							value={ consentType }
+							options={ [
+								{ label: __( 'Mention that you can email', 'jetpack' ), value: 'implicit' },
+								{ label: __( 'Add a privacy checkbox', 'jetpack' ), value: 'explicit' },
+							] }
+							onChange={ value => setAttributes( { consentType: value } ) }
+						/>
+					</BaseControl>
+				</PanelBody>
+			</InspectorControls>
+		</div>
 	);
 };
 

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-multiple.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-multiple.js
@@ -1,6 +1,6 @@
-import { BaseControl, Button } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { withInstanceId } from '@wordpress/compose';
-import { Fragment, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import JetpackFieldControls from './jetpack-field-controls';
 import JetpackFieldLabel from './jetpack-field-label';
@@ -56,21 +56,19 @@ function JetpackFieldMultiple( props ) {
 	};
 
 	return (
-		<Fragment>
-			<BaseControl
+		<>
+			<div
 				id={ `jetpack-field-multiple-${ instanceId }` }
 				className="jetpack-field jetpack-field-multiple"
-				label={
-					<JetpackFieldLabel
-						required={ required }
-						requiredText={ requiredText }
-						label={ label }
-						setAttributes={ setAttributes }
-						isSelected={ isSelected }
-						resetFocus={ () => setInFocus( null ) }
-					/>
-				}
 			>
+				<JetpackFieldLabel
+					required={ required }
+					requiredText={ requiredText }
+					label={ label }
+					setAttributes={ setAttributes }
+					isSelected={ isSelected }
+					resetFocus={ () => setInFocus( null ) }
+				/>
 				<ol
 					className="jetpack-field-multiple__list"
 					id={ `jetpack-field-multiple-${ instanceId }` }
@@ -98,7 +96,7 @@ function JetpackFieldMultiple( props ) {
 						{ __( 'Add option', 'jetpack' ) }
 					</Button>
 				) }
-			</BaseControl>
+			</div>
 
 			<JetpackFieldControls
 				id={ id }
@@ -106,7 +104,7 @@ function JetpackFieldMultiple( props ) {
 				setAttributes={ setAttributes }
 				width={ width }
 			/>
-		</Fragment>
+		</>
 	);
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
@@ -309,6 +309,10 @@ input.components-text-control__input {
 		border-color: currentColor;
 		opacity: 1;
 	}
+
+	.jetpack-field-consent__checkbox + .jetpack-field-label {
+		line-height: normal;
+	}
 }
 
 .jetpack-field-label__width {

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
@@ -240,6 +240,7 @@
 	.rich-text.jetpack-field-label__input {
 		cursor: text;
 		padding-right: 8px;
+		font-weight: bold;
 	}
 
 	.required {
@@ -296,6 +297,18 @@ input.components-text-control__input {
 	textarea.components-textarea-control__input {
 		min-height: 150px;
 	}
+
+	&.jetpack-field-checkbox .jetpack-field-checkbox__checkbox,
+	&.jetpack-field-consent .jetpack-field-consent__checkbox {
+		margin: 0 0.75rem 0 0;
+		border-color: currentColor;
+		opacity: 1;
+	}
+
+	.jetpack-option__type.jetpack-option__type {
+		border-color: currentColor;
+		opacity: 1;
+	}
 }
 
 .jetpack-field-label__width {
@@ -306,16 +319,6 @@ input.components-text-control__input {
 	.components-base-control__field {
 		margin-bottom: 12px;
 	}
-}
-
-.jetpack-field-checkbox__checkbox.jetpack-field-checkbox__checkbox.jetpack-field-checkbox__checkbox {
-	float: left;
-	margin: 3px 5px 0 0;
-}
-
-.jetpack-field-consent__checkbox.jetpack-field-consent__checkbox.jetpack-field-consent__checkbox {
-	float: left;
-	margin: 0 5px 0 0;
 }
 
 // Duplicated to elevate specificity in order to overwrite core styles
@@ -353,6 +356,8 @@ input.components-text-control__input {
 	background: transparent;
 	border-radius: 0;
 	flex-grow: 1;
+	line-height: normal;
+	font-size: inherit;
 
 	&:hover {
 		border-color: #357cb5;
@@ -391,19 +396,22 @@ input.components-text-control__input {
 
 .jetpack-field-checkbox,
 .jetpack-field-consent {
-	.components-base-control__label {
-		display: flex;
-		align-items: center;
+	display: flex;
+	align-items: center;
 
-		.jetpack-field-label {
-			flex-grow: 1;
-		}
+	.jetpack-field-label {
+		flex-grow: 1;
 
 		.jetpack-field-label__input {
-			font-size: 13px;
 			font-weight: 400;
-			padding-left: 10px;
 		}
+	}
+}
+
+.jetpack-field-consent {
+	.jetpack-field-label__input {
+		font-size: 13px;
+		text-transform: uppercase;
 	}
 }
 

--- a/projects/plugins/jetpack/modules/contact-form/css/grunion.css
+++ b/projects/plugins/jetpack/modules/contact-form/css/grunion.css
@@ -49,8 +49,10 @@
 
 .contact-form input[type='radio'],
 .contact-form input[type='checkbox'] {
+	width: 1rem;
+	height: 1rem;
 	float: none;
-	margin: 0 0.75rem 0 5px;
+	margin: 0 0.75rem 0 0;
 }
 
 .contact-form input[type='checkbox'] {
@@ -69,6 +71,8 @@
 	font-size: 13px;
 	font-weight: normal;
 	text-transform: uppercase;
+	display: flex;
+	align-items: center;
 }
 
 .contact-form label.consent-implicit input {

--- a/projects/plugins/jetpack/modules/contact-form/css/grunion.css
+++ b/projects/plugins/jetpack/modules/contact-form/css/grunion.css
@@ -65,6 +65,12 @@
 	display: block;
 }
 
+.contact-form label.consent {
+	font-size: 13px;
+	font-weight: normal;
+	text-transform: uppercase;
+}
+
 .contact-form label.consent-implicit input {
 	display: none;
 }
@@ -77,13 +83,6 @@
 	font-weight: normal;
 	display: inline-flex;
 	align-items: center;
-}
-
-.contact-form .grunion-field-checkbox-wrap,
-.contact-form .grunion-field-consent-wrap,
-.contact-form .grunion-field-checkbox-multiple-wrap,
-.contact-form .grunion-field-radio-wrap {
-	margin-bottom: 1em;
 }
 
 .contact-form label span {


### PR DESCRIPTION
Fixes #27731

#### Changes proposed in this Pull Request:

This task was intended to adjust the styles of the Terms Consent field to comply with the WYSIWYG.
However, other fields also needed some adjustments, so this PR adjusts the styles for the following fields:
* Terms Consent
* Dropdown Field
* Single Choice (Radio)
* Multiple Choice (Checkbox)
* Checkbox

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Create a post and add a Form
* Add each of the fields mentioned above
* Check if their styles now are more similar comparing the Editor and the Live view

