### PR TITLE
My Jetpack: Move Search out of hybrid concept

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-remove-search-hybrid
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-remove-search-hybrid
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Move Search out of hybrid and deprecate Hybrid_Product class

--- a/projects/packages/my-jetpack/src/products/class-hybrid-product.php
+++ b/projects/packages/my-jetpack/src/products/class-hybrid-product.php
@@ -12,6 +12,13 @@ use Automattic\Jetpack\Plugins_Installer;
 use WP_Error;
 
 /**
+ *
+ * DEPRECATED: This class is deprecated and will be removed in a future version.
+ *
+ * All product classes has been moved out of the hybrid class concept
+ *
+ * @deprecated 2.7.2
+ *
  * Class responsible for handling the hybrid products
  *
  * Hybrid products are those that may work both as a stand-alone plugin or with the Jetpack plugin.

--- a/projects/packages/my-jetpack/src/products/class-hybrid-product.php
+++ b/projects/packages/my-jetpack/src/products/class-hybrid-product.php
@@ -15,7 +15,7 @@ use WP_Error;
  *
  * DEPRECATED: This class is deprecated and will be removed in a future version.
  *
- * All product classes has been moved out of the hybrid class concept
+ * All product classes have been moved out of the hybrid class concept
  *
  * @deprecated 2.7.2
  *

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -9,7 +9,7 @@ namespace Automattic\Jetpack\My_Jetpack\Products;
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Constants;
-use Automattic\Jetpack\My_Jetpack\Hybrid_Product;
+use Automattic\Jetpack\My_Jetpack\Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 use Automattic\Jetpack\Search\Module_Control as Search_Module_Control;
 use Jetpack_Options;
@@ -18,7 +18,7 @@ use WP_Error;
 /**
  * Class responsible for handling the Search product
  */
-class Search extends Hybrid_Product {
+class Search extends Product {
 	/**
 	 * The product slug
 	 *

--- a/projects/packages/my-jetpack/tests/php/test-hybrid-product.php
+++ b/projects/packages/my-jetpack/tests/php/test-hybrid-product.php
@@ -30,10 +30,16 @@ class Test_Hybrid_Product extends TestCase {
 	 * @before
 	 */
 	public function set_up() {
+		// Mark this as deprecated since no class is using Hybrid_Product.
+		$deprecated = true;
 
 		// See https://stackoverflow.com/a/41611876.
 		if ( version_compare( phpversion(), '5.7', '<=' ) ) {
 			$this->markTestSkipped( 'avoid bug in PHP 5.6 that throws strict mode warnings for abstract static methods.' );
+		}
+
+		if ( $deprecated ) {
+			$this->markTestSkipped( 'Hybrid_Product is deprecated.' );
 		}
 
 		$this->install_mock_plugins();

--- a/projects/packages/my-jetpack/tests/php/test-search-product.php
+++ b/projects/packages/my-jetpack/tests/php/test-search-product.php
@@ -1,0 +1,169 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Automattic\Jetpack\My_Jetpack;
+
+use Automattic\Jetpack\Connection\Tokens;
+use Automattic\Jetpack\My_Jetpack\Products\Search;
+use Jetpack_Options;
+use PHPUnit\Framework\TestCase;
+use WorDBless\Options as WorDBless_Options;
+use WorDBless\Users as WorDBless_Users;
+
+/**
+ * Unit tests for the REST API endpoints.
+ *
+ * @package automattic/my-jetpack
+ * @see \Automattic\Jetpack\My_Jetpack\Rest_Products
+ */
+class Test_Search_Product extends TestCase {
+
+	/**
+	 * The current user id.
+	 *
+	 * @var int
+	 */
+	private static $user_id;
+
+	/**
+	 * Setting up the test.
+	 *
+	 * @before
+	 */
+	public function set_up() {
+
+		// See https://stackoverflow.com/a/41611876.
+		if ( version_compare( phpversion(), '5.7', '<=' ) ) {
+			$this->markTestSkipped( 'avoid bug in PHP 5.6 that throws strict mode warnings for abstract static methods.' );
+		}
+
+		$this->install_mock_plugins();
+		wp_cache_delete( 'plugins', 'plugins' );
+
+		self::$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_admin',
+				'user_pass'  => '123',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( self::$user_id );
+
+	}
+
+	/**
+	 * Installs the mock plugin present in the test assets folder as if it was the Boost plugin
+	 *
+	 * @return void
+	 */
+	public function install_mock_plugins() {
+		$plugin_dir = WP_PLUGIN_DIR . '/' . Search::$plugin_slug;
+		if ( ! file_exists( $plugin_dir ) ) {
+			mkdir( $plugin_dir, 0777, true );
+		}
+		if ( ! file_exists( WP_PLUGIN_DIR . '/jetpack' ) ) {
+			mkdir( WP_PLUGIN_DIR . '/jetpack', 0777, true );
+		}
+		copy( __DIR__ . '/assets/search-mock-plugin.txt', WP_PLUGIN_DIR . '/jetpack-search/jetpack-search.php' );
+		copy( __DIR__ . '/assets/jetpack-mock-plugin.txt', WP_PLUGIN_DIR . '/jetpack/jetpack.php' );
+	}
+
+	/**
+	 * Returning the environment into its initial state.
+	 *
+	 * @after
+	 */
+	public function tear_down() {
+		WorDBless_Options::init()->clear_options();
+		WorDBless_Users::init()->clear_all_users();
+	}
+
+	/**
+	 * Tests with Jetpack active
+	 */
+	public function test_if_jetpack_active_return_false() {
+		activate_plugin( 'jetpack/jetpack.php' );
+		$this->assertFalse( Search::is_plugin_active() );
+	}
+
+	/**
+	 * Tests with Search active
+	 */
+	public function test_if_jetpack_inactive_and_search_active_return_true() {
+		deactivate_plugins( 'jetpack/jetpack.php' );
+		activate_plugins( Search::get_installed_plugin_filename() );
+		$this->assertTrue( Search::is_plugin_active() );
+	}
+
+	/**
+	 * Tests with both inactive
+	 */
+	public function test_if_jetpack_inactive_and_search_inactive_return_false() {
+		deactivate_plugins( 'jetpack/jetpack.php' );
+		deactivate_plugins( Search::get_installed_plugin_filename() );
+		$this->assertFalse( Search::is_active() );
+	}
+
+	/**
+	 * Tests Search Manage URL with Search plugin
+	 */
+	public function test_search_manage_url_with_search() {
+		deactivate_plugins( 'jetpack/jetpack.php' );
+		activate_plugins( Search::get_installed_plugin_filename() );
+		$this->assertSame( admin_url( 'admin.php?page=jetpack-search' ), Search::get_manage_url() );
+	}
+
+	/**
+	 * Tests Search Manage URL with Jetpack plugin
+	 */
+	public function test_search_manage_url_with_jetpack() {
+		activate_plugins( 'jetpack/jetpack.php' );
+		deactivate_plugins( Search::get_installed_plugin_filename() );
+		$this->assertSame( admin_url( 'admin.php?page=jetpack-search' ), Search::get_manage_url() );
+	}
+
+	/**
+	 * Tests Search Post Activation URL with Jetpack disconected
+	 */
+	public function test_search_post_activation_url_with_jetpack_disconnected() {
+		activate_plugins( 'jetpack/jetpack.php' );
+		deactivate_plugins( Search::get_installed_plugin_filename() );
+		$this->assertSame( '', Search::get_post_activation_url() );
+	}
+
+	/**
+	 * Tests Search Post Activation URL with Search disconected
+	 */
+	public function test_search_post_activation_url_with_search_disconnected() {
+		deactivate_plugins( 'jetpack/jetpack.php' );
+		activate_plugins( Search::get_installed_plugin_filename() );
+		$this->assertSame( '', Search::get_post_activation_url() );
+	}
+
+	/**
+	 * Tests Search Post Activation URL with Jetpack conected
+	 */
+	public function test_search_post_activation_url_with_jetpack_connected() {
+		// Mock site connection.
+		( new Tokens() )->update_blog_token( 'test.test.1' );
+		( new Tokens() )->update_user_token( self::$user_id, 'test.test.' . self::$user_id, true );
+		Jetpack_Options::update_option( 'id', 123 );
+
+		activate_plugins( 'jetpack/jetpack.php' );
+		deactivate_plugins( Search::get_installed_plugin_filename() );
+		$this->assertSame( '', Search::get_post_activation_url() );
+	}
+
+	/**
+	 * Tests Search Post Activation URL with Search conected
+	 */
+	public function test_search_post_activation_url_with_search_connected() {
+		// Mock site connection.
+		( new Tokens() )->update_blog_token( 'test.test.1' );
+		( new Tokens() )->update_user_token( self::$user_id, 'test.test.' . self::$user_id, true );
+		Jetpack_Options::update_option( 'id', 123 );
+
+		deactivate_plugins( 'jetpack/jetpack.php' );
+		activate_plugins( Search::get_installed_plugin_filename() );
+		$this->assertSame( '', Search::get_post_activation_url() );
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This one moves Search out of the concept of a hybrid product.

So, we will prioritize only the standalone plugin and not rely on the Jetpack module itself.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Make `class-search` extends from `Product` and not `Hybrid_Product`.
* Add specific unit tests for it.
* Mark tests and `Hybrid_Product` class as deprecated

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-jwG-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup a new JN site only with the Jetpack plugin
* Goes to My Jetpack page.
* Search should be marked as absent -  `Add Search` should be available.
* Clicks and goes to add it.
* You should be redirected to the `My Jetpack` again after installing.
* Return to `My Jetpack`.
* It now should be active and manage prompts to the `Search` dashboard.
* Goes into the plugin page and deactivates it.
* Now, My Jetpack should reflect it as inactive. 