### PR TITLE
VideoPress: Adjust number of placeholders when loading dashboard videos

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-placeholders-count
+++ b/projects/packages/videopress/changelog/fix-videopress-placeholders-count
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Adjust number of placeholders when loading

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -95,8 +95,12 @@ const useDashboardVideos = () => {
 
 	// Fill with empty videos if loading
 	if ( isFetching ) {
+		const numPlaceholders = Math.max(
+			1, // at least one placeholder
+			Math.min( itemsPerPage, uploadedVideoCount - itemsPerPage * ( page - 1 ) ) // at most the number of videos in the page without query
+		);
 		// Use generated ID to work with React Key
-		videos = new Array( 6 ).fill( {} ).map( () => ( { id: uid() } ) );
+		videos = new Array( numPlaceholders ).fill( {} ).map( () => ( { id: uid() } ) );
 	}
 
 	return {

--- a/projects/packages/videopress/src/client/admin/index.js
+++ b/projects/packages/videopress/src/client/admin/index.js
@@ -25,7 +25,12 @@ initStore();
  */
 function ScrollToTop() {
 	const location = useLocation();
-	useEffect( () => window.scrollTo( 0, 0 ), [ location ] );
+	useEffect( () => {
+		// Timeout to mitigate flickering.
+		setTimeout( () => {
+			window.scrollTo( 0, 0 );
+		}, 0 );
+	}, [ location ] );
 
 	return null;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #28090

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adjusts the number of video placeholders to match the expected number on a given page without query

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard and upload some videos
* Check that when navigating between pages without query the number of placeholders match the number of videos on that page
* Check that when navigating with a query the number of placeholders is always at least the number of videos on that page

https://user-images.githubusercontent.com/8486249/210580182-6727b4a3-bfa2-4a80-b9db-6749c917a999.mp4

https://user-images.githubusercontent.com/8486249/210580174-ff1ec3e9-2b07-4152-a0ad-f23bc17f223a.mp4
