### PR TITLE
[Package] My Jetpack: Add connection support + manage links and append Owner word to connection owner

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/index.jsx
@@ -1,4 +1,4 @@
-import { Button, H3, Text } from '@automattic/jetpack-components';
+import { Button, getRedirectUrl, H3, Text } from '@automattic/jetpack-components';
 import {
 	ManageConnectionDialog,
 	useConnection,
@@ -105,6 +105,14 @@ const ConnectionStatusCard = props => {
 
 			<Text variant="body" mb={ 3 }>
 				{ connectionInfoText }
+				<Button
+					href={ getRedirectUrl( 'why-the-wordpress-com-connection-is-important-for-jetpack' ) }
+					variant="link"
+					weight="regular"
+					isExternalLink={ true }
+				>
+					{ __( 'Learn more about connections', 'jetpack-my-jetpack' ) }
+				</Button>
 			</Text>
 
 			<div className={ styles.status }>
@@ -137,7 +145,7 @@ const ConnectionStatusCard = props => {
 						<ConnectionListItem
 							onClick={ openManageConnectionDialog }
 							text={ __( 'Site connected.', 'jetpack-my-jetpack' ) }
-							actionText={ ! isUserConnected ? __( 'Manage', 'jetpack-my-jetpack' ) : null }
+							actionText={ isUserConnected ? __( 'Manage', 'jetpack-my-jetpack' ) : null }
 						/>
 						{ isUserConnected && (
 							<ConnectionListItem
@@ -205,7 +213,7 @@ ConnectionStatusCard.propTypes = {
 ConnectionStatusCard.defaultProps = {
 	title: __( 'Connection', 'jetpack-my-jetpack' ),
 	connectionInfoText: __(
-		'Jetpack connects your site and user account to the WordPress.com cloud to provide more powerful features.',
+		'Jetpack connects your site and user account to the WordPress.com cloud to provide more powerful features. ',
 		'jetpack-my-jetpack'
 	),
 	redirectUri: null,

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/index.jsx
@@ -104,7 +104,7 @@ const ConnectionStatusCard = props => {
 			<H3>{ title }</H3>
 
 			<Text variant="body" mb={ 3 }>
-				{ connectionInfoText }
+				{ `${ connectionInfoText } ` }
 				<Button
 					href={ getRedirectUrl( 'why-the-wordpress-com-connection-is-important-for-jetpack' ) }
 					variant="link"
@@ -153,9 +153,11 @@ const ConnectionStatusCard = props => {
 								actionText={ __( 'Manage', 'jetpack-my-jetpack' ) }
 								text={ sprintf(
 									/* translators: first placeholder is user name, second is either the (Owner) string or an empty string */
-									__( 'Connected as %1$s %2$s.', 'jetpack-my-jetpack' ),
+									__( 'Connected as %1$s%2$s.', 'jetpack-my-jetpack' ),
 									userConnectionData.currentUser?.wpcomUser?.display_name,
-									userConnectionData.currentUser?.isMaster ? '(Owner)' : ''
+									userConnectionData.currentUser?.isMaster
+										? __( ' (Owner)', 'jetpack-my-jetpack' )
+										: ''
 								) }
 							/>
 						) }
@@ -214,7 +216,7 @@ ConnectionStatusCard.propTypes = {
 ConnectionStatusCard.defaultProps = {
 	title: __( 'Connection', 'jetpack-my-jetpack' ),
 	connectionInfoText: __(
-		'Jetpack connects your site and user account to the WordPress.com cloud to provide more powerful features. ',
+		'Jetpack connects your site and user account to the WordPress.com cloud to provide more powerful features.',
 		'jetpack-my-jetpack'
 	),
 	redirectUri: null,

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/index.jsx
@@ -152,9 +152,10 @@ const ConnectionStatusCard = props => {
 								onClick={ openManageConnectionDialog }
 								actionText={ __( 'Manage', 'jetpack-my-jetpack' ) }
 								text={ sprintf(
-									/* translators: placeholder is user name */
-									__( 'Connected as %s.', 'jetpack-my-jetpack' ),
-									userConnectionData.currentUser?.wpcomUser?.display_name
+									/* translators: first placeholder is user name, second is either the (Owner) string or an empty string */
+									__( 'Connected as %1$s %2$s.', 'jetpack-my-jetpack' ),
+									userConnectionData.currentUser?.wpcomUser?.display_name,
+									userConnectionData.currentUser?.isMaster ? '(Owner)' : ''
 								) }
 							/>
 						) }

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/test/component.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/test/component.jsx
@@ -30,9 +30,9 @@ describe( 'ConnectionStatusCard', () => {
 			expect( screen.getByText( 'Site connected.' ) ).toBeInTheDocument();
 		} );
 
-		it( 'renders the "Manage" button', () => {
+		it( 'Does not render the "Manage" button', () => {
 			setup();
-			expect( screen.getByRole( 'button', { name: 'Manage' } ) ).toBeInTheDocument();
+			expect( screen.queryByRole( 'button', { name: 'Manage' } ) ).not.toBeInTheDocument();
 		} );
 
 		it( 'renders the "You’re not connected" error list item', () => {
@@ -63,9 +63,9 @@ describe( 'ConnectionStatusCard', () => {
 			expect( screen.getByText( 'Site connected.' ) ).toBeInTheDocument();
 		} );
 
-		it( 'renders the "Manage" button', () => {
+		it( 'Does not render the "Manage" button', () => {
 			setup();
-			expect( screen.getByRole( 'button', { name: 'Manage' } ) ).toBeInTheDocument();
+			expect( screen.queryByRole( 'button', { name: 'Manage' } ) ).not.toBeInTheDocument();
 		} );
 
 		it( 'Render the "You’re not connected" error list item', () => {
@@ -98,9 +98,9 @@ describe( 'ConnectionStatusCard', () => {
 			expect( screen.getByText( 'Site connected.' ) ).toBeInTheDocument();
 		} );
 
-		it( 'renders the "Manage" button', () => {
+		it( 'renders the "Manage" buttons', () => {
 			setup();
-			expect( screen.getByRole( 'button', { name: 'Manage' } ) ).toBeInTheDocument();
+			expect( screen.getAllByRole( 'button', { name: 'Manage' } ) ).toHaveLength( 2 );
 		} );
 
 		it( 'renders the "Logged in as" success list item', () => {

--- a/projects/packages/my-jetpack/changelog/modify-myjetpack-connection-owner-view
+++ b/projects/packages/my-jetpack/changelog/modify-myjetpack-connection-owner-view
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Added link to support document
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes first task of #27496

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
In My Jetpack Admin page:
1- Add link to Jetpack connection support documentation
2- Add link to manage connection next to the connection status
3- Append `(Owner)` to the connected user when visiting My Jetpack from the owner's account

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a site, install and connect Jetpack or a standalone plugin
* Verify that in My Jetpack all this information is visible:
<img width="430" alt="Screenshot 2022-12-28 at 17 25 58" src="https://user-images.githubusercontent.com/16329583/209843157-1f0ab962-c22b-4550-9d45-0882b8d36152.png">
* Confirm that the links work
* Disconnect from Jetpack and confirm that it works as expected (link to connect, no link to manage
* Connect with a secondary admin, confirm that the `(Owner)` is not shown

