### PR TITLE
Init 11.7-a.8 plus changelogs

### DIFF
--- a/projects/js-packages/licensing/CHANGELOG.md
+++ b/projects/js-packages/licensing/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.1 - 2022-12-19
+### Changed
+- Updated package dependencies.
+
 ## 0.7.0 - 2022-12-19
 ### Added
 - Add license key selector in My Jetpack activation screen. [#27609]

--- a/projects/js-packages/licensing/changelog/fix-blank-connect-page
+++ b/projects/js-packages/licensing/changelog/fix-blank-connect-page
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Connection: avoid blank connection screen.
-
-

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.7.1-alpha",
+	"version": "0.7.1",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2022-12-19
+### Changed
+- VideoPress: filter the video fields that re-renders the player when changed. [#27862]
+
 ## [0.9.1] - 2022-12-19
 ### Changed
 - Updated package dependencies. [#27887, #27888, #27916]
@@ -548,6 +552,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.9.2]: https://github.com/Automattic/jetpack-videopress/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/Automattic/jetpack-videopress/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/Automattic/jetpack-videopress/compare/v0.8.4...v0.9.0
 [0.8.4]: https://github.com/Automattic/jetpack-videopress/compare/v0.8.3...v0.8.4

--- a/projects/packages/videopress/changelog/fix-blank-connect-page
+++ b/projects/packages/videopress/changelog/fix-blank-connect-page
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update versiony
-
-

--- a/projects/packages/videopress/changelog/update-videopress-check-whick-attrs-re-renders-player
+++ b/projects/packages/videopress/changelog/update-videopress-check-whick-attrs-re-renders-player
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-VideoPress: filter the video fields that re-renders the player when change

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.9.2-alpha",
+	"version": "0.9.2",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.9.2-alpha';
+	const PACKAGE_VERSION = '0.9.2';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 11.7-a.7 - 2022-12-19
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Admin page: avoid blank connection screen. [#28001]
+- Updating changelog and readme entries for 11.7-a.5 [#28000]
+
 ## 11.7-a.5 - 2022-12-19
 ### Enhancements
 - Assistant: update Akismet and Backup names. [#27844]

--- a/projects/plugins/jetpack/changelog/fix-blank-connect-page
+++ b/projects/plugins/jetpack/changelog/fix-blank-connect-page
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Admin page: avoid blank connection screen.

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 11.7-a.6
-
-

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 11.7-a.8
+
+

--- a/projects/plugins/jetpack/changelog/update-clean-jetpack-11.7-a.5.-readme
+++ b/projects/plugins/jetpack/changelog/update-clean-jetpack-11.7-a.5.-readme
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updating changelog and readme entries for 11.7-a.5

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ11_7_a_6",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ11_7_a_7",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ11_7_a_7",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ11_7_a_8",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 11.7-a.7
+ * Version: 11.7-a.8
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -32,7 +32,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.0' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '11.7-a.7' );
+define( 'JETPACK__VERSION', '11.7-a.8' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 11.7-a.6
+ * Version: 11.7-a.7
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -32,7 +32,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.0' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '11.7-a.6' );
+define( 'JETPACK__VERSION', '11.7-a.7' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "11.7.0-a.7",
+	"version": "11.7.0-a.8",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "11.7.0-a.6",
+	"version": "11.7.0-a.7",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Init Jetpack 11.7-a.8 cycle (plus changelogs)

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion

n/a

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Proof-read - mainly checking for blank entries - main Jetpack changelog editorial PR to come later.

