### PR TITLE
Contact Form: Adjust Form placeholder footer links styles

### DIFF
--- a/projects/plugins/jetpack/changelog/update-form-footer-links
+++ b/projects/plugins/jetpack/changelog/update-form-footer-links
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Adjust Form placeholder footer links style

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/edit.js
@@ -10,7 +10,6 @@ import { createBlock, registerBlockVariation } from '@wordpress/blocks';
 import {
 	BaseControl,
 	Button,
-	ExternalLink,
 	Modal,
 	PanelBody,
 	SelectControl,
@@ -206,15 +205,22 @@ export function JetpackContactFormEdit( {
 						{ __( 'Explore Form Patterns', 'jetpack' ) }
 					</Button>
 					<div className="form-placeholder__footer-links">
-						<ExternalLink
+						<Button
+							variant="link"
 							className="form-placeholder__external-link"
 							href={ CUSTOMIZING_FORMS_URL }
+							target="_blank"
 						>
-							{ __( 'Learn more about customizing forms.', 'jetpack' ) }
-						</ExternalLink>
-						<ExternalLink className="form-placeholder__external-link" href={ RESPONSES_PATH }>
-							{ __( 'View and export your form responses here.', 'jetpack' ) }
-						</ExternalLink>
+							{ __( 'Learn more about customizing forms', 'jetpack' ) }
+						</Button>
+						<Button
+							variant="link"
+							className="form-placeholder__external-link"
+							href={ RESPONSES_PATH }
+							target="_blank"
+						>
+							{ __( 'View and export your form responses here', 'jetpack' ) }
+						</Button>
 					</div>
 				</div>
 				{ isPatternsModalOpen && (

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
@@ -134,6 +134,7 @@
 	}
 
 	.form-placeholder__footer-links {
+		font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,sans-serif;
 		display: flex;
 		flex-direction: column;
 		align-items: center;
@@ -145,6 +146,12 @@
 
 	.form-placeholder__external-link {
 		font-size: 13px;
+		padding: 0;
+
+		&:hover, &:active, &:focus {
+			background-color: unset;
+			color: var(--wp-admin-theme-color)
+		}
 
 		svg {
 			width: 1.4em;


### PR DESCRIPTION
Fixes #27984

#### Changes proposed in this Pull Request:
* Changes the Form block placeholder links to prevent unwanted changes from Themes. #27984 for more context

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Create a post and add a Form block
* Check if the placeholder footer links styles match the discussion above

