### PR TITLE
VideoPress: fix render player once file uploads issue

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-fix-rendering-player
+++ b/projects/packages/videopress/changelog/update-videopress-fix-rendering-player
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: fix render player once file uploads issue

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -265,7 +265,7 @@ export default function VideoPressEdit( {
 	 */
 	const [ generatingPreviewCounter, setGeneratingPreviewCounter ] = useState( 0 );
 
-	const rePreviewAttemptTimer = useRef< NodeJS.Timeout >();
+	const rePreviewAttemptTimer = useRef< NodeJS.Timeout | void >();
 
 	/**
 	 * Clean the generating process timer.
@@ -277,7 +277,11 @@ export default function VideoPressEdit( {
 			return;
 		}
 
-		clearInterval( rePreviewAttemptTimer.current );
+		/*
+		 * Clean the timer, and updates the reference
+		 * to force a new attempt in case the preview is not available.
+		 */
+		rePreviewAttemptTimer.current = clearInterval( rePreviewAttemptTimer.current );
 	}
 
 	useEffect( () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/28292

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: fix rendering player once file uploads issue

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Add a new block
* Uploads a file
* Confirm the app renders the player by clicking on the `Done` button


