### PR TITLE
My Jetpack: modify secondary admin view

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/index.jsx
@@ -145,7 +145,11 @@ const ConnectionStatusCard = props => {
 						<ConnectionListItem
 							onClick={ openManageConnectionDialog }
 							text={ __( 'Site connected.', 'jetpack-my-jetpack' ) }
-							actionText={ isUserConnected ? __( 'Manage', 'jetpack-my-jetpack' ) : null }
+							actionText={
+								isUserConnected && userConnectionData.currentUser?.isMaster
+									? __( 'Manage', 'jetpack-my-jetpack' )
+									: null
+							}
 						/>
 						{ isUserConnected && (
 							<ConnectionListItem
@@ -158,6 +162,17 @@ const ConnectionStatusCard = props => {
 									userConnectionData.currentUser?.isMaster
 										? __( ' (Owner)', 'jetpack-my-jetpack' )
 										: ''
+								) }
+							/>
+						) }
+						{ isUserConnected && ! userConnectionData.currentUser?.isMaster && (
+							<ConnectionListItem
+								onClick={ openManageConnectionDialog }
+								actionText={ null }
+								text={ sprintf(
+									/* translators: placeholder is the username of the Jetpack connection owner */
+									__( 'Also connected: %s (Owner).', 'jetpack-my-jetpack' ),
+									userConnectionData.connectionOwner
 								) }
 							/>
 						) }

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/index.jsx
@@ -167,8 +167,6 @@ const ConnectionStatusCard = props => {
 						) }
 						{ isUserConnected && ! userConnectionData.currentUser?.isMaster && (
 							<ConnectionListItem
-								onClick={ openManageConnectionDialog }
-								actionText={ null }
 								text={ sprintf(
 									/* translators: placeholder is the username of the Jetpack connection owner */
 									__( 'Also connected: %s (Owner).', 'jetpack-my-jetpack' ),

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/test/component.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/test/component.jsx
@@ -100,7 +100,7 @@ describe( 'ConnectionStatusCard', () => {
 
 		it( 'renders the "Manage" buttons', () => {
 			setup();
-			expect( screen.getAllByRole( 'button', { name: 'Manage' } ) ).toHaveLength( 2 );
+			expect( screen.getByRole( 'button', { name: 'Manage' } ) ).toBeInTheDocument();
 		} );
 
 		it( 'renders the "Logged in as" success list item', () => {

--- a/projects/packages/my-jetpack/changelog/modify-myjetpack-secondary-owner
+++ b/projects/packages/my-jetpack/changelog/modify-myjetpack-secondary-owner
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Remove one link to manage connection in myjetpack
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27496

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Show connection owner to secondary admins (non-connection owners)
* Remove site connection manage link for secondary admins

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In a test site, add two admin users
* Connect the first user and confirm that it looks like this:
![Screenshot 2022-12-30 at 13 53 02](https://user-images.githubusercontent.com/16329583/210072175-4c2dc0c2-623f-45c9-b96c-65aae0895ba2.png)
Manage links for site and user should be visible, and you should be shown as the owner.
* Connect a second admin, which would be a secondary admin because it does not own the connection.  Confirm that it looks like this:
![Screenshot 2022-12-30 at 13 54 22](https://user-images.githubusercontent.com/16329583/210072312-779f3258-b64c-47df-9250-663a4f8325f8.png)
Manage link for the user but not for the site. It should also show who's the connection owner.

