### PR TITLE
WAF: Run firewall activation hook on both add_option and update_option

### DIFF
--- a/projects/packages/waf/changelog/fix-waf-add-option-hooks
+++ b/projects/packages/waf/changelog/fix-waf-add-option-hooks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix firewall activation hooks on first option updates.

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -57,8 +57,11 @@ class Waf_Runner {
 	 * @return void
 	 */
 	public static function add_hooks() {
+		add_action( 'add_option_' . self::IP_ALLOW_LIST_OPTION_NAME, array( static::class, 'activate' ), 10, 0 );
 		add_action( 'update_option_' . self::IP_ALLOW_LIST_OPTION_NAME, array( static::class, 'activate' ), 10, 0 );
+		add_action( 'add_option_' . self::IP_BLOCK_LIST_OPTION_NAME, array( static::class, 'activate' ), 10, 0 );
 		add_action( 'update_option_' . self::IP_BLOCK_LIST_OPTION_NAME, array( static::class, 'activate' ), 10, 0 );
+		add_action( 'add_option_' . self::IP_LISTS_ENABLED_OPTION_NAME, array( static::class, 'activate' ), 10, 0 );
 		add_action( 'update_option_' . self::IP_LISTS_ENABLED_OPTION_NAME, array( static::class, 'activate' ), 10, 0 );
 		add_action( 'jetpack_waf_rules_update_cron', array( static::class, 'update_rules_cron' ) );
 		// TODO: This doesn't exactly fit here - may need to find another home


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The `Waf_Runner::activate()` hook that is responsible for re-generating firewall rules when options change is currently not being called on the first save of options. This is due to the hooks using `update_option`. The first time the option is created, the `update_option` hook is not called.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `add_option` hooks that call `Waf_Runner::activate()` the first time any of the firewall settings are saved.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Reproduce the issue:
* Running `trunk` on a fresh site, activate the firewall and add some IP addresses to the block list via Jetpack Protect. Click save.
* Check the `block-ip.php` rules file, and validate that it has not been updated.
* Save a second time.
* Check the `block-ip.php` file again, and validate that is has been successfully updated.

Validate the fix:
* Running this branch, repeat the above test but validate the block file is updated immediately upon first save.
