### PR TITLE
Calendar library and Tonesque: various cleanup

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/icalendar-reader.php
+++ b/projects/plugins/jetpack/_inc/lib/icalendar-reader.php
@@ -568,7 +568,7 @@ class iCalendarReader {
 		// rewrite webcal: URI schem to HTTP.
 		$url = preg_replace( '/^webcal/', 'http', $url );
 		// try to fetch.
-		$r = wp_remote_get(
+		$r = wp_safe_remote_get(
 			$url,
 			array(
 				'timeout'   => 3,
@@ -969,8 +969,7 @@ class iCalendarReader {
 
 		if ( ! $all_day && $this->timezone ) {
 			try {
-				$start_time      = new DateTime( $event['DTSTART'] );
-				$timezone_offset = $this->timezone->getOffset( $start_time );
+				$timezone_offset = $this->timezone->getOffset( new DateTime( $event['DTSTART'] ) );
 				$start          += $timezone_offset;
 
 				if ( $end ) {
@@ -1063,8 +1062,7 @@ function icalendar_get_events( $url = '', $count = 5 ) {
 	 * Find your calendar's address
 	 * https://support.google.com/calendar/bin/answer.py?hl=en&answer=37103
 	 */
-	$ical = new iCalendarReader();
-	return $ical->get_events( $url, $count );
+	return ( new iCalendarReader() )->get_events( $url, $count );
 }
 
 /**
@@ -1076,6 +1074,5 @@ function icalendar_get_events( $url = '', $count = 5 ) {
  * @return mixed bool|string false on failure, rendered HTML string on success.
  */
 function icalendar_render_events( $url = '', $args = array() ) {
-	$ical = new iCalendarReader();
-	return $ical->render( $url, $args );
+	return ( new iCalendarReader() )->render( $url, $args );
 }

--- a/projects/plugins/jetpack/_inc/lib/tonesque.php
+++ b/projects/plugins/jetpack/_inc/lib/tonesque.php
@@ -2,11 +2,9 @@
 /**
  * Tonesque
  * Grab an average color representation from an image.
- * Author: Automattic, Matias Ventura
- * Author URI: https://automattic.com/
- * License: GNU General Public License v2 or later
- * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  *
+ * @author Automattic
+ * @author Matias Ventura
  * @package automattic/jetpack
  */
 
@@ -14,7 +12,6 @@
  * Color representation class.
  */
 class Tonesque {
-
 	/**
 	 * Image URL.
 	 *
@@ -65,7 +62,7 @@ class Tonesque {
 	 *
 	 * @param string $image_url Image URL.
 	 *
-	 * @return object Image object.
+	 * @return object|bool Image object or false if the image could not be loaded.
 	 */
 	public static function imagecreatefromurl( $image_url ) {
 		$data = null;
@@ -88,7 +85,7 @@ class Tonesque {
 			}
 
 			if ( empty( $data ) ) {
-				$response = wp_remote_get( $image_url );
+				$response = wp_safe_remote_get( $image_url );
 				if ( is_wp_error( $response ) ) {
 					return false;
 				}
@@ -115,7 +112,7 @@ class Tonesque {
 	 *
 	 * @param string $type Type (hex, rgb, hsv) (optional).
 	 *
-	 * @return color as a string formatted as $type
+	 * @return string|bool color as a string formatted as $type or false if the image could not be loaded.
 	 */
 	public function color( $type = 'hex' ) {
 		// Bail if there is no image to work with.
@@ -126,8 +123,7 @@ class Tonesque {
 		// Finds dominant color.
 		$color = self::grab_color();
 		// Passes value to Color class.
-		$color = self::get_color( $color, $type );
-		return $color;
+		return self::get_color( $color, $type );
 	}
 
 	/**
@@ -135,7 +131,7 @@ class Tonesque {
 	 *
 	 * @param string $type can be 'index' or 'hex'.
 	 *
-	 * @return array with color indices
+	 * @return array|false color indices or false if the image could not be loaded.
 	 */
 	public function grab_points( $type = 'index' ) {
 		$img = $this->image_obj;
@@ -186,7 +182,7 @@ class Tonesque {
 	/**
 	 * Finds the average color of the image based on five sample points
 	 *
-	 * @return array with rgb color
+	 * @return array|bool array with rgb color or false if the image could not be loaded.
 	 */
 	public function grab_color() {
 		$img = $this->image_obj;
@@ -248,8 +244,7 @@ class Tonesque {
 				$color = implode( ',', $c->toHsvInt() );
 				break;
 			default:
-				$color = $c->toHex();
-				return $color;
+				return $c->toHex();
 		}
 
 		return $color;
@@ -260,7 +255,7 @@ class Tonesque {
 	 * Checks contrast against main color
 	 * Gives either black or white for using with opacity
 	 *
-	 * @return string
+	 * @return string|bool Returns black or white or false if the image could not be loaded.
 	 */
 	public function contrast() {
 		if ( ! $this->color ) {

--- a/projects/plugins/jetpack/changelog/improve-ical-reader
+++ b/projects/plugins/jetpack/changelog/improve-ical-reader
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Calendar Library: various fixes

--- a/projects/plugins/jetpack/modules/shortcodes/upcoming-events.php
+++ b/projects/plugins/jetpack/modules/shortcodes/upcoming-events.php
@@ -40,7 +40,7 @@ class Upcoming_Events_Shortcode {
 			'number'  => absint( $atts['number'] ),
 		);
 
-		if ( ! empty( $atts['url'] ) ) {
+		if (  empty( $atts['url'] ) ) {
 			// If the current user can access the Appearance->Widgets page.
 			if ( current_user_can( 'edit_theme_options' ) ) {
 				return sprintf( '<p>%s</p>', __( 'You must specify a URL to an iCalendar feed in the shortcode. This notice is only displayed to administrators.', 'jetpack' ) );

--- a/projects/plugins/jetpack/modules/shortcodes/upcoming-events.php
+++ b/projects/plugins/jetpack/modules/shortcodes/upcoming-events.php
@@ -40,7 +40,7 @@ class Upcoming_Events_Shortcode {
 			'number'  => absint( $atts['number'] ),
 		);
 
-		if (  empty( $atts['url'] ) ) {
+		if ( empty( $atts['url'] ) ) {
 			// If the current user can access the Appearance->Widgets page.
 			if ( current_user_can( 'edit_theme_options' ) ) {
 				return sprintf( '<p>%s</p>', __( 'You must specify a URL to an iCalendar feed in the shortcode. This notice is only displayed to administrators.', 'jetpack' ) );

--- a/projects/plugins/jetpack/modules/shortcodes/upcoming-events.php
+++ b/projects/plugins/jetpack/modules/shortcodes/upcoming-events.php
@@ -27,7 +27,7 @@ class Upcoming_Events_Shortcode {
 	 */
 	public static function shortcode( $atts = array() ) {
 		require_once JETPACK__PLUGIN_DIR . '/_inc/lib/icalendar-reader.php';
-		$atts   = shortcode_atts(
+		$atts = shortcode_atts(
 			array(
 				'url'    => '',
 				'number' => 0,
@@ -35,17 +35,32 @@ class Upcoming_Events_Shortcode {
 			$atts,
 			'upcomingevents'
 		);
-		$args   = array(
+		$args = array(
 			'context' => 'shortcode',
 			'number'  => absint( $atts['number'] ),
 		);
+
+		if ( ! empty( $atts['url'] ) ) {
+			// If the current user can access the Appearance->Widgets page.
+			if ( current_user_can( 'edit_theme_options' ) ) {
+				return sprintf( '<p>%s</p>', __( 'You must specify a URL to an iCalendar feed in the shortcode. This notice is only displayed to administrators.', 'jetpack' ) );
+			}
+			return self::no_upcoming_event_text();
+		}
 		$events = icalendar_render_events( $atts['url'], $args );
 
 		if ( ! $events ) {
-			$events = sprintf( '<p>%s</p>', __( 'No upcoming events', 'jetpack' ) );
+			$events = self::no_upcoming_event_text();
 		}
 
 		return $events;
+	}
+
+	/**
+	 * Returns No Upcoming Event text.
+	 */
+	private static function no_upcoming_event_text() {
+		return sprintf( '<p>%s</p>', __( 'No upcoming events', 'jetpack' ) );
 	}
 }
 add_action( 'plugins_loaded', array( 'Upcoming_Events_Shortcode', 'init' ), 101 );

--- a/projects/plugins/jetpack/modules/widgets/upcoming-events.php
+++ b/projects/plugins/jetpack/modules/widgets/upcoming-events.php
@@ -170,7 +170,7 @@ class Jetpack_Upcoming_Events_Widget extends WP_Widget {
 		echo $args['after_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		/** This action is documented in modules/widgets/gravatar-profile.php */
-		do_action( 'jetpack_stats_extra', 'widget_view', 'grofile' );
+		do_action( 'jetpack_stats_extra', 'widget_view', 'upcoming_events' );
 	}
 
 	/**
@@ -182,7 +182,6 @@ class Jetpack_Upcoming_Events_Widget extends WP_Widget {
 	private function apply_timezone_offset( $events ) {
 		require_once JETPACK__PLUGIN_DIR . '/_inc/lib/icalendar-reader.php';
 
-		$ical = new iCalendarReader();
-		return $ical->apply_timezone_offset( $events );
+		return ( new iCalendarReader() )->apply_timezone_offset( $events );
 	}
 }


### PR DESCRIPTION
## Proposed changes:

* This PR brings in changes to the ical reader via upcoming events, and Tonesque.
* For more context, see this internal conversation: p1671033590541349-slack-C01U2KGS2PQ

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1671033590541349-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* The main aim is to test that the functionality of these features isn't impacted.
* The upcoming events shortcode can be tested using an icalendar link.
* Tonesque can be tested by using the Color Picker plugin.