### PR TITLE
[Boost] Fix woocommerce deprecation warnings

### DIFF
--- a/projects/plugins/boost/changelog/fix-woo-deprecation-warnings
+++ b/projects/plugins/boost/changelog/fix-woo-deprecation-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix woocommerce deprecation warning

--- a/projects/plugins/boost/compatibility/woocommerce.php
+++ b/projects/plugins/boost/compatibility/woocommerce.php
@@ -40,7 +40,7 @@ function get_woocommerce_page_ids() {
 	if ( ! function_exists( 'wc_get_page_id' ) ) {
 		return array();
 	}
-	$page_slugs = array( 'myaccount', 'edit_address', 'shop', 'cart', 'checkout', 'pay', 'view_order', 'terms' );
+	$page_slugs = array( 'myaccount', 'shop', 'cart', 'checkout', 'view_order', 'terms' );
 	$ids        = array_map( 'wc_get_page_id', $page_slugs );
 	$ids        = array_filter(
 		$ids,


### PR DESCRIPTION
In Boost's woocommerce compatibility module, we call `wc_get_page_id` when generating Critical CSS to ensure that key Woocommerce pages are targeted by the generation process.

However, we are getting deprecation warnings about some page types we request:
```
PHP Deprecated:  Function wc_get_page_id was called with an argument that is <strong>deprecated</strong> since version 2.1! The "change_password", "edit_address" and "lost_password" pages are no-longer used - an endpoint is added to the my-account instead.
PHP Deprecated:  Function wc_get_page_id was called with an argument that is <strong>deprecated</strong> since version 2.1! The "pay" and "thanks" pages are no-longer used - an endpoint is added to the checkout instead.
```

This PR removes the deprecated pages from the request.

I thought about following up on more modern approaches to get the `pay` and `edit_address` page details, but neither of these are typically landing pages, and so Critical CSS for them is not very important.

## Proposed changes:
* Fix deprecation warnings from woocommerce

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Generate Critical CSS, ensure no deprecation warnings are generated.