### PR TITLE
VideoPress: Fix local video listed as VideoPress video

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-local-video-listed
+++ b/projects/packages/videopress/changelog/fix-videopress-local-video-listed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fix local video listed as VideoPress video

--- a/projects/packages/videopress/src/client/admin/components/video-list/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-list/index.tsx
@@ -11,7 +11,7 @@ import { useState } from 'react';
  */
 import { VIDEO_PRIVACY_LEVELS, VIDEO_PRIVACY_LEVEL_PRIVATE } from '../../../state/constants';
 import Checkbox from '../checkbox';
-import ConnectVideoRow, { VideoRow, Stats } from '../video-row';
+import ConnectVideoRow, { LocalVideoRow, Stats } from '../video-row';
 import styles from './style.module.scss';
 /**
  * Types
@@ -151,7 +151,7 @@ export const LocalVideoList = ( {
 					return null;
 				}
 				return (
-					<VideoRow
+					<LocalVideoRow
 						key={ `local-video-${ video.id }` }
 						id={ video.id }
 						title={ video.title }

--- a/projects/packages/videopress/src/client/admin/components/video-row/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-row/index.tsx
@@ -121,6 +121,7 @@ export const VideoRow = ( {
 	disableActionButton = false,
 	disabled = false,
 	uploadProgress,
+	isLocalVideo = false,
 }: VideoRowProps ) => {
 	const textRef = useRef( null );
 	const checkboxRef = useRef( null );
@@ -320,9 +321,15 @@ export const VideoRow = ( {
 				) }
 			</div>
 
-			<PublishFirstVideoPopover id={ id } anchor={ anchor } position="top center" />
+			{ ! isLocalVideo && (
+				<PublishFirstVideoPopover id={ id } anchor={ anchor } position="top center" />
+			) }
 		</div>
 	);
+};
+
+export const LocalVideoRow = ( props: VideoRowProps ) => {
+	return <VideoRow isLocalVideo={ true } { ...props } />;
 };
 
 export const ConnectVideoRow = ( { id, ...restProps }: VideoRowProps ) => {

--- a/projects/packages/videopress/src/client/admin/components/video-row/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/video-row/types.ts
@@ -59,6 +59,10 @@ type VideoRowBaseProps = {
 	 * Adornment to be showed after title.
 	 */
 	disableActionButton?: boolean;
+	/**
+	 * True when row is used to show a local video.
+	 */
+	isLocalVideo?: boolean;
 };
 
 type VideoPressVideoProps = VideoRowBaseProps &


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27848

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a `isLocalVideo` flag to `VideoRow` to be used by the local videos library

The problem is caused by a call to `useVideo` by the `PublishFirstVideoPopover` component. When the video is a local one, it is correctly not in the initial data of the VideoPress videos, which causes `useVideo` to fetch it and add it to the VideoPress library.
Adding the flag stops this process, as a local video should not be considered to show the first video popover.
I also added a `LocalVideoRow` component with the flag set as `true` for better visibility. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard and upload a video as normal
* Go to `Media > Add New` and upload a video through there
* Back to the dashboard, reload the page. The local and uploaded videos should be listed separetely

Before | After
-|-
![2023-01-09_16-54-16](https://user-images.githubusercontent.com/8486249/211396330-5171258b-d52f-4b41-b956-2a029dc3889d.png) | ![2023-01-09_16-55-54](https://user-images.githubusercontent.com/8486249/211396346-327daf1e-0946-445c-9d3e-f698df4cbf63.png)


