### PR TITLE
Gifting toggle: Update default value based on plan expiration date

### DIFF
--- a/projects/plugins/jetpack/changelog/update-wpcom_gifting_subscription-default-value
+++ b/projects/plugins/jetpack/changelog/update-wpcom_gifting_subscription-default-value
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Update wpcom_gifting_subscription default value based on plan expiration

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -513,6 +513,18 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 			foreach ( $purchases as $purchase ) {
 				if ( wpcom_purchase_has_feature( $purchase, \WPCOM_Features::SUBSCRIPTION_GIFTING ) ) {
+					/*
+					 * We set default value as false when expiration date not match the following:
+					 * - 54 days before the annual plan expiration.
+					 * - 5 days before the monthly plan expiration.
+					 */
+					$days_of_warning          = false !== strpos( $purchase->product_slug, 'monthly' ) ? 5 : 54;
+					$seconds_until_expiration = strtotime( $purchase->expiry_date ) - time();
+					if ( $seconds_until_expiration >= $days_of_warning * DAY_IN_SECONDS ) {
+						return false;
+					}
+
+					// We set default to the inverse of auto-renew.
 					if ( isset( $purchase->auto_renew ) ) {
 						return ! $purchase->auto_renew;
 					} elseif ( isset( $purchase->user_allows_auto_renew ) ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -517,7 +517,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					 * We set default value as false when expiration date not match the following:
 					 * - 54 days before the annual plan expiration.
 					 * - 5 days before the monthly plan expiration.
-					 * This is to match the gifting banner logic```
+					 * This is to match the gifting banner logic.
 					 */
 					$days_of_warning          = false !== strpos( $purchase->product_slug, 'monthly' ) ? 5 : 54;
 					$seconds_until_expiration = strtotime( $purchase->expiry_date ) - time();

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -517,6 +517,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					 * We set default value as false when expiration date not match the following:
 					 * - 54 days before the annual plan expiration.
 					 * - 5 days before the monthly plan expiration.
+					 * This is to match the gifting banner logic```
 					 */
 					$days_of_warning          = false !== strpos( $purchase->product_slug, 'monthly' ) ? 5 : 54;
 					$seconds_until_expiration = strtotime( $purchase->expiry_date ) - time();


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The proposed changes `wpcom_gifting_subscription` option default value based on a plan expiration date.

Project thread: p9Jlb4-5Ae-p2
Change discussion: p1671220272056839-slack-CKZHG0QCR

This PR doesn't introduce any visible / functional changes. Instead, this PR is a prerequisite for the upcoming changes that will utilize the newly-added site option/setting:

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No, it does not.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
- Testing instructions for Automatticians on the [first comment](https://github.com/Automattic/jetpack/pull/27987#issuecomment-1355802543)

The PR doesn't introduce any visible/functional changes. We can review the code and make sure the are no regressions.

Fixes https://github.com/Automattic/dotcom-forge/issues/1372