### PR TITLE
Jetpack 11.7-a.7: Updating Jetpack's changelog and readme 

### DIFF
--- a/projects/packages/videopress/changelog/update-clean-jetpack-11.7-a.7-readme
+++ b/projects/packages/videopress/changelog/update-clean-jetpack-11.7-a.7-readme
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependency.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.9.2",
+	"version": "0.9.3-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.9.2';
+	const PACKAGE_VERSION = '0.9.3-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -3,9 +3,48 @@
 ### This is a list detailing changes for all Jetpack releases.
 
 ## 11.7-a.7 - 2022-12-19
+### Enhancements
+- Assistant: update Akismet and Backup names. [#27844]
+- Block editor: add a new panel that gives the ability to promote posts after publishing them. [#27928]
+- Dashboard: hide agencies module on Jetpack dashboard if site is WoA. [#27966]
+- Dashboard: update Backup, Anti-spam, and VideoPress logos. [#27847]
+- Form block: allow the required field text to be changed. [#27913]
+- Form block: update the default labels logic to allow fields without any label. [#27628]
+- Form block: update block placeholder styles and update form fields styles to comply with WYSIWYG. [#27855, #27967]
+- Google fonts: add new fonts to Global Style options. [#27441]
+- Slideshow block: implement pagination styles when a gallery has more than five images. [#27936]
+- Slideshow block: update block description. [#27899]
+- Writing prompts: add context to blogging prompt placeholder. [#27895]
+
+### Improved compatibility
+- Launchpad: Sync Launchpad-related options: `launchpad_screen` and `launchpad_checklist_tasks_statuses`. [#27843]
+- Styling: Replaced custom maybe_inline_style() with wp_maybe_inline_styles() which is available in WP core since 5.8.0. [#27965, #27983]
+- Writing prompts: hide placeholder prompts by default. [#27919]
+
+### Bug fixes
+- Dashboard: add translation context to Security product name. [#27920]
+- Form block: fix email formatting for contact form submissions. [#27929]
+- General: Fix deprecation warnings when running with PHP 8.2. [#27968]
+- Hovercards: fix minor Hovercards & AMP compatibility bug [#27828]
+- Subscription block: fix PHP Warning. [#27884]
+- WAF: fix the initialization of the firewall. [#27846]
+
 ### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
 - Admin page: avoid blank connection screen. [#28001]
-- Updating changelog and readme entries for 11.7-a.5 [#28000]
+- Blocks: add missing Jetpack config external, and enqueue connection data in post editor, to be used by blocks. [#27978, #27937]
+- Contact form: add export to Google Drive feature on form responses table. [#27690]
+- E2E tests: add a new tests for Form block. [#27933]
+- Extensions: use isCurrentUserConnected from package instead of from internally shared function. [#27924]
+- Options: Update featured_image_email_enabled option name to wpcom_featured_image_in_email. [#27955]
+- Options: Added new site option of 'wpcom-subscription-emails-use-excerpt'. [#27908]
+- PayPal block: improve stability of Pay with Paypal test. [#27951]
+- Slideshow block: change the labels for Image Size and Transition Effect options. [#27898]
+- Slideshow block: change the arrow's style to match the gallery current style. [#27907]
+- Stats: fix stats chart in masterbar when new experience is turned on. [#27825]
+- Stats Admin: update dependencies. [#27948]
+- Tools: remove dead static-site-generator-webpack-plugin dep, copy a cleaned-up version into the repo. [#27889]
+- Updated package dependencies. [#27874, #27887, #27916]
+- Updating changelog entries. [#27886, #28000]
 
 ## 11.7-a.5 - 2022-12-19
 ### Enhancements

--- a/projects/plugins/jetpack/changelog/update-clean-jetpack-11.7-a.7-readme
+++ b/projects/plugins/jetpack/changelog/update-clean-jetpack-11.7-a.7-readme
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updating changelog entries

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -242,24 +242,23 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 4. Promote your newest posts, pages, and products across your social media channels.
 
 == Changelog ==
-### 11.7-a.5 - 2022-12-19
+### 11.7-a.7 - 2022-12-19
 #### Enhancements
 - Assistant: update Akismet and Backup names.
 - Block editor: add a new panel that gives the ability to promote posts after publishing them.
-- Dashboard: activate license key dropdown selector in the main Jetpack dashboard licenses activation page.
 - Dashboard: hide agencies module on Jetpack dashboard if site is WoA.
 - Dashboard: update Backup, Anti-spam, and VideoPress logos.
 - Form block: allow the required field text to be changed.
 - Form block: update the default labels logic to allow fields without any label.
 - Form block: update block placeholder styles and update form fields styles to comply with WYSIWYG. [#27855, #27967]
 - Google fonts: add new fonts to Global Style options.
-- Slideshow block: implement pagination numbers with more than 5 images.
+- Slideshow block: implement pagination styles when a gallery has more than five images.
 - Slideshow block: update block description.
 - Writing prompts: add context to blogging prompt placeholder.
 
 #### Improved compatibility
 - Launchpad: Sync Launchpad-related options: `launchpad_screen` and `launchpad_checklist_tasks_statuses`.
-- Styling: Removed custom maybe_inline_style() with wp_maybe_inline_styles() which is available in WP core since 5.8.0. [#27965, #27983]
+- Styling: Replaced custom maybe_inline_style() with wp_maybe_inline_styles() which is available in WP core since 5.8.0. [#27965, #27983]
 - Writing prompts: hide placeholder prompts by default.
 
 #### Bug fixes


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Cleaning up the Jetpack plugin changelog and readme - adding in the changes in the 11.7-a.5 readme / changelog too.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* This editorial combines the previously edited changelog here - https://github.com/Automattic/jetpack/pull/28000 into the 11.7-a.7 entry. Entries should be ok but just needs double checking.
* This PR also includes a VideoPress package version bump as a package change had been merged since the init PR.

