### PR TITLE
Make url acceptance more liberal in admin-menus

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -377,8 +377,11 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 				return wp_specialchars_decode( esc_url_raw( $url ) );
 			}
 
-			// Disallow other external URLs.
-			return '';
+			if ( 1 !== preg_match( '#^' . preg_quote( get_site_url() ) . '#i', $url ) ) {
+				// Disallow other external URLs.
+				return '';
+			}
+			// The URL matches that of the site, treat it as an internal URL.
 		}
 
 		// Internal URLs.

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -377,8 +377,8 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 				return wp_specialchars_decode( esc_url_raw( $url ) );
 			}
 
-			if ( 1 !== preg_match( '/^' . preg_quote( get_site_url(), '/' ) . '/i', $url ) ) {
-				// Disallow other external URLs.
+			// Disallow other external URLs.
+			if ( 0 !== strpos( $url, get_site_url() ) ) {
 				return '';
 			}
 			// The URL matches that of the site, treat it as an internal URL.

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -377,7 +377,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 				return wp_specialchars_decode( esc_url_raw( $url ) );
 			}
 
-			if ( 1 !== preg_match( '#^' . preg_quote( get_site_url() ) . '#i', $url ) ) {
+			if ( 1 !== preg_match( '/^' . preg_quote( get_site_url(), '/' ) . '/i', $url ) ) {
 				// Disallow other external URLs.
 				return '';
 			}

--- a/projects/plugins/jetpack/changelog/update-nav-unification-internal-external
+++ b/projects/plugins/jetpack/changelog/update-nav-unification-internal-external
@@ -1,0 +1,8 @@
+Significance: patch
+Type: other
+
+For the admin-menus wpcom API endpoint, treat menu urls pointing back to the site as internal URLs rather than blanking them.
+
+This means that menu items that previously pointed to the current page due to being blanked, are now more likely to point to an actual page.
+
+

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -513,6 +513,14 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 				'__return_true',
 				admin_url( 'admin.php?page=wc-admin&path=customers' ),
 			),
+			// Treat URLs pointing back to the site as internal URLs.
+			array(
+				get_site_url() . '/wp-admin/admin.php?page=elementor-app&ver=3.10.0#site-editor/promotion',
+				'',
+				null,
+				get_site_url() . '/wp-admin/admin.php?page=elementor-app&ver=3.10.0#site-editor/promotion',
+
+			),
 			// Disallowed URLs.
 			array(
 				'javascript:alert("Hello")',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/64691

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Treat menu items with a fully qualified url matching the site url the same as other internal URLs in the admin-menus rest api endpoint.

This API endpoint is used for nav-unification on wpcom. This change improves compatibility with 3rd party plugins, so that their menu links work on WordPress.com.
 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

 1. Set-up a wpcom atomic dev site
 2. Install elementor on it
 3. Go to wordpress.com/home/yourdomain or any other calypso page
 4. Try Templates → Theme Builder, Templates → Kit Library & Templates → Add New menu items. They will all just link back to the current page.
 5. Apply this change to your wpcom atomic dev site
 6. Repeat step four, this time the links should take you to the appropriate page as they do in wp-admin

(You may note that the appropriate page looks like a mess, this is https://github.com/Automattic/page-optimize/issues/59


