### PR TITLE
tests: Update PHP 8.1 test runs

### DIFF
--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -24,28 +24,31 @@ foreach ( file( '.github/versions.sh' ) as $line ) {
 // Default matrix variables. See inline for docs.
 $default_matrix_vars = array(
 	// {string} Name for the job. Required, and must be unique.
-	'name'         => null,
+	'name'                => null,
 
 	// {string} Composer script for the job. Required.
-	'script'       => null,
+	'script'              => null,
 
 	// {string} PHP version to use.
-	'php'          => $versions['PHP_VERSION'],
+	'php'                 => $versions['PHP_VERSION'],
 
 	// {string} Node version to use.
-	'node'         => $versions['NODE_VERSION'],
+	'node'                => $versions['NODE_VERSION'],
 
 	// {string} WordPress version to check out: 'latest', 'previous', 'trunk', or 'none'.
-	'wp'           => 'none',
+	'wp'                  => 'none',
 
-	// {bool} Whether the check is experimental, i.e. it won't make the workflow fail.
-	'experimental' => false,
+	// {bool} Whether the check is experimental, i.e. it won't make the workflow fail. Don't set this when the job is required!
+	'experimental'        => false,
+
+	// {bool} Whether to force package tests to run. Normally they only run when 'wp' is 'latest' or 'none'.
+	'force-package-tests' => false,
 
 	// {int} Job timeout in minutes.
-	'timeout'      => 10,
+	'timeout'             => 10,
 
 	// {string} A valid artifact name for any generated artifacts. If not given, will be derived from the name.
-	'artifact'     => null,
+	'artifact'            => null,
 );
 
 // Matrix definitions. Each will be combined with `$default_matrix_vars` later in processing.
@@ -63,23 +66,24 @@ foreach ( array( '5.6', '7.0', '7.2', '7.3', '7.4', '8.0' ) as $php ) {
 }
 // Merge this into the above once we decide PHP 8.1 is stable and WP latest works with 8.1.
 $matrix[] = array(
-	'name'         => 'PHP tests: PHP 8.1 WP trunk',
-	'script'       => 'test-php',
-	'php'          => '8.1',
-	'wp'           => 'trunk',
-	'timeout'      => 15,
-	'experimental' => true,
+	'name'                => 'PHP tests: PHP 8.1 WP trunk',
+	'script'              => 'test-php',
+	'php'                 => '8.1',
+	'wp'                  => 'trunk',
+	'timeout'             => 20, // 2022-12-19: The WorDBless WP version bump adds up to ~30s extra per project using it, which adds up.
+	'force-package-tests' => true,
 );
 // Uncomment this once WP trunk finally works with 8.2. Then merge into the above once WP latest does and we've cleaned up any problems in our own code.
 // phpcs:ignore Squiz.PHP.CommentedOutCode.Found, Squiz.Commenting.BlockComment.NoEmptyLineBefore
 /*
 $matrix[] = array(
-	'name'         => 'PHP tests: PHP 8.2 WP trunk',
-	'script'       => 'test-php',
-	'php'          => '8.2',
-	'wp'           => 'trunk',
-	'timeout'      => 15,
-	'experimental' => true,
+	'name'                => 'PHP tests: PHP 8.2 WP trunk',
+	'script'              => 'test-php',
+	'php'                 => '8.2',
+	'wp'                  => 'trunk',
+	'timeout'             => 20, // 2022-12-19: The WorDBless WP version bump adds up to ~30s extra per project using it, which adds up.
+	'force-package-tests' => true,
+	'experimental'        => true,
 );
 */
 foreach ( array( 'previous', 'trunk' ) as $wp ) {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -170,6 +170,11 @@ jobs:
                 FAIL=true
                 EXIT=1
               fi
+
+              # Actions seems to slow down if there are a lot of files, so clean up Composer stuff after each test.
+              # We don't do it for JS stuff, as that might break things with how JS does package deps.
+              rm -rf "$DIR/vendor" "$DIR/jetpack_vendor" "$DIR/wordpress"
+
               echo "::endgroup::"
               $FAIL && echo "::error::Tests for $SLUG failed!"
             fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,6 +94,12 @@ jobs:
           FORCE_PACKAGE_TESTS: ${{ matrix.force-package-tests && 'true' || 'false' }}
           CHANGED: ${{ steps.changed.outputs.projects }}
         run: |
+          # If we're going to be making WorDBless use WP "nightlies", remove the relevant package from Composer's cache to get the latest version.
+          if [[ "$WP_BRANCH" == 'trunk' && ( "$TEST_SCRIPT" == "test-php" || "$TEST_SCRIPT" == "test-coverage" ) ]]; then
+            DIR=$(composer config cache-files-dir)
+            rm -rf "$DIR/roots/wordpress"
+          fi
+
           EXIT=0
           mkdir artifacts
           [[ "$TEST_SCRIPT" == "test-coverage" ]] && mkdir coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Run project tests
         env:
-          EXPERIMENTAL: ${{ matrix.experimental && 'true' || 'false' }}
+          FORCE_PACKAGE_TESTS: ${{ matrix.force-package-tests && 'true' || 'false' }}
           CHANGED: ${{ steps.changed.outputs.projects }}
         run: |
           EXIT=0
@@ -111,7 +111,7 @@ jobs:
               if [[ "$WP_BRANCH" != 'none' ]]; then
                 DIR="/tmp/wordpress-$WP_BRANCH/src/wp-content/$SLUG"
               fi
-            elif [[ "$WP_BRANCH" != 'latest' && "$WP_BRANCH" != 'none' && "$EXPERIMENTAL" != "true" ]]; then
+            elif [[ "$WP_BRANCH" != 'latest' && "$WP_BRANCH" != 'none' && "$FORCE_PACKAGE_TESTS" != "true" ]]; then
               echo "Skipping $SLUG, only plugins run for WP_BRANCH = $WP_BRANCH"
               continue
             fi
@@ -153,6 +153,8 @@ jobs:
                 VER=$(composer --format=json --working-dir="$DIR" show | jq -r '.installed[] | select( .name == "roots/wordpress" ) | .version')
                 if [[ -n "$VER" ]]; then
                   echo 'Supposed to run tests against WordPress trunk, so upgrading roots/wordpress to dev-nightly'
+                  # Composer seems to sometimes have issues with deleting the wordpress dir on its own, so do it manually first.
+                  rm -rf "$DIR/wordpress"
                   composer --working-dir="$DIR" require --dev roots/wordpress="dev-nightly as $VER"
                 fi
               fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
A few things need some cleaning up:

* We don't want to set the "experimental" flag when the test is required, so add a new "force-package-tests" flag to indicate that the package tests needs to be run despite 'wp' being 'trunk'.
* Bump the time limit, we're seeing slowness.
* Delete the `wordpress/` dir before the `composer update` that has WorDBless use the WP nightly, Composer seems to sometimes be unhappy about the deletion.
* Actions seems to slow down if there are a lot of files, so clean up Composer stuff after each test.
* Always download latest roots/wordpress version for trunk runs.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1671459250142409-slack-C01U2KGS2PQ

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is the PHP 8.1 job still running the package tests?
* The rest of the changes are hard to really test, it depends on stuff out of our direct control...