### PR TITLE
composer-plugin: Ensure `jetpack_vendor/` exists before creating i18n-map

### DIFF
--- a/projects/packages/composer-plugin/changelog/fix-composer-plugin-no-jetpack_vendor
+++ b/projects/packages/composer-plugin/changelog/fix-composer-plugin-no-jetpack_vendor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensure `jetpack_vendor/` exists before trying to write `jetpack_vendor/i18n-map.php`.

--- a/projects/packages/composer-plugin/src/class-plugin.php
+++ b/projects/packages/composer-plugin/src/class-plugin.php
@@ -142,6 +142,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 		$code = str_replace( 'array (', 'array(', $code );
 		$code = preg_replace( '/ => \n\s*array\(/', ' => array(', $code );
 
+		$filesystem->ensureDirectoryExists( 'jetpack_vendor' );
 		$filesystem->filePutContentsIfModified( 'jetpack_vendor/i18n-map.php', $code );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If something uses the plugin but does not use any "jetpack-library" packages, `jetpack_vendor/` won't exist and the plugin will fail when trying to create the `jetpack_vendor/i18n-map.php` file. Account for this situation by creating the directory if necessary.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/28364#pullrequestreview-1249285416

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout #28364 and merge this in, then see if composer works in `plugins/crm` now.
