### PR TITLE
JSON Endpoint: Create `GET /sites/%s/dropdown-pages/` endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/add-json-endpoint-get-dropdown-pages
+++ b/projects/plugins/jetpack/changelog/add-json-endpoint-get-dropdown-pages
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+JSON Endpoint: Introducing new '/sites/%s/dropdown-pages/' endpoint

--- a/projects/plugins/jetpack/json-endpoints.php
+++ b/projects/plugins/jetpack/json-endpoints.php
@@ -34,6 +34,7 @@ require_once $json_endpoints_dir . 'class.wpcom-json-api-get-taxonomies-endpoint
 require_once $json_endpoints_dir . 'class.wpcom-json-api-get-taxonomy-endpoint.php';
 require_once $json_endpoints_dir . 'class.wpcom-json-api-get-term-endpoint.php';
 require_once $json_endpoints_dir . 'class.wpcom-json-api-list-comments-endpoint.php';
+require_once $json_endpoints_dir . 'class.wpcom-json-api-list-dropdown-pages-endpoint.php';
 require_once $json_endpoints_dir . 'class.wpcom-json-api-list-media-endpoint.php';
 require_once $json_endpoints_dir . 'class.wpcom-json-api-list-post-types-endpoint.php';
 require_once $json_endpoints_dir . 'class.wpcom-json-api-list-post-type-taxonomies-endpoint.php';

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
@@ -59,7 +59,7 @@ class WPCOM_JSON_API_List_Dropdown_Pages_Endpoint extends WPCOM_JSON_API_Post_En
 	 *
 	 * @param string $path - the path.
 	 * @param int    $blog_id - the blog ID.
-	 * @return stdClass[] $pages - An array of page objects. Each page object includes ID and title properties and may include children property. This makes each page object a tree like data structures.
+	 * @return stdClass[] $pages - An array of page objects. Each page object includes ID and title properties and may include children property. This makes each page object a tree-like data structure.
 	 */
 	public function callback( $path = '', $blog_id = 0 ) {
 		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
@@ -48,7 +48,7 @@ class WPCOM_JSON_API_List_Dropdown_Pages_Endpoint extends WPCOM_JSON_API_Post_En
 	private $pages_by_id = array();
 
 	/**
-	 * List of pages by indexed by their parent page ID.
+	 * List of pages indexed by their parent page ID.
 	 *
 	 * @var array<int,WP_Post>
 	 */

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
@@ -53,6 +53,7 @@ class WPCOM_JSON_API_List_Dropdown_Pages_Endpoint extends WPCOM_JSON_API_Post_En
 		}
 
 		$pages = self::get_pages();
+		return $pages;
 	}
 
 	/**

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
@@ -41,7 +41,7 @@ class WPCOM_JSON_API_List_Dropdown_Pages_Endpoint extends WPCOM_JSON_API_Post_En
 	);
 
 	/**
-	 * List of pages by indexed by their page ID.
+	 * List of pages indexed by their page ID.
 	 *
 	 * @var array<int,WP_Post>
 	 */

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
@@ -58,7 +58,7 @@ class WPCOM_JSON_API_List_Dropdown_Pages_Endpoint extends WPCOM_JSON_API_Post_En
 	 * API callback.
 	 *
 	 * @param string $path - the path.
-	 * @param int    $blog_id - the blog id.
+	 * @param int    $blog_id - the blog ID.
 	 * @return stdClass[] $pages - An array of page objects. Each page object includes ID and title properties and may include children property. This makes each page object a tree like data structures.
 	 */
 	public function callback( $path = '', $blog_id = 0 ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
@@ -43,14 +43,14 @@ class WPCOM_JSON_API_List_Dropdown_Pages_Endpoint extends WPCOM_JSON_API_Post_En
 	/**
 	 * List of pages by indexed by their page ID.
 	 *
-	 * @var array
+	 * @var array<int,WP_Post>
 	 */
 	private $pages_by_id = array();
 
 	/**
 	 * List of pages by indexed by their parent page ID.
 	 *
-	 * @var array
+	 * @var array<int,WP_Post>
 	 */
 	private $pages_by_parent = array();
 
@@ -58,7 +58,7 @@ class WPCOM_JSON_API_List_Dropdown_Pages_Endpoint extends WPCOM_JSON_API_Post_En
 	 * API callback.
 	 *
 	 * @param string $path - the path.
-	 * @param string $blog_id - the blog id.
+	 * @param int    $blog_id - the blog id.
 	 * @return stdClass[] $pages - An array of page objects. Each page object includes ID and title properties and may include children property. This makes each page object a tree like data structures.
 	 */
 	public function callback( $path = '', $blog_id = 0 ) {
@@ -82,8 +82,8 @@ class WPCOM_JSON_API_List_Dropdown_Pages_Endpoint extends WPCOM_JSON_API_Post_En
 	/**
 	 * Convert a list of pages to a list of pages by page ID.
 	 *
-	 * @param array $pages - array of pages.
-	 * @return array $pages_by_page_id - indexed array of pages by page ID where index is page ID.
+	 * @param array<WP_Post> $pages - array of pages.
+	 * @return array<int,WP_Post> $pages_by_page_id - indexed array of pages by page ID where index is page ID.
 	 */
 	private static function to_pages_by_id( $pages ) {
 		$pages_by_page_id = array();
@@ -98,8 +98,8 @@ class WPCOM_JSON_API_List_Dropdown_Pages_Endpoint extends WPCOM_JSON_API_Post_En
 	/**
 	 * Convert a list of pages to a list of pages by parent.
 	 *
-	 * @param array $pages - array of pages.
-	 * @return array $pages_by_parent - indexed array of pages by parent where index is page ID.
+	 * @param array<WP_Post> $pages - array of pages.
+	 * @return array<int,WP_Post> $pages_by_parent - indexed array of pages by parent where index is page ID.
 	 */
 	private static function to_pages_by_parent( $pages ) {
 		$pages_by_parent = array();
@@ -116,7 +116,7 @@ class WPCOM_JSON_API_List_Dropdown_Pages_Endpoint extends WPCOM_JSON_API_Post_En
 	/**
 	 * Convert a list of pages to a list of dropdown pages.
 	 *
-	 * @return array $dropdown_pages - array of dropdown pages.
+	 * @return array<stdClass> $dropdown_pages - array of dropdown pages.
 	 */
 	private function create_dropdown_pages() {
 		$dropdown_pages = array();
@@ -141,8 +141,8 @@ class WPCOM_JSON_API_List_Dropdown_Pages_Endpoint extends WPCOM_JSON_API_Post_En
 	/**
 	 * Convert a page to a dropdown page.
 	 *
-	 * @param object $page - the page.
-	 * @return object $dropdown_page - the dropdown page.
+	 * @param WP_Post $page - the page.
+	 * @return stdClass|false $dropdown_page - the dropdown page.
 	 */
 	private function to_dropdown_page( $page ) {
 		if ( ! isset( $page->ID ) ) {
@@ -153,7 +153,7 @@ class WPCOM_JSON_API_List_Dropdown_Pages_Endpoint extends WPCOM_JSON_API_Post_En
 
 		if ( ! isset( $this->pages_by_parent[ $page->ID ] ) ) {
 			unset( $this->pages_by_id[ $page->ID ] );
-			return array(
+			return (object) array(
 				'ID'    => $page->ID,
 				'title' => $title,
 			);
@@ -166,7 +166,7 @@ class WPCOM_JSON_API_List_Dropdown_Pages_Endpoint extends WPCOM_JSON_API_Post_En
 
 		unset( $this->pages_by_id[ $page->ID ] );
 		unset( $this->pages_by_parent[ $page->ID ] );
-		return array(
+		return (object) array(
 			'ID'       => $page->ID,
 			'title'    => $title,
 			'children' => $children,
@@ -176,7 +176,7 @@ class WPCOM_JSON_API_List_Dropdown_Pages_Endpoint extends WPCOM_JSON_API_Post_En
 	/**
 	 * Get the page title.
 	 *
-	 * @param object $page - the page.
+	 * @param WP_Post $page - the page.
 	 * @return string $page_title - the page title.
 	 */
 	private function get_page_title( $page ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
@@ -104,10 +104,10 @@ class WPCOM_JSON_API_List_Dropdown_Pages_Endpoint extends WPCOM_JSON_API_Post_En
 	private static function to_pages_by_parent( $pages ) {
 		$pages_by_parent = array();
 		foreach ( $pages as $page ) {
-			if ( ! empty( $page->post_parent ) ) {
-				$pages_by_parent[ $page->post_parent ][] = $page;
-			} else {
+			if ( empty( $page->post_parent ) ) {
 				$pages_by_parent['root'][] = $page;
+			} else {
+				$pages_by_parent[ $page->post_parent ][] = $page;
 			}
 		}
 		return $pages_by_parent;

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
@@ -104,7 +104,7 @@ class WPCOM_JSON_API_List_Dropdown_Pages_Endpoint extends WPCOM_JSON_API_Post_En
 	private static function to_pages_by_parent( $pages ) {
 		$pages_by_parent = array();
 		foreach ( $pages as $page ) {
-			if ( isset( $page->post_parent ) ) {
+			if ( ! empty( $page->post_parent ) ) {
 				$pages_by_parent[ $page->post_parent ][] = $page;
 			} else {
 				$pages_by_parent['root'][] = $page;

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
@@ -129,7 +129,8 @@ class WPCOM_JSON_API_List_Dropdown_Pages_Endpoint extends WPCOM_JSON_API_Post_En
 
 		if ( ! empty( $this->pages_by_id ) ) {
 			// In case there were some orphans
-			foreach ( $this->pages_by_id as $page_id => $page ) {
+			// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			foreach ( $this->pages_by_id as $_page_id => $page ) {
 				$dropdown_pages[] = $this->to_dropdown_page( $page );
 			}
 		}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
@@ -1,0 +1,76 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+/**
+ * List pages endpoint.
+ */
+new WPCOM_JSON_API_List_Dropdown_Pages_Endpoint(
+	array(
+
+		'description'                          => 'Get a list of dropdown pages.',
+		'min_version'                          => '1.1',
+		'max_version'                          => '1.1',
+
+		'group'                                => 'posts',
+		'stat'                                 => 'posts',
+
+		'method'                               => 'GET',
+		'path'                                 => '/sites/%s/dropdown-pages/',
+		'path_labels'                          => array(
+			'$site' => '(int|string) Site ID or domain',
+		),
+
+		'allow_fallback_to_jetpack_blog_token' => true,
+
+		'example_request'                      => 'https://public-api.wordpress.com/rest/v1.1/sites/en.blog.wordpress.com/dropdown-pages/',
+	)
+);
+
+/**
+ * List pages endpoint class.
+ *
+ * /sites/%s/page-options/ -> $blog_id
+ */
+class WPCOM_JSON_API_List_Dropdown_Pages_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
+	/**
+	 * The response format.
+	 *
+	 * @var array
+	 */
+	public $response_format = array(
+		'dropdown_pages' => '(array:page) An array of page objects.',
+	);
+
+	/**
+	 * API callback.
+	 *
+	 * @param string $path - the path.
+	 * @param string $blog_id - the blog ID.
+	 */
+	public function callback( $path = '', $blog_id = 0 ) {
+		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );
+		if ( is_wp_error( $blog_id ) ) {
+			return $blog_id;
+		}
+
+		$pages = self::get_pages();
+	}
+
+	/**
+	 * Get pages.
+	 *
+	 * @return stdClass[] $pages       Array of objects containing only the ID, post_parent, post_title, and post_status fields.
+	 */
+	protected static function get_pages() {
+		global $wpdb;
+
+		$last_changed = wp_cache_get_last_changed( 'posts' );
+		$cache_key    = "get_pages:$last_changed";
+		$pages        = wp_cache_get( $cache_key, 'dropdown_pages' );
+		if ( false === $pages ) {
+			$pages = $wpdb->get_results( "SELECT {$wpdb->posts}.ID, {$wpdb->posts}.post_title FROM {$wpdb->posts} WHERE {$wpdb->posts}.post_type = 'page' AND {$wpdb->posts}.post_status = 'publish' ORDER BY {$wpdb->posts}.post_title ASC" );
+			wp_cache_set( $cache_key, $pages, 'dropdown_pages' );
+		}
+
+		return $pages;
+	}
+}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
@@ -1,17 +1,17 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
 /**
- * List pages endpoint.
+ * List dropdown pages endpoint.
  */
 new WPCOM_JSON_API_List_Dropdown_Pages_Endpoint(
 	array(
 
-		'description'                          => 'Get a list of dropdown pages.',
+		'description'                          => 'Get a list of pages to be displayed as options in a select-a-page-dropdown.',
 		'min_version'                          => '1.1',
 		'max_version'                          => '1.1',
 
 		'group'                                => 'posts',
-		'stat'                                 => 'posts',
+		'stat'                                 => 'posts:dropdown-pages',
 
 		'method'                               => 'GET',
 		'path'                                 => '/sites/%s/dropdown-pages/',
@@ -26,9 +26,9 @@ new WPCOM_JSON_API_List_Dropdown_Pages_Endpoint(
 );
 
 /**
- * List pages endpoint class.
+ * Endpoint class responsible for listing pages to be displayed as options in a select-a-page-dropdown.
  *
- * /sites/%s/page-options/ -> $blog_id
+ * /sites/%s/dropdown-pages/ -> $blog_id
  */
 class WPCOM_JSON_API_List_Dropdown_Pages_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 	/**
@@ -44,7 +44,8 @@ class WPCOM_JSON_API_List_Dropdown_Pages_Endpoint extends WPCOM_JSON_API_Post_En
 	 * API callback.
 	 *
 	 * @param string $path - the path.
-	 * @param string $blog_id - the blog ID.
+	 * @param string $blog_id - the blog id.
+	 * @return stdClass[] $pages - array of objects containing only the ID and title fields. An empty array if no pages are found.
 	 */
 	public function callback( $path = '', $blog_id = 0 ) {
 		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );
@@ -57,9 +58,9 @@ class WPCOM_JSON_API_List_Dropdown_Pages_Endpoint extends WPCOM_JSON_API_Post_En
 	}
 
 	/**
-	 * Get pages.
+	 * Get all pages for the current site. The results are cached.
 	 *
-	 * @return stdClass[] $pages       Array of objects containing only the ID, post_parent, post_title, and post_status fields.
+	 * @return stdClass[] $pages - array of objects containing only the ID and title fields.
 	 */
 	protected static function get_pages() {
 		global $wpdb;
@@ -68,7 +69,7 @@ class WPCOM_JSON_API_List_Dropdown_Pages_Endpoint extends WPCOM_JSON_API_Post_En
 		$cache_key    = "get_pages:$last_changed";
 		$pages        = wp_cache_get( $cache_key, 'dropdown_pages' );
 		if ( false === $pages ) {
-			$pages = $wpdb->get_results( "SELECT {$wpdb->posts}.ID, {$wpdb->posts}.post_title FROM {$wpdb->posts} WHERE {$wpdb->posts}.post_type = 'page' AND {$wpdb->posts}.post_status = 'publish' ORDER BY {$wpdb->posts}.post_title ASC" );
+			$pages = $wpdb->get_results( "SELECT {$wpdb->posts}.ID, {$wpdb->posts}.post_title as title FROM {$wpdb->posts} WHERE {$wpdb->posts}.post_type = 'page' AND {$wpdb->posts}.post_status = 'publish' ORDER BY {$wpdb->posts}.post_title ASC" );
 			wp_cache_set( $cache_key, $pages, 'dropdown_pages' );
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/71570

The endpoint is needed for re-creation of the "Your homepage displays" setting in the new Reading Settings page. It returns the data necessary to populate the options for the 2 "select your site's page dropdowns".
![Screen Shot 2022-12-21 at 17 43 17](https://user-images.githubusercontent.com/2019970/211761905-439f74e1-3b3c-4254-8747-433276e8875a.png)


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Introduce new public-api endpoint `GET /sites/%s/dropdown-pages/` 
* The endpoint returns a list of the site's page trees. 
  * Each page node is of the following type
    ```
    {
      ID: number;
      title: string;
      children: Page[]
    }
    ```

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pdDOJh-1id-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the PR changes to your sandbox
* Sandbox `public-api.wordpress.com`
* Go to WordPress API developer console
* Ensure `WP.COM API` and `v1.1` are selected
* Search for and select `GET /sites/$site/dropdown-pages/` endpoint
* Replace the `$site` with a site id or a site slug of a test page you own
![Screen Shot 2023-01-02 at 13 27 25](https://user-images.githubusercontent.com/2019970/210236018-fd68d730-7eae-42f3-b703-c6b93cb9dba3.png)
* Execute the API call
* The expected result is a list of all public pages of the specified site. Each page item in the list should contain at least two keys at most: `ID` and `title` (`title` may be not provided if a page does not have one set). 
  * If the selected site has pages which have parents, all those should be listed under `children` prop in their parent object
  * If the selected site has no pages then an empty array should be returned.

![Markup 2023-01-11 at 09 39 45](https://user-images.githubusercontent.com/2019970/211758465-ecfe14b9-a9a9-44dd-a525-352af36f51f2.png)

