### PR TITLE
jetpack/install : Print instructions how to resolve composer errors

### DIFF
--- a/tools/cli/commands/install.js
+++ b/tools/cli/commands/install.js
@@ -105,6 +105,10 @@ export async function handler( argv ) {
 				execa( 'composer', await getInstallArgs( project, 'composer', argv ), {
 					cwd: projectDir( project ),
 					stdio,
+				} ).catch( err => {
+					err.fix =
+						'To resolve issues, try running the command: `cd projects/plugins/jetpack && composer install`';
+					return Promise.reject( err );
 				} ),
 		} );
 	}


### PR DESCRIPTION
When you run `pnpm jetpack/install`, it sometimes fails with a cryptic error.
The solution is to run the composer update in the appropriate directory, but if you are a newbie in Jetpack, it cant take you days.

This simple change is just injecting a suggestion on how to resolve that when that is needed:

```
jetpack 😃 🚀 pnpm jetpack install                                                          (trunk)jetpack
? What type of project are you working on today? plugins
? Please choose which project jetpack
  ⠹ Installing pnpm dependencies
  ✖ Installing composer dependencies for plugins/jetpack
    → Command failed with exit code 2: composer install
Error: Command failed with exit code 2: composer install
    at makeError (/Users/artpi/GIT/jetpack/node_modules/.pnpm/execa@5.0.0/node_modules/execa/lib/error.js:59:11)
    at handlePromise (/Users/artpi/GIT/jetpack/node_modules/.pnpm/execa@5.0.0/node_modules/execa/index.js:114:26)
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  shortMessage: 'Command failed with exit code 2: composer install',
  command: 'composer install',
  exitCode: 2,
  signal: undefined,
  signalDescription: undefined,
  stdout: undefined,
  stderr: undefined,
  failed: true,
  timedOut: false,
  isCanceled: false,
  killed: false,
  fix: 'To resolve issues, try running the command: `cd projects/plugins/jetpack && composer install`',
  context: [Object: null prototype] {}
}

```

## Does this pull request change what data or activity we track or use?

No

## Testing instructions

- Find a branch that triggers "run jetpack install" message
- Run `pnpm composer install`
- See the error (i don't know how to trigger that)
- Run the suggested command