### PR TITLE
Revert PR #27958 to address conflict with WooCommerce

### DIFF
--- a/projects/plugins/jetpack/changelog/revert-atomic-menu-adjustments
+++ b/projects/plugins/jetpack/changelog/revert-atomic-menu-adjustments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Reverts PR #27958 as it conflicts with the way WooCommerce updates submenus

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
@@ -109,44 +109,6 @@
 				}
 			);
 		}
-
-		if ( jetpackAdminMenu.isAtomic ) {
-			document.querySelectorAll( 'li.wp-has-submenu.wp-not-current-submenu' ).forEach( function ( el ) {
-				const submenu = el.querySelector( '.wp-submenu' );
-				const linkElement = el.querySelector( 'a' );
-
-				el.addEventListener( 'mouseover', function() {
-					submenu.style.display = null;
-					submenu.style.top = '-1px';
-					if ( ! isElementInViewport( submenu ) ) {
-						// Repoisition the submenu to the top of the menu item.
-						submenu.style.top = ( linkElement.clientHeight - submenu.clientHeight ) + 'px';
-					}
-					linkElement.focus();
-				} );
-
-				el.addEventListener( 'mouseleave', function() {
-					submenu.style.display = 'none';
-					submenu.style.top = null;
-					if ( document.activeElement === linkElement ) {
-						linkElement.blur();
-					}
-				} );
-			} );
-		}
-	}
-
-	function isElementInViewport( el ) {
-		var rect = el.getBoundingClientRect();
-
-		return (
-			rect.top >= 0 &&
-			rect.left >= 0 &&
-			// Tries to primarily use the window viewport, but if that's not available, uses the documentElement.
-			// The innerWidth attribute must return the viewport width including the size of a rendered scroll bar (if any), or zero if there is no viewport.
-			rect.bottom <= ( window.innerHeight || document.documentElement.clientHeight ) &&
-			rect.right <= ( window.innerWidth || document.documentElement.clientWidth )
-		);
 	}
 
 	function makeAjaxRequest( method, url, contentType, body = null, callback = null ) {

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\Dashboard_Customizations;
 
 use Automattic\Jetpack\Status;
-use Automattic\Jetpack\Status\Host;
 
 /**
  * Class Base_Admin_Menu
@@ -278,7 +277,6 @@ abstract class Base_Admin_Menu {
 			array(
 				'upsellNudgeJitm'  => wp_create_nonce( 'upsell_nudge_jitm' ),
 				'jitmDismissNonce' => wp_create_nonce( 'jitm_dismiss' ),
-				'isAtomic'         => ( new Host() )->is_woa_site(),
 			)
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

As per this Slack discussion (p1673516829563649-slack-C03Q87XT1QF), the way we implemented #27958 conflicts with the way that WooCommerce (re)draws submenu items via Javascript. We want to revert that PR so we can better address the menu (re)positioning logic using a different implementation.

## Proposed changes:

* This PR reverts #27958, which added some out-of-bounds checks and repositioning logic for menus on the WordPress.com Atomic platform

### Other information:

- [N/A] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

No product discussion needed as this is a WordPress.com-specific bugfix.

## Does this pull request change what data or activity we track or use?

No changes to tracking or data.

## Testing instructions:

~~_I am going to need some help here, possibly from @PanosSynetos, to get these steps 100 correct._~~ Done - Steps updated

* Ensure you have a WordPress.com Atomic site with WooCommerce installed
* Navigate to `wp-admin/admin.php?page=wc-admin` and reload the page
* Click on `Analytics` , WooCommerce router should kick in and load the Analytics page (without a full page load)
* The `Analytics` submenu will be visible
* Move your cursor away from the `Analytics` submenu, and it will disappear


https://user-images.githubusercontent.com/2484390/212049530-9ac5c179-8883-4dc6-abd0-90d8517bc700.mp4

---

* Don't reload, or move away - Resize your screen to that of a 13-14" MacBook (or make the window shorter so that the whole menu doesn't fit in)
* Scroll down all the way to the bottom, and hover over `Analytics`
* The menu disappears


https://user-images.githubusercontent.com/2484390/212050784-98746bf3-904d-4d84-8cf0-1110bb950066.mp4


---


* Use the Jetpack Beta plugin to install the code from this branch on your site
* Navigate to the same WooCommerce page in wp-admin and repeat the steps from above
* Verify that the submenu appears correctly and works as expected (without the above hiccups)
* You may see some menus disappear off the bottom of the screen, as we are removing the fixes added in #27958.