### PR TITLE
Connection: add support for the 'connection_disabled' error code

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -78,6 +78,7 @@ class JetpackStateNotices extends React.Component {
 				);
 				break;
 			case 'site_blacklisted':
+			case 'connection_disabled':
 				message = createInterpolateElement(
 					__(
 						"This site can't be connected to WordPress.com because it violates our <a>Terms of Service</a>.",

--- a/projects/plugins/jetpack/changelog/update-deprecate-site-blacklisted
+++ b/projects/plugins/jetpack/changelog/update-deprecate-site-blacklisted
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Add support for the 'connection_disabled' error code.


### PR DESCRIPTION
## Proposed changes:
* add support for the `connection_disabled` error code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p9dueE-6oT-p2

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
Make sure the code looks good, nothing to test at the moment.
We'll test it in the next PR while removing the old error code.