### PR TITLE
VideoPress: Fix minors TS issues in use video data hooks

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-fix-use-media-data-ts
+++ b/projects/packages/videopress/changelog/update-videopress-fix-use-media-data-ts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: TS enhancements in use Video data hooks

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
@@ -168,7 +168,7 @@ export function useSyncMedia(
 	const wasSaving = usePrevious( isSaving );
 	const invalidateResolution = useDispatch( coreStore ).invalidateResolution;
 
-	const [ initialState, setState ] = useState( {} );
+	const [ initialState, setState ] = useState< VideoDataProps >( {} );
 
 	const [ error, setError ] = useState( null );
 
@@ -195,48 +195,43 @@ export function useSyncMedia(
 		const attributesToUpdate: VideoBlockAttributes = {};
 
 		// Build an object with video data to use for the initial state.
-		const initialVideoData = videoFieldsToUpdate.reduce(
-			( acc, key ) => {
-				if ( typeof videoData[ key ] === 'undefined' ) {
-					return acc;
-				}
-
-				let videoDataValue = videoData[ key ];
-
-				// Cast privacy_setting to number to match the block attribute type.
-				if ( 'privacy_setting' === key ) {
-					videoDataValue = Number( videoDataValue );
-				}
-
-				acc[ key ] = videoDataValue;
-				const attrName = mapFieldsToAttributes[ key ] || snakeToCamel( key );
-
-				if ( videoDataValue !== attributes[ attrName ] ) {
-					debug(
-						'%o is out of sync. Updating %o attr from %o to %o ',
-						key,
-						attrName,
-						attributes[ attrName ],
-						videoDataValue
-					);
-					attributesToUpdate[ attrName ] = videoDataValue;
-				}
+		const initialVideoData = videoFieldsToUpdate.reduce( ( acc, key ) => {
+			if ( typeof videoData[ key ] === 'undefined' ) {
 				return acc;
-			},
-			{
-				tracks: [],
 			}
-		);
+
+			let videoDataValue = videoData[ key ];
+
+			// Cast privacy_setting to number to match the block attribute type.
+			if ( 'privacy_setting' === key ) {
+				videoDataValue = Number( videoDataValue );
+			}
+
+			acc[ key ] = videoDataValue;
+			const attrName = mapFieldsToAttributes[ key ] || snakeToCamel( key );
+
+			if ( videoDataValue !== attributes[ attrName ] ) {
+				debug(
+					'%o is out of sync. Updating %o attr from %o to %o ',
+					key,
+					attrName,
+					attributes[ attrName ],
+					videoDataValue
+				);
+				attributesToUpdate[ attrName ] = videoDataValue;
+			}
+			return acc;
+		}, {} );
 
 		updateInitialState( initialVideoData );
+		debug( 'Initial state: ', initialVideoData );
 
 		if ( ! Object.keys( initialVideoData ).length ) {
 			return;
 		}
 
-		const [ tracks, tracksOufOfSync ] = arrangeTracksAttributes( videoData, attributes );
-
 		// Sync video tracks if needed.
+		const [ tracks, tracksOufOfSync ] = arrangeTracksAttributes( videoData, attributes );
 		if ( tracksOufOfSync ) {
 			attributesToUpdate.tracks = tracks;
 		}

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/Readme.md
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/Readme.md
@@ -1,13 +1,13 @@
 # useVideoHook()
 
-Perform a request to the media endpoint.
-Pull and tweak the response to be adequately delivered to the component.
+React custom hook that requests the media endpoint,
+tweaking its response to be adequately delivered to be consumed by the component.
 
 ```jsx
 function myVideoComponent( { id, guid } ) {
-	const [ videoData, isRequestingVideoItem ] = useVideoData( { guid } );
+	const [ videoData, isRequestingVideoData ] = useVideoData( { guid } );
 
-	if ( isRequestingVideoItem ) {
+	if ( isRequestingVideoData ) {
 		return null;
 	}
 

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/Readme.md
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/Readme.md
@@ -1,7 +1,7 @@
 # useVideoHook()
 
 React custom hook that requests the media endpoint,
-tweaking its response to be adequately delivered to be consumed by the component.
+tweaking it's response to be adequately delivered to be consumed by the component.
 
 ```jsx
 function myVideoComponent( { id, guid } ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: Fix minors issues in use video data hooks:
  * Fix some TS issuers
  * Update Readme file

#### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check some types in the useSyncData() hook:

**before**
It shows type errors in the `initialVideoData` var:
<img width="1197" alt="image" src="https://user-images.githubusercontent.com/77539/210325638-db9b355a-6a10-4f79-91d5-9d9566eb31c6.png">

**after**
<img width="672" alt="image" src="https://user-images.githubusercontent.com/77539/210326127-b0f24f9e-405c-4fee-bb0a-d97bffa0a548.png">


* Functionality-wise, it should keep working as expected: You can create a new video block, upload a file, and check the debug() lines:

```cli
localStorage.setItem( 'debug', 'videopress:*' )
```
<img width="789" alt="image" src="https://user-images.githubusercontent.com/77539/210327827-1a1908f9-3bbe-4e62-82ea-afeaea2c5143.png">

