### PR TITLE
VideoPress: Add rating selector on video details page

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-dashboard-rating
+++ b/projects/packages/videopress/changelog/add-videopress-dashboard-rating
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Add rating selector on video details edit page

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
@@ -11,7 +11,7 @@ import {
 	useBreakpointMatch,
 	JetpackVideoPressLogo,
 } from '@automattic/jetpack-components';
-import { SelectControl } from '@wordpress/components';
+import { SelectControl, RadioControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import {
 	Icon,
@@ -33,6 +33,9 @@ import {
 	VIDEO_PRIVACY_LEVEL_PRIVATE,
 	VIDEO_PRIVACY_LEVEL_PUBLIC,
 	VIDEO_PRIVACY_LEVEL_SITE_DEFAULT,
+	VIDEO_RATING_G,
+	VIDEO_RATING_PG_13,
+	VIDEO_RATING_R_17,
 } from '../../../state/constants';
 import { usePermission } from '../../hooks/use-permission';
 import useUnloadPrevent from '../../hooks/use-unload-prevent';
@@ -157,6 +160,7 @@ const EditVideoDetails = () => {
 		height,
 		title,
 		description,
+		rating,
 		privacySetting,
 		// Playback Token
 		isFetchingPlaybackToken,
@@ -169,6 +173,7 @@ const EditVideoDetails = () => {
 		// Metadata
 		setTitle,
 		setDescription,
+		setRating,
 		setPrivacySetting,
 		processing,
 		// Poster Image
@@ -276,43 +281,57 @@ const EditVideoDetails = () => {
 								shortcode={ shortcode ?? '' }
 								loading={ isFetchingData }
 							/>
-							<SelectControl
-								className={ styles.privacy }
-								value={ privacySetting }
-								label={ __( 'Privacy', 'jetpack-videopress-pkg' ) }
-								onChange={ value => setPrivacySetting( value ) }
-								prefix={
-									// Casting for unknown since allowing only a string is a mistake
-									// at WP Components
-									( (
-										<div className={ styles[ 'privacy-icon' ] }>
-											<Icon
-												icon={
-													( privacySetting === VIDEO_PRIVACY_LEVEL_PUBLIC && publicPrivacyIcon ) ||
-													( privacySetting === VIDEO_PRIVACY_LEVEL_PRIVATE &&
-														privatePrivacyIcon ) ||
-													( privacySetting === VIDEO_PRIVACY_LEVEL_SITE_DEFAULT &&
-														siteDefaultPrivacyIcon )
-												}
-											/>
-										</div>
-									 ) as unknown ) as string
-								}
-								options={ [
-									{
-										label: __( 'Site default', 'jetpack-videopress-pkg' ),
-										value: VIDEO_PRIVACY_LEVEL_SITE_DEFAULT,
-									},
-									{
-										label: __( 'Public', 'jetpack-videopress-pkg' ),
-										value: VIDEO_PRIVACY_LEVEL_PUBLIC,
-									},
-									{
-										label: __( 'Private', 'jetpack-videopress-pkg' ),
-										value: VIDEO_PRIVACY_LEVEL_PRIVATE,
-									},
-								] }
-							/>
+							<div className={ styles[ 'side-fields' ] }>
+								<SelectControl
+									className={ styles.field }
+									value={ privacySetting }
+									label={ __( 'Privacy', 'jetpack-videopress-pkg' ) }
+									onChange={ value => setPrivacySetting( value ) }
+									prefix={
+										// Casting for unknown since allowing only a string is a mistake
+										// at WP Components
+										( (
+											<div className={ styles[ 'privacy-icon' ] }>
+												<Icon
+													icon={
+														( privacySetting === VIDEO_PRIVACY_LEVEL_PUBLIC &&
+															publicPrivacyIcon ) ||
+														( privacySetting === VIDEO_PRIVACY_LEVEL_PRIVATE &&
+															privatePrivacyIcon ) ||
+														( privacySetting === VIDEO_PRIVACY_LEVEL_SITE_DEFAULT &&
+															siteDefaultPrivacyIcon )
+													}
+												/>
+											</div>
+										 ) as unknown ) as string
+									}
+									options={ [
+										{
+											label: __( 'Site default', 'jetpack-videopress-pkg' ),
+											value: VIDEO_PRIVACY_LEVEL_SITE_DEFAULT,
+										},
+										{
+											label: __( 'Public', 'jetpack-videopress-pkg' ),
+											value: VIDEO_PRIVACY_LEVEL_PUBLIC,
+										},
+										{
+											label: __( 'Private', 'jetpack-videopress-pkg' ),
+											value: VIDEO_PRIVACY_LEVEL_PRIVATE,
+										},
+									] }
+								/>
+								<RadioControl
+									className={ classnames( styles.field, styles.rating ) }
+									label={ __( 'Rating', 'jetpack-videopress-pkg' ) }
+									selected={ rating }
+									options={ [
+										{ label: __( 'G', 'jetpack-videopress-pkg' ), value: VIDEO_RATING_G },
+										{ label: __( 'PG-13', 'jetpack-videopress-pkg' ), value: VIDEO_RATING_PG_13 },
+										{ label: __( 'R', 'jetpack-videopress-pkg' ), value: VIDEO_RATING_R_17 },
+									] }
+									onChange={ setRating }
+								/>
+							</div>
 						</Col>
 					</Container>
 				</AdminSection>

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/style.module.scss
@@ -62,19 +62,47 @@
 	.link {
 		margin-bottom: calc( var( --spacing-base ) * 3 );
 		font-size: 14px;
-		color: var(--jp-gray-70);
+		color: var( --jp-gray-70 );
 		display: flex;
 		text-decoration: none;
 		align-items: center;
 	}
 }
 
-.privacy {
-	padding: 0 calc(var(--spacing-base) * 3); // 0|24px
-	margin-top: calc(var( --spacing-base) * 4); // 32px
+.side-fields {
+	padding: 0 calc( var( --spacing-base ) * 3 ); // 24px
+	padding-top: var( --spacing-base );
+}
+
+.field {
+	margin-top: calc( var( --spacing-base ) * 3 ); // 24px
 }
 
 .privacy-icon {
 	display: flex;
-	margin-left: var(--spacing-base); // 8px
+	margin-left: var( --spacing-base ); // 8px
+}
+
+.rating {
+	:global {
+		.components-base-control__field div {
+			flex-direction: row;
+			justify-content: flex-start;
+
+			.components-radio-control__input[type="radio"] {
+				&:checked  {
+					background: var( --jp-green-40 );
+					border-color: var( --jp-green-40 );
+				}
+
+				&:focus {
+					box-shadow: 0 0 0 2px #fff, 0 0 0 4px var( --jp-green-40 );
+				}
+			}
+
+			.components-radio-control__option + .components-radio-control__option {
+				margin-left: calc( var( --spacing-base ) * 2 ); // 16px
+			}
+		}
+	}
 }

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/use-edit-details.ts
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/use-edit-details.ts
@@ -14,6 +14,10 @@ import { VIDEO_PRIVACY_LEVELS } from '../../../state/constants';
 import usePlaybackToken from '../../hooks/use-playback-token';
 import usePosterEdit from '../../hooks/use-poster-edit';
 import useVideo from '../../hooks/use-video';
+/**
+ * Types
+ */
+import type { RatingProp } from '../../../types';
 
 const useMetaEdit = ( { videoId, formData, video, updateData } ) => {
 	const updateMeta = useMetaUpdate( videoId );
@@ -29,7 +33,9 @@ const useMetaEdit = ( { videoId, formData, video, updateData } ) => {
 		return ! ( isEmpty( formDataField ) && isEmpty( videoField ) ) && isDifferent;
 	};
 
-	const metaChanged = [ 'title', 'description' ].some( field => hasFieldChanged( field ) );
+	const metaChanged = [ 'title', 'description', 'rating' ].some( field =>
+		hasFieldChanged( field )
+	);
 
 	const setTitle = ( title: string ) => {
 		updateData( { title } );
@@ -37,6 +43,10 @@ const useMetaEdit = ( { videoId, formData, video, updateData } ) => {
 
 	const setDescription = ( description: string ) => {
 		updateData( { description } );
+	};
+
+	const setRating = ( rating: RatingProp ) => {
+		updateData( { rating } );
 	};
 
 	const handleMetaUpdate = () => {
@@ -52,6 +62,7 @@ const useMetaEdit = ( { videoId, formData, video, updateData } ) => {
 	return {
 		setTitle,
 		setDescription,
+		setRating,
 		handleMetaUpdate,
 		metaChanged,
 	};
@@ -86,6 +97,7 @@ export default () => {
 	const [ formData, setFormData ] = useState( {
 		title: video?.title,
 		description: video?.description,
+		rating: video?.rating,
 	} );
 
 	const updateData = newData => {
@@ -175,6 +187,7 @@ export default () => {
 			setFormData( {
 				title: video?.title,
 				description: video?.description,
+				rating: video?.rating,
 			} );
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27165

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a radio control in the video edit page that allows changing the video rating

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard
* Upload a video and go to its edit page
* Change the rating of the video and click `Save`
* Reload the page
* Check that the rating is preserved
* Go to the block editor and add a VideoPress block
* Check that the rating is preserved

Known problem: Setting the rating as `R` and then adding a block causes the rating in the block to change to `G` due to a permission issue.

https://user-images.githubusercontent.com/8486249/212365125-d73f20f4-2506-41a4-a391-17ce55aaaa9e.mp4
