### PR TITLE
E2E tests: increase timeout in social connection step

### DIFF
--- a/projects/plugins/social/changelog/e2e-increase-timeout-social-connection
+++ b/projects/plugins/social/changelog/e2e-increase-timeout-social-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+

--- a/projects/plugins/social/tests/e2e/pages/wp-admin/jetpack-social.js
+++ b/projects/plugins/social/tests/e2e/pages/wp-admin/jetpack-social.js
@@ -11,7 +11,7 @@ export default class JetpackSocialPage extends WpPage {
 	async getStarted() {
 		logger.step( 'Connect Jetpack Social to wordpress.com' );
 		await this.click( 'text=Get Started' );
-		await this.waitForElementToBeHidden( 'button > svg.components-spinner' );
+		await this.waitForElementToBeHidden( 'button > svg.components-spinner', 40000 );
 	}
 
 	async startForFree() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Increase the timeout for waiting on the spinner animation to disappear in the social connection flow. A significant number test runs fail in this point.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* e2e tests pass.

