### PR TITLE
VideoPress: minor TS enhancements in the useSearchParams() hook

### DIFF
--- a/projects/packages/videopress/changelog/update-video-minot-ty-enhancements-in-use-search-params-hook
+++ b/projects/packages/videopress/changelog/update-video-minot-ty-enhancements-in-use-search-params-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: minor TS enhancement in the useSearchParams() hook

--- a/projects/packages/videopress/src/client/admin/hooks/use-search-params/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-search-params/index.ts
@@ -3,6 +3,8 @@
  */
 import { useLocation, useHistory } from 'react-router-dom';
 
+type SearchParamNameProp = 'page' | 'q';
+
 export const useSearchParams = () => {
 	const location = useLocation();
 	const history = useHistory();
@@ -11,21 +13,21 @@ export const useSearchParams = () => {
 	/**
 	 * Gets a given parameter from the search query.
 	 *
-	 * @param {string} parameterName - The name of the parameter to get from the query string.
+	 * @param {SearchParamNameProp} parameterName - The name of the parameter to get from the query string.
 	 * @param {string} defaultValue - The default value to return if the given parameter is not set on the query string.
 	 * @returns {string} - The value of the parameter if it's set. The defaultValue if the parameter is not set.
 	 */
-	const getParam = ( parameterName: string, defaultValue: string = null ) => {
+	const getParam = ( parameterName: SearchParamNameProp, defaultValue: string = null ): string => {
 		return searchParams.has( parameterName ) ? searchParams.get( parameterName ) : defaultValue;
 	};
 
 	/**
 	 * Sets a given parameter on the search query data, but does not refresh the URL.
 	 *
-	 * @param {string} parameterName - The name of the parameter to set on the query string.
+	 * @param {SearchParamNameProp} parameterName - The name of the parameter to set on the query string.
 	 * @param {string} value - The value to be set for the parameter on the query string.
 	 */
-	const setParam = ( parameterName: string, value: string = null ) => {
+	const setParam = ( parameterName: SearchParamNameProp, value: string = null ) => {
 		searchParams.set( parameterName, value );
 	};
 
@@ -33,9 +35,9 @@ export const useSearchParams = () => {
 	 * Deletes a given parameter from the search query data, which results on removing
 	 * it from the URL when it gets updated.
 	 *
-	 * @param {string} parameterName - The name of the parameter to delete.
+	 * @param {SearchParamNameProp} parameterName - The name of the parameter to delete.
 	 */
-	const deleteParam = ( parameterName: string ) => {
+	const deleteParam = ( parameterName: SearchParamNameProp ) => {
 		searchParams.delete( parameterName );
 	};
 

--- a/projects/packages/videopress/src/client/admin/hooks/use-search-params/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-search-params/index.ts
@@ -14,8 +14,8 @@ export const useSearchParams = () => {
 	 * Gets a given parameter from the search query.
 	 *
 	 * @param {SearchParamNameProp} parameterName - The name of the parameter to get from the query string.
-	 * @param {string} defaultValue - The default value to return if the given parameter is not set on the query string.
-	 * @returns {string} - The value of the parameter if it's set. The defaultValue if the parameter is not set.
+	 * @param {string} defaultValue               - The default value to return if the given parameter is not set on the query string.
+	 * @returns {string|null}                       The value of the parameter if it's set. The defaultValue if the parameter is not set.
 	 */
 	const getParam = ( parameterName: SearchParamNameProp, defaultValue: string = null ): string => {
 		return searchParams.has( parameterName ) ? searchParams.get( parameterName ) : defaultValue;
@@ -25,7 +25,7 @@ export const useSearchParams = () => {
 	 * Sets a given parameter on the search query data, but does not refresh the URL.
 	 *
 	 * @param {SearchParamNameProp} parameterName - The name of the parameter to set on the query string.
-	 * @param {string} value - The value to be set for the parameter on the query string.
+	 * @param {string} value                      - The value to be set for the parameter on the query string.
 	 */
 	const setParam = ( parameterName: SearchParamNameProp, value: string = null ) => {
 		searchParams.set( parameterName, value );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: minor TS enhancements in the useSearchParams() hook

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Simply check the TS enhancements:

*Only `page` and `q` are valid name values*
<img width="876" alt="image" src="https://user-images.githubusercontent.com/77539/211495731-0ac7d444-8ce7-4180-bac5-f4177dc2d39b.png">

*Some IDEs show the valid values to use*
<img width="583" alt="Screen Shot 2023-01-10 at 08 08 34" src="https://user-images.githubusercontent.com/77539/211495906-92e83772-09c4-4e03-86ad-eafd2643bb83.png">

