### PR TITLE
VideoPress: add core/embed transform from/to video block

### DIFF
--- a/projects/packages/videopress/.gitattributes
+++ b/projects/packages/videopress/.gitattributes
@@ -14,5 +14,4 @@ build/**         production-include
 changelog/**      production-exclude
 phpunit.xml.dist  production-exclude
 .phpcs.dir.xml    production-exclude
-src/client/**     production-exclude
 tests/**          production-exclude

--- a/projects/packages/videopress/changelog/update-videopress-add-core-embed-transforms
+++ b/projects/packages/videopress/changelog/update-videopress-add-core-embed-transforms
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: add core/embed transform from/to video block

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/index.js
@@ -30,7 +30,7 @@ registerBlockType( name, {
 			{
 				type: 'block',
 				blocks: [ 'core/embed' ],
-				isMatch: attrs => attrs.providerNameSlug !== 'videopress' && pickGUIDFromUrl( attrs?.url ),
+				isMatch: attrs => attrs.providerNameSlug === 'videopress' && pickGUIDFromUrl( attrs?.url ),
 				transform: attrs => {
 					const { url, providerNameSlug } = attrs;
 					const guid = pickGUIDFromUrl( url );

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/index.js
@@ -1,10 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { registerBlockType } from '@wordpress/blocks';
+import { registerBlockType, createBlock } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
+import { getVideoPressUrl, pickGUIDFromUrl } from '../../../lib/url';
 import metadata from './block.json';
 import { VideoPressIcon as icon } from './components/icons';
 import Edit from './edit';
@@ -23,5 +24,47 @@ registerBlockType( name, {
 			src: videoPressBlockExampleImage,
 			isExample: true,
 		},
+	},
+	transforms: {
+		from: [
+			{
+				type: 'block',
+				blocks: [ 'core/embed' ],
+				isMatch: attrs => attrs.providerNameSlug !== 'videopress' && pickGUIDFromUrl( attrs?.url ),
+				transform: attrs => {
+					const { url, providerNameSlug } = attrs;
+					const guid = pickGUIDFromUrl( url );
+					const isCoreEmbedVideoPressVariation = providerNameSlug === 'videopress' && !! guid;
+
+					/*
+					 * Do not add transform when the block
+					 * is not a core/embed VideoPress block variation
+					 */
+					if ( ! isCoreEmbedVideoPressVariation ) {
+						return createBlock( 'core/embed', attrs );
+					}
+
+					return createBlock( 'videopress/video', { ...attrs, guid, src: url } );
+				},
+			},
+		],
+		to: [
+			{
+				type: 'block',
+				blocks: [ 'core/embed' ],
+				isMatch: attrs => attrs?.src || getVideoPressUrl( attrs?.guid, attrs ),
+				transform: attrs => {
+					const { guid, src } = attrs;
+
+					// Build the source (URL) in case it isn't defined.
+					const url = src || getVideoPressUrl( guid, attrs );
+					if ( ! url ) {
+						return createBlock( 'core/embed' );
+					}
+
+					return createBlock( 'core/embed', { ...attrs, url } );
+				},
+			},
+		],
 	},
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: add core/embed transform from/to video block

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to block editor app
* Add an embed block
* Paste a VideoPress video URL. eg: `https://videopress.com/v/PupnE9f3`
* Select keep using the Embed block

<img width="649" alt="image" src="https://user-images.githubusercontent.com/77539/208120026-36801314-b609-4b39-bc33-ac98d5c18639.png">

* Confirm the block provides a transform to the VideoPress video block
<img width="661" alt="image" src="https://user-images.githubusercontent.com/77539/208124647-6772026a-3545-4cff-bc20-fee55decaeaf.png">

* Confirms it transforms properly
* Confirm now the new VideoPress video blocks provide a transform to the core Embed block too.

<img width="669" alt="image" src="https://user-images.githubusercontent.com/77539/208124851-2b793ffc-1ff3-4302-9acc-345c53cafcae.png">



