### PR TITLE
Init 11.7-a.6 plus changelog entries

### DIFF
--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## 0.26.4 - 2022-12-19
+### Added
+- Add Jetpack VaultPress Backup Logo [#27802]
+- Add Jetpack VideoPress logo [#27807]
+
+### Changed
+- Update Backup, Anti-spam, and VideoPress logos [#27847]
+- Updated package dependencies. [#27916]
+
 ## 0.26.3 - 2022-12-12
 ### Changed
 - Updated package dependencies. [#27888]

--- a/projects/js-packages/components/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/components/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/components/changelog/update-backup-branding
+++ b/projects/js-packages/components/changelog/update-backup-branding
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add Jetpack VaultPress Backup Logo

--- a/projects/js-packages/components/changelog/update-jetpack-plugin-new-logos
+++ b/projects/js-packages/components/changelog/update-jetpack-plugin-new-logos
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update Backup, Anti-spam, and VideoPress logos

--- a/projects/js-packages/components/changelog/update-videopress-branding
+++ b/projects/js-packages/components/changelog/update-videopress-branding
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add Jetpack VideoPress logo

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.26.4-alpha",
+	"version": "0.26.4",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 0.24.2 - 2022-12-19
 ### Added
-- Allow to pass custom logo and icon to connection screen [#27802]
+- Allow passing the custom logo and icon to connection screen [#27802]
 
 ### Changed
 - Updated package dependencies. [#27916]

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## 0.24.2 - 2022-12-19
+### Added
+- Allow to pass custom logo and icon to connection screen [#27802]
+
+### Changed
+- Updated package dependencies. [#27916]
+
 ## 0.24.1 - 2022-12-12
 ### Changed
 - Updated package dependencies. [#27888]

--- a/projects/js-packages/connection/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/connection/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/connection/changelog/update-backup-branding
+++ b/projects/js-packages/connection/changelog/update-backup-branding
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Allow to pass custom logo and icon to connection screen

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.24.2-alpha",
+	"version": "0.24.2",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/licensing/CHANGELOG.md
+++ b/projects/js-packages/licensing/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 - 2022-12-19
+### Added
+- Add license key selector in My Jetpack activation screen. [#27609]
+
+### Changed
+- Updated package dependencies. [#27916]
+
+### Fixed
+- Remove useEffect that sets API root and nonce value in JP REST API client causing issue in Jetpack plugin activation page. [#27974]
+
 ## 0.6.9 - 2022-12-02
 ### Changed
 - Updated package dependencies. [#27697]

--- a/projects/js-packages/licensing/changelog/Add license key selector in My Jetpack activation screen
+++ b/projects/js-packages/licensing/changelog/Add license key selector in My Jetpack activation screen
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add license key selector in My jetpack activation screen.

--- a/projects/js-packages/licensing/changelog/fix-activation-page-license-key-dropdown
+++ b/projects/js-packages/licensing/changelog/fix-activation-page-license-key-dropdown
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Remove useEffect that sets API root and nonce value in JP REST API client causing issue in Jetpack plugin activation page.

--- a/projects/js-packages/licensing/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/licensing/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.7.0-alpha",
+	"version": "0.7.0",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {

--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.35 - 2022-12-19
+### Changed
+- Updated package dependencies. [#27916]
+
 ## 0.2.34 - 2022-12-06
 ### Changed
 - Updated package dependencies. [#27340, #27696, #27697]

--- a/projects/js-packages/partner-coupon/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/partner-coupon/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.35-alpha",
+	"version": "0.2.35",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - 2022-12-19
+### Changed
+- Updated package dependencies. [#27916]
+
 ## [0.11.0] - 2022-12-12
 ### Added
 - Media validator for image picker [#27610]
@@ -156,6 +160,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.11.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.9.0...v0.10.0

--- a/projects/js-packages/publicize-components/changelog/renovate-js-unit-testing-packages
+++ b/projects/js-packages/publicize-components/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.11.1-alpha",
+	"version": "0.11.1",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/CHANGELOG.md
+++ b/projects/js-packages/shared-extension-utils/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2022-12-19
+### Added
+- Add new Analytics wrapper hook. [#27937]
+- Add new isCurrentUserConnected utility. [#27923]
+
 ## [0.6.10] - 2022-12-06
 ### Changed
 - Updated package dependencies. [#27688, #27696, #27697]]
@@ -144,6 +149,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: prepare utility for release
 
+[0.7.0]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.6.10...0.7.0
 [0.6.10]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.6.9...0.6.10
 [0.6.9]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.6.8...0.6.9
 [0.6.8]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.6.7...0.6.8

--- a/projects/js-packages/shared-extension-utils/changelog/add-is-current-user-connected-package
+++ b/projects/js-packages/shared-extension-utils/changelog/add-is-current-user-connected-package
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add new isCurrentUserConnected utility.

--- a/projects/js-packages/shared-extension-utils/changelog/add-shared-analytics-wrapper
+++ b/projects/js-packages/shared-extension-utils/changelog/add-shared-analytics-wrapper
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add new Analytics wrapper hook.

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.7.0-alpha",
+	"version": "0.7.0",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/packages/autoloader/CHANGELOG.md
+++ b/projects/packages/autoloader/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.14] - 2022-12-19
+### Changed
+- Use `Composer\ClassMapGenerator\ClassMapGenerator` when available (i.e. with composer 2.4). [#27812]
+
+### Fixed
+- Declare fields for PHP 8.2 compatibility. [#27949]
+
 ## [2.11.13] - 2022-12-02
 ### Changed
 - Updated package dependencies. [#27688]
@@ -285,6 +292,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add Custom Autoloader
 
+[2.11.14]: https://github.com/Automattic/jetpack-autoloader/compare/v2.11.13...v2.11.14
 [2.11.13]: https://github.com/Automattic/jetpack-autoloader/compare/v2.11.12...v2.11.13
 [2.11.12]: https://github.com/Automattic/jetpack-autoloader/compare/v2.11.11...v2.11.12
 [2.11.11]: https://github.com/Automattic/jetpack-autoloader/compare/v2.11.10...v2.11.11

--- a/projects/packages/autoloader/changelog/fix-tests-in-php-8.2
+++ b/projects/packages/autoloader/changelog/fix-tests-in-php-8.2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Declare fields for PHP 8.2 compatibility.

--- a/projects/packages/autoloader/changelog/update-autoloader-use-Composer-ClassMapGenerator-ClassMapGenerator
+++ b/projects/packages/autoloader/changelog/update-autoloader-use-Composer-ClassMapGenerator-ClassMapGenerator
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Use `Composer\ClassMapGenerator\ClassMapGenerator` when available (i.e. with composer 2.4).

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.6] - 2022-12-19
+### Changed
+- Update Backup logo [#27802]
+
+### Fixed
+- Update for PHP 8.2 deprecations. [#27949]
+
 ## [1.10.5] - 2022-12-06
 ### Changed
 - Updated backup layout to improve consistency and remove redundancy. [#27222]
@@ -301,6 +308,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[1.10.6]: https://github.com/Automattic/jetpack-backup/compare/v1.10.5...v1.10.6
 [1.10.5]: https://github.com/Automattic/jetpack-backup/compare/v1.10.4...v1.10.5
 [1.10.4]: https://github.com/Automattic/jetpack-backup/compare/v1.10.3...v1.10.4
 [1.10.3]: https://github.com/Automattic/jetpack-backup/compare/v1.10.2...v1.10.3

--- a/projects/packages/backup/changelog/fix-backup-depcs
+++ b/projects/packages/backup/changelog/fix-backup-depcs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Just moving a dep around. No functional change.
-
-

--- a/projects/packages/backup/changelog/fix-tests-in-php-8.2
+++ b/projects/packages/backup/changelog/fix-tests-in-php-8.2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Update for PHP 8.2 deprecations.

--- a/projects/packages/backup/changelog/update-backup-branding
+++ b/projects/packages/backup/changelog/update-backup-branding
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update Backup logo

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.10.6-alpha';
+	const PACKAGE_VERSION = '1.10.6';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/changelogger/CHANGELOG.md
+++ b/projects/packages/changelogger/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.3] - 2022-12-19
+### Changed
+- `Utils::loadChangeFile()` now throws a custom subclass of `RuntimeException` instead of `RuntimeException` itself. [#27949]
+
 ## [3.2.2] - 2022-12-02
 ### Changed
 - Updated package dependencies. [#27688]
@@ -131,6 +135,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Initial version.
 
+[3.2.3]: https://github.com/Automattic/jetpack-changelogger/compare/3.2.2...3.2.3
 [3.2.2]: https://github.com/Automattic/jetpack-changelogger/compare/3.2.1...3.2.2
 [3.2.1]: https://github.com/Automattic/jetpack-changelogger/compare/3.2.0...3.2.1
 [3.2.0]: https://github.com/Automattic/jetpack-changelogger/compare/3.1.3...3.2.0

--- a/projects/packages/changelogger/changelog/fix-tests-in-php-8.2
+++ b/projects/packages/changelogger/changelog/fix-tests-in-php-8.2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-`Utils::loadChangeFile()` now throws a custom subclass of `RuntimeException` instead of `RuntimeException` itself.

--- a/projects/packages/changelogger/src/Application.php
+++ b/projects/packages/changelogger/src/Application.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 class Application extends SymfonyApplication {
 
-	const VERSION = '3.2.3-alpha';
+	const VERSION = '3.2.3';
 
 	/**
 	 * Constructor.

--- a/projects/packages/composer-plugin/CHANGELOG.md
+++ b/projects/packages/composer-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.8] - 2022-12-19
+### Changed
+- Updated package dependencies. [#27963]
+
 ## [1.1.7] - 2022-12-02
 ### Changed
 - Updated package dependencies. [#27688]
@@ -62,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added the Jetpack Installer package.
 
+[1.1.8]: https://github.com/Automattic/jetpack-composer-plugin/compare/v1.1.7...v1.1.8
 [1.1.7]: https://github.com/Automattic/jetpack-composer-plugin/compare/v1.1.6...v1.1.7
 [1.1.6]: https://github.com/Automattic/jetpack-composer-plugin/compare/v1.1.5...v1.1.6
 [1.1.5]: https://github.com/Automattic/jetpack-composer-plugin/compare/v1.1.4...v1.1.5

--- a/projects/packages/composer-plugin/changelog/renovate-composer-composer-2.x
+++ b/projects/packages/composer-plugin/changelog/renovate-composer-composer-2.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.48.0] - 2022-12-19
+### Changed
+- Provide user locale when fetching info about connected WordPress.com user. [#27928]
+- Update for PHP 8.2 compatibility. [#27949]
+
+### Fixed
+- Declare fields for PHP 8.2 compatibility. [#27968]
+
 ## [1.47.1] - 2022-12-02
 ### Changed
 - Updated package dependencies. [#27696]
@@ -733,6 +741,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[1.48.0]: https://github.com/Automattic/jetpack-connection/compare/v1.47.1...v1.48.0
 [1.47.1]: https://github.com/Automattic/jetpack-connection/compare/v1.47.0...v1.47.1
 [1.47.0]: https://github.com/Automattic/jetpack-connection/compare/v1.46.4...v1.47.0
 [1.46.4]: https://github.com/Automattic/jetpack-connection/compare/v1.46.3...v1.46.4

--- a/projects/packages/connection/changelog/add-promoted-posts-post-publish-panel
+++ b/projects/packages/connection/changelog/add-promoted-posts-post-publish-panel
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Provide user locale when fetching info about connected WordPress.com user

--- a/projects/packages/connection/changelog/fix-jetpack-tests-in-php-8.2
+++ b/projects/packages/connection/changelog/fix-jetpack-tests-in-php-8.2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Declare fields for PHP 8.2 compatibility.

--- a/projects/packages/connection/changelog/fix-tests-in-php-8.2
+++ b/projects/packages/connection/changelog/fix-tests-in-php-8.2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update for PHP 8.2 compatibility.

--- a/projects/packages/connection/changelog/update-reenable-php-8.1-tests
+++ b/projects/packages/connection/changelog/update-reenable-php-8.1-tests
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Set `REQUESTS_SILENCE_PSR0_DEPRECATIONS` when running tests for compat with WP trunk.
-
-

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.48.0-alpha';
+	const PACKAGE_VERSION = '1.48.0';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.0] - 2022-12-19
+### Added
+- Implement detached licenses redux store. [#27609]
+
+### Changed
+- Updated package dependencies. [#27916]
+
+### Fixed
+- Add translation context to Security product name. [#27920]
+
 ## [2.6.1] - 2022-12-12
 ### Changed
 - Updated package dependencies. [#27888]
@@ -694,6 +704,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[2.7.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/2.6.1...2.7.0
 [2.6.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/2.6.0...2.6.1
 [2.6.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/2.5.2...2.6.0
 [2.5.2]: https://github.com/Automattic/jetpack-my-jetpack/compare/2.5.1...2.5.2

--- a/projects/packages/my-jetpack/changelog/Implement detached licenses redux store
+++ b/projects/packages/my-jetpack/changelog/Implement detached licenses redux store
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Implement detached licenses redux store

--- a/projects/packages/my-jetpack/changelog/add-translation-context-security
+++ b/projects/packages/my-jetpack/changelog/add-translation-context-security
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Add translation context to Security product name

--- a/projects/packages/my-jetpack/changelog/fix-tests-in-php-8.2
+++ b/projects/packages/my-jetpack/changelog/fix-tests-in-php-8.2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Update tests for PHP 8.2 compatibility. No change to the package itself.
-
-

--- a/projects/packages/my-jetpack/changelog/renovate-js-unit-testing-packages
+++ b/projects/packages/my-jetpack/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "2.7.0-alpha",
+	"version": "2.7.0",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -30,7 +30,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '2.7.0-alpha';
+	const PACKAGE_VERSION = '2.7.0';
 
 	/**
 	 * Initialize My Jetpack

--- a/projects/packages/promote-posts/CHANGELOG.md
+++ b/projects/packages/promote-posts/CHANGELOG.md
@@ -5,3 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.0 - 2022-12-19
+### Changed
+- Updated package dependencies. [#27906]

--- a/projects/packages/promote-posts/changelog/2022-12-12-13-24-21-796103
+++ b/projects/packages/promote-posts/changelog/2022-12-12-13-24-21-796103
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/promote-posts/package.json
+++ b/projects/packages/promote-posts/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-promote-posts",
-	"version": "0.1.0-alpha",
+	"version": "0.1.0",
 	"description": "Attract high-quality traffic to your site using Promoted Posts. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/promote-posts/#readme",
 	"bugs": {

--- a/projects/packages/promote-posts/src/class-promote-posts.php
+++ b/projects/packages/promote-posts/src/class-promote-posts.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack;
  */
 class Promote_Posts {
 
-	const PACKAGE_VERSION = '0.1.0-alpha';
+	const PACKAGE_VERSION = '0.1.0';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.
@@ -45,7 +45,7 @@ class Promote_Posts {
 			/**
 			 * Action called after initializing Post_List Admin resources.
 			 *
-			 * @since $$next-version$$
+			 * @since 0.1.0
 			 */
 			do_action( 'jetpack_on_promote_posts_init' );
 		}

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.4] - 2022-12-19
+### Changed
+- Updated package dependencies. [#27962]
+
 ## [0.18.3] - 2022-12-12
 ### Added
 - Social: Added a 'more info' link to the plan details in the editor nudge [#27617]
@@ -199,6 +203,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.18.4]: https://github.com/Automattic/jetpack-publicize/compare/v0.18.3...v0.18.4
 [0.18.3]: https://github.com/Automattic/jetpack-publicize/compare/v0.18.2...v0.18.3
 [0.18.2]: https://github.com/Automattic/jetpack-publicize/compare/v0.18.1...v0.18.2
 [0.18.1]: https://github.com/Automattic/jetpack-publicize/compare/v0.18.0...v0.18.1

--- a/projects/packages/publicize/changelog/fix-tests-in-php-8.2
+++ b/projects/packages/publicize/changelog/fix-tests-in-php-8.2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Declare fields in test classes for PHP 8.2 compat. No changes to the package itself.
-
-

--- a/projects/packages/publicize/changelog/renovate-automattic-wordbless-0.x
+++ b/projects/packages/publicize/changelog/renovate-automattic-wordbless-0.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.18.4-alpha",
+	"version": "0.18.4",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/redirect/CHANGELOG.md
+++ b/projects/packages/redirect/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.22] - 2022-12-19
+### Changed
+- Updated package dependencies. 
+
 ## [1.7.21] - 2022-12-02
 ### Changed
 - Updated package dependencies. [#27688]
@@ -164,6 +168,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Create Jetpack Redirect package
 
+[1.7.22]: https://github.com/Automattic/jetpack-redirect/compare/v1.7.21...v1.7.22
 [1.7.21]: https://github.com/Automattic/jetpack-redirect/compare/v1.7.20...v1.7.21
 [1.7.20]: https://github.com/Automattic/jetpack-redirect/compare/v1.7.19...v1.7.20
 [1.7.19]: https://github.com/Automattic/jetpack-redirect/compare/v1.7.18...v1.7.19

--- a/projects/packages/redirect/changelog/fix-tests-in-php-8.2
+++ b/projects/packages/redirect/changelog/fix-tests-in-php-8.2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Remove unused field in unit test that was making PHP 8.2 unhappy. No change to the package itself.
-
-

--- a/projects/packages/roles/CHANGELOG.md
+++ b/projects/packages/roles/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.20] - 2022-12-19
+### Changed
+- Updated package dependencies. 
+
 ## [1.4.19] - 2022-12-02
 ### Changed
 - Updated package dependencies. [#27688]
@@ -131,6 +135,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Jetpack DNA: Introduce a Roles package
 
+[1.4.20]: https://github.com/Automattic/jetpack-roles/compare/v1.4.19...v1.4.20
 [1.4.19]: https://github.com/Automattic/jetpack-roles/compare/v1.4.18...v1.4.19
 [1.4.18]: https://github.com/Automattic/jetpack-roles/compare/v1.4.17...v1.4.18
 [1.4.17]: https://github.com/Automattic/jetpack-roles/compare/v1.4.16...v1.4.17

--- a/projects/packages/roles/changelog/fix-tests-in-php-8.2
+++ b/projects/packages/roles/changelog/fix-tests-in-php-8.2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Declare a field in a test class. No change to the package itself.
-
-

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.31.2] - 2022-12-19
+### Changed
+- Updated package dependencies. [#27887, #27916, #27962]
+
+### Fixed
+- Declare field `REST_Controller->plan`. [#27949]
+- Improve PHP 8.2 compatibility. [#27968]
+
 ## [0.31.1] - 2022-12-06
 ### Changed
 - Updated package dependencies. [#27340, #27688, #27696, #27697]
@@ -624,6 +632,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.31.2]: https://github.com/Automattic/jetpack-search/compare/v0.31.1...v0.31.2
 [0.31.1]: https://github.com/Automattic/jetpack-search/compare/v0.31.0...v0.31.1
 [0.31.0]: https://github.com/Automattic/jetpack-search/compare/v0.30.2...v0.31.0
 [0.30.2]: https://github.com/Automattic/jetpack-search/compare/v0.30.1...v0.30.2

--- a/projects/packages/search/changelog/fix-jetpack-tests-in-php-8.2
+++ b/projects/packages/search/changelog/fix-jetpack-tests-in-php-8.2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Improve PHP 8.2 compatibility.

--- a/projects/packages/search/changelog/fix-tests-in-php-8.2
+++ b/projects/packages/search/changelog/fix-tests-in-php-8.2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Declare field `REST_Controller->plan`.

--- a/projects/packages/search/changelog/renovate-automattic-wordbless-0.x
+++ b/projects/packages/search/changelog/renovate-automattic-wordbless-0.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/search/changelog/renovate-js-unit-testing-packages
+++ b/projects/packages/search/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/search/changelog/renovate-postcss-8.x
+++ b/projects/packages/search/changelog/renovate-postcss-8.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.31.2-alpha",
+	"version": "0.31.2",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.31.2-alpha';
+	const VERSION = '0.31.2';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/stats-admin/CHANGELOG.md
+++ b/projects/packages/stats-admin/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 - 2022-12-19
+### Added
+- Stats: added list posts endpoint. [#27875]
+
+### Changed
+- Stats: changed loading assets from odyssey-stats folder and some names. [#27971]
+- Stats Admin: changed the time to refresh cache buster to 15 min. [#27969]
+
+### Removed
+- Stats: removed style overriding for Odyssey stats. [#27896]
+
+### Fixed
+- Stats: added `hostname` and `admin_url` to config. [#27922]
+- Stats Admin: fixed phpunit CI tests. [#27948]
+
 ## 0.1.1 - 2022-12-06
 ### Changed
 - Stats: explicitly allow only certain API access with blog token to wpcom [#27604]

--- a/projects/packages/stats-admin/changelog/add-stats-list-posts-api
+++ b/projects/packages/stats-admin/changelog/add-stats-list-posts-api
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Stats: added list posts endpoint

--- a/projects/packages/stats-admin/changelog/fix-add-hostname-admin-url-to-config
+++ b/projects/packages/stats-admin/changelog/fix-add-hostname-admin-url-to-config
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Stats: added `hostname` and `admin_url` to config

--- a/projects/packages/stats-admin/changelog/fix-stats-admin-phpunit-tests
+++ b/projects/packages/stats-admin/changelog/fix-stats-admin-phpunit-tests
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Stats Admin: fixed phpunit CI tests

--- a/projects/packages/stats-admin/changelog/remove-stats-css
+++ b/projects/packages/stats-admin/changelog/remove-stats-css
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Stats: removed style overriding for Odyssey stats

--- a/projects/packages/stats-admin/changelog/update-cache-odyssey-cache-buter-15min
+++ b/projects/packages/stats-admin/changelog/update-cache-odyssey-cache-buter-15min
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Stats Admin: changed the time to refresh cache buster to 15 min

--- a/projects/packages/stats-admin/changelog/update-change-calypso-stats-to-odyssey
+++ b/projects/packages/stats-admin/changelog/update-change-calypso-stats-to-odyssey
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Stats: changed loading assets from odyssey-stats folder and some names

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.2.0-alpha",
+	"version": "0.2.0",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -18,7 +18,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.2.0-alpha';
+	const VERSION = '0.2.0';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/status/CHANGELOG.md
+++ b/projects/packages/status/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.3] - 2022-12-19
+### Changed
+- Updated package dependencies.
+
 ## [1.15.2] - 2022-12-02
 ### Changed
 - Updated package dependencies. [#27688]
@@ -220,6 +224,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Introduce a status package
 
+[1.15.3]: https://github.com/Automattic/jetpack-status/compare/v1.15.2...v1.15.3
 [1.15.2]: https://github.com/Automattic/jetpack-status/compare/v1.15.1...v1.15.2
 [1.15.1]: https://github.com/Automattic/jetpack-status/compare/v1.15.0...v1.15.1
 [1.15.0]: https://github.com/Automattic/jetpack-status/compare/v1.14.3...v1.15.0

--- a/projects/packages/status/changelog/fix-tests-in-php-8.2
+++ b/projects/packages/status/changelog/fix-tests-in-php-8.2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Adjust test to work in PHP 8.2. No change to the package itself.
-
-

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.45.0] - 2022-12-19
+### Added
+- Adding new boolean site option of 'wpcom-subscription-emails-use-excerpt'. [#27908]
+- Sync Launchpad-related options: `launchpad_screen` and `launchpad_checklist_tasks_statuses`. [#27843]
+
+### Changed
+- Option: Update featured_image_email_enabled option name to wpcom_featured_image_in_email. [#27955]
+
+### Fixed
+- Improve PHP 8.2 compatibility. [#27968]
+
 ## [1.44.2] - 2022-12-06
 ### Changed
 - Updated package dependencies.
@@ -784,6 +795,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[1.45.0]: https://github.com/Automattic/jetpack-sync/compare/v1.44.2...v1.45.0
 [1.44.2]: https://github.com/Automattic/jetpack-sync/compare/v1.44.1...v1.44.2
 [1.44.1]: https://github.com/Automattic/jetpack-sync/compare/v1.44.0...v1.44.1
 [1.44.0]: https://github.com/Automattic/jetpack-sync/compare/v1.43.2...v1.44.0

--- a/projects/packages/sync/changelog/add-launchpad-sync-options
+++ b/projects/packages/sync/changelog/add-launchpad-sync-options
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Sync Launchpad-related options: `launchpad_screen` and `launchpad_checklist_tasks_statuses`

--- a/projects/packages/sync/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
+++ b/projects/packages/sync/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Adding new boolean site option of 'wpcom-subscription-emails-use-excerpt'

--- a/projects/packages/sync/changelog/fix-jetpack-tests-in-php-8.2
+++ b/projects/packages/sync/changelog/fix-jetpack-tests-in-php-8.2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Improve PHP 8.2 compatibility.

--- a/projects/packages/sync/changelog/update-featured_image_email_enabled-option-name
+++ b/projects/packages/sync/changelog/update-featured_image_email_enabled-option-name
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Option: Update featured_image_email_enabled option name to wpcom_featured_image_in_email

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.45.0-alpha';
+	const PACKAGE_VERSION = '1.45.0';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2022-12-19
+### Changed
+- Updated package dependencies. [#27887, #27888, #27916]
+- Update Jetpack VideoPress logo. [#27807]
+- VideoPress: set fill property of the VideoPress video icons. [#27865]
+
+### Removed
+- Remove src/client files from final bundle. [#27926]
+
 ## [0.9.0] - 2022-12-12
 ### Added
 - Ignore .vscode/ folder [#27794]
@@ -539,6 +548,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.9.1]: https://github.com/Automattic/jetpack-videopress/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/Automattic/jetpack-videopress/compare/v0.8.4...v0.9.0
 [0.8.4]: https://github.com/Automattic/jetpack-videopress/compare/v0.8.3...v0.8.4
 [0.8.3]: https://github.com/Automattic/jetpack-videopress/compare/v0.8.2...v0.8.3

--- a/projects/packages/videopress/changelog/fix-tests-in-php-8.2
+++ b/projects/packages/videopress/changelog/fix-tests-in-php-8.2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Declare field in test for PHP 8.2 compat. No change to the package itself.
-
-

--- a/projects/packages/videopress/changelog/renovate-js-unit-testing-packages
+++ b/projects/packages/videopress/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/changelog/renovate-postcss-8.x
+++ b/projects/packages/videopress/changelog/renovate-postcss-8.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/changelog/renovate-storybook-monorepo
+++ b/projects/packages/videopress/changelog/renovate-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/changelog/update-jetpack-videopress-gitattributes-src-files
+++ b/projects/packages/videopress/changelog/update-jetpack-videopress-gitattributes-src-files
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Remove src/client files from final bundle

--- a/projects/packages/videopress/changelog/update-videopress-branding
+++ b/projects/packages/videopress/changelog/update-videopress-branding
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update Jetpack VideoPress logo

--- a/projects/packages/videopress/changelog/update-videopress-fix-vp-icon-color
+++ b/projects/packages/videopress/changelog/update-videopress-fix-vp-icon-color
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-VideoPress: set fill property of the VideoPress video icons

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.9.1-alpha",
+	"version": "0.9.1",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.9.1-alpha';
+	const PACKAGE_VERSION = '0.9.1';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/waf/CHANGELOG.md
+++ b/projects/packages/waf/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2022-12-19
+### Fixed
+- Fix the initialization of the firewall. [#27846]
+
 ## [0.7.1] - 2022-12-06
 ### Changed
 - html_entity_decode filter now decodes single-quotes too, and uses a Unicode Replacement Character instead of returning empty string on invalid characters. [#27753]
@@ -118,6 +122,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: do not ship .phpcs.dir.xml in production builds.
 
+[0.7.2]: https://github.com/Automattic/jetpack-waf/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/Automattic/jetpack-waf/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/Automattic/jetpack-waf/compare/v0.6.10...v0.7.0
 [0.6.10]: https://github.com/Automattic/jetpack-waf/compare/v0.6.9...v0.6.10

--- a/projects/packages/waf/changelog/fix-protect-waf-init
+++ b/projects/packages/waf/changelog/fix-protect-waf-init
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix the initialization of the firewall.

--- a/projects/packages/wordads/CHANGELOG.md
+++ b/projects/packages/wordads/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.27] - 2022-12-19
+### Changed
+- Updated package dependencies. [#27887, #27916]
+
 ## [0.2.26] - 2022-12-06
 ### Changed
 - Updated package dependencies. [#27688, #27696, #27697]
@@ -137,6 +141,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`
 - Updated package dependencies.
 
+[0.2.27]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.26...v0.2.27
 [0.2.26]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.25...v0.2.26
 [0.2.25]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.24...v0.2.25
 [0.2.24]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.23...v0.2.24

--- a/projects/packages/wordads/changelog/renovate-js-unit-testing-packages
+++ b/projects/packages/wordads/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/wordads/changelog/renovate-postcss-8.x
+++ b/projects/packages/wordads/changelog/renovate-postcss-8.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.2.27-alpha",
+	"version": "0.2.27",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.2.27-alpha';
+	const VERSION = '0.2.27';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 11.7-a.5 - 2022-12-19
+### Enhancements
+- Activate license key dropdown selector in Jetpack plugin's activation page. [#27974]
+- add context to blogging prompt placeholder [#27895]
+- Add new fonts to Global Style options. [#27441]
+- Allow Form required field text to be changed [#27913]
+- Assistant: update Akismet and Backup names [#27844]
+- Block editor: add a new panel allowing you to promote your posts after publishing them. [#27928]
+- Hides agencies module on jetpack dashboard if site is atomic [#27966]
+- Jetpack: switch pagination style in the slideshow block [#27936]
+- Slideshow block: Update block description [#27899]
+- Update Backup, Anti-spam, and VideoPress logos [#27847]
+- Update Form block default labels [#27628]
+- Update Form block placeholder styles [#27855]
+- Update Form fields styles to comply with WYSIWYG [#27967]
+
+### Improved compatibility
+- Blogging prompts: hide placeholder prompts by default [#27919]
+- CSS: Removed custom maybe_inline_style() with wp_maybe_inline_styles() which is available in WP core since 5.8.0 [#27965]
+- General: Fix deprecation warnings when running with PHP 8.2. [#27968]
+- Sync Launchpad-related options: `launchpad_screen` and `launchpad_checklist_tasks_statuses` [#27843]
+
+### Bug fixes
+- Add translation context to Security product name [#27920]
+- Fixes email formatting for contact form submissions [#27929]
+- Fix the initialization of the firewall. [#27846]
+- Minor Hovercards & AMP compatibility bug [#27828]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Add export to Google Drive feature on form responses table [#27690]
+- Blocks: add missing Jetpack config external. [#27978]
+- Blocks: enqueue connection data in post editor, to be used by blocks. [#27937]
+- E2E tests: add a new tests for Form block [#27933]
+- Extensions: use isCurrentUserConnected from package instead of from internally shared function. [#27924]
+- Fix PHP Warning on subscription block [#27884]
+- Improve stability of Pay with Paypal test [#27951]
+- Jetpack Slideshow: Change the labels for Image Size and Transition Effect options. [#27898]
+- Option: Update featured_image_email_enabled option name to wpcom_featured_image_in_email [#27955]
+- Options: Added new site option of 'wpcom-subscription-emails-use-excerpt' [#27908]
+- Remove dead static-site-generator-webpack-plugin dep, copy a cleaned-up version into the repo. [#27889]
+- Remove last place that uses maybe_inline_styles [#27983]
+- Slideshow block: Change the arrow's style to match the gallery current style. [#27907]
+- Stats: fix stats chart in masterbar when new experience is turned on [#27825]
+- Stats Admin: update dependencies [#27948]
+- Updated package dependencies. [#27874]
+- Updated package dependencies. [#27887]
+- Updated package dependencies. [#27916]
+- Updating changelog entries. [#27886]
+
 ## 11.7-a.3 - 2022-12-12
 ### Enhancements
 - Form block: update Form blocks descriptions. [#27819]

--- a/projects/plugins/jetpack/changelog/2022-12-12-13-26-25-789526
+++ b/projects/plugins/jetpack/changelog/2022-12-12-13-26-25-789526
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/Replace custom maybe_inline_style with core wp_maybe_inline_styles
+++ b/projects/plugins/jetpack/changelog/Replace custom maybe_inline_style with core wp_maybe_inline_styles
@@ -1,4 +1,0 @@
-Significance: minor
-Type: compat
-
-CSS: Removed custom maybe_inline_style() with wp_maybe_inline_styles() which is available in WP core since 5.8.0

--- a/projects/plugins/jetpack/changelog/add-context-for-blogging-prompt
+++ b/projects/plugins/jetpack/changelog/add-context-for-blogging-prompt
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-add context to blogging prompt placeholder

--- a/projects/plugins/jetpack/changelog/add-launchpad-sync-options
+++ b/projects/plugins/jetpack/changelog/add-launchpad-sync-options
@@ -1,4 +1,0 @@
-Significance: minor
-Type: compat
-
-Sync Launchpad-related options: `launchpad_screen` and `launchpad_checklist_tasks_statuses`

--- a/projects/plugins/jetpack/changelog/add-license-key-selector
+++ b/projects/plugins/jetpack/changelog/add-license-key-selector
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
+++ b/projects/plugins/jetpack/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Options: Added new site option of 'wpcom-subscription-emails-use-excerpt'

--- a/projects/plugins/jetpack/changelog/add-new-wpcom-subscription-emails-use-excerpt-option#2
+++ b/projects/plugins/jetpack/changelog/add-new-wpcom-subscription-emails-use-excerpt-option#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-promoted-posts-block-after-publishing-content
+++ b/projects/plugins/jetpack/changelog/add-promoted-posts-block-after-publishing-content
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Block editor: add a new panel allowing you to promote your posts after publishing them.

--- a/projects/plugins/jetpack/changelog/add-promoted-posts-post-publish-panel
+++ b/projects/plugins/jetpack/changelog/add-promoted-posts-post-publish-panel
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-reponses-export-to-gdrive
+++ b/projects/plugins/jetpack/changelog/add-reponses-export-to-gdrive
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add export to Google Drive feature on form responses table

--- a/projects/plugins/jetpack/changelog/add-shared-analytics-wrapper
+++ b/projects/plugins/jetpack/changelog/add-shared-analytics-wrapper
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Blocks: enqueue connection data in post editor, to be used by blocks.

--- a/projects/plugins/jetpack/changelog/add-stats-list-posts-api
+++ b/projects/plugins/jetpack/changelog/add-stats-list-posts-api
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-translation-context-security
+++ b/projects/plugins/jetpack/changelog/add-translation-context-security
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Add translation context to Security product name

--- a/projects/plugins/jetpack/changelog/e2e-add-form-block
+++ b/projects/plugins/jetpack/changelog/e2e-add-form-block
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-E2E tests: add a new tests for Form block

--- a/projects/plugins/jetpack/changelog/e2e-fix-disabled-sync-assert
+++ b/projects/plugins/jetpack/changelog/e2e-fix-disabled-sync-assert
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-

--- a/projects/plugins/jetpack/changelog/fix-activation-page-license-key-dropdown
+++ b/projects/plugins/jetpack/changelog/fix-activation-page-license-key-dropdown
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Activate license key dropdown selector in Jetpack plugin's activation page.

--- a/projects/plugins/jetpack/changelog/fix-backup-depcs
+++ b/projects/plugins/jetpack/changelog/fix-backup-depcs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/fix-change-slideshow-arrows
+++ b/projects/plugins/jetpack/changelog/fix-change-slideshow-arrows
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Slideshow block: Change the arrow's style to match the gallery current style.

--- a/projects/plugins/jetpack/changelog/fix-change-slideshow-option-labels
+++ b/projects/plugins/jetpack/changelog/fix-change-slideshow-option-labels
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack Slideshow: Change the labels for Image Size and Transition Effect options.

--- a/projects/plugins/jetpack/changelog/fix-contact-form-email-formatting
+++ b/projects/plugins/jetpack/changelog/fix-contact-form-email-formatting
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Fixes email formatting for contact form submissions

--- a/projects/plugins/jetpack/changelog/fix-deprecate-inline-styles
+++ b/projects/plugins/jetpack/changelog/fix-deprecate-inline-styles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Remove last place that uses maybe_inline_styles

--- a/projects/plugins/jetpack/changelog/fix-hovercard-amp-error
+++ b/projects/plugins/jetpack/changelog/fix-hovercard-amp-error
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Minor Hovercards & AMP compatibility bug

--- a/projects/plugins/jetpack/changelog/fix-jetpack-tests-for-wp-trunk
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-tests-for-wp-trunk
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Fix tests for WordPress trunk's new Requests library.
-
-

--- a/projects/plugins/jetpack/changelog/fix-jetpack-tests-in-php-8.2
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-tests-in-php-8.2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-General: Fix deprecation warnings when running with PHP 8.2.

--- a/projects/plugins/jetpack/changelog/fix-missing-jetpackconfig
+++ b/projects/plugins/jetpack/changelog/fix-missing-jetpackconfig
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Blocks: add missing Jetpack config external.

--- a/projects/plugins/jetpack/changelog/fix-protect-waf-init
+++ b/projects/plugins/jetpack/changelog/fix-protect-waf-init
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Fix the initialization of the firewall.

--- a/projects/plugins/jetpack/changelog/fix-stats-admin-phpunit-tests
+++ b/projects/plugins/jetpack/changelog/fix-stats-admin-phpunit-tests
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Stats Admin: update dependencies

--- a/projects/plugins/jetpack/changelog/fix-stats-chart-in-masterbar-when-new-stats-is-on
+++ b/projects/plugins/jetpack/changelog/fix-stats-chart-in-masterbar-when-new-stats-is-on
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Stats: fix stats chart in masterbar when new experience is turned on

--- a/projects/plugins/jetpack/changelog/fix-subscription-block-undefined-key-warning
+++ b/projects/plugins/jetpack/changelog/fix-subscription-block-undefined-key-warning
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Fix PHP Warning on subscription block

--- a/projects/plugins/jetpack/changelog/form-editable-required-text
+++ b/projects/plugins/jetpack/changelog/form-editable-required-text
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Allow Form required field text to be changed

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 11.7-a.6
+
+

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 11.7-a.4
-
-

--- a/projects/plugins/jetpack/changelog/modify-carousel-dots-spacing
+++ b/projects/plugins/jetpack/changelog/modify-carousel-dots-spacing
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Minor styling change
-
-

--- a/projects/plugins/jetpack/changelog/remove-static-site-generator-webpack-plugin-dep
+++ b/projects/plugins/jetpack/changelog/remove-static-site-generator-webpack-plugin-dep
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Remove dead static-site-generator-webpack-plugin dep, copy a cleaned-up version into the repo.

--- a/projects/plugins/jetpack/changelog/renovate-automattic-wordbless-0.x
+++ b/projects/plugins/jetpack/changelog/renovate-automattic-wordbless-0.x
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/renovate-composer-composer-2.x
+++ b/projects/plugins/jetpack/changelog/renovate-composer-composer-2.x
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/renovate-js-unit-testing-packages
+++ b/projects/plugins/jetpack/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-postcss-8.x
+++ b/projects/plugins/jetpack/changelog/renovate-postcss-8.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/try-e2e-paypal-wait-for-response
+++ b/projects/plugins/jetpack/changelog/try-e2e-paypal-wait-for-response
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Improve stability of Pay with Paypal test

--- a/projects/plugins/jetpack/changelog/update-agencies-module-hide-on-atomic-sites
+++ b/projects/plugins/jetpack/changelog/update-agencies-module-hide-on-atomic-sites
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Hides agencies module on jetpack dashboard if site is atomic

--- a/projects/plugins/jetpack/changelog/update-assistant-product-names
+++ b/projects/plugins/jetpack/changelog/update-assistant-product-names
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Assistant: update Akismet and Backup names

--- a/projects/plugins/jetpack/changelog/update-blogging-prompts-default-false
+++ b/projects/plugins/jetpack/changelog/update-blogging-prompts-default-false
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-Blogging prompts: hide placeholder prompts by default

--- a/projects/plugins/jetpack/changelog/update-clean-jetpack-11.7-a.3-readme
+++ b/projects/plugins/jetpack/changelog/update-clean-jetpack-11.7-a.3-readme
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updating changelog entries.

--- a/projects/plugins/jetpack/changelog/update-featured_image_email_enabled-option-name
+++ b/projects/plugins/jetpack/changelog/update-featured_image_email_enabled-option-name
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Option: Update featured_image_email_enabled option name to wpcom_featured_image_in_email

--- a/projects/plugins/jetpack/changelog/update-fonts
+++ b/projects/plugins/jetpack/changelog/update-fonts
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Add new fonts to Global Style options.

--- a/projects/plugins/jetpack/changelog/update-form-block-placeholder-styles
+++ b/projects/plugins/jetpack/changelog/update-form-block-placeholder-styles
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Update Form block placeholder styles

--- a/projects/plugins/jetpack/changelog/update-form-default-labels
+++ b/projects/plugins/jetpack/changelog/update-form-default-labels
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Update Form block default labels

--- a/projects/plugins/jetpack/changelog/update-form-fields-style
+++ b/projects/plugins/jetpack/changelog/update-form-fields-style
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Update Form fields styles to comply with WYSIWYG

--- a/projects/plugins/jetpack/changelog/update-is-current-user-connected-usage
+++ b/projects/plugins/jetpack/changelog/update-is-current-user-connected-usage
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Extensions: use isCurrentUserConnected from package instead of from internally shared function.

--- a/projects/plugins/jetpack/changelog/update-jetpack-plugin-new-logos
+++ b/projects/plugins/jetpack/changelog/update-jetpack-plugin-new-logos
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Update Backup, Anti-spam, and VideoPress logos

--- a/projects/plugins/jetpack/changelog/update-payments-intro-pattern-category
+++ b/projects/plugins/jetpack/changelog/update-payments-intro-pattern-category
@@ -1,5 +1,0 @@
-Significance: patch
-Type: bugfix
-Comment: Minor bugfix for wpcom
-
-

--- a/projects/plugins/jetpack/changelog/update-slideshow-block-description
+++ b/projects/plugins/jetpack/changelog/update-slideshow-block-description
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Slideshow block: Update block description

--- a/projects/plugins/jetpack/changelog/update-slideshow-tweak-paginator
+++ b/projects/plugins/jetpack/changelog/update-slideshow-tweak-paginator
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Jetpack: switch pagination style in the slideshow block

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -5745,7 +5745,7 @@ endif;
 	/**
 	 * Maybe inlines a stylesheet.
 	 *
-	 * @deprecated since $$next-version$$.
+	 * @deprecated since 11.7.
 	 *
 	 * @param string $tag The tag that would link to the external asset.
 	 * @param string $handle The registered handle of the script in question.
@@ -5753,7 +5753,7 @@ endif;
 	 * @return string
 	 */
 	public static function maybe_inline_style( $tag, $handle ) { //phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		_deprecated_function( __METHOD__, '$$next-version$$', 'wp_maybe_inline_styles' );
+		_deprecated_function( __METHOD__, '11.7', 'wp_maybe_inline_styles' );
 
 		return $tag;
 	}

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ11_7_a_4",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ11_7_a_5",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ11_7_a_5",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ11_7_a_6",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 11.7-a.5
+ * Version: 11.7-a.6
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -32,7 +32,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.0' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '11.7-a.5' );
+define( 'JETPACK__VERSION', '11.7-a.6' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 11.7-a.4
+ * Version: 11.7-a.5
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -32,7 +32,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.0' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '11.7-a.4' );
+define( 'JETPACK__VERSION', '11.7-a.5' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "11.7.0-a.4",
+	"version": "11.7.0-a.5",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "11.7.0-a.5",
+	"version": "11.7.0-a.6",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
* Init Jetpack 11.7-a.6 cycle (plus changelog entries)

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion

n/a

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Proof-read - main Jetpack changelog edit to come later.

