### PR TITLE
Revert "Tiled Gallery block: Adding styles to squareish tiled gallery images on WoA sites"

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-woa-squarish-tiled-galleries
+++ b/projects/plugins/jetpack/changelog/fix-woa-squarish-tiled-galleries
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Tiled Gallery block: Ensuring localhost and WoA sites with squareish gallery images display those images with correct aspect ratios.

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -12,7 +12,6 @@ namespace Automattic\Jetpack\Extensions;
 
 use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Status;
-use Automattic\Jetpack\Status\Host;
 use Jetpack;
 use Jetpack_Gutenberg;
 use Jetpack_Plan;
@@ -185,21 +184,6 @@ class Tiled_Gallery {
 				|| 'is-style-circle' === $attr['className']
 			);
 	}
-
-	/**
-	 * Adds an equal aspect ratio to squareish (square and circular) tiled gallery images on WoA sites.
-	 *
-	 * Without this, these images in newly added tiled galleries on private WoA sites
-	 * (and public if broken on the private sites) have un-equal spect ratios.
-	 */
-	public static function add_woa_squareish_styles() {
-		$is_atomic_site = ( new Host() )->is_woa_site();
-		$status         = new Status();
-		if ( $is_atomic_site || $status->is_local_site() ) {
-			wp_enqueue_style( 'jetpack-squareish-tiled-gallery-styles', plugins_url( 'modules/tiled-gallery/tiled-gallery/squareish.css', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
-		}
-	}
 }
 
 Tiled_Gallery::register();
-Tiled_Gallery::add_woa_squareish_styles();

--- a/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/squareish.css
+++ b/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/squareish.css
@@ -1,3 +1,0 @@
-.wp-block-jetpack-tiled-gallery.is-style-square img, .wp-block-jetpack-tiled-gallery.is-style-circle img {
-	aspect-ratio: 1/1;
-}


### PR DESCRIPTION
This PR reverts Automattic/jetpack#27858, due to PHP notices being displayed (on localhost / WoA sites that would have Tiled Gallery blocks active - but only if testing bleeding edge at the moment): 

```
PHP Notice:  Function wp_enqueue_style was called <strong>incorrectly</strong>. Scripts and styles should not be registered or enqueued until the <code>wp_enqueue_scripts</code>, <code>admin_enqueue_scripts</code>, or <code>login_enqueue_scripts</code> hooks. This notice was triggered by the <code>jetpack-squareish-tiled-gallery-styles</code> handle. Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 3.3.0.) in /var/www/html/wp-includes/functions.php on line 5835
```

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion

pdWQjU-av-p2 

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* This reverts https://github.com/Automattic/jetpack/pull/27858 - if testing Tiled Galleries via localhost or WoA PHP warning should now disappear.