### PR TITLE
Creating new release

### DIFF
--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 11.7-a.11 - 2022-12-29
+### Bug fixes
+- Premium subscriptions / paid newsletters: Reverting previously merged changes which caused fatal errors in production. [#28102]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Updating changelog entries for the Jetpack plugin [#28089]
+
 ## 11.7-a.9 - 2022-12-27
 ### Major Enhancements
 - Blocks: add launchpad on save modal. [#27976]
@@ -18,7 +25,6 @@
 - Subscription / Premium Content block: restrict posts to either paid subscribers or email subscribers (available with a Beta filter only), and add option for subscribers to pay while subscribing via the Subscription block, if the site owner creates one or more "newsletter" paid plans. [#26417]
 - VideoPress: do not convert core/embed to videopress/video on-the-fly (WordPress.com sites). [#27942]
 
-
 ### Improved compatibility
 - VideoPress: make sure the Videopress shortcode is not registered if standalone VideoPress plugin already registered it. [#27842]
 
@@ -30,7 +36,6 @@
 - Shortcodes: update the Mixcloud oEmbed API Endpoint to the new version. [#28061]
 - Subscription block: ensure custom button spacing is correct when the button is on its own line. [#28057]
 - Writing Prompts: do not display within mobile app. [#28023]
-
 
 ### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
 - Blaze: changing Promote Post package reference to new name: Blaze. [#28073]

--- a/projects/plugins/jetpack/changelog/init-release-cycle#2
+++ b/projects/plugins/jetpack/changelog/init-release-cycle#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 11.7-a.12
+
+

--- a/projects/plugins/jetpack/changelog/revert-paid-newsletters
+++ b/projects/plugins/jetpack/changelog/revert-paid-newsletters
@@ -1,4 +1,0 @@
-Significance: minor
-Type: bugfix
-
-Premium subscriptions / paid newsletters: Reverting previously merged changes which caused fatal errors in production.

--- a/projects/plugins/jetpack/changelog/update-clean-jetpack-11.7-a.9-readme
+++ b/projects/plugins/jetpack/changelog/update-clean-jetpack-11.7-a.9-readme
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updating changelog entries for the Jetpack plugin

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ11_7_a_11",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ11_7_a_12",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ11_7_a_10",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ11_7_a_11",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 11.7-a.10
+ * Version: 11.7-a.11
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -32,7 +32,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.0' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '11.7-a.10' );
+define( 'JETPACK__VERSION', '11.7-a.11' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 11.7-a.11
+ * Version: 11.7-a.12
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -32,7 +32,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.0' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '11.7-a.11' );
+define( 'JETPACK__VERSION', '11.7-a.12' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "11.7.0-a.11",
+	"version": "11.7.0-a.12",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "11.7.0-a.10",
+	"version": "11.7.0-a.11",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -242,35 +242,9 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 4. Promote your newest posts, pages, and products across your social media channels.
 
 == Changelog ==
-### 11.7-a.9 - 2022-12-27
-#### Major Enhancements
-- Blocks: add launchpad on save modal.
-- Revue block: remove functionality due to Revue shutting down, add placeholder messaging instead.
-
-#### Enhancements
-- Contact form: move responses export to a modal triggered by a single "Export" button.
-- Dashboard: use minimized CSS for the stats widget.
-- Global Styles: add new fonts for better i18n.
-- Form block: adjust Form placeholder icon and link colors for better consistency.
-- Form block: update Form child blocks icons.
-- Slideshow block: reduce bullet size and change the CSS justify-content to flex-start.
-- Slideshow block: replace pencil icon with edit text.
-- Subscription / Premium Content block: restrict posts to either paid subscribers or email subscribers (available with a Beta filter only), and add option for subscribers to pay while subscribing via the Subscription block, if the site owner creates one or more "newsletter" paid plans.
-- VideoPress: do not convert core/embed to videopress/video on-the-fly (WordPress.com sites).
-
-
-#### Improved compatibility
-- VideoPress: make sure the Videopress shortcode is not registered if standalone VideoPress plugin already registered it.
-
+### 11.7-a.11 - 2022-12-29
 #### Bug fixes
-- Form block: adjust Form placeholder footer links style to prevent theme clashes.
-- Internationalization: fix context for translated product name.
-- Payment block: fix the upgrade nudge for Payment blocks in the Site Editor on WordPress.com sites.
-- Premium Content block: fix bug in JWT library encode() method.
-- Shortcodes: update the Mixcloud oEmbed API Endpoint to the new version.
-- Subscription block: ensure custom button spacing is correct when the button is on its own line.
-- Writing Prompts: do not display within mobile app.
-
+- Premium subscriptions / paid newsletters: Reverting previously merged changes which caused fatal errors in production.
 
 --------
 


### PR DESCRIPTION


#### Changes proposed in this Pull Request:

* Bumps Jetpack to 11.7-a.12 after releasing 11.7-a.11 in `jetpack-production` for the next WoA release.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion

n/a

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:


* Check version numbers. For comparison, here is a previous PR for a similar situation: https://github.com/Automattic/jetpack/pull/23947

