### PR TITLE
Blogging Prompts: Don't display within app webviews

### DIFF
--- a/projects/plugins/jetpack/changelog/update-dont-display-prompts-in-app
+++ b/projects/plugins/jetpack/changelog/update-dont-display-prompts-in-app
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Blogging Prompts: Don't display within mobile app

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompts/blogging-prompts.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompts/blogging-prompts.php
@@ -10,6 +10,7 @@
 namespace Automattic\Jetpack\Extensions\BloggingPrompts;
 
 use Automattic\Jetpack\Blocks;
+use Automattic\Jetpack\Device_Detection\User_Agent_Info;
 
 require_once __DIR__ . '/settings.php';
 
@@ -35,6 +36,11 @@ function register_extension() {
 function inject_blogging_prompts() {
 	// Return early if we are not in the block editor.
 	if ( ! wp_should_load_block_editor_scripts_and_styles() ) {
+		return;
+	}
+
+	// Or if the editor's loading in a webview within the mobile app.
+	if ( User_Agent_Info::is_mobile_app() ) {
 		return;
 	}
 


### PR DESCRIPTION
If a block is unsupported in the mobile app, a user can still edit it via a web view (known as the "Unsupported Block Editor" or "UBE"). Since the introduction of the blogging/writing prompts on WordPress.com, the block no longer loads within the UBE. The prompts display instead.

You can see an example of how this looks here:

<img src="https://user-images.githubusercontent.com/2998162/208720610-2fec14c0-c5fb-4725-b601-c434830d415a.png" width="40%">

This PR fixes that issue by preventing the prompts from displaying if it's detected that the editor is loading from the mobile app.

#### Changes proposed in this Pull Request:

* This PR uses [the `is_mobile_app` function](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/device-detection/src/class-user-agent-info.php#L1434-L1459) from [the device-detection package](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/device-detection) to detect whether the mobile app in use. If the function returns `true`, then blogging prompts will not be added to the editor.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion

p1671538462755229-slack-C0126N6JH7Z

#### Does this pull request change what data or activity we track or use?

No, it does not.

#### Testing instructions:

* In a web browser and on a simple WordPress.com site, create a blog post and add a block that isn't supported in the app. Examples of unsupported blocks at the time of writing include Tag Cloud or Archives. Save the post.
* Navigate to the post in the iOS or Android app. 
* Tap the question mark to the unsupported block's upper right then **Edit using web editor** to bring up the UBE.
* Verify that it's possible to edit the block within the UBE.