### PR TITLE
Admin Page: avoid blank connection screen

### DIFF
--- a/projects/js-packages/licensing/changelog/fix-blank-connect-page
+++ b/projects/js-packages/licensing/changelog/fix-blank-connect-page
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Connection: avoid blank connection screen.
+
+

--- a/projects/js-packages/licensing/components/activation-screen/index.jsx
+++ b/projects/js-packages/licensing/components/activation-screen/index.jsx
@@ -68,6 +68,12 @@ const ActivationScreen = props => {
 	const [ activatedProduct, setActivatedProduct ] = useState( null );
 
 	useEffect( () => {
+		const { apiRoot, apiNonce } = window?.myJetpackRest || {};
+		restApi.setApiRoot( apiRoot );
+		restApi.setApiNonce( apiNonce );
+	}, [] );
+
+	useEffect( () => {
 		if ( availableLicenses && availableLicenses[ 0 ] ) {
 			setLicense( availableLicenses[ 0 ].license_key );
 		}

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.7.0",
+	"version": "0.7.1-alpha",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {

--- a/projects/packages/videopress/changelog/fix-blank-connect-page
+++ b/projects/packages/videopress/changelog/fix-blank-connect-page
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Update versions
-
-

--- a/projects/packages/videopress/changelog/fix-blank-connect-page
+++ b/projects/packages/videopress/changelog/fix-blank-connect-page
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Update versions
+
+

--- a/projects/packages/videopress/changelog/fix-blank-connect-page
+++ b/projects/packages/videopress/changelog/fix-blank-connect-page
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update versiony
+
+

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.9.1",
+	"version": "0.9.2-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.9.2-alpha",
+	"version": "0.9.1",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.9.1';
+	const PACKAGE_VERSION = '0.9.2-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.9.2-alpha';
+	const PACKAGE_VERSION = '0.9.1';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -68,10 +68,7 @@ import {
 	isWooCommerceActive,
 } from 'state/initial-state';
 import {
-	getDetachedLicenses as getAvailableLicenses,
-	getDetachedLicensesLoadingInfo as getFetchingAvailableLicense,
 	updateLicensingActivationNoticeDismiss as updateLicensingActivationNoticeDismissAction,
-	updateUserLicenses as updateUserLicensesAction,
 	updateUserLicensesCounts as updateUserLicensesCountsAction,
 } from 'state/licensing';
 import { fetchModules as fetchModulesAction } from 'state/modules';
@@ -169,9 +166,6 @@ class Main extends React.Component {
 				state: { previousPath: this.props.location.pathname },
 			} );
 		}
-
-		// Loads current user licenses
-		this.props.updateUserLicenses();
 	}
 
 	/*
@@ -481,12 +475,10 @@ class Main extends React.Component {
 					navComponent = null;
 					pageComponent = (
 						<ActivationScreen
-							availableLicenses={ this.props.availableLicenses }
-							currentRecommendationsStep={ this.props.currentRecommendationsStep }
-							fetchingAvailableLicenses={ this.props.fetchingAvailableLicenses }
 							siteRawUrl={ this.props.siteRawUrl }
 							onActivationSuccess={ this.onLicenseActivationSuccess }
 							siteAdminUrl={ this.props.siteAdminUrl }
+							currentRecommendationsStep={ this.props.currentRecommendationsStep }
 						/>
 					);
 				} else {
@@ -792,8 +784,6 @@ export default connect(
 			hasSeenWCConnectionModal: getHasSeenWCConnectionModal( state ),
 			partnerCoupon: getPartnerCoupon( state ),
 			currentRecommendationsStep: getInitialRecommendationsStep( state ),
-			availableLicenses: getAvailableLicenses( state ),
-			fetchingAvailableLicenses: getFetchingAvailableLicense( state ),
 		};
 	},
 	dispatch => ( {
@@ -808,9 +798,6 @@ export default connect(
 		},
 		resetConnectUser: () => {
 			return dispatch( resetConnectUser() );
-		},
-		updateUserLicenses: () => {
-			return dispatch( updateUserLicensesAction() );
 		},
 		updateLicensingActivationNoticeDismiss: () => {
 			return dispatch( updateLicensingActivationNoticeDismissAction() );

--- a/projects/plugins/jetpack/changelog/fix-blank-connect-page
+++ b/projects/plugins/jetpack/changelog/fix-blank-connect-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Admin page: avoid blank connection screen.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Revert "Jetpack plugin: Activate license key dropdown selection in Jetpack plugin's activation page. (#27974)"

This reverts commit 823886c.
See discussion in p1671462760334689-slack-CBG1CP4EN

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion

* See discussion in p1671462760334689-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

To reproduce, your site needs to be disconected from Jetpack, and you can then try to go to the connection screen again.

For example:

* Site running bleeding edge, connected to jetpack
* disconnect
* reconnect, but don’t finish the wpcom connection
* visit dash

