### PR TITLE
Subscribe Block: ensure custom button spacing is correct

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sprintf-placeholder
+++ b/projects/plugins/jetpack/changelog/fix-sprintf-placeholder
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscribe Block: ensure custom button spacing is correct when the button is on its own line.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -286,7 +286,7 @@ function get_element_styles_from_attributes( $attributes ) {
 
 		// Account for custom margins on inline forms.
 		$submit_button_styles .= true === get_attribute( $attributes, 'buttonOnNewLine' )
-			? sprintf( 'width: calc(100% - %spx;', get_attribute( $attributes, 'spacing', DEFAULT_SPACING_VALUE ) )
+			? sprintf( 'width: calc(100%% - %dpx);', get_attribute( $attributes, 'spacing', DEFAULT_SPACING_VALUE ) )
 			: 'width: 100%;';
 	}
 


### PR DESCRIPTION
Fixes #28037

#### Changes proposed in this Pull Request:

This is a follow-up to #26947.

Let's make sure the "100%" do not get in the way of our sprintf replacements.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:

* Start with a site connected to WordPress.com with the Subscriptions module active.
* Go to Posts > Add New
* Switch to the Code editor

<img width="402" alt="Screenshot 2022-12-22 at 12 57 07" src="https://user-images.githubusercontent.com/426388/209129820-6256f4fd-355a-4014-a400-b57bf9efff36.png">


* Paste the following: 
```
<!-- wp:jetpack/subscriptions {"subscribePlaceholder":"Email Address","buttonOnNewLine":true,"buttonWidth":"100%","submitButtonText":"Subscribe","buttonBackgroundColor":"black","customTextColor":"#ffe030","fontSize":"1.75rem","customFontSize":"1.75rem","borderRadius":50,"borderWeight":1,"borderColor":"black","padding":24,"spacing":15,"className":"is-style-split"} /-->
```
* Ensure the block's button is properly displayed on the frontend.
