### PR TITLE
E2E tests: new test for subscribe block

### DIFF
--- a/projects/plugins/jetpack/changelog/e2e-subscription-block
+++ b/projects/plugins/jetpack/changelog/e2e-subscription-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+E2E tests: add test for subscribe block

--- a/projects/plugins/jetpack/tests/e2e/specs/blocks/free-blocks.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/blocks/free-blocks.test.js
@@ -142,6 +142,8 @@ test.describe.parallel( 'Free blocks', () => {
 	} );
 
 	test( 'Subscribe block', async ( { page } ) => {
+		await prerequisitesBuilder( page ).withActiveModules( [ 'subscriptions' ] ).build();
+
 		await test.step( 'Can visit the block editor and add a Subscribe block', async () => {
 			const blockId = await blockEditor.insertBlock(
 				SubscribeBlock.name(),

--- a/projects/plugins/jetpack/tests/e2e/specs/blocks/free-blocks.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/blocks/free-blocks.test.js
@@ -5,6 +5,7 @@ import {
 	EventbriteBlock,
 	FormBlock,
 	TiledGalleryBlock,
+	SubscribeBlock,
 } from 'jetpack-e2e-commons/pages/wp-admin/index.js';
 import { PostFrontendPage } from 'jetpack-e2e-commons/pages/index.js';
 import config from 'config';
@@ -135,6 +136,31 @@ test.describe.parallel( 'Free blocks', () => {
 			const frontend = await PostFrontendPage.init( page );
 			expect(
 				await frontend.isRenderedBlockPresent( TiledGalleryBlock ),
+				'Block should be displayed'
+			).toBeTruthy();
+		} );
+	} );
+
+	test( 'Subscribe block', async ( { page } ) => {
+		await test.step( 'Can visit the block editor and add a Subscribe block', async () => {
+			const blockId = await blockEditor.insertBlock(
+				SubscribeBlock.name(),
+				SubscribeBlock.title()
+			);
+			const block = new SubscribeBlock( blockId, page );
+			await block.checkBlock();
+		} );
+
+		await test.step( 'Can publish a post with a Subscribe block', async () => {
+			await blockEditor.selectPostTitle();
+			await blockEditor.publishPost();
+			await blockEditor.viewPost();
+		} );
+
+		await test.step( 'Can assert that Subscribe block is rendered', async () => {
+			const frontend = await PostFrontendPage.init( page );
+			expect(
+				await frontend.isRenderedBlockPresent( SubscribeBlock ),
 				'Block should be displayed'
 			).toBeTruthy();
 		} );

--- a/tools/e2e-commons/bin/e2e-env.sh
+++ b/tools/e2e-commons/bin/e2e-env.sh
@@ -70,6 +70,7 @@ configure_wp_env() {
 	fi
 	$BASE_CMD wp option set permalink_structure ""
 	$BASE_CMD wp jetpack module deactivate sso
+	$BASE_CMD wp jetpack module activate subscriptions
 	$BASE_CMD wp theme activate twentytwentyone
 
 	echo

--- a/tools/e2e-commons/bin/e2e-env.sh
+++ b/tools/e2e-commons/bin/e2e-env.sh
@@ -70,7 +70,6 @@ configure_wp_env() {
 	fi
 	$BASE_CMD wp option set permalink_structure ""
 	$BASE_CMD wp jetpack module deactivate sso
-	$BASE_CMD wp jetpack module activate subscriptions
 	$BASE_CMD wp theme activate twentytwentyone
 
 	echo

--- a/tools/e2e-commons/pages/wp-admin/blocks/subscribe.js
+++ b/tools/e2e-commons/pages/wp-admin/blocks/subscribe.js
@@ -1,0 +1,36 @@
+import PageActions from '../../page-actions.js';
+
+export default class SubscribeBlock extends PageActions {
+	constructor( blockId, page ) {
+		super( page, 'Subscribe' );
+		this.blockTitle = SubscribeBlock.title();
+		this.page = page;
+		this.blockSelector = '#block-' + blockId;
+	}
+
+	static name() {
+		return 'subscriptions';
+	}
+
+	static title() {
+		return 'Subscribe';
+	}
+
+	async checkBlock() {
+		await this.page.waitForResponse(
+			r =>
+				decodeURIComponent( r.url() ).match( /wpcom\/v2\/subscribers\/counts/ ) &&
+				r.status() === 200
+		);
+	}
+
+	/**
+	 * Checks whether block is rendered on frontend
+	 *
+	 * @param {page} page Playwright page instance
+	 */
+	static async isRendered( page ) {
+		await page.waitForSelector( '.wp-block-jetpack-subscriptions__container #subscribe-field-1' );
+		await page.waitForSelector( '.wp-block-jetpack-subscriptions__container button' );
+	}
+}

--- a/tools/e2e-commons/pages/wp-admin/index.js
+++ b/tools/e2e-commons/pages/wp-admin/index.js
@@ -6,6 +6,7 @@ export { default as SimplePaymentBlock } from './blocks/simple-payments.js';
 export { default as WordAdsBlock } from './blocks/word-ads.js';
 export { default as FormBlock } from './blocks/form.js';
 export { default as TiledGalleryBlock } from './blocks/tilled-gallery.js';
+export { default as SubscribeBlock } from './blocks/subscribe.js';
 
 export { default as DashboardPage } from './dashboard.js';
 export { default as InPlacePlansPage } from './in-place-plans.js';


### PR DESCRIPTION
## Proposed changes:

Add a new e2e test for subscribe block.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* There should be a new e2e test called `Subscribe block` part of the blocks job. All e2e tests should pass.

