### PR TITLE
[Boost] Don't show <1x on images that are exactly the right size

### DIFF
--- a/projects/plugins/boost/app/features/image-guide/src/ui/Bubble.svelte
+++ b/projects/plugins/boost/app/features/image-guide/src/ui/Bubble.svelte
@@ -28,7 +28,7 @@
 				<div class="label" in:fade={{ delay: 200, duration: 300 }}>
 					{#if $oversizedRatio > 9}
 						{Math.floor( $oversizedRatio )}x
-					{:else if $oversizedRatio > 1}
+					{:else if $oversizedRatio > 0.99}
 						{#if severity === 'normal'}
 							<Checkmark />
 						{:else}

--- a/projects/plugins/boost/changelog/fix-image-guide-1x
+++ b/projects/plugins/boost/changelog/fix-image-guide-1x
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Don't show <1x on images that are exactly the right size


### PR DESCRIPTION
When an image is exactly right-sized, the Image Guide was showing `<1x` in the badge. This PR fixes that, with a small margin for error (showing exactly right sizing for anything with 99% of exact).

## Proposed changes:
* Fix the threshold at which "<1x" is shown by the Image Guide

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* View a page with an exactly-correct sized image on it.
* Check that the image guide shows a checkmark instead of "<1x" on it.

