### PR TITLE
E2E tests: remove broken selection of complete plan 

### DIFF
--- a/projects/plugins/jetpack/changelog/e2e-remove-complete-plan-selection
+++ b/projects/plugins/jetpack/changelog/e2e-remove-complete-plan-selection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: small e2e test update
+
+

--- a/projects/plugins/jetpack/tests/e2e/specs/connection/connection.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/connection/connection.test.js
@@ -36,7 +36,7 @@ test.describe( 'Connection', () => {
 
 	test( 'Classic', async ( { page } ) => {
 		await test.step( 'Can start classic connection', async () => {
-			await doClassicConnection( page, true );
+			await doClassicConnection( page );
 		} );
 
 		await test.step( 'Can assert that site is connected', async () => {

--- a/tools/e2e-commons/flows/jetpack-connect.js
+++ b/tools/e2e-commons/flows/jetpack-connect.js
@@ -19,16 +19,16 @@ import { expect } from '@playwright/test';
 
 const cardCredentials = config.get( 'testCardCredentials' );
 
-export async function doClassicConnection( page, freePlan = true ) {
+export async function doClassicConnection( page, plan = 'free' ) {
 	const jetpackPage = await JetpackPage.init( page );
 	await jetpackPage.connect();
 	await ( await AuthorizePage.init( page ) ).approve();
 
-	if ( freePlan ) {
+	if ( plan === 'free' ) {
 		await ( await PickAPlanPage.init( page ) ).select( 'free' );
 		await RecommendationsPage.init( page );
 	} else {
-		await ( await PickAPlanPage.init( page ) ).select( 'complete' );
+		await ( await PickAPlanPage.init( page ) ).select( plan );
 		await ( await CheckoutPage.init( page ) ).processPurchase( cardCredentials );
 		await ( await ThankYouPage.init( page ) ).waitForSetupAndProceed();
 	}

--- a/tools/e2e-commons/pages/wpcom/pick-a-plan.js
+++ b/tools/e2e-commons/pages/wpcom/pick-a-plan.js
@@ -1,4 +1,5 @@
 import WpPage from '../wp-page.js';
+import logger from '../../logger.cjs';
 
 export default class PickAPlanPage extends WpPage {
 	constructor( page ) {
@@ -10,22 +11,12 @@ export default class PickAPlanPage extends WpPage {
 
 	async select( product = 'free' ) {
 		switch ( product ) {
-			case 'complete':
-				return await this.selectComplete();
 			case 'free':
+				const freePlanButton = '.jetpack-product-store__jetpack-free a';
+				await this.click( freePlanButton );
+				break;
 			default:
-				return await this.selectFreePlan();
+				logger.error( `Selecting plan '${ product }' is not implemented! Add it yourself?` );
 		}
-	}
-
-	async selectFreePlan() {
-		const freePlanButton = '.jetpack-product-store__jetpack-free a';
-		return await this.click( freePlanButton );
-	}
-
-	async selectComplete() {
-		const buttonSelector =
-			'div[data-e2e-product-slug="jetpack_complete"] [class*="summary"] button';
-		return await this.click( buttonSelector );
 	}
 }


### PR DESCRIPTION
## Proposed changes:
Follow up of #26464. 
The pricing page selectors are no longer valid and the flow that selects the complete plan is broken. Because it's not currently used anywhere, I've decided to remove it altogether. It should be added if needed, when needed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
1156386383419466-as-1203041725942801/f

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* e2e tests should pass