### PR TITLE
VideoPress: Allow edit privacy on video details page

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-privacy-edit-page
+++ b/projects/packages/videopress/changelog/update-videopress-privacy-edit-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: Support edit privacy on edit details page

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
@@ -11,8 +11,14 @@ import {
 	useBreakpointMatch,
 	JetpackVideoPressLogo,
 } from '@automattic/jetpack-components';
+import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Icon, chevronRightSmall, arrowLeft } from '@wordpress/icons';
+import {
+	Icon,
+	chevronRightSmall,
+	arrowLeft,
+	globe as siteDefaultPrivacyIcon,
+} from '@wordpress/icons';
 import classnames from 'classnames';
 import { useEffect } from 'react';
 import { useHistory, Prompt } from 'react-router-dom';
@@ -20,7 +26,14 @@ import { useHistory, Prompt } from 'react-router-dom';
  * Internal dependencies
  */
 import { Link } from 'react-router-dom';
+import privatePrivacyIcon from '../../../components/icons/crossed-eye-icon';
+import publicPrivacyIcon from '../../../components/icons/uncrossed-eye-icon';
 import { VideoPlayer } from '../../../components/video-frame-selector';
+import {
+	VIDEO_PRIVACY_LEVEL_PRIVATE,
+	VIDEO_PRIVACY_LEVEL_PUBLIC,
+	VIDEO_PRIVACY_LEVEL_SITE_DEFAULT,
+} from '../../../state/constants';
 import { usePermission } from '../../hooks/use-permission';
 import useUnloadPrevent from '../../hooks/use-unload-prevent';
 import { useVideosQuery } from '../../hooks/use-videos';
@@ -144,6 +157,7 @@ const EditVideoDetails = () => {
 		height,
 		title,
 		description,
+		privacySetting,
 		// Playback Token
 		isFetchingPlaybackToken,
 		// Page State/Actions
@@ -155,6 +169,7 @@ const EditVideoDetails = () => {
 		// Metadata
 		setTitle,
 		setDescription,
+		setPrivacySetting,
 		processing,
 		// Poster Image
 		useVideoAsThumbnail,
@@ -260,6 +275,43 @@ const EditVideoDetails = () => {
 								src={ url ?? '' }
 								shortcode={ shortcode ?? '' }
 								loading={ isFetchingData }
+							/>
+							<SelectControl
+								className={ styles.privacy }
+								value={ privacySetting }
+								label={ __( 'Privacy', 'jetpack-videopress-pkg' ) }
+								onChange={ value => setPrivacySetting( value ) }
+								prefix={
+									// Casting for unknown since allowing only a string is a mistake
+									// at WP Components
+									( (
+										<div className={ styles[ 'privacy-icon' ] }>
+											<Icon
+												icon={
+													( privacySetting === VIDEO_PRIVACY_LEVEL_PUBLIC && publicPrivacyIcon ) ||
+													( privacySetting === VIDEO_PRIVACY_LEVEL_PRIVATE &&
+														privatePrivacyIcon ) ||
+													( privacySetting === VIDEO_PRIVACY_LEVEL_SITE_DEFAULT &&
+														siteDefaultPrivacyIcon )
+												}
+											/>
+										</div>
+									 ) as unknown ) as string
+								}
+								options={ [
+									{
+										label: __( 'Site default', 'jetpack-videopress-pkg' ),
+										value: VIDEO_PRIVACY_LEVEL_SITE_DEFAULT,
+									},
+									{
+										label: __( 'Public', 'jetpack-videopress-pkg' ),
+										value: VIDEO_PRIVACY_LEVEL_PUBLIC,
+									},
+									{
+										label: __( 'Private', 'jetpack-videopress-pkg' ),
+										value: VIDEO_PRIVACY_LEVEL_PRIVATE,
+									},
+								] }
 							/>
 						</Col>
 					</Container>

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/style.module.scss
@@ -68,3 +68,13 @@
 		align-items: center;
 	}
 }
+
+.privacy {
+	padding: 0 calc(var(--spacing-base) * 3); // 0|24px
+	margin-top: calc(var( --spacing-base) * 4); // 32px
+}
+
+.privacy-icon {
+	display: flex;
+	margin-left: var(--spacing-base); // 8px
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #27164 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add new `select` on `edit-video-details` page.
* Call `updatePrivacy` on save change.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spawn a new JN site with VideoPress.
* Connect Jetpack.
* Upload a new video.
* Insert this video in a post and publish.
* Open the post. You should see the video.
* Goes into VP dashboard and clicks `Edit video details`.
* Change privacy to `private.`
* Click on `Save changes.`
* It should reflect the new privacy at the post and the video card at the dashboard.

#### Demo


https://user-images.githubusercontent.com/1663717/211410237-de644e8c-dcae-4f29-a28b-e82b8e0d30c4.mp4



