### PR TITLE
Jetpack: adjust phpcs:ignore usage for wpcom compat

### DIFF
--- a/projects/plugins/jetpack/changelog/update-patch-phpcs-usage-for-wpcom-compat
+++ b/projects/plugins/jetpack/changelog/update-patch-phpcs-usage-for-wpcom-compat
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Move a phpcs ignore so that wpcom doesn't throw linting error.
+
+

--- a/projects/plugins/jetpack/modules/simple-payments/simple-payments.php
+++ b/projects/plugins/jetpack/modules/simple-payments/simple-payments.php
@@ -93,7 +93,7 @@ class Jetpack_Simple_Payments {
 		 *
 		 * @see https://developer.paypal.com/docs/integration/direct/express-checkout/integration-jsv4/add-paypal-button/
 		 */
-		wp_register_script(
+		wp_register_script( // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion -- Ignored here instead of on the $ver param line since wpcom isn't in sync with ruleset changes in: https://github.com/Automattic/jetpack/pull/28199
 			'paypal-checkout-js',
 			'https://www.paypalobjects.com/api/checkout.js',
 			array(),


### PR DESCRIPTION
## Proposed changes:

WPcom rulesets aren't up to date with changes in #28199 , so adjust an ignore so linting can pass on wpcom, specifically the `WordPress.WP.EnqueuedResourceParameters.MissingVersion`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
Internal: p1673469545273599-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

Proofread.