### PR TITLE
[Boost] Run page speed locally

### DIFF
--- a/projects/plugins/boost/app/features/speed-score/Speed_Score_Request.php
+++ b/projects/plugins/boost/app/features/speed-score/Speed_Score_Request.php
@@ -9,9 +9,9 @@
 
 namespace Automattic\Jetpack_Boost\Features\Speed_Score;
 
+use Automattic\Jetpack_Boost\Lib\Boost_API;
 use Automattic\Jetpack_Boost\Lib\Cacheable;
 use Automattic\Jetpack_Boost\Lib\Url;
-use Automattic\Jetpack_Boost\Lib\Utils;
 
 /**
  * Class Speed_Score_Request
@@ -153,12 +153,8 @@ class Speed_Score_Request extends Cacheable {
 	 * @return true|\WP_Error True on success, WP_Error on failure.
 	 */
 	public function execute() {
-		$blog_id = (int) \Jetpack_Options::get_option( 'id' );
-
-		$response = Utils::send_wpcom_request(
-			'POST',
-			sprintf( '/sites/%d/jetpack-boost/speed-scores', $blog_id ),
-			null,
+		$response = $this->get_client()->post(
+			'speed-scores',
 			array(
 				'request_id'     => $this->get_cache_id(),
 				'url'            => Url::normalize( $this->url ),
@@ -204,13 +200,9 @@ class Speed_Score_Request extends Cacheable {
 	 * @return true|\WP_Error True on success, WP_Error on failure.
 	 */
 	public function poll_update() {
-		$blog_id = (int) \Jetpack_Options::get_option( 'id' );
-
-		$response = Utils::send_wpcom_request(
-			'GET',
+		$response = $this->get_client()->get(
 			sprintf(
-				'/sites/%d/jetpack-boost/speed-scores/%s',
-				$blog_id,
+				'speed-scores/%s',
 				$this->get_cache_id()
 			)
 		);
@@ -309,5 +301,9 @@ class Speed_Score_Request extends Cacheable {
 				)
 			);
 		}
+	}
+
+	private function get_client() {
+		return Boost_API::get_client();
 	}
 }

--- a/projects/plugins/boost/changelog/update-boost-allow-running-page-speed-locally
+++ b/projects/plugins/boost/changelog/update-boost-allow-running-page-speed-locally
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update Speed_Score_Request to use Boost_API client, which will allow mocking requests to wp.com easier.


### PR DESCRIPTION
Related to https://github.com/Automattic/boost-developer/pull/5.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* These changes will allow page speed to be ran through the local boost cloud just like cloud css.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

In order to test this, let's assume you've already setup your local website to work with jetpack boost and a local boost cloud instance.

* Install [this version](https://github.com/Automattic/boost-developer/tree/update/page-speed-support) of the Jetpack Boost: Companion plugin;
* **no longer necessary, as it's now part of the boost companion plugin** ~~Next, you will have to bypass the jetpack connection for your website. You can do that by following the steps [explained here](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/boost/docs/DEVELOPEMENT_GUIDE.md#bypassing-the-jetpack-connection)~~;
* Open the Boost dashboard and if everything's okay, you should see page speed requests in your boost cloud console.