### PR TITLE
Add `restricted_tld` field to the response of GET /site endpoint.

### DIFF
--- a/projects/plugins/jetpack/changelog/add-site-option-restrict-tld
+++ b/projects/plugins/jetpack/changelog/add-site-option-restrict-tld
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Site list API: Exposing `restricted_tld` site option.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -144,7 +144,6 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'default_post_format',
 		'default_category',
 		'allowed_file_types',
-		'allowed_tld',
 		'show_on_front',
 		/** This filter is documented in modules/likes.php */
 		'default_likes_enabled',
@@ -195,6 +194,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'blogging_prompts_settings',
 		'launchpad_screen',
 		'launchpad_checklist_tasks_statuses',
+		'restricted_tld',
 	);
 
 	/**
@@ -659,9 +659,6 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				case 'allowed_file_types':
 					$options[ $key ] = $site->allowed_file_types();
 					break;
-				case 'allowed_tld':
-					$options[ $key ] = $site->get_allowed_tld();
-					break;
 				case 'show_on_front':
 					$options[ $key ] = $site->get_show_on_front();
 					break;
@@ -849,6 +846,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'launchpad_checklist_tasks_statuses':
 					$options[ $key ] = $site->get_launchpad_checklist_tasks_statuses();
+					break;
+				case 'restricted_tld':
+					$options[ $key ] = $site->get_restricted_tld();
 					break;
 			}
 		}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -144,6 +144,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'default_post_format',
 		'default_category',
 		'allowed_file_types',
+		'allowed_tld',
 		'show_on_front',
 		/** This filter is documented in modules/likes.php */
 		'default_likes_enabled',
@@ -657,6 +658,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'allowed_file_types':
 					$options[ $key ] = $site->allowed_file_types();
+					break;
+				case 'allowed_tld':
+					$options[ $key ] = $site->allowed_tld();
 					break;
 				case 'show_on_front':
 					$options[ $key ] = $site->get_show_on_front();

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -660,7 +660,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					$options[ $key ] = $site->allowed_file_types();
 					break;
 				case 'allowed_tld':
-					$options[ $key ] = $site->allowed_tld();
+					$options[ $key ] = $site->get_allowed_tld();
 					break;
 				case 'show_on_front':
 					$options[ $key ] = $site->get_show_on_front();

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -850,6 +850,16 @@ abstract class SAL_Site {
 	}
 
 	/**
+	 * Get the option storing the TLD restriction for this site.
+	 *
+	 * @return string
+	 */
+	public function get_restricted_tld() {
+		return get_option( 'restricted_tld' );
+	}
+
+
+	/**
 	 * Returns a date/time string with the date the site was last updated, or a default date/time string otherwise.
 	 *
 	 * @return string
@@ -1387,15 +1397,6 @@ abstract class SAL_Site {
 	 */
 	public function get_anchor_podcast() {
 		return get_option( 'anchor_podcast' );
-	}
-
-	/**
-	 * Get the option storing the allowed TLD for this site.
-	 *
-	 * @return string
-	 */
-	public function get_allowed_tld() {
-		return get_option( 'allowed_tld' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -858,7 +858,6 @@ abstract class SAL_Site {
 		return get_option( 'restricted_tld' );
 	}
 
-
 	/**
 	 * Returns a date/time string with the date the site was last updated, or a default date/time string otherwise.
 	 *

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1390,6 +1390,15 @@ abstract class SAL_Site {
 	}
 
 	/**
+	 * Get the option storing the allowed TLD for this site.
+	 *
+	 * @return string
+	 */
+	public function get_allowed_tld() {
+		return get_option( 'allowed_tld' );
+	}
+
+	/**
 	 * Check if the site is currently being built by the DIFM Lite team.
 	 *
 	 * @return bool


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR adds `restricted_tld` field to the response of `GET /site/%s` endpoint. It is part of the task of implementing domain TLD restriction for the sites created via the dotlink partnership version of Link in Bio flow. Please refer to Automattic/martech#1320 for more info.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Does this pull request change what data or activity we track or use?

My PR adds no data or activity we track or use.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Deploy this PR to your sandbox.
2. Pick a random test site.
3. Go to the developer console: https://developer.wordpress.com/docs/api/console/ and log in as the site owner.
4. Make request to `GET /sites/<slte slug>`, and see the `restricted_tld` field under the site option to be `false`.
5. In `wpsh`, run `switch_to_blog()` to switch into the context of your test site, and run update_option( 'restricted_tld', 'link' )`
6. Repeat the 4th step again, and make sure `restricted_tld` is now `link`.

