### PR TITLE
VideoPress: avoid requesting unneeded preview when block mounts

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-avoid-requesting-unneeded-video-preview
+++ b/projects/packages/videopress/changelog/update-videopress-avoid-requesting-unneeded-video-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: avoid requesting unneeded preview when block mounts

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-player/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-player/index.js
@@ -95,7 +95,7 @@ export default function VideoPressPlayer( {
 		}
 
 		// Once the video is loaded, delegate the height to the player (iFrame)
-		if ( preview ) {
+		if ( preview.html ) {
 			// Hack to mitigate the flickr when the player is
 			setTimeout( () => {
 				setVideoPlayerTemporaryHeightState( 'auto' );
@@ -126,6 +126,7 @@ export default function VideoPressPlayer( {
 	// Set video is loaded as False when `html` is not available.
 	useEffect( () => {
 		if ( html ) {
+			setIsVideoPlayerLoaded( true );
 			return;
 		}
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -199,10 +199,18 @@ export default function VideoPressEdit( {
 	const { filename } = videoData;
 
 	// Get video preview status.
+	const defaultPreview = { html: null, scripts: [], width: null, height: null };
 	const { preview, isRequestingEmbedPreview } = useSelect(
 		select => {
+			if ( ! videoPressUrl ) {
+				return {
+					preview: defaultPreview,
+					isRequestingEmbedPreview: false,
+				};
+			}
+
 			return {
-				preview: select( coreStore ).getEmbedPreview( videoPressUrl ) || false,
+				preview: select( coreStore ).getEmbedPreview( videoPressUrl ) || defaultPreview,
 				isRequestingEmbedPreview:
 					select( coreStore ).isRequestingEmbedPreview( videoPressUrl ) || false,
 			};
@@ -211,9 +219,7 @@ export default function VideoPressEdit( {
 	);
 
 	// Pick video properties from preview.
-	const { html: previewHtml, scripts, width: previewWidth, height: previewHeight } = preview
-		? preview
-		: { html: null, scripts: [], width: null, height: null };
+	const { html: previewHtml, scripts, width: previewWidth, height: previewHeight } = preview;
 
 	/*
 	 * Store the preview markup and video thumbnail image
@@ -285,40 +291,50 @@ export default function VideoPressEdit( {
 	}
 
 	useEffect( () => {
-		// Attempts limit achieved. Bail early.
+		debug( 'Generating preview ➡ Attemp %o 🔥', generatingPreviewCounter );
 		if ( generatingPreviewCounter >= VIDEO_PREVIEW_ATTEMPTS_LIMIT ) {
+			debug( 'Generating preview ➡ attempts number reached out 😪', generatingPreviewCounter );
 			return cleanRegeneratingProcessTimer();
 		}
 
 		// VideoPress URL is not defined. Bail early and cleans the time.
 		if ( ! videoPressUrl ) {
+			debug( 'Generating preview ➡ No URL Provided 👋🏻' );
 			return cleanRegeneratingProcessTimer();
 		}
 
 		// Bail early (clean the timer) if the preview is already being requested.
 		if ( isRequestingEmbedPreview ) {
+			debug( 'Generating preview ➡ Requesting… ⌛' );
 			return cleanRegeneratingProcessTimer();
 		}
 
 		// Bail early (clean the timer) when preview is defined.
-		if ( preview ) {
+		if ( preview.html ) {
+			debug( 'Generating preview ➡ Preview achieved 🎉 %o', preview );
 			setGeneratingPreviewCounter( 0 ); // reset counter.
 			return cleanRegeneratingProcessTimer();
 		}
 
 		// Bail early when it has been already started.
 		if ( rePreviewAttemptTimer?.current ) {
+			debug( 'Generating preview ➡ Process already requested ⌛' );
 			return;
 		}
 
 		rePreviewAttemptTimer.current = setTimeout( () => {
 			// Abort whether the preview is already defined.
-			if ( preview ) {
+			if ( preview.html ) {
+				debug( 'Generating preview ➡ Preview already achieved 🎉 %o', preview );
 				setGeneratingPreviewCounter( 0 ); // reset counter.
 				return;
 			}
 
 			setGeneratingPreviewCounter( v => v + 1 );
+			debug(
+				'Generating preview ➡ Not obtained. Start %o attempt 💉',
+				generatingPreviewCounter + 1 // +1 because the counter is updated after the effect.
+			);
 			invalidateCachedEmbedPreview();
 		}, 2000 );
 
@@ -400,7 +416,7 @@ export default function VideoPressEdit( {
 
 	// Generating video preview.
 	if (
-		( isRequestingEmbedPreview || ! preview ) &&
+		( isRequestingEmbedPreview || ! preview.html ) &&
 		generatingPreviewCounter > 0 &&
 		generatingPreviewCounter < VIDEO_PREVIEW_ATTEMPTS_LIMIT
 	) {
@@ -418,7 +434,7 @@ export default function VideoPressEdit( {
 	}
 
 	// 5 - Generating video preview failed.
-	if ( generatingPreviewCounter >= VIDEO_PREVIEW_ATTEMPTS_LIMIT && ! preview ) {
+	if ( generatingPreviewCounter >= VIDEO_PREVIEW_ATTEMPTS_LIMIT && ! preview.html ) {
 		return (
 			<div { ...blockProps } className={ blockMainClassName }>
 				<PlaceholderWrapper

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -291,7 +291,7 @@ export default function VideoPressEdit( {
 	}
 
 	useEffect( () => {
-		debug( 'Generating preview ➡ Attemp %o 🔥', generatingPreviewCounter );
+		debug( 'Generating preview ➡ Attemp %o 💉', generatingPreviewCounter );
 		if ( generatingPreviewCounter >= VIDEO_PREVIEW_ATTEMPTS_LIMIT ) {
 			debug( 'Generating preview ➡ attempts number reached out 😪', generatingPreviewCounter );
 			return cleanRegeneratingProcessTimer();
@@ -312,7 +312,6 @@ export default function VideoPressEdit( {
 		// Bail early (clean the timer) when preview is defined.
 		if ( preview.html ) {
 			debug( 'Generating preview ➡ Preview achieved 🎉 %o', preview );
-			setGeneratingPreviewCounter( 0 ); // reset counter.
 			return cleanRegeneratingProcessTimer();
 		}
 
@@ -332,7 +331,7 @@ export default function VideoPressEdit( {
 
 			setGeneratingPreviewCounter( v => v + 1 );
 			debug(
-				'Generating preview ➡ Not obtained. Start %o attempt 💉',
+				'Generating preview ➡ Not achieved so far. Start attempt %o 🔥',
 				generatingPreviewCounter + 1 // +1 because the counter is updated after the effect.
 			);
 			invalidateCachedEmbedPreview();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Continue with https://github.com/Automattic/jetpack/pull/28296; this PR improves the getting preview process avoiding an unneeded request when the block mounts. Also, it adds some debug() logs to follow the process workflow.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: avoid requesting unneeded preview when block mounts 

### Other information:

- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set the debug() scope
```
localStorage.setItem( 'debug', 'videopress:video:edit' )
```
* Go to Block editor
* Add a new video block instance 
* Without these changes, confirm the client performs a request trying to get the preview data
<img width="1263" alt="Screen Shot 2023-01-12 at 09 40 38" src="https://user-images.githubusercontent.com/77539/212032413-48e24883-fdd8-4f7b-b016-c4cf7d28ed41.png">

* With these changes, confirm the client doesn't trigger the request
* Upload a new file
* Confirm the file is uploaded and the player renders appropriately. Take a look at the dev console.

<img width="857" alt="image" src="https://user-images.githubusercontent.com/77539/212035487-9b97231f-3260-4fc0-bc32-2295073e3531.png">

* Confirm the `Generating preview ➡ Preview achieved 🎉 ` shows once in the workflow.
