### PR TITLE
Fix `Linting / ESLint (non-excluded files only)` test 

### DIFF
--- a/projects/js-packages/image-guide/changelog/fix-eslint-test-failure
+++ b/projects/js-packages/image-guide/changelog/fix-eslint-test-failure
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Adding prepare script back to package.json, was needed for an ESlint test

--- a/projects/js-packages/image-guide/package.json
+++ b/projects/js-packages/image-guide/package.json
@@ -15,6 +15,7 @@
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic",
 	"scripts": {
+		"prepare": "pnpm build",
 		"build": "tsc",
 		"clean": "rm -rf build/",
 		"watch": "pnpm run build && pnpm webpack watch",


### PR DESCRIPTION
It looks like the `Linting / ESLint (non-excluded files only)` test uses the `prepare` script that was removed in [this PR](https://github.com/Automattic/jetpack/pull/28080). Without it, it is not able to find the `jetpack-image-guide` package.

There may be a better long term fix than just adding it back like this, but this should fix trunk and allow tests to pass at least for now.

#### Changes proposed in this Pull Request:

This PR adds the `prepare` script back to the package.json file for the `jetpack-image-guide` package

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion

Context: p1672251936898689/1672246333.206819-slack-CDLH4C1UZ

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:
Changing this file does not run the test that removing `prepare` broke, so I'll provide links to other PRs that are failing this test due to this, as well as link to a branch where I manually added `prepare` back to show that the test passes

1. Go to [this PR](https://github.com/Automattic/jetpack/pull/28095) to see the test failing
![image](https://user-images.githubusercontent.com/65001528/209871433-e5ae70d2-2677-4d7d-8ca2-736133800f22.png)
2. Go to [this PR](https://github.com/Automattic/jetpack/pull/28072), where `prepare` has been added back, to see the test passing
![image](https://user-images.githubusercontent.com/65001528/209871497-a8f5629c-4cef-41d2-b686-27df05cb4c7c.png)
