### PR TITLE
Jetpack: Remove user connection requirement from brute force protection (protect) module

### DIFF
--- a/projects/plugins/jetpack/_inc/client/security/protect.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/protect.jsx
@@ -1,7 +1,6 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import Button from 'components/button';
-import ConnectUserBar from 'components/connect-user-bar';
 import FoldableCard from 'components/foldable-card';
 import { FormFieldset, FormLegend, FormLabel } from 'components/forms';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
@@ -164,14 +163,6 @@ export const Protect = withModuleSettingsFormHelpers(
 							</SettingsGroup>
 						</FoldableCard>
 					</SettingsGroup>
-
-					{ ! this.props.hasConnectedOwner && ! this.props.isOfflineMode && (
-						<ConnectUserBar
-							feature="protect"
-							featureLabel={ __( 'Protect', 'jetpack' ) }
-							text={ __( 'Connect to set up brute force attack protection.', 'jetpack' ) }
-						/>
-					) }
 				</SettingsCard>
 			);
 		}

--- a/projects/plugins/jetpack/changelog/remove-brute-force-user-connection
+++ b/projects/plugins/jetpack/changelog/remove-brute-force-user-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Remove requirement to connect WordPress.com account to use Brute Force Protection feature

--- a/projects/plugins/jetpack/modules/protect.php
+++ b/projects/plugins/jetpack/modules/protect.php
@@ -6,7 +6,7 @@
  * Recommendation Order: 4
  * First Introduced: 3.4
  * Requires Connection: Yes
- * Requires User Connection: Yes
+ * Requires User Connection: No
  * Auto Activate: Yes
  * Module Tags: Recommended
  * Feature: Security


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR removes the requirement for a user connection to access the brute force protection (aka "protect") module. The module and related infrastructure works on a site-only connection, so the user requirement can be safely removed to make this feature available to more users.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the user requirement from the protect module's header info
* Removes the connection prompt from the brute force protection's settings box

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

TBD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Partially - this change removes the requirement for a user connection to access the brute force protection feature. Documentation may need to be updated to reflect this change.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* TBD

