### PR TITLE
VideoPress: Improve "no videos" dashboard to have only one CTA

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-first-video-ui
+++ b/projects/packages/videopress/changelog/update-videopress-first-video-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: Update no video dashboard UI to have one CTA

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -153,10 +153,6 @@ const Admin = () => {
 		onSelectFiles: handleFilesUpload,
 	} );
 
-	const addNewLabel = __( 'Add new video', 'jetpack-videopress-pkg' );
-	const addFirstLabel = __( 'Add your first video', 'jetpack-videopress-pkg' );
-	const addVideoLabel = hasVideos ? addNewLabel : addFirstLabel;
-
 	useAnalyticsTracks( { pageViewEventName: 'jetpack_videopress_admin_page_view' } );
 
 	return (
@@ -224,23 +220,29 @@ const Admin = () => {
 									/>
 								) }
 
-								<FormFileUpload
-									onChange={ evt =>
-										handleFilesUpload( filterVideoFiles( evt.currentTarget.files ) )
-									}
-									accept={ fileInputExtensions }
-									multiple={ hasVideoPressPurchase }
-									render={ ( { openFileDialog } ) => (
-										<Button
-											fullWidth={ isSm }
-											onClick={ openFileDialog }
-											isLoading={ loading }
-											disabled={ ! canUpload }
-										>
-											{ addVideoLabel }
-										</Button>
-									) }
-								/>
+								{ hasVideos ? (
+									<FormFileUpload
+										onChange={ evt =>
+											handleFilesUpload( filterVideoFiles( evt.currentTarget.files ) )
+										}
+										accept={ fileInputExtensions }
+										multiple={ hasVideoPressPurchase }
+										render={ ( { openFileDialog } ) => (
+											<Button
+												fullWidth={ isSm }
+												onClick={ openFileDialog }
+												isLoading={ loading }
+												disabled={ ! canUpload }
+											>
+												{ __( 'Add new video', 'jetpack-videopress-pkg' ) }
+											</Button>
+										) }
+									/>
+								) : (
+									<Text variant="title-medium">
+										{ __( "Let's add your first video below!", 'jetpack-videopress-pkg' ) }
+									</Text>
+								) }
 
 								{ ! hasVideoPressPurchase && <UpgradeTrigger hasUsedVideo={ hasVideos } /> }
 							</Col>
@@ -258,13 +260,8 @@ const Admin = () => {
 								</Col>
 							) : (
 								<Col sm={ 4 } md={ 6 } lg={ 12 } className={ styles[ 'first-video-wrapper' ] }>
-									<Text variant="headline-small">
-										{ __( "Let's add your first video", 'jetpack-videopress-pkg' ) }
-									</Text>
 									<VideoUploadArea
-										className={ classnames( styles[ 'upload-area' ], {
-											[ styles.small ]: isSm,
-										} ) }
+										className={ styles[ 'upload-area' ] }
 										onSelectFiles={ handleFilesUpload }
 									/>
 								</Col>

--- a/projects/packages/videopress/src/client/admin/components/admin-page/styles.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/styles.module.scss
@@ -50,11 +50,6 @@
 .upload-area {
 	width: 100%;
 	max-width: 552px;
-	margin-top: calc( var( --spacing-base ) * 6 );
-
-	&.small {
-		margin-top: calc( var( --spacing-base ) * 3 );
-	}
 }
 
 .upgrade-trigger {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26742 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Replace `Add new video` button for `Let's add your first video below!` message.
* Remove `margin-top` from `VideoUploadArea`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pe4Cmx-kA-p2#comment-196

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new JN site with VideoPress.
* Connect the site.
* You should see the initial dashboard, without the `Add new video` button.

#### Demo 💻 

_With upgrade banner_

![CleanShot 2023-01-09 at 16 25 05](https://user-images.githubusercontent.com/1663717/211392674-a519b185-6567-4398-aa64-88a63b02f4ee.png)

_Without upgrade banner_
![CleanShot 2023-01-09 at 16 26 33](https://user-images.githubusercontent.com/1663717/211392694-ecd7476d-be15-4fb4-a4a9-5896a2c6ed1b.png)


