### PR TITLE
[Image Guide] Fix image guide prepare script

### DIFF
--- a/projects/js-packages/image-guide/changelog/fix-image-guide-prepare
+++ b/projects/js-packages/image-guide/changelog/fix-image-guide-prepare
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Fixed an issue that would break the release process

--- a/projects/js-packages/image-guide/package.json
+++ b/projects/js-packages/image-guide/package.json
@@ -15,7 +15,7 @@
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic",
 	"scripts": {
-		"prepare": "pnpm build",
+		"prepare": "[ -e ./build/index.js ] || pnpm build",
 		"build": "tsc",
 		"clean": "rm -rf build/",
 		"watch": "pnpm run build && pnpm webpack watch",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The prepare script on image-guide caused a dilemma. If present, it would break the release because pnpm is not available on the mirror repo workers. However, the repo is already built in the mirror repo, so it doesn't need to built it again.
On the other hand, it needs to build in prepare script in the mono repo. This change will check if the package is already built before running the build process to prevent it from failing in mirror repo.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
p1672769596909349/1671775119.411749-slack-C01U2KGS2PQ

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
None