### PR TITLE
Add the skeleton for jetpack/forms

### DIFF
--- a/projects/packages/forms/.gitattributes
+++ b/projects/packages/forms/.gitattributes
@@ -1,0 +1,17 @@
+# Files not needed to be distributed in the package.
+.gitattributes    export-ignore
+.github/          export-ignore
+package.json      export-ignore
+
+# Files to include in the mirror repo, but excluded via gitignore
+# Remember to end all directories with `/**` to properly tag every file.
+# /src/js/example.min.js  production-include
+
+# Files to exclude from the mirror repo, but included in the monorepo.
+# Remember to end all directories with `/**` to properly tag every file.
+.gitignore        production-exclude
+changelog/**      production-exclude
+phpunit.xml.dist  production-exclude
+.phpcs.dir.xml    production-exclude
+tests/**          production-exclude
+.phpcsignore      production-exclude

--- a/projects/packages/forms/.gitignore
+++ b/projects/packages/forms/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+node_modules/

--- a/projects/packages/forms/.gitignore
+++ b/projects/packages/forms/.gitignore
@@ -1,2 +1,3 @@
 vendor/
+wordpress/
 node_modules/

--- a/projects/packages/forms/.phpcs.dir.xml
+++ b/projects/packages/forms/.phpcs.dir.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="jetpack-forms" />
+			</property>
+		</properties>
+	</rule>
+	<rule ref="Jetpack.Functions.I18n">
+		<properties>
+			<property name="text_domain" value="jetpack-forms" />
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.Utils.I18nTextDomainFixer">
+		<properties>
+			<property name="old_text_domain" type="array" />
+			<property name="new_text_domain" value="jetpack-forms" />
+		</properties>
+	</rule>
+
+</ruleset>

--- a/projects/packages/forms/.phpcsignore
+++ b/projects/packages/forms/.phpcsignore
@@ -1,1 +1,0 @@
-src/class-example.php

--- a/projects/packages/forms/.phpcsignore
+++ b/projects/packages/forms/.phpcsignore
@@ -1,0 +1,1 @@
+src/class-example.php

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+

--- a/projects/packages/forms/README.md
+++ b/projects/packages/forms/README.md
@@ -1,0 +1,20 @@
+# forms
+
+Jetpack Forms
+
+## How to install forms
+
+### Installation From Git Repo
+
+## Contribute
+
+## Get Help
+
+## Security
+
+Need to report a security vulnerability? Go to [https://automattic.com/security/](https://automattic.com/security/) or directly to our security bug bounty site [https://hackerone.com/automattic](https://hackerone.com/automattic).
+
+## License
+
+forms is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt)
+

--- a/projects/packages/forms/changelog/add-jetpack-forms
+++ b/projects/packages/forms/changelog/add-jetpack-forms
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added a new jetpack/forms package

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -50,7 +50,7 @@
 		},
 		"textdomain": "jetpack-forms",
 		"version-constants": {
-			"::PACKAGE_VERSION": "src/class-forms.php"
+			"::PACKAGE_VERSION": "src/class-jetpack-forms.php"
 		}
 	},
 	"config": {

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -1,0 +1,51 @@
+{
+	"name": "automattic/jetpack-forms",
+	"description": "Jetpack Forms",
+	"type": "jetpack-library",
+	"license": "GPL-2.0-or-later",
+	"require": {},
+	"require-dev": {
+		"yoast/phpunit-polyfills": "1.0.4",
+		"automattic/jetpack-changelogger": "@dev",
+		"automattic/wordbless": "dev-master"
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"scripts": {
+		"phpunit": [
+			"./vendor/phpunit/phpunit/phpunit --colors=always"
+		],
+		"test-coverage": [
+			"php -dpcov.directory=. ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
+		],
+		"test-php": [
+			"@composer phpunit"
+		],
+		"build-production": "echo 'Add your build step to composer.json, please!'",
+		"build-development": "echo 'Add your build step to composer.json, please!'",
+		"post-update-cmd": "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\""
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../../packages/*",
+			"options": {
+				"monorepo": true
+			}
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"extra": {
+		"branch-alias": {
+			"dev-trunk": "0.1.x-dev"
+		},
+		"textdomain": "jetpack-forms",
+		"version-constants": {
+			"::PACKAGE_VERSION": "src/class-forms.php"
+		}
+	}
+}

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -40,6 +40,11 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"extra": {
+		"autotagger": true,
+		"mirror-repo": "Automattic/jetpack-forms",
+		"changelogger": {
+			"link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
+		},
 		"branch-alias": {
 			"dev-trunk": "0.1.x-dev"
 		},

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -52,5 +52,10 @@
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-forms.php"
 		}
+	},
+	"config": {
+		"allow-plugins": {
+			"roots/wordpress-core-installer": true
+		}
 	}
 }

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,0 +1,29 @@
+{
+	"private": true,
+	"name": "@automattic/jetpack-forms",
+	"version": "0.1.0-alpha",
+	"description": "Jetpack Forms",
+	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
+	"bugs": {
+		"url": "https://github.com/Automattic/jetpack/labels/[Package] Forms"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Automattic/jetpack.git",
+		"directory": "projects/packages/forms"
+	},
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic",
+	"scripts": {
+		"build": "echo 'Not implemented.'",
+		"build-js": "echo 'Not implemented.'",
+		"build-production": "echo 'Not implemented.'",
+		"build-production-js": "echo 'Not implemented.'",
+		"clean": "true"
+	},
+	"devDependencies": {},
+	"engines": {
+		"node": "^16.13.2",
+		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
+	}
+}

--- a/projects/packages/forms/phpunit.xml.dist
+++ b/projects/packages/forms/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
+	<testsuites>
+		<testsuite name="main">
+			<directory prefix="test" suffix=".php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+	<filter>
+		<whitelist processUncoveredFilesFromWhitelist="false">
+			<!-- Better to only include "src" than to add "." and then exclude "tests", "vendor", and so on, as PHPUnit still scans the excluded directories. -->
+			<!-- Add additional lines for any files or directories outside of src/ that need coverage. -->
+			<directory suffix=".php">src</directory>
+		</whitelist>
+	</filter>
+</phpunit>

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Package description here
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack;
+
+/**
+ * Class description.
+ */
+class Jetpack_Forms {
+
+	const PACKAGE_VERSION = '1.0.0-alpha';
+
+}

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -5,13 +5,13 @@
  * @package automattic/jetpack-forms
  */
 
-namespace Automattic\Jetpack;
+namespace Automattic\Jetpack\Forms;
 
 /**
  * Class description.
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '1.0.0-alpha';
+	const PACKAGE_VERSION = '0.1.0';
 
 }

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -12,6 +12,6 @@ namespace Automattic\Jetpack\Forms;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.1.0';
+	const PACKAGE_VERSION = '0.1.0-alpha';
 
 }

--- a/projects/packages/forms/tests/php/bootstrap.php
+++ b/projects/packages/forms/tests/php/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Bootstrap.
+ *
+ * @package automattic/
+ */
+
+/**
+ * Include the composer autoloader.
+ */
+require_once __DIR__ . '/../../vendor/autoload.php';


### PR DESCRIPTION
Fixes #28410
Part of #28405.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

This patch adds the skeleton for a new `jetpack/forms` package which will be used to eventually migrate all contact form related code to make moving forward with upcoming improvements easier.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pcsBup-Fk-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This PR doesn't introduces any functional changes, nor should it affect any existing processes quite yet.

