### PR TITLE
Stats: Add loading spinner

### DIFF
--- a/projects/packages/stats-admin/changelog/add-loading-spinner-for-stats
+++ b/projects/packages/stats-admin/changelog/add-loading-spinner-for-stats
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: add loading spinner for Stats Dashboard

--- a/projects/packages/stats-admin/composer.json
+++ b/projects/packages/stats-admin/composer.json
@@ -48,7 +48,7 @@
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-stats-admin",
 		"branch-alias": {
-			"dev-trunk": "0.2.x-dev"
+			"dev-trunk": "0.3.x-dev"
 		},
 		"textdomain": "jetpack-stats-admin",
 		"version-constants": {

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.2.2-alpha",
+	"version": "0.3.0-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -86,6 +86,15 @@ class Dashboard {
 		?>
 		<div id="wpcom" class="jp-stats-dashboard">
 			<div class="hide-if-js"><?php esc_html_e( 'Your Jetpack Stats dashboard requires JavaScript to function properly.', 'jetpack-stats-admin' ); ?></div>
+			<div class="hide-if-no-js">
+				<img
+					class="jp-stats-dashboard-loading-spinner"
+					width="32"
+					height="32"
+					alt=<?php echo esc_attr( __( 'Loading', 'jetpack-stats-admin' ) ); ?>
+					src="//en.wordpress.com/i/loading/loading-64.gif"
+				/>
+			</div>
 		</div>
 		<script>
 			jQuery(document).ready(function($) {
@@ -145,6 +154,21 @@ class Dashboard {
 			'jp-stats-dashboard',
 			$this->get_config_data_js(),
 			'before'
+		);
+
+		add_action(
+			'admin_head',
+			function () {
+				echo '<style>
+				.jp-stats-dashboard-loading-spinner {
+					position: absolute;
+					left: 50%;
+					top: 50%;
+					transform: translate( -50%, -50% );
+				}
+				</style>';
+			},
+			100
 		);
 	}
 

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -84,9 +84,9 @@ class Dashboard {
 	 */
 	public function render() {
 		?>
-		<div id="wpcom" class="jp-stats-dashboard">
+		<div id="wpcom" class="jp-stats-dashboard" style="height: calc(100vh - 100px);">
 			<div class="hide-if-js"><?php esc_html_e( 'Your Jetpack Stats dashboard requires JavaScript to function properly.', 'jetpack-stats-admin' ); ?></div>
-			<div class="hide-if-no-js">
+			<div class="hide-if-no-js" style="height: 100%">
 				<img
 					class="jp-stats-dashboard-loading-spinner"
 					width="32"
@@ -164,7 +164,6 @@ class Dashboard {
 					position: absolute;
 					left: 50%;
 					top: 50%;
-					transform: translate( -50%, -50% );
 				}
 				</style>';
 			},

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -91,6 +91,7 @@ class Dashboard {
 					class="jp-stats-dashboard-loading-spinner"
 					width="32"
 					height="32"
+					style="position: absolute; left: 50%; top: 50%;"
 					alt=<?php echo esc_attr( __( 'Loading', 'jetpack-stats-admin' ) ); ?>
 					src="//en.wordpress.com/i/loading/loading-64.gif"
 				/>
@@ -154,20 +155,6 @@ class Dashboard {
 			'jp-stats-dashboard',
 			$this->get_config_data_js(),
 			'before'
-		);
-
-		add_action(
-			'admin_head',
-			function () {
-				echo '<style>
-				.jp-stats-dashboard-loading-spinner {
-					position: absolute;
-					left: 50%;
-					top: 50%;
-				}
-				</style>';
-			},
-			100
 		);
 	}
 

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -18,7 +18,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.2.2-alpha';
+	const VERSION = '0.3.0-alpha';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats-admin/tests/php/test-stats-dashboard.php
+++ b/projects/packages/stats-admin/tests/php/test-stats-dashboard.php
@@ -25,7 +25,7 @@ class Test_Plan extends Stats_Test_Case {
 	 * Test has root dom.
 	 */
 	public function test_render() {
-		$this->expectOutputRegex( '/<div id="wpcom" class="jp-stats-dashboard">/i' );
+		$this->expectOutputRegex( '/<div id="wpcom" class="jp-stats-dashboard".*>/i' );
 		( new Dashboard() )->render();
 	}
 

--- a/projects/plugins/jetpack/changelog/add-loading-spinner-for-stats
+++ b/projects/plugins/jetpack/changelog/add-loading-spinner-for-stats
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2010,7 +2010,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "19d34515a0201eec283a62dde17c63baddc6e47f"
+                "reference": "219ee9c83263cb0dbdbc0ff6c2b6eeb3682bf30b"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -2027,7 +2027,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-stats-admin",
                 "branch-alias": {
-                    "dev-trunk": "0.2.x-dev"
+                    "dev-trunk": "0.3.x-dev"
                 },
                 "textdomain": "jetpack-stats-admin",
                 "version-constants": {


### PR DESCRIPTION
## Proposed changes:
The PR adds loading spinner for Stats Dashboard.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Open the Traffic settings page.  (/wp-admin/admin.php?page=jetpack#/traffic?term=jetpack%20stats)
* Expand the Jetpack Stats section and enable the “new Jetpack Stats experience” toggle.
* Set network speed to Slow 3G and disable cache
* Open `/wp-admin/admin.php?page=stats`
* Ensure spinner shows up on loading

<img width="317" alt="image" src="https://user-images.githubusercontent.com/1425433/211231908-0c2d2ed8-0c1b-4048-bfe2-ac9b76378c4c.png">
