### PR TITLE
[Boost] Update image guide tooltip link to use jetpack redirect

### DIFF
--- a/projects/plugins/boost/app/features/image-guide/src/ui/Popup.svelte
+++ b/projects/plugins/boost/app/features/image-guide/src/ui/Popup.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { getRedirectUrl } from '@automattic/jetpack-components';
 	import { backOut } from 'svelte/easing';
 	import { fly } from 'svelte/transition';
 	import JetpackLogo from './JetpackLogo.svelte';
@@ -37,7 +38,7 @@
 	$: previewHeight = Math.floor( previewWidth / ( $fileSize.width / $fileSize.height ) );
 	$: ratio = maybeDecimals( $oversizedRatio );
 
-	const DOCUMENTATION_URL = `https://jetpack.com/support/jetpack-boost/image-performance-guide/`;
+	const DOCUMENTATION_URL = getRedirectUrl( 'jetpack-support-boost-image-performance-guide' );
 </script>
 
 <div class="details" in:fly={{ duration: 150, y: 4, easing: backOut }}>

--- a/projects/plugins/boost/changelog/boost-update-image-guide-tooltip-link-use-jetpack-redirect
+++ b/projects/plugins/boost/changelog/boost-update-image-guide-tooltip-link-use-jetpack-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Update image guide front-end tooltip link to use jetpack redirect.

--- a/projects/plugins/boost/changelog/boost-update-image-guide-tooltip-link-use-jetpack-redirect
+++ b/projects/plugins/boost/changelog/boost-update-image-guide-tooltip-link-use-jetpack-redirect
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Update image guide front-end tooltip link to use jetpack redirect.
+Updated image guide front-end tooltip link to use jetpack redirect.

--- a/projects/plugins/boost/rollup.config.js
+++ b/projects/plugins/boost/rollup.config.js
@@ -219,7 +219,11 @@ export default [
 			format: 'iife',
 			name: 'app',
 			file: `${ GUIDE_PATH }/dist/guide.js`,
+			globals: {
+				'@wordpress/components': 'wp.components',
+			},
 		},
+		external: [ '@wordpress/components' ],
 		plugins: [
 			replace( {
 				preventAssignment: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #28257.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR updates the image guide build process to work with `@automattic/jetpack-components`, to allow links to use jetpack redirect.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
PCYsg-pY7-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install the latest version of boost and enable Image Guide;
* Open a page with images and check the tooltip for one of the images;
* The link should use jetpack redirect.