### PR TITLE
Boost: Fix regenerate admin notice

### DIFF
--- a/projects/plugins/boost/app/admin/class-admin.php
+++ b/projects/plugins/boost/app/admin/class-admin.php
@@ -61,9 +61,6 @@ class Admin {
 
 		// Set up Super Cache info system if WP Super Cache available.
 		Super_Cache_Info::init();
-
-		// Admin Notices
-		Regenerate_Admin_Notice::init();
 	}
 
 	public function handle_admin_menu() {

--- a/projects/plugins/boost/app/features/optimizations/critical-css/Critical_CSS.php
+++ b/projects/plugins/boost/app/features/optimizations/critical-css/Critical_CSS.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\Jetpack_Boost\Features\Optimizations\Critical_CSS;
 
+use Automattic\Jetpack_Boost\Admin\Regenerate_Admin_Notice;
 use Automattic\Jetpack_Boost\Contracts\Feature;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Admin_Bar_Compatibility;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Invalidator;
@@ -67,6 +68,10 @@ class Critical_CSS implements Feature, Has_Endpoints {
 		add_filter( 'jetpack_boost_js_constants', array( $this, 'add_critical_css_constants' ) );
 
 		REST_API::register( $this->get_endpoints() );
+
+		// Admin Notices
+		Regenerate_Admin_Notice::init();
+
 		return true;
 	}
 

--- a/projects/plugins/boost/changelog/fix-regenerate-notice
+++ b/projects/plugins/boost/changelog/fix-regenerate-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed an issue where notice to regenerate critical CSS were showing unnecessarily


### PR DESCRIPTION
Fixes #27393

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Show regenerate notice only when critical CSS module is enabled

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
None

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Keep critical CSS disabled and swap the theme. Make sure the notice doesn't appear
* Upgrade Boost and swap theme. Make sure the notice doesn't appear.

