### PR TITLE
Jetpack Boost: Image Guide DOM & Resizing improvements

### DIFF
--- a/projects/plugins/boost/app/assets/src/css/main/variables.scss
+++ b/projects/plugins/boost/app/assets/src/css/main/variables.scss
@@ -38,6 +38,7 @@ $jetpack_green_100: #001c09;
 
 :root {
     --jp-yellow-20: #F0C930;
+	--jp-green: #{$jetpack_green};
 }
 
 $red_50: #D63638;

--- a/projects/plugins/boost/app/assets/src/js/global.d.ts
+++ b/projects/plugins/boost/app/assets/src/js/global.d.ts
@@ -45,6 +45,7 @@ declare global {
 			online: boolean;
 			assetPath: string;
 			getStarted: boolean;
+			canResizeImages: boolean;
 		};
 		optimizations: Optimizations;
 		shownAdminNoticeIds: string[];

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/ResizingUnavailable.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/ResizingUnavailable.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { __ } from '@wordpress/i18n';
+</script>
+
+<div class="jetpack-boost-notice">
+	<h2>{__( 'Image resizing is unavailable', 'jetpack-boost' )}</h2>
+	<p>
+		{__(
+			"It looks like your server doesn't have Imagick or GD extensions installed.",
+			'jetpack-boost'
+		)}
+	</p>
+	<p>
+		{__(
+			"Jetpack Boost is able to work without these extensions, but it's likely that it's going to be difficult for you to optimize the images that the Image Guide will identify without one of these extensions.",
+			'jetpack-boost'
+		)}
+	</p>
+	<p>
+		{__(
+			'Please contact your hosting provider or system administrator and ask them to install or activate one of these extensions.',
+			'jetpack-boost'
+		)}
+	</p>
+</div>
+
+<style lang="scss">
+	.jetpack-boost-notice {
+		border: 2px solid var( --jp-green );
+		padding: 24px 24px;
+		margin: 0 -24px;
+		border-radius: 4px;
+	}
+</style>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -113,7 +113,7 @@
 				<h3 slot="title">{__( 'Image Guide', 'jetpack-boost' )}<span class="beta">Beta</span></h3>
 				<p slot="description">
 					{__(
-						`This feature helps you speed up your website by showing you which images are too large. When you browse your site, the image guide will show you an overlay with information about each image's size.`,
+						`This feature helps you discover the images are too large. When you browse your site, the image guide will show you an overlay with information about each image's size.`,
 						'jetpack-boost'
 					)}
 				</p>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -14,6 +14,7 @@
 	import CriticalCssMeta from '../elements/CriticalCssMeta.svelte';
 	import Module from '../elements/Module.svelte';
 	import PremiumCTA from '../elements/PremiumCTA.svelte';
+	import ResizingUnavailable from '../elements/ResizingUnavailable.svelte';
 	import SuperCacheInfo from '../elements/SuperCacheInfo.svelte';
 
 	const criticalCssLink = getRedirectUrl( 'jetpack-boost-critical-css' );
@@ -112,10 +113,14 @@
 				<h3 slot="title">{__( 'Image Guide', 'jetpack-boost' )}<span class="beta">Beta</span></h3>
 				<p slot="description">
 					{__(
-						`Detect images that are too large on the site to help you catch images that are too large while you browse the site.`,
+						`This feature helps you speed up your website by showing you which images are too large. When you browse your site, the image guide will show you an overlay with information about each image's size.`,
 						'jetpack-boost'
 					)}
 				</p>
+				<!-- svelte-ignore missing-declaration -->
+				{#if false === Jetpack_Boost.site.canResizeImages}
+					<ResizingUnavailable />
+				{/if}
 			</Module>
 		</div>
 	{/if}

--- a/projects/plugins/boost/app/features/image-guide/Image_Guide.php
+++ b/projects/plugins/boost/app/features/image-guide/Image_Guide.php
@@ -9,6 +9,10 @@ class Image_Guide implements Feature {
 
 	public function setup() {
 
+		if ( is_admin() ) {
+			add_filter( 'jetpack_boost_js_constants', array( $this, 'can_resize_images' ) );
+		}
+
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$override = defined( 'JETPACK_BOOST_IMAGE_GUIDE' ) && JETPACK_BOOST_IMAGE_GUIDE && isset( $_GET['jb-debug-ig'] );
 
@@ -23,6 +27,14 @@ class Image_Guide implements Feature {
 		 * The priority determines where the admin bar menu item is placed.
 		 */
 		add_action( 'admin_bar_menu', array( $this, 'add_to_adminbar' ), 500 );
+	}
+
+	public function can_resize_images( $constants ) {
+		if ( ! isset( $constants['site'] ) ) {
+			$constants['site'] = array();
+		}
+		$constants['site']['canResizeImages'] = wp_image_editor_supports( array( 'methods' => array( 'resize' ) ) );
+		return $constants;
 	}
 
 	public static function get_slug() {

--- a/projects/plugins/boost/app/features/image-guide/src/index.ts
+++ b/projects/plugins/boost/app/features/image-guide/src/index.ts
@@ -50,7 +50,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 const stores: MeasurableImageStore[] = [];
 
 /**
- * Guides need to recaculate dimensions and possibly weights.
+ * Guides need to recalculate dimensions and possibly weights.
  * This is done when the window is resized,
  * but because that event is fired multiple times,
  * it's better to debounce it.

--- a/projects/plugins/boost/app/features/image-guide/src/ui/Bubble.svelte
+++ b/projects/plugins/boost/app/features/image-guide/src/ui/Bubble.svelte
@@ -75,7 +75,8 @@
 		border-radius: 50%;
 		text-align: center;
 
-		text-shadow: 0 0 1px rgba( 0, 0, 0, 0.25 );
+		border: 1px solid hsl(0deg 0% 100% / 0.05);
+		text-shadow: 0 0 1px hsl(0, 0%, 0% / 0.15);
 		cursor: default;
 		transition: background-color 300ms ease;
 
@@ -122,9 +123,10 @@
 			margin-top: -10px;
 		}
 		.bubble {
-			width: 14px;
-			height: 14px;
+			width: 10px;
+			height: 10px;
 			font-size: 0px;
+			border: 1px solid hsl(0deg 0% 100% / 0.3);
 			:global(svg) {
 				display: none;
 			}

--- a/projects/plugins/boost/app/features/image-guide/src/ui/Bubble.svelte
+++ b/projects/plugins/boost/app/features/image-guide/src/ui/Bubble.svelte
@@ -75,8 +75,8 @@
 		border-radius: 50%;
 		text-align: center;
 
-		border: 1px solid hsl(0deg 0% 100% / 0.05);
-		text-shadow: 0 0 1px hsl(0, 0%, 0% / 0.15);
+		border: 1px solid hsl( 0deg 0% 100% / 0.05 );
+		text-shadow: 0 0 1px hsl( 0, 0%, 0% / 0.15 );
 		cursor: default;
 		transition: background-color 300ms ease;
 
@@ -126,8 +126,8 @@
 			width: 10px;
 			height: 10px;
 			font-size: 0px;
-			border: 1px solid hsl(0deg 0% 100% / 0.3);
-			:global(svg) {
+			border: 1px solid hsl( 0deg 0% 100% / 0.3 );
+			:global( svg ) {
 				display: none;
 			}
 		}

--- a/projects/plugins/boost/app/features/image-guide/src/ui/Bubble.svelte
+++ b/projects/plugins/boost/app/features/image-guide/src/ui/Bubble.svelte
@@ -125,6 +125,9 @@
 			width: 14px;
 			height: 14px;
 			font-size: 0px;
+			:global(svg) {
+				display: none;
+			}
 		}
 	}
 </style>

--- a/projects/plugins/boost/app/features/image-guide/src/ui/Popup.svelte
+++ b/projects/plugins/boost/app/features/image-guide/src/ui/Popup.svelte
@@ -74,7 +74,7 @@
 					but pay attention whether the image appears blurry.
 				</div>
 			{/if}
-			<a class="documentation" href="{DOCUMENTATION_URL}" target="_blank noreferrer">Learn more</a>
+			<a class="documentation" href={DOCUMENTATION_URL} target="_blank noreferrer">Learn more</a>
 		</div>
 		{#if $imageURL}
 			<img

--- a/projects/plugins/boost/changelog/boost-fix-image-guide-containers
+++ b/projects/plugins/boost/changelog/boost-fix-image-guide-containers
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Added Image Guide Improvements
+
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Update the image guide component to be positioned correctly within the DOM tree and to prevent it from being obscured by other elements with a higher z-index
* Fixed typos
* Added image resizing library detection

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
pc9hqz-1sC-p2#comment-1074

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Build and install the plugin