### PR TITLE
Boost: Add image guide tracks

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/utils/analytics.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/analytics.ts
@@ -7,16 +7,24 @@ export async function recordBoostEvent(
 	eventProp: TracksEventProperties
 ): Promise< RecordSuccess > {
 	const defaultProps: { [ key: string ]: string } = {};
-	if ( 'version' in Jetpack_Boost ) {
-		defaultProps.boost_version = Jetpack_Boost.version;
-	}
-	if ( 'connection' in Jetpack_Boost ) {
-		defaultProps.jetpack_connection = Jetpack_Boost.connection.connected
-			? 'connected'
-			: 'disconnected';
-	}
-	if ( 'optimizations' in Jetpack_Boost ) {
-		defaultProps.optimizations = JSON.stringify( Jetpack_Boost.optimizations );
+
+	/**
+	 * Jetpack Boost constant is not available on the front end.
+	 *
+	 * So we need to check if it exists before using it in case this function is called from the front end.
+	 */
+	if ( typeof Jetpack_Boost !== 'undefined' ) {
+		if ( 'version' in Jetpack_Boost ) {
+			defaultProps.boost_version = Jetpack_Boost.version;
+		}
+		if ( 'connection' in Jetpack_Boost ) {
+			defaultProps.jetpack_connection = Jetpack_Boost.connection.connected
+				? 'connected'
+				: 'disconnected';
+		}
+		if ( 'optimizations' in Jetpack_Boost ) {
+			defaultProps.optimizations = JSON.stringify( Jetpack_Boost.optimizations );
+		}
 	}
 
 	eventProp = { ...defaultProps, ...eventProp };

--- a/projects/plugins/boost/app/features/image-guide/Image_Guide.php
+++ b/projects/plugins/boost/app/features/image-guide/Image_Guide.php
@@ -4,6 +4,7 @@ namespace Automattic\Jetpack_Boost\Features\Image_Guide;
 
 use Automattic\Jetpack_Boost\Admin\Admin;
 use Automattic\Jetpack_Boost\Contracts\Feature;
+use Automattic\Jetpack_Boost\Lib\Analytics;
 
 class Image_Guide implements Feature {
 
@@ -22,6 +23,10 @@ class Image_Guide implements Feature {
 		}
 
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+
+		// Enqueue the tracks library.
+		$tracks = Analytics::get_tracking();
+		add_action( 'wp_enqueue_scripts', array( $tracks, 'enqueue_tracks_scripts' ) );
 
 		/**
 		 * The priority determines where the admin bar menu item is placed.

--- a/projects/plugins/boost/app/features/image-guide/src/analytics.ts
+++ b/projects/plugins/boost/app/features/image-guide/src/analytics.ts
@@ -1,0 +1,96 @@
+import { get } from 'svelte/store';
+import { recordBoostEvent } from '../../../assets/src/js/utils/analytics';
+import { MeasurableImageStore } from './stores/MeasurableImageStore';
+import type { Dimensions, Weight } from '@automattic/jetpack-image-guide';
+
+type ImageProperties = {
+	severity: 'red' | 'yellow' | 'green';
+	oversizedRatio: number;
+	fileSize: Dimensions & Weight;
+	sizeOnPage: Dimensions;
+	expectedSize: Dimensions;
+	potentialSavings: number | null;
+	imageURL: string;
+};
+
+export default class ImageGuideAnalytics {
+	static trackingComplete = false;
+
+	/**
+	 * Track the image guide analytics for a single image.
+	 *
+	 * @param { MeasurableImageStore } imageStore
+	 */
+	public static async trackImageOutcome( imageStore: MeasurableImageStore ) : Promise < ImageProperties > {
+		return new Promise( resolve => {
+			// Wait until the image is loaded and then track the state.
+			imageStore.loading.subscribe( loading => {
+				if ( !loading ) {
+					const oversizedRatio = get( imageStore.oversizedRatio );
+					const severity = oversizedRatio > 4 ? 'red' : oversizedRatio > 2.5 ? 'yellow' : 'green';
+					const fileSize = get( imageStore.fileSize );
+					const sizeOnPage = get( imageStore.sizeOnPage );
+					const expectedSize = get( imageStore.expectedSize );
+					const potentialSavings = get( imageStore.potentialSavings );
+					const imageURL = get( imageStore.url );
+	
+					const props: ImageProperties = {
+						severity,
+						oversizedRatio,
+						fileSize,
+						sizeOnPage,
+						expectedSize,
+						potentialSavings,
+						imageURL,
+					};
+	
+					recordBoostEvent( 'image_guide_image_state', {
+						...props,
+						windowDimensions: {
+							width: window.innerWidth,
+							height: window.innerHeight,
+						},
+						devicePixelRatio: window.devicePixelRatio,
+					} );
+	
+					resolve( props );
+				}
+			} );
+		} );
+	}
+	
+	/**
+	 * Track events to record the outcome of the image guide for the current page.
+	 *
+	 * @param  imageStores
+	 */
+	public static async trackPage( imageStores: MeasurableImageStore[] ) {
+		if( ! imageStores.length || ImageGuideAnalytics.trackingComplete ) {
+			return;
+		}
+	
+		// Flag to indicate that tracking has already ran for the current page load
+		ImageGuideAnalytics.trackingComplete = true;
+
+		// Record events for each image and collect promises with properties of image that will resolve when the image is loaded.
+		const promises: Promise < ImageProperties >[] = imageStores.map( ImageGuideAnalytics.trackImageOutcome );
+	
+		// Wait for all images to be loaded and then track the overall outcome.
+		const results = await Promise.all( promises );
+		const totalPotentialSavings = results.reduce( ( total, result ) => {
+			return total + (result.potentialSavings || 0);
+		}, 0 );
+	
+		recordBoostEvent( 'image_guide_page_outcome', {
+			totalPotentialSavings,
+			redSeverityCount: results.filter( result => result.severity === 'red' ).length,
+			yellowSeverityCount: results.filter( result => result.severity === 'yellow' ).length,
+			greenSeverityCount: results.filter( result => result.severity === 'green' ).length,
+			windowDimensions: {
+				width: window.innerWidth,
+				height: window.innerHeight,
+			},
+			devicePixelRatio: window.devicePixelRatio,
+		} );
+	}
+}

--- a/projects/plugins/boost/app/features/image-guide/src/analytics.ts
+++ b/projects/plugins/boost/app/features/image-guide/src/analytics.ts
@@ -1,5 +1,6 @@
 import { get } from 'svelte/store';
 import { recordBoostEvent } from '../../../assets/src/js/utils/analytics';
+import { guideState } from './stores/GuideState';
 import { MeasurableImageStore } from './stores/MeasurableImageStore';
 import type { Dimensions, Weight } from '@automattic/jetpack-image-guide';
 
@@ -44,7 +45,7 @@ export default class ImageGuideAnalytics {
 						imageURL,
 					};
 	
-					recordBoostEvent( 'image_guide_image_state', {
+					recordBoostEvent( 'image_guide_image_outcome', {
 						...props,
 						windowDimensions: {
 							width: window.innerWidth,
@@ -91,6 +92,24 @@ export default class ImageGuideAnalytics {
 				height: window.innerHeight,
 			},
 			devicePixelRatio: window.devicePixelRatio,
+		} );
+	}
+
+	/**
+	 * Track the state of the UI when the user loads a page.
+	 */
+	public static trackInitialState() {
+		recordBoostEvent( 'image_guide_initial_ui_state', {
+			imageGuideState: get( guideState )
+		} );
+	}
+
+	/**
+	 * Track the state of the UI when the user changes it.
+	 */
+	public static trackUIStateChange() {
+		recordBoostEvent( 'image_guide_ui_state_change', {
+			imageGuideState: get( guideState )
 		} );
 	}
 }

--- a/projects/plugins/boost/app/features/image-guide/src/index.ts
+++ b/projects/plugins/boost/app/features/image-guide/src/index.ts
@@ -79,6 +79,8 @@ function debounceDimensionUpdates() {
  * to look for new images.
  */
 function initialize() {
+	ImageGuideAnalytics.trackInitialState();
+
 	guideState.subscribe( async $state => {
 		if ( $state === 'paused' ) {
 			return;

--- a/projects/plugins/boost/app/features/image-guide/src/index.ts
+++ b/projects/plugins/boost/app/features/image-guide/src/index.ts
@@ -1,4 +1,5 @@
 import { getMeasurableImages } from '@automattic/jetpack-image-guide';
+import ImageGuideAnalytics from './analytics';
 import { attachGuides } from './initialize';
 import { guideState } from './stores/GuideState';
 import AdminBarToggle from './ui/AdminBarToggle.svelte';
@@ -91,6 +92,8 @@ function initialize() {
 		);
 		const filteredImages = discardSmallImages( measurableImages );
 		stores.push( ...attachGuides( filteredImages ) );
+
+		ImageGuideAnalytics.trackPage( stores );
 	} );
 }
 

--- a/projects/plugins/boost/app/features/image-guide/src/ui/AdminBarToggle.svelte
+++ b/projects/plugins/boost/app/features/image-guide/src/ui/AdminBarToggle.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { recordBoostEvent } from '../../../../assets/src/js/utils/analytics';
 	import { guideState, guideLabel } from '../stores/GuideState';
 	import JetpackLogo from './JetpackLogo.svelte';
 
@@ -6,6 +7,7 @@
 
 	function toggleUI() {
 		guideState.cycle();
+		recordBoostEvent( 'cycle_image_guide_ui', { state: $guideState } );
 	}
 </script>
 

--- a/projects/plugins/boost/app/features/image-guide/src/ui/AdminBarToggle.svelte
+++ b/projects/plugins/boost/app/features/image-guide/src/ui/AdminBarToggle.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { recordBoostEvent } from '../../../../assets/src/js/utils/analytics';
+	import ImageGuideAnalytics from '../analytics';
 	import { guideState, guideLabel } from '../stores/GuideState';
 	import JetpackLogo from './JetpackLogo.svelte';
 
@@ -7,7 +7,7 @@
 
 	function toggleUI() {
 		guideState.cycle();
-		recordBoostEvent( 'cycle_image_guide_ui', { state: $guideState } );
+		ImageGuideAnalytics.trackUIStateChange();
 	}
 </script>
 

--- a/projects/plugins/boost/changelog/add-image-guide-tracks
+++ b/projects/plugins/boost/changelog/add-image-guide-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added tracking that helps understand the effectiveness of image-guide


### PR DESCRIPTION
Fixes Automattic/boost-cloud#173 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Track the initial state of Image Guide UI on page load
* Track the image-guide outcome of each image on a page
* Track the summery result of the impact of image guide in a page
* Track image-guide UI toggle

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
None

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Open a front-end page with image guide
* Make sure it tracks the initial state of the Guide UI
* Enable the image guide
* Make sure it tracks the outcome of each image on image-guide
* Make sure it tracks the summary of the page, including total potential saving, and red/yellow/green count.
* Make sure it tracks when you toggle the image-guide UI.

