### PR TITLE
VideoPress: improve blocks building process

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1188,6 +1188,7 @@ importers:
       '@wordpress/url': 3.23.0
       autoprefixer: 10.4.12
       classnames: 2.3.1
+      copy-webpack-plugin: 11.0.0
       debug: 4.3.4
       filesize: 8.0.6
       jest: 29.3.1
@@ -1227,6 +1228,7 @@ importers:
       '@wordpress/icons': 9.13.0
       '@wordpress/url': 3.23.0
       classnames: 2.3.1
+      copy-webpack-plugin: 11.0.0_webpack@5.72.1
       debug: 4.3.4
       filesize: 8.0.6
       react: 17.0.2
@@ -3761,6 +3763,7 @@ packages:
   /@colors/colors/1.5.0:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
+    requiresBuild: true
     dev: true
 
   /@dabh/diagnostics/2.0.3:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4102,7 +4102,7 @@ packages:
       debug: 4.3.4
       espree: 9.4.1
       globals: 13.19.0
-      ignore: 5.2.1
+      ignore: 5.2.4
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       minimatch: 3.1.2
@@ -12371,7 +12371,7 @@ packages:
       globals: 13.19.0
       globby: 11.1.0
       grapheme-splitter: 1.0.4
-      ignore: 5.2.1
+      ignore: 5.2.4
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
       is-glob: 4.0.3
@@ -13463,7 +13463,7 @@ packages:
       array-union: 2.1.0
       dir-glob: 3.0.1
       fast-glob: 3.2.12
-      ignore: 5.2.1
+      ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
     dev: true
@@ -13897,6 +13897,11 @@ packages:
   /ignore/5.2.1:
     resolution: {integrity: sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==}
     engines: {node: '>= 4'}
+
+  /ignore/5.2.4:
+    resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
+    engines: {node: '>= 4'}
+    dev: true
 
   /immutable/4.1.0:
     resolution: {integrity: sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1246,7 +1246,6 @@ importers:
       '@wordpress/icons': 9.13.0
       '@wordpress/url': 3.23.0
       classnames: 2.3.1
-      copy-webpack-plugin: 11.0.0_webpack@5.72.1
       debug: 4.3.4
       filesize: 8.0.6
       react: 17.0.2
@@ -1271,6 +1270,7 @@ importers:
       '@types/wordpress__components': 19.10.0_sfoxds7t5ydpegc3knd667wn6m
       '@wordpress/browserslist-config': 5.5.0
       autoprefixer: 10.4.12_postcss@8.4.20
+      copy-webpack-plugin: 11.0.0_webpack@5.72.1
       jest: 29.3.1
       jest-environment-jsdom: 29.3.1
       postcss: 8.4.20

--- a/projects/packages/videopress/.gitattributes
+++ b/projects/packages/videopress/.gitattributes
@@ -14,4 +14,5 @@ build/**         production-include
 changelog/**      production-exclude
 phpunit.xml.dist  production-exclude
 .phpcs.dir.xml    production-exclude
+src/client/**     production-exclude
 tests/**          production-exclude

--- a/projects/packages/videopress/changelog/update-videopress-copy-blocks-def-build
+++ b/projects/packages/videopress/changelog/update-videopress-copy-blocks-def-build
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: improve blocks building process

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -80,6 +80,7 @@
 		"@wordpress/icons": "9.13.0",
 		"@wordpress/url": "3.23.0",
 		"classnames": "2.3.1",
+		"copy-webpack-plugin": "11.0.0",
 		"debug": "4.3.4",
 		"filesize": "8.0.6",
 		"react": "17.0.2",

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -52,7 +52,8 @@
 		"sass-loader": "12.4.0",
 		"typescript": "4.8.2",
 		"webpack": "5.72.1",
-		"webpack-cli": "4.9.1"
+		"webpack-cli": "4.9.1",
+		"copy-webpack-plugin": "11.0.0"
 	},
 	"engines": {
 		"node": "^16.13.2",
@@ -80,7 +81,6 @@
 		"@wordpress/icons": "9.13.0",
 		"@wordpress/url": "3.23.0",
 		"classnames": "2.3.1",
-		"copy-webpack-plugin": "11.0.0",
 		"debug": "4.3.4",
 		"filesize": "8.0.6",
 		"react": "17.0.2",

--- a/projects/packages/videopress/src/class-block-editor-extensions.php
+++ b/projects/packages/videopress/src/class-block-editor-extensions.php
@@ -67,7 +67,7 @@ class Block_Editor_Extensions {
 	public static function enqueue_extensions() {
 		self::enqueue_script();
 
-		$videopress_extensions_file        = __DIR__ . '/client/block-editor/extensions/index.json';
+		$videopress_extensions_file        = __DIR__ . '/../build/block-editor/extensions/index.json';
 		$videopress_extensions_file_exists = file_exists( $videopress_extensions_file );
 		if ( ! $videopress_extensions_file_exists ) {
 			return;

--- a/projects/packages/videopress/src/class-block-editor-extensions.php
+++ b/projects/packages/videopress/src/class-block-editor-extensions.php
@@ -49,19 +49,6 @@ class Block_Editor_Extensions {
 	}
 
 	/**
-	 * Gets the bridge script URL depending on the environment we are in
-	 *
-	 * @return string
-	 */
-	public static function get_block_editor_extensions_url() {
-		return Assets::get_file_url_for_environment(
-			'../build/block-editor/extensions/index.js', // <- production
-			'client/block-editor/extensions/index.js', // <- development
-			__FILE__
-		);
-	}
-
-	/**
 	 * Enqueues the jwt bridge script.
 	 */
 	public static function enqueue_extensions() {
@@ -110,17 +97,18 @@ class Block_Editor_Extensions {
 	 * Enqueues only the JS script
 	 *
 	 * @param string $handle The script handle to identify the script.
-	 * @return bool True if the script was successfully localized, false otherwise.
 	 */
 	public static function enqueue_script( $handle = self::SCRIPT_HANDLE ) {
-		$enqueued = wp_enqueue_script(
+		Assets::register_script(
 			$handle,
-			self::get_block_editor_extensions_url(),
-			array(),
-			Package_Version::PACKAGE_VERSION,
-			false
+			'../build/block-editor/extensions/index.js',
+			__FILE__,
+			array(
+				'in_footer'  => false,
+				'textdomain' => 'jetpack-videopress-pkg',
+			)
 		);
 
-		return $enqueued;
+		Assets::enqueue_script( $handle );
 	}
 }

--- a/projects/packages/videopress/src/class-block-editor-extensions.php
+++ b/projects/packages/videopress/src/class-block-editor-extensions.php
@@ -129,7 +129,7 @@ class Block_Editor_Extensions {
 	public static function enqueue_script( $handle = self::SCRIPT_HANDLE ) {
 		Assets::register_script(
 			$handle,
-			'../build/block-editor/extensions/index.js',
+			'../build/block-editor/index.js',
 			__FILE__,
 			array(
 				'in_footer'  => false,

--- a/projects/packages/videopress/src/class-block-editor-extensions.php
+++ b/projects/packages/videopress/src/class-block-editor-extensions.php
@@ -49,11 +49,11 @@ class Block_Editor_Extensions {
 	}
 
 	/**
-	 * Enqueues the jwt bridge script.
+	 * Return the extensions list
+	 *
+	 * @return array The extensions list.
 	 */
-	public static function enqueue_extensions() {
-		self::enqueue_script();
-
+	public static function get_list() {
 		$videopress_extensions_file        = __DIR__ . '/../build/block-editor/extensions/index.json';
 		$videopress_extensions_file_exists = file_exists( $videopress_extensions_file );
 		if ( ! $videopress_extensions_file_exists ) {
@@ -65,7 +65,7 @@ class Block_Editor_Extensions {
 			file_get_contents( $videopress_extensions_file )
 		);
 
-		$beta_extensions = array_map(
+		$extensions_list = array_map(
 			function ( $extension ) {
 				return (array) array(
 					'name'      => $extension,
@@ -75,6 +75,34 @@ class Block_Editor_Extensions {
 			},
 			$videopress_extensions_data['beta']
 		);
+
+		return $extensions_list;
+	}
+
+	/**
+	 * Check if the extension is available
+	 *
+	 * @param string $slug The extension slug.
+	 * @return boolean True if the extension is available, false otherwise.
+	 */
+	public static function is_extension_available( $slug ) {
+		$extensions_list = self::get_list();
+		foreach ( $extensions_list as $extension ) {
+			if ( $extension['name'] === $slug ) {
+				return $extension['isEnabled'];
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Enqueues the extensions script.
+	 */
+	public static function enqueue_extensions() {
+		self::enqueue_script();
+
+		$extensions_list = self::get_list();
 
 		$site_type = 'jetpack';
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -87,7 +115,7 @@ class Block_Editor_Extensions {
 			self::SCRIPT_HANDLE,
 			'videoPressEditorState',
 			array(
-				'extensions' => $beta_extensions,
+				'extensions' => $extensions_list,
 				'siteType'   => $site_type,
 			)
 		);

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -183,7 +183,7 @@ class Initializer {
 	 * @return void
 	 */
 	public static function register_videopress_video_block() {
-		$videopress_video_metadata_file        = __DIR__ . '/client/block-editor/blocks/video/block.json';
+		$videopress_video_metadata_file        = __DIR__ . '/../build/block-editor/blocks/video/block.json';
 		$videopress_video_metadata_file_exists = file_exists( $videopress_video_metadata_file );
 		if ( ! $videopress_video_metadata_file_exists ) {
 			return;
@@ -209,7 +209,7 @@ class Initializer {
 	 * @return void
 	 */
 	public static function register_videopress_chapters_block() {
-		$videopress_chapters_metadata_file        = __DIR__ . '/client/block-editor/blocks/video-chapters/block.json';
+		$videopress_chapters_metadata_file        = __DIR__ . '/../build/block-editor/blocks/video-chapters/block.json';
 		$videopress_chapters_metadata_file_exists = file_exists( $videopress_chapters_metadata_file );
 
 		if ( ! $videopress_chapters_metadata_file_exists ) {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video-chapters/block.json
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video-chapters/block.json
@@ -20,8 +20,8 @@
 		}
 	},
 	"textdomain": "jetpack-videopress",
-	"editorScript": "file:../../../../../build/block-editor/video-chapters/index.js",
-	"editorStyle": "file:../../../../../build/block-editor/video-chapters/index.css",
-	"style": "file:../../../../../build/block-editor/video-chapters/style-index.css",
-	"viewScript": "file:../../../../../build/block-editor/video-chapters/view.js"
+	"editorScript": "file:index.js",
+	"editorStyle": "file:index.css",
+	"style": "file:style-index.css",
+	"viewScript": "file:view.js"
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
@@ -119,8 +119,8 @@
 		}
 	},
 	"textdomain": "jetpack-videopress",
-	"editorScript": "file:../../../../../build/block-editor/index.js",
-	"editorStyle": "file:../../../../../build/block-editor/index.css",
-	"style": "file:../../../../../build/block-editor/style-index.css",
-	"viewScript": "file:../../../../../build/block-editor/view.js"
+	"editorScript": "file:index.js",
+	"editorStyle": "file:index.css",
+	"style": "file:style-index.css",
+	"viewScript": "file:view.js"
 }

--- a/projects/packages/videopress/src/client/block-editor/extend/core-embed/index.js
+++ b/projects/packages/videopress/src/client/block-editor/extend/core-embed/index.js
@@ -5,10 +5,13 @@ import { isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import { unregisterBlockVariation } from '@wordpress/blocks';
 import domReady from '@wordpress/dom-ready';
 import { addFilter } from '@wordpress/hooks';
+import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
 import withCoreEmbedVideoPressBlock from './edit';
+
+const debug = debugFactory( 'videopress:extend:core/embed' );
 
 const extendCoreEmbedVideoPressBlock = ( settings, name ) => {
 	if ( isSimpleSite() ) {
@@ -40,6 +43,7 @@ addFilter(
 domReady( function () {
 	// @todo: horrible hack to make the unregister work
 	setTimeout( () => {
+		debug( 'unregister core/embed videopress variation' );
 		unregisterBlockVariation( 'core/embed', 'videopress' );
 	}, 0 );
 } );

--- a/projects/packages/videopress/src/client/block-editor/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/index.ts
@@ -1,8 +1,3 @@
-/**
- * Internal dependencies
- */
-import './blocks/video';
-
 /*
  * Extensibility
  */

--- a/projects/packages/videopress/webpack.config.js
+++ b/projects/packages/videopress/webpack.config.js
@@ -47,6 +47,10 @@ module.exports = [
 						from: './*/block.json',
 						to: './block-editor/blocks/[path]/[name].json',
 					},
+					{
+						from: 'src/client/block-editor/extensions/index.json',
+						to: './block-editor/extensions/index.json',
+					},
 				],
 			} ),
 		],

--- a/projects/packages/videopress/webpack.config.js
+++ b/projects/packages/videopress/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require( 'path' );
 const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
+const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 
 module.exports = [
 	{
@@ -38,6 +39,15 @@ module.exports = [
 		plugins: [
 			...jetpackWebpackConfig.StandardPlugins( {
 				DependencyExtractionPlugin: { injectPolyfill: true },
+			} ),
+			new CopyWebpackPlugin( {
+				patterns: [
+					{
+						context: 'src/client/block-editor/blocks',
+						from: './*/block.json',
+						to: './block-editor/blocks/[path]/[name].json',
+					},
+				],
 			} ),
 		],
 		module: {

--- a/projects/packages/videopress/webpack.config.js
+++ b/projects/packages/videopress/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = [
 			'admin/index': './src/client/admin/index.js',
 
 			// Block editor extensions
-			'block-editor/extensions/index': './src/client/block-editor/extensions/index.ts',
+			'block-editor/index': './src/client/block-editor/index.ts',
 		},
 		mode: jetpackWebpackConfig.mode,
 		devtool: jetpackWebpackConfig.isDevelopment ? 'source-map' : false,

--- a/projects/packages/videopress/webpack.config.js
+++ b/projects/packages/videopress/webpack.config.js
@@ -4,14 +4,23 @@ const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpac
 module.exports = [
 	{
 		entry: {
-			'block-editor/index': './src/client/block-editor/index.js',
-			'block-editor/view': './src/client/block-editor/view.js',
-			'lib/videopress-token-bridge': './src/client/lib/videopress-token-bridge.js',
-			'admin/index': './src/client/admin/index.js',
-			'block-editor/extensions/index': './src/client/block-editor/extensions/index.ts',
-			'block-editor/video-chapters/index':
+			// Video block
+			'block-editor/blocks/video/index': './src/client/block-editor/blocks/video/index.js',
+			'block-editor/blocks/video/view': './src/client/block-editor/blocks/video/view.js',
+
+			// Video Chapters block
+			'block-editor/blocks/video-chapters/index':
 				'./src/client/block-editor/blocks/video-chapters/index.js',
-			'block-editor/video-chapters/view': './src/client/block-editor/blocks/video-chapters/view.js',
+			'block-editor/blocks/video-chapters/view':
+				'./src/client/block-editor/blocks/video-chapters/view.js',
+
+			'lib/videopress-token-bridge': './src/client/lib/videopress-token-bridge.js',
+
+			// VideoPress dashboard page
+			'admin/index': './src/client/admin/index.js',
+
+			// Block editor extensions
+			'block-editor/extensions/index': './src/client/block-editor/extensions/index.ts',
 		},
 		mode: jetpackWebpackConfig.mode,
 		devtool: jetpackWebpackConfig.isDevelopment ? 'source-map' : false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/28016

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add `block.json` files to the `build`directory, for every block registered on the plugin
* Add `extensions/index.json` file to the `build` directory
* Update code references to the JSON files so they point to the `build` version
* Remove `src/client` code from the final plugin bundle
* Integrate extended block scripts

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Launch a new JN site with VideoPress standalone plugin and connect it (you can use the free plan)
* Go to the editor
* Look for the VideoPress block:

<img width="401" alt="Screen Shot 2022-12-20 at 16 31 15" src="https://user-images.githubusercontent.com/6760046/208751286-8b78d403-d247-4d17-9463-0f5c043cf01c.png">

* Confirm that you can add the block to the editor
* Confirm that you can upload one video and use it
* Confirm that you can edit the video informations on the right side sidebar:

<img width="700" alt="Screen Shot 2022-12-20 at 16 34 53" src="https://user-images.githubusercontent.com/6760046/208751542-69f19dc4-d9bb-4ca4-ad07-53fb3239cca1.png">

* In other words, confirm that block is present and working as expected
* Do the same testing on WPCOM