### PR TITLE
Protect: Round ProgressBar percentage values

### DIFF
--- a/projects/plugins/protect/changelog/fix-protect-progress-bar-decimals
+++ b/projects/plugins/protect/changelog/fix-protect-progress-bar-decimals
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Round percentage values in progress bar component

--- a/projects/plugins/protect/src/js/components/progress-bar/index.jsx
+++ b/projects/plugins/protect/src/js/components/progress-bar/index.jsx
@@ -16,7 +16,7 @@ const ProgressBar = ( { className, total = 100, value } ) => {
 	}
 
 	// The percentage should not be allowed to be more than 100
-	const progress = Math.min( Math.floor( ( value / total ) * 100 ), 100 );
+	const progress = Math.min( Math.ceil( ( value / total ) * 100 ), 100 );
 
 	const style = {
 		width: `${ progress }%`,

--- a/projects/plugins/protect/src/js/components/progress-bar/index.jsx
+++ b/projects/plugins/protect/src/js/components/progress-bar/index.jsx
@@ -16,7 +16,7 @@ const ProgressBar = ( { className, total = 100, value } ) => {
 	}
 
 	// The percentage should not be allowed to be more than 100
-	const progress = Math.min( ( value / total ) * 100, 100 );
+	const progress = Math.min( Math.floor( ( value / total ) * 100 ), 100 );
 
 	const style = {
 		width: `${ progress }%`,

--- a/projects/plugins/protect/src/js/components/progress-bar/index.jsx
+++ b/projects/plugins/protect/src/js/components/progress-bar/index.jsx
@@ -16,7 +16,7 @@ const ProgressBar = ( { className, total = 100, value } ) => {
 	}
 
 	// The percentage should not be allowed to be more than 100
-	const progress = Math.min( Math.ceil( ( value / total ) * 100 ), 100 );
+	const progress = Math.min( Math.round( ( value / total ) * 100 ), 100 );
 
 	const style = {
 		width: `${ progress }%`,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Wraps a `Math.round()` around the generation of the `progress` value in the `ProgressBar` component, to prevent values such as `57` from displaying as `56.999...`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

1201069996155224-as-1203676699052006

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Easiest way to test this one is by using Storybook:

* `cd projects/js-packages/storybook`
* `npm run storybook:dev`
* Update the value of one of the progress bar stories in `projects/plugins/protect/src/js/components/progress-bar/stories/index.jsx` to `57`.
* Validate that without this branch applied, it displays `56.999...%`, and with this branch applies it rounds it up to `57%`.