### PR TITLE
Switch from h4 to h2 in PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,11 +5,11 @@ Please add testing instructions to projects/plugins/jetpack/to-test.md in a new 
 
 Fixes #
 
-## Changes proposed in this Pull Request:
+## Proposed changes:
 <!--- Explain what functional changes your PR includes -->
 *
 
-## Other information:
+### Other information:
 
 - [ ] Have you written new tests for your changes, if applicable?
 - [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,25 +5,25 @@ Please add testing instructions to projects/plugins/jetpack/to-test.md in a new 
 
 Fixes #
 
-#### Changes proposed in this Pull Request:
+## Changes proposed in this Pull Request:
 <!--- Explain what functional changes your PR includes -->
 *
 
-#### Other information:
+## Other information:
 
 - [ ] Have you written new tests for your changes, if applicable?
 - [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
 - [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?
 
-#### Jetpack product discussion
+## Jetpack product discussion
 <!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
 <!-- Make sure any changes to existing products have been discussed and agreed upon -->
 
-#### Does this pull request change what data or activity we track or use?
+## Does this pull request change what data or activity we track or use?
 <!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
 <!--- Check existing Jetpack support documents for a preview of the information we need. -->
 
-#### Testing instructions:
+## Testing instructions:
 <!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
 <!-- Please include detailed testing steps, explaining how to test your change. -->
 <!-- Bear in mind that context you working on is not obvious for everyone.  -->

--- a/projects/github-actions/repo-gardening/changelog/change-pull-request-template-headings
+++ b/projects/github-actions/repo-gardening/changelog/change-pull-request-template-headings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Changed headings in the `PULL_REQUEST_TEMPLATE`

--- a/projects/github-actions/repo-gardening/changelog/change-pull-request-template-headings
+++ b/projects/github-actions/repo-gardening/changelog/change-pull-request-template-headings
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: changed
 
 Changed headings in the `PULL_REQUEST_TEMPLATE`

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -349,13 +349,13 @@ function renderRecommendations( statusChecks ) {
 			'Please edit your PR description and explain what functional changes your PR includes, and why those changes are needed.',
 		hasPrivacy: `We would recommend that you add a section to the PR description to specify whether this PR includes any changes to data or privacy, like so:
 ~~~
-#### Does this pull request change what data or activity we track or use?
+## Does this pull request change what data or activity we track or use?
 
 My PR adds *x* and *y*.
 ~~~`,
 		hasTesting: `Please include detailed testing steps, explaining how to test your change, like so:
 ~~~
-#### Testing instructions:
+## Testing instructions:
 
 * Go to '..'
 *


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Switches from h4 to h2 headings in `PULL_REQUEST_TEMPLATE`. This is more semantically correct document structure, and makes it easier to parse the pull request description.

## Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

N/A

## Testing instructions:

N/A