### PR TITLE
Minor: Allow extra argument 'style_variation_slug' to '/sites/%s/themes/mine' endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/allow-post-arg-theme-mine
+++ b/projects/plugins/jetpack/changelog/allow-post-arg-theme-mine
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+WordPress.com REST API: Allow the endpoint '/sites/%s/themes/mine' to receive the 'style_variation_slug' argument as part of the POST body.

--- a/projects/plugins/jetpack/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -42,6 +42,7 @@ new Jetpack_JSON_API_Themes_Active_Endpoint(
 		),
 		'request_format'          => array(
 			'theme'                => '(string) The ID of the theme that should be activated',
+			'style_variation_slug' => '(string) The slug of the style variation to apply to the theme',
 			'dont_change_homepage' => '(bool) Whether the homepage of the site should be replaced with the theme homepage',
 		),
 		'response_format'         => Jetpack_JSON_API_Themes_Endpoint::$_response_format,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR allows the endpoint `/sites/%s/themes/mine` to receive the`style_variation_slug` argument as part of the POST body.

This change is part of the work done in the project pbxlJb-39D-p2, specifically the task https://github.com/Automattic/wp-calypso/pull/71754 which essentially entails applying a style variation upon theme activation.

#### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up a Jurassic Ninja (JN) site.
* SSH to your JN site. You can find the credentials by directly accessing to your JN site's wp-admin.
* Patch this PR via the Jetpack rsync command pdWQjU-77-p2.
* Add the following snippet to the bottom of `/srv/users/[USER]/apps/[USER]/public/wp-load.php`:
```php
add_action('jetpack_pre_switch_theme', function($arg1, $args ) {
        error_log( var_export( $arg1, true ) );
        error_log( var_export( $args, true ) );
}, 10, 2);
```
* Run `tail -F /srv/users/[USER]/apps/[USER]/public/wp-content/debug.log.`
* Select the JN site via Calypso using the calypso.live link provided in this [PR](https://github.com/Automattic/wp-calypso/pull/71754) (for instance, https://container-IDENTIFIER.calypso.live/DOMAIN.jurassic.ninja?flags=themes/showcase-i4/details-and-preview).
* Head to the Theme Showcase, find a theme with style variations and select one of the styles and press the "Activate" button.
* Ensure that the output of the log includes the key `style_variation_slug`:
```
[timestamp] `THEME'
[timestamp] array (
  'theme' => 'THEME',
  'style_variation_slug' => 'STYLE_VARIATION_SLUG'
)
```