### PR TITLE
Site Settings API: Expose `show_on_front` and `page_on_front` options

### DIFF
--- a/projects/plugins/jetpack/changelog/update-reading-settings-expose-your-homepage-displays-options
+++ b/projects/plugins/jetpack/changelog/update-reading-settings-expose-your-homepage-displays-options
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Site Settings API: Exposing `show_on_front` and `page_on_front` options

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -814,6 +814,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 				case 'woocommerce_store_city':
 				case 'woocommerce_default_country':
 				case 'woocommerce_store_postcode':
+				case 'page_on_front':
 					$sanitized_value = sanitize_text_field( $value );
 					if ( update_option( $key, $sanitized_value ) ) {
 						$updated[ $key ] = $sanitized_value;
@@ -822,8 +823,6 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 				case 'date_format':
 				case 'time_format':
-				case 'show_on_front':
-				case 'page_on_front':
 					// settings are stored as strings.
 					// raw_value is used to help preserve any escaped characters that might exist in the formatted string.
 					$sanitized_value = sanitize_text_field( $raw_value );
@@ -981,6 +980,29 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 				case 'jetpack_are_blogging_prompts_enabled':
 					update_option( 'jetpack_blogging_prompts_enabled', (bool) $value );
 					$updated[ $key ] = (bool) $value;
+					break;
+
+				case 'show_on_front':
+					if ( in_array( $value, array( 'page', 'posts' ), true ) && update_option( $key, $value ) ) {
+							$updated[ $key ] = $value;
+					}
+					break;
+
+				case 'page_on_front':
+					$all_page_ids = get_all_page_ids();
+
+					$valid_page_id = false;
+					foreach ( $all_page_ids as $page_id ) {
+						if ( $page_id === (string) $value ) {
+							$valid_page_id = true;
+							break;
+						}
+					}
+
+					if ( $valid_page_id && update_option( $key, $value ) ) {
+						$updated[ $key ] = $value;
+					}
+
 					break;
 
 				default:

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -439,6 +439,8 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'wpcom_gifting_subscription'       => (bool) get_option( 'wpcom_gifting_subscription', $this->get_wpcom_gifting_subscription_default() ),
 						'jetpack_blogging_prompts_enabled' => (bool) jetpack_are_blogging_prompts_enabled(),
 						'wpcom_subscription_emails_use_excerpt' => $this->get_wpcom_subscription_emails_use_excerpt_option(),
+						'show_on_front'                    => (string) get_option( 'show_on_front' ),
+						'page_on_front'                    => (string) get_option( 'page_on_front' ),
 					);
 
 					if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -820,6 +822,8 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 				case 'date_format':
 				case 'time_format':
+				case 'show_on_front':
+				case 'page_on_front':
 					// settings are stored as strings.
 					// raw_value is used to help preserve any escaped characters that might exist in the formatted string.
 					$sanitized_value = sanitize_text_field( $raw_value );

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -814,7 +814,6 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 				case 'woocommerce_store_city':
 				case 'woocommerce_default_country':
 				case 'woocommerce_store_postcode':
-				case 'page_on_front':
 					$sanitized_value = sanitize_text_field( $value );
 					if ( update_option( $key, $sanitized_value ) ) {
 						$updated[ $key ] = $sanitized_value;

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -119,6 +119,8 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			'wpcom_gifting_subscription'              => '(bool) Whether gifting is enabled for non auto-renew sites',
 			'jetpack_blogging_prompts_enabled'        => '(bool) Whether writing prompts are shown in the editor when starting a new post.',
 			'wpcom_subscription_emails_use_excerpt'   => '(bool) Whether site subscription emails (e.g. New Post email notification) will use post excerpts',
+			'show_on_front'                           => '(string) Whether homepage should display related posts or a static page. The expected value is \'posts\' or \'page\'.',
+			'page_on_front'                           => '(string) The page ID of the page to use as the site\'s homepage. It will apply only if \'show_on_front\' is set to \'page\'.',
 		),
 
 		'response_format' => array(

--- a/projects/plugins/jetpack/tests/php/json-api/test-class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test-class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -260,6 +260,8 @@ class WP_Test_WPCOM_JSON_API_Site_Settings_V1_4_Endpoint extends WP_UnitTestCase
 					'posts_per_page'                       => '(int) Number of posts to show on blog pages',
 					'posts_per_rss'                        => '(int) Number of posts to show in the RSS feed',
 					'rss_use_excerpt'                      => '(bool) Whether the RSS feed will use post excerpts',
+					'show_on_front'                        => '(string) Whether homepage should display related posts or a static page. The expected value is \'posts\' or \'page\'.',
+					'page_on_front'                        => '(string) The page ID of the page to use as the site\'s homepage. It will apply only if \'show_on_front\' is set to \'page\'.',
 				),
 
 				'response_format' => array(

--- a/projects/plugins/jetpack/tests/php/json-api/test-class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test-class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -327,7 +327,7 @@ class WP_Test_WPCOM_JSON_API_Site_Settings_V1_4_Endpoint extends WP_UnitTestCase
 			'woocommerce_onboarding_profile string'     => array( 'woocommerce_onboarding_profile', 'string', array( 'string' ) ),
 			'woocommerce_onboarding_profile bool'       => array( 'woocommerce_onboarding_profile', true, array( true ) ),
 			'woocommerce_onboarding_profile example'    => array( 'woocommerce_onboarding_profile', $this->onboarding_profile_example, $this->onboarding_profile_example ),
-			'show_on_front'                             => array( 'show_on_front', 'page' ),
+			'show_on_front'                             => array( 'show_on_front', 'page', 'page' ),
 		);
 	}
 }

--- a/projects/plugins/jetpack/tests/php/json-api/test-class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test-class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -327,6 +327,7 @@ class WP_Test_WPCOM_JSON_API_Site_Settings_V1_4_Endpoint extends WP_UnitTestCase
 			'woocommerce_onboarding_profile string'     => array( 'woocommerce_onboarding_profile', 'string', array( 'string' ) ),
 			'woocommerce_onboarding_profile bool'       => array( 'woocommerce_onboarding_profile', true, array( true ) ),
 			'woocommerce_onboarding_profile example'    => array( 'woocommerce_onboarding_profile', $this->onboarding_profile_example, $this->onboarding_profile_example ),
+			'show_on_front'                             => array( 'show_on_front', 'page' ),
 		);
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR addresses one of the many tasks to implement calypsofied Reading Settings page. Exposing the two of options will allow for saving and retrieving "Your Homepage Displays" setting.

![Screen Shot 2022-12-21 at 17 43 17](https://user-images.githubusercontent.com/2019970/208959512-c26984e8-2d03-4320-b7a8-7d5d142cd795.png)


Fixes https://github.com/Automattic/wp-calypso/issues/71411

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add `show_on_front` and `page_on_front` to the list of options expected to be provided by the GET `site/%s/settings` endpoint
* Allow for and handle saving of `show_on_front` and `page_on_front` via the POST `site/%s/settings` endpoint

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox `public-api.wordpress.com`
* Go to wpcom developer console
* Test saving the `show_on_front` and `page_on_front` values with the POST `/sites/$site_id/settings` api
![Screen Shot 2022-12-22 at 09 51 54](https://user-images.githubusercontent.com/2019970/209096727-6dbd15eb-5d66-4471-8d4e-b7acdb98b804.png)
* Test retrieving the options with the GET `/sites/$site_id/settings` api
![Screen Shot 2022-12-22 at 09 56 04](https://user-images.githubusercontent.com/2019970/209096495-24b9a1ad-5263-47b6-807a-93732c966449.png)


