### PR TITLE
Blocks: Add generic on save modal for site editor and post editor to go back to Launchpad

### DIFF
--- a/projects/plugins/jetpack/changelog/add-launchpad_modal_all_flows
+++ b/projects/plugins/jetpack/changelog/add-launchpad_modal_all_flows
@@ -1,0 +1,4 @@
+Significance: minor
+Type: major
+
+add support for all Launchpad flows for the on save Site Editor modal

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -6,6 +6,7 @@ import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { getModalContentFromFlow, isModalSupportedByFlow } from './util';
 import './editor.scss';
 
 export const name = 'launchpad-save-modal';
@@ -29,6 +30,8 @@ export const settings = {
 			query: `siteSlug=${ siteFragment }`,
 		} );
 
+		const modalContent = getModalContentFromFlow( siteIntentOption );
+
 		useEffect( () => {
 			if ( prevIsSaving === true && isSaving === false ) {
 				setIsModalOpen( true );
@@ -36,9 +39,9 @@ export const settings = {
 		}, [ isSaving, prevIsSaving ] );
 
 		const showModal =
+			isModalSupportedByFlow( siteIntentOption ) &&
 			isInsideSiteEditor &&
 			launchpadScreenOption === 'full' &&
-			siteIntentOption === 'link-in-bio' &&
 			! dontShowAgain &&
 			isModalOpen;
 
@@ -54,15 +57,8 @@ export const settings = {
 				>
 					<div className="launchpad__save-modal-body">
 						<div className="launchpad__save-modal-text">
-							<h1 className="launchpad__save-modal-heading">
-								{ __( 'Your site is ready to launch!', 'jetpack' ) }
-							</h1>
-							<p className="launchpad__save-modal-message">
-								{ __(
-									'Launching your Link in Bio will allow you to share a link with others and promote your site.',
-									'jetpack'
-								) }
-							</p>
+							<h1 className="launchpad__save-modal-heading">{ modalContent.heading }</h1>
+							<p className="launchpad__save-modal-message">{ modalContent.body }</p>
 						</div>
 						<div className="launchpad__save-modal-controls">
 							<CheckboxControl

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/util.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/util.js
@@ -1,5 +1,3 @@
-import { __ } from '@wordpress/i18n';
-
 const FLOWS = {
 	NEWSLETTER: 'newsletter',
 	LINK_IN_BIO: 'link-in-bio',
@@ -9,30 +7,4 @@ const FLOWS = {
 
 export function isModalSupportedByFlow( flow ) {
 	return Object.values( FLOWS ).includes( flow );
-}
-
-export function getModalContentFromFlow( flow ) {
-	switch ( flow ) {
-		case FLOWS.NEWSLETTER:
-			return {
-				heading: __( 'Finish your Newsletter setup!', 'jetpack' ),
-				body: __( 'You are just moments away from growing your audience.', 'jetpack' ),
-			};
-		case FLOWS.LINK_IN_BIO:
-			return {
-				heading: __( 'Your site is ready to launch!', 'jetpack' ),
-				body: __(
-					'Launching your Link in Bio will allow you to share a link with others and promote your site.',
-					'jetpack'
-				),
-			};
-		case FLOWS.FREE:
-		case FLOWS.VIDEOPRESS:
-			return {
-				heading: __( 'Your site is ready to launch!', 'jetpack' ),
-				body: __( 'Bring your new site to life by launching it.', 'jetpack' ),
-			};
-		default:
-			return null;
-	}
 }

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/util.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/util.js
@@ -1,0 +1,38 @@
+import { __ } from '@wordpress/i18n';
+
+const FLOWS = {
+	NEWSLETTER: 'newsletter',
+	LINK_IN_BIO: 'link-in-bio',
+	FREE: 'free',
+	VIDEOPRESS: 'videopress',
+};
+
+export function isModalSupportedByFlow( flow ) {
+	return Object.values( FLOWS ).includes( flow );
+}
+
+export function getModalContentFromFlow( flow ) {
+	switch ( flow ) {
+		case FLOWS.NEWSLETTER:
+			return {
+				heading: __( 'Finish your Newsletter setup!', 'jetpack' ),
+				body: __( 'You are just moments away from growing your audience.', 'jetpack' ),
+			};
+		case FLOWS.LINK_IN_BIO:
+			return {
+				heading: __( 'Your site is ready to launch!', 'jetpack' ),
+				body: __(
+					'Launching your Link in Bio will allow you to share a link with others and promote your site.',
+					'jetpack'
+				),
+			};
+		case FLOWS.FREE:
+		case FLOWS.VIDEOPRESS:
+			return {
+				heading: __( 'Your site is ready to launch!', 'jetpack' ),
+				body: __( 'Bring your new site to life by launching it.', 'jetpack' ),
+			};
+		default:
+			return null;
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [LaunchPad - Site Editor Save Modal - Adapt for non-LIB flows](https://github.com/Automattic/wp-calypso/issues/71717) and [LaunchPad - adapt and enable the back-to-launchpad modal in the post/page editor](https://github.com/Automattic/wp-calypso/issues/72093)

## Proposed changes:
This PR provides a generic modal for all Launchpad flows to allow the user to go back to the Launchpad screen from the Site Editor and Post Editor once they have saved their progress.

<img width="866" alt="image" src="https://user-images.githubusercontent.com/20927667/213217851-efc777e5-b74a-4b00-8219-75dea44cd11c.png">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
paYE8P-1Kg-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

### Testing on WPCOM
1. Sandbox `public-api.wordpress.com` along with a Launchpad enabled site
2. Run `bin/jetpack-downloader test jetpack add/launchpad_modal_all_flows` on your sandbox
3. Go to the Site Editor
4. Make a change and save. You should see the modal appear.
5. Go to the Post Editor.
6. Test publishing a new post and updating the post once it's published. You should see the modal appear on save.
7. Test with different flows - `newsletter`, `link-in-bio`, `free`, `videopress`.