### PR TITLE
Boost: Add tracks events for errors

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Score.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Score.svelte
@@ -85,7 +85,7 @@
 			currentScoreConfigString = $scoreConfigString;
 		} catch ( err ) {
 			recordBoostEvent( 'speed_score_request_error', {
-				errorMessage: castToString( err.message ),
+				error_message: castToString( err.message ),
 			} );
 			// eslint-disable-next-line no-console
 			console.log( err );

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Score.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Score.svelte
@@ -14,6 +14,8 @@
 	import ComputerIcon from '../../../svg/computer.svg';
 	import MobileIcon from '../../../svg/mobile.svg';
 	import RefreshIcon from '../../../svg/refresh.svg';
+	import { recordBoostEvent } from '../../../utils/analytics';
+	import { castToString } from '../../../utils/cast-to-string';
 	import debounce from '../../../utils/debounce';
 	import PopOut from '../elements/PopOut.svelte';
 	import ScoreBar from '../elements/ScoreBar.svelte';
@@ -82,6 +84,9 @@
 			showPrevScores = didScoresChange( $scores ) && ! $scores.isStale;
 			currentScoreConfigString = $scoreConfigString;
 		} catch ( err ) {
+			recordBoostEvent( 'speed_score_request_error', {
+				errorMessage: castToString( err.message ),
+			} );
 			// eslint-disable-next-line no-console
 			console.log( err );
 			loadError = err;

--- a/projects/plugins/boost/changelog/add-error-tracks
+++ b/projects/plugins/boost/changelog/add-error-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added tracking when speed score request fails


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/boost-cloud#190

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Track when speed score request fails

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
None

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Rig the speed-score request to timeout
* Make sure `speed_score_request_error` event is tracked
