### PR TITLE
Fix exceeding search limits in Jetpack Complete

### DIFF
--- a/projects/packages/search/changelog/fix-search-disabled-in-complete
+++ b/projects/packages/search/changelog/fix-search-disabled-in-complete
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix disabling search plan for Jetpack Complete
+
+

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.31.3",
+	"version": "0.31.4-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.31.3';
+	const VERSION = '0.31.4-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/class-plan.php
+++ b/projects/packages/search/src/class-plan.php
@@ -103,6 +103,14 @@ class Plan {
 	}
 
 	/**
+	 * Returns true if the plan usage is exceeded and search should no longer work.
+	 */
+	public function must_upgrade() {
+		$plan_info = $this->get_plan_info();
+		return isset( $plan_info['plan_usage']['must_upgrade'] ) && $plan_info['plan_usage']['must_upgrade'];
+	}
+
+	/**
 	 * Returns true if the plan only supports Classic Search.
 	 */
 	public function supports_only_classic_search() {

--- a/projects/packages/search/src/dashboard/class-dashboard.php
+++ b/projects/packages/search/src/dashboard/class-dashboard.php
@@ -217,7 +217,7 @@ class Dashboard {
 		if (
 			property_exists( $current_screen, 'base' ) &&
 			strpos( $current_screen->base, 'jetpack_page_' ) !== false &&
-			! $this->plan->supports_search()
+			( ! $this->plan->supports_search() || $this->plan->must_upgrade() )
 		) {
 			$this->module_control->deactivate();
 		}

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -64,7 +64,6 @@ export default function DashboardPage( { isLoading = false } ) {
 
 	const isFreePlan = useSelect( select => select( STORE_ID ).isFreePlan() );
 	const isOverLimit = useSelect( select => select( STORE_ID ).isOverLimit() );
-	const isDisabledFromOverLimitOnFreePlan = isOverLimit && isFreePlan;
 
 	const updateOptions = useDispatch( STORE_ID ).updateJetpackSettings;
 	const isInstantSearchPromotionActive = useSelect( select =>
@@ -146,7 +145,7 @@ export default function DashboardPage( { isLoading = false } ) {
 							siteAdminUrl={ siteAdminUrl }
 							updateOptions={ updateOptions }
 							domain={ domain }
-							isDisabledFromOverLimit={ isDisabledFromOverLimitOnFreePlan }
+							isDisabledFromOverLimit={ isOverLimit }
 							isInstantSearchPromotionActive={ isInstantSearchPromotionActive }
 							supportsOnlyClassicSearch={ supportsOnlyClassicSearch }
 							supportsSearch={ supportsSearch }

--- a/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/sections/plan-usage-section.jsx
@@ -150,6 +150,16 @@ const upgradeMessageRequests = apiData => {
 	return { description: message, cta: cta };
 };
 
+const upgradeMessageSearchDisabled = () => {
+	// Always returns a valid message.
+	const message = __(
+		'You’ve exceeded the limits available for your search plan.',
+		'jetpack-search-pkg'
+	);
+	const cta = __( 'Upgrade now to restore Jetpack Search functionality.', 'jetpack-search-pkg' );
+	return { description: message, cta: cta };
+};
+
 const upgradeMessageNoOverage = () => {
 	// Always returns a valid message.
 	const message = __(
@@ -197,7 +207,10 @@ const upgradeMessageFromAPIData = apiData => {
 	// apiData.currentUsage.upgrade_reason.requests
 	// apiData.currentUsage.months_over_plan_records_limit
 	// apiData.currentUsage.months_over_plan_requests_limit
-	if ( ! apiData.currentUsage.should_upgrade && ! apiData.currentUsage.must_upgrade ) {
+	if ( apiData.currentUsage.must_upgrade ) {
+		return upgradeMessageSearchDisabled();
+	}
+	if ( ! apiData.currentUsage.should_upgrade ) {
 		return null;
 	}
 	// Handle both case.
@@ -220,7 +233,11 @@ const upgradeMessageFromAPIData = apiData => {
 };
 
 const PlanUsageSection = ( { isFreePlan, planInfo, sendPaidPlanToCart, isPlanJustUpgraded } ) => {
-	const upgradeMessage = isFreePlan ? upgradeMessageFromAPIData( planInfo ) : null;
+	// For free plan, we want to show the CTA early.
+	// For complete plan, we only show the final CTA once search is already disabled.
+	// It's just because it was added later, and we didn't want to redesign existing CTAs at the time.
+	const upgradeMessage =
+		isFreePlan || planInfo.currentUsage.must_upgrade ? upgradeMessageFromAPIData( planInfo ) : null;
 	const usageInfo = usageInfoFromAPIData( planInfo );
 
 	return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:

A site that has Jetpack Complete with exceeded Jetpack Search limits cannot use the instant search feature.
We should not allow toggling the instant search option, the same way we don't allow it for Jetpack Search Free that is over limit.

In the past, `must_upgrade` didn't check for the plan that blog has, but now it's safe to base the decision to disable instant search option only on that parameter.

Additionally, I've added one final CTA that's shown to both Jetpack Search Free and Jetpack Complete users once their search plan is disabled after three months of overages:

![image](https://user-images.githubusercontent.com/6437642/212453742-c3a894a6-0d1a-4fd7-bf5b-19d6f0666f23.png)


#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
panfyZ-1wq-p2#comment-3810

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

A8C-only:

- Purchase Jetpack Complete for your blog.
- Apply sticker `jetpack_search_comp_disabled` to your blog (for example using wpsh).
- Search dashboard should now gray out option to enable instant search and the final CTA should be visible.

Alternatively, have Jetpack Search Free plan, and apply sticker `jetpack_search_free_disabled`.