### PR TITLE
Admin page: avoid warning when disconnecting Jetpack

### DIFF
--- a/projects/js-packages/connection/changelog/fix-warning-disconnect
+++ b/projects/js-packages/connection/changelog/fix-warning-disconnect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid warnings when disconnecting a site from WordPress.com.

--- a/projects/js-packages/connection/components/disconnect-dialog/index.jsx
+++ b/projects/js-packages/connection/components/disconnect-dialog/index.jsx
@@ -223,7 +223,7 @@ const DisconnectDialog = props => {
 	 * Need to have the ID of the connected user and the ID of the connected site.
 	 */
 	const canProvideFeedback = useCallback( () => {
-		return connectedUser.ID && connectedSiteId;
+		return !! ( connectedUser.ID && connectedSiteId );
 	}, [ connectedUser, connectedSiteId ] );
 
 	/**

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.24.2",
+	"version": "0.24.3-alpha",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* When disconnecting a site from WordPress.com, you may get the following warning:

```
Warning: Failed prop type: Invalid prop `canProvideFeedback` of type `number` supplied to `StepDisconnectConfirm`, expected `boolean`.
```

This should fix that warning.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:

* Start from a site that's connected to WordPress.com.
* go to Jetpack > Dashboard
* Open your browser dev tools
* Scroll down, click on the "Manage connection" link to open the disconnect modal
* Click to disconnect your site from WordPress.com.
* You should not see the error I mentioned above.
