### PR TITLE
[Boost] Mention live chat on premium purchase success page

### DIFF
--- a/projects/plugins/boost/app/admin/class-config.php
+++ b/projects/plugins/boost/app/admin/class-config.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack_Boost\Admin;
 
 use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack_Boost\Features\Optimizations\Optimizations;
 use Automattic\Jetpack_Boost\Lib\Premium_Features;
 use Automattic\Jetpack_Boost\REST_API\Permissions\Nonce;
@@ -46,6 +47,7 @@ class Config {
 				'online'     => ! ( new Status() )->is_offline_mode(),
 				'assetPath'  => plugins_url( $internal_path, JETPACK_BOOST_PATH ),
 				'getStarted' => self::is_getting_started(),
+				'isAtomic'   => ( new Host() )->is_woa_site(),
 			),
 			'preferences'           => array(
 				'prioritySupport' => Premium_Features::has_feature( Premium_Features::PRIORITY_SUPPORT ),

--- a/projects/plugins/boost/app/assets/src/js/pages/purchase-success/PurchaseSuccess.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/purchase-success/PurchaseSuccess.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
+	import { getRedirectUrl } from '@automattic/jetpack-components';
 	import { onMount } from 'svelte';
 	import { Button } from '@wordpress/components';
 	import { __ } from '@wordpress/i18n';
 	import BackButton from '../../elements/BackButton.svelte';
 	import ReactComponent from '../../elements/ReactComponent.svelte';
+	import TemplatedString from '../../elements/TemplatedString.svelte';
 	import { updateModuleState } from '../../stores/modules';
 	import Logo from '../../svg/jetpack-green.svg';
 	import { requestCloudCss } from '../../utils/cloud-css';
+	import externalLinkTemplateVar from '../../utils/external-link-template-var';
+
+	const wpcomPricingUrl = getRedirectUrl( 'wpcom-pricing' );
 
 	// svelte-ignore unused-export-let - Ignored values supplied by svelte-navigator.
 	export let location, navigate;
@@ -34,7 +39,21 @@
 				<ul class="jb-checklist my-2">
 					<li>{__( 'Automatic critical CSS regeneration', 'jetpack-boost' )}</li>
 					<li>{__( 'Performance scores are recalculated after each change', 'jetpack-boost' )}</li>
-					<li>{__( 'Dedicated email support', 'jetpack-boost' )}</li>
+
+					<li>
+						<!-- svelte-ignore missing-declaration Jetpack_Boost -->
+						{#if Jetpack_Boost.site.isAtomic}
+							<TemplatedString
+								template={__(
+									`Dedicated email support plus priority Live Chat if <link>your plan</link> <strong>includes Premium Support</strong>`,
+									'jetpack-boost'
+								)}
+								vars={externalLinkTemplateVar( wpcomPricingUrl )}
+							/>
+						{:else}
+							{__( 'Dedicated email support', 'jetpack-boost' )}
+						{/if}
+					</li>
 				</ul>
 				<ReactComponent
 					this={Button}

--- a/projects/plugins/boost/app/assets/src/js/pages/purchase-success/PurchaseSuccess.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/purchase-success/PurchaseSuccess.svelte
@@ -45,7 +45,7 @@
 						{#if Jetpack_Boost.site.isAtomic}
 							<TemplatedString
 								template={__(
-									`Dedicated email support plus priority Live Chat if <link>your plan</link> <strong>includes Premium Support</strong>`,
+									`Dedicated email support plus priority Live Chat if <link>your plan</link> includes <strong>Premium Support</strong>`,
 									'jetpack-boost'
 								)}
 								vars={externalLinkTemplateVar( wpcomPricingUrl )}

--- a/projects/plugins/boost/changelog/mention-live-chat-on-purchase-success-page-wpcom-only
+++ b/projects/plugins/boost/changelog/mention-live-chat-on-purchase-success-page-wpcom-only
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update text (only on wordpress.com) on purchase successful page to include link to live support.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #28011.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates text on premium purchase success page to include link to live chat.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pc9hqz-1sd-p2#comment-1069

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup this version of the plugin on your test site;
* Once setup is done, open WP-admin and navigate to `yourtestsite.com/wp-admin/admin.php?page=jetpack-boost#purchase-successful` to see the page in question. You should see the same text as the image tagged **Before**;
* Next, you need to make Boost "think" your website is one hosted on WordPress.com. To do that, edit this line https://github.com/Automattic/jetpack/blob/f75cc44a0ae1b092b275df36e36134b5ac7ef5d6/projects/plugins/boost/app/admin/class-config.php#L50 to say:
```php
'isAtomic'   => true, 
```
* Save the file and open the page again. The text should be the same as the image tagged **After**.

### Before
![image](https://user-images.githubusercontent.com/11799079/211297963-9bac8860-b0c1-46bb-921e-82517472adc0.png)

### After
![image](https://user-images.githubusercontent.com/11799079/211297766-9b0b732c-d67d-4966-adfc-58e0c8696374.png)
