### PR TITLE
Odyssey Stats: Fix WP Footer Position

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-odyssey-stats-footer-position
+++ b/projects/packages/stats-admin/changelog/fix-odyssey-stats-footer-position
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: fixed
 
 Fix Odyssey Stats footer position

--- a/projects/packages/stats-admin/changelog/fix-odyssey-stats-footer-position
+++ b/projects/packages/stats-admin/changelog/fix-odyssey-stats-footer-position
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Fix Odyssey Stats footer position

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.3.0",
+	"version": "0.3.1-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -84,7 +84,7 @@ class Dashboard {
 	 */
 	public function render() {
 		?>
-		<div id="wpcom" class="jp-stats-dashboard">
+		<div id="wpcom" class="jp-stats-dashboard" style="min-height: calc(100vh - 100px);">
 			<div class="hide-if-js"><?php esc_html_e( 'Your Jetpack Stats dashboard requires JavaScript to function properly.', 'jetpack-stats-admin' ); ?></div>
 			<div class="hide-if-no-js" style="height: 100%">
 				<img

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -84,7 +84,7 @@ class Dashboard {
 	 */
 	public function render() {
 		?>
-		<div id="wpcom" class="jp-stats-dashboard" style="height: calc(100vh - 100px);">
+		<div id="wpcom" class="jp-stats-dashboard">
 			<div class="hide-if-js"><?php esc_html_e( 'Your Jetpack Stats dashboard requires JavaScript to function properly.', 'jetpack-stats-admin' ); ?></div>
 			<div class="hide-if-no-js" style="height: 100%">
 				<img

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -18,7 +18,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.3.0';
+	const VERSION = '0.3.1-alpha';
 
 	/**
 	 * Singleton Main instance.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #28307 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Odyssey Stats: remove CSS inline height definition from the `#wpcom` div 

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable Odyssey Stats and go to Odyssey Stats
* Ensure the WP footer appears at the bottom as usual 

#### Screenshots

| Before | After |
| ------- | ----- |
|![image](https://user-images.githubusercontent.com/6406071/211989305-44bf0c11-87d6-4eed-9e8b-0a28eb5a0253.png)|![image](https://user-images.githubusercontent.com/6406071/211989395-97feb805-5f78-4e7b-920f-044f442e1d3a.png)|


