### PR TITLE
Reading Settings: Add `default_option_subscription_options` filter

### DIFF
--- a/projects/plugins/jetpack/changelog/add-default_option_subscription_options-filter
+++ b/projects/plugins/jetpack/changelog/add-default_option_subscription_options-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add default_option_subscription_options filter

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -440,11 +440,11 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'launchpad_screen'                 => (string) get_option( 'launchpad_screen' ),
 						'wpcom_featured_image_in_email'    => (bool) get_option( 'wpcom_featured_image_in_email' ),
 						'wpcom_gifting_subscription'       => (bool) get_option( 'wpcom_gifting_subscription', $this->get_wpcom_gifting_subscription_default() ),
-						'subscription_options'             => (array) get_option( 'subscription_options', array() ),
 						'wpcom_subscription_emails_use_excerpt' => $this->get_wpcom_subscription_emails_use_excerpt_option(),
 						'show_on_front'                    => (string) get_option( 'show_on_front' ),
 						'page_on_front'                    => (string) get_option( 'page_on_front' ),
 						'page_for_posts'                   => (string) get_option( 'page_for_posts' ),
+						'subscription_options'             => (array) get_option( 'subscription_options' ),
 					);
 
 					if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -594,7 +594,7 @@ class Jetpack_Subscriptions {
 	 * Reeturn merged `subscription_options` option with module default settings.
 	 */
 	public function get_settings() {
-		return wp_parse_args( (array) get_option( 'subscription_options', array() ), $this->get_default_settings() );
+		return wp_parse_args( (array) get_option( 'subscription_options' ), $this->get_default_settings() );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -998,3 +998,32 @@ function jetpack_blog_subscriptions_init() {
 }
 
 add_action( 'widgets_init', 'jetpack_blog_subscriptions_init' );
+
+/**
+ * Sets the default value for `subscription_options` site option.
+ *
+ * This default value is available across Simple, Atomic and Jetpack sites,
+ * including the /sites/$site/settings endpoint.
+ *
+ * @param array  $default Default `subscription_options` array.
+ * @param string $option Option name.
+ * @param bool   $passed_default Whether `get_option()` passed a default value.
+ *
+ * @return array Default value of `subscription_options`.
+ */
+function subscription_options_fallback( $default, $option, $passed_default ) {
+	if ( $passed_default ) {
+		return $default;
+	}
+
+	$site_url    = get_home_url();
+	$display_url = preg_replace( '(^https?://)', '', untrailingslashit( $site_url ) );
+
+	return array(
+		/* translators: Both %1$s and %2$s is site address */
+		'invitation'     => sprintf( __( "Howdy,\nYou recently subscribed to <a href='%1\$s'>%2\$s</a> and we need to verify the email you provided. Once you confirm below, you'll be able to receive and read new posts.\n\nIf you believe this is an error, ignore this message and nothing more will happen.", 'jetpack' ), $site_url, $display_url ),
+		'comment_follow' => __( "Howdy.\n\nYou recently followed one of my posts. This means you will receive an email when new comments are posted.\n\nTo activate, click confirm below. If you believe this is an error, ignore this message and we'll never bother you again.", 'jetpack' ),
+	);
+}
+
+add_filter( 'default_option_subscription_options', 'subscription_options_fallback', 10, 3 );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/71711

## Proposed changes:
The purpose of this PR is to add a new `default_option_{$option}` filter that introduces the default value for `subscription_options` site option.

This new default value will be available throughout Simple, Atomic and Jetpack sites, including the `/sites/$site/settings` endpoint.

![Markup on 2023-01-12 at 17:01:39](https://user-images.githubusercontent.com/25105483/212117369-e36eb276-2ec3-47c6-8e3a-fd577d2cb28d.png)


ℹ️ The PR does not remove the existing code duplications we discussed in p1673520270548479/1673515812.459759-slack-CBG1CP4EN. This is something we will address in a separate PR.

This also means that the default value used in the emails:

![Markup on 2023-01-12 at 16:16:25](https://user-images.githubusercontent.com/25105483/212105619-8df33e86-b910-4cbe-9422-63dafc2405fa.png)

 is still being loaded from the original `get_default_settings()` function. This will be addressed in a separate PR as well. Here is the related task for both issues: https://github.com/Automattic/wp-calypso/issues/72013.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
- Slack: p1673520270548479/1673515812.459759-slack-CBG1CP4EN
- project board: pdDOJh-17o-p2
- related P2 post: pdDOJh-1j6-p2 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No, it does not.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a new site where the settings related to the `subscription_options` haven't been touched yet ("Welcome Email" & "Comment follow email").

For Atomic and Jetpack sites make sure that the Subscriptions module is enabled. This can be done in _Calypso → Settings → Discussion_ (page bottom):

![Markup on 2023-01-12 at 16:27:54](https://user-images.githubusercontent.com/25105483/212108774-4f88df96-a244-47a0-8971-1616af97e321.png)

Or in _WP Admin → Jetpack → Settings → Discussion_.

2. Sandbox `public-api.wordpress.com`. When testing with Simple site, it needs to be sandboxed as well. This is necessary to observe the changes in the WP Admin of the site.
3. Apply the PR to your sandbox. You can use [the script in the comment below](https://github.com/Automattic/jetpack/pull/28320#issuecomment-1380491385) for that.
4. For testing with Atomic and Jetpack sites, the following resources may help: PCYsg-eg0-p2 (Jetpack) and pb5gDS-1rQ-p2 (Atomic). Jurassic Ninja can be used for emulating Jetpack site. Please note the site needs to be connected to your WordPress.com account.
5. In the staging Calypso environment navigate to `https://wordpress.com/settings/reading/[site-address]`. Both "Welcome email text" and "Comment follow email text" text areas should contain the default values.
6. The same should apply to the related text areas in `/wp-admin/options-reading.php`.
7. If you prefer, you can also change the default values in the source code and build and sync everything. Once you reload the pages, your custom default values should appear. This can help to confirm the PR is working as expected - since the default values in this PR are the same as they are in production currently - so the change in WP Admin cannot be noticed until we change the default values in the source to something else. 🙂 