### PR TITLE
Add/auto publish for image guide

### DIFF
--- a/projects/js-packages/image-guide/changelog/add-auto-publish-for-image-guide
+++ b/projects/js-packages/image-guide/changelog/add-auto-publish-for-image-guide
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Turn on auto-publish

--- a/projects/js-packages/image-guide/composer.json
+++ b/projects/js-packages/image-guide/composer.json
@@ -43,6 +43,7 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"extra": {
+		"npmjs-autopublish": true,
 		"mirror-repo": "Automattic/jetpack-image-guide",
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-image-guide/compare/v${old}...v${new}"


### PR DESCRIPTION
Add auto-publish to image-guide [as per @jeherve's suggestion](https://github.com/Automattic/jetpack/pull/27952#discussion_r1053514746)

Thanks @jeherve! :)

#### Changes proposed in this Pull Request:
* Turn on autopublish for image-guide

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Check the changes.

