### PR TITLE
Fix PHP 8.2 issues when running Jetpack tests

### DIFF
--- a/projects/packages/connection/changelog/fix-jetpack-tests-in-php-8.2
+++ b/projects/packages/connection/changelog/fix-jetpack-tests-in-php-8.2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Declare fields for PHP 8.2 compatibility.

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -46,6 +46,20 @@ class Manager {
 	private $plugin = null;
 
 	/**
+	 * Error handler object.
+	 *
+	 * @var Error_Handler
+	 */
+	public $error_handler = null;
+
+	/**
+	 * Jetpack_XMLRPC_Server object
+	 *
+	 * @var Jetpack_XMLRPC_Server
+	 */
+	public $xmlrpc_server = null;
+
+	/**
 	 * Holds extra parameters that will be sent along in the register request body.
 	 *
 	 * Use Manager::add_register_request_param to add values to this array.

--- a/projects/packages/search/changelog/fix-jetpack-tests-in-php-8.2
+++ b/projects/packages/search/changelog/fix-jetpack-tests-in-php-8.2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improve PHP 8.2 compatibility.

--- a/projects/packages/search/src/dashboard/class-dashboard.php
+++ b/projects/packages/search/src/dashboard/class-dashboard.php
@@ -108,7 +108,7 @@ class Dashboard {
 		} else {
 			// always add the page, but hide it from the menu.
 			$page_suffix = add_submenu_page(
-				null,
+				'',
 				__( 'Jetpack Search', 'jetpack-search-pkg' ),
 				_x( 'Search', 'product name shown in menu', 'jetpack-search-pkg' ),
 				'manage_options',

--- a/projects/packages/sync/changelog/fix-jetpack-tests-in-php-8.2
+++ b/projects/packages/sync/changelog/fix-jetpack-tests-in-php-8.2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improve PHP 8.2 compatibility.

--- a/projects/packages/sync/src/class-queue.php
+++ b/projects/packages/sync/src/class-queue.php
@@ -22,12 +22,20 @@ class Queue {
 	 * @var string
 	 */
 	public $id;
+
 	/**
 	 * Keeps track of the rows.
 	 *
 	 * @var int
 	 */
 	private $row_iterator;
+
+	/**
+	 * Random number.
+	 *
+	 * @var int
+	 */
+	public $random_int;
 
 	/**
 	 * Queue constructor.

--- a/projects/packages/sync/src/modules/class-callables.php
+++ b/projects/packages/sync/src/modules/class-callables.php
@@ -395,7 +395,7 @@ class Callables extends Module {
 					// The @ is not enough to suppress errors when dealing with libxml,
 					// we have to tell it directly how we want to handle errors.
 					libxml_use_internal_errors( true );
-					$dom_doc->loadHTML( mb_convert_encoding( $action_link, 'HTML-ENTITIES', 'UTF-8' ) );
+					$dom_doc->loadHTML( '<?xml encoding="utf-8" ?>' . $action_link );
 					libxml_use_internal_errors( false );
 
 					$link_elements = $dom_doc->getElementsByTagName( 'a' );

--- a/projects/plugins/jetpack/changelog/fix-jetpack-tests-in-php-8.2
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-tests-in-php-8.2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+General: Fix deprecation warnings when running with PHP 8.2.

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -53,21 +53,21 @@ class Jetpack_Admin {
 	/** Constructor. */
 	private function __construct() {
 		require_once JETPACK__PLUGIN_DIR . '_inc/lib/admin-pages/class.jetpack-react-page.php';
-		$this->jetpack_react = new Jetpack_React_Page();
+		$jetpack_react = new Jetpack_React_Page();
 
 		require_once JETPACK__PLUGIN_DIR . '_inc/lib/admin-pages/class.jetpack-settings-page.php';
-		$this->fallback_page = new Jetpack_Settings_Page();
+		$fallback_page = new Jetpack_Settings_Page();
 
 		require_once JETPACK__PLUGIN_DIR . '_inc/lib/admin-pages/class-jetpack-about-page.php';
-		$this->jetpack_about = new Jetpack_About_Page();
+		$jetpack_about = new Jetpack_About_Page();
 
-		add_action( 'admin_init', array( $this->jetpack_react, 'react_redirects' ), 0 );
-		add_action( 'admin_menu', array( $this->jetpack_react, 'add_actions' ), 998 );
-		add_action( 'jetpack_admin_menu', array( $this->jetpack_react, 'jetpack_add_dashboard_sub_nav_item' ) );
-		add_action( 'jetpack_admin_menu', array( $this->jetpack_react, 'jetpack_add_settings_sub_nav_item' ) );
+		add_action( 'admin_init', array( $jetpack_react, 'react_redirects' ), 0 );
+		add_action( 'admin_menu', array( $jetpack_react, 'add_actions' ), 998 );
+		add_action( 'jetpack_admin_menu', array( $jetpack_react, 'jetpack_add_dashboard_sub_nav_item' ) );
+		add_action( 'jetpack_admin_menu', array( $jetpack_react, 'jetpack_add_settings_sub_nav_item' ) );
 		add_action( 'jetpack_admin_menu', array( $this, 'admin_menu_debugger' ) );
-		add_action( 'jetpack_admin_menu', array( $this->fallback_page, 'add_actions' ) );
-		add_action( 'jetpack_admin_menu', array( $this->jetpack_about, 'add_actions' ) );
+		add_action( 'jetpack_admin_menu', array( $fallback_page, 'add_actions' ) );
+		add_action( 'jetpack_admin_menu', array( $jetpack_about, 'add_actions' ) );
 
 		// Add redirect to current page for activation/deactivation of modules.
 		add_action( 'jetpack_pre_activate_module', array( $this, 'fix_redirect' ), 10, 2 );

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -80,6 +80,34 @@ abstract class WPCOM_JSON_API_Endpoint {
 	public $max_version = WPCOM_JSON_API__CURRENT_VERSION;
 
 	/**
+	 * Forced endpoint environment when running on WPCOM
+	 *
+	 * @var string '', 'wpcom', 'secure', or 'jetpack'
+	 */
+	public $force = '';
+
+	/**
+	 * Whether the endpoint is deprecated
+	 *
+	 * @var bool
+	 */
+	public $deprecated = false;
+
+	/**
+	 * Version of the endpoint this endpoint is deprecated in favor of.
+	 *
+	 * @var string
+	 */
+	protected $new_version = WPCOM_JSON_API__CURRENT_VERSION;
+
+	/**
+	 * Whether the endpoint is only available on WordPress.com hosted blogs
+	 *
+	 * @var bool
+	 */
+	public $jp_disabled = false;
+
+	/**
 	 * Path at which to serve this endpoint: sprintf() format.
 	 *
 	 * @var string
@@ -189,6 +217,13 @@ abstract class WPCOM_JSON_API_Endpoint {
 	 * @var string
 	 */
 	public $example_response = '';
+
+	/**
+	 * OAuth2 scope required when running on WPCOM
+	 *
+	 * @var string
+	 */
+	public $required_scope = '';
 
 	/**
 	 * Set to true if the endpoint implements its own filtering instead of the standard `fields` query method

--- a/projects/plugins/jetpack/class.json-api.php
+++ b/projects/plugins/jetpack/class.json-api.php
@@ -31,6 +31,13 @@ class WPCOM_JSON_API {
 	public $endpoints = array();
 
 	/**
+	 * Endpoint being processed.
+	 *
+	 * @var WPCOM_JSON_API_Endpoint
+	 */
+	public $endpoint = null;
+
+	/**
 	 * Token details.
 	 *
 	 * @var array

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -20,6 +20,13 @@ class Jetpack_Carousel {
 	public $prebuilt_widths = array( 370, 700, 1000, 1200, 1400, 2000 );
 
 	/**
+	 * Localization strings and other data for the JavaScript
+	 *
+	 * @var array
+	 */
+	public $localize_strings;
+
+	/**
 	 * Represents whether or not this is the first load of Carousel on a page. Default is true.
 	 *
 	 * @var bool

--- a/projects/plugins/jetpack/modules/comment-likes.php
+++ b/projects/plugins/jetpack/modules/comment-likes.php
@@ -26,6 +26,27 @@ require_once __DIR__ . '/likes/jetpack-likes-settings.php';
 class Jetpack_Comment_Likes {
 
 	/**
+	 * Jetpack_Likes_Settings object
+	 *
+	 * @var Jetpack_Likes_Settings
+	 */
+	public $settings;
+
+	/**
+	 * Blog ID
+	 *
+	 * @var int
+	 */
+	public $blog_id;
+
+	/**
+	 * Site home URL domain
+	 *
+	 * @var string
+	 */
+	public $domain;
+
+	/**
 	 * Initialize comment like module
 	 */
 	public static function init() {
@@ -42,11 +63,10 @@ class Jetpack_Comment_Likes {
 	 * Construct comment like module.
 	 */
 	private function __construct() {
-		$this->settings  = new Jetpack_Likes_Settings();
-		$this->blog_id   = Jetpack_Options::get_option( 'id' );
-		$this->url       = home_url();
-		$this->url_parts = wp_parse_url( $this->url );
-		$this->domain    = $this->url_parts['host'];
+		$this->settings = new Jetpack_Likes_Settings();
+		$this->blog_id  = Jetpack_Options::get_option( 'id' );
+		$url_parts      = wp_parse_url( home_url() );
+		$this->domain   = $url_parts['host'];
 
 		add_action( 'template_redirect', array( $this, 'frontend_init' ) );
 		add_action( 'admin_init', array( $this, 'admin_init' ) );

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -767,7 +767,7 @@ class Grunion_Contact_Form_Plugin {
 		// phpcs:disable WordPress.Security.NonceVerification.Missing -- Checked below for logged-in users only, see https://plugins.trac.wordpress.org/ticket/1859
 		$id   = isset( $_POST['contact-form-id'] ) ? sanitize_text_field( wp_unslash( $_POST['contact-form-id'] ) ) : null;
 		$hash = isset( $_POST['contact-form-hash'] ) ? sanitize_text_field( wp_unslash( $_POST['contact-form-hash'] ) ) : null;
-		$hash = preg_replace( '/[^\da-f]/i', '', $hash );
+		$hash = is_string( $hash ) ? preg_replace( '/[^\da-f]/i', '', $hash ) : $hash;
 		// phpcs:enable
 
 		if ( ! is_string( $id ) || ! is_string( $hash ) ) {

--- a/projects/plugins/jetpack/modules/custom-css/csstidy/class.csstidy-optimise.php
+++ b/projects/plugins/jetpack/modules/custom-css/csstidy/class.csstidy-optimise.php
@@ -38,6 +38,7 @@
  * @author Florian Schmitz (floele at gmail dot com) 2005-2006
  * @version 1.0
  */
+#[AllowDynamicProperties]
 class csstidy_optimise { // phpcs:ignore
 	/**
 	 * Constructor

--- a/projects/plugins/jetpack/modules/custom-css/csstidy/class.csstidy-print.php
+++ b/projects/plugins/jetpack/modules/custom-css/csstidy/class.csstidy-print.php
@@ -38,6 +38,7 @@
  * @author Florian Schmitz (floele at gmail dot com) 2005-2006
  * @version 1.0.1
  */
+#[AllowDynamicProperties]
 class csstidy_print { // phpcs:ignore
 
 	/**

--- a/projects/plugins/jetpack/modules/custom-css/csstidy/class.csstidy.php
+++ b/projects/plugins/jetpack/modules/custom-css/csstidy/class.csstidy.php
@@ -72,6 +72,7 @@ require __DIR__ . '/class.csstidy-optimise.php';
  * @author Florian Schmitz (floele at gmail dot com) 2005-2006
  * @version 1.3.1
  */
+#[AllowDynamicProperties]
 class csstidy { // phpcs:ignore
 
 	/**

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -40,6 +40,13 @@ require_once __DIR__ . '/likes/jetpack-likes-settings.php';
 class Jetpack_Likes {
 
 	/**
+	 * Jetpack_Likes_Settings object
+	 *
+	 * @var Jetpack_Likes_Settings
+	 */
+	public $settings;
+
+	/**
 	 * Initialize class
 	 */
 	public static function init() {

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-settings.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-settings.php
@@ -8,6 +8,13 @@ use Automattic\Jetpack\Sync\Settings;
 class Jetpack_Likes_Settings {
 
 	/**
+	 * False if running on WPCOM Simple
+	 *
+	 * @var bool
+	 */
+	public $in_jetpack;
+
+	/**
 	 * Constructor function.
 	 */
 	public function __construct() {

--- a/projects/plugins/jetpack/modules/shortcodes/unavailable.php
+++ b/projects/plugins/jetpack/modules/shortcodes/unavailable.php
@@ -11,6 +11,15 @@
  */
 class Jetpack_Shortcode_Unavailable {
 	/**
+	 * Shortcodes that are unavailable.
+	 *
+	 * Key is the shortcode, value is string explaining why.
+	 *
+	 * @var array
+	 */
+	public $shortcodes;
+
+	/**
 	 * Set up the actions and filters for the class to listen to.
 	 *
 	 * @param array $shortcodes An associative array of keys being the shortcodes that are unavailable, and a string explaining why.

--- a/projects/plugins/jetpack/tests/php/_inc/lib/mocks/class-simplepie-file.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/mocks/class-simplepie-file.php
@@ -10,6 +10,8 @@ if ( ! class_exists( 'SimplePie_File' ) ) {
 	 * Class SimplePie_Locator
 	 */
 	class SimplePie_File {
+		public $body;
+
 		/**
 		 * Constructor
 		 *

--- a/projects/plugins/jetpack/tests/php/modules/contact-form/test-class.grunion-contact-form.php
+++ b/projects/plugins/jetpack/tests/php/modules/contact-form/test-class.grunion-contact-form.php
@@ -14,6 +14,9 @@ require_once JETPACK__PLUGIN_DIR . 'modules/contact-form/grunion-contact-form.ph
  */
 class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
+	private $post;
+	private $plugin;
+
 	/**
 	 * Sets up the test environment before the class tests begin.
 	 */

--- a/projects/plugins/jetpack/tests/php/modules/infinite-scroll/test_class.infinite-scroll.php
+++ b/projects/plugins/jetpack/tests/php/modules/infinite-scroll/test_class.infinite-scroll.php
@@ -8,6 +8,8 @@ require __DIR__ . '/../../../../modules/infinite-scroll/infinity.php';
  */
 class WP_Test_The_Neverending_Home_Page extends WP_UnitTestCase {
 
+	private $infinite_scroll;
+
 	/**
 	 * Set up.
 	 */

--- a/projects/plugins/jetpack/tests/php/modules/publicize/test_class.publicize.php
+++ b/projects/plugins/jetpack/tests/php/modules/publicize/test_class.publicize.php
@@ -38,6 +38,8 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 */
 	private $user_id;
 
+	private $publicize;
+
 	/**
 	 * Index in 'publicize_connections' test data of normal connection.
 	 *

--- a/projects/plugins/jetpack/tests/php/modules/sharedaddy/test-class.recaptcha.php
+++ b/projects/plugins/jetpack/tests/php/modules/sharedaddy/test-class.recaptcha.php
@@ -3,6 +3,11 @@ require_once JETPACK__PLUGIN_DIR . 'modules/sharedaddy/recaptcha.php';
 
 class WP_Test_Jetpack_ReCaptcha extends WP_UnitTestCase {
 
+	private $site_key;
+	private $secret_key;
+	private $recaptcha;
+	private $recaptcha_lazy;
+
 	/**
 	 * Set up.
 	 */

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.flickr.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.flickr.php
@@ -11,7 +11,7 @@ class WP_Test_Jetpack_Shortcodes_Flickr extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$this->pre_http_req_function = function ( $preempt, $parsed_args, $url ) {
+		$pre_http_req_function = function ( $preempt, $parsed_args, $url ) {
 			if ( 'https://embedr.flickr.com/photos/49931239842' === $url ) {
 				return array(
 					'body' => '<div class="slide slide-video" data-rapid="video" data-slideshow-position="" >
@@ -41,18 +41,10 @@ class WP_Test_Jetpack_Shortcodes_Flickr extends WP_UnitTestCase {
 
 		add_filter(
 			'pre_http_request',
-			$this->pre_http_req_function,
+			$pre_http_req_function,
 			10,
 			3
 		);
-	}
-
-	/**
-	 * Runs on every test.
-	 */
-	public function tear_down() {
-		remove_filter( 'pre_http_request', $this->pre_http_req_function );
-		parent::tear_down();
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.mixcloud.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.mixcloud.php
@@ -14,6 +14,8 @@ require_once __DIR__ . '/trait.http-request-cache.php';
 class WP_Test_Jetpack_Shortcodes_Mixcloud extends WP_UnitTestCase {
 	use Automattic\Jetpack\Tests\HttpRequestCacheTrait;
 
+	private $invalid_markup;
+
 	/**
 	 * Runs before every test
 	 *

--- a/projects/plugins/jetpack/tests/php/modules/widgets/test_contact-info-widget.php
+++ b/projects/plugins/jetpack/tests/php/modules/widgets/test_contact-info-widget.php
@@ -11,6 +11,8 @@ class WP_Test_Contact_Info_Widget extends WP_UnitTestCase {
 
 	const TEST_API_KEY = '12345abcde';
 
+	private $contact_info_widget;
+
 	/**
 	 * This method is called before each test.
 	 */

--- a/projects/plugins/jetpack/tests/php/modules/widgets/test_social-icons-widget.php
+++ b/projects/plugins/jetpack/tests/php/modules/widgets/test_social-icons-widget.php
@@ -9,6 +9,8 @@ require_once JETPACK__PLUGIN_DIR . 'modules/widgets/social-icons.php';
  */
 class WP_Test_Social_Icons_Widget extends WP_UnitTestCase {
 
+	private $social_icon_widget;
+
 	/**
 	 * This method is called before each test.
 	 */

--- a/projects/plugins/jetpack/tests/php/modules/widgets/test_wordpress-post-widget.php
+++ b/projects/plugins/jetpack/tests/php/modules/widgets/test_wordpress-post-widget.php
@@ -5,6 +5,13 @@ require __DIR__ . '/../../../../modules/widgets/wordpress-post-widget.php';
 class WP_Test_Jetpack_Display_Posts_Widget extends WP_UnitTestCase {
 
 	/**
+	 * Jetpack_Display_Posts_Widget object.
+	 *
+	 * @var Jetpack_Display_Posts_Widget
+	 */
+	private $inst;
+
+	/**
 	 * WP_Test_Jetpack_Display_Posts_Widget constructor.
 	 */
 	public function __construct() {

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -847,7 +847,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		delete_transient( 'jetpack_plugin_api_action_links_refresh' );
 		$helper_all = new Jetpack_Sync_Test_Helper();
 
-		$helper_all->array_override = array( '<a href="fun.php">fun</a>' );
+		$helper_all->array_override = array( '<a href="fun.php">fun 😀</a>' );
 		add_filter( 'plugin_action_links', array( $helper_all, 'filter_override_array' ), 10 );
 
 		$helper_jetpack                 = new Jetpack_Sync_Test_Helper();
@@ -862,7 +862,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		$expected_array = array(
 			'hello.php'           => array(
-				'fun' => admin_url( 'fun.php' ),
+				'fun 😀' => admin_url( 'fun.php' ),
 			),
 			'jetpack/jetpack.php' => array(
 				'settings' => admin_url( 'settings.php' ),

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-constants.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-constants.php
@@ -9,7 +9,7 @@ use Automattic\Jetpack\Sync\Modules\Constants;
  */
 class WP_Test_Jetpack_Sync_Constants extends WP_Test_Jetpack_Sync_Base {
 	protected $post_id;
-	protected $constants_module;
+	protected $constant_module;
 
 	/**
 	 * Set up.

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full-immediately.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full-immediately.php
@@ -17,9 +17,11 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 	private $full_sync;
 
 	private $full_sync_end_checksum;
+	private $full_sync_end_range;
 	private $full_sync_start_config;
 	private $synced_user_ids;
 
+	private $started_sync_count  = 0;
 	private $test_posts_count    = 20;
 	private $test_comments_count = 11;
 
@@ -1232,9 +1234,9 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_full_sync_sends_previous_interval_end_on_comments() {
-		$this->post_id = self::factory()->post->create();
+		$post_id = self::factory()->post->create();
 		for ( $i = 0; $i < 25; $i ++ ) {
-			self::factory()->comment->create_post_comments( $this->post_id );
+			self::factory()->comment->create_post_comments( $post_id );
 		}
 		// The first event is for full sync start.
 		$this->full_sync->start( array( 'comments' => true ) );

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -166,6 +166,7 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 	public function test_sync_new_page() {
 		$this->post->post_type = 'page';
+		wp_insert_post( $this->post );
 
 		$this->sender->do_sync();
 

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -166,7 +166,6 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 	public function test_sync_new_page() {
 		$this->post->post_type = 'page';
-		$this->post_id         = wp_insert_post( $this->post );
 
 		$this->sender->do_sync();
 
@@ -1284,10 +1283,11 @@ That was a cool video.';
 	 * @return array[] Test parameters.
 	 */
 	public function provider_jetpack_published_post_no_action() {
+		// @todo This seems somewhat broken, $this->post isn't set yet when this runs.
 		return array(
 			array( null, $this->post ),
 			array( 'alpha', $this->post ),
-			array( $this->post_id, null ),
+			array( isset( $this->post->ID ) ? $this->post->ID : null, null ),
 			array( -1111, $this->post ),
 		);
 	}

--- a/projects/plugins/jetpack/tests/php/test_class.functions.opengraph.php
+++ b/projects/plugins/jetpack/tests/php/test_class.functions.opengraph.php
@@ -6,6 +6,8 @@
  */
 class WP_Test_Functions_OpenGraph extends Jetpack_Attachment_Test_Case {
 
+	private $icon_id;
+
 	/**
 	 * Include Open Graph functions before each test.
 	 *

--- a/projects/plugins/jetpack/tests/php/test_functions.photon.php
+++ b/projects/plugins/jetpack/tests/php/test_functions.photon.php
@@ -2,6 +2,8 @@
 
 class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
+	private $custom_photon_domain;
+
 	/**
 	 * Tear down.
 	 */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This includes Jetpack itself and a few things in packages that are caught by Jetpack's tests (but not the packages' own tests or they'd be in #27949 instead).

packages/connection:
* Declare fields in Manager class.

packages/search:
* Pass empty string instead of null to `add_submenu_page()`, internally the latter was being converted to the former anyway.

packages/sync:
* Declare field in Queue class.
* When loading action links HTML, prepend an XML encoding declaration instead of using `mb_convert_encoding()` with "HTML-ENTITIES".
  * Also add an appropriate character to the Jetpack test hitting this to make sure this works.

plugins/jetpack:
* Declare fields in lots of classes.
* Use local variables instead of properties that aren't used outside of the method they're set in.
* Add an `is_string` check before a `preg_replace` in `Grunion_Contact_Form_Plugin`
* Set `AllowDynamicProperties` on csstidy classes. This will make it easier if we ever try to bring in a newer upstream version.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/issues/27927

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?
* Actually running this with PHP 8.2 would be a pain, since WordPress itself throws deprecation warnings for a bunch of tests.

