### PR TITLE
[Boost] Update image guide tooltip presentation

### DIFF
--- a/projects/plugins/boost/app/features/image-guide/src/ui/Popup.svelte
+++ b/projects/plugins/boost/app/features/image-guide/src/ui/Popup.svelte
@@ -71,8 +71,8 @@
 			{:else}
 				{@const  stretchedBy = maybeDecimals( 1 / $oversizedRatio ) }
 				<div class="explanation">
-					The image file is {stretchedBy}x smaller than expected on this screen. This might be okay,
-					but pay attention whether the image appears blurry.
+					The image file is {stretchedBy}x smaller than expected on this screen. This might be fine,
+					but you may want to check if the image appears blurry.
 				</div>
 			{/if}
 		</div>

--- a/projects/plugins/boost/app/features/image-guide/src/ui/Popup.svelte
+++ b/projects/plugins/boost/app/features/image-guide/src/ui/Popup.svelte
@@ -2,6 +2,7 @@
 	import { backOut } from 'svelte/easing';
 	import { fly } from 'svelte/transition';
 	import JetpackLogo from './JetpackLogo.svelte';
+	import External from './assets/External.svelte';
 	import type { MeasurableImageStore } from '../stores/MeasurableImageStore';
 	import type { GuideSize } from '../types';
 
@@ -146,7 +147,7 @@
 
 		<div class="info">
 			<a class="documentation" href={DOCUMENTATION_URL} target="_blank noreferrer"
-				>Learn how to improve site speed by optimizing images</a
+				>Learn how to improve site speed by optimizing images <External /></a
 			>
 		</div>
 	</div>

--- a/projects/plugins/boost/app/features/image-guide/src/ui/Popup.svelte
+++ b/projects/plugins/boost/app/features/image-guide/src/ui/Popup.svelte
@@ -155,7 +155,7 @@
 
 <style lang="scss">
 	a {
-		color: #069e08 !important;
+		color: #3c434a !important;
 		font-weight: 600 !important;
 
 		&.documentation {

--- a/projects/plugins/boost/app/features/image-guide/src/ui/Popup.svelte
+++ b/projects/plugins/boost/app/features/image-guide/src/ui/Popup.svelte
@@ -74,7 +74,6 @@
 					but pay attention whether the image appears blurry.
 				</div>
 			{/if}
-			<a class="documentation" href={DOCUMENTATION_URL} target="_blank noreferrer">Learn more</a>
 		</div>
 		{#if $imageURL}
 			<img
@@ -138,11 +137,18 @@
 				{/if}
 			</div>
 		</div>
+
 		{#if imageOrigin !== origin}
 			<div class="info">
 				Unable to estimate file size savings because the image is hosted on a different domain.
 			</div>
 		{/if}
+
+		<div class="info">
+			<a class="documentation" href={DOCUMENTATION_URL} target="_blank noreferrer"
+				>Learn how to improve site speed by optimizing images</a
+			>
+		</div>
 	</div>
 </div>
 

--- a/projects/plugins/boost/app/features/image-guide/src/ui/assets/External.svelte
+++ b/projects/plugins/boost/app/features/image-guide/src/ui/assets/External.svelte
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+	<path
+		d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"
+	/>
+</svg>
+
+<style>
+	svg {
+		width: 1em;
+		height: 1em;
+		margin: 0px;
+		vertical-align: middle;
+		fill: currentcolor;
+	}
+</style>

--- a/projects/plugins/boost/changelog/image-guide-tooltip-link-presentation
+++ b/projects/plugins/boost/changelog/image-guide-tooltip-link-presentation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated image guide tooltip link position, text and included an icon.

--- a/projects/plugins/boost/changelog/image-guide-tooltip-link-presentation
+++ b/projects/plugins/boost/changelog/image-guide-tooltip-link-presentation
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Updated image guide tooltip link position, text and included an icon.
+Updated image guide tooltip link position, text and included an icon. Also updated description text for small images.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #28247, moves link position to the bottom of the tooltip and changes the link text. It also updates the description for smaller images.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates image guide link presentation.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pc9hqz-1wd-p2#comment-1141

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup this version of the plugin on your test site;
* Enable image guide on website;
* Go to a page that has images on it;

Before:
![image](https://user-images.githubusercontent.com/11799079/211856153-532ad6d3-894a-48d5-8081-47ed1c3458ed.png)

After:
![image](https://user-images.githubusercontent.com/11799079/211856179-c12a8f48-43f3-4afc-a460-1576ea483f49.png)
