### PR TITLE
Revise Jetpack connection agreement text to comply with our User Agreement

### DIFF
--- a/projects/js-packages/components/changelog/update-toc-text-location
+++ b/projects/js-packages/components/changelog/update-toc-text-location
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Revise Jetpack connection agreement text to comply with our User Agreement

--- a/projects/js-packages/components/components/pricing-card/index.tsx
+++ b/projects/js-packages/components/components/pricing-card/index.tsx
@@ -1,7 +1,8 @@
 import { getCurrencyObject } from '@automattic/format-currency';
 import { Button } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
-import { PricingCardProps } from './types';
+import TermsOfService from '../terms-of-service';
+import type { PricingCardProps } from './types';
 import type { CurrencyObject } from '@automattic/format-currency/src/types';
 import type React from 'react';
 
@@ -90,18 +91,30 @@ const PricingCard: React.FC< PricingCardProps > = ( {
 				<div className="jp-components__pricing-card__extra-content-wrapper">{ props.children }</div>
 			) }
 
+			{ /*
+			 * Keep the option to pass custom terms of service text,
+			 * but by default, use the shared `TermsOfService` component
+			 * and pass the CTA button's text to it
+			 */ }
 			{ props.tosText && <div className="jp-components__pricing-card__tos">{ props.tosText }</div> }
 
 			{ props.ctaText && (
-				<div className="jp-components__pricing-card__cta">
-					<Button
-						className="jp-components__pricing-card__button"
-						label={ props.ctaText }
-						onClick={ props.onCtaClick }
-					>
-						{ props.ctaText }
-					</Button>
-				</div>
+				<>
+					{ ! props.tosText && (
+						<div className="jp-components__pricing-card__tos">
+							<TermsOfService agreeButtonLabel={ props.ctaText } />
+						</div>
+					) }
+					<div className="jp-components__pricing-card__cta">
+						<Button
+							className="jp-components__pricing-card__button"
+							label={ props.ctaText }
+							onClick={ props.onCtaClick }
+						>
+							{ props.ctaText }
+						</Button>
+					</div>
+				</>
 			) }
 
 			{ props.infoText && (

--- a/projects/js-packages/components/components/pricing-card/index.tsx
+++ b/projects/js-packages/components/components/pricing-card/index.tsx
@@ -90,6 +90,8 @@ const PricingCard: React.FC< PricingCardProps > = ( {
 				<div className="jp-components__pricing-card__extra-content-wrapper">{ props.children }</div>
 			) }
 
+			{ props.tosText && <div className="jp-components__pricing-card__tos">{ props.tosText }</div> }
+
 			{ props.ctaText && (
 				<div className="jp-components__pricing-card__cta">
 					<Button

--- a/projects/js-packages/components/components/pricing-card/style.scss
+++ b/projects/js-packages/components/components/pricing-card/style.scss
@@ -98,10 +98,15 @@
 		align-items: center;
 	}
 
-	&__info {
+	&__info,
+	&__tos {
 		font-size: var( --font-label );
 		line-height: 20px;
 		letter-spacing: -0.02em;
 		color: var( --jp-gray-60 );
+	}
+
+	&__tos {
+		margin-top: 24px;
 	}
 }

--- a/projects/js-packages/components/components/pricing-card/types.ts
+++ b/projects/js-packages/components/components/pricing-card/types.ts
@@ -45,4 +45,8 @@ export type PricingCardProps = {
 	 * The TOS copy.
 	 */
 	tosText?: React.ReactNode;
+	/**
+	 * Optional Child nodes
+	 */
+	children?: React.ReactNode;
 };

--- a/projects/js-packages/components/components/pricing-card/types.ts
+++ b/projects/js-packages/components/components/pricing-card/types.ts
@@ -42,7 +42,7 @@ export type PricingCardProps = {
 	 */
 	infoText?: React.ReactNode;
 	/**
-	 * Optional Child nodes
+	 * The TOS copy.
 	 */
-	children?: React.ReactNode;
+	tosText?: React.ReactNode;
 };

--- a/projects/js-packages/components/components/pricing-table/index.tsx
+++ b/projects/js-packages/components/components/pricing-table/index.tsx
@@ -1,5 +1,3 @@
-import { ExternalLink } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, check, closeSmall } from '@wordpress/icons';
 import classnames from 'classnames';
@@ -12,9 +10,9 @@ import {
 	ReactElement,
 } from 'react';
 import React, { CSSProperties } from 'react';
-import getRedirectUrl from '../../../components/tools/jp-redirect';
 import IconTooltip from '../icon-tooltip';
 import useBreakpointMatch from '../layout/use-breakpoint-match';
+import TermsOfService from '../terms-of-service';
 import Text from '../text';
 import styles from './styles.module.scss';
 import {
@@ -23,19 +21,6 @@ import {
 	PricingTableHeaderProps,
 	PricingTableItemProps,
 } from './types';
-
-const ToS = createInterpolateElement(
-	__(
-		'By clicking the button above, you agree to our <tosLink>Terms of Service</tosLink> and to <shareDetailsLink>share details</shareDetailsLink> with WordPress.com.',
-		'jetpack'
-	),
-	{
-		tosLink: <ExternalLink href={ getRedirectUrl( 'wpcom-tos' ) } />,
-		shareDetailsLink: (
-			<ExternalLink href={ getRedirectUrl( 'jetpack-support-what-data-does-jetpack-sync' ) } />
-		),
-	}
-);
 
 const INCLUDED_TEXT = __( 'Included', 'jetpack' );
 const NOT_INCLUDED_TEXT = __( 'Not included', 'jetpack' );
@@ -200,7 +185,9 @@ const PricingTable: React.FC< PricingTableProps > = ( {
 							) }
 						</Text>
 					) }
-					<Text variant="body-small">{ ToS }</Text>
+					<Text variant="body-small">
+						<TermsOfService multipleButtons />
+					</Text>
 				</div>
 			</div>
 		</PricingTableContext.Provider>

--- a/projects/js-packages/components/components/pricing-table/index.tsx
+++ b/projects/js-packages/components/components/pricing-table/index.tsx
@@ -185,9 +185,7 @@ const PricingTable: React.FC< PricingTableProps > = ( {
 							) }
 						</Text>
 					) }
-					<Text variant="body-small">
-						<TermsOfService multipleButtons />
-					</Text>
+					<TermsOfService multipleButtons />
 				</div>
 			</div>
 		</PricingTableContext.Provider>

--- a/projects/js-packages/components/components/pricing-table/styles.module.scss
+++ b/projects/js-packages/components/components/pricing-table/styles.module.scss
@@ -1,25 +1,24 @@
 .container {
-	--padding: calc( var( --spacing-base ) * 4 );
-	color: var( --jp-black );
-
+	--padding: calc(var(--spacing-base) * 4);
+	color: var(--jp-black);
 }
 
 .table {
-	--gap: calc( var( --spacing-base ) * 3 );
+	--gap: calc(var(--spacing-base) * 3);
 	position: relative;
-	padding: var( --padding ) 0;
+	padding: var(--padding) 0;
 
 	.is-viewport-large & {
 		display: grid;
-		grid-template-columns: repeat( var( --columns ), 1fr );
+		grid-template-columns: repeat(var(--columns), 1fr);
 		grid-auto-flow: column;
-		grid-template-rows: repeat( var( --rows ), minmax( min-content, max-content ) );
-		column-gap: var( --gap );
+		grid-template-rows: repeat(var(--rows), minmax(min-content, max-content));
+		column-gap: var(--gap);
 	}
 }
 
 .card {
-	margin-top: var( --padding );
+	margin-top: var(--padding);
 
 	.is-viewport-large & {
 		display: contents;
@@ -27,9 +26,9 @@
 
 	&.is-primary {
 		> * {
-			background: var( --jp-white );
+			background: var(--jp-white);
 			position: relative;
-	
+
 			&::after {
 				content: '';
 				position: absolute;
@@ -38,26 +37,26 @@
 				right: 0;
 				bottom: 0;
 				z-index: -1;
-				box-shadow: 0px 4px 24px rgba( 0, 0, 0, 0.05 );
+				box-shadow: 0px 4px 24px rgba(0, 0, 0, 0.05);
 			}
 		}
 	}
 
 	> :first-child {
-		border-top-left-radius: var( --jp-border-radius );
-		border-top-right-radius: var( --jp-border-radius );
+		border-top-left-radius: var(--jp-border-radius);
+		border-top-right-radius: var(--jp-border-radius);
 		border-width: 1px 1px 0;
 	}
 
 	> :last-child {
 		border-width: 0 1px 1px;
-		border-bottom-left-radius: var( --jp-border-radius );
-		border-bottom-right-radius: var( --jp-border-radius );
+		border-bottom-left-radius: var(--jp-border-radius);
+		border-bottom-right-radius: var(--jp-border-radius);
 	}
 }
 
 .header {
-	padding: var( --padding );
+	padding: var(--padding);
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
@@ -66,11 +65,11 @@
 .item {
 	display: flex;
 	align-items: center;
-	padding-bottom: calc( var( --spacing-base ) * 2 );
+	padding-bottom: calc(var(--spacing-base) * 2);
 	position: relative;
 
-	&:not( :nth-child(2) ) {
-		padding-top: calc( var( --spacing-base ) * 2 );
+	&:not(:nth-child(2)) {
+		padding-top: calc(var(--spacing-base) * 2);
 
 		&::before {
 			content: '';
@@ -80,12 +79,12 @@
 			right: var(--padding);
 			height: 1px;
 			.is-viewport-large & {
-				width: calc( 100% + var(--gap) );
+				width: calc(100% + var(--gap));
 				left: 0;
 				right: unset;
 			}
 			z-index: 5;
-			background-color: var( --jp-gray );
+			background-color: var(--jp-gray);
 
 			// Last pricing column doesn't have any grid gap on the right. So override the default width specified above.
 			.is-viewport-large .table > :last-child & {
@@ -95,31 +94,31 @@
 	}
 
 	&:last-of-type {
-		padding-bottom: var( --padding );
+		padding-bottom: var(--padding);
 	}
 }
 
 .last-feature {
-	padding-bottom: var( --padding );
+	padding-bottom: var(--padding);
 }
 
 .value {
-	padding-left: var( --padding );
-	padding-right: var( --padding );
+	padding-left: var(--padding);
+	padding-right: var(--padding);
 }
 
 .icon {
-	margin: 0 var( --spacing-base );
-	fill: var( --fill, var( --jp-gray ) );
+	margin: 0 var(--spacing-base);
+	fill: var(--fill, var(--jp-gray));
 	flex-shrink: 0;
 }
 
 .icon-check {
-	--fill: var( --jp-green-40 );
+	--fill: var(--jp-green-40);
 }
 
 .icon-cross {
-	--fill: var( --jp-red-50 );
+	--fill: var(--jp-red-50);
 }
 
 .popover {
@@ -127,12 +126,12 @@
 
 	.is-viewport-large & {
 		top: 1px;
-		margin: 0 var( --spacing-base );
+		margin: 0 var(--spacing-base);
 	}
 }
 
 .item .popover-icon {
-	fill: var( --jp-gray-20 );
+	fill: var(--jp-gray-20);
 	flex-shrink: 0;
 }
 
@@ -145,8 +144,8 @@
 	}
 
 	.is-viewport-large & {
-		padding-left: var( --padding );
-		padding-right: var( --padding );
+		padding-left: var(--padding);
+		padding-right: var(--padding);
 		grid-column: 2;
 		white-space: nowrap;
 		overflow: hidden;
@@ -157,5 +156,5 @@
 	display: flex;
 	align-items: right;
 	justify-content: right;
-	margin: 0 calc( var( --spacing-base ) * 4 );
+	margin: 0 calc(var(--spacing-base) * 4);
 }

--- a/projects/js-packages/components/components/pricing-table/styles.module.scss
+++ b/projects/js-packages/components/components/pricing-table/styles.module.scss
@@ -109,16 +109,16 @@
 
 .icon {
 	margin: 0 var(--spacing-base);
-	fill: var(--fill, var(--jp-gray));
+	fill: var(--jp-gray);
 	flex-shrink: 0;
-}
 
-.icon-check {
-	--fill: var(--jp-green-40);
-}
+	&.icon-check {
+		fill: var(--jp-green-40);
+	}
 
-.icon-cross {
-	--fill: var(--jp-red-50);
+	&.icon-cross {
+		fill: var(--jp-red-50);
+	}
 }
 
 .popover {

--- a/projects/js-packages/components/components/product-offer/index.tsx
+++ b/projects/js-packages/components/components/product-offer/index.tsx
@@ -85,6 +85,8 @@ const ProductOffer: React.FC< ProductOfferProps > = ( {
 					{ error }
 				</Alert>
 
+				{ buttonDisclaimer }
+
 				{ ( ! isBundle || ( isBundle && ! hasRequiredPlan ) ) && (
 					<Button
 						onClick={ addProductUrl ? null : onAdd }
@@ -104,8 +106,6 @@ const ProductOffer: React.FC< ProductOfferProps > = ( {
 						<Text>{ __( 'Active on your site', 'jetpack' ) }</Text>
 					</div>
 				) }
-
-				{ buttonDisclaimer }
 			</div>
 		</div>
 	);

--- a/projects/js-packages/components/components/terms-of-service/index.tsx
+++ b/projects/js-packages/components/components/terms-of-service/index.tsx
@@ -2,50 +2,38 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import classNames from 'classnames';
 import { getRedirectUrl } from '../../../components';
-import type { MultipleButtonsProps, SingleButtonProps, TermsOfServiceProps } from './types';
+import Text from '../text';
+import type { TermsOfServiceProps } from './types';
 import './styles.scss';
 
-const Wrapper: React.FC< TermsOfServiceProps > = ( { className, ...textProps } ) => (
-	<p className={ classNames( className, 'terms-of-service' ) }>
-		<Text { ...textProps } />
-	</p>
-);
-
-const Text: React.FC< MultipleButtonsProps | SingleButtonProps > = ( {
+const TermsOfService: React.FC< TermsOfServiceProps > = ( {
+	className,
 	multipleButtons,
 	agreeButtonLabel,
-} ) => {
-	const tosLink = (
-		<a
-			className="terms-of-service__link"
-			href={ getRedirectUrl( 'wpcom-tos' ) }
-			rel="noopener noreferrer"
-			target="_blank"
-		/>
-	);
-	const shareDetailsLink = (
-		<a
-			className="terms-of-service__link"
-			href={ getRedirectUrl( 'jetpack-support-what-data-does-jetpack-sync' ) }
-			rel="noopener noreferrer"
-			target="_blank"
-		/>
+} ) => (
+	<Text className={ classNames( className, 'terms-of-service' ) }>
+		{ multipleButtons ? (
+			<MultipleButtonsText />
+		) : (
+			<SingleButtonText agreeButtonLabel={ agreeButtonLabel } />
+		) }
+	</Text>
+);
+
+const MultipleButtonsText = () =>
+	createInterpolateElement(
+		__(
+			'By clicking the buttons above, you agree to our <tosLink>Terms of Service</tosLink> and to <shareDetailsLink>share details</shareDetailsLink> with WordPress.com.',
+			'jetpack'
+		),
+		{
+			tosLink: <Link slug="wpcom-tos" />,
+			shareDetailsLink: <Link slug="jetpack-support-what-data-does-jetpack-sync" />,
+		}
 	);
 
-	if ( multipleButtons ) {
-		return createInterpolateElement(
-			__(
-				'By clicking the buttons above, you agree to our <tosLink>Terms of Service</tosLink> and to <shareDetailsLink>share details</shareDetailsLink> with WordPress.com.',
-				'jetpack'
-			),
-			{
-				tosLink,
-				shareDetailsLink,
-			}
-		);
-	}
-
-	return createInterpolateElement(
+const SingleButtonText = ( { agreeButtonLabel } ) =>
+	createInterpolateElement(
 		sprintf(
 			/* translators: %s is a button label */
 			__(
@@ -56,10 +44,20 @@ const Text: React.FC< MultipleButtonsProps | SingleButtonProps > = ( {
 		),
 		{
 			strong: <strong />,
-			tosLink,
-			shareDetailsLink,
+			tosLink: <Link slug="wpcom-tos" />,
+			shareDetailsLink: <Link slug="jetpack-support-what-data-does-jetpack-sync" />,
 		}
 	);
-};
 
-export default Wrapper;
+const Link: React.FC< { slug: string; children?: React.ReactNode } > = ( { slug, children } ) => (
+	<a
+		className="terms-of-service__link"
+		href={ getRedirectUrl( slug ) }
+		rel="noopener noreferrer"
+		target="_blank"
+	>
+		{ children }
+	</a>
+);
+
+export default TermsOfService;

--- a/projects/js-packages/components/components/terms-of-service/index.tsx
+++ b/projects/js-packages/components/components/terms-of-service/index.tsx
@@ -3,15 +3,24 @@ import { __, sprintf } from '@wordpress/i18n';
 import { getRedirectUrl } from '../../../components';
 import type { TermsOfServiceProps } from './types';
 
-const TermsOfService: React.FC< TermsOfServiceProps > = ( {
-	multipleButtons,
-	agreeButtonLabel,
-} ) => {
+const Wrapper: React.FC< TermsOfServiceProps > = props => (
+	<p className="terms-of-service">
+		<Text { ...props } />
+	</p>
+);
+
+const Text: React.FC< TermsOfServiceProps > = ( { multipleButtons, agreeButtonLabel } ) => {
 	const tosLink = (
-		<a href={ getRedirectUrl( 'wpcom-tos' ) } rel="noopener noreferrer" target="_blank" />
+		<a
+			className="terms-of-service__link"
+			href={ getRedirectUrl( 'wpcom-tos' ) }
+			rel="noopener noreferrer"
+			target="_blank"
+		/>
 	);
 	const shareDetailsLink = (
 		<a
+			className="terms-of-service__link"
 			href={ getRedirectUrl( 'jetpack-support-what-data-does-jetpack-sync' ) }
 			rel="noopener noreferrer"
 			target="_blank"
@@ -48,4 +57,4 @@ const TermsOfService: React.FC< TermsOfServiceProps > = ( {
 	);
 };
 
-export default TermsOfService;
+export default Wrapper;

--- a/projects/js-packages/components/components/terms-of-service/index.tsx
+++ b/projects/js-packages/components/components/terms-of-service/index.tsx
@@ -1,0 +1,51 @@
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { getRedirectUrl } from '../../../components';
+import type { TermsOfServiceProps } from './types';
+
+const TermsOfService: React.FC< TermsOfServiceProps > = ( {
+	multipleButtons,
+	agreeButtonLabel,
+} ) => {
+	const tosLink = (
+		<a href={ getRedirectUrl( 'wpcom-tos' ) } rel="noopener noreferrer" target="_blank" />
+	);
+	const shareDetailsLink = (
+		<a
+			href={ getRedirectUrl( 'jetpack-support-what-data-does-jetpack-sync' ) }
+			rel="noopener noreferrer"
+			target="_blank"
+		/>
+	);
+
+	if ( multipleButtons ) {
+		return createInterpolateElement(
+			__(
+				'By clicking the buttons above, you agree to our <tosLink>Terms of Service</tosLink> and to <shareDetailsLink>share details</shareDetailsLink> with WordPress.com.',
+				'jetpack'
+			),
+			{
+				tosLink,
+				shareDetailsLink,
+			}
+		);
+	}
+
+	return createInterpolateElement(
+		sprintf(
+			/* translators: %s is a button label */
+			__(
+				'By clicking the <strong>%s</strong> button, you agree to our <tosLink>Terms of Service</tosLink> and to <shareDetailsLink>share details</shareDetailsLink> with WordPress.com.',
+				'jetpack'
+			),
+			agreeButtonLabel
+		),
+		{
+			strong: <strong />,
+			tosLink,
+			shareDetailsLink,
+		}
+	);
+};
+
+export default TermsOfService;

--- a/projects/js-packages/components/components/terms-of-service/index.tsx
+++ b/projects/js-packages/components/components/terms-of-service/index.tsx
@@ -2,6 +2,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { getRedirectUrl } from '../../../components';
 import type { TermsOfServiceProps } from './types';
+import './styles.scss';
 
 const Wrapper: React.FC< TermsOfServiceProps > = props => (
 	<p className="terms-of-service">

--- a/projects/js-packages/components/components/terms-of-service/index.tsx
+++ b/projects/js-packages/components/components/terms-of-service/index.tsx
@@ -1,16 +1,20 @@
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import classNames from 'classnames';
 import { getRedirectUrl } from '../../../components';
-import type { TermsOfServiceProps } from './types';
+import type { MultipleButtonsProps, SingleButtonProps, TermsOfServiceProps } from './types';
 import './styles.scss';
 
-const Wrapper: React.FC< TermsOfServiceProps > = props => (
-	<p className="terms-of-service">
-		<Text { ...props } />
+const Wrapper: React.FC< TermsOfServiceProps > = ( { className, ...textProps } ) => (
+	<p className={ classNames( className, 'terms-of-service' ) }>
+		<Text { ...textProps } />
 	</p>
 );
 
-const Text: React.FC< TermsOfServiceProps > = ( { multipleButtons, agreeButtonLabel } ) => {
+const Text: React.FC< MultipleButtonsProps | SingleButtonProps > = ( {
+	multipleButtons,
+	agreeButtonLabel,
+} ) => {
 	const tosLink = (
 		<a
 			className="terms-of-service__link"

--- a/projects/js-packages/components/components/terms-of-service/styles.scss
+++ b/projects/js-packages/components/components/terms-of-service/styles.scss
@@ -1,0 +1,8 @@
+.terms-of-service {
+	font-size: var(--font-body);
+	color: var(--jp-black);
+
+	.terms-of-service__link {
+		color: var(--jp-green-50);
+	}
+}

--- a/projects/js-packages/components/components/terms-of-service/test/index.test.jsx
+++ b/projects/js-packages/components/components/terms-of-service/test/index.test.jsx
@@ -1,13 +1,5 @@
 import { render, screen } from '@testing-library/react';
-// Component under test
 import TermsOfService from '..';
-// Mocks
-import { getRedirectUrl } from '../../..';
-jest.mock( '../../..', () => ( {
-	__esModule: true,
-	...jest.requireActual( '../../..' ),
-	getRedirectUrl: jest.fn(),
-} ) );
 
 describe( 'TermsofService', () => {
 	it( "references only 'the buttons above' if multipleButtons is true", () => {
@@ -38,47 +30,23 @@ describe( 'TermsofService', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'links to the correct Terms of Service document (single button)', () => {
-		const testUrl = 'https://example.com';
-		getRedirectUrl.mockReturnValue( testUrl );
-
+	it( 'links to the Terms of Service document (single button)', () => {
 		render( <TermsOfService agreeButtonLabel={ 'whatever' } /> );
-		expect( screen.getByText( 'Terms of Service', { selector: 'a' } ) ).toHaveAttribute(
-			'href',
-			testUrl
-		);
+		expect( screen.getByText( 'Terms of Service', { selector: 'a' } ) ).toBeInTheDocument();
 	} );
 
-	it( 'links to the correct Terms of Service document (multiple buttons)', () => {
-		const testUrl = 'https://example.com';
-		getRedirectUrl.mockReturnValue( testUrl );
-
+	it( 'links to the Terms of Service document (multiple buttons)', () => {
 		render( <TermsOfService multipleButtons /> );
-		expect( screen.getByText( 'Terms of Service', { selector: 'a' } ) ).toHaveAttribute(
-			'href',
-			testUrl
-		);
+		expect( screen.getByText( 'Terms of Service', { selector: 'a' } ) ).toBeInTheDocument();
 	} );
 
-	it( 'links to the correct data sharing document (single button)', () => {
-		const testUrl = 'https://example.com';
-		getRedirectUrl.mockReturnValue( testUrl );
-
+	it( 'links to the data sharing document (single button)', () => {
 		render( <TermsOfService agreeButtonLabel={ 'whatever' } /> );
-		expect( screen.getByText( 'share details', { selector: 'a' } ) ).toHaveAttribute(
-			'href',
-			testUrl
-		);
+		expect( screen.getByText( 'share details', { selector: 'a' } ) ).toBeInTheDocument();
 	} );
 
-	it( 'links to the correct data sharing document (multiple buttons)', () => {
-		const testUrl = 'https://example.com';
-		getRedirectUrl.mockReturnValue( testUrl );
-
+	it( 'links to the data sharing document (multiple buttons)', () => {
 		render( <TermsOfService multipleButtons /> );
-		expect( screen.getByText( 'share details', { selector: 'a' } ) ).toHaveAttribute(
-			'href',
-			testUrl
-		);
+		expect( screen.getByText( 'share details', { selector: 'a' } ) ).toBeInTheDocument();
 	} );
 } );

--- a/projects/js-packages/components/components/terms-of-service/test/index.test.jsx
+++ b/projects/js-packages/components/components/terms-of-service/test/index.test.jsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react';
+// Component under test
+import TermsOfService from '..';
+// Mocks
+import { getRedirectUrl } from '../../..';
+jest.mock( '../../..', () => ( {
+	__esModule: true,
+	...jest.requireActual( '../../..' ),
+	getRedirectUrl: jest.fn(),
+} ) );
+
+describe( 'TermsofService', () => {
+	it( "references only 'the buttons above' if multipleButtons is true", () => {
+		render( <TermsOfService multipleButtons /> );
+		expect(
+			screen.getByText(
+				( content, { textContent } ) =>
+					content !== '' && // filter out parent/wrapper elements
+					textContent.startsWith(
+						`By clicking the buttons above, you agree to our Terms of Service`
+					)
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'references the label of the agreement button if one is defined', () => {
+		const buttonLabel = 'The best button ever';
+
+		render( <TermsOfService agreeButtonLabel={ buttonLabel } /> );
+		expect(
+			screen.getByText(
+				( content, { textContent } ) =>
+					content !== '' && // filter out parent/wrapper elements
+					textContent.startsWith(
+						`By clicking the ${ buttonLabel } button, you agree to our Terms of Service`
+					)
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'links to the correct Terms of Service document (single button)', () => {
+		const testUrl = 'https://example.com';
+		getRedirectUrl.mockReturnValue( testUrl );
+
+		render( <TermsOfService agreeButtonLabel={ 'whatever' } /> );
+		expect( screen.getByText( 'Terms of Service', { selector: 'a' } ) ).toHaveAttribute(
+			'href',
+			testUrl
+		);
+	} );
+
+	it( 'links to the correct Terms of Service document (multiple buttons)', () => {
+		const testUrl = 'https://example.com';
+		getRedirectUrl.mockReturnValue( testUrl );
+
+		render( <TermsOfService multipleButtons /> );
+		expect( screen.getByText( 'Terms of Service', { selector: 'a' } ) ).toHaveAttribute(
+			'href',
+			testUrl
+		);
+	} );
+
+	it( 'links to the correct data sharing document (single button)', () => {
+		const testUrl = 'https://example.com';
+		getRedirectUrl.mockReturnValue( testUrl );
+
+		render( <TermsOfService agreeButtonLabel={ 'whatever' } /> );
+		expect( screen.getByText( 'share details', { selector: 'a' } ) ).toHaveAttribute(
+			'href',
+			testUrl
+		);
+	} );
+
+	it( 'links to the correct data sharing document (multiple buttons)', () => {
+		const testUrl = 'https://example.com';
+		getRedirectUrl.mockReturnValue( testUrl );
+
+		render( <TermsOfService multipleButtons /> );
+		expect( screen.getByText( 'share details', { selector: 'a' } ) ).toHaveAttribute(
+			'href',
+			testUrl
+		);
+	} );
+} );

--- a/projects/js-packages/components/components/terms-of-service/types.ts
+++ b/projects/js-packages/components/components/terms-of-service/types.ts
@@ -1,4 +1,4 @@
-export type MultipleButtonsProps = {
+type MultipleButtonsProps = {
 	/**
 	 * Indicates whether there are multiple buttons present that would imply agreement if clicked.
 	 */
@@ -10,7 +10,7 @@ export type MultipleButtonsProps = {
 	agreeButtonLabel?: undefined;
 };
 
-export type SingleButtonProps = {
+type SingleButtonProps = {
 	/**
 	 * Indicates whether there are multiple buttons present that would imply agreement if clicked.
 	 */

--- a/projects/js-packages/components/components/terms-of-service/types.ts
+++ b/projects/js-packages/components/components/terms-of-service/types.ts
@@ -1,0 +1,4 @@
+export type TermsOfServiceProps = {
+	multipleButtons?: boolean;
+	agreeButtonLabel?: string;
+};

--- a/projects/js-packages/components/components/terms-of-service/types.ts
+++ b/projects/js-packages/components/components/terms-of-service/types.ts
@@ -1,4 +1,25 @@
-export type TermsOfServiceProps = {
-	multipleButtons?: boolean;
-	agreeButtonLabel?: string;
+type MultipleButtonsProps = {
+	/**
+	 * Indicates whether there are multiple buttons present that would imply agreement if clicked.
+	 */
+	multipleButtons: true;
+
+	/**
+	 * The text label of the button someone would click to agree to the terms.
+	 */
+	agreeButtonLabel?: undefined;
 };
+
+type SingleButtonProps = {
+	/**
+	 * Indicates whether there are multiple buttons present that would imply agreement if clicked.
+	 */
+	multipleButtons?: false;
+
+	/**
+	 * The text label of the button someone would click to agree to the terms.
+	 */
+	agreeButtonLabel: string;
+};
+
+export type TermsOfServiceProps = MultipleButtonsProps | SingleButtonProps;

--- a/projects/js-packages/components/components/terms-of-service/types.ts
+++ b/projects/js-packages/components/components/terms-of-service/types.ts
@@ -1,4 +1,4 @@
-type MultipleButtonsProps = {
+export type MultipleButtonsProps = {
 	/**
 	 * Indicates whether there are multiple buttons present that would imply agreement if clicked.
 	 */
@@ -10,7 +10,7 @@ type MultipleButtonsProps = {
 	agreeButtonLabel?: undefined;
 };
 
-type SingleButtonProps = {
+export type SingleButtonProps = {
 	/**
 	 * Indicates whether there are multiple buttons present that would imply agreement if clicked.
 	 */
@@ -22,4 +22,9 @@ type SingleButtonProps = {
 	agreeButtonLabel: string;
 };
 
-export type TermsOfServiceProps = MultipleButtonsProps | SingleButtonProps;
+export type TermsOfServiceProps = {
+	/**
+	 * Represents additional CSS classes to be added to the component's root.
+	 */
+	className?: string;
+} & ( MultipleButtonsProps | SingleButtonProps );

--- a/projects/js-packages/components/index.ts
+++ b/projects/js-packages/components/index.ts
@@ -41,6 +41,7 @@ export { default as Text, H2, H3, Title } from './components/text';
 export { default as numberFormat } from './components/number-format';
 export { default as QRCode } from './components/qr-code';
 export { default as Button } from './components/button';
+export { default as TermsOfService } from './components/terms-of-service';
 export {
 	default as PricingTable,
 	PricingTableColumn,

--- a/projects/js-packages/connection/changelog/update-toc-text-location
+++ b/projects/js-packages/connection/changelog/update-toc-text-location
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Revise Jetpack connection agreement text to comply with our User Agreement

--- a/projects/js-packages/connection/components/connect-screen/basic/style.scss
+++ b/projects/js-packages/connection/components/connect-screen/basic/style.scss
@@ -2,14 +2,16 @@
 @import '@wordpress/base-styles/mixins';
 
 .jp-connection__connect-screen {
+	--spacing-base: 8px;
+
 	&__loading {
 		display: none;
 	}
 
-	&__tos {
-		margin-top: 28px;
+	.terms-of-service {
+		margin-top: calc(var(--spacing-base) * 4);
+		margin-bottom: calc(var(--spacing-base) * 3);
 		max-width: 360px;
-		margin-bottom: 28px;
 	}
 
 	.jp-action-button {

--- a/projects/js-packages/connection/components/connect-screen/basic/style.scss
+++ b/projects/js-packages/connection/components/connect-screen/basic/style.scss
@@ -21,6 +21,11 @@
 	.jp-action-button {
 		margin-top: 40px;
 
+		&--button {
+			border-radius: 4px;
+			font-weight: 600;
+		}
+
 		button {
 			max-width: 100%;
 

--- a/projects/js-packages/connection/components/connect-screen/basic/style.scss
+++ b/projects/js-packages/connection/components/connect-screen/basic/style.scss
@@ -9,6 +9,7 @@
 	&__tos {
 		margin-top: 28px;
 		max-width: 360px;
+		margin-bottom: 28px;
 	}
 
 	.jp-action-button {

--- a/projects/js-packages/connection/components/connect-screen/basic/style.scss
+++ b/projects/js-packages/connection/components/connect-screen/basic/style.scss
@@ -12,6 +12,10 @@
 		margin-top: calc(var(--spacing-base) * 4);
 		margin-bottom: calc(var(--spacing-base) * 3);
 		max-width: 360px;
+
+		a {
+			text-decoration: underline;
+		}
 	}
 
 	.jp-action-button {

--- a/projects/js-packages/connection/components/connect-screen/basic/test/component.jsx
+++ b/projects/js-packages/connection/components/connect-screen/basic/test/component.jsx
@@ -4,8 +4,9 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import ConnectScreen from '../visual';
 
+const CONNECTION_BUTTON_LABEL = 'Setup Jetpack';
 const requiredProps = {
-	buttonLabel: 'Setup Jetpack',
+	buttonLabel: CONNECTION_BUTTON_LABEL,
 };
 
 describe( 'ConnectScreen', () => {
@@ -18,16 +19,37 @@ describe( 'ConnectScreen', () => {
 		expect( screen.getByText( 'Connect children' ) ).toBeInTheDocument();
 	} );
 
-	it( 'shows button and tos', () => {
+	it( 'displays required terms of service text and a clickable connection button with the proper label text', () => {
 		render( <ConnectScreen { ...requiredProps } /> );
-		expect( screen.getByRole( 'button', { name: 'Setup Jetpack' } ) ).toBeInTheDocument();
-		expect( screen.getByText( /By clicking the button above/i ) ).toBeInTheDocument();
+
+		expect(
+			screen.getByText(
+				( content, { textContent } ) =>
+					content !== '' && // filter out parent/wrapper elements
+					textContent.startsWith(
+						`By clicking the ${ CONNECTION_BUTTON_LABEL } button, you agree to our Terms of Service`
+					)
+			)
+		).toBeInTheDocument();
+
+		expect( screen.getByRole( 'button', { name: CONNECTION_BUTTON_LABEL } ) ).toBeEnabled();
 	} );
 
-	it( 'remove button and tos', () => {
+	it( 'displays neither terms of service nor a connection button if `showConnectButton` is false', () => {
 		render( <ConnectScreen { ...requiredProps } showConnectButton={ false } /> );
-		expect( screen.queryByRole( 'button', { name: 'Setup Jetpack' } ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( /By clicking the button above/i ) ).not.toBeInTheDocument();
+
+		expect(
+			screen.queryByText(
+				( content, { textContent } ) =>
+					content !== '' && // filter out parent/wrapper elements
+					textContent.startsWith(
+						`By clicking the ${ CONNECTION_BUTTON_LABEL } button, you agree to our Terms of Service`
+					)
+			)
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: CONNECTION_BUTTON_LABEL } )
+		).not.toBeInTheDocument();
 	} );
 
 	it( 'applies correct href to terms of service', () => {

--- a/projects/js-packages/connection/components/connect-screen/basic/test/component.jsx
+++ b/projects/js-packages/connection/components/connect-screen/basic/test/component.jsx
@@ -54,14 +54,14 @@ describe( 'ConnectScreen', () => {
 
 	it( 'applies correct href to terms of service', () => {
 		render( <ConnectScreen { ...requiredProps } /> );
-		const terms = screen.getByRole( 'link', { name: 'Terms of Service (opens in a new tab)' } );
+		const terms = screen.getByRole( 'link', { name: 'Terms of Service' } );
 		expect( terms ).toHaveAttribute( 'href', 'https://jetpack.com/redirect/?source=wpcom-tos' );
 		expect( terms ).toHaveAttribute( 'target', '_blank' );
 	} );
 
 	it( 'applies correct href to share', () => {
 		render( <ConnectScreen { ...requiredProps } /> );
-		const share = screen.getByRole( 'link', { name: 'share details (opens in a new tab)' } );
+		const share = screen.getByRole( 'link', { name: 'share details' } );
 		expect( share ).toHaveAttribute(
 			'href',
 			'https://jetpack.com/redirect/?source=jetpack-support-what-data-does-jetpack-sync'

--- a/projects/js-packages/connection/components/connect-screen/basic/visual.jsx
+++ b/projects/js-packages/connection/components/connect-screen/basic/visual.jsx
@@ -1,37 +1,9 @@
-import { getRedirectUrl, ActionButton } from '@automattic/jetpack-components';
-import { createInterpolateElement } from '@wordpress/element';
-import { sprintf, __ } from '@wordpress/i18n';
+import { ActionButton, TermsOfService } from '@automattic/jetpack-components';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ConnectScreenLayout from '../layout';
 import './style.scss';
 
-export const ToS = ( { buttonLabel } ) => {
-	return createInterpolateElement(
-		sprintf(
-			/* translators: placeholder is a button label */
-			__(
-				'By clicking the <strong>%s</strong> button, you agree to our <tosLink>Terms of Service</tosLink> and to <shareDetailsLink>share details</shareDetailsLink> with WordPress.com.',
-				'jetpack'
-			),
-			buttonLabel
-		),
-
-		{
-			strong: <strong />,
-			tosLink: (
-				<a href={ getRedirectUrl( 'wpcom-tos' ) } rel="noopener noreferrer" target="_blank" />
-			),
-			shareDetailsLink: (
-				<a
-					href={ getRedirectUrl( 'jetpack-support-what-data-does-jetpack-sync' ) }
-					rel="noopener noreferrer"
-					target="_blank"
-				/>
-			),
-		}
-	);
-};
 /**
  * The Connection Screen Visual component..
  *
@@ -69,7 +41,7 @@ const ConnectScreenVisual = props => {
 				{ showConnectButton && (
 					<>
 						<div className="jp-connection__connect-screen__tos">
-							<ToS buttonLabel={ buttonLabel } />
+							<TermsOfService agreeButtonLabel={ buttonLabel } />
 						</div>
 						<ActionButton
 							label={ buttonLabel }

--- a/projects/js-packages/connection/components/connect-screen/basic/visual.jsx
+++ b/projects/js-packages/connection/components/connect-screen/basic/visual.jsx
@@ -1,25 +1,37 @@
 import { getRedirectUrl, ActionButton } from '@automattic/jetpack-components';
-import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { sprintf, __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ConnectScreenLayout from '../layout';
 import './style.scss';
 
-export const ToS = createInterpolateElement(
-	__(
-		'By clicking the button above, you agree to our <tosLink>Terms of Service</tosLink> and to <shareDetailsLink>share details</shareDetailsLink> with WordPress.com.',
-		'jetpack'
-	),
-	{
-		tosLink: <ExternalLink href={ getRedirectUrl( 'wpcom-tos' ) } />,
-		shareDetailsLink: (
-			<ExternalLink href={ getRedirectUrl( 'jetpack-support-what-data-does-jetpack-sync' ) } />
+export const ToS = ( { buttonLabel } ) => {
+	return createInterpolateElement(
+		sprintf(
+			/* translators: placeholder is a button label */
+			__(
+				'By clicking the <strong>%s</strong> button, you agree to our <tosLink>Terms of Service</tosLink> and to <shareDetailsLink>share details</shareDetailsLink> with WordPress.com.',
+				'jetpack'
+			),
+			buttonLabel
 		),
-	}
-);
 
+		{
+			strong: <strong />,
+			tosLink: (
+				<a href={ getRedirectUrl( 'wpcom-tos' ) } rel="noopener noreferrer" target="_blank" />
+			),
+			shareDetailsLink: (
+				<a
+					href={ getRedirectUrl( 'jetpack-support-what-data-does-jetpack-sync' ) }
+					rel="noopener noreferrer"
+					target="_blank"
+				/>
+			),
+		}
+	);
+};
 /**
  * The Connection Screen Visual component..
  *
@@ -56,14 +68,15 @@ const ConnectScreenVisual = props => {
 
 				{ showConnectButton && (
 					<>
+						<div className="jp-connection__connect-screen__tos">
+							<ToS buttonLabel={ buttonLabel } />
+						</div>
 						<ActionButton
 							label={ buttonLabel }
 							onClick={ handleButtonClick }
 							displayError={ displayButtonError }
 							isLoading={ buttonIsLoading }
 						/>
-
-						<div className="jp-connection__connect-screen__tos">{ ToS }</div>
 					</>
 				) }
 

--- a/projects/js-packages/connection/components/connect-screen/layout/style.scss
+++ b/projects/js-packages/connection/components/connect-screen/layout/style.scss
@@ -16,7 +16,7 @@
 	}
 
 	&__left {
-		padding: 25px;
+		padding: calc(var(--spacing-base) * 3);
 
 		@include break-small {
 			padding: 64px 96px;

--- a/projects/js-packages/connection/components/connect-screen/required-plan/style.scss
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/style.scss
@@ -22,9 +22,12 @@
 		display: none;
 	}
 
-	.terms-of-service {
-		margin-top: calc(var(--spacing-base) * 4);
-		margin-bottom: var(--spacing-base);
+	/** There's a header above this list, which makes the top spacing
+	  * look a bit taller than it actually is
+	  */
+	ul.jp-product-promote {
+		margin-block-start: calc(var(--spacing-base) * 3);
+		margin-block-end: calc(var(--spacing-base) * 4);
 	}
 
 	&__pricing-card {
@@ -50,6 +53,11 @@
 			margin: 24px 0px 32px;
 			justify-content: center;
 			align-items: center;
+		}
+
+		.terms-of-service {
+			margin-top: calc(var(--spacing-base) * 4);
+			margin-bottom: var(--spacing-base);
 		}
 	}
 

--- a/projects/js-packages/connection/components/connect-screen/required-plan/style.scss
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/style.scss
@@ -56,9 +56,11 @@
 	&__with-subscription {
 		margin-top: calc(var(--spacing-base) * 4);
 
-		.jp-action-button {
-			display: inline;
-		}
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: flex-start;
+		gap: 1ch;
+		line-height: 1;
 
 		.jp-action-button--button.components-button.is-primary {
 			display: inline;

--- a/projects/js-packages/connection/components/connect-screen/required-plan/style.scss
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/style.scss
@@ -45,7 +45,7 @@
 	}
 
 	&__with-subscription {
-		margin-top: 38px;
+		margin-top: calc(var(--spacing-base) * 4);
 
 		.jp-action-button {
 			display: inline;

--- a/projects/js-packages/connection/components/connect-screen/required-plan/style.scss
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/style.scss
@@ -10,38 +10,37 @@
 .jp-connection__connect-screen-required-plan {
 	@include break-xlarge {
 		position: relative;
-		background: linear-gradient(to right, white 70%, #F9F9F6 30%);
+		background: linear-gradient(to right, white 70%, #f9f9f6 30%);
 	}
 
 	&__loading {
 		display: none;
 	}
 
-	&__toc-info {
+	&__tos-info {
 		margin-bottom: 8px;
 		margin-top: 16px;
-		font-size: var( --font-label );
+		font-size: var(--font-label);
 		line-height: 20px;
 		letter-spacing: -0.02em;
-		color: var( --jp-gray-60 );
+		color: var(--jp-gray-60);
 	}
 
 	&__pricing-card {
-
 		@include break-xlarge {
 			position: absolute;
 			top: 14%;
 			left: 62%;
 		}
 
-		.jp-action-button--button.components-button  {
+		.jp-action-button--button.components-button {
 			width: 100%;
 			height: auto;
 			font-size: 18px;
 			font-weight: 500;
-			background: var( --jp-black ) !important;
-			color: var( --jp-white ) !important;
-			border-radius: var( --jp-border-radius );
+			background: var(--jp-black) !important;
+			color: var(--jp-white) !important;
+			border-radius: var(--jp-border-radius);
 			padding: 14px 24px;
 			margin: 24px 0px 32px;
 			justify-content: center;
@@ -58,9 +57,9 @@
 
 		.jp-action-button--button.components-button {
 			display: inline;
-			font-size: var( --font-title-small );
+			font-size: var(--font-title-small);
 			line-height: 20px;
-			color: var( --jp-black ) !important;
+			color: var(--jp-black) !important;
 			background: inherit !important;
 			text-decoration: underline;
 
@@ -71,8 +70,8 @@
 			padding: 0;
 
 			&:hover {
-			background: inherit;
-				text-decoration-thickness: var( --jp-underline-thickness );
+				background: inherit;
+				text-decoration-thickness: var(--jp-underline-thickness);
 			}
 
 			&:focus {
@@ -81,9 +80,10 @@
 			}
 		}
 
-		.jp-components-spinner__inner, .jp-components-spinner__outer {
-			border-top-color: var( --jp-black ); 
-			border-right-color: var( --jp-black ); 
+		.jp-components-spinner__inner,
+		.jp-components-spinner__outer {
+			border-top-color: var(--jp-black);
+			border-right-color: var(--jp-black);
 		}
 	}
 }

--- a/projects/js-packages/connection/components/connect-screen/required-plan/style.scss
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/style.scss
@@ -17,13 +17,9 @@
 		display: none;
 	}
 
-	&__tos-info {
-		margin-bottom: 8px;
-		margin-top: 16px;
-		font-size: var(--font-label);
-		line-height: 20px;
-		letter-spacing: -0.02em;
-		color: var(--jp-gray-60);
+	.terms-of-service {
+		margin-top: calc(var(--spacing-base) * 4);
+		margin-bottom: var(--spacing-base);
 	}
 
 	&__pricing-card {

--- a/projects/js-packages/connection/components/connect-screen/required-plan/style.scss
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/style.scss
@@ -60,7 +60,7 @@
 			display: inline;
 		}
 
-		.jp-action-button--button.components-button {
+		.jp-action-button--button.components-button.is-primary {
 			display: inline;
 			font-size: var(--font-title-small);
 			line-height: 20px;

--- a/projects/js-packages/connection/components/connect-screen/required-plan/style.scss
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/style.scss
@@ -17,6 +17,15 @@
 		display: none;
 	}
 
+	&__toc-info {
+		margin-bottom: 8px;
+		margin-top: 16px;
+		font-size: var( --font-label );
+		line-height: 20px;
+		letter-spacing: -0.02em;
+		color: var( --jp-gray-60 );
+	}
+
 	&__pricing-card {
 
 		@include break-xlarge {

--- a/projects/js-packages/connection/components/connect-screen/required-plan/style.scss
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/style.scss
@@ -2,8 +2,13 @@
 @import '@wordpress/base-styles/mixins';
 
 .jp-connection__connect-screen-layout__left {
+	/**
+	  * Start with 100% width;
+	  * then account for a 384px pricing card that floats to the right;
+	  * finally give 32px of padding between content and the pricing card
+	  */
 	@include break-xlarge {
-		width: 70%;
+		width: calc(100% - 384px - var(--spacing-base) * 4);
 	}
 }
 
@@ -23,10 +28,14 @@
 	}
 
 	&__pricing-card {
+		/** Line up with the top of the product logo,
+		  * and mirror 96px horizontal padding seen in
+		  * .jp-connection__connect-screen-layout__left
+		 */
 		@include break-xlarge {
 			position: absolute;
-			top: 14%;
-			left: 62%;
+			top: calc(var(--spacing-base) * 8);
+			right: calc(var(--spacing-base) * 12);
 		}
 
 		.jp-action-button--button.components-button {

--- a/projects/js-packages/connection/components/connect-screen/required-plan/test/component.jsx
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/test/component.jsx
@@ -4,8 +4,10 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import ConnectScreenRequiredPlan from '../visual';
 
+const CONNECTION_BUTTON_LABEL = 'Setup Jetpack';
+
 const requiredProps = {
-	buttonLabel: 'Setup Jetpack',
+	buttonLabel: CONNECTION_BUTTON_LABEL,
 	pricingTitle: 'Jetpack Backup',
 	priceBefore: 9,
 	priceAfter: 4.5,
@@ -21,18 +23,36 @@ describe( 'ConnectScreenRequiredPlan', () => {
 		expect( screen.getByText( 'Connect children' ) ).toBeInTheDocument();
 	} );
 
-	it( 'shows button, tos and subscription', () => {
+	it( 'displays required terms of service text, a prompt for existing subscriptions,and a clickable connection button with the proper label text', () => {
 		render( <ConnectScreenRequiredPlan { ...requiredProps } /> );
-		expect( screen.getByRole( 'button', { name: 'Setup Jetpack' } ) ).toBeInTheDocument();
-		expect( screen.getByText( /By clicking the button above/i ) ).toBeInTheDocument();
-		expect( screen.getByText( /Already have a subscription?/i ) ).toBeInTheDocument();
+
+		expect(
+			screen.getByText(
+				( content, { textContent } ) =>
+					content !== '' && // filter out parent/wrapper elements
+					textContent.startsWith(
+						`By clicking the ${ CONNECTION_BUTTON_LABEL } button, you agree to our Terms of Service`
+					)
+			)
+		).toBeInTheDocument();
+		expect( screen.getByText( 'Already have a subscription?' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: CONNECTION_BUTTON_LABEL } ) ).toBeEnabled();
 	} );
 
-	it( 'remove button, tos and subscription', () => {
+	it( 'does not display terms of service text, a connection button, or an existing subscription prompt when `showConnectButton` is false', () => {
 		render( <ConnectScreenRequiredPlan { ...requiredProps } showConnectButton={ false } /> );
+		expect(
+			screen.queryByText(
+				( content, { textContent } ) =>
+					content !== '' && // filter out parent/wrapper elements
+					textContent.startsWith(
+						`By clicking the ${ CONNECTION_BUTTON_LABEL } button, you agree to our Terms of Service`
+					)
+			)
+		).not.toBeInTheDocument();
+
+		expect( screen.queryByText( 'Already have a subscription?' ) ).not.toBeInTheDocument();
 		expect( screen.queryByRole( 'button', { name: 'Setup Jetpack' } ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( /By clicking the button above/i ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( /Already have a subscription?/i ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'applies correct href to terms of service', () => {

--- a/projects/js-packages/connection/components/connect-screen/required-plan/test/component.jsx
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/test/component.jsx
@@ -57,14 +57,14 @@ describe( 'ConnectScreenRequiredPlan', () => {
 
 	it( 'applies correct href to terms of service', () => {
 		render( <ConnectScreenRequiredPlan { ...requiredProps } /> );
-		const terms = screen.getByRole( 'link', { name: 'Terms of Service (opens in a new tab)' } );
+		const terms = screen.getByRole( 'link', { name: 'Terms of Service' } );
 		expect( terms ).toHaveAttribute( 'href', 'https://jetpack.com/redirect/?source=wpcom-tos' );
 		expect( terms ).toHaveAttribute( 'target', '_blank' );
 	} );
 
 	it( 'applies correct href to share', () => {
 		render( <ConnectScreenRequiredPlan { ...requiredProps } /> );
-		const share = screen.getByRole( 'link', { name: 'share details (opens in a new tab)' } );
+		const share = screen.getByRole( 'link', { name: 'share details' } );
 		expect( share ).toHaveAttribute(
 			'href',
 			'https://jetpack.com/redirect/?source=jetpack-support-what-data-does-jetpack-sync'

--- a/projects/js-packages/connection/components/connect-screen/required-plan/visual.jsx
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/visual.jsx
@@ -87,7 +87,7 @@ const ConnectScreenRequiredPlanVisual = props => {
 					>
 						{ showConnectButton && (
 							<>
-								<div className="jp-connection__connect-screen-required-plan__toc-info">{ tos }</div>
+								<div className="jp-connection__connect-screen-required-plan__tos-info">{ tos }</div>
 								<ActionButton
 									label={ buttonLabel }
 									onClick={ handleButtonClick }

--- a/projects/js-packages/connection/components/connect-screen/required-plan/visual.jsx
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/visual.jsx
@@ -65,9 +65,7 @@ const ConnectScreenRequiredPlanVisual = props => {
 					>
 						{ showConnectButton && (
 							<>
-								<div className="jp-connection__connect-screen-required-plan__tos-info">
-									<TermsOfService agreeButtonLabel={ buttonLabel } />
-								</div>
+								<TermsOfService agreeButtonLabel={ buttonLabel } />
 								<ActionButton
 									label={ buttonLabel }
 									onClick={ handleButtonClick }

--- a/projects/js-packages/connection/components/connect-screen/required-plan/visual.jsx
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/visual.jsx
@@ -1,7 +1,7 @@
 import { getRedirectUrl, PricingCard, ActionButton } from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { sprintf, __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ConnectScreenLayout from '../layout';
@@ -32,12 +32,20 @@ const ConnectScreenRequiredPlanVisual = props => {
 	} = props;
 
 	const tos = createInterpolateElement(
-		__(
-			'By clicking the button above, you agree to our <tosLink>Terms of Service</tosLink> and to <shareDetailsLink>share details</shareDetailsLink> with WordPress.com.',
-			'jetpack'
+		sprintf(
+			/* translators: placeholder is a button label */
+			__(
+				'By clicking the <strong>%s</strong> button, you agree to our <tosLink>Terms of Service</tosLink> and to <shareDetailsLink>share details</shareDetailsLink> with WordPress.com.',
+				'jetpack'
+			),
+			buttonLabel
 		),
+
 		{
-			tosLink: <ExternalLink href={ getRedirectUrl( 'wpcom-tos' ) } />,
+			strong: <strong />,
+			tosLink: (
+				<a href={ getRedirectUrl( 'wpcom-tos' ) } rel="noopener noreferrer" target="_blank" />
+			),
 			shareDetailsLink: (
 				<ExternalLink href={ getRedirectUrl( 'jetpack-support-what-data-does-jetpack-sync' ) } />
 			),
@@ -76,15 +84,17 @@ const ConnectScreenRequiredPlanVisual = props => {
 						priceBefore={ priceBefore }
 						currencyCode={ pricingCurrencyCode }
 						priceAfter={ priceAfter }
-						infoText={ showConnectButton ? tos : '' }
 					>
 						{ showConnectButton && (
-							<ActionButton
-								label={ buttonLabel }
-								onClick={ handleButtonClick }
-								displayError={ displayButtonError }
-								isLoading={ buttonIsLoading }
-							/>
+							<>
+								<div className="jp-connection__connect-screen-required-plan__toc-info">{ tos }</div>
+								<ActionButton
+									label={ buttonLabel }
+									onClick={ handleButtonClick }
+									displayError={ displayButtonError }
+									isLoading={ buttonIsLoading }
+								/>
+							</>
 						) }
 					</PricingCard>
 				</div>

--- a/projects/js-packages/connection/components/connect-screen/required-plan/visual.jsx
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/visual.jsx
@@ -1,7 +1,6 @@
-import { getRedirectUrl, PricingCard, ActionButton } from '@automattic/jetpack-components';
-import { ExternalLink } from '@wordpress/components';
+import { ActionButton, PricingCard, TermsOfService } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
-import { sprintf, __ } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ConnectScreenLayout from '../layout';
@@ -30,27 +29,6 @@ const ConnectScreenRequiredPlanVisual = props => {
 		buttonIsLoading,
 		logo,
 	} = props;
-
-	const tos = createInterpolateElement(
-		sprintf(
-			/* translators: placeholder is a button label */
-			__(
-				'By clicking the <strong>%s</strong> button, you agree to our <tosLink>Terms of Service</tosLink> and to <shareDetailsLink>share details</shareDetailsLink> with WordPress.com.',
-				'jetpack'
-			),
-			buttonLabel
-		),
-
-		{
-			strong: <strong />,
-			tosLink: (
-				<a href={ getRedirectUrl( 'wpcom-tos' ) } rel="noopener noreferrer" target="_blank" />
-			),
-			shareDetailsLink: (
-				<ExternalLink href={ getRedirectUrl( 'jetpack-support-what-data-does-jetpack-sync' ) } />
-			),
-		}
-	);
 
 	const withSubscription = createInterpolateElement(
 		__( 'Already have a subscription? <connectButton/>', 'jetpack' ),
@@ -87,7 +65,9 @@ const ConnectScreenRequiredPlanVisual = props => {
 					>
 						{ showConnectButton && (
 							<>
-								<div className="jp-connection__connect-screen-required-plan__tos-info">{ tos }</div>
+								<div className="jp-connection__connect-screen-required-plan__tos-info">
+									<TermsOfService agreeButtonLabel={ buttonLabel } />
+								</div>
 								<ActionButton
 									label={ buttonLabel }
 									onClick={ handleButtonClick }

--- a/projects/js-packages/connection/index.jsx
+++ b/projects/js-packages/connection/index.jsx
@@ -19,7 +19,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 export { default as ConnectScreen } from './components/connect-screen/basic';
 export { default as ConnectScreenLayout } from './components/connect-screen/layout';
-export { ToS } from './components/connect-screen/basic/visual';
 export { default as ConnectScreenRequiredPlan } from './components/connect-screen/required-plan';
 export { default as ConnectButton } from './components/connect-button';
 export { default as InPlaceConnection } from './components/in-place-connection';

--- a/projects/plugins/boost/app/assets/src/css/components/connection.scss
+++ b/projects/plugins/boost/app/assets/src/css/components/connection.scss
@@ -121,6 +121,7 @@
 	text-align: center;
 	margin-left: auto;
 	margin-right: auto;
+	margin-bottom: 0.5rem;
 
 	@include breakpoint(md) {
 		width: 445px;

--- a/projects/plugins/boost/app/assets/src/css/components/connection.scss
+++ b/projects/plugins/boost/app/assets/src/css/components/connection.scss
@@ -65,6 +65,7 @@
 
 	svg {
 		fill: $jetpack-green;
+		flex-shrink: 0;
 	}
 
 	span {

--- a/projects/plugins/boost/app/assets/src/css/components/connection.scss
+++ b/projects/plugins/boost/app/assets/src/css/components/connection.scss
@@ -129,16 +129,6 @@
 	}
 }
 
-/* Emulate .jp-connection__connect-screen-required-plan__tos-info */
-.jb-connection__terms-of-service {
-	margin-bottom: 8px;
-	margin-top: 16px;
-	font-size: var(--font-label);
-	line-height: 20px;
-	letter-spacing: -0.02em;
-	color: var(--jp-gray-60);
-}
-
 /* Emulate .jp-components__pricing-card__button */
 .jb-connection .components-button.is-jb-primary {
 	align-self: center;

--- a/projects/plugins/boost/app/assets/src/css/components/connection.scss
+++ b/projects/plugins/boost/app/assets/src/css/components/connection.scss
@@ -50,7 +50,7 @@
 }
 
 .jb-connection .checklist {
-	border: 1px solid #DCDCDE;
+	border: 1px solid #dcdcde;
 	display: grid;
 	grid-template-columns: 1fr 1fr;
 	grid-gap: 24px;
@@ -74,7 +74,6 @@
 		color: $primary-grey;
 	}
 }
-
 
 .jb-connection__iframe {
 	width: 100%;
@@ -108,7 +107,8 @@
 
 .jb-connection__title {
 	margin: 0 0 24px 0;
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif,
+		'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 	font-style: normal;
 	font-weight: 700;
 
@@ -126,5 +126,37 @@
 
 	@include breakpoint(md) {
 		width: 445px;
+	}
+}
+
+/* Emulate .jp-connection__connect-screen-required-plan__tos-info */
+.jb-connection__terms-of-service {
+	margin-bottom: 8px;
+	margin-top: 16px;
+	font-size: var(--font-label);
+	line-height: 20px;
+	letter-spacing: -0.02em;
+	color: var(--jp-gray-60);
+}
+
+/* Emulate .jp-components__pricing-card__button */
+.jb-connection .components-button.is-jb-primary {
+	align-self: center;
+
+	display: inline-flex;
+	justify-content: center;
+	align-items: center;
+
+	width: 100%;
+	max-width: 600px;
+	margin: 24px 0 32px;
+	border-radius: var(--jp-border-radius);
+
+	background: var(--jp-black);
+	color: var(--jp-white);
+	font-weight: 500;
+
+	@include breakpoint(md) {
+		max-width: 445px;
 	}
 }

--- a/projects/plugins/boost/app/assets/src/css/components/connection.scss
+++ b/projects/plugins/boost/app/assets/src/css/components/connection.scss
@@ -148,15 +148,11 @@
 	align-items: center;
 
 	width: 100%;
-	max-width: 600px;
+	max-width: 200px;
 	margin: 24px 0 32px;
 	border-radius: var(--jp-border-radius);
 
 	background: var(--jp-black);
 	color: var(--jp-white);
 	font-weight: 500;
-
-	@include breakpoint(md) {
-		max-width: 445px;
-	}
 }

--- a/projects/plugins/boost/app/assets/src/js/pages/benefits/BenefitsInterstitial.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/benefits/BenefitsInterstitial.svelte
@@ -3,7 +3,7 @@
 	import React from 'react';
 	import { derived } from 'svelte/store';
 	import { createInterpolateElement } from '@wordpress/element';
-	import { __ } from '@wordpress/i18n';
+	import { __, sprintf } from '@wordpress/i18n';
 	import BackButton from '../../elements/BackButton.svelte';
 	import ReactComponent from '../../elements/ReactComponent.svelte';
 	import config from '../../stores/config';
@@ -21,17 +21,25 @@
 	// svelte-ignore unused-export-let - Ignored values supplied by svelte-navigator.
 	export let location, navigate;
 
-	const infoText = createInterpolateElement(
-		__(
-			`By clicking the button above, you agree to our <tosLink>Terms of Service</tosLink> and to <shareLink>share details</shareLink> with WordPress.com.`,
-			'jetpack-boost'
+	const ctaText = __( 'Upgrade Jetpack Boost', 'jetpack-boost' );
+
+	const tosText = createInterpolateElement(
+		sprintf(
+			/* translators: placeholder is a button label */
+			__(
+				'By clicking the <strong>%s</strong> button, you agree to our <tosLink>Terms of Service</tosLink> and to <shareDetailsLink>share details</shareDetailsLink> with WordPress.com.',
+				'jetpack-boost'
+			),
+			ctaText
 		),
+
 		{
+			strong: React.createElement( 'strong' ),
 			tosLink: React.createElement( 'a', {
 				href: jetpackURL( 'https://jetpack.com/redirect/?source=wpcom-tos' ),
 				target: '_blank',
 			} ),
-			shareLink: React.createElement( 'a', {
+			shareDetailsLink: React.createElement( 'a', {
 				href: jetpackURL(
 					'https://jetpack.com/redirect/?source=jetpack-support-what-data-does-jetpack-sync'
 				),
@@ -78,9 +86,9 @@
 						priceAfter={$pricing.yearly.priceAfter / 12}
 						priceDetails={__( '/month, paid yearly', 'jetpack-boost' )}
 						currencyCode={$pricing.yearly.currencyCode}
-						ctaText={__( 'Upgrade Jetpack Boost', 'jetpack-boost' )}
+						{ctaText}
 						onCtaClick={goToCheckout}
-						{infoText}
+						{tosText}
 					/>
 				{/if}
 			</div>

--- a/projects/plugins/boost/app/assets/src/js/pages/benefits/BenefitsInterstitial.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/benefits/BenefitsInterstitial.svelte
@@ -80,7 +80,7 @@
 					<!-- svelte-ignore missing-declaration Jetpack_Boost -->
 					<ReactComponent
 						this={PricingCard}
-						title={'Jetpack Boost'}
+						title={__( 'Jetpack Boost', 'jetpack-boost' )}
 						icon={`${ Jetpack_Boost.site.assetPath }../static/images/forward.svg`}
 						priceBefore={$pricing.yearly.priceBefore / 12}
 						priceAfter={$pricing.yearly.priceAfter / 12}

--- a/projects/plugins/boost/app/assets/src/js/pages/connection/Connection.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/connection/Connection.svelte
@@ -56,12 +56,10 @@
 			{/if}
 
 			<div class="jb-connection-overlay">
-				<p class="jb-connection__terms-of-service">
-					<ReactComponent
-						this={TermsOfService}
-						agreeButtonLabel={__( 'Get Started', 'jetpack-boost' )}
-					/>
-				</p>
+				<ReactComponent
+					this={TermsOfService}
+					agreeButtonLabel={__( 'Get Started', 'jetpack-boost' )}
+				/>
 			</div>
 
 			<button

--- a/projects/plugins/boost/app/assets/src/js/pages/connection/Connection.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/connection/Connection.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
+	import { TermsOfService } from '@automattic/jetpack-components';
 	import { __ } from '@wordpress/i18n';
 	import ErrorNotice from '../../elements/ErrorNotice.svelte';
-	import TemplatedString from '../../elements/TemplatedString.svelte';
+	import ReactComponent from '../../elements/ReactComponent.svelte';
 	import Footer from '../../sections/Footer.svelte';
 	import Header from '../../sections/Header.svelte';
 	import { connection } from '../../stores/connection';
 	import CheckboxIcon from '../../svg/checkbox.svg';
-	import externalLinkTemplateVar from '../../utils/external-link-template-var';
-	import { jetpackURL } from '../../utils/jetpack-url';
 
 	const benefits = [
 		__( 'Speed up your site load time', 'jetpack-boost' ),
@@ -58,23 +57,9 @@
 
 			<div class="jb-connection-overlay">
 				<p>
-					<TemplatedString
-						template={__(
-							`By clicking the Get Started button, you agree to our <tosLink>Terms of Service</tosLink> and to <shareLink>share details</shareLink> with WordPress.com.`,
-							'jetpack-boost'
-						)}
-						vars={{
-							...externalLinkTemplateVar(
-								jetpackURL( 'https://jetpack.com/redirect/?source=wpcom-tos' ),
-								'tosLink'
-							),
-							...externalLinkTemplateVar(
-								jetpackURL(
-									'https://jetpack.com/redirect/?source=jetpack-support-what-data-does-jetpack-sync'
-								),
-								'shareLink'
-							),
-						}}
+					<ReactComponent
+						this={TermsOfService}
+						agreeButtonLabel={__( 'Get Started', 'jetpack-boost' )}
 					/>
 				</p>
 			</div>

--- a/projects/plugins/boost/app/assets/src/js/pages/connection/Connection.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/connection/Connection.svelte
@@ -56,24 +56,11 @@
 				/>
 			{/if}
 
-			<button
-				type="button"
-				class="components-button is-jb-primary"
-				on:click={connection.initialize}
-				disabled={$connection.isConnecting}
-			>
-				{#if $connection.isConnecting}
-					{__( 'Connecting to WordPress.com', 'jetpack-boost' )}
-				{:else}
-					{__( 'Get Started', 'jetpack-boost' )}
-				{/if}
-			</button>
-
 			<div class="jb-connection-overlay">
 				<p>
 					<TemplatedString
 						template={__(
-							`By clicking the button above, you agree to our <tosLink>Terms of Service</tosLink> and to <shareLink>share details</shareLink> with WordPress.com.`,
+							`By clicking the Get Started button, you agree to our <tosLink>Terms of Service</tosLink> and to <shareLink>share details</shareLink> with WordPress.com.`,
 							'jetpack-boost'
 						)}
 						vars={{
@@ -91,6 +78,19 @@
 					/>
 				</p>
 			</div>
+
+			<button
+				type="button"
+				class="components-button is-jb-primary"
+				on:click={connection.initialize}
+				disabled={$connection.isConnecting}
+			>
+				{#if $connection.isConnecting}
+					{__( 'Connecting to WordPress.com', 'jetpack-boost' )}
+				{:else}
+					{__( 'Get Started', 'jetpack-boost' )}
+				{/if}
+			</button>
 		</div>
 	</div>
 

--- a/projects/plugins/boost/app/assets/src/js/pages/connection/Connection.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/connection/Connection.svelte
@@ -56,7 +56,7 @@
 			{/if}
 
 			<div class="jb-connection-overlay">
-				<p>
+				<p class="jb-connection__terms-of-service">
 					<ReactComponent
 						this={TermsOfService}
 						agreeButtonLabel={__( 'Get Started', 'jetpack-boost' )}

--- a/projects/plugins/boost/changelog/update-toc-text-location
+++ b/projects/plugins/boost/changelog/update-toc-text-location
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Revise Jetpack connection agreement text to comply with our User Agreement

--- a/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
@@ -226,7 +226,6 @@ export class ConnectButton extends React.Component {
 					</p>
 				) }
 				{ this.renderContent() }
-				{ this.props.children }
 				<DisconnectDialog
 					apiNonce={ this.props.apiNonce }
 					apiRoot={ this.props.apiRoot }

--- a/projects/plugins/jetpack/_inc/client/components/contextualized-connection/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/contextualized-connection/index.jsx
@@ -70,7 +70,9 @@ const ContextualizedConnection = props => {
 							redirectUri={ redirectUri }
 							connectLabel={ buttonLabel }
 						/>
-						<div className="jp-contextualized-connection__tos">{ ToS }</div>
+						<div className="jp-contextualized-connection__tos">
+							<ToS buttonLabel={ buttonLabel } />
+						</div>
 					</>
 				) }
 			</div>

--- a/projects/plugins/jetpack/_inc/client/components/contextualized-connection/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/contextualized-connection/index.jsx
@@ -1,5 +1,5 @@
-import { JetpackLogo } from '@automattic/jetpack-components';
-import { ConnectButton, ToS } from '@automattic/jetpack-connection';
+import { JetpackLogo, TermsOfService } from '@automattic/jetpack-components';
+import { ConnectButton } from '@automattic/jetpack-connection';
 import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -71,7 +71,7 @@ const ContextualizedConnection = props => {
 							connectLabel={ buttonLabel }
 						/>
 						<div className="jp-contextualized-connection__tos">
-							<ToS buttonLabel={ buttonLabel } />
+							<TermsOfService agreeButtonLabel={ buttonLabel } />
 						</div>
 					</>
 				) }

--- a/projects/plugins/jetpack/_inc/client/components/contextualized-connection/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/components/contextualized-connection/test/component.js
@@ -12,6 +12,7 @@ describe( 'ContextualizedConnection', () => {
 		redirectTo: 'Elsewhere',
 		isSiteConnected: false,
 		title: 'Test title',
+		buttonLabel: 'Setup Jetpack',
 		setHasSeenWCConnectionModal: jest.fn(),
 	};
 
@@ -47,15 +48,21 @@ describe( 'ContextualizedConnection', () => {
 	} );
 
 	describe( 'When the user has not connected their WordPress.com account', () => {
-		it( 'renders the "Set up Jetpack" button', () => {
+		it( 'renders the connection button', () => {
 			render( <ContextualizedConnection { ...testProps } /> );
-			expect( screen.getByRole( 'button', { name: 'Connect' } ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'button', { name: testProps.buttonLabel } ) ).toBeInTheDocument();
 		} );
 
-		it( 'renders the TOS', () => {
+		it( 'renders terms of service text that references the connection button label', () => {
 			render( <ContextualizedConnection { ...testProps } /> );
 			expect(
-				screen.getByText( /By clicking the button above, you agree to our/ )
+				screen.getByText(
+					( content, element ) =>
+						content !== '' && // filter out parent elements
+						element.textContent.startsWith(
+							`By clicking the ${ testProps.buttonLabel } button, you agree to our Terms of Service`
+						)
+				)
 			).toBeInTheDocument();
 		} );
 	} );

--- a/projects/plugins/jetpack/changelog/update-toc-text-position
+++ b/projects/plugins/jetpack/changelog/update-toc-text-position
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Revise Jetpack connection agreement text to comply with our User Agreement

--- a/projects/plugins/social/changelog/update-toc-text-location
+++ b/projects/plugins/social/changelog/update-toc-text-location
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Revise Jetpack connection agreement text to comply with our User Agreement

--- a/projects/plugins/social/src/js/components/connection-screen/index.js
+++ b/projects/plugins/social/src/js/components/connection-screen/index.js
@@ -1,28 +1,13 @@
 import { Dialog, ProductOffer, Text, getRedirectUrl } from '@automattic/jetpack-components';
 import { useConnection } from '@automattic/jetpack-connection';
-import { ExternalLink } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { sprintf, __ } from '@wordpress/i18n';
 import React from 'react';
 import { STORE_ID } from '../../store';
 import background from './background.svg';
 import illustration from './illustration.png';
 import styles from './styles.module.scss';
-
-const tos = createInterpolateElement(
-	__(
-		'By clicking the button above, you agree to our <tosLink>Terms of Service</tosLink> and to <shareDetailsLink>share details</shareDetailsLink> with WordPress.com.',
-		'jetpack-social'
-	),
-	{
-		tosLink: <ExternalLink href={ getRedirectUrl( 'wpcom-tos' ) } />,
-		shareDetailsLink: (
-			<ExternalLink href={ getRedirectUrl( 'jetpack-support-what-data-does-jetpack-sync' ) } />
-		),
-	}
-);
-
 const ConnectionScreen = () => {
 	const connectProps = useSelect( select => {
 		const store = select( STORE_ID );
@@ -43,6 +28,37 @@ const ConnectionScreen = () => {
 		redirectUri: 'admin.php?page=jetpack-social',
 		...connectProps,
 	} );
+
+	const buttonText = __( 'Get Started', 'jetpack-social' );
+	const tos = createInterpolateElement(
+		sprintf(
+			/* translators: placeholder is a button label */
+			__(
+				'By clicking the <strong>%s</strong> button, you agree to our <tosLink>Terms of Service</tosLink> and to <shareDetailsLink>share details</shareDetailsLink> with WordPress.com.',
+				'jetpack-social'
+			),
+			buttonText
+		),
+		{
+			strong: <strong />,
+			tosLink: (
+				<a href={ getRedirectUrl( 'wpcom-tos' ) } rel="noopener noreferrer" target="_blank" />
+			),
+			shareDetailsLink: (
+				<a
+					href={ getRedirectUrl( 'jetpack-support-what-data-does-jetpack-sync' ) }
+					rel="noopener noreferrer"
+					target="_blank"
+				/>
+			),
+		}
+	);
+
+	const getButtonDisclaimer = () => (
+		<Text variant="body-small" className={ styles.tos } mt={ 3 }>
+			{ tos }
+		</Text>
+	);
 
 	return (
 		<Dialog
@@ -65,18 +81,16 @@ const ConnectionScreen = () => {
 						isCard={ false }
 						isBundle={ false }
 						onAdd={ handleRegisterSite }
-						buttonText={ __( 'Get Started', 'jetpack-social' ) }
+						buttonText={ buttonText }
 						icon="social"
 						isLoading={ siteIsRegistering || userIsConnecting }
+						buttonDisclaimer={ getButtonDisclaimer() }
 						error={
 							registrationError
 								? __( 'An error occurred. Please try again.', 'jetpack-social' )
 								: null
 						}
 					/>
-					<Text variant="body-small" className={ styles.tos } mt={ 3 }>
-						{ tos }
-					</Text>
 				</div>
 			}
 			secondary={

--- a/projects/plugins/social/src/js/components/connection-screen/index.js
+++ b/projects/plugins/social/src/js/components/connection-screen/index.js
@@ -1,4 +1,4 @@
-import { Dialog, ProductOffer, TermsOfService, Text } from '@automattic/jetpack-components';
+import { Dialog, ProductOffer, TermsOfService } from '@automattic/jetpack-components';
 import { useConnection } from '@automattic/jetpack-connection';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -30,12 +30,6 @@ const ConnectionScreen = () => {
 
 	const buttonText = __( 'Get Started', 'jetpack-social' );
 
-	const getButtonDisclaimer = () => (
-		<Text variant="body-small" className={ styles.tos } mt={ 3 }>
-			<TermsOfService agreeButtonLabel={ buttonText } />
-		</Text>
-	);
-
 	return (
 		<Dialog
 			className={ styles.card }
@@ -60,7 +54,12 @@ const ConnectionScreen = () => {
 						buttonText={ buttonText }
 						icon="social"
 						isLoading={ siteIsRegistering || userIsConnecting }
-						buttonDisclaimer={ getButtonDisclaimer() }
+						buttonDisclaimer={
+							<TermsOfService
+								className={ styles[ 'terms-of-service' ] }
+								agreeButtonLabel={ buttonText }
+							/>
+						}
 						error={
 							registrationError
 								? __( 'An error occurred. Please try again.', 'jetpack-social' )

--- a/projects/plugins/social/src/js/components/connection-screen/index.js
+++ b/projects/plugins/social/src/js/components/connection-screen/index.js
@@ -1,8 +1,7 @@
-import { Dialog, ProductOffer, Text, getRedirectUrl } from '@automattic/jetpack-components';
+import { Dialog, ProductOffer, TermsOfService, Text } from '@automattic/jetpack-components';
 import { useConnection } from '@automattic/jetpack-connection';
 import { useSelect } from '@wordpress/data';
-import { createInterpolateElement } from '@wordpress/element';
-import { sprintf, __ } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import React from 'react';
 import { STORE_ID } from '../../store';
 import background from './background.svg';
@@ -30,33 +29,10 @@ const ConnectionScreen = () => {
 	} );
 
 	const buttonText = __( 'Get Started', 'jetpack-social' );
-	const tos = createInterpolateElement(
-		sprintf(
-			/* translators: placeholder is a button label */
-			__(
-				'By clicking the <strong>%s</strong> button, you agree to our <tosLink>Terms of Service</tosLink> and to <shareDetailsLink>share details</shareDetailsLink> with WordPress.com.',
-				'jetpack-social'
-			),
-			buttonText
-		),
-		{
-			strong: <strong />,
-			tosLink: (
-				<a href={ getRedirectUrl( 'wpcom-tos' ) } rel="noopener noreferrer" target="_blank" />
-			),
-			shareDetailsLink: (
-				<a
-					href={ getRedirectUrl( 'jetpack-support-what-data-does-jetpack-sync' ) }
-					rel="noopener noreferrer"
-					target="_blank"
-				/>
-			),
-		}
-	);
 
 	const getButtonDisclaimer = () => (
 		<Text variant="body-small" className={ styles.tos } mt={ 3 }>
-			{ tos }
+			<TermsOfService agreeButtonLabel={ buttonText } />
 		</Text>
 	);
 

--- a/projects/plugins/social/src/js/components/connection-screen/styles.module.scss
+++ b/projects/plugins/social/src/js/components/connection-screen/styles.module.scss
@@ -24,15 +24,9 @@
 	padding: 0 !important;
 }
 
-.tos {
-	display: block;
-	color: var( --jp-gray-50 );
-	max-width: 500px;
-	margin-bottom: calc(var( --spacing-base )*3);
-
-	a {
-		color: inherit;
-	}
+.terms-of-service {
+	margin-top: calc(var(--spacing-base) * 4);
+	margin-bottom: calc(var(--spacing-base) * 3);
 }
 
 .sidebar {

--- a/projects/plugins/social/src/js/components/connection-screen/styles.module.scss
+++ b/projects/plugins/social/src/js/components/connection-screen/styles.module.scss
@@ -28,6 +28,7 @@
 	display: block;
 	color: var( --jp-gray-50 );
 	max-width: 500px;
+	margin-bottom: calc(var( --spacing-base )*3);
 
 	a {
 		color: inherit;

--- a/projects/plugins/social/tests/e2e/pages/wp-admin/jetpack-social.js
+++ b/projects/plugins/social/tests/e2e/pages/wp-admin/jetpack-social.js
@@ -10,7 +10,7 @@ export default class JetpackSocialPage extends WpPage {
 
 	async getStarted() {
 		logger.step( 'Connect Jetpack Social to wordpress.com' );
-		await this.click( 'text=Get Started' );
+		await this.click( 'button >> text=Get Started' );
 		await this.waitForElementToBeHidden( 'button > svg.components-spinner', 40000 );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes # 1202858161751496-as-1203651563192009/f

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the connection agreement text for all plugins to show above the button to comply with the guidelines PCYsg-9m2-p2

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-_kep-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a test site
* Jetpack Plugin
   * Build Jetpack plugin by running `jetpack build plugins/jetpack` 
   * Install and Navigate to the Jetpack page (`wp-admin/admin.php?page=jetpack#/`)
   * Confirm that Terms and condition text is displayed above the button 
   * ![Screenshot 2023-01-17 at 2 32 44 PM](https://user-images.githubusercontent.com/2027003/212854939-66a72d98-1edc-4942-b403-1dccd93f9d30.png)
* Jetpack ValutPress Backup plugin 
   * Build Jetpack Backup plugin by running `jetpack build plugins/backup` 
   * Install and Navigate to Jetpack Backup page (`wp-admin/admin.php?page=jetpack-backup`)
   * Confirm that Terms and condition text is displayed above the button
   * ![Screenshot 2023-01-17 at 2 37 00 PM](https://user-images.githubusercontent.com/2027003/212856670-001676ad-197c-4220-b17d-b8497ed87c4f.png)
* Jetpack Boost Plugin 
   *  Build Jetpack Boost plugin by running `jetpack build plugins/boost` 
   *  Install and Navigate to Jetpack Boost page (`wp-admin/admin.php?page=jetpack-boost`)
   * Confirm that Terms and condition text is displayed above the button
   * ![Screenshot 2023-01-17 at 2 43 27 PM](https://user-images.githubusercontent.com/2027003/212857185-60743433-977e-4af3-99c8-5b3f1d3e3674.png)
* Jetpack Social Plugin 
   *  Build Jetpack Boost plugin by running `jetpack build plugins/social` 
   *  Install and Navigate to Jetpack Boost page (`wp-admin/admin.php?page=jetpack-social`)
   * Confirm that Terms and condition text is displayed above the button
   * ![Screenshot 2023-01-17 at 2 45 09 PM](https://user-images.githubusercontent.com/2027003/212857550-af029cb1-5965-4af6-ab5d-46f1c6edaa20.png)
* My Jetpack - Connect your site screen 
  * Build Jetpack plugin by running `jetpack build plugins/jetpack` 
  * Install and Navigate to the My Jetpack page (`wp-admin/admin.php?page=my-jetpack`) and ensure you still haven't connected your site.
  * You will see the message as below and click on the button
  * ![Screenshot 2023-01-17 at 2 54 27 PM](https://user-images.githubusercontent.com/2027003/212863125-5caa6453-6ef5-40ff-8815-3736fbf1176d.png)

  * On the connection screen confirm that Terms and condition text is displayed above the button
  * ![Screenshot 2023-01-17 at 3 08 19 PM](https://user-images.githubusercontent.com/2027003/212862940-01a3c127-16dc-4749-9e8e-b78325e3683c.png)




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203651563192009