### PR TITLE
Add a new endpoint template-loader to resolve the correct template by type

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-template-loader.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-template-loader.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * REST API endpoint for resolving template.
+ *
+ * @package automattic/jetpack
+ */
+
+/**
+ * Returns the correct template for the site's page based on the template type
+ */
+class WPCOM_REST_API_V2_Endpoint_Template_Loader extends WP_REST_Controller {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'wpcom/v2';
+		$this->rest_base = 'template-loader';
+
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Called automatically on `rest_api_init()`.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			sprintf(
+				'/%s/(?P<template_type>\w+)',
+				$this->rest_base
+			),
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_item' ),
+				'permission_callback' => array( $this, 'permissions_check' ),
+				'args'                => array(
+					'template_type' => array(
+						'description'       => __( 'The type of the template.', 'jetpack' ),
+						'type'              => 'string',
+						'required'          => true,
+						'validate_callback' => array( $this, 'validate_template_type' ),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Checks if the user has permissions to make the request.
+	 *
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function permissions_check() {
+		// Verify if the current user has edit_theme_options capability.
+		// This capability is required to edit/view/delete templates.
+		if ( ! current_user_can( 'edit_theme_options' ) ) {
+			return new WP_Error(
+				'rest_cannot_manage_templates',
+				__( 'Sorry, you are not allowed to access the templates on this site.', 'jetpack' ),
+				array(
+					'status' => rest_authorization_required_code(),
+				)
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validate the template type.
+	 *
+	 * @param string $template_type The template type.
+	 * @return boolean True if the template type is valid.
+	 */
+	public function validate_template_type( $template_type ) {
+		$template_types = array_keys( get_default_block_template_types() );
+		if ( ! in_array( $template_type, $template_types, true ) ) {
+			return new WP_Error(
+				'rest_invalid_param',
+				sprintf(
+					/* translators: %s: The template type. */
+					__( 'The template type %s are not allowed.', 'jetpack' ),
+					$template_type
+				),
+				array( 'status' => 400 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieves the template by specified type.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_item( $request ) {
+		$template_type = $request['template_type'];
+
+		// A list of template candidates, in descending order of priority.
+		$templates      = apply_filters( "{$template_type}_template_hierarchy", array( "{$template_type}.php" ) );
+		$template       = locate_template( $templates );
+		$block_template = resolve_block_template( $template_type, $templates, $template );
+
+		if ( empty( $block_template ) ) {
+			return new WP_Error( 'not_found', 'Template not found', array( 'status' => 404 ) );
+		}
+
+		return rest_ensure_response(
+			array(
+				'type' => $block_template->type,
+				'id'   => $block_template->id,
+			)
+		);
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Template_Loader' );

--- a/projects/plugins/jetpack/changelog/add-wpcom-v2-template-loader-endpoint
+++ b/projects/plugins/jetpack/changelog/add-wpcom-v2-template-loader-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add a new endpoint, template-loader, to resolve the correct template by its type


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/71375, https://github.com/Automattic/wp-calypso/pull/71702

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Before we use a tricks `/<page>?_wp-find-template=true` to resolve the template of the current page, but it doesn't work if we want to proxy the request from wpcom to Jetpack due to the authentication issue. Thus, we propose to add a new endpoint called `template-loader` to resolve the template by its type, e.g.: home.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

N/A

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* Create a [Jurassic Ninja sandbox](https://jurassic.ninja/create/?jetpack-beta&branch=add/wpcom-v2-template-loader-endpoint) against this PR.
* Setup Jetpack on your site to connect with WordPress
* Apply D97093-code to your sandbox
* Apply this PR to your sandbox
  `bin/jetpack-downloader test jetpack add/wpcom-v2-template-loader-endpoint`
* Go to API Console and follow the steps below to verify you're able to get correct response
  * Select `WP REST API > wpcom/v2`
  * Call `/sites/<your_site/template-loader/home`