### PR TITLE
Remove the Image Guide feature-flag

### DIFF
--- a/projects/plugins/boost/app/features/image-guide/Image_Guide.php
+++ b/projects/plugins/boost/app/features/image-guide/Image_Guide.php
@@ -15,7 +15,7 @@ class Image_Guide implements Feature {
 		}
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$override = defined( 'JETPACK_BOOST_IMAGE_GUIDE' ) && JETPACK_BOOST_IMAGE_GUIDE && isset( $_GET['jb-debug-ig'] );
+		$override = isset( $_GET['jb-debug-ig'] );
 
 		// Show the UI only when the user is logged in, with sufficient permissions and isn't looking at the dashboard.
 		if ( true !== $override && ( is_admin() || ! is_user_logged_in() || ! current_user_can( 'manage_options' ) ) ) {

--- a/projects/plugins/boost/app/features/optimizations/Optimizations.php
+++ b/projects/plugins/boost/app/features/optimizations/Optimizations.php
@@ -35,11 +35,8 @@ class Optimizations implements Has_Setup {
 			new $critical_css_class(),
 			new Lazy_Images(),
 			new Render_Blocking_JS(),
+			new Image_Guide(),
 		);
-
-		if ( defined( 'JETPACK_BOOST_IMAGE_GUIDE' ) && JETPACK_BOOST_IMAGE_GUIDE ) {
-			$features[] = new Image_Guide();
-		}
 
 		foreach ( $features as $feature ) {
 			$slug                    = $feature->get_slug();

--- a/projects/plugins/boost/changelog/boost-enable-image-guide
+++ b/projects/plugins/boost/changelog/boost-enable-image-guide
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Enable the Image Guide feature without a constant


### PR DESCRIPTION
Allow access to the Image Guide without using the hidden feature-flag / constant.

## Proposed changes:
* Add Image Guide to the list of available modules without using the feature-flag.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Make sure the Image Guide works without the feature flag.