### PR TITLE
Add jetpack-mu-wpcom version constant

### DIFF
--- a/projects/plugins/jetpack-mu-wpcom/changelog/add-jetpack-mu-wpcom-version-constant
+++ b/projects/plugins/jetpack-mu-wpcom/changelog/add-jetpack-mu-wpcom-version-constant
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add `JETPACK_MU_WPCOM__PLUGIN_VERSION` in `.extra.version-constants`.

--- a/projects/plugins/jetpack-mu-wpcom/composer.json
+++ b/projects/plugins/jetpack-mu-wpcom/composer.json
@@ -48,6 +48,9 @@
 		"autotagger": true,
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-mu-wpcom/compare/v${old}...v${new}"
+		},
+		"version-constants": {
+			"JETPACK_MU_WPCOM__PLUGIN_VERSION": "jetpack-mu-wpcom.php"
 		}
 	},
 	"config": {

--- a/projects/plugins/jetpack-mu-wpcom/composer.lock
+++ b/projects/plugins/jetpack-mu-wpcom/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a314be548572ea9a9aa328bbcab407f7",
+    "content-hash": "a0971a03b9ecbfe3ad45ecf4c3131d28",
     "packages": [],
     "packages-dev": [
         {

--- a/projects/plugins/jetpack-mu-wpcom/jetpack-mu-wpcom.php
+++ b/projects/plugins/jetpack-mu-wpcom/jetpack-mu-wpcom.php
@@ -33,6 +33,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+define( 'JETPACK_MU_WPCOM__PLUGIN_VERSION', '0.2.0-alpha' );
 define( 'JETPACK_MU_WPCOM__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 
 // Shared code for src/features

--- a/projects/plugins/jetpack-mu-wpcom/src/features/coming-soon/coming-soon.php
+++ b/projects/plugins/jetpack-mu-wpcom/src/features/coming-soon/coming-soon.php
@@ -139,7 +139,7 @@ function render_fallback_coming_soon_page() {
 	add_filter( 'woocommerce_demo_store', '__return_false' ); // Prevent the the wocommerce demo store notice from displaying.
 	add_filter( 'jetpack_open_graph_image_default', __NAMESPACE__ . '\coming_soon_share_image' ); // Set the default OG image.
 	add_filter( 'jetpack_twitter_cards_image_default', __NAMESPACE__ . '\coming_soon_share_image' ); // Set the default Twitter Card image.
-	wp_enqueue_style( 'recoleta-font', '//s1.wp.com/i/fonts/recoleta/css/400.min.css', array(), A8C_ETK_PLUGIN_VERSION );
+	wp_enqueue_style( 'recoleta-font', '//s1.wp.com/i/fonts/recoleta/css/400.min.css', array(), JETPACK_MU_WPCOM__PLUGIN_VERSION );
 
 	include __DIR__ . '/fallback-coming-soon-page.php';
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Add `JETPACK_MU_WPCOM__PLUGIN_VERSION` in `.extra.version-constants`.
* Use that version constant for a `wp_enqueue_style()` call to avoid not finding the constant `A8C_ETK_PLUGIN_VERSION`.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion

Internal, task: 1203453160997315-as-1203572719572519/f

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

To test the `JETPACK_MU_WPCOM__PLUGIN_VERSION`, from local dev you could try running:

```sh
tools/project-version.sh -v -C -u 1.0.0 plugins/jetpack-mu-wpcom
```

Which should update the plugin header, `JETPACK_MU_WPCOM__PLUGIN_VERSION` version constant, and add a changelog file with the new version specified.