### PR TITLE
Image Guide: Fix image guide package

### DIFF
--- a/projects/js-packages/image-guide/changelog/fix-image-guide-package
+++ b/projects/js-packages/image-guide/changelog/fix-image-guide-package
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Fix packaging issues to publish to npm
+
+

--- a/projects/js-packages/image-guide/composer.json
+++ b/projects/js-packages/image-guide/composer.json
@@ -48,6 +48,7 @@
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-image-guide/compare/v${old}...v${new}"
 		},
-		"autotagger": true
+		"autotagger": true,
+		"release-branch-prefix": "image-guide"
 	}
 }

--- a/projects/js-packages/image-guide/package.json
+++ b/projects/js-packages/image-guide/package.json
@@ -15,7 +15,6 @@
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic",
 	"scripts": {
-		"prepare": "pnpm build",
 		"build": "tsc",
 		"clean": "rm -rf build/",
 		"watch": "pnpm run build && pnpm webpack watch",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removed prepare script as that was being run on mirror repo. Causing publishing to fail due to missing pnpm.
* Defined a release branch prefix to allow publishing image-guide independent of any plugin.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
p1671775119411749-slack-C01U2KGS2PQ

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
None