### PR TITLE
PHP Unit tests: update transport library after changes in WP Core.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-core-transports-tests
+++ b/projects/plugins/jetpack/changelog/fix-core-transports-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+PHP Unit tests: update Transports library after changes in WP Core.

--- a/projects/plugins/jetpack/tests/php/_inc/lib/class-tweetstorm-requests-transport-override.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/class-tweetstorm-requests-transport-override.php
@@ -73,9 +73,11 @@ class Tweetstorm_Requests_Transport_Override implements WpOrg\Requests\Transport
 	/**
 	 * Self-test whether the transport can be used.
 	 *
+	 * @param array<string, bool> $capabilities Optional. Associative array of capabilities to test against, i.e. `['<capability>' => true]`.
+	 *
 	 * @return bool
 	 */
-	public static function test() {
+	public static function test( $capabilities = array() ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return true;
 	}
 }

--- a/projects/plugins/jetpack/tests/php/_inc/lib/class-tweetstorm-requests-transport-override.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/class-tweetstorm-requests-transport-override.php
@@ -8,7 +8,7 @@
 /**
  * Helper class for loading fixtures when testing Tweetstorm external requests.
  */
-class Tweetstorm_Requests_Transport_Override implements Requests_Transport {
+class Tweetstorm_Requests_Transport_Override implements WpOrg\Requests\Transport {
 	/**
 	 * Perform a request.
 	 *


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The changes were made here:
- External Libraries: Update Requests library to version 2.0.0. ( https://core.trac.wordpress.org/changeset/54997/ )

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion

p1671140631265029-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Is CI happy?