### PR TITLE
Fix export modal connect link

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-export-modal-redirect-link
+++ b/projects/plugins/jetpack/changelog/fix-export-modal-redirect-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Use a newly created redirect for "Connect Google Drive" export modal's link. This new redirect will take the user directly to the site's marketing/connections page (bypassing the site selection screen)

--- a/projects/plugins/jetpack/modules/contact-form/admin.php
+++ b/projects/plugins/jetpack/modules/contact-form/admin.php
@@ -1349,7 +1349,7 @@ class Grunion_Admin {
 		} else {
 			$button_html = sprintf(
 				'<a href="%1$s" class="button button-primary export-button export-gdrive" title="%2$s" rel="noopener noreferer" target="_blank">%3$s</a>',
-				esc_url( Redirect::get_url( 'calypso-marketing-connections-base' ) ),
+				esc_url( Redirect::get_url( 'jetpack-form-responses-connect' ) ),
 				esc_attr__( 'connect to Google Drive', 'jetpack' ),
 				esc_html__( 'Connect Google Drive', 'jetpack' )
 			);


### PR DESCRIPTION
This PR will use a new redirect resource to point to the correct page.

Fixes #28145 

#### Changes proposed in this Pull Request:
The current redirect resource is to the base page for marketing/connections. The new one will point directly to the site's marketing/connections page.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
p8oabR-11U-p2#comment-6915


#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

On a Jetpack-connected test site, make sure you have some contact form responses on your test site (showing in the Feedback area in wp-admin). From that Feedback area, you should see a single "Export" button. Click it to open the Export modal.

On the "Google Sheet" section, export button should read "Connect Google Drive" (if it reads "Export", it means you're already connected, go to https://wordpress.com/marketing/connections and disconnect from Google Drive, then follow the above steps to get to the export modal).

Clicking on export modal's "Connect Google Drive" should open a new tab directly to the marketing/connections page for the site.