### PR TITLE
[Boost] Fix toggling Image Guide from requesting page speed refresh

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Score.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Score.svelte
@@ -54,13 +54,17 @@
 	 */
 	const scoreConfigString = derived(
 		[ modules, criticalCssStatus ],
-		( [ $modules, $criticalCssStatus ] ) =>
-			JSON.stringify( {
-				modules: $modules,
+		( [ $modules, $criticalCssStatus ] ) => {
+			const scoreModules = Object.assign( {}, $modules );
+			delete scoreModules[ 'image-guide' ];
+
+			return JSON.stringify( {
+				modules: scoreModules,
 				criticalCss: {
 					created: $criticalCssStatus.created,
 				},
-			} )
+			} );
+		}
 	);
 
 	/**

--- a/projects/plugins/boost/changelog/prevent-toggling-image-guide-from-refreshing-page-speed
+++ b/projects/plugins/boost/changelog/prevent-toggling-image-guide-from-refreshing-page-speed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix enabling/disabling image guide from the Settings page requesting a page speed score refresh.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #28255.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* These changes should prevent page speed refresh requests when enabling/disabling Image Guide from the settings page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup latest version of Jetpack Boost with the Image Guide feature (pc9hqz-1sC-p2);
* Go to the Settings page and enable Image Guide. It shouldn't request a page speed scores refresh.