### PR TITLE
Blaze: remove from the Jetpack extension list.

### DIFF
--- a/projects/plugins/jetpack/changelog/rm-blaze-jetpack-extension
+++ b/projects/plugins/jetpack/changelog/rm-blaze-jetpack-extension
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Blaze: remove extension from extension list.

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -46,7 +46,6 @@
 	],
 	"beta": [
 		"amazon",
-		"blaze",
 		"google-docs-embed",
 		"launchpad-save-modal",
 		"post-publish-promote-post-panel",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Since the extension was extracted from the Jetpack and into a package in #28062, the panel gets registered outside of the traditional Jetpack setup. It does not rely on that extension list, and will be registered regardless of the settings there. We can consequently remove the item from the list with no consequences.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion

* N/a

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start on a WoA site or a WordPress.com simple site running this branch.
* Go to Posts > Add New and publish a new post.
* You should continue to see the panel being added.
