### PR TITLE
Removing box-sizing:border-box from Base Styles

### DIFF
--- a/projects/js-packages/base-styles/changelog/fix-base-styles-box-sizing
+++ b/projects/js-packages/base-styles/changelog/fix-base-styles-box-sizing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Base styles: Removed box-sizing which caused a style issue in the customizer-themes dashboard.

--- a/projects/js-packages/base-styles/package.json
+++ b/projects/js-packages/base-styles/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-base-styles",
-	"version": "0.3.16",
+	"version": "0.3.17-alpha",
 	"description": "Jetpack components base styles",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/base-styles/#readme",
 	"bugs": {

--- a/projects/js-packages/base-styles/style.scss
+++ b/projects/js-packages/base-styles/style.scss
@@ -83,10 +83,6 @@
 /********* Generic styles *********/
 $wp-gray-dark: #23282d;
 
-* {
-	box-sizing: border-box;
-}
-
 body {
 	min-height: 100%;
 	margin: 0;


### PR DESCRIPTION
Fixes #27622

#### Changes proposed in this Pull Request:

* This PR removes the `box-sizing: border-box;` CSS which exists in `js-packages/base-styles/style.scss`. The style was added one year ago, initially via [this PR](https://github.com/Automattic/jetpack/pull/21730), but the styling side effect it caused was only spotted a few months ago when the base-styles were imported into `jetpack/extensions/index.scss` [here](https://github.com/Automattic/jetpack/pull/25852).
* The primary observable issue it caused was that theme names were cropped in the Customizer when browsing installed themes (see the linked issue).

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion

Slack: p1669287540640319-slack-CDLH4C1UZ


#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* To test without this PR applied, visit the Customizer on a site - `wp-admin/customize.php` - then click Change to change the active theme. The result should show the theme names cropped.
* Then apply this PR to a test site connected to Jetpack, and visit the same Customizer themes page. No theme names should be cropped.
* The base styles are also imported in several other places, namely connection / disconnection dialogs, IDC error messaging,  icon tooltip components, pricing card components, VideoPress chapter modals in particular. It would be worth taking a look at any of these features where possible to make sure styling hasn't been affected.

Before applying the PR:

<img width="1488" alt="Screen Shot 2022-12-20 at 4 09 40 pm" src="https://user-images.githubusercontent.com/16754605/208712959-e244c50d-99dd-4b1d-b8b2-daafb4f4faaa.png">

After applying the PR:

<img width="1479" alt="Screen Shot 2022-12-20 at 4 14 23 pm" src="https://user-images.githubusercontent.com/16754605/208713828-d7882795-1638-4f14-94ac-a6ea81f28b68.png">

