### PR TITLE
VideoPress: skip rating checking when pulling video data for block

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-skip-rating-checking-in-editor-context
+++ b/projects/packages/videopress/changelog/update-videopress-skip-rating-checking-in-editor-context
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: skip rating checking when pulling video data for the block

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
@@ -162,7 +162,11 @@ export function useSyncMedia(
 	options: UseSyncMediaOptionsProps
 ): UseSyncMediaProps {
 	const { id, guid } = attributes;
-	const { videoData, isRequestingVideoData } = useVideoData( { id, guid } );
+	const { videoData, isRequestingVideoData } = useVideoData( {
+		id,
+		guid,
+		skipRatingChecking: true,
+	} );
 
 	const isSaving = useSelect( select => select( editorStore ).isSavingPost(), [] );
 	const wasSaving = usePrevious( isSaving );

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
@@ -165,7 +165,7 @@ export function useSyncMedia(
 	const { videoData, isRequestingVideoData } = useVideoData( {
 		id,
 		guid,
-		skipRatingChecking: true,
+		skipRatingControl: true,
 	} );
 
 	const isSaving = useSelect( select => select( editorStore ).isSavingPost(), [] );

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/index.ts
@@ -26,7 +26,7 @@ import { UseVideoDataProps, UseVideoDataArgumentsProps, VideoDataProps } from '.
 export default function useVideoData( {
 	id,
 	guid,
-	skipRatingChecking = false,
+	skipRatingControl = false,
 }: UseVideoDataArgumentsProps ): UseVideoDataProps {
 	const [ videoData, setVideoData ] = useState< VideoDataProps >( {} );
 	const [ isRequestingVideoData, setIsRequestingVideoData ] = useState( false );
@@ -46,7 +46,7 @@ export default function useVideoData( {
 				}
 
 				// Add the birthdate to skip the rating check if it's required.
-				if ( skipRatingChecking ) {
+				if ( skipRatingControl ) {
 					params.birth_day = '1';
 					params.birth_month = '1';
 					params.birth_year = '2000';

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/index.ts
@@ -11,7 +11,10 @@ import { decodeEntities } from '../../../lib/url';
 /**
  * Types
  */
-import { WPCOMRestAPIVideosGetEndpointResponseProps } from '../../../types';
+import {
+	WPCOMRestAPIVideosGetEndpointRequestArguments,
+	WPCOMRestAPIVideosGetEndpointResponseProps,
+} from '../../../types';
 import { UseVideoDataProps, UseVideoDataArgumentsProps, VideoDataProps } from './types';
 
 /**
@@ -23,6 +26,7 @@ import { UseVideoDataProps, UseVideoDataArgumentsProps, VideoDataProps } from '.
 export default function useVideoData( {
 	id,
 	guid,
+	skipRatingChecking = false,
 }: UseVideoDataArgumentsProps ): UseVideoDataProps {
 	const [ videoData, setVideoData ] = useState< VideoDataProps >( {} );
 	const [ isRequestingVideoData, setIsRequestingVideoData ] = useState( false );
@@ -34,12 +38,26 @@ export default function useVideoData( {
 		async function fetchVideoItem() {
 			try {
 				const tokenData = await getMediaToken( 'playback', { id, guid } );
-				const params = tokenData?.token
-					? `?${ new URLSearchParams( { metadata_token: tokenData.token } ).toString() }`
+				const params: WPCOMRestAPIVideosGetEndpointRequestArguments = {};
+
+				// Add the token to the request if it exists.
+				if ( tokenData?.token ) {
+					params.metadata_token = tokenData.token;
+				}
+
+				// Add the birthdate to skip the rating check if it's required.
+				if ( skipRatingChecking ) {
+					params.birth_day = '1';
+					params.birth_month = '1';
+					params.birth_year = '2000';
+				}
+
+				const requestArgs = Object.keys( params ).length
+					? `?${ new URLSearchParams( params ).toString() }`
 					: '';
 
 				const response: WPCOMRestAPIVideosGetEndpointResponseProps = await apiFetch( {
-					url: `https://public-api.wordpress.com/rest/v1.1/videos/${ guid }${ params }`,
+					url: `https://public-api.wordpress.com/rest/v1.1/videos/${ guid }${ requestArgs }`,
 					credentials: 'omit',
 					global: true,
 				} );

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/types.ts
@@ -7,7 +7,7 @@ import { VideoGUID, VideoId } from '../../blocks/video/types';
 export type UseVideoDataArgumentsProps = {
 	id?: VideoId;
 	guid?: VideoGUID;
-	isPrivate?: boolean;
+	skipRatingChecking: boolean;
 };
 
 export type VideoDataProps = {

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/types.ts
@@ -7,7 +7,7 @@ import { VideoGUID, VideoId } from '../../blocks/video/types';
 export type UseVideoDataArgumentsProps = {
 	id?: VideoId;
 	guid?: VideoGUID;
-	skipRatingChecking: boolean;
+	skipRatingControl: boolean;
 };
 
 export type VideoDataProps = {

--- a/projects/packages/videopress/src/client/types.ts
+++ b/projects/packages/videopress/src/client/types.ts
@@ -93,6 +93,13 @@ export type WPV2mediaGetEndpointResponseProps = {
 /*
  * https://public-api.wordpress.com/rest/v1.1/videos/${ guid }
  */
+export type WPCOMRestAPIVideosGetEndpointRequestArguments = {
+	metadata_token?: string;
+	birth_day?: string;
+	birth_month?: string;
+	birth_year?: string;
+};
+
 export type WPCOMRestAPIVideosGetEndpointResponseProps = {
 	// source_url: string;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

To skip the rating checking that the `videos/` endpoint does, this PR adds an option to the `useVideoData() `hook, which will pass birthdate arguments to the `videos/` endpoint to jump it finally.
Ideally, we might add a new argument to the endpoint that allows skip it explicitly, something like `skip_rating_control`.

Keep in mind this change won't affect the Rating control at the player level, meaning that it will keep showing the rating form to the users.

Fixes https://github.com/Automattic/jetpack/issues/28349

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: skip rating checking when pulling video data for the block

### Other information:

- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard
* Go to a video details page
* Set the rating for a video with `R`

<img width="817" alt="Screen Shot 2023-01-16 at 08 18 27" src="https://user-images.githubusercontent.com/77539/212630125-5ef906b2-af41-474a-9eb3-ca6b6c48807b.png">

* Save the video details
* Go to the block editor
* Create a new block
* Set the via by selecting the previous video from the Media Gallery
* Confirm the video is not shown because of the rating setting
* Confirm the block populates with the video data (title, description, **rating**, etc.)
* Confirm the player shows the rating control from

<img width="681" alt="Screen Shot 2023-01-16 at 08 18 01" src="https://user-images.githubusercontent.com/77539/212630150-8f193672-93a1-4518-9112-c8fa1400271d.png">


