### PR TITLE
Jetpack: fix some add_submenu_page calls

### DIFF
--- a/projects/packages/search/changelog/fix-28108-php-errors
+++ b/projects/packages/search/changelog/fix-28108-php-errors
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Replace null with empty string on first param in some add_submenu_page() call to prevent PHP notice.
+
+

--- a/projects/packages/search/src/customberg/class-customberg.php
+++ b/projects/packages/search/src/customberg/class-customberg.php
@@ -56,9 +56,9 @@ class Customberg {
 			return;
 		}
 
-		// Intentionally omits adding a submenu via the first null argument.
+		// Intentionally omits adding a submenu via the first empty argument.
 		$hook = add_submenu_page(
-			null,
+			'',
 			__( 'Jetpack Search', 'jetpack-search-pkg' ),
 			__( 'Search', 'jetpack-search-pkg' ),
 			'manage_options', // Must be an admin.

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-about-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-about-page.php
@@ -41,7 +41,7 @@ class Jetpack_About_Page extends Jetpack_Admin_Page {
 	public function get_page_hook() {
 		// Add the main admin Jetpack menu.
 		return add_submenu_page(
-			null,
+			'',
 			esc_html__( 'About Jetpack', 'jetpack' ),
 			'',
 			'jetpack_admin_page',

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -31,7 +31,7 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 	 */
 	public function get_page_hook() {
 		return add_submenu_page(
-			null,
+			'',
 			__( 'Jetpack Settings', 'jetpack' ),
 			__( 'Settings', 'jetpack' ),
 			'jetpack_manage_modules',
@@ -108,7 +108,7 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 								<?php $list_table->search_box( __( 'Search', 'jetpack' ), 'srch-term' ); ?>
 								<p><?php esc_html_e( 'View:', 'jetpack' ); ?></p>
 								<div class="button-group filter-active">
-									<button type="button" class="button 
+									<button type="button" class="button
 									<?php // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is view logic.
 									if ( empty( $_GET['activated'] ) ) {
 										echo 'active';
@@ -116,14 +116,14 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 									?>
 										">
 									<?php esc_html_e( 'All', 'jetpack' ); ?></button>
-									<button type="button" class="button 
+									<button type="button" class="button
 									<?php // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is view logic.
 									if ( ! empty( $_GET['activated'] ) && 'true' === $_GET['activated'] ) {
 										echo 'active';
 									}
 									?>
 									" data-filter-by="activated" data-filter-value="true"><?php esc_html_e( 'Active', 'jetpack' ); ?></button>
-									<button type="button" class="button 
+									<button type="button" class="button
 									<?php // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is view logic.
 									if ( ! empty( $_GET['activated'] ) && 'false' === $_GET['activated'] ) {
 										echo 'active';
@@ -133,21 +133,21 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 								</div>
 								<p><?php esc_html_e( 'Sort by:', 'jetpack' ); ?></p>
 								<div class="button-group sort">
-									<button type="button" class="button 
+									<button type="button" class="button
 									<?php // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is view logic.
 									if ( empty( $_GET['sort_by'] ) ) {
 										echo 'active';
 									}
 									?>
 									" data-sort-by="name"><?php esc_html_e( 'Alphabetical', 'jetpack' ); ?></button>
-									<button type="button" class="button 
+									<button type="button" class="button
 									<?php // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is view logic.
 									if ( ! empty( $_GET['sort_by'] ) && 'introduced' === $_GET['sort_by'] ) {
 										echo 'active';
 									}
 									?>
 									" data-sort-by="introduced" data-sort-order="reverse"><?php esc_html_e( 'Newest', 'jetpack' ); ?></button>
-									<button type="button" class="button 
+									<button type="button" class="button
 									<?php // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is view logic.
 									if ( ! empty( $_GET['sort_by'] ) && 'sort' === $_GET['sort_by'] ) {
 										echo 'active';

--- a/projects/plugins/jetpack/changelog/fix-28108-php-errors
+++ b/projects/plugins/jetpack/changelog/fix-28108-php-errors
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Replace null with empty string on first param in some add_submenu_page() calls
+
+

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -136,13 +136,13 @@ class Jetpack_Admin {
 			return;
 		} elseif ( class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'custom-css' ) ) { // If the Custom CSS module is enabled, add the Additional CSS menu item and link to the Customizer.
 			// Add in our legacy page to support old bookmarks and such.
-			add_submenu_page( null, __( 'CSS', 'jetpack' ), __( 'Additional CSS', 'jetpack' ), 'edit_theme_options', 'editcss', array( __CLASS__, 'customizer_redirect' ) );
+			add_submenu_page( '', __( 'CSS', 'jetpack' ), __( 'Additional CSS', 'jetpack' ), 'edit_theme_options', 'editcss', array( __CLASS__, 'customizer_redirect' ) );
 
 			// Add in our new page slug that will redirect to the customizer.
 			$hook = add_theme_page( __( 'CSS', 'jetpack' ), __( 'Additional CSS', 'jetpack' ), 'edit_theme_options', 'editcss-customizer-redirect', array( __CLASS__, 'customizer_redirect' ) );
 			add_action( "load-{$hook}", array( __CLASS__, 'customizer_redirect' ) );
 		} else { // Link to the Jetpack Settings > Writing page, highlighting the Custom CSS setting.
-			add_submenu_page( null, __( 'CSS', 'jetpack' ), __( 'Additional CSS', 'jetpack' ), 'edit_theme_options', 'editcss', array( __CLASS__, 'theme_enhancements_redirect' ) );
+			add_submenu_page( '', __( 'CSS', 'jetpack' ), __( 'Additional CSS', 'jetpack' ), 'edit_theme_options', 'editcss', array( __CLASS__, 'theme_enhancements_redirect' ) );
 
 			$hook = add_theme_page( __( 'CSS', 'jetpack' ), __( 'Additional CSS', 'jetpack' ), 'edit_theme_options', 'editcss-theme-enhancements-redirect', array( __CLASS__, 'theme_enhancements_redirect' ) );
 			add_action( "load-{$hook}", array( __CLASS__, 'theme_enhancements_redirect' ) );
@@ -550,7 +550,7 @@ class Jetpack_Admin {
 		require_once JETPACK__PLUGIN_DIR . '_inc/lib/debugger.php';
 		Jetpack_Debugger::disconnect_and_redirect();
 		$debugger_hook = add_submenu_page(
-			null,
+			'',
 			__( 'Debugging Center', 'jetpack' ),
 			'',
 			'manage_options',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fixes #28108 - Replace null with empty string on first param in some `add_submenu_page()` calls to avoid errors:

```
PHP Deprecated:  strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
PHP Deprecated:  str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated
```

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

After patching in an environment running PHP 8.2, you can test that the affected submenus still work, for example if you have Jetpack active test the "Appearance > Additional CSS" submenu item. No PHP notices should be generated for the `add_submenu_page` calls being modified here.