### PR TITLE
Docs: Include mention of `jetpack_blocks_variation` filter

### DIFF
--- a/projects/plugins/jetpack/changelog/improve-jetpack-blocks-variation-filter
+++ b/projects/plugins/jetpack/changelog/improve-jetpack-blocks-variation-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Mention `jetpack_blocks_variation` filter in Beta Extensions doc

--- a/projects/plugins/jetpack/extensions/README.md
+++ b/projects/plugins/jetpack/extensions/README.md
@@ -81,6 +81,7 @@ Generally, all new extensions should start out as a beta.
 - Before you develop, remember to add your extension's slug to the beta array in `extensions/index.json`.
 - In the `wp-config.php` for your Docker environment (`docker/wordpress/wp-config.php`) or in your custom mu-plugins file (`docker/mu-plugins/yourfile.php`), enable beta extensions with the following snippet: `define( 'JETPACK_BETA_BLOCKS', true );`
 - When you use this constant, you'll get all blocks: Beta blocks, Experimental blocks, and Production blocks.
+- You can also filter to specific extensions: `add_filter( 'jetpack_blocks_variation', function () { return 'beta'; } );`.
 - In the WordPress.com environment, Automatticians will be able to see beta extensions with no further configuration
 - In a Jurassic Ninja site, you must go to Settings > Jetpack Constants, and enable the `JETPACK_BETA_BLOCKS` option there.
 - Once you've successfully beta tested your new extension, you can open new PR to make your extension live!


### PR DESCRIPTION
From p1673872153055239-slack-CDLH4C1UZ

## Proposed changes:

Includes a mention of the `jetpack_blocks_variation` filter in the Beta Extensions docs.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [X] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

N/A.