### PR TITLE
Add export connection polling

### DIFF
--- a/projects/plugins/jetpack/changelog/add-export-modal-connection-polling
+++ b/projects/plugins/jetpack/changelog/add-export-modal-connection-polling
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add a polling function on "Connect Google Drive" button. After clicking (opens new tab to connect from Calypso), the polling function will check the connection status every 5 seconds. When successful, the button will change into Export"

--- a/projects/plugins/jetpack/modules/contact-form/admin.php
+++ b/projects/plugins/jetpack/modules/contact-form/admin.php
@@ -1428,7 +1428,9 @@ class Grunion_Admin {
 			return;
 		}
 
-		require_once JETPACK__PLUGIN_DIR . '_inc/lib/class-jetpack-google-drive-helper.php';
+		if ( ! class_exists( 'Jetpack_Google_Drive_Helper' ) ) {
+			require_once JETPACK__PLUGIN_DIR . '_inc/lib/class-jetpack-google-drive-helper.php';
+		}
 		$has_valid_connection = Jetpack_Google_Drive_Helper::has_valid_connection( $user_id );
 
 		$replacement_html = $has_valid_connection

--- a/projects/plugins/jetpack/modules/contact-form/admin.php
+++ b/projects/plugins/jetpack/modules/contact-form/admin.php
@@ -1351,13 +1351,7 @@ class Grunion_Admin {
 		$has_valid_connection = Jetpack_Google_Drive_Helper::has_valid_connection( $user_id );
 
 		if ( $has_valid_connection ) {
-			$button_html = get_submit_button(
-				esc_html__( 'Export', 'jetpack' ),
-				'primary export-button export-gdrive',
-				'jetpack-export-feedback-gdrive',
-				false,
-				array( 'data-nonce-name' => $this->export_nonce_field_gdrive )
-			);
+			$button_html = $this->get_gdrive_export_button_markup();
 		} else {
 			$slug        = 'jetpack-form-responses-connect';
 			$button_html = sprintf(
@@ -1432,13 +1426,7 @@ class Grunion_Admin {
 		$has_valid_connection = Jetpack_Google_Drive_Helper::has_valid_connection( $user_id );
 
 		$replacement_html = $has_valid_connection
-			? get_submit_button(
-				esc_html__( 'Export', 'jetpack' ),
-				'primary export-button export-gdrive',
-				'jetpack-export-feedback-gdrive',
-				false,
-				array( 'data-nonce-name' => $this->export_nonce_field_gdrive )
-			)
+			? $this->get_gdrive_export_button_markup()
 			: '';
 
 		wp_send_json(
@@ -1446,6 +1434,21 @@ class Grunion_Admin {
 				'connection' => $has_valid_connection,
 				'html'       => $replacement_html,
 			)
+		);
+	}
+
+	/**
+	 * Markup helper so we DRY, returns the button markup for the export to GDrive feature.
+	 *
+	 * @return string The HTML button markup
+	 */
+	public function get_gdrive_export_button_markup() {
+		return get_submit_button(
+			esc_html__( 'Export', 'jetpack' ),
+			'primary export-button export-gdrive',
+			'jetpack-export-feedback-gdrive',
+			false,
+			array( 'data-nonce-name' => $this->export_nonce_field_gdrive )
 		);
 	}
 }

--- a/projects/plugins/jetpack/modules/contact-form/admin.php
+++ b/projects/plugins/jetpack/modules/contact-form/admin.php
@@ -1173,7 +1173,7 @@ class Grunion_Admin {
 		add_thickbox();
 		$localized_strings = array(
 			'exportError'       => esc_js( __( 'There was an error exporting your results', 'jetpack' ) ),
-			'waitingConnection' => esc_js( __( 'Waiting connection...', 'jetpack' ) ),
+			'waitingConnection' => esc_js( __( 'Waiting for connection...', 'jetpack' ) ),
 		);
 		wp_localize_script( 'grunion-admin', 'exportParameters', $localized_strings );
 	}

--- a/projects/plugins/jetpack/modules/contact-form/admin.php
+++ b/projects/plugins/jetpack/modules/contact-form/admin.php
@@ -1411,6 +1411,7 @@ class Grunion_Admin {
 
 		if (
 			! $user_id ||
+			! current_user_can( 'export' ) ||
 			empty( sanitize_text_field( $post_data[ $this->export_nonce_field_gdrive ] ) ) ||
 			! wp_verify_nonce( sanitize_text_field( $post_data[ $this->export_nonce_field_gdrive ] ), 'feedback_export' )
 		) {

--- a/projects/plugins/jetpack/modules/contact-form/admin.php
+++ b/projects/plugins/jetpack/modules/contact-form/admin.php
@@ -1336,8 +1336,8 @@ class Grunion_Admin {
 	}
 
 	/**
-	 * Return HTML markup for the export to gdrive button.
-	 * If the user doesn't hold a Google Drive connection, it will return get_gdrive_connection_hint().
+	 * Render/output HTML markup for the export to gdrive section.
+	 * If the user doesn't hold a Google Drive connection a button to connect will render (See grunion-admin.js).
 	 */
 	public function get_gdrive_export_section() {
 		$user_connected = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || ( new Connection_Manager( 'jetpack' ) )->is_user_connected( get_current_user_id() );
@@ -1402,8 +1402,8 @@ class Grunion_Admin {
 	}
 
 	/**
-	 * Ajax handler. Returns a payload with connection status and html to replace
-	 * the Connect button with the Export button. Export button is copy from $button_html seen on get_gdrive_export_section
+	 * Ajax handler. Sends a payload with connection status and html to replace
+	 * the Connect button with the Export button using get_gdrive_export_button
 	 */
 	public function test_gdrive_connection() {
 		$post_data = wp_unslash( $_POST );

--- a/projects/plugins/jetpack/modules/contact-form/js/grunion-admin.js
+++ b/projects/plugins/jetpack/modules/contact-form/js/grunion-admin.js
@@ -213,7 +213,7 @@ jQuery( function ( $ ) {
 		$this.attr( 'disabled', 'disabled' );
 		$this.text(
 			( window.exportParameters && window.exportParameters.waitingConnection ) ||
-				'Waiting connection...'
+				'Waiting for connection...'
 		);
 		startPollingConnection( { name, value } );
 	} );

--- a/projects/plugins/jetpack/modules/contact-form/js/grunion-admin.js
+++ b/projects/plugins/jetpack/modules/contact-form/js/grunion-admin.js
@@ -179,6 +179,45 @@ jQuery( function ( $ ) {
 		} );
 	} );
 
+	function startPollingConnection( { name, value } ) {
+		let hasConnection = false;
+		let replacementHtml = null;
+		let interval = setInterval( function () {
+			if ( hasConnection ) {
+				return;
+			}
+			$.post(
+				ajaxurl,
+				{
+					action: 'grunion_gdrive_connection',
+					[ name ]: value,
+				},
+				function ( data ) {
+					if ( data && data.connection && data.html ) {
+						clearInterval( interval );
+						hasConnection = true;
+						replacementHtml = $( data.html );
+						$( '#jetpack-form-responses-connect' ).replaceWith( replacementHtml );
+					}
+				}
+			).fail( function () {
+				clearInterval( interval );
+			} );
+		}, 5000 );
+	}
+
+	$( document ).on( 'click', '#jetpack-form-responses-connect', function () {
+		const $this = $( this );
+		const name = $this.data( 'nonce-name' );
+		const value = $( '#' + name ).attr( 'value' );
+		$this.attr( 'disabled', 'disabled' );
+		$this.text(
+			( window.exportParameters && window.exportParameters.waitingConnection ) ||
+				'Waiting connection...'
+		);
+		startPollingConnection( { name, value } );
+	} );
+
 	// Handle export to Google Drive
 	$( document ).on( 'click', '#jetpack-export-feedback-gdrive', function ( event ) {
 		event.preventDefault();


### PR DESCRIPTION
When using the Form Responses export modal and creating a new GDrive connection, if the user closes the Calypso connections settings page, there is no hint on what to do with the modal, it just says "Connect Google Drive".

#### Changes proposed in this Pull Request:
This PR adds a polling function, waiting for a successful connection to GDrive. Once successful, the link will turn into a usable Export button.

![polling](https://user-images.githubusercontent.com/157240/210638057-6c8be2b4-83d9-4706-ae76-ac4dee920c0c.gif)

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
If you are already connected to GDrive, head to wordpress.com/marketing/connections and disconnect Google Drive.

Use a test site with some form responses. Use the sidebar entry to get to Form Responses list. Open the modal by clicking "Export" at the top of the list.

The second section on the modal (Google Sheet) should have a button "Connect Google Drive". Click it to land again on wordpress.com/marketing/connections, now connect to Google Drive, then close the tab.

Back at the modal, the button should be disabled and read "Waiting connection...", then suddenly change into "Export". Click on it to verify it's working.