### PR TITLE
[Boost] Clean up leftover image guide gating.

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -2,7 +2,7 @@
 	import { getRedirectUrl } from '@automattic/jetpack-components';
 	import { __ } from '@wordpress/i18n';
 	import TemplatedString from '../../../elements/TemplatedString.svelte';
-	import { isModuleAvailableStore, modules } from '../../../stores/modules';
+	import { modules } from '../../../stores/modules';
 	import {
 		requestCloudCss,
 		pollCloudCssStatus,
@@ -23,7 +23,7 @@
 
 	// svelte-ignore unused-export-let - Ignored values supplied by svelte-navigator.
 	export let location, navigate;
-	const isImageGuideActive = isModuleAvailableStore( 'image-guide' );
+
 	$: cloudCssAvailable = !! $modules[ 'cloud-css' ];
 </script>
 
@@ -107,23 +107,22 @@
 		</p>
 	</Module>
 
-	{#if $isImageGuideActive}
-		<div class="settings">
-			<Module slug={'image-guide'}>
-				<h3 slot="title">{__( 'Image Guide', 'jetpack-boost' )}<span class="beta">Beta</span></h3>
-				<p slot="description">
-					{__(
-						`This feature helps you discover the images are too large. When you browse your site, the image guide will show you an overlay with information about each image's size.`,
-						'jetpack-boost'
-					)}
-				</p>
-				<!-- svelte-ignore missing-declaration -->
-				{#if false === Jetpack_Boost.site.canResizeImages}
-					<ResizingUnavailable />
-				{/if}
-			</Module>
-		</div>
-	{/if}
+	<div class="settings">
+		<Module slug={'image-guide'}>
+			<h3 slot="title">{__( 'Image Guide', 'jetpack-boost' )}<span class="beta">Beta</span></h3>
+			<p slot="description">
+				{__(
+					`This feature helps you discover the images are too large. When you browse your site, the image guide will show you an overlay with information about each image's size.`,
+					'jetpack-boost'
+				)}
+			</p>
+			<!-- svelte-ignore missing-declaration -->
+			{#if false === Jetpack_Boost.site.canResizeImages}
+				<ResizingUnavailable />
+			{/if}
+		</Module>
+	</div>
+
 	<SuperCacheInfo />
 </div>
 

--- a/projects/plugins/boost/changelog/fix-image-guide-gate-leftovers
+++ b/projects/plugins/boost/changelog/fix-image-guide-gate-leftovers
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Remove leftovers from the image-guide feature gate
+
+

--- a/projects/plugins/boost/rollup.config.js
+++ b/projects/plugins/boost/rollup.config.js
@@ -65,10 +65,6 @@ if ( ! production ) {
 }
 
 const GUIDE_PATH = `app/features/image-guide`;
-/**
- * Replace the variable with `production` when publishing.
- */
-const imageGuideProduction = false;
 
 export default [
 	/**
@@ -215,7 +211,7 @@ export default [
 	{
 		input: `${ GUIDE_PATH }/src/index.ts`,
 		output: {
-			sourcemap: ! imageGuideProduction,
+			sourcemap: ! production,
 			format: 'iife',
 			name: 'app',
 			file: `${ GUIDE_PATH }/dist/guide.js`,
@@ -251,21 +247,21 @@ export default [
 			postcss( {
 				extensions: [ '.css', '.sss', '.pcss', '.sass', '.scss' ],
 				extract: path.resolve( `${ GUIDE_PATH }/dist/guide.css` ),
-				minimize: imageGuideProduction,
+				minimize: production,
 			} ),
 
 			svelteSVG(),
 			svelte( {
-				preprocess: sveltePreprocess( { sourceMap: ! imageGuideProduction } ),
+				preprocess: sveltePreprocess( { sourceMap: ! production } ),
 				compilerOptions: {
 					// enable run-time checks when not in production
-					dev: ! imageGuideProduction,
+					dev: ! production,
 				},
 			} ),
 
 			typescript( {
-				sourceMap: ! imageGuideProduction,
-				inlineSources: ! imageGuideProduction,
+				sourceMap: ! production,
+				inlineSources: ! production,
 				// In order to let @rollup/plugin-typescript hanlde TS files from js-packages
 				// we need to include those here and pass the custom tsconfig as well
 				include: tsconfig.include,


### PR DESCRIPTION
@dilirity pointed out a few spots I missed while removing the image guide gating yesterday. This PR cleans them up.

## Proposed changes:
* Cleanup leftover feature gates for the Image Guide.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Make sure the image guide still builds and operates correctly.

