### PR TITLE
Top Posts widget: avoid Fatals when switching to Offline mode

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-top-posts-offline
+++ b/projects/plugins/jetpack/changelog/fix-top-posts-offline
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Widgets: avoid errors with the Top Posts Widget when activating Offline mode on your site.

--- a/projects/plugins/jetpack/modules/widgets/top-posts.php
+++ b/projects/plugins/jetpack/modules/widgets/top-posts.php
@@ -12,6 +12,7 @@
 
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Stats\WPCOM_Stats;
+use Automattic\Jetpack\Status;
 
 /**
  * Register the widget for use in Appearance -> Widgets
@@ -24,9 +25,11 @@ add_action( 'widgets_init', 'jetpack_top_posts_widget_init' );
 function jetpack_top_posts_widget_init() {
 	// Currently, this widget depends on the Stats Module.
 	if (
-		( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM )
-	&&
-		! Jetpack::is_module_active( 'stats' )
+		! ( defined( 'IS_WPCOM' ) && IS_WPCOM )
+		&& (
+			! Jetpack::is_module_active( 'stats' )
+			|| ( new Status() )->is_offline_mode()
+		)
 	) {
 		return;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

It is possible to activate the Top Posts widget on a live site (when the Stats module is active), and then access that same site when in offline mode. This typically happens when accessing a development site via localhost when it was created using a live URL, for example.

When this happens, the widget is already registered and set, but the `convert_stats_array_to_object` function (added in #26719) isn't available anymore because stats aren't loaded. This creates a Fatal that this commit should avoid.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Check out this branch on your local install.
* Connect your site to WordPress.com.
* Go to Appearance > Themes and pick an old theme, like Twenty Twenty.
* Go to Appearance > Widgets and add the Top Posts widget to your site
* Now access your site via localhost; the widget shouldn't be there on the frontend, but you should not get a fatal.
