### PR TITLE
Fix Paid Newsletters Fatal Errors

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/access-check.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/access-check.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Extensions\Premium_Content;
 
+use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Token_Subscription_Service;
+
 require __DIR__ . '/subscription-service/include.php';
 
 /**
@@ -91,8 +93,9 @@ function current_visitor_can_access( $attributes, $block ) {
 		return false;
 	}
 
-	$paywall  = subscription_service();
-	$can_view = $paywall->visitor_can_view_content( array( $selected_plan_id ) );
+	$paywall      = subscription_service();
+	$access_level = Token_Subscription_Service::POST_ACCESS_LEVEL_SUBSCRIBERS; // Only subscribers should be granted access to the premium content
+	$can_view     = $paywall->visitor_can_view_content( array( $selected_plan_id ), $access_level );
 
 	if ( $can_view ) {
 		/**

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
@@ -17,13 +17,15 @@ use Automattic\Jetpack\Extensions\Premium_Content\JWT;
  */
 abstract class Token_Subscription_Service implements Subscription_Service {
 
-	const JWT_AUTH_TOKEN_COOKIE_NAME    = 'jp-premium-content-session';
-	const DECODE_EXCEPTION_FEATURE      = 'memberships';
-	const DECODE_EXCEPTION_MESSAGE      = 'Problem decoding provided token';
-	const REST_URL_ORIGIN               = 'https://subscribe.wordpress.com/';
-	const BLOG_SUB_ACTIVE               = 'active';
-	const BLOG_SUB_PENDING              = 'pending';
-	const POST_ACCESS_LEVEL_SUBSCRIBERS = 'subscribers';
+	const JWT_AUTH_TOKEN_COOKIE_NAME         = 'jp-premium-content-session';
+	const DECODE_EXCEPTION_FEATURE           = 'memberships';
+	const DECODE_EXCEPTION_MESSAGE           = 'Problem decoding provided token';
+	const REST_URL_ORIGIN                    = 'https://subscribe.wordpress.com/';
+	const BLOG_SUB_ACTIVE                    = 'active';
+	const BLOG_SUB_PENDING                   = 'pending';
+	const POST_ACCESS_LEVEL_EVERYBODY        = 'everybody';
+	const POST_ACCESS_LEVEL_SUBSCRIBERS      = 'subscribers';
+	const POST_ACCESS_LEVEL_PAID_SUBSCRIBERS = 'paid_subscribers';
 
 	/**
 	 * Initialize the token subscription service.
@@ -115,16 +117,16 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 			return true;
 		}
 
-		if ( empty( $access_level ) || $access_level === 'everybody' ) {
+		if ( empty( $access_level ) || $access_level === self::POST_ACCESS_LEVEL_EVERYBODY ) {
 			// empty level means the post is not gated for paid users
 			return true;
 		}
 
-		if ( $access_level === 'subscribers' ) {
+		if ( $access_level === self::POST_ACCESS_LEVEL_SUBSCRIBERS ) {
 			return $is_blog_subscriber || $is_paid_subscriber;
 		}
 
-		if ( $access_level === 'paid_subscribers' ) {
+		if ( $access_level === self::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS ) {
 			return $is_paid_subscriber;
 		}
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -643,8 +643,10 @@ function render_jetpack_subscribe_form( $data, $classes, $styles ) {
  *
  * @return mixed
  */
-function jetpack_filter_excerpt_for_newsletter( $excerpt, $post ) {
-	if ( false !== strpos( $post->post_content, '<!-- wp:jetpack/subscriptions -->' ) ) {
+function jetpack_filter_excerpt_for_newsletter( $excerpt, $post = null ) {
+	// The blogmagazine theme is overidding WP core `get_the_excerpt` filter and only passing the excerpt
+	// TODO: Until this is fixed, return the excerpt without gating. See https://github.com/Automattic/jetpack/pull/28102#issuecomment-1369161116
+	if ( $post && false !== strpos( $post->post_content, '<!-- wp:jetpack/subscriptions -->' ) ) {
 		$excerpt .= sprintf(
 			// translators: %s is the permalink url to the current post.
 			__( "<p><a href='%s'>View post</a> to subscribe to site newsletter.</p>", 'jetpack' ),

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -644,7 +644,7 @@ function render_jetpack_subscribe_form( $data, $classes, $styles ) {
  * @return mixed
  */
 function jetpack_filter_excerpt_for_newsletter( $excerpt, $post = null ) {
-	// The blogmagazine theme is overidding WP core `get_the_excerpt` filter and only passing the excerpt
+	// The blogmagazine theme is overriding WP core `get_the_excerpt` filter and only passing the excerpt
 	// TODO: Until this is fixed, return the excerpt without gating. See https://github.com/Automattic/jetpack/pull/28102#issuecomment-1369161116
 	if ( $post && false !== strpos( $post->post_content, '<!-- wp:jetpack/subscriptions -->' ) ) {
 		$excerpt .= sprintf(

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -454,8 +454,7 @@ class Jetpack_Memberships {
 
 		$newsletter_access_level = self::get_newsletter_access_level();
 		$paywall                 = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
-		// TODO: Figure out why the `get_the_ID` is passed here when the function accepts a `$is_blog_subscriber` param
-		return $paywall->visitor_can_view_content( self::get_all_plans_id_jetpack_recurring_payments(), $newsletter_access_level, get_the_ID() );
+		return $paywall->visitor_can_view_content( self::get_all_plans_id_jetpack_recurring_payments(), $newsletter_access_level );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -454,6 +454,7 @@ class Jetpack_Memberships {
 
 		$newsletter_access_level = self::get_newsletter_access_level();
 		$paywall                 = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
+		// TODO: Figure out why the `get_the_ID` is passed here when the function accepts a `$is_blog_subscriber` param
 		return $paywall->visitor_can_view_content( self::get_all_plans_id_jetpack_recurring_payments(), $newsletter_access_level, get_the_ID() );
 	}
 


### PR DESCRIPTION
### Overview
Relates to https://github.com/Automattic/jetpack/pull/26417 and https://github.com/Automattic/jetpack/pull/28102

The `paid-newsletters` branch was reverted in https://github.com/Automattic/jetpack/pull/28102 due to [the following errors](https://github.com/Automattic/jetpack/pull/28102#issuecomment-1368735458). This PR fixes those errors so that the branch can be merged and deployed in the next Jetpack release.

### Testing instructions:

#### The first error:

```
PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function Automattic\Jetpack\Extensions\Subscriptions\jetpack_filter_excerpt_for_newsletter(), 1 passed in /wordpress/core/6.1.1/wp-includes/class-wp-hook.php on line 308 and exactly 2 expected in /wordpress/plugins/jetpack/11.7-a.9/extensions/blocks/subscriptions/subscriptions.php:657
Stack trace:
#0 /wordpress/core/6.1.1/wp-includes/class-wp-hook.php(308): Automattic\Jetpack\Extensions\Subscriptions\jetpack_filter_excerpt_for_newsletter('The long-term u...')
#1 /wordpress/core/6.1.1/wp-includes/plugin.php(205): WP_Hook->apply_filters('The long-term u...', Array)
#2 /srv/htdocs/wp-content/themes/blogmagazine/inc/dglib/core/functions.php(252): apply_filters('get_the_excerpt', 'The long-term u...')
#3 /srv/htdocs/wp-content/themes/blogmagazine/inc/dglib/core/functions.php(262): dglib_get_excerpt(150, true, 'Read More...')
#4 /srv/htdocs/wp-content/themes/blogmagazine/template-parts/layouts/classic.php(57): dglib_the_excerpt(150, true, 'Read More...')
#5 /wordpress/core/6.1.1/wp-includes/template.php(785): require('/srv/htdocs/wp-...')
#6 /wordpress/core/6.1.1/wp-includes/template.php(718): load_template('/srv/htdocs/wp-...', false, Array)
#7 /wordpress/core/6.1.1/wp-includes/general-template.php(204): locate_template(Array, true, false, Array)
#8 /srv/htdocs/wp-content/themes/blogmagazine/archive.php(37): get_template_part('template-parts/...')
#9 /wordpress/core/6.1.1/wp-includes/template-loader.php(106): include('/srv/htdocs/wp-...')
#10 /wordpress/core/6.1.1/wp-blog-header.php(19): require_once('/wordpress/core...')
#11 /wordpress/core/6.1.1/index.php(17): require('/wordpress/core...')
#12 {main}
  thrown in /wordpress/plugins/jetpack/11.7-a.9/extensions/blocks/subscriptions/subscriptions.php on line 657
```

1. Install the `blogmagazine` theme ( [link](https://wordpress.org/themes/blogmagazine/) ) on a Jetpack site
2. Create a post with a newsletter setting
3. View the index page of the blog
4. An error should not be thrown on the page. You can also tail the logs and check for errors with `jetpack docker tail `

#### The second error:

```
PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Token_Subscription_Service::visitor_can_view_content(), 1 passed in /wordpress/plugins/jetpack/11.7-a.9/extensions/blocks/premium-content/_inc/access-check.php on line 95 and exactly 2 expected in /wordpress/plugins/jetpack/11.7-a.9/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php:54
Stack trace:
#0 /wordpress/plugins/jetpack/11.7-a.9/extensions/blocks/premium-content/_inc/access-check.php(95): Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Token_Subscription_Service->visitor_can_view_content(Array)
#1 /wordpress/plugins/jetpack/11.7-a.9/extensions/blocks/premium-content/subscriber-view/subscriber-view.php(55): Automattic\Jetpack\Extensions\Premium_Content\current_visitor_can_access(Array, Object(WP_Block))
#2 /wordpress/core/6.1.1/wp-includes/class-wp-block.php(256): Automattic\Jetpack\Extensions\Premium_Content\render_subscriber_view_block(Array, '\n<div class="wp...', Object(WP_Block))
#3 /wordpress/core/6.1.1/wp-includes/class-wp-block.php(242): WP_Block->render()
#4 /wordpress/core/6.1.1/wp-includes/blocks.php(1051): WP_Block->render()
#5 /wordpress/core/6.1.1/wp-includes/blocks.php(1089): render_block(Array)
#6 /wordpress/core/6.1.1/wp-includes/class-wp-hook.php(308): do_blocks('<!-- wp:premium...')
#7 /wordpress/core/6.1.1/wp-includes/plugin.php(205): WP_Hook->apply_filters('<!-- wp:premium...', Array)
#8 /wordpress/core/6.1.1/wp-includes/post-template.php(255): apply_filters('the_content', '<!-- wp:premium...')
#9 /wordpress/themes/pub/lodestar/components/post/content.php(41): the_content('Continue readin...')
#10 /wordpress/core/6.1.1/wp-includes/template.php(785): require('/wordpress/them...')
#11 /wordpress/core/6.1.1/wp-includes/template.php(718): load_template('/wordpress/them...', false, Array)
#12 /wordpress/core/6.1.1/wp-includes/general-template.php(204): locate_template(Array, true, false, Array)
#13 /wordpress/themes/pub/lodestar/single.php(19): get_template_part('components/post...', '')
#14 /wordpress/core/6.1.1/wp-includes/template-loader.php(106): include('/wordpress/them...')
#15 /wordpress/core/6.1.1/wp-blog-header.php(19): require_once('/wordpress/core...')
#16 /wordpress/core/6.1.1/index.php(17): require('/wordpress/core...')
#17 {main}
  thrown in /wordpress/plugins/jetpack/11.7-a.9/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php on line 54
```

I was unable to reproduce this error on WPCOM with the premium content blog; however, the error is clear based on the stacktrace and a fix was pushed to this branch.


1. Sync branch to WPCOM
2. Add the  premium content to a post 
3. Verify a subscriber can view the content while a non-subscriber cannot view the content
4. Verify no errors are thrown in `php-errors.php`

### Does this pull request change what data or activity we track or use?
No additional information.
