### PR TITLE
Blaze: only enqueue script in post editor

### DIFF
--- a/projects/packages/blaze/changelog/fix-fatal-site-editor-blaze
+++ b/projects/packages/blaze/changelog/fix-fatal-site-editor-blaze
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Do not load the Blaze panel in the site editor or the widget editor.

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -43,7 +43,7 @@ class Blaze {
 		if ( ! did_action( 'jetpack_on_blaze_init' ) ) {
 			if ( self::should_initialize() ) {
 				add_filter( 'post_row_actions', array( $this, 'jetpack_blaze_row_action' ), 10, 2 );
-				add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
+				add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_block_editor_assets' ) );
 			}
 
 			/**
@@ -133,8 +133,19 @@ class Blaze {
 
 	/**
 	 * Enqueue block editor assets.
+	 *
+	 * @param string $hook The current admin page.
 	 */
-	public function enqueue_block_editor_assets() {
+	public function enqueue_block_editor_assets( $hook ) {
+		/*
+		 * We do not want (nor need) Blaze in the site editor or the widget editor, only in the post editor.
+		 * Enqueueing the script in those editors would cause a fatal error.
+		 * See #20357 for more info.
+		 */
+		if ( ! in_array( $hook, array( 'post.php', 'post-new.php' ), true ) ) {
+			return;
+		}
+
 		Assets::register_script(
 			'jetpack-promote-editor',
 			'../build/editor.js',


### PR DESCRIPTION
Fixes #28184

#### Changes proposed in this Pull Request:

1. We do not need Blaze in the site editor, since we cannot promote specific posts from there.
2. The Blaze panel relies on `@wordpress/editor`, which we cannot use in the site editor or the widget editor.
3. When we enqueue the Blaze panel in the site editor or the widget editor, we run into this issue: #20357. This causes Fatal errors just like the one we experienced and worked around in #21763.

To solve this issue, we switch to using the `admin_enqueue_scripts` hook to decide whether when to enqueue our script. It allows us to conditionally enqueue the file based on the page we're on, which is something the `enqueue_block_editor_assets` hook does not allow yet.


#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion

* p1672870282744879-slack-C01U2KGS2PQ

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start on a WordPress.com simple site or a WoA site using a block theme like Twenty Twenty Three.
* Go to Posts > Add New and publish a new post; you should see the Blaze panel after publishing
* Go to Appearance > Site editor, the page should load just fine.

