### PR TITLE
Jetpack: Allow for deactivating multiple plugins when activating a module

### DIFF
--- a/projects/packages/status/changelog/fix-jetpack-old-plugin-deactivation
+++ b/projects/packages/status/changelog/fix-jetpack-old-plugin-deactivation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Modules: Allow for deactivating multiple plugins when activating a module.

--- a/projects/packages/status/src/class-modules.php
+++ b/projects/packages/status/src/class-modules.php
@@ -416,11 +416,17 @@ class Modules {
 
 				// Check and see if the old plugin is active.
 				if ( isset( $jetpack->plugins_to_deactivate[ $module ] ) ) {
-					// Deactivate the old plugin.
-					if ( \Jetpack_Client_Server::deactivate_plugin( $jetpack->plugins_to_deactivate[ $module ][0], $jetpack->plugins_to_deactivate[ $module ][1] ) ) {
-						// If we deactivated the old plugin, remembere that with ::state() and redirect back to this page to activate the module
-						// We can't activate the module on this page load since the newly deactivated old plugin is still loaded on this page load.
-						$state->state( 'deactivated_plugins', $module );
+					// Deactivate the old plugins.
+					$deactivated = array();
+					foreach ( $jetpack->plugins_to_deactivate[ $module ] as $idx => $deactivate_me ) {
+						if ( \Jetpack_Client_Server::deactivate_plugin( $deactivate_me[0], $deactivate_me[1] ) ) {
+							// If we deactivated the old plugin, remembere that with ::state() and redirect back to this page to activate the module
+							// We can't activate the module on this page load since the newly deactivated old plugin is still loaded on this page load.
+							$deactivated[] = "$module:$idx";
+						}
+					}
+					if ( $deactivated ) {
+						$state->state( 'deactivated_plugins', join( ',', $deactivated ) );
 						wp_safe_redirect( add_query_arg( 'jetpack_restate', 1 ) );
 						exit;
 					}

--- a/projects/plugins/jetpack/changelog/fix-jetpack-old-plugin-deactivation
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-old-plugin-deactivation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Modules: Allow for deactivating multiple plugins when activating a module.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -127,20 +127,44 @@ class Jetpack {
 	 * @var array Plugins to deactivate by module.
 	 */
 	public $plugins_to_deactivate = array(
-		'stats'               => array( 'stats/stats.php', 'WordPress.com Stats' ),
-		'shortlinks'          => array( 'stats/stats.php', 'WordPress.com Stats' ),
-		'sharedaddy'          => array( 'sharedaddy/sharedaddy.php', 'Sharedaddy' ),
-		'twitter-widget'      => array( 'wickett-twitter-widget/wickett-twitter-widget.php', 'Wickett Twitter Widget' ),
-		'contact-form'        => array( 'grunion-contact-form/grunion-contact-form.php', 'Grunion Contact Form' ),
-		'contact-form'        => array( 'mullet/mullet-contact-form.php', 'Mullet Contact Form' ),
-		'custom-css'          => array( 'safecss/safecss.php', 'WordPress.com Custom CSS' ),
-		'random-redirect'     => array( 'random-redirect/random-redirect.php', 'Random Redirect' ),
-		'videopress'          => array( 'video/video.php', 'VideoPress' ),
-		'widget-visibility'   => array( 'jetpack-widget-visibility/widget-visibility.php', 'Jetpack Widget Visibility' ),
-		'widget-visibility'   => array( 'widget-visibility-without-jetpack/widget-visibility-without-jetpack.php', 'Widget Visibility Without Jetpack' ),
-		'sharedaddy'          => array( 'jetpack-sharing/sharedaddy.php', 'Jetpack Sharing' ),
-		'gravatar-hovercards' => array( 'jetpack-gravatar-hovercards/gravatar-hovercards.php', 'Jetpack Gravatar Hovercards' ),
-		'latex'               => array( 'wp-latex/wp-latex.php', 'WP LaTeX' ),
+		'stats'               => array(
+			array( 'stats/stats.php', 'WordPress.com Stats' ),
+		),
+		'shortlinks'          => array(
+			array( 'stats/stats.php', 'WordPress.com Stats' ),
+		),
+		'sharedaddy'          => array(
+			array( 'sharedaddy/sharedaddy.php', 'Sharedaddy' ),
+		),
+		'twitter-widget'      => array(
+			array( 'wickett-twitter-widget/wickett-twitter-widget.php', 'Wickett Twitter Widget' ),
+		),
+		'contact-form'        => array(
+			array( 'grunion-contact-form/grunion-contact-form.php', 'Grunion Contact Form' ),
+			array( 'mullet/mullet-contact-form.php', 'Mullet Contact Form' ),
+		),
+		'custom-css'          => array(
+			array( 'safecss/safecss.php', 'WordPress.com Custom CSS' ),
+		),
+		'random-redirect'     => array(
+			array( 'random-redirect/random-redirect.php', 'Random Redirect' ),
+		),
+		'videopress'          => array(
+			array( 'video/video.php', 'VideoPress' ),
+		),
+		'widget-visibility'   => array(
+			array( 'jetpack-widget-visibility/widget-visibility.php', 'Jetpack Widget Visibility' ),
+			array( 'widget-visibility-without-jetpack/widget-visibility-without-jetpack.php', 'Widget Visibility Without Jetpack' ),
+		),
+		'sharedaddy'          => array(
+			array( 'jetpack-sharing/sharedaddy.php', 'Jetpack Sharing' ),
+		),
+		'gravatar-hovercards' => array(
+			array( 'jetpack-gravatar-hovercards/gravatar-hovercards.php', 'Jetpack Gravatar Hovercards' ),
+		),
+		'latex'               => array(
+			array( 'wp-latex/wp-latex.php', 'WP LaTeX' ),
+		),
 	);
 
 	/**
@@ -2515,10 +2539,12 @@ class Jetpack {
 		}
 
 		$deactivated = array();
-		foreach ( $to_deactivate as $module => $deactivate_me ) {
-			list( $probable_file, $probable_title ) = $deactivate_me;
-			if ( Jetpack_Client_Server::deactivate_plugin( $probable_file, $probable_title ) ) {
-				$deactivated[] = $module;
+		foreach ( $to_deactivate as $module => $deactivate_us ) {
+			foreach ( $deactivate_us as $i => $deactivate_me ) {
+				list( $probable_file, $probable_title ) = $deactivate_me;
+				if ( Jetpack_Client_Server::deactivate_plugin( $probable_file, $probable_title ) ) {
+					$deactivated[] = "$module:$i";
+				}
 			}
 		}
 
@@ -3393,10 +3419,12 @@ p {
 			return;
 		}
 
-		foreach ( $this->plugins_to_deactivate as $deactivate_me ) {
-			if ( "plugin-activation-error_{$deactivate_me[0]}" === $action ) {
-				/* translators: Plugin name to deactivate. */
-				self::bail_on_activation( sprintf( __( 'Jetpack contains the most recent version of the old &#8220;%1$s&#8221; plugin.', 'jetpack' ), $deactivate_me[1] ), false );
+		foreach ( $this->plugins_to_deactivate as $deactivate_us ) {
+			foreach ( $deactivate_us as $deactivate_me ) {
+				if ( "plugin-activation-error_{$deactivate_me[0]}" === $action ) {
+					/* translators: Plugin name to deactivate. */
+					self::bail_on_activation( sprintf( __( 'Jetpack contains the most recent version of the old &#8220;%1$s&#8221; plugin.', 'jetpack' ), $deactivate_me[1] ), false );
+				}
 			}
 		}
 	}
@@ -4083,11 +4111,12 @@ p {
 			$deactivated_plugins = explode( ',', $deactivated_plugins );
 			$deactivated_titles  = array();
 			foreach ( $deactivated_plugins as $deactivated_plugin ) {
-				if ( ! isset( $this->plugins_to_deactivate[ $deactivated_plugin ] ) ) {
+				list( $module, $idx ) = explode( ':', $deactivated_plugin );
+				if ( ! isset( $this->plugins_to_deactivate[ $module ][ $idx ] ) ) {
 					continue;
 				}
 
-				$deactivated_titles[] = '<strong>' . str_replace( ' ', '&nbsp;', $this->plugins_to_deactivate[ $deactivated_plugin ][1] ) . '</strong>';
+				$deactivated_titles[] = '<strong>' . str_replace( ' ', '&nbsp;', $this->plugins_to_deactivate[ $module ][ $idx ][1] ) . '</strong>';
 			}
 
 			if ( $deactivated_titles ) {

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -127,18 +127,6 @@ class Jetpack {
 	 * @var array Plugins to deactivate by module.
 	 */
 	public $plugins_to_deactivate = array(
-		'stats'               => array(
-			array( 'stats/stats.php', 'WordPress.com Stats' ),
-		),
-		'shortlinks'          => array(
-			array( 'stats/stats.php', 'WordPress.com Stats' ),
-		),
-		'sharedaddy'          => array(
-			array( 'sharedaddy/sharedaddy.php', 'Sharedaddy' ),
-		),
-		'twitter-widget'      => array(
-			array( 'wickett-twitter-widget/wickett-twitter-widget.php', 'Wickett Twitter Widget' ),
-		),
 		'contact-form'        => array(
 			array( 'grunion-contact-form/grunion-contact-form.php', 'Grunion Contact Form' ),
 			array( 'mullet/mullet-contact-form.php', 'Mullet Contact Form' ),
@@ -146,8 +134,27 @@ class Jetpack {
 		'custom-css'          => array(
 			array( 'safecss/safecss.php', 'WordPress.com Custom CSS' ),
 		),
+		'gravatar-hovercards' => array(
+			array( 'jetpack-gravatar-hovercards/gravatar-hovercards.php', 'Jetpack Gravatar Hovercards' ),
+		),
+		'latex'               => array(
+			array( 'wp-latex/wp-latex.php', 'WP LaTeX' ),
+		),
 		'random-redirect'     => array(
 			array( 'random-redirect/random-redirect.php', 'Random Redirect' ),
+		),
+		'sharedaddy'          => array(
+			array( 'sharedaddy/sharedaddy.php', 'Sharedaddy' ),
+			array( 'jetpack-sharing/sharedaddy.php', 'Jetpack Sharing' ),
+		),
+		'shortlinks'          => array(
+			array( 'stats/stats.php', 'WordPress.com Stats' ),
+		),
+		'stats'               => array(
+			array( 'stats/stats.php', 'WordPress.com Stats' ),
+		),
+		'twitter-widget'      => array(
+			array( 'wickett-twitter-widget/wickett-twitter-widget.php', 'Wickett Twitter Widget' ),
 		),
 		'videopress'          => array(
 			array( 'video/video.php', 'VideoPress' ),
@@ -155,15 +162,6 @@ class Jetpack {
 		'widget-visibility'   => array(
 			array( 'jetpack-widget-visibility/widget-visibility.php', 'Jetpack Widget Visibility' ),
 			array( 'widget-visibility-without-jetpack/widget-visibility-without-jetpack.php', 'Widget Visibility Without Jetpack' ),
-		),
-		'sharedaddy'          => array(
-			array( 'jetpack-sharing/sharedaddy.php', 'Jetpack Sharing' ),
-		),
-		'gravatar-hovercards' => array(
-			array( 'jetpack-gravatar-hovercards/gravatar-hovercards.php', 'Jetpack Gravatar Hovercards' ),
-		),
-		'latex'               => array(
-			array( 'wp-latex/wp-latex.php', 'WP LaTeX' ),
 		),
 	);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Jetpack includes a list of modules and corresponding old plugins that should be deactivated when the module is activated.

It turns out, though, that the contact-form module should deactivate both the Grunion Contact Form and Mullet Contact Form plugins, and the widget-visibility module should deactivate both Jetpack Widget Visibility and Widget Visibility Without Jetpack. The way the array definition is structured, only the second of each pair would be checked for.

This restructures the array to be able to correctly handle these cases.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None, but caught by one of the new phpcs sniffs related to pdWQjU-bv-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create dummy plugins in `wp-content/plugins/grunion-contact-form/grunion-contact-form.php` and `wp-content/plugins/mullet/mullet-contact-form.php`. Activate both.
* Go into Jetpack's module settings and activate the Contact Form module.
* Check that both dummy plugins were deactivated.
* When visiting Jetpack's dashboard, check that an appropriate message is presented.
* Activate only one of the dummy plugins. Check that Jetpack's Contact Form module gets disabled. Re-enable Contact Form, and see that the dummy plugin got disabled.
* Repeat for the other dummy plugin.