### PR TITLE
WooExpress Trial: Add eComm trial to plans list

### DIFF
--- a/projects/plugins/jetpack/class.jetpack-plan.php
+++ b/projects/plugins/jetpack/class.jetpack-plan.php
@@ -109,6 +109,7 @@ class Jetpack_Plan {
 				'ecommerce-bundle',
 				'ecommerce-bundle-monthly',
 				'ecommerce-bundle-2y',
+				'ecommerce-trial-bundle-monthly',
 				'pro-plan',
 			),
 			'supports' => array(),


### PR DESCRIPTION
Fixes Automattic/wp-calypso#71809

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add the product plan slug `ecommerce-trial-bundle-monthly` to `Jetpack_Plans` so it's recognized by Atomic sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Apply this patch to your sandbox: `bin/jetpack-downloader test jetpack add/ecomm-trial-to-plans`
* Sandbox `public-api.wordpress.com`
* Visit `wordpress.com/setup/wooexpress` to create a new eCommerce Trial site
* You should land in the dashboard and *eventually* you'll see the site URL to your site update to indicate it's on Atomic at `*.wpcomstaging.com`
* The "eCommerce Trial" plan name text should appear in the sidebar next to "Upgrades":

<img width="288" alt="Screen Shot 2023-01-17 at 10 32 36 AM" src="https://user-images.githubusercontent.com/2124984/212940878-7989edaa-0f7a-400b-84f2-5c46199f219b.png">
