### PR TITLE
List Posts API: Allow to fetch all posts in one request

### DIFF
--- a/projects/plugins/jetpack/changelog/2022-12-29-14-48-56-448582
+++ b/projects/plugins/jetpack/changelog/2022-12-29-14-48-56-448582
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+List Posts API: Allow for fetching all posts in one go.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
@@ -124,7 +124,7 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 		$is_eligible_for_page_handle = true;
 		$site                        = $this->get_platform()->get_site( $blog_id );
 
-		if ( $args['number'] < 1 ) {
+		if ( $args['number'] < 1 && $args['number'] !== -1 ) {
 			$args['number'] = 20;
 		} elseif ( 100 < $args['number'] ) {
 			return new WP_Error( 'invalid_number', 'The NUMBER parameter must be less than or equal to 100.', 400 );
@@ -207,16 +207,21 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 		}
 
 		$query = array(
-			'posts_per_page' => $args['number'],
-			'order'          => $args['order'],
-			'orderby'        => $args['order_by'],
-			'post_type'      => $args['type'],
-			'post_status'    => $status,
-			'post_parent'    => isset( $args['parent_id'] ) ? $args['parent_id'] : null,
-			'author'         => isset( $args['author'] ) && 0 < $args['author'] ? $args['author'] : null,
-			's'              => isset( $args['search'] ) && '' !== $args['search'] ? $args['search'] : null,
-			'fields'         => 'ids',
+			'order'       => $args['order'],
+			'orderby'     => $args['order_by'],
+			'post_type'   => $args['type'],
+			'post_status' => $status,
+			'post_parent' => isset( $args['parent_id'] ) ? $args['parent_id'] : null,
+			'author'      => isset( $args['author'] ) && 0 < $args['author'] ? $args['author'] : null,
+			's'           => isset( $args['search'] ) && '' !== $args['search'] ? $args['search'] : null,
+			'fields'      => 'ids',
 		);
+
+		if ( $args['number'] === -1 ) {
+			$is_eligible_for_page_handle = false;
+		} else {
+			$query['posts_per_page'] = $args['number'];
+		}
 
 		if ( ! is_user_logged_in() ) {
 			$query['has_password'] = false;

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
@@ -86,8 +86,11 @@ class WPCOM_JSON_API_List_Posts_v1_2_Endpoint extends WPCOM_JSON_API_List_Posts_
 		$args                        = $this->query_args();
 		$is_eligible_for_page_handle = true;
 		$site                        = $this->get_platform()->get_site( $blog_id );
+		$query_all_pages             = $args['number'] === -1 && $args['type'] === 'page';
 
-		if ( $args['number'] < 1 && $args['number'] !== -1 ) {
+		if ( $query_all_pages ) {
+			$is_eligible_for_page_handle = false;
+		} elseif ( $args['number'] < 1 ) {
 			$args['number'] = 20;
 		} elseif ( 100 < $args['number'] ) {
 			return new WP_Error( 'invalid_number', 'The NUMBER parameter must be less than or equal to 100.', 400 );
@@ -174,21 +177,16 @@ class WPCOM_JSON_API_List_Posts_v1_2_Endpoint extends WPCOM_JSON_API_List_Posts_
 		}
 
 		$query = array(
-			'order'       => $args['order'],
-			'orderby'     => $args['order_by'],
-			'post_type'   => $args['type'],
-			'post_status' => $status,
-			'post_parent' => isset( $args['parent_id'] ) ? $args['parent_id'] : null,
-			'author'      => isset( $args['author'] ) && 0 < $args['author'] ? $args['author'] : null,
-			's'           => isset( $args['search'] ) && '' !== $args['search'] ? $args['search'] : null,
-			'fields'      => 'ids',
+			'posts_per_page' => $query_all_pages ? null : $args['number'],
+			'order'          => $args['order'],
+			'orderby'        => $args['order_by'],
+			'post_type'      => $args['type'],
+			'post_status'    => $status,
+			'post_parent'    => isset( $args['parent_id'] ) ? $args['parent_id'] : null,
+			'author'         => isset( $args['author'] ) && 0 < $args['author'] ? $args['author'] : null,
+			's'              => isset( $args['search'] ) && '' !== $args['search'] ? $args['search'] : null,
+			'fields'         => 'ids',
 		);
-
-		if ( $args['number'] === -1 ) {
-			$is_eligible_for_page_handle = false;
-		} else {
-			$query['posts_per_page'] = $args['number'];
-		}
 
 		if ( ! is_user_logged_in() ) {
 			$query['has_password'] = false;

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
@@ -87,7 +87,7 @@ class WPCOM_JSON_API_List_Posts_v1_2_Endpoint extends WPCOM_JSON_API_List_Posts_
 		$is_eligible_for_page_handle = true;
 		$site                        = $this->get_platform()->get_site( $blog_id );
 
-		if ( $args['number'] < 1 ) {
+		if ( $args['number'] < 1 && $args['number'] !== -1 ) {
 			$args['number'] = 20;
 		} elseif ( 100 < $args['number'] ) {
 			return new WP_Error( 'invalid_number', 'The NUMBER parameter must be less than or equal to 100.', 400 );
@@ -174,16 +174,21 @@ class WPCOM_JSON_API_List_Posts_v1_2_Endpoint extends WPCOM_JSON_API_List_Posts_
 		}
 
 		$query = array(
-			'posts_per_page' => $args['number'],
-			'order'          => $args['order'],
-			'orderby'        => $args['order_by'],
-			'post_type'      => $args['type'],
-			'post_status'    => $status,
-			'post_parent'    => isset( $args['parent_id'] ) ? $args['parent_id'] : null,
-			'author'         => isset( $args['author'] ) && 0 < $args['author'] ? $args['author'] : null,
-			's'              => isset( $args['search'] ) && '' !== $args['search'] ? $args['search'] : null,
-			'fields'         => 'ids',
+			'order'       => $args['order'],
+			'orderby'     => $args['order_by'],
+			'post_type'   => $args['type'],
+			'post_status' => $status,
+			'post_parent' => isset( $args['parent_id'] ) ? $args['parent_id'] : null,
+			'author'      => isset( $args['author'] ) && 0 < $args['author'] ? $args['author'] : null,
+			's'           => isset( $args['search'] ) && '' !== $args['search'] ? $args['search'] : null,
+			'fields'      => 'ids',
 		);
+
+		if ( $args['number'] === -1 ) {
+			$is_eligible_for_page_handle = false;
+		} else {
+			$query['posts_per_page'] = $args['number'];
+		}
 
 		if ( ! is_user_logged_in() ) {
 			$query['has_password'] = false;

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
@@ -21,7 +21,7 @@ new WPCOM_JSON_API_List_Posts_v1_2_Endpoint(
 		'allow_fallback_to_jetpack_blog_token' => true,
 
 		'query_parameters'                     => array(
-			'number'                => '(int=20) The number of posts to return. Limit: 100.',
+			'number'                => '(int=20) The number of posts to return. Limit: 100. Setting the value to -1 and having type set to \'page\' will return all pages without any limits.',
 			'offset'                => '(int=0) 0-indexed offset.',
 			'page'                  => '(int) Return the Nth 1-indexed page of posts. Takes precedence over the <code>offset</code> parameter.',
 			'page_handle'           => '(string) A page handle, returned from a previous API call as a <code>meta.next_page</code> property. This is the most efficient way to fetch the next page of results.',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/71570

As part of implementing the new Reading Settings page, we are re-implementing the "Your homepage displays" setting to be frontend rendered (in calypso). The setting has two select dropdowns which need to be populated with a list of all site's pages. The current `GET /sites/${siteId}/posts` does not allow for fetching more than 100 posts at a time. This PR addresses this issue by allowing to set `number=-1` together with `type=page` args on the request which will result in all posts of type page (a.k.a. pages) to be returned in a single request.

![Screen Shot 2022-12-21 at 17 43 17](https://user-images.githubusercontent.com/2019970/209984730-95bdfc21-c330-4005-99a8-be73d37ba987.png)


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* setting the following query args `number=-1&type=page` will return all site's posts of type page - without any paginiation and limits

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pdDOJh-1gN-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No, it does not.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
To test those changes ideally you have an access to a blog with more than 100 public pages.

* Apply the patch to your sandbox
* Sandbox `public-api.wordpress.com`
* Go to wordpress dev console and execute the `GET /sites/$siteId/posts` request with, and without, `number` set to `-1` and `type` set to `page` and compare the results. With the args set there should be no limit on the number of pages received in response whereas without the args set the default limit is 20 posts.

![Annotation on 2022-12-29 at 18-33-07](https://user-images.githubusercontent.com/2019970/209989149-eae344c0-7873-44ec-8993-662bf2c934ac.png)

![Screen Shot 2022-12-29 at 18 28 20](https://user-images.githubusercontent.com/2019970/209989076-7a1a7a50-bbf8-4b55-9f36-d5dc775578a7.png)
