### PR TITLE
Protect: Poll for scan status when scanner is idle and no lastChecked value is available

### DIFF
--- a/projects/plugins/protect/changelog/fix-protect-poll-when-scan-initializing
+++ b/projects/plugins/protect/changelog/fix-protect-poll-when-scan-initializing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Poll for scan status while scanner is provisioning

--- a/projects/plugins/protect/src/js/components/scan-page/use-status-polling.js
+++ b/projects/plugins/protect/src/js/components/scan-page/use-status-polling.js
@@ -38,8 +38,11 @@ const useStatusPolling = () => {
 							throw newStatus?.errorMessage;
 						}
 
-						if ( statusIsInProgress( newStatus?.status ) ) {
-							setStatusProgress( newStatus.current_progress );
+						if (
+							statusIsInProgress( newStatus?.status ) ||
+							scanIsInitializing( newStatus?.status, newStatus?.lastChecked )
+						) {
+							setStatusProgress( newStatus?.current_progress );
 							pollTimeout = setTimeout( () => {
 								pollStatus()
 									.then( result => resolve( result ) )

--- a/projects/plugins/protect/src/js/components/scan-page/use-status-polling.js
+++ b/projects/plugins/protect/src/js/components/scan-page/use-status-polling.js
@@ -62,7 +62,7 @@ const useStatusPolling = () => {
 		};
 
 		if (
-			! statusIsInProgress( status?.status ) ||
+			! statusIsInProgress( status?.status ) &&
 			! scanIsInitializing( status?.status, status?.lastChecked )
 		) {
 			return;

--- a/projects/plugins/protect/src/js/components/scan-page/use-status-polling.js
+++ b/projects/plugins/protect/src/js/components/scan-page/use-status-polling.js
@@ -23,6 +23,10 @@ const useStatusPolling = () => {
 		const statusIsInProgress = currentStatus =>
 			[ 'scheduled', 'scanning' ].indexOf( currentStatus ) >= 0;
 
+		// if there has never been a scan, and the scan status is idle, then we must still be getting set up
+		const scanIsInitializing = ( currentStatus, lastChecked ) =>
+			! lastChecked && currentStatus === 'idle';
+
 		const pollStatus = () => {
 			return new Promise( ( resolve, reject ) => {
 				apiFetch( {
@@ -57,7 +61,10 @@ const useStatusPolling = () => {
 			} );
 		};
 
-		if ( ! statusIsInProgress( status?.status ) ) {
+		if (
+			! statusIsInProgress( status?.status ) ||
+			! scanIsInitializing( status?.status, status?.lastChecked )
+		) {
 			return;
 		}
 
@@ -78,7 +85,8 @@ const useStatusPolling = () => {
 
 		return () => clearTimeout( pollTimeout );
 	}, [
-		status.status,
+		status?.status,
+		status?.lastChecked,
 		setScanIsUnavailable,
 		setStatus,
 		setStatusProgress,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR ensures that the app considers a scan status that is "idle" and does not have any "lastChecked" value as essentially an in-progress scan. If a scan is considered to be in progress, the app should poll the endpoint until a complete scan result is received. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1673367221997009-slack-C04E0KTGW9Z

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a site running this branch
* Edit `projects/plugins/protect/src/class-scan-status.php:144-156` so that `$status->status = 'idle'` and `$status->last_checked = null`
* Open the Protect scan tab, and validate via the network tab that the scan API is polled every ten seconds.
* Remove your changes to the scan status class
* Validate that the Protect app stops polling once it receives a scan status containing a `lastChecked` value.

(You can also try simulating this scenario by removing the initial scan from `vp_backup_status` table, as described in p1673392183488839/1673367221.997009-slack-C04E0KTGW9Z)