### PR TITLE
 VideoPress: update libs used to upload a video in the dashboard context

### DIFF
--- a/projects/packages/videopress/changelog/videopress-update-uploading-process-in-dashboard
+++ b/projects/packages/videopress/changelog/videopress-update-uploading-process-in-dashboard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: update libs used to upload a video in the dashboard context

--- a/projects/packages/videopress/src/client/state/actions.js
+++ b/projects/packages/videopress/src/client/state/actions.js
@@ -6,7 +6,9 @@ import { addQueryArgs } from '@wordpress/url';
 /**
  * Internal dependencies
  */
-import { uploadVideo as videoPressUpload, getJWT, uploadFromLibrary } from '../hooks/use-uploader';
+import { uploadFromLibrary } from '../hooks/use-uploader';
+import getMediaToken from '../lib/get-media-token';
+import videoPressUpload from '../lib/resumable-file-uploader';
 import uid from '../utils/uid';
 import {
 	SET_IS_FETCHING_VIDEOS,
@@ -242,7 +244,7 @@ const uploadVideo = file => async ( { dispatch } ) => {
 	dispatch( { type: SET_VIDEO_UPLOADING, id: tempId, title: file?.name } );
 
 	// @todo: this should be stored in the state
-	const jwt = await getJWT();
+	const tokenData = await getMediaToken( 'upload-jwt' );
 
 	const onSuccess = async data => {
 		dispatch( { type: SET_VIDEO_PROCESSING, id: tempId, data } );
@@ -255,7 +257,7 @@ const uploadVideo = file => async ( { dispatch } ) => {
 	};
 
 	videoPressUpload( {
-		data: jwt,
+		tokenData,
 		file,
 		onError: noop,
 		onProgress,

--- a/projects/packages/videopress/src/client/state/actions.js
+++ b/projects/packages/videopress/src/client/state/actions.js
@@ -8,7 +8,7 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import { uploadFromLibrary } from '../hooks/use-uploader';
 import getMediaToken from '../lib/get-media-token';
-import videoPressUpload from '../lib/resumable-file-uploader';
+import fileUploader from '../lib/resumable-file-uploader';
 import uid from '../utils/uid';
 import {
 	SET_IS_FETCHING_VIDEOS,
@@ -256,7 +256,7 @@ const uploadVideo = file => async ( { dispatch } ) => {
 		dispatch( { type: SET_VIDEO_UPLOAD_PROGRESS, id: tempId, bytesSent, bytesTotal } );
 	};
 
-	videoPressUpload( {
+	fileUploader( {
 		tokenData,
 		file,
 		onError: noop,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

As part of https://github.com/Automattic/jetpack/issues/27991, this PR replaces the libs used to upload the video in the dashboard context:

* use `getMediaToken()` library to get the `jwt-upload ` token
* use `resumableFileUploader()` to handle the uploading file process

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: update libs used to upload a video in the dashboard context:
  * use `getMediaToken()` library to get the `jwt-upload ` token
  * use `resumableFileUploader()` to handle the uploading file process

#### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to VideoPress dashboard
* Upload a new video 
* You'd like to confirm how the app requests the token hitting the admin-ajax endpoint
<img width="1369" alt="Screen Shot 2023-01-04 at 12 42 36" src="https://user-images.githubusercontent.com/77539/210557487-5619d573-302d-47ea-8560-0b8b2308480b.png">
* Confirm everything works as usual

