### PR TITLE
Contact Form: Fix Form submission showing extra colon

### DIFF
--- a/projects/plugins/jetpack/changelog/y
+++ b/projects/plugins/jetpack/changelog/y
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix extra colon for form fields without label

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -2873,10 +2873,10 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 					$field       = $form->fields[ $field_id ];
 					$field_index = array_search( $field_id, $field_ids['all'], true );
 
-					$label = $field->get_attribute( 'label' );
+					$label = $field->get_attribute( 'label' ) ? $field->get_attribute( 'label' ) . ':' : '';
 
 					$compiled_form[ $field_index ] = sprintf(
-						'<div class="field-name">%1$s:</div> <div class="field-value">%2$s</div>',
+						'<div class="field-name">%1$s</div> <div class="field-value">%2$s</div>',
 						wp_kses( $label, array() ),
 						self::escape_and_sanitize_field_value( $extra_fields[ $extra_field_keys[ $i ] ] )
 					);


### PR DESCRIPTION
Fixes #28223

## Proposed changes:

* Hides the colon for form fields without a label on the form submission page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Create a post and add a Form block
* Make sure to have a form field without a label
* Save the post and go to the live page
* Submit the form and ensure the fields without labels don't show a `:` 

c.c. @coder-karen for cherry-picking