### PR TITLE
Odyssey Stats: Disable on Atomic sites

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { isWoASite, userCanConnectAccount } from 'state/initial-state';
+
 class DashStatsBottom extends Component {
 	statsBottom() {
 		let generalStats;
@@ -97,7 +98,7 @@ class DashStatsBottom extends Component {
 					<div className="jp-at-a-glance__stats-ctas">
 						{
 							// Only show link for non-atomic Jetpack sites.
-							! isWoASite &&
+							! this.props.isWoASite &&
 								createInterpolateElement( __( '<button>View detailed stats</button>', 'jetpack' ), {
 									button: (
 										<Button

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
@@ -10,8 +10,7 @@ import analytics from 'lib/analytics';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { userCanConnectAccount } from 'state/initial-state';
-
+import { isWoASite, userCanConnectAccount } from 'state/initial-state';
 class DashStatsBottom extends Component {
 	statsBottom() {
 		let generalStats;
@@ -96,14 +95,18 @@ class DashStatsBottom extends Component {
 				<div className="jp-at-a-glance__stats-cta">
 					<div className="jp-at-a-glance__stats-cta-description" />
 					<div className="jp-at-a-glance__stats-ctas">
-						{ createInterpolateElement( __( '<button>View detailed stats</button>', 'jetpack' ), {
-							button: (
-								<Button
-									onClick={ this.trackViewDetailedStats }
-									href={ this.props.siteAdminUrl + 'admin.php?page=stats' }
-								/>
-							),
-						} ) }
+						{
+							// Only show link for non-atomic Jetpack sites.
+							! isWoASite &&
+								createInterpolateElement( __( '<button>View detailed stats</button>', 'jetpack' ), {
+									button: (
+										<Button
+											onClick={ this.trackViewDetailedStats }
+											href={ this.props.siteAdminUrl + 'admin.php?page=stats' }
+										/>
+									),
+								} )
+						}
 						{ ! this.props.isLinked && this.props.userCanConnectAccount && (
 							<ConnectButton
 								connectUser={ true }
@@ -159,6 +162,7 @@ DashStatsBottom.defaultProps = {
 
 export default connect( state => {
 	return {
+		isWoASite: isWoASite( state ),
 		userCanConnectAccount: userCanConnectAccount( state ),
 	};
 } )( DashStatsBottom );

--- a/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
@@ -245,8 +245,8 @@ class SiteStatsComponent extends React.Component {
 								</span>
 							</CompactFormToggle>
 						</FormFieldset>
-						{ ! isWoASite && (
-							// Disable Odyssey Stats on WoA sites, which should use Calypso Stats instead.
+						{ ! this.props.isWoASite && (
+							// Hide Odyssey Stats toggle on WoA sites, which should use Calypso Stats instead.
 							<FormFieldset>
 								<CompactFormToggle
 									checked={ !! this.props.getOptionValue( 'enable_calypso_stats' ) }

--- a/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
@@ -15,6 +15,8 @@ import SettingsGroup from 'components/settings-group';
 import analytics from 'lib/analytics';
 import { filter, includes } from 'lodash';
 import React from 'react';
+import { connect } from 'react-redux';
+import { isWoASite } from 'state/initial-state';
 
 class SiteStatsComponent extends React.Component {
 	constructor( props ) {
@@ -243,19 +245,22 @@ class SiteStatsComponent extends React.Component {
 								</span>
 							</CompactFormToggle>
 						</FormFieldset>
-						<FormFieldset>
-							<CompactFormToggle
-								checked={ !! this.props.getOptionValue( 'enable_calypso_stats' ) }
-								disabled={ ! isStatsActive || unavailableInOfflineMode }
-								toggling={ this.props.isSavingAnyOption( [ 'stats', 'enable_calypso_stats' ] ) }
-								onChange={ this.handleStatsOptionToggle( 'enable_calypso_stats' ) }
-							>
-								<span className="jp-form-toggle-explanation">
-									{ /* This toggle enables Odyssey Stats. */ }
-									{ __( 'Enable a new Jetpack Stats experience (Experimental)', 'jetpack' ) }
-								</span>
-							</CompactFormToggle>
-						</FormFieldset>
+						{ ! isWoASite && (
+							// Disable Odyssey Stats on WoA sites, which should use Calypso Stats instead.
+							<FormFieldset>
+								<CompactFormToggle
+									checked={ !! this.props.getOptionValue( 'enable_calypso_stats' ) }
+									disabled={ ! isStatsActive || unavailableInOfflineMode }
+									toggling={ this.props.isSavingAnyOption( [ 'stats', 'enable_calypso_stats' ] ) }
+									onChange={ this.handleStatsOptionToggle( 'enable_calypso_stats' ) }
+								>
+									<span className="jp-form-toggle-explanation">
+										{ /* This toggle enables Odyssey Stats. */ }
+										{ __( 'Enable a new Jetpack Stats experience (Experimental)', 'jetpack' ) }
+									</span>
+								</CompactFormToggle>
+							</FormFieldset>
+						) }
 						<FormFieldset>
 							<FormLegend>{ __( 'Count logged in page views from', 'jetpack' ) }</FormLegend>
 							{ Object.keys( siteRoles ).map( key => (
@@ -303,4 +308,6 @@ class SiteStatsComponent extends React.Component {
 	}
 }
 
-export const SiteStats = withModuleSettingsFormHelpers( SiteStatsComponent );
+export const SiteStats = connect( state => ( {
+	isWoASite: isWoASite( state ),
+} ) )( withModuleSettingsFormHelpers( SiteStatsComponent ) );

--- a/projects/plugins/jetpack/changelog/disable-odyssey-on-woa
+++ b/projects/plugins/jetpack/changelog/disable-odyssey-on-woa
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Disabled Odyssey Stats for Atomic sites

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -23,6 +23,7 @@ use Automattic\Jetpack\Stats\Options as Stats_Options;
 use Automattic\Jetpack\Stats\Tracking_Pixel as Stats_Tracking_Pixel;
 use Automattic\Jetpack\Stats\XMLRPC_Provider as Stats_XMLRPC;
 use Automattic\Jetpack\Stats_Admin\Dashboard as StatsDashboard;
+use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\Tracking;
 
 if ( defined( 'STATS_DASHBOARD_SERVER' ) ) {

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -284,10 +284,15 @@ function stats_admin_menu() {
 	}
 
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	if ( ! Stats_Options::get_option( 'enable_calypso_stats' ) || isset( $_GET['noheader'] ) ) {
+	if ( ( new Host() )->is_woa_site() || ! Stats_Options::get_option( 'enable_calypso_stats' ) || isset( $_GET['noheader'] ) ) {
+		// Show old Jetpack Stats interface for:
+		// - Atomic sites.
+		// - When the "enable_calypso_stats" option is disabled.
+		// - When being shown in the adminbar outside of wp-admin.
 		$hook = add_submenu_page( 'jetpack', __( 'Stats', 'jetpack' ), __( 'Stats', 'jetpack' ), 'view_stats', 'stats', 'jetpack_admin_ui_stats_report_page_wrapper' );
 		add_action( "load-$hook", 'stats_reports_load' );
 	} else {
+		// Enable the new Odyssey Stats experience.
 		$stats_dashboard = new StatsDashboard();
 		$hook            = add_submenu_page( 'jetpack', __( 'Stats', 'jetpack' ), __( 'Stats', 'jetpack' ), 'view_stats', 'stats', array( $stats_dashboard, 'render' ) );
 		add_action( "load-$hook", array( $stats_dashboard, 'admin_init' ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #28156.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Disable Odyssey Stats on Atomic sites, regardless of option values.
* Hide the link to Jetpack Stats on Atomic sites on the main dashboard.
* Hide the Odyssey Stats settings toggle on Jetpack's Traffic settings page.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Check for the following on a Jetpack site:
* Ensure you can enable and experience Odyssey Stats by opening Jetpack traffic settings and toggling on the "new Jetpack Stats experience."
(See `/wp-admin/admin.php?page=jetpack#/traffic?term=jetpack%20stats`).
* Ensure that the "View detailed stats" button is still visible on the Jetpack dashboard.
(See `/wp-admin/admin.php?page=jetpack#/dashboard`).

Check for the following on an Atomic site:
* Ensure you cannot see the toggle for enabling Odyssey Stats in the Jetpack traffic settings page.
(See `/wp-admin/admin.php?page=jetpack#/traffic?term=jetpack%20stats`).
* Ensure that the "View detailed stats" button is no longer present on the Jetpack dashboard.
(See `/wp-admin/admin.php?page=jetpack#/dashboard`).