### PR TITLE
Image guide: Updating the package version and changelogger

### DIFF
--- a/projects/js-packages/image-guide/CHANGELOG.md
+++ b/projects/js-packages/image-guide/CHANGELOG.md
@@ -5,3 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.0 - 2022-12-23
+### Added
+- Turn on auto-publish
+
+### Removed
+- Minor package.json change - removing private entry.

--- a/projects/js-packages/image-guide/changelog/update-image-guide-package-version
+++ b/projects/js-packages/image-guide/changelog/update-image-guide-package-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Minor package.json change - removing private entry.

--- a/projects/js-packages/image-guide/package.json
+++ b/projects/js-packages/image-guide/package.json
@@ -1,7 +1,6 @@
 {
-	"private": false,
 	"name": "@automattic/jetpack-image-guide",
-	"version": "0.1.0-alpha",
+	"version": "0.1.0",
 	"description": "Go through the dom to analyze image size on screen vs actual file size.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/image-guide/#readme",
 	"type": "module",

--- a/projects/js-packages/image-guide/package.json
+++ b/projects/js-packages/image-guide/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-image-guide",
-	"version": "0.1.0",
+	"version": "0.1.1-alpha",
 	"description": "Go through the dom to analyze image size on screen vs actual file size.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/image-guide/#readme",
 	"type": "module",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* This PR adds a minor package.json file change, a new changelog entry, and updates the changelogger and release version (away from alpha) for the image guide js-package. This is in order to release a tagged version in the [mirror repository](https://github.com/Automattic/jetpack-image-guide/) and for the package to then be available on npm.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion

p1671775119411749-slack-C01U2KGS2PQ

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* This needs proof-reading - check the package version looks correct.