### PR TITLE
Blaze: rely on method instead of filter to check for eligibility

### DIFF
--- a/projects/plugins/jetpack/changelog/update-blaze-conditions-masterbar
+++ b/projects/plugins/jetpack/changelog/update-blaze-conditions-masterbar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Masterbar: update Blaze conditions to rely on the existing method from the package.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -6013,6 +6013,10 @@ endif;
 				'replacement' => null,
 				'version'     => 'jetpack-11.0.0',
 			),
+			'jetpack_dsp_promote_posts_enabled'            => array(
+				'replacement' => null,
+				'version'     => 'jetpack-11.8.0',
+			),
 		);
 
 		foreach ( $filter_deprecated_list as $tag => $args ) {

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Dashboard_Customizations;
 
+use Automattic\Jetpack\Blaze;
 use Automattic\Jetpack\Connection\Client;
 use Jetpack_Plan;
 
@@ -365,17 +366,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		// performance settings already have a link to Page Optimize settings page.
 		$this->hide_submenu_page( 'options-general.php', 'page-optimize' );
 
-		/**
-		 * Wether to show the Advertising menu under the main Tools menu.
-		 *
-		 * @module masterbar
-		 *
-		 * @since 11.4
-		 *
-		 * @param bool $menu_enabled Wether the menu entry is shown.
-		 * @param int  $user_id      The Advertising menu will be shown/hidden for this user.
-		 */
-		if ( apply_filters( 'jetpack_dsp_promote_posts_enabled', false, get_current_user_id() ) ) {
+		if ( Blaze::should_initialize() ) {
 			add_submenu_page( 'tools.php', esc_attr__( 'Advertising', 'jetpack' ), __( 'Advertising', 'jetpack' ), 'manage_options', 'https://wordpress.com/advertising/' . $this->domain, null, 1 );
 		}
 	}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Dashboard_Customizations;
 
+use Automattic\Jetpack\Blaze;
 use JITM;
 
 require_once __DIR__ . '/class-admin-menu.php';
@@ -346,7 +347,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	public function add_options_menu() {
 		parent::add_options_menu();
 
-		if ( apply_filters( 'dsp_promote_posts_enabled', false, get_current_user_id() ) ) {
+		if ( Blaze::should_initialize() ) {
 			add_submenu_page( 'tools.php', esc_attr__( 'Advertising', 'jetpack' ), __( 'Advertising', 'jetpack' ), 'manage_options', 'https://wordpress.com/advertising/' . $this->domain, null, 1 );
 		}
 		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 10 );


### PR DESCRIPTION
## Proposed changes:

See #28088 for another example of this.

This is possible thanks to the recent improvements in that method. It also lays the foundation for us using that method to dynamically check for eligibility via an API call.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* 1386-gh-dotcom-forge

## Does this pull request change what data or activity we track or use?
* No

## Testing instructions:

This can be tested on WordPress.com simple and WoA.

* Open a site's wp-admin > Posts
* Check that you see the "Blaze" item under published posts. That means your site is eligible for Blaze (your account is in English, your site is not private, ...)
* Now check the admin menu on the left; you should see the Advertising menu under "Tools"
* Now make a change to not be eligible anymore, such as making your site private.
* The advertising menu should disappear.
