### PR TITLE
Add viewers to /users endpoint when include_viewers is true

### DIFF
--- a/projects/plugins/jetpack/changelog/add-include-viewers-in-users
+++ b/projects/plugins/jetpack/changelog/add-include-viewers-in-users
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Adds a include_viewer parameter to the /sites/$site_id/users endpoint.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -16,13 +16,13 @@ new WPCOM_JSON_API_List_Users_Endpoint(
 		),
 
 		'query_parameters'     => array(
-			'number'         => '(int=20) Limit the total number of authors returned.',
-			'offset'         => '(int=0) The first n authors to be skipped in the returned array.',
-			'order'          => array(
+			'number'          => '(int=20) Limit the total number of authors returned.',
+			'offset'          => '(int=0) The first n authors to be skipped in the returned array.',
+			'order'           => array(
 				'DESC' => 'Return authors in descending order.',
 				'ASC'  => 'Return authors in ascending order.',
 			),
-			'order_by'       => array(
+			'order_by'        => array(
 				'ID'           => 'Order by ID (default).',
 				'login'        => 'Order by username.',
 				'nicename'     => 'Order by nicename.',
@@ -32,11 +32,12 @@ new WPCOM_JSON_API_List_Users_Endpoint(
 				'display_name' => 'Order by display name.',
 				'post_count'   => 'Order by number of posts published.',
 			),
-			'authors_only'   => '(bool) Set to true to fetch authors only',
-			'type'           => "(string) Specify the post type to query authors for. Only works when combined with the `authors_only` flag. Defaults to 'post'. Post types besides post and page need to be whitelisted using the <code>rest_api_allowed_post_types</code> filter.",
-			'search'         => '(string) Find matching users.',
-			'search_columns' => "(array) Specify which columns to check for matching users. Can be any of 'ID', 'user_login', 'user_email', 'user_url', 'user_nicename', and 'display_name'. Only works when combined with `search` parameter.",
-			'role'           => '(string) Specify a specific user role to fetch.',
+			'authors_only'    => '(bool) Set to true to fetch authors only',
+			'include_viewers' => '(bool) Set to true to include viewers for Simple sites',
+			'type'            => "(string) Specify the post type to query authors for. Only works when combined with the `authors_only` flag. Defaults to 'post'. Post types besides post and page need to be whitelisted using the <code>rest_api_allowed_post_types</code> filter.",
+			'search'          => '(string) Find matching users.',
+			'search_columns'  => "(array) Specify which columns to check for matching users. Can be any of 'ID', 'user_login', 'user_email', 'user_url', 'user_nicename', and 'display_name'. Only works when combined with `search` parameter.",
+			'role'            => '(string) Specify a specific user role to fetch.',
 		),
 
 		'response_format'      => array(
@@ -162,11 +163,14 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 		remove_filter( 'user_search_columns', array( $this, 'api_user_override_search_columns' ) );
 
-		$return = array();
+		$return          = array();
+		$include_viewers = (bool) $args['include_viewers'];
 		foreach ( array_keys( $this->response_format ) as $key ) {
 			switch ( $key ) {
 				case 'found':
-					$return[ $key ] = (int) $user_query->get_total();
+					$user_count     = (int) $user_query->get_total();
+					$viewer_count   = $include_viewers ? (int) get_count_private_blog_users( $blog_id ) : 0;
+					$return[ $key ] = $user_count + $viewer_count;
 					break;
 				case 'users':
 					$users        = array();
@@ -183,7 +187,41 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 						}
 					}
 
-					$return[ $key ] = $users;
+					$page    = ( (int) ( $args['offset'] / $args['number'] ) ) + 1;
+					$viewers = $include_viewers ? get_private_blog_users(
+						$blog_id,
+						array(
+							'page'     => $page,
+							'per_page' => $args['number'],
+						)
+					) : array();
+					$viewers = array_map( array( $this, 'get_author' ), $viewers );
+
+					// we restrict search field to name when include_viewers is true.
+					if ( $include_viewers && ! empty( $args['search'] ) ) {
+						$viewers = array_filter(
+							$viewers,
+							function ( $viewer ) use ( $args ) {
+								// remove special database search characters from search term
+								$search_term = str_replace( '*', '', $args['search'] );
+								return strpos( $viewer->name, $search_term ) !== false;
+							}
+						);
+					}
+
+					$combined_users = array_merge( $users, $viewers );
+
+					// When viewers are included, we ignore the order & orderby parameters.
+					if ( $include_viewers ) {
+						usort(
+							$combined_users,
+							function ( $a, $b ) {
+								return strcmp( $a->name, $b->name );
+							}
+						);
+					}
+
+					$return[ $key ] = $combined_users;
 					break;
 			}
 		}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -217,7 +217,7 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 						usort(
 							$combined_users,
 							function ( $a, $b ) {
-								return strcmp( $a->name, $b->name );
+								return strcmp( strtolower( $a->name ), strtolower( $b->name ) );
 							}
 						);
 					}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -164,7 +164,7 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 		remove_filter( 'user_search_columns', array( $this, 'api_user_override_search_columns' ) );
 
 		$is_wpcom        = defined( 'IS_WPCOM' ) && IS_WPCOM;
-		$include_viewers = (bool) $args['include_viewers'] && $is_wpcom;
+		$include_viewers = (bool) isset( $args['include_viewers'] ) && $args['include_viewers'] && $is_wpcom;
 
 		$page    = ( (int) ( $args['offset'] / $args['number'] ) ) + 1;
 		$viewers = $include_viewers ? get_private_blog_users(

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -163,8 +163,8 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 		remove_filter( 'user_search_columns', array( $this, 'api_user_override_search_columns' ) );
 
-		$return          = array();
-		$include_viewers = (bool) $args['include_viewers'];
+		$is_wpcom        = defined( 'IS_WPCOM' ) && IS_WPCOM;
+		$include_viewers = (bool) $args['include_viewers'] && $is_wpcom;
 
 		$page    = ( (int) ( $args['offset'] / $args['number'] ) ) + 1;
 		$viewers = $include_viewers ? get_private_blog_users(
@@ -188,6 +188,7 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 			);
 		}
 
+		$return = array();
 		foreach ( array_keys( $this->response_format ) as $key ) {
 			switch ( $key ) {
 				case 'found':


### PR DESCRIPTION
## Proposed changes:

PT: pcmemI-1uJ-p2
Specific finding that led to this diff: pcmemI-1wa-p2#comment-1276

For simple sites, our new team page does not display viewers currently. This is because for simple sites, viewers are an entirely different implementation in a different table, and is normally accessed through a corresponding `/sites/$site_id/viewers` endpoint.

Since it's clumsy on the frontend to call these two endpoints and combine data, we're introducing a new `include_viewers` argument to `/sites/$site_id/users/` which when set to true:

- only supports searching based on name for viewer
- ignores order and order by parameters for the entire list and sorts by name

This implementation should satisfy our current requirement while being entirely backwards compatible.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
NA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Use the [API console](https://developer.wordpress.com/docs/api/console/) to test.
* Here's a full example request: `/sites/205868500/users?include_viewers=1&http_envelope=1&number=100&order=ASC&order_by=display_name&search=%2Aa8c%2A&search_columns%5B%5D=display_name&search_columns%5B%5D=user_login&offset=0 that includes a search parameter as formatted by the frontend.`