### PR TITLE
build: Use PR commit SHA in plugin artifact version numbers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,7 @@ jobs:
       - name: Prepare plugin zips
         id: prepare
         env:
-          SHA: ${{ github.event.pull_request.head.ref || github.sha }}
+          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           mkdir work
           mkdir zips
@@ -278,9 +278,10 @@ jobs:
           SECRET: ${{ secrets.JPBETA_SECRET }}
           PLUGIN_DATA: ${{ steps.prepare.outputs.plugin-data }}
           PR: ${{ github.event.number }}
+          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           curl -v --fail -L \
-            --url "https://betadownload.jetpack.me/gh-action.php?run_id=$GITHUB_RUN_ID&pr=$PR&commit=$GITHUB_SHA" \
+            --url "https://betadownload.jetpack.me/gh-action.php?run_id=$GITHUB_RUN_ID&pr=$PR&commit=$SHA" \
             --form-string "repo=$GITHUB_REPOSITORY" \
             --form-string "branch=${GITHUB_REF#refs/heads/}" \
             --form-string "plugins=$PLUGIN_DATA" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,13 +202,15 @@ jobs:
 
       - name: Prepare plugin zips
         id: prepare
+        env:
+          SHA: ${{ github.event.pull_request.head.ref || github.sha }}
         run: |
           mkdir work
           mkdir zips
 
           # Current version must compare greather than any previously used current version for this PR.
           # Assume GH run IDs are monotonic.
-          VERSUFFIX="${GITHUB_RUN_ID}-g${GITHUB_SHA:0:8}"
+          VERSUFFIX="${GITHUB_RUN_ID}-g${SHA:0:8}"
 
           # Plugin data is passed as a JSON object.
           PLUGIN_DATA="{}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,7 +208,7 @@ jobs:
 
           # Current version must compare greather than any previously used current version for this PR.
           # Assume GH run IDs are monotonic.
-          VERSUFFIX="${GITHUB_RUN_ID}-g$(cd monorepo && git rev-parse --short HEAD)"
+          VERSUFFIX="${GITHUB_RUN_ID}-g${GITHUB_SHA:0:8}"
 
           # Plugin data is passed as a JSON object.
           PLUGIN_DATA="{}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We intend for the version number in the plugin artifacts to include the short hash for the PR head, but the logic used was picking up the merge commit GitHub creates instead. Fix that.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1673446178951349/1673439636.004289-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check that the version numbers in the plugins artifact produced by the Build job end with "-g02fcd480" (or whatever the SHA of the HEAD commit on this PR is).
* Select this branch in the Jetpack Beta Tester plugin and see the version numbers there too.