### PR TITLE
Prevent access to OpenAI endpoint from outside WPCOM

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -31,31 +31,6 @@ class Jetpack_AI_Helper {
 	public static $image_generation_cache_timeout = MONTH_IN_SECONDS;
 
 	/**
-	 * Checks if a given request is allowed to get AI data from WordPress.com.
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 *
-	 * @return true|WP_Error True if the request has access, WP_Error object otherwise.
-	 */
-	public static function get_status_permission_check( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-
-		/*
-		 * This may need to be updated
-		 * to take into account the different ways we can make requests
-		 * (from a WordPress.com site, from a Jetpack site).
-		 */
-		if ( ! current_user_can( 'edit_posts' ) ) {
-			return new WP_Error(
-				'rest_forbidden',
-				__( 'Sorry, you are not allowed to access Jetpack AI help on this site.', 'jetpack' ),
-				array( 'status' => rest_authorization_required_code() )
-			);
-		}
-
-		return true;
-	}
-
-	/**
 	 * Get the name of the transient for image generation. Unique per prompt and allows for reuse of results for the same prompt across entire WPCOM.
 	 * I expext "puppy" to always be from cache.
 	 *

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -86,7 +86,7 @@ class Jetpack_AI_Helper {
 			return $result;
 		}
 
-		$response = Client::wpcom_json_api_request_as_user(
+		$response = Client::wpcom_json_api_request_as_blog(
 			sprintf( '/sites/%d/jetpack-ai/completions', $site_id ),
 			2,
 			array(
@@ -152,7 +152,7 @@ class Jetpack_AI_Helper {
 			return $result;
 		}
 
-		$response = Client::wpcom_json_api_request_as_user(
+		$response = Client::wpcom_json_api_request_as_blog(
 			sprintf( '/sites/%d/jetpack-ai/images/generations', $site_id ),
 			2,
 			array(

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
@@ -116,7 +116,7 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 	 * @param  WP_REST_Request $request The request.
 	 */
 	public function request_gpt_completion( $request ) {
-		return Jetpack_AI_Helper::get_gpt_completion( $request['content'] );
+		return Jetpack_AI_Helper::get_gpt_completion( sanitize_textarea_field( $request['content'] ) );
 	}
 
 	/**
@@ -125,7 +125,7 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 	 * @param  WP_REST_Request $request The request.
 	 */
 	public function request_dalle_generation( $request ) {
-		return Jetpack_AI_Helper::get_dalle_generation( $request['prompt'] );
+		return Jetpack_AI_Helper::get_dalle_generation( sanitize_textarea_field( $request['prompt'] ) );
 	}
 }
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
@@ -50,6 +50,24 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 	}
 
 	/**
+	 * Checks if a given request is allowed to get AI data from WordPress.com.
+	 *
+	 * @return true|WP_Error True if the request has access, WP_Error object otherwise.
+	 */
+	public function permissions_check() {
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			// Only post editors can access the endpoints
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you are not allowed to access Jetpack AI help on this site.', 'jetpack' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+	/**
 	 * Register routes.
 	 */
 	public function register_routes() {
@@ -60,7 +78,7 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'request_gpt_completion' ),
-					'permission_callback' => array( 'Jetpack_AI_Helper', 'get_status_permission_check' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
 				),
 				'args' => array(
 					'content' => array( 'required' => true ),
@@ -75,7 +93,7 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'request_dalle_generation' ),
-					'permission_callback' => array( 'Jetpack_AI_Helper', 'get_status_permission_check' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
 				),
 				'args' => array(
 					'prompt' => array( 'required' => true ),

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
@@ -32,14 +32,7 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 		$this->wpcom_is_wpcom_only_endpoint = true;
 
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			if ( get_current_site()->id !== 1 ) {
-				// If the current WPCOM siteis not a simple site
-				return;
-			}
 			$this->is_wpcom = true;
-		} elseif ( ! ( new Automattic\Jetpack\Status\Host() )->is_woa_site() ) {
-			// If this is not an atomic site, we want to bail and not even load the endpoint for now.
-			return;
 		}
 
 		if ( ! class_exists( 'Jetpack_AI_Helper' ) ) {
@@ -65,7 +58,21 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 			);
 		}
 
-		return true;
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			// Only allow WPCOM simple sites and Atomic
+			if ( get_current_site()->id !== 1 ) {
+				return true;
+			}
+		} elseif ( ( new Automattic\Jetpack\Status\Host() )->is_woa_site() ) {
+			// If not WPCOM, we allow only of this is a WoA site
+			return true;
+		}
+
+		return new WP_Error(
+			'rest_forbidden',
+			__( 'Sorry, you are not allowed to access Jetpack AI help on this site.', 'jetpack' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
 	}
 	/**
 	 * Register routes.

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
@@ -31,6 +31,10 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 		$this->is_wpcom = false;
 
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			if ( get_current_site()->id !== 1 ) {
+				// If the current WPCOM siteis not a simple site
+				return;
+			}
 			$this->is_wpcom                     = true;
 			$this->wpcom_is_wpcom_only_endpoint = true;
 		} elseif ( ! ( new Automattic\Jetpack\Status\Host() )->is_woa_site() ) {

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
@@ -28,15 +28,15 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 	 * WPCOM_REST_API_V2_Endpoint_AI constructor.
 	 */
 	public function __construct() {
-		$this->is_wpcom = false;
+		$this->is_wpcom                     = false;
+		$this->wpcom_is_wpcom_only_endpoint = true;
 
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			if ( get_current_site()->id !== 1 ) {
 				// If the current WPCOM siteis not a simple site
 				return;
 			}
-			$this->is_wpcom                     = true;
-			$this->wpcom_is_wpcom_only_endpoint = true;
+			$this->is_wpcom = true;
 		} elseif ( ! ( new Automattic\Jetpack\Status\Host() )->is_woa_site() ) {
 			// If this is not an atomic site, we want to bail and not even load the endpoint for now.
 			return;

--- a/projects/plugins/jetpack/changelog/fix-prevent-access-to-endpoint
+++ b/projects/plugins/jetpack/changelog/fix-prevent-access-to-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Prevent access of WPCOM endpoint for other sites than WPCOM simple sites


### PR DESCRIPTION
## Proposed changes:

Prevent access to WPCOM endpoint 

## Testing instructions

On your sandbox, use

```
./bin/jetpack-downloader test jetpack  trunk
```

Make sure the AI blocks work from a WPCOM site ( sandbox your site and test ).
Following [this comment](https://github.com/Automattic/jetpack/pull/28043#issuecomment-1377546608), test that the blocks WORK on an Atomic site (or any jetpack site)

Now apply this patch:
```
./bin/jetpack-downloader reset jetpack fix/prevent-access-to-endpoint &&  ./bin/jetpack-downloader test jetpack fix/prevent-access-to-endpoint
```

Make sure the AI blocks work from a WPCOM site ( sandbox your site and test ).
But now you should not be able to make the blocks work on Atomic or Jetpack site.