### PR TITLE
My Jetpack: Move VideoPress out of hybrid concept

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-remove-videopress-hybrid
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-remove-videopress-hybrid
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+My Jetpack: Move VideoPress from Hybrid

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -16,7 +16,8 @@
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.0.4",
 		"automattic/jetpack-changelogger": "@dev",
-		"automattic/wordbless": "@dev"
+		"automattic/wordbless": "@dev",
+		"automattic/jetpack-videopress": "@dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "2.7.1",
+	"version": "2.7.2-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -30,7 +30,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '2.7.1';
+	const PACKAGE_VERSION = '2.7.2-alpha';
 
 	/**
 	 * Initialize My Jetpack

--- a/projects/packages/my-jetpack/src/products/class-videopress.php
+++ b/projects/packages/my-jetpack/src/products/class-videopress.php
@@ -7,13 +7,13 @@
 
 namespace Automattic\Jetpack\My_Jetpack\Products;
 
-use Automattic\Jetpack\My_Jetpack\Hybrid_Product;
+use Automattic\Jetpack\My_Jetpack\Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 
 /**
  * Class responsible for handling the VideoPress product
  */
-class Videopress extends Hybrid_Product {
+class Videopress extends Product {
 
 	/**
 	 * The product slug
@@ -145,8 +145,6 @@ class Videopress extends Hybrid_Product {
 	public static function get_manage_url() {
 		if ( method_exists( 'Automattic\Jetpack\VideoPress\Initializer', 'should_initialize_admin_ui' ) && \Automattic\Jetpack\VideoPress\Initializer::should_initialize_admin_ui() ) {
 			return \Automattic\Jetpack\VideoPress\Admin_UI::get_admin_page_url();
-		} else {
-			return admin_url( 'admin.php?page=jetpack#/settings?term=videopress' );
 		}
 	}
 

--- a/projects/packages/my-jetpack/tests/php/assets/videopress-mock-plugin.txt
+++ b/projects/packages/my-jetpack/tests/php/assets/videopress-mock-plugin.txt
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Jetpack VideoPress Plugin
+ *
+ * Plugin Name:       VideoPress
+ * Description:       Jetpack VideoPress mock
+ * Author:            Automattic
+ * Author URI:        https://automattic.com
+ * License:           GPL-2.0+
+ * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
+ */

--- a/projects/packages/my-jetpack/tests/php/test-videopress-product.php
+++ b/projects/packages/my-jetpack/tests/php/test-videopress-product.php
@@ -1,0 +1,171 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Automattic\Jetpack\My_Jetpack;
+
+use Automattic\Jetpack\Connection\Tokens;
+use Automattic\Jetpack\My_Jetpack\Products\Videopress;
+use Jetpack_Options;
+use PHPUnit\Framework\TestCase;
+use WorDBless\Options as WorDBless_Options;
+use WorDBless\Users as WorDBless_Users;
+
+/**
+ * Unit tests for the REST API endpoints.
+ *
+ * @package automattic/my-jetpack
+ * @see \Automattic\Jetpack\My_Jetpack\Rest_Products
+ */
+class Test_Videopress_Product extends TestCase {
+
+	/**
+	 * The current user id.
+	 *
+	 * @var int
+	 */
+	private static $user_id;
+
+	/**
+	 * Setting up the test.
+	 *
+	 * @before
+	 */
+	public function set_up() {
+
+		// See https://stackoverflow.com/a/41611876.
+		if ( version_compare( phpversion(), '5.7', '<=' ) ) {
+			$this->markTestSkipped( 'avoid bug in PHP 5.6 that throws strict mode warnings for abstract static methods.' );
+		}
+
+		$this->install_mock_plugins();
+		wp_cache_delete( 'plugins', 'plugins' );
+
+		self::$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_admin',
+				'user_pass'  => '123',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( self::$user_id );
+
+	}
+
+	/**
+	 * Installs the mock plugin present in the test assets folder as if it was the Boost plugin
+	 *
+	 * @return void
+	 */
+	public function install_mock_plugins() {
+		$plugin_dir = WP_PLUGIN_DIR . '/' . Videopress::$plugin_slug;
+		if ( ! file_exists( $plugin_dir ) ) {
+			mkdir( $plugin_dir, 0777, true );
+		}
+		if ( ! file_exists( WP_PLUGIN_DIR . '/jetpack' ) ) {
+			mkdir( WP_PLUGIN_DIR . '/jetpack', 0777, true );
+		}
+		copy( __DIR__ . '/assets/videopress-mock-plugin.txt', WP_PLUGIN_DIR . '/jetpack-videopress/jetpack-videopress.php' );
+		copy( __DIR__ . '/assets/jetpack-mock-plugin.txt', WP_PLUGIN_DIR . '/jetpack/jetpack.php' );
+	}
+
+	/**
+	 * Returning the environment into its initial state.
+	 *
+	 * @after
+	 */
+	public function tear_down() {
+		WorDBless_Options::init()->clear_options();
+		WorDBless_Users::init()->clear_all_users();
+	}
+
+	/**
+	 * Tests with Jetpack active
+	 */
+	public function test_if_jetpack_active_return_false() {
+		activate_plugins( 'jetpack/jetpack.php' );
+		$this->assertFalse( Videopress::is_plugin_active() );
+	}
+
+	/**
+	 * Tests with Videopress active
+	 */
+	public function test_if_jetpack_inactive_and_videopress_active_return_true() {
+		deactivate_plugins( 'jetpack/jetpack.php' );
+		activate_plugins( Videopress::get_installed_plugin_filename() );
+		$this->assertTrue( Videopress::is_plugin_active() );
+	}
+
+	/**
+	 * Tests with both inactive
+	 */
+	public function test_if_jetpack_inactive_and_videopress_inactive_return_false() {
+		deactivate_plugins( 'jetpack/jetpack.php' );
+		deactivate_plugins( Videopress::get_installed_plugin_filename() );
+		$this->assertFalse( Videopress::is_plugin_active() );
+	}
+
+	/**
+	 * Tests Videopress Manage URL with Jetpack plugin
+	 */
+	public function test_videopress_manage_url_with_jetpack() {
+		activate_plugins( 'jetpack/jetpack.php' );
+		deactivate_plugins( Videopress::get_installed_plugin_filename() );
+		$this->assertSame( null, Videopress::get_manage_url() );
+	}
+
+	/**
+	 * Tests Videopress Manage URL with Videopress plugin
+	 */
+	public function test_videopress_manage_url_with_videopress() {
+		deactivate_plugins( 'jetpack/jetpack.php' );
+		activate_plugins( Videopress::get_installed_plugin_filename() );
+		\Automattic\Jetpack\VideoPress\Initializer::update_init_options( array( 'admin_ui' => true ) );
+		$this->assertSame( admin_url( 'admin.php?page=jetpack-videopress' ), Videopress::get_manage_url() );
+	}
+
+	/**
+	 * Tests Videopress Post Activation URL with Jetpack disconected
+	 */
+	public function test_videopress_post_activation_url_with_jetpack_disconnected() {
+		activate_plugins( 'jetpack/jetpack.php' );
+		deactivate_plugins( Videopress::get_installed_plugin_filename() );
+		$this->assertSame( '', Videopress::get_post_activation_url() );
+	}
+
+	/**
+	 * Tests Videopress Post Activation URL with Videopress disconected
+	 */
+	public function test_videopress_post_activation_url_with_videopress_disconnected() {
+		deactivate_plugins( 'jetpack/jetpack.php' );
+		activate_plugins( Videopress::get_installed_plugin_filename() );
+		$this->assertSame( '', Videopress::get_post_activation_url() );
+	}
+
+	/**
+	 * Tests Videopress Post Activation URL with Jetpack conected
+	 */
+	public function test_videopress_post_activation_url_with_jetpack_connected() {
+		// Mock site connection.
+		( new Tokens() )->update_blog_token( 'test.test.1' );
+		( new Tokens() )->update_user_token( self::$user_id, 'test.test.' . self::$user_id, true );
+		Jetpack_Options::update_option( 'id', 123 );
+
+		activate_plugins( 'jetpack/jetpack.php' );
+		deactivate_plugins( Videopress::get_installed_plugin_filename() );
+		$this->assertSame( '', Videopress::get_post_activation_url() );
+	}
+
+	/**
+	 * Tests Videopress Post Activation URL with Videopress conected
+	 */
+	public function test_videopress_post_activation_url_with_videopress_connected() {
+		// Mock site connection.
+		( new Tokens() )->update_blog_token( 'test.test.1' );
+		( new Tokens() )->update_user_token( self::$user_id, 'test.test.' . self::$user_id, true );
+		Jetpack_Options::update_option( 'id', 123 );
+
+		deactivate_plugins( 'jetpack/jetpack.php' );
+		activate_plugins( Videopress::get_installed_plugin_filename() );
+		$this->assertSame( '', Videopress::get_post_activation_url() );
+	}
+
+}

--- a/projects/plugins/backup/changelog/update-my-jetpack-remove-videopress-hybrid
+++ b/projects/plugins/backup/changelog/update-my-jetpack-remove-videopress-hybrid
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -827,7 +827,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "6933e1a9f9cf005f0448c845a5a85d625a56c83b"
+                "reference": "eb4eefaa216570b48bdb99116b7b001a949e7ec4"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -841,6 +841,7 @@
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-videopress": "@dev",
                 "automattic/wordbless": "@dev",
                 "yoast/phpunit-polyfills": "1.0.4"
             },

--- a/projects/plugins/boost/changelog/update-my-jetpack-remove-videopress-hybrid
+++ b/projects/plugins/boost/changelog/update-my-jetpack-remove-videopress-hybrid
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -735,7 +735,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "6933e1a9f9cf005f0448c845a5a85d625a56c83b"
+                "reference": "eb4eefaa216570b48bdb99116b7b001a949e7ec4"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -749,6 +749,7 @@
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-videopress": "@dev",
                 "automattic/wordbless": "@dev",
                 "yoast/phpunit-polyfills": "1.0.4"
             },

--- a/projects/plugins/jetpack/changelog/update-my-jetpack-remove-videopress-hybrid
+++ b/projects/plugins/jetpack/changelog/update-my-jetpack-remove-videopress-hybrid
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1267,7 +1267,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "6933e1a9f9cf005f0448c845a5a85d625a56c83b"
+                "reference": "eb4eefaa216570b48bdb99116b7b001a949e7ec4"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1281,6 +1281,7 @@
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-videopress": "@dev",
                 "automattic/wordbless": "@dev",
                 "yoast/phpunit-polyfills": "1.0.4"
             },

--- a/projects/plugins/protect/changelog/update-my-jetpack-remove-videopress-hybrid
+++ b/projects/plugins/protect/changelog/update-my-jetpack-remove-videopress-hybrid
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -745,7 +745,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "6933e1a9f9cf005f0448c845a5a85d625a56c83b"
+                "reference": "eb4eefaa216570b48bdb99116b7b001a949e7ec4"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -759,6 +759,7 @@
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-videopress": "@dev",
                 "automattic/wordbless": "@dev",
                 "yoast/phpunit-polyfills": "1.0.4"
             },

--- a/projects/plugins/search/changelog/update-my-jetpack-remove-videopress-hybrid
+++ b/projects/plugins/search/changelog/update-my-jetpack-remove-videopress-hybrid
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -745,7 +745,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "6933e1a9f9cf005f0448c845a5a85d625a56c83b"
+                "reference": "eb4eefaa216570b48bdb99116b7b001a949e7ec4"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -759,6 +759,7 @@
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-videopress": "@dev",
                 "automattic/wordbless": "@dev",
                 "yoast/phpunit-polyfills": "1.0.4"
             },

--- a/projects/plugins/social/changelog/update-my-jetpack-remove-videopress-hybrid
+++ b/projects/plugins/social/changelog/update-my-jetpack-remove-videopress-hybrid
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -745,7 +745,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "6933e1a9f9cf005f0448c845a5a85d625a56c83b"
+                "reference": "eb4eefaa216570b48bdb99116b7b001a949e7ec4"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -759,6 +759,7 @@
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-videopress": "@dev",
                 "automattic/wordbless": "@dev",
                 "yoast/phpunit-polyfills": "1.0.4"
             },

--- a/projects/plugins/starter-plugin/changelog/update-my-jetpack-remove-videopress-hybrid
+++ b/projects/plugins/starter-plugin/changelog/update-my-jetpack-remove-videopress-hybrid
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -745,7 +745,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "6933e1a9f9cf005f0448c845a5a85d625a56c83b"
+                "reference": "eb4eefaa216570b48bdb99116b7b001a949e7ec4"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -759,6 +759,7 @@
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-videopress": "@dev",
                 "automattic/wordbless": "@dev",
                 "yoast/phpunit-polyfills": "1.0.4"
             },

--- a/projects/plugins/videopress/changelog/update-my-jetpack-remove-videopress-hybrid
+++ b/projects/plugins/videopress/changelog/update-my-jetpack-remove-videopress-hybrid
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -745,7 +745,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "6933e1a9f9cf005f0448c845a5a85d625a56c83b"
+                "reference": "eb4eefaa216570b48bdb99116b7b001a949e7ec4"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -759,6 +759,7 @@
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-videopress": "@dev",
                 "automattic/wordbless": "@dev",
                 "yoast/phpunit-polyfills": "1.0.4"
             },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This one moves VideoPress out of the concept of a hybrid product.

So, we will prioritize only the standalone plugin and not rely on the Jetpack module itself.

Closes #27764  

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Make `class-videopress` extends from `Product` and not `HybridProduct`.
* Manage always goes for the `VideoPress` dashboard.
* Add specific unit tests for it.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-jwG-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup a new JN site only with the Jetpack plugin
* Goes to My Jetpack page.
* VideoPress should be marked as absent -  `Add VideoPress` should be available.
* Clicks and goes to add it.
* You should be redirected to the `VideoPress` dashboard after installing.
* Return to `My Jetpack`.
* It now should be active and manage prompts to the `VideoPress` dashboard.
* Goes into the plugin page and deactivates it.
* Now, My Jetpack should reflect it as inactive. 