### PR TITLE
Revert Revert Add review prompt for social plugin

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -475,8 +475,10 @@ importers:
   projects/js-packages/publicize-components:
     specifiers:
       '@automattic/color-studio': 2.5.0
+      '@automattic/jetpack-analytics': workspace:*
       '@automattic/jetpack-base-styles': workspace:*
       '@automattic/jetpack-components': workspace:*
+      '@automattic/jetpack-connection': workspace:*
       '@automattic/jetpack-shared-extension-utils': workspace:*
       '@automattic/jetpack-webpack-config': workspace:*
       '@automattic/social-previews': 1.1.5
@@ -511,7 +513,9 @@ importers:
       refx: 3.1.1
       rememo: 4.0.1
     dependencies:
+      '@automattic/jetpack-analytics': link:../analytics
       '@automattic/jetpack-components': link:../components
+      '@automattic/jetpack-connection': link:../connection
       '@automattic/jetpack-shared-extension-utils': link:../shared-extension-utils
       '@automattic/social-previews': 1.1.5_jpwft5hzbbmso7udylr5tohhxm
       '@wordpress/annotations': 2.22.0_react@17.0.2
@@ -1862,6 +1866,7 @@ importers:
       '@automattic/jetpack-components': workspace:*
       '@automattic/jetpack-connection': workspace:*
       '@automattic/jetpack-publicize-components': workspace:*
+      '@automattic/jetpack-shared-extension-utils': workspace:*
       '@automattic/jetpack-webpack-config': workspace:*
       '@babel/core': 7.20.5
       '@babel/preset-env': 7.20.2
@@ -1898,6 +1903,7 @@ importers:
       '@automattic/jetpack-components': link:../../js-packages/components
       '@automattic/jetpack-connection': link:../../js-packages/connection
       '@automattic/jetpack-publicize-components': link:../../js-packages/publicize-components
+      '@automattic/jetpack-shared-extension-utils': link:../../js-packages/shared-extension-utils
       '@wordpress/api-fetch': 6.19.0
       '@wordpress/components': 22.1.0_oh345hcsaunslvozv24xisnbli
       '@wordpress/data': 7.6.0_react@17.0.2

--- a/projects/js-packages/image-guide/changelog/Test
+++ b/projects/js-packages/image-guide/changelog/Test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+This is for testing purposes, this will be removed

--- a/projects/js-packages/image-guide/changelog/Test
+++ b/projects/js-packages/image-guide/changelog/Test
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-This is for testing purposes, this will be removed

--- a/projects/js-packages/publicize-components/changelog/add-review-prompt-for-social-plugin
+++ b/projects/js-packages/publicize-components/changelog/add-review-prompt-for-social-plugin
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a review request prompt for Jetpack Social plugin

--- a/projects/js-packages/publicize-components/index.js
+++ b/projects/js-packages/publicize-components/index.js
@@ -11,6 +11,7 @@ export { default as TwitterOptions } from './src/components/twitter/options';
 export { default as SocialPreviewsModal } from './src/components/social-previews/modal';
 export { default as SocialPreviewsPanel } from './src/components/social-previews/panel';
 export { default as PublicizePanel } from './src/components/panel';
+export { default as ReviewPrompt } from './src/components/review-prompt';
 
 export { default as useSocialMediaConnections } from './src/hooks/use-social-media-connections';
 export { default as useSocialMediaMessage } from './src/hooks/use-social-media-message';

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.11.1",
+	"version": "0.12.0-alpha",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {
@@ -21,6 +21,8 @@
 	"dependencies": {
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
+		"@automattic/jetpack-analytics": "workspace:*",
+		"@automattic/jetpack-connection": "workspace:*",
 		"@automattic/social-previews": "1.1.5",
 		"@wordpress/api-fetch": "6.19.0",
 		"@wordpress/blocks": "11.21.0",

--- a/projects/js-packages/publicize-components/src/components/review-prompt/index.jsx
+++ b/projects/js-packages/publicize-components/src/components/review-prompt/index.jsx
@@ -1,0 +1,67 @@
+/**
+ * Panel that requests a review of the Jetpack Social Plugin
+ * Shows in the post publish panel of the editor
+ */
+
+import { Button, ThemeProvider } from '@automattic/jetpack-components';
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
+import { __, sprintf } from '@wordpress/i18n';
+import { useCallback } from 'react';
+import styles from './styles.module.scss';
+
+const ReviewPrompt = ( { href, onClose } ) => {
+	const { recordEvent } = useAnalytics( {
+		pageViewEventName: 'social_plugin_review_prompt',
+		pageViewNamespace: 'jetpack',
+		pageViewSuffix: 'view',
+	} );
+
+	const recordReviewClick = useCallback( () => {
+		recordEvent( 'jetpack_social_plugin_review_prompt_new_review_click' );
+	}, [ recordEvent ] );
+
+	const handleDismiss = useCallback( () => {
+		recordEvent( 'jetpack_social_plugin_review_prompt_dismiss_click' );
+		onClose();
+	}, [ recordEvent, onClose ] );
+
+	return (
+		<ThemeProvider>
+			<div className={ styles.prompt }>
+				<h2 className={ styles.header }>
+					{
+						/* translators: %s is the celebration emoji */
+						sprintf( __( 'Presto! %s', 'jetpack' ), String.fromCodePoint( 0x1f389 ) )
+					}
+				</h2>
+				<p>
+					{ __(
+						'Just like that, Jetpack Social has shared your post to your connected social accounts.',
+						'jetpack'
+					) }
+				</p>
+				<p>
+					{ __(
+						'Please leave a review to let others know how easy getting your posts on social media can be!',
+						'jetpack'
+					) }
+				</p>
+				<div className={ styles.buttons }>
+					<Button
+						onClick={ recordReviewClick }
+						isExternalLink
+						href={ href }
+						className={ styles.button }
+					>
+						{ __( 'Leave a Review', 'jetpack' ) }
+					</Button>
+					<Button onClick={ handleDismiss } variant="link" className={ styles.button }>
+						{ __( 'Dismiss', 'jetpack' ) }
+					</Button>
+				</div>
+			</div>
+		</ThemeProvider>
+	);
+};
+
+export default ReviewPrompt;

--- a/projects/js-packages/publicize-components/src/components/review-prompt/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/review-prompt/styles.module.scss
@@ -1,0 +1,41 @@
+.prompt {
+	border: 2px solid var( --jp-green-40 );
+	border-radius: 4px;
+	padding: calc( var( --spacing-base ) * 2 ) calc( var( --spacing-base ) * 3 );
+	display: block;
+	justify-content: space-between;
+	align-items: center;
+	gap: calc( var( --spacing-base ) * 3 );
+	text-align: left;
+	background: none;
+	margin: 0;
+	width: 100%;
+	text-decoration: none;
+	color: var( --jp-gray-90 );
+
+	&:focus, &:active {
+		outline-color: var( --jp-black );
+	}
+
+	// somewhat unfortunate specificity override
+	.buttons button.button {
+		font-size: var( --font-body-small );
+	}
+}
+
+.header {
+	font-size: var( --font-body );
+}
+
+.buttons {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-base);
+	align-content: space-between;
+}
+
+.button {
+	width: 100%;
+	align-items: center;
+	justify-content: space-between;
+}

--- a/projects/js-packages/publicize-components/src/hooks/use-publicize-config/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-publicize-config/index.js
@@ -23,6 +23,10 @@ export default function usePublicizeConfig() {
 	const isRePublicizeFeatureAvailable =
 		getJetpackExtensionAvailability( republicizeFeatureName )?.available || isShareLimitEnabled;
 	const isPostPublished = useSelect( select => select( editorStore ).isCurrentPostPublished(), [] );
+	const isPostAlreadyShared = useSelect(
+		select => select( 'jetpack/publicize' ).getJetpackSocialPostAlreadyShared(),
+		[]
+	);
 	const connectionsRootUrl =
 		getJetpackData()?.social?.publicizeConnectionsUrl ??
 		'https://wordpress.com/marketing/connections/';
@@ -86,6 +90,7 @@ export default function usePublicizeConfig() {
 		isRePublicizeUpgradableViaUpsell,
 		hidePublicizeFeature,
 		isShareLimitEnabled,
+		isPostAlreadyShared,
 		numberOfSharesRemaining: sharesData.shares_remaining,
 		hasPaidPlan: !! getJetpackData()?.social?.hasPaidPlan,
 		isEnhancedPublishingEnabled: !! getJetpackData()?.social?.isEnhancedPublishingEnabled,

--- a/projects/js-packages/publicize-components/src/hooks/use-saving-post/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-saving-post/index.js
@@ -44,3 +44,24 @@ export function usePostJustPublished( fn, deps ) {
 		fn();
 	}, [ isPublishing, wasPublishing, fn, deps ] );
 }
+
+/**
+ * React hook to detect when a post just started publishing,
+ * running the callback when it happens.
+ * Additionally, it accepts a dependency array which is passed to useEffect hook.
+ *
+ * @param {Function} fn - Callback function to run when the post starts publishing.
+ * @param {Array} deps  - Dependency array.
+ */
+export function usePostStartedPublishing( fn, deps ) {
+	const isPublishing = useSelect( select => select( editorStore ).isPublishingPost(), [] );
+	const wasPublishing = usePrevious( isPublishing );
+
+	useEffect( () => {
+		if ( ! ( ! wasPublishing && isPublishing ) ) {
+			return;
+		}
+
+		fn();
+	}, [ isPublishing, wasPublishing, fn, deps ] );
+}

--- a/projects/js-packages/publicize-components/src/store/selectors.js
+++ b/projects/js-packages/publicize-components/src/store/selectors.js
@@ -552,6 +552,17 @@ export function getJetpackSocialOptions() {
 }
 
 /**
+ * Get whether the post has already been shared.
+ *
+ * @returns {Object} Object with Jetpack Social options.
+ */
+export function getJetpackSocialPostAlreadyShared() {
+	const { getEditedPostAttribute } = select( editorStore );
+	const meta = getEditedPostAttribute( 'meta' );
+	return get( meta, [ 'jetpack_social_post_already_shared' ], {} );
+}
+
+/**
  * Get a list of all attached media.
  *
  * @returns {Array} An array of media IDs.

--- a/projects/js-packages/shared-extension-utils/changelog/extend-use-analytics-hook
+++ b/projects/js-packages/shared-extension-utils/changelog/extend-use-analytics-hook
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add additional methods to useAnalytics hook, allow for view event by passing initial props

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.7.0",
+	"version": "0.8.0-alpha",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/src/hooks/readme.md
+++ b/projects/js-packages/shared-extension-utils/src/hooks/readme.md
@@ -21,3 +21,25 @@ tracks.recordEvent( 'jetpack_editor_block_upgrade_click', {
 	context,
 } );
 ```
+
+The hook function also accepts parameters to record a "page view" event when the component renders.
+You can also import a wrapped version of `recordEvent` that checks for a Jetpack connected user before actually recording the event.  
+
+```es6
+const Component = () => {
+	const { recordEvent } = useAnalytics( {
+			pageViewEventName: 'view_event_name',
+			pageViewNamespace: 'jetpack',
+			pageViewSuffix: '',
+		} );
+	const recordClick = useCallback( () => { recordEvent( 'event_name', {} ) }, [] );
+	
+	return (
+		<Button
+			onClick={ recordClick }
+		>
+			{ __( 'Action Button', 'jetpack' ) }
+		</Button>
+	)
+}
+```

--- a/projects/js-packages/shared-extension-utils/src/hooks/use-analytics.js
+++ b/projects/js-packages/shared-extension-utils/src/hooks/use-analytics.js
@@ -1,10 +1,34 @@
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { useConnection } from '@automattic/jetpack-connection';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useState, useCallback } from '@wordpress/element';
 
-const useAnalytics = () => {
-	const { isUserConnected, userConnectionData = {} } = useConnection();
+const { tracks } = jetpackAnalytics;
+const { recordEvent } = tracks;
+
+const useAnalytics = ( {
+	pageViewEventName,
+	pageViewNamespace = 'jetpack',
+	pageViewSuffix = 'page_view',
+	pageViewEventProperties = {},
+} ) => {
+	const [ pageViewRecorded, setPageViewRecorded ] = useState( false );
+	const { isUserConnected, isRegistered, userConnectionData = {} } = useConnection();
 	const { wpcomUser: { login, ID } = {}, blogId } = userConnectionData.currentUser || {};
+
+	/**
+	 * Record an event async
+	 * Check to ensure there is a connected user first
+	 */
+	const recordEventAsync = useCallback(
+		async ( event, properties = {} ) => {
+			// Do nothing if there is not a connected user.
+			if ( ! ( isUserConnected && ID && login ) ) {
+				return;
+			}
+			recordEvent( event, properties );
+		},
+		[ isUserConnected, ID, login ]
+	);
 
 	/**
 	 * Initialize tracks with user and blog data.
@@ -20,7 +44,43 @@ const useAnalytics = () => {
 		} );
 	}, [ blogId, ID, login, isUserConnected ] );
 
-	return jetpackAnalytics;
+	/**
+	 * Track a page-view type event.
+	 * It's considered a page view event when the component is mounted.
+	 */
+	useEffect( () => {
+		const pageViewEvent = pageViewEventName
+			? `${ pageViewNamespace }_${ pageViewEventName }_${ pageViewSuffix }`
+			: null;
+
+		// Also, only run if the site is registered.
+		if ( ! isRegistered ) {
+			return;
+		}
+
+		if ( ! pageViewEvent ) {
+			return;
+		}
+
+		// Ensuring we only record the view event once
+		if ( ! pageViewRecorded ) {
+			recordEventAsync( pageViewEvent, pageViewEventProperties );
+			setPageViewRecorded( true );
+		}
+	}, [
+		pageViewRecorded,
+		pageViewNamespace,
+		pageViewEventName,
+		pageViewSuffix,
+		isRegistered,
+		pageViewEventProperties,
+		recordEventAsync,
+	] );
+
+	return {
+		recordEvent: recordEventAsync,
+		tracks: tracks,
+	};
 };
 
 export default useAnalytics;

--- a/projects/js-packages/shared-extension-utils/src/hooks/use-analytics.js
+++ b/projects/js-packages/shared-extension-utils/src/hooks/use-analytics.js
@@ -6,11 +6,11 @@ const { tracks } = jetpackAnalytics;
 const { recordEvent } = tracks;
 
 const useAnalytics = ( {
-	pageViewEventName,
+	pageViewEventName = null,
 	pageViewNamespace = 'jetpack',
 	pageViewSuffix = 'page_view',
 	pageViewEventProperties = {},
-} ) => {
+} = {} ) => {
 	const [ pageViewRecorded, setPageViewRecorded ] = useState( false );
 	const { isUserConnected, isRegistered, userConnectionData = {} } = useConnection();
 	const { wpcomUser: { login, ID } = {}, blogId } = userConnectionData.currentUser || {};

--- a/projects/packages/publicize/changelog/add-already-shared-meta
+++ b/projects/packages/publicize/changelog/add-already-shared-meta
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+added already shared meta value for post editor api

--- a/projects/packages/publicize/composer.json
+++ b/projects/packages/publicize/composer.json
@@ -58,7 +58,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.18.x-dev"
+			"dev-trunk": "0.19.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.18.4",
+	"version": "0.19.0-alpha",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1045,6 +1045,17 @@ abstract class Publicize_Base {
 			'auth_callback' => array( $this, 'message_meta_auth_callback' ),
 		);
 
+		$already_shared_flag_args = array(
+			'type'          => 'boolean',
+			'description'   => __( 'Whether or not the post has already been shared.', 'jetpack-publicize-pkg' ),
+			'single'        => true,
+			'default'       => false,
+			'show_in_rest'  => array(
+				'name' => 'jetpack_social_post_already_shared',
+			),
+			'auth_callback' => array( $this, 'message_meta_auth_callback' ),
+		);
+
 		$jetpack_social_options_args = array(
 			'type'          => 'object',
 			'description'   => __( 'Post options related to Jetpack Social.', 'jetpack-publicize-pkg' ),
@@ -1075,11 +1086,13 @@ abstract class Publicize_Base {
 			$message_args['object_subtype']                  = $post_type;
 			$tweetstorm_args['object_subtype']               = $post_type;
 			$publicize_feature_enable_args['object_subtype'] = $post_type;
+			$already_shared_flag_args['object_subtype']      = $post_type;
 			$jetpack_social_options_args['object_subtype']   = $post_type;
 
 			register_meta( 'post', $this->POST_MESS, $message_args );
 			register_meta( 'post', $this->POST_TWEETSTORM, $tweetstorm_args );
 			register_meta( 'post', self::POST_PUBLICIZE_FEATURE_ENABLED, $publicize_feature_enable_args );
+			register_meta( 'post', $this->POST_DONE . 'all', $already_shared_flag_args );
 			register_meta( 'post', self::POST_JETPACK_SOCIAL_OPTIONS, $jetpack_social_options_args );
 		}
 	}

--- a/projects/plugins/jetpack/changelog/add-review-prompt-for-social-plugin
+++ b/projects/plugins/jetpack/changelog/add-review-prompt-for-social-plugin
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1685,7 +1685,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/publicize",
-                "reference": "e1361b207ed7ddaddcd764020b0d4e455fd49014"
+                "reference": "a15743c92315940bb988e928858ecff8a53b4a89"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1708,7 +1708,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.18.x-dev"
+                    "dev-trunk": "0.19.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/add-review-prompt-for-social-plugin
+++ b/projects/plugins/social/changelog/add-review-prompt-for-social-plugin
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a review request prompt for Jetpack Social plugin

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1062,7 +1062,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/publicize",
-                "reference": "e1361b207ed7ddaddcd764020b0d4e455fd49014"
+                "reference": "a15743c92315940bb988e928858ecff8a53b4a89"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1085,7 +1085,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.18.x-dev"
+                    "dev-trunk": "0.19.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/package.json
+++ b/projects/plugins/social/package.json
@@ -31,6 +31,7 @@
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-connection": "workspace:*",
 		"@automattic/jetpack-publicize-components": "workspace:*",
+		"@automattic/jetpack-shared-extension-utils": "workspace:*",
 		"@wordpress/api-fetch": "6.19.0",
 		"@wordpress/components": "22.1.0",
 		"@wordpress/data": "7.6.0",

--- a/projects/plugins/social/src/js/editor.js
+++ b/projects/plugins/social/src/js/editor.js
@@ -1,11 +1,15 @@
-import { JetpackLogo, SocialIcon } from '@automattic/jetpack-components';
+import { JetpackLogo, SocialIcon, getRedirectUrl } from '@automattic/jetpack-components';
 import {
 	SocialPreviewsModal,
 	SocialPreviewsPanel,
 	usePublicizeConfig,
 	useSocialMediaConnections,
 	PublicizePanel,
+	ReviewPrompt,
+	usePostStartedPublishing,
 } from '@automattic/jetpack-publicize-components';
+import { getJetpackData } from '@automattic/jetpack-shared-extension-utils';
+import apiFetch from '@wordpress/api-fetch';
 import { PanelBody } from '@wordpress/components';
 import { dispatch, useSelect } from '@wordpress/data';
 import domReady from '@wordpress/dom-ready';
@@ -13,6 +17,7 @@ import {
 	PluginSidebar,
 	PluginSidebarMoreMenuItem,
 	PluginPrePublishPanel,
+	PluginPostPublishPanel,
 } from '@wordpress/edit-post';
 import { store as editorStore, PostTypeSupportCheck } from '@wordpress/editor';
 import { useState, useCallback } from '@wordpress/element';
@@ -41,13 +46,25 @@ registerPlugin( 'jetpack-social', {
 
 const JetpackSocialSidebar = () => {
 	const [ isModalOpened, setIsModalOpened ] = useState( false );
+	const [ isReviewRequestDismissed, setIsReviewRequestDismissed ] = useState(
+		getJetpackData()?.social?.reviewRequestDismissed ?? true
+	);
+	const [ shouldReviewRequestShow, setShouldReviewRequestShow ] = useState( false );
 
 	const openModal = useCallback( () => setIsModalOpened( true ), [] );
 	const closeModal = useCallback( () => setIsModalOpened( false ), [] );
 
 	const { hasConnections, hasEnabledConnections } = useSocialMediaConnections();
-	const { isPublicizeEnabled, hidePublicizeFeature } = usePublicizeConfig();
+	const { isPublicizeEnabled, hidePublicizeFeature, isPostAlreadyShared } = usePublicizeConfig();
 	const isPostPublished = useSelect( select => select( editorStore ).isCurrentPostPublished(), [] );
+	// Determine if the review request should show right before the post publishes
+	// The publicize-enabled meta and related connections are disabled after publishing
+	usePostStartedPublishing( () => {
+		setShouldReviewRequestShow(
+			! isPostAlreadyShared && isPublicizeEnabled && hasEnabledConnections
+		);
+	}, [ isPostAlreadyShared, hasEnabledConnections, isPublicizeEnabled ] );
+
 	const PanelDescription = () => (
 		<Description
 			{ ...{
@@ -59,6 +76,23 @@ const JetpackSocialSidebar = () => {
 			} }
 		/>
 	);
+
+	// Handle when the review request is dismissed
+	const handleReviewDismiss = useCallback( () => {
+		const reviewRequestDismissUpdatePath =
+			getJetpackData()?.social?.dismissReviewRequestPath ?? null;
+		// Save that the user has dismissed this by calling to the social plugin API method
+		apiFetch( {
+			path: reviewRequestDismissUpdatePath,
+			method: 'POST',
+			data: { dismissed: true },
+		} ).catch( error => {
+			throw error;
+		} );
+
+		setIsReviewRequestDismissed( true );
+	}, [] );
+
 	return (
 		<PostTypeSupportCheck supportKeys="publicize">
 			{ isModalOpened && <SocialPreviewsModal onClose={ closeModal } /> }
@@ -93,6 +127,15 @@ const JetpackSocialSidebar = () => {
 			>
 				<SocialPreviewsPanel openModal={ openModal } />
 			</PluginPrePublishPanel>
+
+			{ ! isReviewRequestDismissed && shouldReviewRequestShow && (
+				<PluginPostPublishPanel id="publicize-title">
+					<ReviewPrompt
+						href={ getRedirectUrl( 'jetpack-social-plugin-reviews' ) }
+						onClose={ handleReviewDismiss }
+					/>
+				</PluginPostPublishPanel>
+			) }
 		</PostTypeSupportCheck>
 	);
 };


### PR DESCRIPTION
Reverts Automattic/jetpack#28066

This PR is to work on fixing the issues from #27917 and re-introduce the functionality without errors.

Errors were being caused because the `useAnalytics` hook function was expecting arguments and did not allow for a call without arguments - which is how the hook was implemented in #27940. This PR makes the object passed to the `useAnalytics` hook optional:

```
const useAnalytics = ( {
	pageViewEventName = null,
	pageViewNamespace = 'jetpack',
	pageViewSuffix = 'page_view',
	pageViewEventProperties = {},
} = {} ) => { ... }
```

#### Does this pull request change what data or activity we track or use?
Yes, see #27917

#### Testing instructions:
- Repeat the test plan for #27917 and confirm that analytics events, including the view event, are still being fired properly for the Jetpack Social review promt
- Activate the Jetpack plugin on your test site and test adding a Payments block ( see [this issue](https://github.com/Automattic/jetpack/pull/27940#issuecomment-1363604547) ). Confirm that there are no console errors.
- All builds/ tests on this PR should be passing.