### PR TITLE
Image Guide Cleanup

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -112,7 +112,7 @@
 			<h3 slot="title">{__( 'Image Guide', 'jetpack-boost' )}<span class="beta">Beta</span></h3>
 			<p slot="description">
 				{__(
-					`This feature helps you discover the images are too large. When you browse your site, the image guide will show you an overlay with information about each image's size.`,
+					`This feature helps you discover images that are too large. When you browse your site, the image guide will show you an overlay with information about each image's size.`,
 					'jetpack-boost'
 				)}
 			</p>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -19,7 +19,7 @@
 
 	const criticalCssLink = getRedirectUrl( 'jetpack-boost-critical-css' );
 	const deferJsLink = getRedirectUrl( 'jetpack-boost-defer-js' );
-	const lazyLoadlink = getRedirectUrl( 'jetpack-boost-lazy-load' );
+	const lazyLoadLink = getRedirectUrl( 'jetpack-boost-lazy-load' );
 
 	// svelte-ignore unused-export-let - Ignored values supplied by svelte-navigator.
 	export let location, navigate;
@@ -102,7 +102,7 @@
 					`Improve page loading speed by only loading images when they are required. Read more on <link>web.dev</link>.`,
 					'jetpack-boost'
 				)}
-				vars={externalLinkTemplateVar( lazyLoadlink )}
+				vars={externalLinkTemplateVar( lazyLoadLink )}
 			/>
 		</p>
 	</Module>

--- a/projects/plugins/boost/app/features/image-guide/Image_Guide.php
+++ b/projects/plugins/boost/app/features/image-guide/Image_Guide.php
@@ -51,8 +51,8 @@ class Image_Guide implements Feature {
 	}
 
 	public function enqueue_assets() {
-		wp_enqueue_script( 'jetpack-boost-image-guide', plugins_url( 'dist/guide.js', __FILE__ ), array(), JETPACK_BOOST_VERSION, true );
-		wp_enqueue_style( 'jetpack-boost-image-guide', plugins_url( 'dist/guide.css', __FILE__ ), array(), JETPACK_BOOST_VERSION, 'screen' );
+		wp_enqueue_script( 'jetpack-boost-guide', plugins_url( 'dist/guide.js', __FILE__ ), array(), JETPACK_BOOST_VERSION, true );
+		wp_enqueue_style( 'jetpack-boost-guide', plugins_url( 'dist/guide.css', __FILE__ ), array(), JETPACK_BOOST_VERSION, 'screen' );
 	}
 
 	/**
@@ -66,14 +66,14 @@ class Image_Guide implements Feature {
 
 		$bar->add_menu(
 			array(
-				'id'     => 'jetpack-boost-image-guide',
+				'id'     => 'jetpack-boost-guide',
 				'parent' => null,
 				'group'  => null,
 				'title'  => __( 'Jetpack Boost', 'jetpack-boost' ),
 				'href'   => admin_url( 'admin.php?page=' . Admin::MENU_SLUG ),
 				'meta'   => array(
 					'target' => '_self',
-					'class'  => 'jetpack-boost-image-guide',
+					'class'  => 'jetpack-boost-guide',
 				),
 			)
 		);

--- a/projects/plugins/boost/app/features/image-guide/src/index.ts
+++ b/projects/plugins/boost/app/features/image-guide/src/index.ts
@@ -30,7 +30,7 @@ function discardSmallImages( images: MeasurableImage[] ) {
  * Initialize the AdminBarToggle component when the DOM is ready.
  */
 document.addEventListener( 'DOMContentLoaded', () => {
-	const adminBarToggle = document.getElementById( 'wp-admin-bar-jetpack-boost-image-guide' );
+	const adminBarToggle = document.getElementById( 'wp-admin-bar-jetpack-boost-guide' );
 	const link = adminBarToggle?.querySelector( 'a' );
 	if ( adminBarToggle && link ) {
 		const href = link.getAttribute( 'href' );

--- a/projects/plugins/boost/app/features/image-guide/src/stores/GuideState.ts
+++ b/projects/plugins/boost/app/features/image-guide/src/stores/GuideState.ts
@@ -11,7 +11,6 @@ import { derived, Writable, writable } from 'svelte/store';
 const LS_KEY = 'jetpack-boost-guide';
 const store = {
 	active: 'Active',
-	always_on: 'Always On',
 	paused: 'Paused',
 } as const;
 

--- a/projects/plugins/boost/app/features/image-guide/src/ui/Main.svelte
+++ b/projects/plugins/boost/app/features/image-guide/src/ui/Main.svelte
@@ -27,9 +27,7 @@
 			return;
 		}
 
-		if ( $guideState !== 'always_on' ) {
-			show = false;
-		}
+		show = false;
 	}
 
 	function getGuideSize( width = -1, height = -1 ): GuideSize {
@@ -53,7 +51,6 @@
 	const sizeOnPage = stores[ 0 ].sizeOnPage;
 	$: size = getGuideSize( $sizeOnPage.width, $sizeOnPage.height );
 
-	$: show = $guideState === 'always_on' ? 0 : false;
 	$: toggleBackdrop( show !== false );
 	let position = {
 		top: 0,
@@ -68,7 +65,7 @@
 	}
 </script>
 
-{#if $guideState === 'active' || $guideState === 'always_on'}
+{#if $guideState === 'active'}
 	<div
 		class="guide {size}"
 		class:show={show !== false}

--- a/projects/plugins/boost/app/features/image-guide/src/ui/Main.svelte
+++ b/projects/plugins/boost/app/features/image-guide/src/ui/Main.svelte
@@ -7,7 +7,7 @@
 	import type { GuideSize } from '../types';
 
 	export let stores: MeasurableImageStore[];
-	let show: number | false;
+	let show: number | false = false;
 
 	/**
 	 * This onMount is triggered when the window loads

--- a/projects/plugins/boost/changelog/update-boost-image-guide-cleanup
+++ b/projects/plugins/boost/changelog/update-boost-image-guide-cleanup
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Minor tweaks
+
+


### PR DESCRIPTION
Cleaned up a few bits here & there to prepare for a release.

## Proposed changes:

* Updated feature description
* Removed always on state

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/orgs/Automattic/projects/548/views/2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

1. Apply the patch
2. Test out the image guide
3. Cycle through states
4. Make sure turning the guide on/off is a decent workaround [for lazy-loading images](https://github.com/Automattic/jetpack/issues/28344)

