### PR TITLE
Jetpack: fix VideoPress fullscreen option when using shortcode

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ideopress-fix-fullscreen-option-issue
+++ b/projects/plugins/jetpack/changelog/update-ideopress-fix-fullscreen-option-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack: fix the fullscreen option when using videopress shortcode

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
@@ -700,9 +700,9 @@ class VideoPress_Player {
 				. "' width='" . esc_attr( $videopress_options['width'] )
 				. "' height='" . esc_attr( $videopress_options['height'] )
 				. "' src='" . esc_attr( $iframe_url )
-				. "' frameborder='0' allowfullscreen'"
+				. "' frameborder='0' allowfullscreen"
 				. $cover
-				. "' allow='clipboard-write'></iframe>"
+				. " allow='clipboard-write'></iframe>"
 				. "<script src='" . esc_attr( $js_url ) . "'></script>";
 
 		} else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Jetpack: fix the fullscreen option when using videopress shortcode

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate Jetpack plugin
* Deactivate VideoPress standalone plugin
* Add a video using a shortcode
* Confirm, with these changes, the player shows the Fullscreen option enabled


 before | after
-----|-----
<img width="234" alt="Screen Shot 2023-01-13 at 12 47 31" src="https://user-images.githubusercontent.com/77539/212324050-aa061cdd-4247-47cd-8ad4-79521580fb93.png"> | <img width="191" alt="Screen Shot 2023-01-13 at 12 49 23" src="https://user-images.githubusercontent.com/77539/212324046-561172ad-d0a6-4ec1-8d2d-90b68dc3e29f.png">


