### PR TITLE
E2E tests: fix waitForResponse predicates

### DIFF
--- a/tools/e2e-commons/pages/wp-admin/blocks/simple-payments.js
+++ b/tools/e2e-commons/pages/wp-admin/blocks/simple-payments.js
@@ -35,7 +35,9 @@ export default class SimplePaymentBlock extends PageActions {
 	}
 
 	async waitForResponse() {
-		await this.page.waitForResponse( r => r.url().match( /jp_pay_product/ ) && r.status() === 200 );
+		await this.page.waitForResponse(
+			r => decodeURIComponent( r.url() ).match( /jp_pay_product/ ) && r.status() === 200
+		);
 	}
 
 	getSelector( selector ) {

--- a/tools/e2e-commons/pages/wp-admin/blocks/simple-payments.js
+++ b/tools/e2e-commons/pages/wp-admin/blocks/simple-payments.js
@@ -35,9 +35,7 @@ export default class SimplePaymentBlock extends PageActions {
 	}
 
 	async waitForResponse() {
-		const testUrl = /^https?:\/\/.*%2Fwp%2Fv2%2Fjp_pay_product/;
-
-		await this.page.waitForResponse( resp => testUrl.test( resp.url() ) );
+		await this.page.waitForResponse( r => r.url().match( /jp_pay_product/ ) && r.status() === 200 );
 	}
 
 	getSelector( selector ) {

--- a/tools/e2e-commons/pages/wp-admin/blocks/tilled-gallery.js
+++ b/tools/e2e-commons/pages/wp-admin/blocks/tilled-gallery.js
@@ -33,7 +33,9 @@ export default class TiledGallery extends PageActions {
 	}
 
 	async waitForResponse() {
-		await this.page.waitForResponse( r => r.url().match( /wp\/v2\/media/ ) && r.status() === 200 );
+		await this.page.waitForResponse(
+			r => decodeURIComponent( r.url() ).match( /wp\/v2\/media/ ) && r.status() === 200
+		);
 	}
 
 	async linkToAttachment() {

--- a/tools/e2e-commons/pages/wp-admin/blocks/tilled-gallery.js
+++ b/tools/e2e-commons/pages/wp-admin/blocks/tilled-gallery.js
@@ -33,9 +33,7 @@ export default class TiledGallery extends PageActions {
 	}
 
 	async waitForResponse() {
-		const testUrl = /^https?:\/\/.*%2Fwp%2Fv2%2Fmedia/;
-
-		await this.page.waitForResponse( resp => testUrl.test( resp.url() ) );
+		await this.page.waitForResponse( r => r.url().match( /wp\/v2\/media/ ) && r.status() === 200 );
 	}
 
 	async linkToAttachment() {


### PR DESCRIPTION
## Proposed changes:

Fix for `waitForResponse` predicates breaking 2 blocks tests.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1673355003210429-slack-C03QNBQKG73

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* e2e tests pass