### PR TITLE
Jetpack: Fix tests for core's new Requests library

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-tests-for-wp-trunk
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-tests-for-wp-trunk
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix tests for WordPress trunk's new Requests library.
+
+

--- a/projects/plugins/jetpack/tests/php/_inc/lib/class-tweetstorm-requests-transport-override.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/class-tweetstorm-requests-transport-override.php
@@ -75,7 +75,7 @@ class Tweetstorm_Requests_Transport_Override implements Requests_Transport {
 	 *
 	 * @return bool
 	 */
-	public static function test( $capabilities = array() ) {
+	public static function test( $capabilities = array() ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return true;
 	}
 }

--- a/projects/plugins/jetpack/tests/php/_inc/lib/class-tweetstorm-requests-transport-override.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/class-tweetstorm-requests-transport-override.php
@@ -75,7 +75,7 @@ class Tweetstorm_Requests_Transport_Override implements Requests_Transport {
 	 *
 	 * @return bool
 	 */
-	public static function test() {
+	public static function test( $capabilities = array() ) {
 		return true;
 	}
 }

--- a/projects/plugins/jetpack/tests/php/bootstrap.php
+++ b/projects/plugins/jetpack/tests/php/bootstrap.php
@@ -141,6 +141,16 @@ if ( '1' === getenv( 'LEGACY_FULL_SYNC' ) ) {
 
 require $test_root . '/includes/bootstrap.php';
 
+// Disable warning about deprecated request library.
+// @todo Remove this once we drop support for WordPress 6.1
+define( 'REQUESTS_SILENCE_PSR0_DEPRECATIONS', true );
+
+// Work around https://core.trac.wordpress.org/ticket/57341
+// Remove this once that's fixed.
+if ( ! class_exists( 'Requests' ) ) {
+	require ABSPATH . WPINC . '/class-requests.php';
+}
+
 // Load the shortcodes module to test properly.
 if ( ! function_exists( 'shortcode_new_to_old_params' ) && ! in_running_uninstall_group() ) {
 	require __DIR__ . '/../../modules/shortcodes.php';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
WordPress core has merged an updated version of their Requests library, which caused our tests to fail in three separate ways.

First, while they provide compatibility for the old way of doing things, using that results in deprecation warnings which cause our tests to fail. We can define a constant to suppress those warnings for now, and once we drop support for WordPress 6.1 we can remove that and update everything fully to the new library.

Second, in one place we extend a class and override a method that has a slightly changed signature. Fortunately the new signature needed for the subclass is compatible with a base class still using the old one, so we can just update it and code running with WP 6.1 will be fine with it.

Third, they made one mistake in their compatibility layer. We can work around that by loading the correct file. Note this only works around it for tests; if this somehow doesn't get fixed in time for WP 6.2 we'll have to do something for the one call in `_inc/lib/class-jetpack-tweetstorm-helper.php` too.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1671140631265029-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?