### PR TITLE
Jetpack/Backup/Social: Init new cycles and backport changelogs

### DIFF
--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## 0.24.4 - 2023-01-02
+### Fixed
+- Connection: Fix box-sizing layout issue on Manage Connection modal [#28101]
+
 ## 0.24.3 - 2022-12-27
 ### Fixed
 - Avoid warnings when disconnecting a site from WordPress.com. [#28003]

--- a/projects/js-packages/connection/changelog/fix-manage-connection-box-sizing
+++ b/projects/js-packages/connection/changelog/fix-manage-connection-box-sizing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Connection: Fix box-sizing layout issue on Manage Connection modal

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.24.4-alpha",
+	"version": "0.24.4",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2023-01-02
+### Added
+- Add a review request prompt for Jetpack Social plugin [#28072]
+
 ## [0.11.1] - 2022-12-19
 ### Changed
 - Updated package dependencies. [#27916]
@@ -160,6 +164,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.12.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.10.0...v0.10.1

--- a/projects/js-packages/publicize-components/changelog/add-review-prompt-for-social-plugin
+++ b/projects/js-packages/publicize-components/changelog/add-review-prompt-for-social-plugin
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add a review request prompt for Jetpack Social plugin

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.12.0-alpha",
+	"version": "0.12.0",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/CHANGELOG.md
+++ b/projects/js-packages/shared-extension-utils/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2023-01-02
+### Added
+- Add additional methods to useAnalytics hook, allow for view event by passing initial props [#28072]
+
 ## [0.7.0] - 2022-12-19
 ### Added
 - Add new Analytics wrapper hook. [#27937]
@@ -149,6 +153,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: prepare utility for release
 
+[0.8.0]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.7.0...0.8.0
 [0.7.0]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.6.10...0.7.0
 [0.6.10]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.6.9...0.6.10
 [0.6.9]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.6.8...0.6.9

--- a/projects/js-packages/shared-extension-utils/changelog/extend-use-analytics-hook
+++ b/projects/js-packages/shared-extension-utils/changelog/extend-use-analytics-hook
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add additional methods to useAnalytics hook, allow for view event by passing initial props

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.8.0-alpha",
+	"version": "0.8.0",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2023-01-02
+### Added
+- Blaze package: Add config initialization, initialization checks for loading. [#28077]
+
 ## [0.2.0] - 2022-12-27
 ### Added
 - Add new Post-publish panel in the block editor [#28073]
@@ -13,4 +17,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.3.0]: https://github.com/automattic/jetpack-blaze/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/automattic/jetpack-blaze/compare/v0.1.0...v0.2.0

--- a/projects/packages/blaze/changelog/update-blaze-package-todos
+++ b/projects/packages/blaze/changelog/update-blaze-package-todos
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Blaze package: Add config initialization, initialization checks for loading.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.3.0-alpha",
+	"version": "0.3.0",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Sync\Settings as Sync_Settings;
  */
 class Blaze {
 
-	const PACKAGE_VERSION = '0.3.0-alpha';
+	const PACKAGE_VERSION = '0.3.0';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.
@@ -77,7 +77,7 @@ class Blaze {
 		/**
 		 * Filter to disable all Blaze functionality.
 		 *
-		 * @since $$next-version$$
+		 * @since 0.3.0
 		 *
 		 * @param bool $should_initialize Whether Blaze should be enabled. Default to true.
 		 */

--- a/projects/packages/config/CHANGELOG.md
+++ b/projects/packages/config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.0] - 2023-01-02
+### Added
+- Blaze package: Add config initialization, initialization checks for loading. [#28077]
+
 ## [1.12.0] - 2022-12-12
 ### Added
 - Config: add option to init stats-admin [#27565]
@@ -160,6 +164,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Trying to add deterministic initialization.
 
+[1.13.0]: https://github.com/Automattic/jetpack-config/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/Automattic/jetpack-config/compare/v1.11.1...v1.12.0
 [1.11.1]: https://github.com/Automattic/jetpack-config/compare/v1.11.0...v1.11.1
 [1.11.0]: https://github.com/Automattic/jetpack-config/compare/v1.10.0...v1.11.0

--- a/projects/packages/config/changelog/update-blaze-package-todos
+++ b/projects/packages/config/changelog/update-blaze-package-todos
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Blaze package: Add config initialization, initialization checks for loading.

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.2] - 2023-01-02
+### Added
+- My Jetpack: Move VideoPress from Hybrid [#28097]
+
+### Changed
+- My Jetpack: Move Search out of hybrid and deprecate Hybrid_Product class [#28113]
+
 ## [2.7.1] - 2022-12-27
 ### Changed
 - Fix layout visual issues [#28055]
@@ -710,6 +717,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[2.7.2]: https://github.com/Automattic/jetpack-my-jetpack/compare/2.7.1...2.7.2
 [2.7.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/2.7.0...2.7.1
 [2.7.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/2.6.1...2.7.0
 [2.6.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/2.6.0...2.6.1

--- a/projects/packages/my-jetpack/changelog/modify-myjetpack-connection-owner-view
+++ b/projects/packages/my-jetpack/changelog/modify-myjetpack-connection-owner-view
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Added link to support document
-
-

--- a/projects/packages/my-jetpack/changelog/modify-myjetpack-secondary-owner
+++ b/projects/packages/my-jetpack/changelog/modify-myjetpack-secondary-owner
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Remove one link to manage connection in myjetpack
-
-

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-remove-search-hybrid
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-remove-search-hybrid
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-My Jetpack: Move Search out of hybrid and deprecate Hybrid_Product class

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-remove-videopress-hybrid
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-remove-videopress-hybrid
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-My Jetpack: Move VideoPress from Hybrid

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "2.7.2-alpha",
+	"version": "2.7.2",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -30,7 +30,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '2.7.2-alpha';
+	const PACKAGE_VERSION = '2.7.2';
 
 	/**
 	 * Initialize My Jetpack

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.0] - 2023-01-02
+### Added
+- Added already shared meta value for post editor api. [#28072]
+
 ## [0.18.4] - 2022-12-19
 ### Changed
 - Updated package dependencies. [#27962]
@@ -203,6 +207,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.19.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.18.4...v0.19.0
 [0.18.4]: https://github.com/Automattic/jetpack-publicize/compare/v0.18.3...v0.18.4
 [0.18.3]: https://github.com/Automattic/jetpack-publicize/compare/v0.18.2...v0.18.3
 [0.18.2]: https://github.com/Automattic/jetpack-publicize/compare/v0.18.1...v0.18.2

--- a/projects/packages/publicize/changelog/add-already-shared-meta
+++ b/projects/packages/publicize/changelog/add-already-shared-meta
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-added already shared meta value for post editor api

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.19.0-alpha",
+	"version": "0.19.0",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2023-01-02
+### Fixed
+- VideoPress: fix plugin presence check and default height. [#28083]
+
 ## [0.10.0] - 2022-12-27
 ### Added
 - VideoPress: add core/embed transform from/to video block [#27979]
@@ -568,6 +572,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.10.1]: https://github.com/Automattic/jetpack-videopress/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/Automattic/jetpack-videopress/compare/v0.9.2...v0.10.0
 [0.9.2]: https://github.com/Automattic/jetpack-videopress/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/Automattic/jetpack-videopress/compare/v0.9.0...v0.9.1

--- a/projects/packages/videopress/changelog/update-videopress-shortcode-enhancements
+++ b/projects/packages/videopress/changelog/update-videopress-shortcode-enhancements
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-VideoPress: Fix plugin presence check and default height

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.10.1-alpha",
+	"version": "0.10.1",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.10.1-alpha';
+	const PACKAGE_VERSION = '0.10.1';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/plugins/backup/CHANGELOG.md
+++ b/projects/plugins/backup/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.4.3-beta - 2023-01-02
+### Changed
+- Update Backup logo [#27802]
+- Updated package dependencies. [#27688, #27874]
+
 ## 1.4.2 - 2022-12-06
 ### Changed
 - Add real-time backups details in plugin FAQs [#27470]

--- a/projects/plugins/backup/changelog/add-license-key-selector
+++ b/projects/plugins/backup/changelog/add-license-key-selector
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/backup/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
+++ b/projects/plugins/backup/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/backup/changelog/add-promoted-posts-post-publish-panel
+++ b/projects/plugins/backup/changelog/add-promoted-posts-post-publish-panel
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/backup/changelog/add-sync-request-full-response-logging
+++ b/projects/plugins/backup/changelog/add-sync-request-full-response-logging
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/backup/changelog/add-sync-request-full-response-logging#2
+++ b/projects/plugins/backup/changelog/add-sync-request-full-response-logging#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/backup/changelog/add-woo-sync-whitelist
+++ b/projects/plugins/backup/changelog/add-woo-sync-whitelist
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/backup/changelog/backport-release-changelogs
+++ b/projects/plugins/backup/changelog/backport-release-changelogs
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Backport changelog and readme from release

--- a/projects/plugins/backup/changelog/changelogger-merge
+++ b/projects/plugins/backup/changelog/changelogger-merge
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Minor update to changelog package that supports git merge strategy. Should not affect shipped code.
-
-

--- a/projects/plugins/backup/changelog/fix-backup-depcs
+++ b/projects/plugins/backup/changelog/fix-backup-depcs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Just moving a dep around. No functional change.
-
-

--- a/projects/plugins/backup/changelog/fix-backup-depcs#2
+++ b/projects/plugins/backup/changelog/fix-backup-depcs#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/backup/changelog/init-release-cycle
+++ b/projects/plugins/backup/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Init 1.4.4-alpha
+
+

--- a/projects/plugins/backup/changelog/prerelease
+++ b/projects/plugins/backup/changelog/prerelease
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Init 1.4.3-alpha

--- a/projects/plugins/backup/changelog/renovate-composer-composer-2.x
+++ b/projects/plugins/backup/changelog/renovate-composer-composer-2.x
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/backup/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/backup/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/backup/changelog/renovate-yoast-phpunit-polyfills-1.x
+++ b/projects/plugins/backup/changelog/renovate-yoast-phpunit-polyfills-1.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/backup/changelog/update-backup-branding
+++ b/projects/plugins/backup/changelog/update-backup-branding
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update Backup logo

--- a/projects/plugins/backup/changelog/update-blaze-package-todos
+++ b/projects/plugins/backup/changelog/update-blaze-package-todos
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/backup/changelog/update-connection-error-notice-redesign
+++ b/projects/plugins/backup/changelog/update-connection-error-notice-redesign
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/backup/changelog/update-connection-error-notice-redesign#2
+++ b/projects/plugins/backup/changelog/update-connection-error-notice-redesign#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/backup/changelog/update-connection-error-notice-redesign#3
+++ b/projects/plugins/backup/changelog/update-connection-error-notice-redesign#3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/backup/changelog/update-init-with-config-package
+++ b/projects/plugins/backup/changelog/update-init-with-config-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/backup/changelog/update-my-jetpack-remove-videopress-hybrid
+++ b/projects/plugins/backup/changelog/update-my-jetpack-remove-videopress-hybrid
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -34,7 +34,7 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"config": {
-		"autoloader-suffix": "9559eef123208b7d1b9c15b978567267_backupⓥ1_4_3_beta",
+		"autoloader-suffix": "9559eef123208b7d1b9c15b978567267_backupⓥ1_4_4_alpha",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -34,7 +34,7 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"config": {
-		"autoloader-suffix": "9559eef123208b7d1b9c15b978567267_backupⓥ1_4_3_alpha",
+		"autoloader-suffix": "9559eef123208b7d1b9c15b978567267_backupⓥ1_4_3_beta",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/backup/jetpack-backup.php
+++ b/projects/plugins/backup/jetpack-backup.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack VaultPress Backup
  * Plugin URI: https://jetpack.com/jetpack-backup
  * Description: Easily restore or download a backup of your site from a specific moment in time.
- * Version: 1.4.3-alpha
+ * Version: 1.4.3-beta
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later

--- a/projects/plugins/backup/jetpack-backup.php
+++ b/projects/plugins/backup/jetpack-backup.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack VaultPress Backup
  * Plugin URI: https://jetpack.com/jetpack-backup
  * Description: Easily restore or download a backup of your site from a specific moment in time.
- * Version: 1.4.3-beta
+ * Version: 1.4.4-alpha
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 11.7-beta - 2023-01-02
+### Enhancements
+- Blaze: enable functionality within the Jetpack plugin. [#28077]
+- Stats: make the toggle for enabling Odyssey Stats visible for all users. [#28105]
+- VideoPress: fix cover attribute on player and add muted attribute on video shortcode. [#28083]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Updating testing instructions for 11.7 [#28098]
+
 ## 11.7-a.11 - 2022-12-29
 ### Bug fixes
 - Premium subscriptions / paid newsletters: Reverting previously merged changes which caused fatal errors in production. [#28102]

--- a/projects/plugins/jetpack/changelog/add-review-prompt-for-social-plugin
+++ b/projects/plugins/jetpack/changelog/add-review-prompt-for-social-plugin
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 11.7-a.10
-
-

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 11.8-a.0
+
+

--- a/projects/plugins/jetpack/changelog/init-release-cycle#2
+++ b/projects/plugins/jetpack/changelog/init-release-cycle#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 11.7-a.12
-
-

--- a/projects/plugins/jetpack/changelog/revert-27854-update-fonts-i18n-filter
+++ b/projects/plugins/jetpack/changelog/revert-27854-update-fonts-i18n-filter
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Revert "Add new i18n fonts and rename them via filter" #28122
-
-

--- a/projects/plugins/jetpack/changelog/update-blaze-package-todos
+++ b/projects/plugins/jetpack/changelog/update-blaze-package-todos
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Enable Blaze functionality!

--- a/projects/plugins/jetpack/changelog/update-blaze-package-todos#2
+++ b/projects/plugins/jetpack/changelog/update-blaze-package-todos#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-blaze-package-todos#3
+++ b/projects/plugins/jetpack/changelog/update-blaze-package-todos#3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-my-jetpack-remove-videopress-hybrid
+++ b/projects/plugins/jetpack/changelog/update-my-jetpack-remove-videopress-hybrid
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-odyssey-stats-toggle-visibility
+++ b/projects/plugins/jetpack/changelog/update-odyssey-stats-toggle-visibility
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Stats: Make Odyssey Stats toggle visible for all

--- a/projects/plugins/jetpack/changelog/update-totest-11.7
+++ b/projects/plugins/jetpack/changelog/update-totest-11.7
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updating testing instructions for 11.7

--- a/projects/plugins/jetpack/changelog/update-videopress-shortcode-enhancements
+++ b/projects/plugins/jetpack/changelog/update-videopress-shortcode-enhancements
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-VideoPress: Fix cover attribute on player and muted attribute on video shortcode override

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ11_7_beta",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ11_8_a_0",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ11_7_a_12",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ11_7_beta",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 11.7-a.12
+ * Version: 11.7-beta
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -32,7 +32,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.0' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '11.7-a.12' );
+define( 'JETPACK__VERSION', '11.7-beta' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 11.7-beta
+ * Version: 11.8-a.0
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -32,7 +32,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.0' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '11.7-beta' );
+define( 'JETPACK__VERSION', '11.8-a.0' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "11.7.0-a.12",
+	"version": "11.7.0-beta",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "11.7.0-beta",
+	"version": "11.8.0-a.0",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -242,9 +242,69 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 4. Promote your newest posts, pages, and products across your social media channels.
 
 == Changelog ==
-### 11.7-a.11 - 2022-12-29
+### 11.7-beta - 2023-01-02
+#### Major Enhancements
+- Blocks: add launchpad on save modal.
+- Revue block: remove functionality due to Revue shutting down, add placeholder messaging instead.
+
+#### Enhancements
+- Assistant: update Akismet and Backup names.
+- Blaze: enable functionality within the Jetpack plugin.
+- Block editor: add a new panel that gives the ability to promote posts after publishing them.
+- Contact form: move responses export to a modal triggered by a single "Export" button.
+- Dashboard: activate license key dropdown selector in the main Jetpack dashboard licenses activation page.
+- Dashboard: hide agencies module on Jetpack dashboard if site is WoA.
+- Dashboard: update Backup, Anti-spam, and VideoPress logos.
+- Dashboard: use minimized CSS for the stats widget.
+- Form block: styling adjustments including placeholder icon and link color adjustments, placeholder background color, placeholder styles and form fields styles updated to comply with WYSIWYG.
+- Form block: allow the required field text to be changed.
+- Form block: move contact-form/salesforce-lead-form out of beta blocks and into production. Add beta badge on settings.
+- Form block: simplify Form block sidebar to make the UI easier to use.
+- Form block: update Form blocks descriptions and child blocks icons.
+- Form block: update the default labels logic to allow fields without any label.
+- Global Styles: add new fonts for better i18n.
+- Google fonts: add new fonts to Global Style options.
+- Slideshow block: implement pagination styles when a gallery has more than five images.
+- Slideshow block: reduce bullet size and change the CSS justify-content to flex-start, plus replace pencil icon with edit text.
+- Slideshow block: update block description.
+- Stats: make the toggle for enabling Odyssey Stats visible for all users.
+- Subscription / Premium Content block: restrict posts to either paid subscribers or email subscribers (available with a Beta filter only), and add option for subscribers to pay while subscribing via the Subscription block, if the site owner creates one or more "newsletter" paid plans.
+- Subscription block: add a checkbox to include/exclude social followers.
+- Subscriptions block: change the label "email subscribers" to "subscribers" in the pre/post publish panel, as it also includes followers.
+- VideoPress: do not convert core/embed to videopress/video on-the-fly (WordPress.com sites).
+- VideoPress: fix cover attribute on player and add muted attribute on video shortcode.
+- Writing prompts: add a writing setting to disable showing prompts when starting a new post.
+- Writing prompts: add context to blogging prompt placeholder.
+- Writing prompts: add filter for whether prompts are enabled or not
+
+#### Improved compatibility
+- Launchpad: Sync Launchpad-related options: `launchpad_screen` and `launchpad_checklist_tasks_statuses`.
+- Site Editor: dashboard link points to wordpress.com.
+- Styling: Replaced custom maybe_inline_style() with wp_maybe_inline_styles() which is available in WP core since 5.8.0. [#27965, #27983]
+- VideoPress: make sure the Videopress shortcode is not registered if standalone VideoPress plugin already registered it.
+- Writing prompts: hide placeholder prompts by default.
+
 #### Bug fixes
+- Admin Page: avoid querying for WAF settings when the feature is not active.
+- Dashboard: add translation context to Security product name.
+- Form block: add line breaks back to plain text email submissions.
+- Form block: adjust Form placeholder footer links style to prevent theme clashes.
+- Form block: fix contact form view responses URL.
+- Form block: fix email formatting for contact form submissions.
+- Form block: fix patterns modal scrollbar behavior and filter query.
+- General: Fix deprecation warnings when running with PHP 8.2.
+- Hovercards: fix minor Hovercards & AMP compatibility bug
+- Internationalization: fix context for translated product name.
+- Payment block: fix the upgrade nudge for Payment blocks in the Site Editor on WordPress.com sites.
+- Premium Content block: fix bug in JWT library encode() method.
 - Premium subscriptions / paid newsletters: Reverting previously merged changes which caused fatal errors in production.
+- Shortcodes: update the Mixcloud oEmbed API Endpoint to the new version.
+- Subscription block: ensure custom button spacing is correct when the button is on its own line.
+- Subscription block: fix PHP Warning.
+- VideoPress block: fix video player issue in some VideoMaker theme patterns.
+- WAF: fix Jetpack Settings WAF module plan check, and initialization of the firewall.
+- WAF: fix WPA click tracking in Agencies card.
+- Writing Prompts: do not display within mobile app.
 
 --------
 

--- a/projects/plugins/social/CHANGELOG.md
+++ b/projects/plugins/social/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.6.0-beta - 2023-01-02
+### Added
+- Add a review request prompt for Jetpack Social plugin. [#28072]
+- Add the adminUrl to the initial editor state. [#27617]
+- Add simple JS React test. [#27122]
+- Redirect to admin page on plugin activation, and add link to admin page from plugins page. [#24586]
+
+### Changed
+- Updated package dependencies. [#27340, #27688, #27689, #27696, #27697, #27874, #27887, #27916, #27962]
+
 ## 1.5.1 - 2022-12-06
 ### Changed
 - Updated package dependencies. [#26069]

--- a/projects/plugins/social/changelog/add-license-key-selector
+++ b/projects/plugins/social/changelog/add-license-key-selector
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/social/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
+++ b/projects/plugins/social/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/social/changelog/add-promoted-posts-post-publish-panel
+++ b/projects/plugins/social/changelog/add-promoted-posts-post-publish-panel
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/social/changelog/add-review-prompt-for-social-plugin
+++ b/projects/plugins/social/changelog/add-review-prompt-for-social-plugin
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add a review request prompt for Jetpack Social plugin

--- a/projects/plugins/social/changelog/add-social-rect-test
+++ b/projects/plugins/social/changelog/add-social-rect-test
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add simple JS React test

--- a/projects/plugins/social/changelog/add-sync-request-full-response-logging
+++ b/projects/plugins/social/changelog/add-sync-request-full-response-logging
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/social/changelog/add-sync-request-full-response-logging#2
+++ b/projects/plugins/social/changelog/add-sync-request-full-response-logging#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/social/changelog/add-woo-sync-whitelist
+++ b/projects/plugins/social/changelog/add-woo-sync-whitelist
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/social/changelog/backport-release-changelogs
+++ b/projects/plugins/social/changelog/backport-release-changelogs
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Backport changelog and readme from release

--- a/projects/plugins/social/changelog/change-jetpack-social-admin-page-improvements
+++ b/projects/plugins/social/changelog/change-jetpack-social-admin-page-improvements
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Redirect to admin page on plugin activation, and add link to admin page from plugins page.

--- a/projects/plugins/social/changelog/change-jetpack-social-author
+++ b/projects/plugins/social/changelog/change-jetpack-social-author
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated the author name and URL for the .org repo
-
-

--- a/projects/plugins/social/changelog/changelogger-merge
+++ b/projects/plugins/social/changelog/changelogger-merge
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Minor update to changelog package that supports git merge strategy. Should not affect shipped code.
-
-

--- a/projects/plugins/social/changelog/e2e-increase-timeout-social-connection
+++ b/projects/plugins/social/changelog/e2e-increase-timeout-social-connection
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-

--- a/projects/plugins/social/changelog/fix-social-upgrade-redirects
+++ b/projects/plugins/social/changelog/fix-social-upgrade-redirects
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added the adminUrl to the initial editor state

--- a/projects/plugins/social/changelog/init-release-cycle
+++ b/projects/plugins/social/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Init 1.6.1-alpha
+
+

--- a/projects/plugins/social/changelog/prerelease
+++ b/projects/plugins/social/changelog/prerelease
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Init 1.5.2-alpha

--- a/projects/plugins/social/changelog/renovate-automattic-wordbless-0.x
+++ b/projects/plugins/social/changelog/renovate-automattic-wordbless-0.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/social/changelog/renovate-babel-monorepo
+++ b/projects/plugins/social/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/social/changelog/renovate-composer-composer-2.x
+++ b/projects/plugins/social/changelog/renovate-composer-composer-2.x
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/social/changelog/renovate-js-unit-testing-packages
+++ b/projects/plugins/social/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/social/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/social/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/social/changelog/renovate-major-jest-monorepo
+++ b/projects/plugins/social/changelog/renovate-major-jest-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/social/changelog/renovate-postcss-8.x
+++ b/projects/plugins/social/changelog/renovate-postcss-8.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/social/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/social/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/social/changelog/renovate-yoast-phpunit-polyfills-1.x
+++ b/projects/plugins/social/changelog/renovate-yoast-phpunit-polyfills-1.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/social/changelog/update-blaze-package-todos
+++ b/projects/plugins/social/changelog/update-blaze-package-todos
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/social/changelog/update-connection-error-notice-redesign
+++ b/projects/plugins/social/changelog/update-connection-error-notice-redesign
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/social/changelog/update-connection-error-notice-redesign#2
+++ b/projects/plugins/social/changelog/update-connection-error-notice-redesign#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/social/changelog/update-connection-error-notice-redesign#3
+++ b/projects/plugins/social/changelog/update-connection-error-notice-redesign#3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/social/changelog/update-init-with-config-package
+++ b/projects/plugins/social/changelog/update-init-with-config-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/social/changelog/update-my-jetpack-remove-videopress-hybrid
+++ b/projects/plugins/social/changelog/update-my-jetpack-remove-videopress-hybrid
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -81,6 +81,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_socialⓥ1_6_0_alpha"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_socialⓥ1_6_0_beta"
 	}
 }

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -81,6 +81,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_socialⓥ1_6_0_beta"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_socialⓥ1_6_1_alpha"
 	}
 }

--- a/projects/plugins/social/jetpack-social.php
+++ b/projects/plugins/social/jetpack-social.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Social
  * Plugin URI: https://wordpress.org/plugins/jetpack-social
  * Description: Share your site’s posts on several social media networks automatically when you publish a new post.
- * Version: 1.6.0-alpha
+ * Version: 1.6.0-beta
  * Author: Automattic - Jetpack Social team
  * Author URI: https://jetpack.com/social/
  * License: GPLv2 or later

--- a/projects/plugins/social/jetpack-social.php
+++ b/projects/plugins/social/jetpack-social.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Social
  * Plugin URI: https://wordpress.org/plugins/jetpack-social
  * Description: Share your site’s posts on several social media networks automatically when you publish a new post.
- * Version: 1.6.0-beta
+ * Version: 1.6.1-alpha
  * Author: Automattic - Jetpack Social team
  * Author URI: https://jetpack.com/social/
  * License: GPLv2 or later


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Initializes new cycles and backports changes from releasing Jetpack, Backup, and Social.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion

n/a

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Proof-read. Make sure versions are correct. The Jetpack changelog and readme should actually be good to go (no need for an edit PR for those) unless you see anything obvious needing a change there. Social and Backup need readme edits so that will come.

