### PR TITLE
Jetpack: Fix AaG card icon alignment for CRM and Boost cards

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/banner/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/banner/style.scss
@@ -107,7 +107,7 @@
 	}
 
 	.dops-banner__icon-circle-svg {
-		transform: translate( 1px, 1px );
+		transform: translate( 1px, 4px );
 	}
 
 	@include breakpoint( '>480px' ) {

--- a/projects/plugins/jetpack/changelog/fix-aag-card-icon-allignment
+++ b/projects/plugins/jetpack/changelog/fix-aag-card-icon-allignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix icon allignment on at a glance page


### PR DESCRIPTION
Small tweak to align CRM and Boost icons on the At a Glance page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open At a Glance page with a free plan
* Check the alignment of the icons for Boost and CRM cards
* Apply the patch, and check that the icons are properly aligned now.

Before:
<img width="733" alt="Screenshot 2023-01-09 at 15 37 15" src="https://user-images.githubusercontent.com/5654161/211267889-10fedfee-4aef-4fe3-a983-81f42669a478.png">
After:
<img width="733" alt="Screenshot 2023-01-09 at 15 37 31" src="https://user-images.githubusercontent.com/5654161/211267926-128fe1dd-cda5-42a2-9ece-44e360062d4a.png">


