### PR TITLE
Status: add 2 new methods to detect whether a site is private

### DIFF
--- a/projects/packages/status/changelog/add-status-private-coming-soon-site
+++ b/projects/packages/status/changelog/add-status-private-coming-soon-site
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add 2 new methods to detect whether a site is private or not.

--- a/projects/packages/status/composer.json
+++ b/projects/packages/status/composer.json
@@ -45,7 +45,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "1.15.x-dev"
+			"dev-trunk": "1.16.x-dev"
 		}
 	}
 }

--- a/projects/packages/status/src/class-status.php
+++ b/projects/packages/status/src/class-status.php
@@ -315,6 +315,43 @@ class Status {
 	}
 
 	/**
+	 * Whether the site is currently private or not.
+	 * On WordPress.com and WoA, sites can be marked as private
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool True if the site is private.
+	 */
+	public function is_private_site() {
+		$ret = Cache::get( 'is_private_site' );
+		if ( null === $ret ) {
+			$is_private_site = '-1' === get_option( 'blog_public' );
+			Cache::set( 'is_private_site', $is_private_site );
+			return $is_private_site;
+		}
+		return $ret;
+	}
+
+	/**
+	 * Whether the site is currently unlaunched or not.
+	 * On WordPress.com and WoA, sites can be marked as "coming soon", aka unlaunched
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool True if the site is not launched.
+	 */
+	public function is_coming_soon() {
+		$ret = Cache::get( 'is_coming_soon' );
+		if ( null === $ret ) {
+			$is_coming_soon = (bool) ( function_exists( 'site_is_coming_soon' ) && \site_is_coming_soon() )
+				|| get_option( 'wpcom_public_coming_soon' );
+			Cache::set( 'is_coming_soon', $is_coming_soon );
+			return $is_coming_soon;
+		}
+		return $ret;
+	}
+
+	/**
 	 * Returns the site slug suffix to be used as part of Calypso URLs.
 	 *
 	 * Strips http:// or https:// from a url, replaces forward slash with ::.

--- a/projects/packages/status/tests/php/test-status.php
+++ b/projects/packages/status/tests/php/test-status.php
@@ -538,4 +538,44 @@ class Test_Status extends TestCase {
 		);
 	}
 
+	/**
+	 * Test that is_private_site returns true when get_option is set to -1.
+	 *
+	 * @covers Automattic\Jetpack\Status::is_private_site
+	 */
+	public function test_is_private_site() {
+		Functions\when( 'get_option' )->justReturn( '-1' );
+
+		$this->assertTrue( $this->status_obj->is_private_site() );
+	}
+
+	/**
+	 * Test that is_coming_soon returns true when a site is set to coming soon.
+	 *
+	 * @covers Automattic\Jetpack\Status::is_coming_soon
+	 * @dataProvider get_coming_soon_status
+	 *
+	 * @param bool $site_is_coming_soon      Site is coming soon value.
+	 * @param int  $wpcom_public_coming_soon wpcom_public_coming_soon option value.
+	 * @param bool $expected                 Expected result.
+	 */
+	public function test_is_coming_soon( $site_is_coming_soon, $wpcom_public_coming_soon, $expected ) {
+		Functions\when( 'site_is_coming_soon' )->justReturn( $site_is_coming_soon );
+		Functions\when( 'get_option' )->justReturn( $wpcom_public_coming_soon );
+		$this->assertSame( $expected, $this->status_obj->is_coming_soon() );
+	}
+
+	/**
+	 * Mock data for test_is_coming_soon
+	 *
+	 * @return array
+	 */
+	public function get_coming_soon_status() {
+		return array(
+			'Jetpack public site'       => array( null, false, false ),
+			'WoA public site'           => array( false, false, false ),
+			'WoA private site'          => array( true, false, true ),
+			'wpcom simple private site' => array( null, true, true ),
+		);
+	}
 }

--- a/projects/plugins/backup/changelog/add-status-private-coming-soon-site
+++ b/projects/plugins/backup/changelog/add-status-private-coming-soon-site
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1182,7 +1182,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "295e13cbb1b584a5435c8a467773bffd5f90a5e2"
+                "reference": "c558b54d0365cf2d4dbe04ce0884afd1cf20d7a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -1200,7 +1200,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.15.x-dev"
+                    "dev-trunk": "1.16.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/boost/changelog/add-status-private-coming-soon-site
+++ b/projects/plugins/boost/changelog/add-status-private-coming-soon-site
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1096,7 +1096,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "295e13cbb1b584a5435c8a467773bffd5f90a5e2"
+                "reference": "c558b54d0365cf2d4dbe04ce0884afd1cf20d7a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -1114,7 +1114,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.15.x-dev"
+                    "dev-trunk": "1.16.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/add-status-private-coming-soon-site
+++ b/projects/plugins/jetpack/changelog/add-status-private-coming-soon-site
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2076,7 +2076,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "295e13cbb1b584a5435c8a467773bffd5f90a5e2"
+                "reference": "c558b54d0365cf2d4dbe04ce0884afd1cf20d7a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -2094,7 +2094,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.15.x-dev"
+                    "dev-trunk": "1.16.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/changelog/add-status-private-coming-soon-site
+++ b/projects/plugins/protect/changelog/add-status-private-coming-soon-site
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1161,7 +1161,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "295e13cbb1b584a5435c8a467773bffd5f90a5e2"
+                "reference": "c558b54d0365cf2d4dbe04ce0884afd1cf20d7a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -1179,7 +1179,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.15.x-dev"
+                    "dev-trunk": "1.16.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/changelog/add-status-private-coming-soon-site
+++ b/projects/plugins/search/changelog/add-status-private-coming-soon-site
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1240,7 +1240,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "295e13cbb1b584a5435c8a467773bffd5f90a5e2"
+                "reference": "c558b54d0365cf2d4dbe04ce0884afd1cf20d7a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -1258,7 +1258,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.15.x-dev"
+                    "dev-trunk": "1.16.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/add-status-private-coming-soon-site
+++ b/projects/plugins/social/changelog/add-status-private-coming-soon-site
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1229,7 +1229,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "295e13cbb1b584a5435c8a467773bffd5f90a5e2"
+                "reference": "c558b54d0365cf2d4dbe04ce0884afd1cf20d7a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -1247,7 +1247,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.15.x-dev"
+                    "dev-trunk": "1.16.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/starter-plugin/changelog/add-status-private-coming-soon-site
+++ b/projects/plugins/starter-plugin/changelog/add-status-private-coming-soon-site
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1097,7 +1097,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "295e13cbb1b584a5435c8a467773bffd5f90a5e2"
+                "reference": "c558b54d0365cf2d4dbe04ce0884afd1cf20d7a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -1115,7 +1115,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.15.x-dev"
+                    "dev-trunk": "1.16.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/videopress/changelog/add-status-private-coming-soon-site
+++ b/projects/plugins/videopress/changelog/add-status-private-coming-soon-site
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1161,7 +1161,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "295e13cbb1b584a5435c8a467773bffd5f90a5e2"
+                "reference": "c558b54d0365cf2d4dbe04ce0884afd1cf20d7a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -1179,7 +1179,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.15.x-dev"
+                    "dev-trunk": "1.16.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
## Proposed changes:

* This was suggested in #28315. We should be able to use this in different places in the Jetpack plugin. I'll open a follow-up PR to start using the methods once this is merged.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Do the tests pass?
