### PR TITLE
Blaze: do not display the UI on private or unlaunched sites.

### DIFF
--- a/projects/packages/blaze/changelog/update-blaze-conditions-private-site
+++ b/projects/packages/blaze/changelog/update-blaze-conditions-private-site
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Do not display the Blaze UI on private or unlaunched sites.

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -64,7 +64,8 @@ class Blaze {
 	 */
 	public static function should_initialize() {
 		$should_initialize = true;
-		$user_data         = ( defined( 'IS_WPCOM' ) && IS_WPCOM )
+		$is_wpcom          = defined( 'IS_WPCOM' ) && IS_WPCOM;
+		$user_data         = $is_wpcom
 			? array( 'user_locale' => get_user_locale() )
 			: ( new Jetpack_Connection() )->get_connected_user_data();
 
@@ -92,8 +93,22 @@ class Blaze {
 
 		// Only show the UI on WordPress.com Simple and WoA sites for now.
 		if (
-			! ( defined( 'IS_WPCOM' ) && IS_WPCOM )
+			! $is_wpcom
 			&& ! ( new Host() )->is_woa_site()
+		) {
+			$should_initialize = false;
+		}
+
+		/*
+		 * Do not show the UI on private sites
+		 * nor on sites that have not been launched yet.
+		 */
+		if (
+			'-1' === get_option( 'blog_public' )
+			|| (
+				( function_exists( 'site_is_coming_soon' ) && \site_is_coming_soon() )
+				|| (bool) get_option( 'wpcom_public_coming_soon' )
+			)
 		) {
 			$should_initialize = false;
 		}


### PR DESCRIPTION
## Proposed changes:

This is mostly relevant on WordPress.com sites. We do not need to promote posts on sites where posts are not publicly accessible.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* 1386-gh-dotcom-forge

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Test on a WordPress.com simple site (you can use D97738-code for that) or a WoA site that is set to public.
* Go to the Post list, in wp-admin: `wp-admin/edit.php`
* You should see the "Blaze" option when moving your mouse over a post row (if the post is published).
* Visit the Site's Visibility settings under Settings > General in Calypso.
* Switch the site to private.
* Back to the post list, the "Blaze" option should now be gone.
* Visit the Visibility settings again, and switch the site to "coming soon".
* Back to the post list, you should still not see the Blaze option.
