### PR TITLE
Carousel: check array to avoid PHP warnings

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-array-check
+++ b/projects/plugins/jetpack/changelog/fix-carousel-array-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Carousel: verify array to avoid PHP warnings

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -836,9 +836,11 @@ class Jetpack_Carousel {
 			foreach ( $attributes as $k => $v ) {
 				$attributes_html .= esc_attr( $k ) . '="' . esc_attr( $v ) . '" ';
 			}
-			foreach ( $image_elements as $image_html ) {
-				$find[]    = $image_html;
-				$replace[] = str_replace( '<img ', "<img $attributes_html", $image_html );
+			if ( is_array( $image_elements ) ) {
+				foreach ( $image_elements as $image_html ) {
+					$find[]    = $image_html;
+					$replace[] = str_replace( '<img ', "<img $attributes_html", $image_html );
+				}
 			}
 		}
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -831,16 +831,18 @@ class Jetpack_Carousel {
 			}
 			$image_elements = $selected_images[ $attachment->ID ];
 
+			if ( ! is_array( $image_elements ) ) {
+				continue;
+			}
+
 			$attributes      = $this->add_data_to_images( array(), $attachment );
 			$attributes_html = '';
 			foreach ( $attributes as $k => $v ) {
 				$attributes_html .= esc_attr( $k ) . '="' . esc_attr( $v ) . '" ';
 			}
-			if ( is_array( $image_elements ) ) {
-				foreach ( $image_elements as $image_html ) {
-					$find[]    = $image_html;
-					$replace[] = str_replace( '<img ', "<img $attributes_html", $image_html );
-				}
+			foreach ( $image_elements as $image_html ) {
+				$find[]    = $image_html;
+				$replace[] = str_replace( '<img ', "<img $attributes_html", $image_html );
 			}
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixing PHP Warning: Invalid argument supplied for foreach() in /wordpress/plugins/jetpack/11.6-beta/modules/carousel/jetpack-carousel.php on 
line 839

The warning shows up on different sites and in different scenarios. For example, some sites have a plugin or a theme that overrides img 
parameters or Jetpack Carousel so the error is thrown.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adding is_array check

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* TBD
*

