### PR TITLE
My Jetpack: Move Social out of hybrid concept

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-remove-social-hybrid
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-remove-social-hybrid
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Move Social out of hybrid product

--- a/projects/packages/my-jetpack/src/products/class-social.php
+++ b/projects/packages/my-jetpack/src/products/class-social.php
@@ -7,13 +7,13 @@
 
 namespace Automattic\Jetpack\My_Jetpack\Products;
 
-use Automattic\Jetpack\My_Jetpack\Hybrid_Product;
+use Automattic\Jetpack\My_Jetpack\Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 
 /**
  * Class responsible for handling the Social product
  */
-class Social extends Hybrid_Product {
+class Social extends Product {
 
 	/**
 	 * The product slug
@@ -126,9 +126,7 @@ class Social extends Hybrid_Product {
 	 * @return string
 	 */
 	public static function get_manage_url() {
-		if ( static::is_jetpack_plugin_active() ) {
-			return admin_url( 'admin.php?page=jetpack#/settings?term=publicize' );
-		} elseif ( static::is_plugin_active() ) {
+		if ( static::is_plugin_active() ) {
 			return admin_url( 'admin.php?page=jetpack-social' );
 		}
 	}

--- a/projects/packages/my-jetpack/tests/php/assets/social-mock-plugin.txt
+++ b/projects/packages/my-jetpack/tests/php/assets/social-mock-plugin.txt
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Jetpack Social Plugin
+ *
+ * Plugin Name:       Social
+ * Description:       Jetpack Social mock
+ * Author:            Automattic
+ * Author URI:        https://automattic.com
+ * License:           GPL-2.0+
+ * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
+ */

--- a/projects/packages/my-jetpack/tests/php/test-social-product.php
+++ b/projects/packages/my-jetpack/tests/php/test-social-product.php
@@ -1,0 +1,172 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Automattic\Jetpack\My_Jetpack;
+
+use Automattic\Jetpack\Connection\Tokens;
+use Automattic\Jetpack\My_Jetpack\Products\Social;
+use Jetpack_Options;
+use PHPUnit\Framework\TestCase;
+use WorDBless\Options as WorDBless_Options;
+use WorDBless\Users as WorDBless_Users;
+
+/**
+ * Unit tests for the REST API endpoints.
+ *
+ * @package automattic/my-jetpack
+ * @see \Automattic\Jetpack\My_Jetpack\Rest_Products
+ */
+class Test_Social_Product extends TestCase {
+
+	/**
+	 * The current user id.
+	 *
+	 * @var int
+	 */
+	private static $user_id;
+
+	/**
+	 * Setting up the test.
+	 *
+	 * @before
+	 */
+	public function set_up() {
+
+		// See https://stackoverflow.com/a/41611876.
+		if ( version_compare( phpversion(), '5.7', '<=' ) ) {
+			$this->markTestSkipped( 'avoid bug in PHP 5.6 that throws strict mode warnings for abstract static methods.' );
+		}
+
+		$this->install_mock_plugins();
+		wp_cache_delete( 'plugins', 'plugins' );
+
+		self::$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_admin',
+				'user_pass'  => '123',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( self::$user_id );
+
+	}
+
+	/**
+	 * Installs the mock plugin present in the test assets folder as if it was the Boost plugin
+	 *
+	 * @return void
+	 */
+	public function install_mock_plugins() {
+		$plugin_dir = WP_PLUGIN_DIR . '/' . Social::$plugin_slug;
+		if ( ! file_exists( $plugin_dir ) ) {
+			mkdir( $plugin_dir, 0777, true );
+		}
+		if ( ! file_exists( WP_PLUGIN_DIR . '/jetpack' ) ) {
+			mkdir( WP_PLUGIN_DIR . '/jetpack', 0777, true );
+		}
+		copy( __DIR__ . '/assets/social-mock-plugin.txt', WP_PLUGIN_DIR . '/jetpack-social/jetpack-social.php' );
+		copy( __DIR__ . '/assets/jetpack-mock-plugin.txt', WP_PLUGIN_DIR . '/jetpack/jetpack.php' );
+	}
+
+	/**
+	 * Returning the environment into its initial state.
+	 *
+	 * @after
+	 */
+	public function tear_down() {
+
+		WorDBless_Options::init()->clear_options();
+		WorDBless_Users::init()->clear_all_users();
+
+	}
+
+	/**
+	 * Tests with Jetpack active
+	 */
+	public function test_if_jetpack_active_return_false() {
+		activate_plugin( 'jetpack/jetpack.php' );
+		$this->assertFalse( Social::is_plugin_active() );
+	}
+
+	/**
+	 * Tests with Social active
+	 */
+	public function test_if_jetpack_inactive_and_social_active_return_true() {
+		deactivate_plugins( 'jetpack/jetpack.php' );
+		activate_plugins( Social::get_installed_plugin_filename() );
+		$this->assertTrue( Social::is_plugin_active() );
+	}
+
+	/**
+	 * Tests with both inactive
+	 */
+	public function test_if_jetpack_inactive_and_social_inactive_return_false() {
+		deactivate_plugins( 'jetpack/jetpack.php' );
+		deactivate_plugins( Social::get_installed_plugin_filename() );
+		$this->assertFalse( Social::is_active() );
+	}
+
+	/**
+	 * Tests Social Manage URL with Social plugin
+	 */
+	public function test_social_manage_url_with_social() {
+		deactivate_plugins( 'jetpack/jetpack.php' );
+		activate_plugins( Social::get_installed_plugin_filename() );
+		$this->assertSame( admin_url( 'admin.php?page=jetpack-social' ), Social::get_manage_url() );
+	}
+
+	/**
+	 * Tests Social Manage URL with Jetpack plugin
+	 */
+	public function test_social_manage_url_with_jetpack() {
+		activate_plugins( 'jetpack/jetpack.php' );
+		deactivate_plugins( Social::get_installed_plugin_filename() );
+		$this->assertSame( null, Social::get_manage_url() );
+	}
+
+	/**
+	 * Tests Social Post Activation URL with Jetpack disconected
+	 */
+	public function test_social_post_activation_url_with_jetpack_disconnected() {
+		activate_plugins( 'jetpack/jetpack.php' );
+		deactivate_plugins( Social::get_installed_plugin_filename() );
+		$this->assertSame( null, Social::get_post_activation_url() );
+	}
+
+	/**
+	 * Tests Social Post Activation URL with Social disconected
+	 */
+	public function test_social_post_activation_url_with_social_disconnected() {
+		deactivate_plugins( 'jetpack/jetpack.php' );
+		activate_plugins( Social::get_installed_plugin_filename() );
+		$this->assertSame( admin_url( 'admin.php?page=jetpack-social' ), Social::get_post_activation_url() );
+	}
+
+	/**
+	 * Tests Social Post Activation URL with Jetpack conected
+	 */
+	public function test_social_post_activation_url_with_jetpack_connected() {
+		// Mock site connection.
+		( new Tokens() )->update_blog_token( 'test.test.1' );
+		( new Tokens() )->update_user_token( self::$user_id, 'test.test.' . self::$user_id, true );
+		Jetpack_Options::update_option( 'id', 123 );
+
+		activate_plugins( 'jetpack/jetpack.php' );
+		deactivate_plugins( Social::get_installed_plugin_filename() );
+		$this->assertSame( null, Social::get_post_activation_url() );
+	}
+
+	/**
+	 * Tests Social Post Activation URL with Social conected
+	 */
+	public function test_social_post_activation_url_with_social_connected() {
+		// Mock site connection.
+		( new Tokens() )->update_blog_token( 'test.test.1' );
+		( new Tokens() )->update_user_token( self::$user_id, 'test.test.' . self::$user_id, true );
+		Jetpack_Options::update_option( 'id', 123 );
+
+		deactivate_plugins( 'jetpack/jetpack.php' );
+		activate_plugins( Social::get_installed_plugin_filename() );
+		$this->assertSame( admin_url( 'admin.php?page=jetpack-social' ), Social::get_post_activation_url() );
+	}
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This one moves Social out of the concept of a hybrid product.

So, we will prioritize only the standalone plugin and not rely on the Jetpack module itself.

Closes #27765 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Make `class-social` extends from `Product` and not `HybridProduct`.
* Manage always goes for the `Social` dashboard.
* Add specific unit tests for it.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-jwG-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup a new JN site only with the Jetpack plugin
* Goes to My Jetpack page.
* Social should be marked as absent -  `Add Social` should be available.
* Clicks and goes to add it.
* You should be redirected to the `Social` dashboard after installing.
* Return to `My Jetpack`.
* It now should be active, and manage prompts to the `Social` dashboard.
* Goes into the plugin page and deactivates it.
* Now, My Jetpack should reflect it as inactive. 