### PR TITLE
Add Subscribers & Team submenus for WPCOM

### DIFF
--- a/projects/plugins/jetpack/changelog/add-subscribers-menu
+++ b/projects/plugins/jetpack/changelog/add-subscribers-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Reorganizes Users menu into Subscribers and Team

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -338,8 +338,8 @@ class Admin_Menu extends Base_Admin_Menu {
 			$this->hide_submenu_page( 'users.php', 'user-new.php' );
 		}
 
-		add_submenu_page( 'users.php', esc_attr__( 'Subscribers', 'jetpack' ), __( 'Subscribers', 'jetpack' ), 'list_users', 'https://wordpress.com/people/subscribers/' . $this->domain, null, 1 );
-		add_submenu_page( 'users.php', esc_attr__( 'Team Members', 'jetpack' ), __( 'Team', 'jetpack' ), 'list_users', 'https://wordpress.com/people/team-members/' . $this->domain, null, 2 );
+		add_submenu_page( $slug, esc_attr__( 'Subscribers', 'jetpack' ), __( 'Subscribers', 'jetpack' ), 'list_users', 'https://wordpress.com/people/subscribers/' . $this->domain, null, 1 );
+		add_submenu_page( $slug, esc_attr__( 'Team Members', 'jetpack' ), __( 'Team', 'jetpack' ), 'list_users', 'https://wordpress.com/people/team-members/' . $this->domain, null, 2 );
 		add_submenu_page( $slug, esc_attr__( 'Account Settings', 'jetpack' ), __( 'Account Settings', 'jetpack' ), 'read', 'https://wordpress.com/me/account' );
 		$this->update_submenus( $slug, $submenus_to_update );
 	}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -329,14 +329,19 @@ class Admin_Menu extends Base_Admin_Menu {
 			'profile.php' => 'https://wordpress.com/me',
 		);
 
+		$slug = current_user_can( 'list_users' ) ? 'users.php' : 'profile.php';
+
 		if ( self::DEFAULT_VIEW === $this->get_preferred_view( 'users.php' ) ) {
-			$submenus_to_update['users.php']    = 'https://wordpress.com/people/team/' . $this->domain;
-			$submenus_to_update['user-new.php'] = 'https://wordpress.com/people/new/' . $this->domain;
+			// Hide All Users submenu.
+			$this->hide_submenu_page( $slug, $slug );
+			// Hide Add New submenu.
+			$this->hide_submenu_page( 'users.php', 'user-new.php' );
 		}
 
-		$slug = current_user_can( 'list_users' ) ? 'users.php' : 'profile.php';
-		$this->update_submenus( $slug, $submenus_to_update );
+		add_submenu_page( 'users.php', esc_attr__( 'Subscribers', 'jetpack' ), __( 'Subscribers', 'jetpack' ), 'list_users', 'https://wordpress.com/people/subscribers/' . $this->domain, null, 1 );
+		add_submenu_page( 'users.php', esc_attr__( 'Team Members', 'jetpack' ), __( 'Team', 'jetpack' ), 'list_users', 'https://wordpress.com/people/team-members/' . $this->domain, null, 2 );
 		add_submenu_page( $slug, esc_attr__( 'Account Settings', 'jetpack' ), __( 'Account Settings', 'jetpack' ), 'read', 'https://wordpress.com/me/account' );
+		$this->update_submenus( $slug, $submenus_to_update );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -331,13 +331,16 @@ class WPcom_Admin_Menu extends Admin_Menu {
 			'grofiles-user-settings' => 'https://wordpress.com/me/account',
 		);
 
+		$slug = current_user_can( 'list_users' ) ? 'users.php' : 'profile.php';
+
 		if ( self::DEFAULT_VIEW === $this->get_preferred_view( 'users.php' ) ) {
-			$submenus_to_update['users.php'] = 'https://wordpress.com/people/team/' . $this->domain;
+			// Hide All Users submenu.
+			$this->hide_submenu_page( $slug, $slug );
 		}
 
-		$slug = current_user_can( 'list_users' ) ? 'users.php' : 'profile.php';
+		add_submenu_page( 'users.php', esc_attr__( 'Subscribers', 'jetpack' ), __( 'Subscribers', 'jetpack' ), 'list_users', 'https://wordpress.com/people/subscribers/' . $this->domain, null, 1 );
+		add_submenu_page( 'users.php', esc_attr__( 'Team Members', 'jetpack' ), __( 'Team', 'jetpack' ), 'list_users', 'https://wordpress.com/people/team-members/' . $this->domain, null, 2 );
 		$this->update_submenus( $slug, $submenus_to_update );
-		add_submenu_page( 'users.php', esc_attr__( 'Add New', 'jetpack' ), __( 'Add New', 'jetpack' ), 'promote_users', 'https://wordpress.com/people/new/' . $this->domain, null, 1 );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-admin-menu.php
@@ -333,12 +333,21 @@ class Test_Admin_Menu extends WP_UnitTestCase {
 
 		// On WP.com users can only invite other users, not create them (missing create_users cap).
 		if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
-			$this->assertSame( 'https://wordpress.com/people/new/' . static::$domain, $submenu['users.php'][2][2] );
 			$account_key = 6;
 		}
 
-		$this->assertSame( 'https://wordpress.com/people/team/' . static::$domain, $submenu['users.php'][0][2] );
-		$this->assertSame( 'https://wordpress.com/me', $submenu['users.php'][3][2] );
+		// Make sure All Users is hidden
+		$this->assertSame( 'users.php', $submenu['users.php'][0][2] );
+		$this->assertSame( 'hide-if-js', $submenu['users.php'][0][4] );
+
+		$this->assertSame( 'https://wordpress.com/people/subscribers/' . static::$domain, $submenu['users.php'][1][2] );
+		$this->assertSame( 'https://wordpress.com/people/team-members/' . static::$domain, $submenu['users.php'][2][2] );
+
+		// Make sure Add New is hidden
+		$this->assertSame( 'user-new.php', $submenu['users.php'][3][2] );
+		$this->assertSame( 'hide-if-js', $submenu['users.php'][3][4] );
+
+		$this->assertSame( 'https://wordpress.com/me', $submenu['users.php'][5][2] );
 		$this->assertSame( 'https://wordpress.com/me/account', $submenu['users.php'][ $account_key ][2] );
 	}
 

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
@@ -276,7 +276,7 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 		// Check that menu always links to Calypso when no preferred view has been set.
 		static::$admin_menu->set_preferred_view( 'users.php', 'unknown' );
 		static::$admin_menu->add_users_menu();
-		$this->assertSame( 'https://wordpress.com/people/team/' . static::$domain, array_shift( $submenu['users.php'] )[2] );
+		$this->assertSame( 'hide-if-js', array_shift( $submenu['users.php'] )[4] );
 	}
 
 	/**


### PR DESCRIPTION
This changes the Users menu to have Subscribers and Team. 

Notes:
- The changes only affect WPCOM Simple and Atomic sites for now. 

See: 
* PT: pcmemI-1uJ-p2 
* Design: pbAok1-3rs-p2 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changes User menu to remove "All Users" and "Add New" and adds "Subscribers" and "Team"
* New pages have been built in Calypso for these features, [see PRs](https://github.com/Automattic/wp-calypso/issues?q=label%3A%22User+Management+Revamp%22+sort%3Aupdated-desc+is%3Aclosed)

<table>
<tr>
	<th></th>
	<th>Old</th>
	<th>New</th>
</tr>
<tr>
<td>Simple</td>
<td><img width="272" alt="simple-old" src="https://user-images.githubusercontent.com/533/211738000-91d0cbb0-22d7-4352-9045-ad95bd62a014.png"></td>
<td><img width="269" alt="simple-new" src="https://user-images.githubusercontent.com/533/211738028-e9f75da8-e023-4b62-9582-422130402431.png"></td>
</tr>
<tr>
<td>Atomic</td>
<td><img width="268" alt="atomic-old" src="https://user-images.githubusercontent.com/533/211738076-c74d435f-6972-4fc4-922b-b3de670ea1bb.png"></td>
<td><img width="273" alt="atomic-new" src="https://user-images.githubusercontent.com/533/211738130-370262d2-2fdc-45eb-836b-930c6c4564cf.png"></td>
</tr>
</table>

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pcmemI-1EP-p2 
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this on your sandbox.
* Go to a simple site, make sure that the user menu is displaying correctly.
* To test for Atomic, you need a WoA test environment. Apply the diff to woa/wp-content/plugins/jetpack/modules/masterbar path. And make sure you see Subscribers and Team.
* Jetpack connected sites Admin menu remains unchanged.