### PR TITLE
VideoPress: add support to replace video by setting an URL from the Replace control

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-replace-by-url-from-toolbar
+++ b/projects/packages/videopress/changelog/update-videopress-replace-by-url-from-toolbar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Support replace the video by setting an URL from the replace control

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
@@ -73,10 +73,7 @@
 			"type": "string"
 		},
 		"src": {
-			"type": "string",
-			"source": "attribute",
-			"selector": "video",
-			"attribute": "src"
+			"type": "string"
 		},
 		"cacheHtml": {
 			"type": "string",

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/replace-control/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/replace-control/index.tsx
@@ -8,18 +8,21 @@ import { AdminAjaxQueryAttachmentsResponseItemProps } from '../../../../../types
  */
 import { VIDEOPRESS_VIDEO_ALLOWED_MEDIA_TYPES } from '../../constants';
 import { VideoBlockAttributes } from '../../types';
+import './style.scss';
 
 type ReplaceControlProps = {
 	attributes: VideoBlockAttributes;
 	setAttributes: ( attributes: VideoBlockAttributes ) => void;
 	onUploadFileStart: ( media: File ) => void;
 	onSelectVideoFromLibrary: ( media: AdminAjaxQueryAttachmentsResponseItemProps ) => void;
+	onSelectURL: ( url: string ) => void;
 };
 
 const ReplaceControl = ( {
 	attributes,
 	onUploadFileStart,
 	onSelectVideoFromLibrary,
+	onSelectURL,
 }: ReplaceControlProps ) => {
 	/**
 	 * Handler to define the prop to run
@@ -43,6 +46,8 @@ const ReplaceControl = ( {
 			accept="video/*"
 			allowedTypes={ VIDEOPRESS_VIDEO_ALLOWED_MEDIA_TYPES }
 			onSelect={ selectMediaHandler }
+			mediaURL={ attributes.src }
+			onSelectURL={ onSelectURL }
 		/>
 	);
 };

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/replace-control/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/replace-control/style.scss
@@ -1,0 +1,7 @@
+// These tweaks should be addressed by core
+.block-editor-link-control__search-item-details {
+	max-width: 144px;
+}
+.block-editor-media-flow__url-input {
+	padding-right: 12px;
+}

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
@@ -12,6 +12,7 @@ import { __ } from '@wordpress/i18n';
  */
 import useResumableUploader from '../../../../../hooks/use-resumable-uploader';
 import { uploadFromLibrary } from '../../../../../hooks/use-uploader';
+import { pickGUIDFromUrl } from '../../../../../lib/url';
 import { VIDEOPRESS_VIDEO_ALLOWED_MEDIA_TYPES } from '../../constants';
 import { PlaceholderWrapper } from '../../edit';
 import { description, title } from '../../index';
@@ -100,34 +101,6 @@ const VideoPressUploader = ( {
 		onSuccess: handleUploadSuccess,
 	} );
 
-	/*
-	 * Returns true if the object represents a valid host for a VideoPress video.
-	 * Private vidoes are hosted under video.wordpress.com
-	 */
-	const isValidVideoPressUrl = urlObject => {
-		const validHosts = [ 'videopress.com', 'video.wordpress.com' ];
-		return urlObject.protocol === 'https:' && validHosts.includes( urlObject.host );
-	};
-
-	/**
-	 * Helper function to pick up the guid
-	 * from the VideoPress URL.
-	 *
-	 * @param {string} url - VideoPress URL.
-	 * @returns {void}       The guid picked up from the URL. Otherwise, False.
-	 */
-	const getGuidFromVideoUrl = url => {
-		try {
-			const urlObject = new URL( url );
-			if ( isValidVideoPressUrl( urlObject ) ) {
-				const videoGuid = urlObject.pathname.match( /^\/v\/([a-zA-Z0-9]+)$/ );
-				return videoGuid.length === 2 ? videoGuid[ 1 ] : false;
-			}
-		} catch ( e ) {
-			return false;
-		}
-	};
-
 	/**
 	 * Handler to add a video via an URL.
 	 *
@@ -135,7 +108,7 @@ const VideoPressUploader = ( {
 	 * @param {string} id - Attachment ID if available
 	 */
 	function onSelectURL( videoUrl, id = undefined ) {
-		const videoGuid = getGuidFromVideoUrl( videoUrl );
+		const videoGuid = pickGUIDFromUrl( videoUrl );
 		if ( ! videoGuid ) {
 			setUploadErrorDataState( {
 				data: { message: __( 'Invalid VideoPress URL', 'jetpack-videopress-pkg' ) },

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -19,7 +19,7 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import getMediaToken from '../../../lib/get-media-token';
-import { getVideoPressUrl } from '../../../lib/url';
+import { getVideoPressUrl, pickGUIDFromUrl } from '../../../lib/url';
 import { useSyncMedia } from '../../hooks/use-video-data-update';
 import ColorPanel from './components/color-panel';
 import DetailsPanel from './components/details-panel';
@@ -480,6 +480,16 @@ export default function VideoPressEdit( {
 							title: media.title,
 							description: media.description,
 						} );
+					} }
+					onSelectURL={ url => {
+						const videoGuid = pickGUIDFromUrl( url );
+						if ( ! videoGuid ) {
+							debug( 'Invalid URL. No video GUID  provided' );
+							return;
+						}
+
+						// Update guid based on the URL.
+						setAttributes( { guid: videoGuid, src: url } );
 					} }
 				/>
 			</BlockControls>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

~# Branched off from https://github.com/Automattic/jetpack/pull/28206~

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: add support to replace video by setting an URL from the Replace control

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Get a VideoPress video block instance
* Confirm the Replace control shows the URL option
<img width="402" alt="Screen Shot 2023-01-09 at 06 23 00" src="https://user-images.githubusercontent.com/77539/211251433-5385dffa-0540-4c90-a19a-9ff54bc27d30.png">
* Add a valid VideoPress video URL, for instance: `https://videopress.com/v/ezoR6kzb`
* Confirm the block renders the video
<img width="681" alt="Screen Shot 2023-01-09 at 06 28 13" src="https://user-images.githubusercontent.com/77539/211251556-969531ef-0546-4256-a1e1-3c538957ab37.png">
