### PR TITLE
Update a line in the response data export modal under CSV section

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-export-modal-csv-copy
+++ b/projects/plugins/jetpack/changelog/fix-export-modal-csv-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Comment: Updated the description on the response data export modal under CSV section

--- a/projects/plugins/jetpack/modules/contact-form/admin.php
+++ b/projects/plugins/jetpack/modules/contact-form/admin.php
@@ -1320,7 +1320,7 @@ class Grunion_Admin {
 			</div>
 			<div class="export-card__body">
 				<div class="export-card__body-description">
-					<?php esc_html_e( 'Download your response form data via CSV file.', 'jetpack' ); ?>
+					<?php esc_html_e( 'Download your form response data via CSV file.', 'jetpack' ); ?>
 				</div>
 				<div class="export-card__body-cta">
 					<?php


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/28211

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The data export modal has a “Download your response form data via CSV file” line under the CSV file section.
* This proposed change is to use better wording: "Download your form response data via CSV file"

### Other information:

- [ ] Have you written new tests for your changes, if applicable? - N/A
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?  - No
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)? -  No

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p8oabR-11U-p2#comment-6961

## Does this pull request change what data or activity we track or use?

No changes to privacy data or activity tracker.

<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- On a Jetpack-connected test site, make sure you have some contact form responses (showing in the Feedback area in wp-admin).
- From that Feedback area, you should see a single "Export" button. Click it to open the Export modal.
- From the Export modal, check the line under CSV file option
- The line should read "Download your form response data via CSV file” and not "Download your response form data via CSV file".