### PR TITLE
Settings API: Allow to un-assign `page_for_posts` and `page_on_front` on `POST` request

### DIFF
--- a/projects/plugins/jetpack/changelog/update-settings-api-unassign-page_for_posts-and-page_on_front
+++ b/projects/plugins/jetpack/changelog/update-settings-api-unassign-page_for_posts-and-page_on_front
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Settings API: Allow to unassign 'page_for_posts' and 'page_on_front' options

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -1017,29 +1017,19 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 
 				case 'page_on_front':
-					if ( ! $this->is_valid_page_id( $value ) ) {
-						break;
-					}
-
-					$page_for_posts = get_option( 'page_for_posts' );
-					if ( $page_for_posts === $value ) {
-						// page for posts and page on front can't be the same
-						break;
-					}
-
-					if ( update_option( $key, $value ) ) {
-						$updated[ $key ] = $value;
-					}
-
-					break;
 				case 'page_for_posts':
+					if ( $value === '' ) { // empty is not applicable because '0' may be a valid page id
+						delete_option( $key );
+					}
+
 					if ( ! $this->is_valid_page_id( $value ) ) {
 						break;
 					}
 
-					$page_on_front = get_option( 'page_on_front' );
-					if ( $page_on_front === $value ) {
-						// page on front and page for posts can't be the same
+					$related_option_key   = $key === 'page_on_front' ? 'page_for_posts' : 'page_on_front';
+					$related_option_value = get_option( $related_option_key );
+					if ( $related_option_value === $value ) {
+						// page_on_front and page_for_posts are not allowed to be the same
 						break;
 					}
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -1033,7 +1033,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					$related_option_key   = $key === 'page_on_front' ? 'page_for_posts' : 'page_on_front';
 					$related_option_value = get_option( $related_option_key );
 					if ( $related_option_value === $value ) {
-						// page_on_front and page_forposts are not allowed to be the same
+						// page_on_front and page_for_posts are not allowed to be the same
 						break;
 					}
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -1018,7 +1018,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 				case 'page_on_front':
 				case 'page_for_posts':
-					if ( $value === '' ) { // empty is not applicable because '0' may be a valid page id
+					if ( $value === '' ) { // empty function is not applicable here because '0' may be a valid page id
 						if ( delete_option( $key ) ) {
 							$updated[ $key ] = null;
 						}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -1019,7 +1019,11 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 				case 'page_on_front':
 				case 'page_for_posts':
 					if ( $value === '' ) { // empty is not applicable because '0' may be a valid page id
-						delete_option( $key );
+						if ( delete_option( $key ) ) {
+							$updated[ $key ] = null;
+						}
+
+						break;
 					}
 
 					if ( ! $this->is_valid_page_id( $value ) ) {
@@ -1029,7 +1033,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					$related_option_key   = $key === 'page_on_front' ? 'page_for_posts' : 'page_on_front';
 					$related_option_value = get_option( $related_option_key );
 					if ( $related_option_value === $value ) {
-						// page_on_front and page_for_posts are not allowed to be the same
+						// page_on_front and page_forposts are not allowed to be the same
 						break;
 					}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/72119

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* update `POST /sites/$site/settings/` api so that when an empty string is passed for `page_on_front` or `page_for_posts` options they will be deleted (a.k.a. unassigned)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
I will suggest two ways for testing this PR changes.

### Test with Calypso UI
![Screen Shot 2023-01-16 at 12 13 26](https://user-images.githubusercontent.com/2019970/212665260-b2a55c29-8e36-4f08-8917-9ca3ee2b8294.png)
This requires running local version of calypso with [the branch](https://github.com/Automattic/wp-calypso/tree/add/reading-settings-your-homepage-displays) applied.
* Go to `http://calypso.localhost:3000/settings/reading/$your-test-site`, e.g.: `http://calypso.localhost:3000/settings/reading/simple-site.blog`
* First assign some value other than **—— Default ——**  to **Your homepage displays**
* **Save** and reload the page
* Assign **—— Default ——** to **Your homepage displays** and **Save**
* Reload the page and ensure the **—— Default ——** is correctly displayed as the current value for **Your homepage displays**
* Do the same but for **Default posts page** input

### Test with cURL
1. When you press **Save** in `https://wordpress.com/settings/reading/$your-site` a call to `POST /sites/$site/settings/` is made. In Chrome dev tools in the **Network** tab you can copy the request as cURL.
2. Paste the request in a text editor of your choice 
3. Edit it as you wish. In the body of the request you can set `page_on_front` or `page_for_posts` to an empty string (e.g.: `page_on_front: ""`). 
4. Then copy the edited cURL snippet, paste it in your terminal and execute it as is.
5. Ensure that the correct value is returned on a `GET /sites/$site/settings/`. You can use wpcom API dev console for that. 
