### PR TITLE
Google Fonts Provider: Fix Global Styles font collection

### DIFF
--- a/projects/packages/google-fonts-provider/changelog/fix-global-styles-fonts
+++ b/projects/packages/google-fonts-provider/changelog/fix-global-styles-fonts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use wp_get_global_styles() and fallback to gutenberg_get_global_styles() since the latter was removed from Gutenberg

--- a/projects/packages/google-fonts-provider/package.json
+++ b/projects/packages/google-fonts-provider/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-google-fonts-provider",
-	"version": "0.4.0",
+	"version": "0.4.1-alpha",
 	"description": "WordPress Webfonts provider for Google Fonts",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/google-fonts-provider/#readme",
 	"bugs": {

--- a/projects/packages/google-fonts-provider/src/introspectors/class-global-styles.php
+++ b/projects/packages/google-fonts-provider/src/introspectors/class-global-styles.php
@@ -19,7 +19,7 @@ class Global_Styles {
 	 * @return void
 	 */
 	public static function enqueue_global_styles_fonts() {
-		if ( is_admin() || ! function_exists( 'wp_enqueue_webfont' ) ) {
+		if ( is_admin() || !function_exists( 'wp_enqueue_webfont' ) ) {
 			return;
 		}
 
@@ -40,13 +40,14 @@ class Global_Styles {
 	 * @return array Font faces from Global Styles settings.
 	 */
 	public static function collect_fonts_from_global_styles() {
-		if ( ! function_exists( 'gutenberg_get_global_styles' ) ) {
-			return array();
+		if ( ! function_exists( 'gutenberg_get_global_styles' ) && ! function_exists( 'wp_get_global_styles' ) ) {
+			return [];
 		}
 
-		$global_styles = gutenberg_get_global_styles();
+		$global_styles = function_exists( 'wp_get_global_styles' ) ?
+			wp_get_global_styles() : gutenberg_get_global_styles();
 
-		$found_webfonts = array();
+		$found_webfonts = [];
 
 		// Look for fonts in block presets...
 		if ( isset( $global_styles['blocks'] ) ) {
@@ -88,7 +89,7 @@ class Global_Styles {
 	 * @return string|null
 	 */
 	protected static function extract_font_slug_from_setting( $setting ) {
-		if ( ! isset( $setting['typography']['fontFamily'] ) ) {
+		if ( !isset( $setting['typography']['fontFamily'] ) ) {
 			return null;
 		}
 

--- a/projects/packages/google-fonts-provider/src/introspectors/class-global-styles.php
+++ b/projects/packages/google-fonts-provider/src/introspectors/class-global-styles.php
@@ -19,7 +19,7 @@ class Global_Styles {
 	 * @return void
 	 */
 	public static function enqueue_global_styles_fonts() {
-		if ( is_admin() || !function_exists( 'wp_enqueue_webfont' ) ) {
+		if ( is_admin() || ! function_exists( 'wp_enqueue_webfont' ) ) {
 			return;
 		}
 
@@ -41,13 +41,13 @@ class Global_Styles {
 	 */
 	public static function collect_fonts_from_global_styles() {
 		if ( ! function_exists( 'gutenberg_get_global_styles' ) && ! function_exists( 'wp_get_global_styles' ) ) {
-			return [];
+			return array();
 		}
 
 		$global_styles = function_exists( 'wp_get_global_styles' ) ?
 			wp_get_global_styles() : gutenberg_get_global_styles();
 
-		$found_webfonts = [];
+		$found_webfonts = array();
 
 		// Look for fonts in block presets...
 		if ( isset( $global_styles['blocks'] ) ) {
@@ -89,7 +89,7 @@ class Global_Styles {
 	 * @return string|null
 	 */
 	protected static function extract_font_slug_from_setting( $setting ) {
-		if ( !isset( $setting['typography']['fontFamily'] ) ) {
+		if ( ! isset( $setting['typography']['fontFamily'] ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/71641

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Since gutenberg_get_global_styles function was removed, use wp_get_global_styles() instead and fallback to the former when the function is not present.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use Jetpack Beta and switch to this branch (do the same for WPCOM)
* Activate TT3 on your site
* Make sure that Global Styles fonts are working for texts and headings are working
  * Open the GS sidebar.
  * Open Typography.
  * Select Headings.
  * Pick a different, externally provided, font and save.
  * Preview the site. If it's a Dotcom free site, append the `?preview-global-styles` query param to preview the custom GS.
  * Make sure the selected font is used correctly on the site's headings.
* Try it again with Gutenberg 15 (you can use the `gutenberg-edge` sticker on Dotcom).