### PR TITLE
E2E tests: disable blocks with Gutenberg suite

### DIFF
--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -81,12 +81,14 @@ switch ( process.env.GITHUB_EVENT_NAME ) {
 			const refType = process.env.REF_TYPE;
 
 			if ( repoName === 'jetpack-production' ) {
-				projects.push( {
-					project: 'Blocks with latest Gutenberg',
-					path: 'projects/plugins/jetpack/tests/e2e',
-					testArgs: [ 'blocks', '--retries=1' ],
-					suite: 'gutenberg',
-				} );
+				// Tests with Gutenberg fail since Gutenberg 14.9.0 introduced an iframe in the block editor.
+				// Temporary disable the suite until a permanent fix is in place.
+				// projects.push( {
+				// 	project: 'Blocks with latest Gutenberg',
+				// 	path: 'projects/plugins/jetpack/tests/e2e',
+				// 	testArgs: [ 'blocks', '--retries=1' ],
+				// 	suite: 'gutenberg',
+				// } );
 
 				if ( refType === 'tag' || refName === 'trunk' ) {
 					projects.push( {


### PR DESCRIPTION
## Proposed changes:

Gutenberg 14.9.0 introduced an iframe in the block editor breaking our blocks tests with Gutenberg active. The fix may take more time, so I disabled the failing suite to cut the noise.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1673532890167639-slack-C03QNBQKG73

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* After merge, check that `Blocks with latest Gutenberg` job doesn't run in the e2e tests workflow.