### PR TITLE
Blocks: add missing jetpack Config external

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-missing-jetpackconfig
+++ b/projects/plugins/jetpack/changelog/fix-missing-jetpackconfig
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Blocks: add missing Jetpack config external.

--- a/projects/plugins/jetpack/tools/webpack.config.extensions.js
+++ b/projects/plugins/jetpack/tools/webpack.config.extensions.js
@@ -115,6 +115,12 @@ const sharedWebpackConfig = {
 			DependencyExtractionPlugin: { injectPolyfill: true },
 		} ),
 	],
+	externals: {
+		...jetpackWebpackConfig.externals,
+		jetpackConfig: JSON.stringify( {
+			consumer_slug: 'jetpack',
+		} ),
+	},
 	module: {
 		strictExportPresence: true,
 		rules: [


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This should suppress the build warning:

`jetpackConfig is missing in your webpack config file. See @automattic/jetpack-config`

See https://github.com/Automattic/jetpack/pull/27940#issuecomment-1354775274

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion

* n/a

#### Does this pull request change what data or activity we track or use?

* No
#### Testing instructions:

* Run `jetpack build plugins/jetpack`
* Go to Posts > Add New
* Ensure you do not see the error above in the console.

