### PR TITLE
Blaze: do not load the UI if the JSON API module is inactive

### DIFF
--- a/projects/packages/blaze/changelog/update-blaze-conditions-json-api
+++ b/projects/packages/blaze/changelog/update-blaze-conditions-json-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Do not load the Blaze UI if the JSON API module is inactive.

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -115,7 +115,7 @@ class Blaze {
 
 		// The feature relies on this module for now.
 		// See 1386-gh-dotcom-forge
-		if ( ! ( new Modules() )->is_active( 'json-api' ) ) {
+		if ( ! $is_wpcom && ! ( new Modules() )->is_active( 'json-api' ) ) {
 			$should_initialize = false;
 		}
 

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -98,6 +98,10 @@ class Blaze {
 			$should_initialize = false;
 		}
 
+		if ( ! ( new Modules() )->is_active( 'json-api' ) ) {
+			$should_initialize = false;
+		}
+
 		/**
 		 * Filter to disable all Blaze functionality.
 		 *


### PR DESCRIPTION
## Proposed changes:

The Blaze interface is currently not fully working when the JSON API module is inactive. Let's not promote Blaze in this case.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* 1386-gh-dotcom-forge

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Test on a WoA site
* Go to the Post list, in wp-admin: `wp-admin/edit.php?post_type=post`
* You should see the "Blaze" option when moving your mouse over a post row (if the post is published).
* Go to `https://yoursite.com/wp-admin/admin.php?page=jetpack_modules`
* Disable the JSON API module.
* Reload the post list in wp-admin.
* The Blaze option should not be there anymore.