### PR TITLE
Jetpack: Fix export modal nonces

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-csv-export-nonce
+++ b/projects/plugins/jetpack/changelog/fix-csv-export-nonce
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Use separate nonce names for export options, wp_nonce_field would use the name also as id of the element, preventing the normal DOM operations when more than one is present.

--- a/projects/plugins/jetpack/modules/contact-form/admin.php
+++ b/projects/plugins/jetpack/modules/contact-form/admin.php
@@ -1123,11 +1123,18 @@ add_action( 'admin_notices', 'grunion_feedback_admin_notice' );
  */
 class Grunion_Admin {
 	/**
-	 * Define nonce field name
+	 * CSV export nonce field name
 	 *
-	 * @var string The nonce field name.
+	 * @var string The nonce field name for CSV export.
 	 */
-	private $export_nonce_field = 'feedback_export_nonce';
+	private $export_nonce_field_csv = 'feedback_export_nonce_csv';
+
+	/**
+	 * GDrive export nonce field name
+	 *
+	 * @var string The nonce field name for GDrive export.
+	 */
+	private $export_nonce_field_gdrive = 'feedback_export_nonce_gdrive';
 
 	/**
 	 * Instantiates this singleton class
@@ -1241,8 +1248,8 @@ class Grunion_Admin {
 		$post_data = wp_unslash( $_POST );
 		if (
 			! current_user_can( 'export' )
-			|| empty( sanitize_text_field( $post_data[ $this->export_nonce_field ] ) )
-			|| ! wp_verify_nonce( sanitize_text_field( $post_data[ $this->export_nonce_field ] ), 'feedback_export' )
+			|| empty( sanitize_text_field( $post_data[ $this->export_nonce_field_gdrive ] ) )
+			|| ! wp_verify_nonce( sanitize_text_field( $post_data[ $this->export_nonce_field_gdrive ] ), 'feedback_export' )
 		) {
 			wp_send_json_error(
 				__( 'You aren’t authorized to do that.', 'jetpack' ),
@@ -1296,7 +1303,7 @@ class Grunion_Admin {
 			'primary export-button export-csv',
 			'jetpack-export-feedback-csv',
 			false,
-			array( 'data-nonce-name' => $this->export_nonce_field )
+			array( 'data-nonce-name' => $this->export_nonce_field_csv )
 		);
 		?>
 		<div class="export-card">
@@ -1315,7 +1322,7 @@ class Grunion_Admin {
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- we're literally building all this html to output it
 					echo $button_csv_html;
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- we're literally building all this html to output it
-					echo wp_nonce_field( 'feedback_export', $this->export_nonce_field, false, false );
+					echo wp_nonce_field( 'feedback_export', $this->export_nonce_field_csv, false, false );
 					?>
 				</div>
 			</div>
@@ -1344,7 +1351,7 @@ class Grunion_Admin {
 				'primary export-button export-gdrive',
 				'jetpack-export-feedback-gdrive',
 				false,
-				array( 'data-nonce-name' => $this->export_nonce_field )
+				array( 'data-nonce-name' => $this->export_nonce_field_gdrive )
 			);
 		} else {
 			$button_html = sprintf(
@@ -1384,7 +1391,7 @@ class Grunion_Admin {
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- we're literally building all this html to output it
 					echo $button_html;
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- we're literally building all this html to output it
-					echo wp_nonce_field( 'feedback_export', $this->export_nonce_field, false, false );
+					echo wp_nonce_field( 'feedback_export', $this->export_nonce_field_gdrive, false, false );
 					?>
 				</div>
 			</div>

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -1767,11 +1767,13 @@ class Grunion_Contact_Form_Plugin {
 	 * Extracts feedback entries based on POST data.
 	 */
 	public function get_feedback_entries_from_post() {
-		if ( empty( $_POST['feedback_export_nonce'] ) ) {
+		if ( empty( $_POST['feedback_export_nonce_csv'] ) && empty( $_POST['feedback_export_nonce_gdrive'] ) ) {
 			return;
+		} elseif ( ! empty( $_POST['feedback_export_nonce_csv'] ) ) {
+			check_admin_referer( 'feedback_export', 'feedback_export_nonce_csv' );
+		} elseif ( ! empty( $_POST['feedback_export_nonce_gdrive'] ) ) {
+			check_admin_referer( 'feedback_export', 'feedback_export_nonce_gdrive' );
 		}
-
-		check_admin_referer( 'feedback_export', 'feedback_export_nonce' );
 
 		if ( ! current_user_can( 'export' ) ) {
 			return;

--- a/projects/plugins/jetpack/modules/contact-form/js/grunion-admin.js
+++ b/projects/plugins/jetpack/modules/contact-form/js/grunion-admin.js
@@ -226,7 +226,7 @@ jQuery( function ( $ ) {
 	$( document ).on( 'click', '#jetpack-export-feedback-csv', function ( e ) {
 		e.preventDefault();
 
-		var nonceName = $( '#jetpack-export-feedback' ).data( 'nonce-name' );
+		var nonceName = $( e.target ).data( 'nonce-name' );
 		var nonce = $( '#' + nonceName ).attr( 'value' );
 
 		var date = window.location.search.match( /(\?|\&)m=(\d+)/ );


### PR DESCRIPTION
This PR implements new nonce naming for each export method.

Fixes #28146 

#### Changes proposed in this Pull Request:
`wp_nonce_field` uses the same string for `name` and `id` of the created input element. Duplicated element IDs prevent normal DOM operations, excluding the input from the POST request.

Using a unique nonce name for each export method solves the issue.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
p8oabR-11U-p2#comment-6916

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
On a Jetpack-connected test site, make sure you have some contact form responses on your test site (showing in the Feedback area in wp-admin). From that Feedback area, you should see a single "Export" button. Click it to open the Export modal.

Use both export methods, CSV should download successfully with content and generated Google Sheet should reflect the same data.
