### PR TITLE
Protect: Fix API response property name case styling

### DIFF
--- a/projects/plugins/protect/changelog/fix-protect-snake-case-variables
+++ b/projects/plugins/protect/changelog/fix-protect-snake-case-variables
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed invalid property names

--- a/projects/plugins/protect/src/js/components/scan-page/use-status-polling.js
+++ b/projects/plugins/protect/src/js/components/scan-page/use-status-polling.js
@@ -35,12 +35,12 @@ const useStatusPolling = () => {
 				} )
 					.then( newStatus => {
 						if ( newStatus?.error ) {
-							throw newStatus?.errorMessage;
+							throw newStatus?.error_message;
 						}
 
 						if (
 							statusIsInProgress( newStatus?.status ) ||
-							scanIsInitializing( newStatus?.status, newStatus?.lastChecked )
+							scanIsInitializing( newStatus?.status, newStatus?.last_checked )
 						) {
 							setStatusProgress( newStatus?.current_progress );
 							pollTimeout = setTimeout( () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR fixes some invalid property names, which are returned by the API in snake case style instead of camel case.
* This fix has already been manually applied to the `1.2.0` release, this PR backports the fix into `trunk`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a site with a scan plan, validate that a manual scan can run from start to finish and then display the scan results.

