### PR TITLE
VideoPress: tweak the footer of the uploader component

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-tweak-uploader-component-footer
+++ b/projects/packages/videopress/changelog/update-videopress-tweak-uploader-component-footer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: tweak the footer of the uploader component

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/style.scss
@@ -9,9 +9,6 @@
 	align-items: center;
 	justify-content: space-between;
 	border-top: 1px solid $gray-200;
-	padding: 1em;
-	margin: 0 -1em -1em;
-	min-height: 27px;
 	gap: 16px;
 
 	&__file-info {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { Button, Spinner, TextControl } from '@wordpress/components';
+import { Button, TextControl } from '@wordpress/components';
 import { useDebounce } from '@wordpress/compose';
 import { useState, useEffect } from '@wordpress/element';
 import { escapeHTML } from '@wordpress/escape-html';
@@ -199,63 +199,55 @@ const UploaderProgress = ( {
 			/>
 
 			<div className="videopress-uploader-progress">
-				{ uploadedVideoData ? (
+				{ roundedProgress < 100 ? (
 					<>
-						<span>{ __( 'Upload Complete!', 'jetpack-videopress-pkg' ) } 🎉</span>
-						<Button
-							variant="primary"
-							onClick={ handleDoneUpload }
-							disabled={ isFinishingUpdate }
-							isBusy={ isFinishingUpdate }
-						>
-							{ __( 'Done', 'jetpack-videopress-pkg' ) }
-						</Button>
+						<div className="videopress-uploader-progress__file-info">
+							<div className="videopress-uploader-progress__progress">
+								<div className="videopress-uploader-progress__progress-loaded" style={ cssWidth } />
+							</div>
+							<div className="videopress-upload__percent-complete">
+								{ sprintf(
+									/* translators: Placeholder is an upload progress percenatage number, from 0-100. */
+									__( 'Uploading (%1$s%%)', 'jetpack-videopress-pkg' ),
+									roundedProgress
+								) }
+							</div>
+							<div className="videopress-uploader-progress__file-size">{ fileSizeLabel }</div>
+						</div>
+						{ isReplacing && (
+							<div className="videopress-uploader-progress__actions">
+								<Button onClick={ onReplaceCancel } variant="tertiary" isDestructive>
+									{ __( 'Cancel', 'jetpack-videopress-pkg' ) }
+								</Button>
+							</div>
+						) }
+						<div className="videopress-uploader-progress__actions">
+							{ roundedProgress < 100 && (
+								<Button
+									variant="tertiary"
+									onClick={ onPauseOrResume }
+									disabled={ ! supportPauseOrResume }
+								>
+									{ paused ? resumeText : pauseText }
+								</Button>
+							) }
+						</div>
 					</>
 				) : (
 					<>
-						{ roundedProgress < 100 ? (
-							<>
-								<div className="videopress-uploader-progress__file-info">
-									<div className="videopress-uploader-progress__progress">
-										<div
-											className="videopress-uploader-progress__progress-loaded"
-											style={ cssWidth }
-										/>
-									</div>
-									<div className="videopress-upload__percent-complete">
-										{ sprintf(
-											/* translators: Placeholder is an upload progress percenatage number, from 0-100. */
-											__( 'Uploading (%1$s%%)', 'jetpack-videopress-pkg' ),
-											roundedProgress
-										) }
-									</div>
-									<div className="videopress-uploader-progress__file-size">{ fileSizeLabel }</div>
-								</div>
-								{ isReplacing && (
-									<div className="videopress-uploader-progress__actions">
-										<Button variant="link" onClick={ onReplaceCancel } isDestructive>
-											{ __( 'Cancel', 'jetpack-videopress-pkg' ) }
-										</Button>
-									</div>
-								) }
-								<div className="videopress-uploader-progress__actions">
-									{ roundedProgress < 100 && (
-										<Button
-											variant="link"
-											onClick={ onPauseOrResume }
-											disabled={ ! supportPauseOrResume }
-										>
-											{ paused ? resumeText : pauseText }
-										</Button>
-									) }
-								</div>
-							</>
+						{ uploadedVideoData ? (
+							<span>{ __( 'Upload Complete!', 'jetpack-videopress-pkg' ) } 🎉</span>
 						) : (
-							<>
-								<span>{ __( 'Finishing up …', 'jetpack-videopress-pkg' ) } 🎬</span>
-								<Spinner />
-							</>
+							<span>{ __( 'Finishing up …', 'jetpack-videopress-pkg' ) } 🎬</span>
 						) }
+						<Button
+							variant="primary"
+							onClick={ handleDoneUpload }
+							disabled={ ! uploadedVideoData || isFinishingUpdate }
+							isBusy={ ! uploadedVideoData || isFinishingUpdate }
+						>
+							{ __( 'Done', 'jetpack-videopress-pkg' ) }
+						</Button>
 					</>
 				) }
 			</div>

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
@@ -3,6 +3,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { Button, Spinner, TextControl } from '@wordpress/components';
+import { useDebounce } from '@wordpress/compose';
 import { useState, useEffect } from '@wordpress/element';
 import { escapeHTML } from '@wordpress/escape-html';
 import { __, sprintf } from '@wordpress/i18n';
@@ -80,6 +81,10 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 		} );
 	};
 
+	const debouncedSsendUpdatePoster = useDebounce( posterData => {
+		sendUpdatePoster( posterData );
+	}, 1000 );
+
 	const sendUpdateTitleRequest = () => {
 		return updateMeta( { title } );
 	};
@@ -119,12 +124,12 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 		}
 
 		if ( videoPosterImageData ) {
-			return sendUpdatePoster( { poster_attachment_id: videoPosterImageData?.id } );
+			return debouncedSsendUpdatePoster( { poster_attachment_id: videoPosterImageData?.id } );
 		}
 
 		// Check if videoFrameMs is not undefined or null instead of bool check to allow 0ms. selection
 		if ( 'undefined' !== typeof videoFrameMs && null !== videoFrameMs ) {
-			sendUpdatePoster( { at_time: videoFrameMs, is_millisec: true } );
+			debouncedSsendUpdatePoster( { at_time: videoFrameMs, is_millisec: true } );
 		}
 	}, [ videoPosterImageData, videoFrameMs, guid ] );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: tweak the footer of the uploader component. Debounce the request to generate the poster.

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a new video block instance
* Start to upload a new file
* Confirm it works as expected
* Confirm there isn't visual in the transition between uploading and finishing statuses

Status | Before | After
------|--------|-----
Uploading | <img width="544" alt="image" src="https://user-images.githubusercontent.com/77539/212274175-5b07f23f-e3cc-4280-bfa0-36f3f48253a7.png"> | <img width="549" alt="image" src="https://user-images.githubusercontent.com/77539/212273909-d840c12d-72ee-4bdb-8b88-67a18f3fe058.png">
Finishing | <img width="532" alt="image" src="https://user-images.githubusercontent.com/77539/212274280-fe03c69c-6650-450d-97e2-01a50bdc49dd.png"> | <img width="547" alt="image" src="https://user-images.githubusercontent.com/77539/212273571-e01da26c-8139-4351-8d67-658bd5694f17.png">

