### PR TITLE
VideoPress: set video by providing a valid GUID value

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-set-video-by-pasting-guid
+++ b/projects/packages/videopress/changelog/update-videopress-set-video-by-pasting-guid
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: set block video by providing a GUID value

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/replace-control/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/replace-control/index.tsx
@@ -2,12 +2,16 @@
  * WordPress dependencies
  */
 import { MediaReplaceFlow } from '@wordpress/block-editor';
-import { AdminAjaxQueryAttachmentsResponseItemProps } from '../../../../../types';
 /**
  * Internal dependencies
  */
 import { VIDEOPRESS_VIDEO_ALLOWED_MEDIA_TYPES } from '../../constants';
-import { VideoBlockAttributes } from '../../types';
+/**
+ * Types
+ */
+import type { AdminAjaxQueryAttachmentsResponseItemProps } from '../../../../../types';
+import type { VideoBlockAttributes } from '../../types';
+
 import './style.scss';
 
 type ReplaceControlProps = {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
@@ -109,7 +109,7 @@ const VideoPressUploader = ( {
 	 */
 	function onSelectURL( videoSource, id ) {
 		// If the video source is a VideoPress URL, we can use it directly.
-		const videoUrlData = buildVideoPressURL( videoSource, attributes );
+		const videoUrlData = buildVideoPressURL( videoSource );
 		if ( ! videoUrlData ) {
 			setUploadErrorDataState( {
 				data: { message: __( 'Invalid VideoPress URL', 'jetpack-videopress-pkg' ) },

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
@@ -109,15 +109,15 @@ const VideoPressUploader = ( {
 	 */
 	function onSelectURL( videoSource, id ) {
 		// If the video source is a VideoPress URL, we can use it directly.
-		const isValidURL = buildVideoPressURL( videoSource, attributes );
-		if ( ! isValidURL ) {
+		const videoUrlData = buildVideoPressURL( videoSource, attributes );
+		if ( ! videoUrlData ) {
 			setUploadErrorDataState( {
 				data: { message: __( 'Invalid VideoPress URL', 'jetpack-videopress-pkg' ) },
 			} );
 			return;
 		}
 
-		setAttributes( { guid: isValidURL.guid, src: isValidURL.url, id } );
+		setAttributes( { guid: videoUrlData.guid, src: videoUrlData.url, id } );
 		handleDoneUpload();
 	}
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
  */
 import useResumableUploader from '../../../../../hooks/use-resumable-uploader';
 import { uploadFromLibrary } from '../../../../../hooks/use-uploader';
-import { pickGUIDFromUrl, getVideoPressUrl, isVideoPressGuid } from '../../../../../lib/url';
+import { buildVideoPressURL } from '../../../../../lib/url';
 import { VIDEOPRESS_VIDEO_ALLOWED_MEDIA_TYPES } from '../../constants';
 import { PlaceholderWrapper } from '../../edit';
 import { description, title } from '../../index';
@@ -109,24 +109,16 @@ const VideoPressUploader = ( {
 	 */
 	function onSelectURL( videoSource, id ) {
 		// If the video source is a VideoPress URL, we can use it directly.
-		const videoGuidFromUrl = pickGUIDFromUrl( videoSource );
-		if ( videoGuidFromUrl ) {
-			setAttributes( { guid: videoGuidFromUrl, src: videoSource, id } );
-			handleDoneUpload();
+		const isValidURL = buildVideoPressURL( videoSource, attributes );
+		if ( ! isValidURL ) {
+			setUploadErrorDataState( {
+				data: { message: __( 'Invalid VideoPress URL', 'jetpack-videopress-pkg' ) },
+			} );
 			return;
 		}
 
-		// If the video source is a VideoPress GUID, let's build the URL.
-		const videoGuid = isVideoPressGuid( videoSource );
-		if ( videoGuid ) {
-			setAttributes( { guid: videoGuid, src: getVideoPressUrl( videoGuid, attributes ), id } );
-			handleDoneUpload();
-			return;
-		}
-
-		setUploadErrorDataState( {
-			data: { message: __( 'Invalid VideoPress URL', 'jetpack-videopress-pkg' ) },
-		} );
+		setAttributes( { guid: isValidURL.guid, src: isValidURL.url, id } );
+		handleDoneUpload();
 	}
 
 	const startUpload = file => {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -482,7 +482,7 @@ export default function VideoPressEdit( {
 						} );
 					} }
 					onSelectURL={ videoSource => {
-						const videoUrlData = buildVideoPressURL( videoSource, attributes );
+						const videoUrlData = buildVideoPressURL( videoSource );
 						if ( ! videoUrlData ) {
 							debug( 'Invalid URL. No video GUID  provided' );
 							return;

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -19,7 +19,7 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import getMediaToken from '../../../lib/get-media-token';
-import { getVideoPressUrl, pickGUIDFromUrl } from '../../../lib/url';
+import { buildVideoPressURL, getVideoPressUrl } from '../../../lib/url';
 import { useSyncMedia } from '../../hooks/use-video-data-update';
 import ColorPanel from './components/color-panel';
 import DetailsPanel from './components/details-panel';
@@ -481,15 +481,15 @@ export default function VideoPressEdit( {
 							description: media.description,
 						} );
 					} }
-					onSelectURL={ url => {
-						const videoGuid = pickGUIDFromUrl( url );
-						if ( ! videoGuid ) {
+					onSelectURL={ videoSource => {
+						const videoUrlData = buildVideoPressURL( videoSource, attributes );
+						if ( ! videoUrlData ) {
 							debug( 'Invalid URL. No video GUID  provided' );
 							return;
 						}
 
 						// Update guid based on the URL.
-						setAttributes( { guid: videoGuid, src: url } );
+						setAttributes( { guid: videoUrlData.guid, src: videoUrlData.url } );
 					} }
 				/>
 			</BlockControls>

--- a/projects/packages/videopress/src/client/lib/get-media-token/index.ts
+++ b/projects/packages/videopress/src/client/lib/get-media-token/index.ts
@@ -15,8 +15,8 @@ import {
  * Return media token data hiting the admin-ajax endpoint.
  *
  * @param {MediaTokenScopeProps} scope  - The scope of the token to request.
- * @param {GetMediaTokenArgsProps} args - function arguments
- * @returns {MediaTokenProps}            Media token data.
+ * @param {GetMediaTokenArgsProps} args - function arguments.
+ * @returns {MediaTokenProps}             Media token data.
  */
 const getMediaToken = function (
 	scope: MediaTokenScopeProps,

--- a/projects/packages/videopress/src/client/lib/url/index.ts
+++ b/projects/packages/videopress/src/client/lib/url/index.ts
@@ -107,10 +107,14 @@ export function isVideoPressGuid( value: string ): boolean | VideoGUID {
  */
 export function buildVideoPressURL(
 	value: string | VideoGUID,
-	attributes: VideoPressUrlOptions
+	attributes?: VideoPressUrlOptions
 ): false | { url: string; guid: VideoGUID } {
 	const isGuidValue = isVideoPressGuid( value );
 	if ( isGuidValue ) {
+		if ( ! attributes ) {
+			return { url: `https://videopress.com/v/${ value }`, guid: value };
+		}
+
 		return { url: getVideoPressUrl( value, attributes ), guid: value };
 	}
 

--- a/projects/packages/videopress/src/client/lib/url/index.ts
+++ b/projects/packages/videopress/src/client/lib/url/index.ts
@@ -1,5 +1,5 @@
 import { addQueryArgs } from '@wordpress/url';
-import { VideoBlockAttributes } from '../../block-editor/blocks/video/types';
+import { VideoBlockAttributes, VideoGUID } from '../../block-editor/blocks/video/types';
 
 export const getVideoPressUrl = (
 	guid: string,
@@ -79,3 +79,18 @@ export const pickGUIDFromUrl = ( url: string ) => {
 
 	return urlParts.groups.guid;
 };
+
+/**
+ * Check if a string is a valid VideoPress GUID.
+ *
+ * @param {string} value - The string to check.
+ * @returns {boolean | VideoGUID} Video GUID if the string is valid, false otherwise.
+ */
+export function isVideoPressGuid( value: string ): boolean | VideoGUID {
+	const guid = value.match( /^[a-zA-Z\d]{8}$/ );
+	if ( ! guid ) {
+		return false;
+	}
+
+	return guid[ 0 ];
+}

--- a/projects/packages/videopress/src/client/lib/url/index.ts
+++ b/projects/packages/videopress/src/client/lib/url/index.ts
@@ -1,6 +1,21 @@
 import { addQueryArgs } from '@wordpress/url';
 import { VideoBlockAttributes, VideoGUID } from '../../block-editor/blocks/video/types';
 
+type VideoPressUrlOptions = Pick<
+	VideoBlockAttributes,
+	| 'autoplay'
+	| 'controls'
+	| 'loop'
+	| 'muted'
+	| 'playsinline'
+	| 'poster'
+	| 'preload'
+	| 'seekbarColor'
+	| 'seekbarPlayedColor'
+	| 'seekbarLoadingColor'
+	| 'useAverageColor'
+>;
+
 export const getVideoPressUrl = (
 	guid: string,
 	{
@@ -15,20 +30,7 @@ export const getVideoPressUrl = (
 		seekbarPlayedColor,
 		seekbarLoadingColor,
 		useAverageColor,
-	}: Pick<
-		VideoBlockAttributes,
-		| 'autoplay'
-		| 'controls'
-		| 'loop'
-		| 'muted'
-		| 'playsinline'
-		| 'poster'
-		| 'preload'
-		| 'seekbarColor'
-		| 'seekbarPlayedColor'
-		| 'seekbarLoadingColor'
-		| 'useAverageColor'
-	>
+	}: VideoPressUrlOptions
 ) => {
 	if ( ! guid ) {
 		return null;
@@ -64,7 +66,7 @@ export const getVideoPressUrl = (
 	return addQueryArgs( `https://videopress.com/v/${ guid }`, options );
 };
 
-export const pickGUIDFromUrl = ( url: string ) => {
+export const pickGUIDFromUrl: ( url: string ) => null | string = url => {
 	if ( ! url ) {
 		return null;
 	}
@@ -93,4 +95,29 @@ export function isVideoPressGuid( value: string ): boolean | VideoGUID {
 	}
 
 	return guid[ 0 ];
+}
+
+/**
+ * Build a VideoPress URL from a VideoPress GUID or a VideoPress URL.
+ * The function returns an { url, guid } object, or false.
+ *
+ * @param {string | VideoGUID} value        - The VideoPress GUID or URL.
+ * @param {VideoPressUrlOptions} attributes - The VideoPress URL options.
+ * @returns {false | string}                  VideoPress URL if the string is valid, false otherwise.
+ */
+export function buildVideoPressURL(
+	value: string | VideoGUID,
+	attributes: VideoPressUrlOptions
+): false | { url: string; guid: VideoGUID } {
+	const isGuidValue = isVideoPressGuid( value );
+	if ( isGuidValue ) {
+		return { url: getVideoPressUrl( value, attributes ), guid: value };
+	}
+
+	const isGuidFromUrl = pickGUIDFromUrl( value );
+	if ( isGuidFromUrl ) {
+		return { url: value, guid: isGuidFromUrl };
+	}
+
+	return false;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: set video by providing a valid GUID value

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### URL to test

public
```
https://videopress.com/v/FJwnjRC8
```

public
```
https://videopress.com/v/ezoR6kzb
```

```
https://videopress.com/v/2t1P9030
```


* Go to the block editor
* Create a video block instance

<img width="654" alt="image" src="https://user-images.githubusercontent.com/77539/211387044-739a7365-71cb-40a1-8009-0debeddfe161.png">

* Confirm it's possible to set the video source by adding a valid URL (`https://videopress.com/v/FJwnjRC8` for instance)
<img width="649" alt="image" src="https://user-images.githubusercontent.com/77539/211387128-fc78fcb8-9bfe-43c7-b5e9-e1b3c0ce0381.png">
* Same, but now pasting only the guid
<img width="649" alt="image" src="https://user-images.githubusercontent.com/77539/211387290-3182b431-bf25-4b0a-9c12-abdd9502a403.png">
* Confirm the same behavior but now using the replace video control
<img width="662" alt="image" src="https://user-images.githubusercontent.com/77539/211387473-dbcf050f-e015-4003-8d84-e85754bd3afa.png">
