### PR TITLE
VideoPress: fix duplicating uploaded file when replacing the video

### DIFF
--- a/projects/packages/videopress/changelog/videopress-fix-duplicated-file-when-replacing
+++ b/projects/packages/videopress/changelog/videopress-fix-duplicated-file-when-replacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: fix duplicating uploaded file when replacing the video

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/replace-control/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/replace-control/index.tsx
@@ -49,7 +49,7 @@ const ReplaceControl = ( {
 	return (
 		<MediaReplaceFlow
 			mediaId={ attributes.id }
-			handleUpload={ true }
+			handleUpload={ false }
 			accept="video/*"
 			allowedTypes={ VIDEOPRESS_VIDEO_ALLOWED_MEDIA_TYPES }
 			onFilesUpload={ onFileUploadHandler }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/replace-control/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/replace-control/index.tsx
@@ -27,23 +27,18 @@ const ReplaceControl = ( {
 	onSelectVideoFromLibrary,
 }: ReplaceControlProps ) => {
 	/**
-	 * Uploading file handler.
+	 * Handler to define the prop to run
+	 * when the user selects a video from the media library,
+	 * or when the user uploads a video.
 	 *
-	 * @param {FileList} media - media file to upload
+	 * @param { AdminAjaxQueryAttachmentsResponseItemProps | FileList } media - The media selected by the user.
 	 */
-	function onFileUploadHandler( media: FileList ): void {
-		/*
-		 * Allow uploading only (the first) one file
-		 * @todo: Allow uploading multiple files
-		 */
-		const file = media?.[ 0 ] ? media[ 0 ] : media;
-
-		const isFileUploading = file instanceof File;
-		if ( ! isFileUploading ) {
+	function selectMediaHandler( media: AdminAjaxQueryAttachmentsResponseItemProps | FileList ) {
+		if ( media?.[ 0 ]?.name && media?.[ 0 ]?.size && media?.[ 0 ]?.type ) {
+			onUploadFileStart( media[ 0 ] as File );
 			return;
 		}
-
-		onUploadFileStart( file );
+		onSelectVideoFromLibrary( media as AdminAjaxQueryAttachmentsResponseItemProps );
 	}
 
 	return (
@@ -52,8 +47,7 @@ const ReplaceControl = ( {
 			handleUpload={ false }
 			accept="video/*"
 			allowedTypes={ VIDEOPRESS_VIDEO_ALLOWED_MEDIA_TYPES }
-			onFilesUpload={ onFileUploadHandler }
-			onSelect={ onSelectVideoFromLibrary }
+			onSelect={ selectMediaHandler }
 		/>
 	);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/28195

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* VideoPress: fix duplicating uploaded file when replacing the video

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Block Editor
* Create a VideoPress video block
* Set the block video
* Replace by uploading a new file
**Before**
* Confirm the app uploads two videos. You may like to take a look at the `new` request endpoint
<img width="1244" alt="Screen Shot 2023-01-05 at 17 03 42" src="https://user-images.githubusercontent.com/77539/210838603-11b24596-ce11-405a-b281-24ac23bc7659.png">

**After**
* Confirm only one video is uploaded