### PR TITLE
Bump Jetpack Boost version to 1.7.0

### DIFF
--- a/projects/plugins/boost/changelog/update-boost-version-1.7.0
+++ b/projects/plugins/boost/changelog/update-boost-version-1.7.0
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+New Feature: Jetpack Boost Image Guide

--- a/projects/plugins/boost/changelog/update-boost-version-1.7.0#2
+++ b/projects/plugins/boost/changelog/update-boost-version-1.7.0#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -3,7 +3,7 @@
 	"description": "Boost your WordPress site's performance, from the creators of Jetpack",
 	"type": "library",
 	"license": "GPL-2.0-or-later",
-	"version": "1.6.1-alpha",
+	"version": "1.7.0-alpha",
 	"authors": [
 		{
 			"name": "Automattic, Inc.",
@@ -71,7 +71,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ1_6_1_alpha",
+		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ1_7_0_alpha",
 		"allow-plugins": {
 			"roots/wordpress-core-installer": true,
 			"automattic/jetpack-autoloader": true,

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2f6e86f1416c465e24cae5d65d5b1c57",
+    "content-hash": "7725e34863afd968d0b9c6aa0ce0a95b",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -9,7 +9,7 @@
  * Plugin Name:       Jetpack Boost
  * Plugin URI:        https://jetpack.com/boost
  * Description:       Boost your WordPress site's performance, from the creators of Jetpack
- * Version: 1.6.1-alpha
+ * Version: 1.7.0-alpha
  * Author:            Automattic - Jetpack Site Speed team
  * Author URI:        https://jetpack.com/boost/
  * License:           GPL-2.0+
@@ -29,7 +29,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'JETPACK_BOOST_VERSION', '1.6.1-alpha' );
+define( 'JETPACK_BOOST_VERSION', '1.7.0-alpha' );
 define( 'JETPACK_BOOST_SLUG', 'jetpack-boost' );
 
 if ( ! defined( 'JETPACK_BOOST_CLIENT_NAME' ) ) {

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-boost",
-	"version": "1.6.1-alpha",
+	"version": "1.7.0-alpha",
 	"description": "Boost your WordPress site's performance, from the creators of Jetpack",
 	"directories": {
 		"test": "tests"

--- a/projects/plugins/boost/readme.txt
+++ b/projects/plugins/boost/readme.txt
@@ -31,7 +31,7 @@ Improving Core Web Vitals helps you rank higher on Google. A faster website also
 
 ### Performance Modules
 
-Optimise your website with the same techniques used on the world's most successful websites.
+Optimize your website with the same techniques used on the world's most successful websites.
 
 Each technique that is used to increase website performance is packaged up as a module that you can activate and try out.
 


### PR DESCRIPTION
## Proposed changes:
Bump the version for release to 1.7.0

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
N/A

