### PR TITLE
Boost/ignore analytics failures

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/utils/analytics.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/analytics.ts
@@ -1,11 +1,7 @@
-type RecordSuccess = {
-	success: boolean;
-};
-
 export async function recordBoostEvent(
 	eventName: string,
 	eventProp: TracksEventProperties
-): Promise< RecordSuccess > {
+): Promise< void > {
 	const defaultProps: { [ key: string ]: string } = {};
 	if ( 'version' in Jetpack_Boost ) {
 		defaultProps.boost_version = Jetpack_Boost.version;
@@ -21,26 +17,25 @@ export async function recordBoostEvent(
 
 	eventProp = { ...defaultProps, ...eventProp };
 
-	return new Promise( ( resolve, reject ) => {
+	return new Promise( resolve => {
 		if (
 			typeof jpTracksAJAX !== 'undefined' &&
 			typeof jpTracksAJAX.record_ajax_event === 'function'
 		) {
 			jpTracksAJAX
 				.record_ajax_event( `boost_${ eventName }`, 'click', eventProp )
-				.done( data => {
-					const successData = { success: 'success' in data && data.success === true };
-					resolve( successData );
-				} )
+				.done( resolve )
 				.fail( xhr => {
 					// eslint-disable-next-line no-console
 					console.log(
 						`Recording event 'boost_${ eventName }' failed with error: ${ xhr.responseText }`
 					);
-					reject( xhr.responseText );
+					resolve();
 				} );
 		} else {
-			reject( 'Invalid jpTracksAJAX object.' );
+			// eslint-disable-next-line no-console
+			console.log( 'Invalid jpTracksAJAX object.' );
+			resolve();
 		}
 	} );
 }

--- a/projects/plugins/boost/changelog/boost-ignore-analytics-failures
+++ b/projects/plugins/boost/changelog/boost-ignore-analytics-failures
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Don't let analytics failures prevent features from functioning


### PR DESCRIPTION
When an analytics call fails, do not throw the error up the call stack; just log it to console and move on.

#### Changes proposed in this Pull Request:
* When an analytics call fails, do not throw the error up the call stack; just log it to console and move on.

#### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Deliberately break analytics and ensure that nothing else breaks. :)