### PR TITLE
[Jetpack AI] Easier enabling for testing, forums link

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -68,6 +68,13 @@ class Jetpack_AI_Helper {
 			$default = true;
 		}
 
+		/**
+		 * Filter whether the AI features are enabled in the Jetpack plugin.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool $default Are AI features enabled? Defaults to false.
+		 */
 		return apply_filters( 'jetpack_ai_enabled', $default );
 	}
 

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -56,6 +56,22 @@ class Jetpack_AI_Helper {
 	}
 
 	/**
+	 * Return true if these features should be active on the current site.
+	 * Currently, it's limited to WPCOM Simple and Atomic.
+	 */
+	public static function is_enabled() {
+		$default = false;
+
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$default = true;
+		} elseif ( ( new Automattic\Jetpack\Status\Host() )->is_woa_site() ) {
+			$default = true;
+		}
+
+		return apply_filters( 'jetpack_ai_enabled', $default );
+	}
+
+	/**
 	 * Get the name of the transient for image generation. Unique per prompt and allows for reuse of results for the same prompt across entire WPCOM.
 	 * I expext "puppy" to always be from cache.
 	 *

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
@@ -36,7 +36,7 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 		}
 
 		if ( ! \Jetpack_AI_Helper::is_enabled() ) {
-			return false;
+			return;
 		}
 
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
@@ -28,18 +28,15 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 	 * WPCOM_REST_API_V2_Endpoint_AI constructor.
 	 */
 	public function __construct() {
-		$this->is_wpcom = false;
-
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			$this->is_wpcom                     = true;
-			$this->wpcom_is_wpcom_only_endpoint = true;
-		} elseif ( ! ( new Automattic\Jetpack\Status\Host() )->is_woa_site() ) {
-			// If this is not an atomic site, we want to bail and not even load the endpoint for now.
-			return;
-		}
+		$this->is_wpcom                     = true;
+		$this->wpcom_is_wpcom_only_endpoint = true;
 
 		if ( ! class_exists( 'Jetpack_AI_Helper' ) ) {
 			require_once JETPACK__PLUGIN_DIR . '_inc/lib/class-jetpack-ai-helper.php';
+		}
+
+		if ( ! \Jetpack_AI_Helper::is_enabled() ) {
+			return false;
 		}
 
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );

--- a/projects/plugins/jetpack/changelog/jetpack-ai-block-tweaks
+++ b/projects/plugins/jetpack/changelog/jetpack-ai-block-tweaks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+AI Features now have a link to the Forums thread to gather feedback, different icon and simplified way of enabling for testing

--- a/projects/plugins/jetpack/extensions/blocks/ai-image/ai-image.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-image/ai-image.php
@@ -10,7 +10,6 @@
 namespace Automattic\Jetpack\Extensions\AIImage;
 
 use Automattic\Jetpack\Blocks;
-use Automattic\Jetpack\Status\Host;
 use Jetpack_Gutenberg;
 
 const FEATURE_NAME = 'ai-image';
@@ -22,12 +21,18 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
-	if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || ( new Host() )->is_woa_site() ) {
-		Blocks::jetpack_register_block(
-			BLOCK_NAME,
-			array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
-		);
+	if ( ! class_exists( 'Jetpack_AI_Helper' ) ) {
+		require_once JETPACK__PLUGIN_DIR . '_inc/lib/class-jetpack-ai-helper.php';
 	}
+
+	if ( ! \Jetpack_AI_Helper::is_enabled() ) {
+		return;
+	}
+
+	Blocks::jetpack_register_block(
+		BLOCK_NAME,
+		array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
+	);
 }
 add_action( 'init', __NAMESPACE__ . '\register_block' );
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-image/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-image/edit.js
@@ -105,7 +105,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 					</Flex>
 				</Placeholder>
 			) }
-			{ ! errorMessage && ! attributes.requestedPrompt && (
+			{ ! errorMessage && ! loadingImages && resultImages.length === 0 && (
 				<Placeholder label={ __( 'AI Image', 'jetpack' ) }>
 					<div>
 						<TextareaControl

--- a/projects/plugins/jetpack/extensions/blocks/ai-image/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-image/index.js
@@ -1,4 +1,3 @@
-import { useBlockProps } from '@wordpress/block-editor';
 import { ExternalLink } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
@@ -71,10 +70,7 @@ export const settings = {
 	},
 	edit,
 	/* @TODO Write the block editor output */
-	save: args => {
-		const blockProps = useBlockProps.save();
-		return <div { ...blockProps }>{ args.attributes.content }</div>;
-	},
+	save: () => '',
 	attributes,
 	example: {
 		attributes: {

--- a/projects/plugins/jetpack/extensions/blocks/ai-image/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-image/index.js
@@ -1,3 +1,4 @@
+import { getRedirectUrl } from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
@@ -29,7 +30,7 @@ export const settings = {
 					'jetpack'
 				) }
 			</p>
-			<ExternalLink href="https://en.forums.wordpress.com/?post_type=topic&p=3907816">
+			<ExternalLink href={ getRedirectUrl( 'jetpack_ai_feedback' ) }>
 				{ __( 'Share your feedback.', 'jetpack' ) }
 			</ExternalLink>
 		</Fragment>

--- a/projects/plugins/jetpack/extensions/blocks/ai-image/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-image/index.js
@@ -1,4 +1,5 @@
 import { useBlockProps } from '@wordpress/block-editor';
+import { ExternalLink } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { getIconColor } from '../../shared/block-icons';
@@ -19,21 +20,32 @@ export const settings = {
 		<Fragment>
 			<p>
 				{ __(
-					'Automatically generate an illustration for your post, powered by AI magic. We are experimenting with this feature and can tweak or remove it at any point.',
+					'Automatically generate an illustration for your post, powered by AI magic.',
 					'jetpack'
 				) }
 			</p>
+			<p>
+				{ __(
+					'We are experimenting with this feature and can tweak or remove it at any point.',
+					'jetpack'
+				) }
+			</p>
+			<ExternalLink href="https://en.forums.wordpress.com/?post_type=topic&p=3907816">
+				{ __( 'Share your feedback.', 'jetpack' ) }
+			</ExternalLink>
 		</Fragment>
 	),
 	icon: {
-		src: 'welcome-write-blog',
+		src: 'superhero',
 		foreground: getIconColor(),
 	},
 	category: 'media',
 	keywords: [
 		_x( 'AI', 'block search term', 'jetpack' ),
+		_x( 'AL', 'block search term', 'jetpack' ),
 		_x( 'DALLe', 'block search term', 'jetpack' ),
 		_x( 'Diffusion', 'block search term', 'jetpack' ),
+		_x( 'Magic', 'block search term', 'jetpack' ),
 	],
 	supports: {
 		// Support for block's alignment (left, center, right, wide, full). When true, it adds block controls to change block’s alignment.

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/ai-paragraph.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/ai-paragraph.php
@@ -10,7 +10,6 @@
 namespace Automattic\Jetpack\Extensions\AIParagraph;
 
 use Automattic\Jetpack\Blocks;
-use Automattic\Jetpack\Status\Host;
 use Jetpack_Gutenberg;
 
 const FEATURE_NAME = 'ai-paragraph';
@@ -22,13 +21,18 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
-	// Only load this block on WordPress.com.
-	if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || ( new Host() )->is_woa_site() ) {
-		Blocks::jetpack_register_block(
-			BLOCK_NAME,
-			array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
-		);
+	if ( ! class_exists( 'Jetpack_AI_Helper' ) ) {
+		require_once JETPACK__PLUGIN_DIR . '_inc/lib/class-jetpack-ai-helper.php';
 	}
+
+	if ( ! \Jetpack_AI_Helper::is_enabled() ) {
+		return;
+	}
+
+	Blocks::jetpack_register_block(
+		BLOCK_NAME,
+		array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
+	);
 }
 add_action( 'init', __NAMESPACE__ . '\register_block' );
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
@@ -1,5 +1,6 @@
 import { useBlockProps } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
+import { ExternalLink } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { getIconColor } from '../../shared/block-icons';
@@ -20,20 +21,31 @@ export const settings = {
 		<Fragment>
 			<p>
 				{ __(
-					'Automatically generate new paragraphs using your existing content, powered by AI magic. We are experimenting with this feature and can tweak or remove it at any point.',
+					'Automatically generate new paragraphs using your existing content, powered by AI magic.',
 					'jetpack'
 				) }
 			</p>
+			<p>
+				{ __(
+					'We are experimenting with this feature and can tweak or remove it at any point.',
+					'jetpack'
+				) }
+			</p>
+			<ExternalLink href="https://en.forums.wordpress.com/?post_type=topic&p=3907816">
+				{ __( 'Share your feedback.', 'jetpack' ) }
+			</ExternalLink>
 		</Fragment>
 	),
 	icon: {
-		src: 'welcome-write-blog',
+		src: 'superhero',
 		foreground: getIconColor(),
 	},
 	category: 'text',
 	keywords: [
 		_x( 'AI', 'block search term', 'jetpack' ),
 		_x( 'GPT', 'block search term', 'jetpack' ),
+		_x( 'AL', 'block search term', 'jetpack' ),
+		_x( 'Magic', 'block search term', 'jetpack' ),
 	],
 	supports: {
 		// Support for block's alignment (left, center, right, wide, full). When true, it adds block controls to change block’s alignment.

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
@@ -1,3 +1,4 @@
+import { getRedirectUrl } from '@automattic/jetpack-components';
 import { useBlockProps } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { ExternalLink } from '@wordpress/components';
@@ -31,7 +32,7 @@ export const settings = {
 					'jetpack'
 				) }
 			</p>
-			<ExternalLink href="https://en.forums.wordpress.com/?post_type=topic&p=3907816">
+			<ExternalLink href={ getRedirectUrl( 'jetpack_ai_feedback' ) }>
 				{ __( 'Share your feedback.', 'jetpack' ) }
 			</ExternalLink>
 		</Fragment>


### PR DESCRIPTION
## Proposed changes:

- Easier switch to enable/disable feature that will also allow us to disable it quickly
- Different icon (superhero)
- Link to the WPCOM Forums for gathering external feedback
- When no image is selected, the block was leaving artifacts in the saved state. That is fixed now.


## Jetpack product discussion
pbOQVh-2TF-p2

## Does this pull request change what data or activity we track or use?

NO

## Testing instructions:
* Try on a Jetpack / ngrok site. Observe the blocks inactive.
* Set ENABLE_BETA_BLOCKS to true
* Enable Hello Dolly plugin, paste this code to plugin file editor (`/wp-admin/plugin-editor.php?plugin=hello.php`)
```
add_filter( 'jetpack_ai_enabled', function( $default ) {
    return true;
}, 10, 1 );

```
- Try to use blocks (search for magic) in the editor, see them working
- Write a prompt, do not choose the image
- Save
- Observe the block still appearing (but without results). Previously it would leave trash markup