### PR TITLE
Cherry pick/super cache

### DIFF
--- a/projects/plugins/super-cache/changelog/cherry-pick-super-cache
+++ b/projects/plugins/super-cache/changelog/cherry-pick-super-cache
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Cherry picking stuff from the 1.9.2 release branch
+
+

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -321,7 +321,7 @@ function wpsc_is_boost_active() {
  */
 function wpsc_hide_boost_banner() {
 	check_ajax_referer( 'wpsc_dismiss_boost_banner', 'nonce' );
-	update_option( 'wpsc_2022_boost_banner', 0, 'no' );
+	update_user_option( get_current_user_id(), 'wpsc_dismissed_boost_banner', '1' );
 
 	wp_die();
 }
@@ -347,7 +347,8 @@ add_action( 'wp_ajax_wpsc_activate_boost', 'wpsc_ajax_activate_boost' );
  */
 function wpsc_jetpack_boost_install_banner() {
 	// Don't show the banner if Boost is installed, or the banner has been dismissed.
-	if ( wpsc_is_boost_active() || ! get_option( 'wpsc_2022_boost_banner', true ) ) {
+	$is_dismissed = '1' === get_user_option( 'wpsc_dismissed_boost_banner' );
+	if ( wpsc_is_boost_active() || $is_dismissed ) {
 		return;
 	}
 

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -371,7 +371,7 @@ function wpsc_jetpack_boost_install_banner() {
 					<p id="wpsc-install-invitation">
 						<?php
 							esc_html_e(
-								'Caching is a great start, but there is so much more to speeding up your site. Find out how much your cache is speeding up your site, and more with Jetpack Boost.',
+								'Caching is a great start, but there is more to maximize your site speed. Find out how much your cache speeds up your site and make it blazing fast with Jetpack Boost, the easiest WordPress speed optimization plugin developed by Super Cache engineers.',
 								'wp-super-cache'
 							);
 						?>

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -209,7 +209,7 @@ function wpsupercache_deactivate() {
 	wp_clear_scheduled_hook( 'wp_cache_gc_watcher' );
 	wp_cache_replace_line('^ *\$cache_enabled', '$cache_enabled = false;', $wp_cache_config_file);
 	wp_cache_disable_plugin( false ); // don't delete configuration file
-	delete_option( 'wpsc_2022_boost_banner' );
+	delete_user_option( get_current_user_id(), 'wpsc_dismissed_boost_banner' );
 }
 register_deactivation_hook( __FILE__, 'wpsupercache_deactivate' );
 


### PR DESCRIPTION
Cherry-pick updates from the Super Cache 1.9.2 beta branch back to trunk. Includes:
- Updated copy on the boost banner,
- Handling dismissal via user options,
- Clearing user setting on deactivation.

#### Changes proposed in this Pull Request:
* Cherry-pick updates from the Super Cache 1.9.2 beta branch back to trunk. Includes.

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* These were tested in the 1.9.2 build
* Test the boost banner dismisses properly.