### PR TITLE
My Jetpack: Manage Connection modal layout fix

### DIFF
--- a/projects/js-packages/connection/changelog/fix-manage-connection-box-sizing
+++ b/projects/js-packages/connection/changelog/fix-manage-connection-box-sizing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Connection: Fix box-sizing layout issue on Manage Connection modal

--- a/projects/js-packages/connection/components/manage-connection-dialog/style.scss
+++ b/projects/js-packages/connection/components/manage-connection-dialog/style.scss
@@ -40,6 +40,7 @@
 		align-items:center;
 		position: sticky;
 		bottom: 0;
+		box-sizing: border-box;
 	}
 
 	&__link {

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.24.3",
+	"version": "0.24.4-alpha",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #28100

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Changes the `box-sizing` of the modal footer.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Connect Jetpack
* Go to My Jetpack
* Click on `Manage`
* Check that the modal's footer is shown correctly

Before | After
-|-
![2022-12-28_14-52-30](https://user-images.githubusercontent.com/8486249/209855533-b0763890-f687-4272-a294-744b01fd542b.png) | ![2022-12-28_15-09-52](https://user-images.githubusercontent.com/8486249/209855539-15863c2b-6c2c-4043-9f3d-c11b53839ff4.png)

