### PR TITLE
Licensing: Fix issue in activate license key button not working.

### DIFF
--- a/projects/js-packages/licensing/changelog/fix-activation-page-error-message
+++ b/projects/js-packages/licensing/changelog/fix-activation-page-error-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix issue with activation screen failing to activate due to incorrect JP Rest API root and nonce value.

--- a/projects/js-packages/licensing/components/activation-screen/index.jsx
+++ b/projects/js-packages/licensing/components/activation-screen/index.jsx
@@ -68,12 +68,6 @@ const ActivationScreen = props => {
 	const [ activatedProduct, setActivatedProduct ] = useState( null );
 
 	useEffect( () => {
-		const { apiRoot, apiNonce } = window?.myJetpackRest || {};
-		restApi.setApiRoot( apiRoot );
-		restApi.setApiNonce( apiNonce );
-	}, [] );
-
-	useEffect( () => {
 		if ( availableLicenses && availableLicenses[ 0 ] ) {
 			setLicense( availableLicenses[ 0 ].license_key );
 		}

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.7.1",
+	"version": "0.7.2-alpha",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {


### PR DESCRIPTION
This is a follow up PR to https://github.com/Automattic/jetpack/pull/27609. This is supposedly part of the follow up PR #27974  but due to a bug it was reverted. 

This PR only fixes the issue in the activation screen (`wp-admin/admin.php?page=jetpack#/license/activation`) which no longer works due to incorrect Jetpack REST API root and nonce value. This does not enable the selector in this particular activation screen _(will be tackled in a separate PR)_

<img width="1137" alt="Screen Shot 2022-12-20 at 4 43 19 PM" src="https://user-images.githubusercontent.com/56598660/208622879-347379d8-968b-4f29-a519-ac8afd58639d.png">


#### Changes proposed in this Pull Request:
* Remove `useEffect` that sets Jetpack REST API root and nonce in Activation screen.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
Context: 1202858161751496-as-1201858908716176

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
  1. Goto https://cloud.jetpack.com/pricing and purchase a product or two. (Make sure you do not activate the license key)
  2. Launch a test site that uses a build of the Jetpack plugin based on this branch (Make sure you build the Licensing js package, My Jetpack package and Jetpack plugin)
  3. Connect your site to Jetpack, if it's not already
  4. Go to Jetpack dashboard, click the **Activate your product license** now button.
  <img width="2550" alt="208045713-62eb8032-0cd7-4705-bef7-a207988a2e7c" src="https://user-images.githubusercontent.com/56598660/208623288-8bd0be95-54ea-4f41-ad62-eb5a2b5f917e.png">
  
  5. In the activation screen (`wp-admin/admin.php?page=jetpack#/license/activation`), input a valid or invalid license key and press **activate** button.
<img width="1096" alt="Screen Shot 2022-12-20 at 4 56 08 PM" src="https://user-images.githubusercontent.com/56598660/208625804-fd201b54-5602-4e04-8c01-a09b992948df.png">

  6. Confirm that the **activate** button works for both valid or invalid keys.
<img width="1099" alt="Screen Shot 2022-12-20 at 4 56 24 PM" src="https://user-images.githubusercontent.com/56598660/208626223-5e058a53-6469-4a9b-b54a-d7132fcc1d3e.png">
<img width="1109" alt="Screen Shot 2022-12-20 at 5 01 21 PM" src="https://user-images.githubusercontent.com/56598660/208626524-5acd598c-39fd-4041-8fbd-49ac5177e00e.png">

  7. Additionally make sure that the **My Jetpack activation page** `my-jetpack#/add-license` also works correctly.

