### PR TITLE
Beta: update admin menu to use parent Jetpack menu

### DIFF
--- a/projects/plugins/beta/changelog/update-beta-menu
+++ b/projects/plugins/beta/changelog/update-beta-menu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Admin menu: ensure that the Jetpack Beta menu always lives under the main Jetpack menu.

--- a/projects/plugins/beta/composer.json
+++ b/projects/plugins/beta/composer.json
@@ -8,6 +8,7 @@
 		"issues": "https://github.com/Automattic/jetpack/issues"
 	},
 	"require": {
+		"automattic/jetpack-admin-ui": "@dev",
 		"automattic/jetpack-autoloader": "@dev",
 		"composer/semver": "3.3.2",
 		"erusev/parsedown": "1.7.4"

--- a/projects/plugins/beta/composer.lock
+++ b/projects/plugins/beta/composer.lock
@@ -4,8 +4,66 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b04e1bb56a46b33246b7d8fa5973cab9",
+    "content-hash": "92efc2ebd18c5e82b5a0160a2e03169a",
     "packages": [
+        {
+            "name": "automattic/jetpack-admin-ui",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/admin-ui",
+                "reference": "9405b138a2b173706dd3f977c71ca2ea55e3710b"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/wordbless": "dev-master",
+                "yoast/phpunit-polyfills": "1.0.4"
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-admin-ui",
+                "textdomain": "jetpack-admin-ui",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.2.x-dev"
+                },
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-admin-menu.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "post-install-cmd": [
+                    "WorDBless\\Composer\\InstallDropin::copy"
+                ],
+                "post-update-cmd": [
+                    "WorDBless\\Composer\\InstallDropin::copy"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Generic Jetpack wp-admin UI elements",
+            "transport-options": {
+                "relative": true
+            }
+        },
         {
             "name": "automattic/jetpack-autoloader",
             "version": "dev-trunk",
@@ -1031,6 +1089,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "automattic/jetpack-admin-ui": 20,
         "automattic/jetpack-autoloader": 20,
         "automattic/jetpack-changelogger": 20
     },

--- a/projects/plugins/beta/src/class-admin.php
+++ b/projects/plugins/beta/src/class-admin.php
@@ -7,7 +7,7 @@
 
 namespace Automattic\JetpackBeta;
 
-use Jetpack;
+use Automattic\Jetpack\Admin_UI\Admin_Menu;
 
 /**
  * Handles the Jetpack Beta plugin Admin functions.
@@ -36,24 +36,13 @@ class Admin {
 	 * Action for `admin_menu` and `network_admin_menu`.
 	 */
 	public static function add_actions() {
-		if ( class_exists( Jetpack::class ) ) {
-			self::$hookname = add_submenu_page(
-				'jetpack',
-				'Jetpack Beta',
-				'Jetpack Beta',
-				'update_plugins',
-				'jetpack-beta',
-				array( self::class, 'render' )
-			);
-		} else {
-			self::$hookname = add_menu_page(
-				'Jetpack Beta',
-				'Jetpack Beta',
-				'update_plugins',
-				'jetpack-beta',
-				array( self::class, 'render' )
-			);
-		}
+		self::$hookname = Admin_Menu::add_menu(
+			'Jetpack Beta',
+			'Jetpack Beta',
+			'update_plugins',
+			'jetpack-beta',
+			array( self::class, 'render' )
+		);
 
 		if ( false !== self::$hookname ) {
 			add_action( 'load-' . self::$hookname, array( self::class, 'admin_page_load' ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Until now, the Jetpack Beta plugin used its own menu implementation: it would declare a new "Jetpack Beta" top-level admin menu, or would move in the Jetpack menu if the Jetpack plugin was installed.

Since we've since developed the Admin UI package, we should now be able to have Jetpack Beta use that package and always be under the Jetpack menu.

This has the benefit of always having the Jetpack menu items in the same spot. It also makes things easier when you use Jetpack Beta with another Jetpack standalone plugin like Jetpack Boost. Until now, in that case you had 2 top-level menus: Jetpack (for Boost) and Jetpack Beta (for the beta plugin). Now it's only going to be the one "Jetpack" menu.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:

* Start with a site that only has the Jetpack Beta plugin, and nothing else. You should see a "Jetpack" top menu item, and a Jetpack Beta submenu.
* Install the Boost plugin. The one "Jetpack" top menu item should remain, with the Jetpack Beta and the Boost submenus.
* Install the Jetpack plugin, and see the same submenus remain, plus the Jetpack plugin ones.
