### PR TITLE
Rollback phpcsstandards updates to fix trunk test failures.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -61,7 +61,7 @@
             "dist": {
                 "type": "path",
                 "url": "projects/packages/codesniffer",
-                "reference": "7b278c14eb3d0b5929db3eac2cfe29503c249ee8"
+                "reference": "c8726443864676c10b023bf28d894b2003cfebff"
             },
             "require": {
                 "automattic/vipwpcs": "^2.3",
@@ -73,6 +73,8 @@
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
+                "phpcsstandards/phpcsextra": "1.0.0-alpha3",
+                "phpcsstandards/phpcsutils": "1.0.0-alpha3",
                 "wp-coding-standards/wpcs": "2022-02-07 as 2.3.1",
                 "yoast/phpunit-polyfills": "1.0.4"
             },

--- a/projects/packages/codesniffer/changelog/rollback-phpcsstandards-updates
+++ b/projects/packages/codesniffer/changelog/rollback-phpcsstandards-updates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Rolled back a dependency update that caused breaking changes in Jetpack trunk.

--- a/projects/packages/codesniffer/composer.json
+++ b/projects/packages/codesniffer/composer.json
@@ -14,6 +14,8 @@
 	"require-dev": {
 		"automattic/jetpack-changelogger": "@dev",
 		"wp-coding-standards/wpcs": "2022-02-07 as 2.3.1",
+		"phpcsstandards/phpcsutils": "1.0.0-alpha3",
+		"phpcsstandards/phpcsextra": "1.0.0-alpha3",
 		"yoast/phpunit-polyfills": "1.0.4"
 	},
 	"autoload": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes trunk test failures by forcing a downgrade of two dependencies of the `codesniffer` package. The breaking change in 1.0.0-alpha4 of these packages was a removal of a static property and replacement of it with a method. The `wp-coding-standards/wpcs` package that uses these utils is not yet updated to use that change. I haven't looked at updating it yet, we should work on that in a separate PR.


#### Changes proposed in this Pull Request:
* Downgraded `phpcsstandards/phpcsextra` to `1.0.0-alpha3`.
* Downgraded `phpcsstandards/phpcsutils` to `1.0.0-alpha3`.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Observe the tests.

