### PR TITLE
jetpack: Remove workaround for WP Core ticket 57341

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-workaround-for-core-tickt-57341
+++ b/projects/plugins/jetpack/changelog/remove-workaround-for-core-tickt-57341
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Remove testing workaround for https://core.trac.wordpress.org/ticket/57341. No change to the plugin itself.
+
+

--- a/projects/plugins/jetpack/tests/php/bootstrap.php
+++ b/projects/plugins/jetpack/tests/php/bootstrap.php
@@ -145,12 +145,6 @@ require $test_root . '/includes/bootstrap.php';
 // @todo Remove this once we drop support for WordPress 6.1
 define( 'REQUESTS_SILENCE_PSR0_DEPRECATIONS', true );
 
-// Work around https://core.trac.wordpress.org/ticket/57341
-// Remove this once that's fixed.
-if ( ! class_exists( 'Requests' ) ) {
-	require ABSPATH . WPINC . '/class-requests.php';
-}
-
 // Load the shortcodes module to test properly.
 if ( ! function_exists( 'shortcode_new_to_old_params' ) && ! in_running_uninstall_group() ) {
 	require __DIR__ . '/../../modules/shortcodes.php';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We added a workaround for a Core issue that was causing our trunk tests to fail. That core issue has now been resolved.

See https://core.trac.wordpress.org/ticket/57341

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Related to #27981

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?
