### PR TITLE
Hook up packages/jetpack-forms to plugins/jetpack

### DIFF
--- a/projects/packages/forms/changelog/add-forms-dependency
+++ b/projects/packages/forms/changelog/add-forms-dependency
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added a public load_contact_form method for initializing the contact form module.

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -14,4 +14,9 @@ class Jetpack_Forms {
 
 	const PACKAGE_VERSION = '0.1.0-alpha';
 
+	/**
+	 * Load the contact form module.
+	 */
+	public static function load_contact_form() {
+	}
 }

--- a/projects/plugins/jetpack/changelog/add-forms-dependency
+++ b/projects/plugins/jetpack/changelog/add-forms-dependency
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Added the dependency on automattic/jetpack-forms

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -26,6 +26,7 @@
 		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-device-detection": "@dev",
 		"automattic/jetpack-error": "@dev",
+		"automattic/jetpack-forms": "@dev",
 		"automattic/jetpack-google-fonts-provider": "@dev",
 		"automattic/jetpack-identity-crisis": "@dev",
 		"automattic/jetpack-jitm": "@dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dc0cbe8e26c2170694a504dd282d294a",
+    "content-hash": "885f93512258c1b17a95fec63e503ec8",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -910,6 +910,67 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Jetpack Error - a wrapper around WP_Error.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-forms",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/forms",
+                "reference": "fb95e8781f9cd26bc4cb8f3d6645a99a748a6248"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/wordbless": "dev-master",
+                "yoast/phpunit-polyfills": "1.0.4"
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-forms",
+                "changelogger": {
+                    "link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "textdomain": "jetpack-forms",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-jetpack-forms.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "build-production": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ],
+                "build-development": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ],
+                "post-update-cmd": [
+                    "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Jetpack Forms",
             "transport-options": {
                 "relative": true
             }
@@ -5495,6 +5556,7 @@
         "automattic/jetpack-constants": 20,
         "automattic/jetpack-device-detection": 20,
         "automattic/jetpack-error": 20,
+        "automattic/jetpack-forms": 20,
         "automattic/jetpack-google-fonts-provider": 20,
         "automattic/jetpack-identity-crisis": 20,
         "automattic/jetpack-jitm": 20,

--- a/projects/plugins/jetpack/modules/contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form.php
@@ -20,7 +20,17 @@ use Automattic\Jetpack\Forms\Jetpack_Forms;
  * Additional Search Queries: contact, form, grunion, feedback, submission, contact form, email, feedback, contact form plugin, custom form, custom form plugin, form builder, forms, form maker, survey, contact by jetpack, contact us, forms free
  */
 
-if ( defined( 'JETPACK_FORMS_PACKAGE_ENABLED' ) && JETPACK_FORMS_PACKAGE_ENABLED ) {
+/**
+ * Whether to load the newer Jetpack Forms package.
+ *
+ * @use add_filter( 'jetpack_contact_form_use_package', '__return_true' );
+ * @module contact-form
+ *
+ * @since $$next-version$$
+ *
+ * @param bool $load_contact_form_package Load Jetpack Forms package. Default to false.
+ */
+if ( apply_filters( 'jetpack_contact_form_use_package', false ) ) {
 	Jetpack_Forms::load_contact_form();
 	return true; // Not returning true will cause the module to become deactivated.
 }

--- a/projects/plugins/jetpack/modules/contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form.php
@@ -5,6 +5,8 @@
  * @package automattic/jetpack
  */
 
+use Automattic\Jetpack\Forms\Jetpack_Forms;
+
 /**
  * Module Name: Contact Form
  * Module Description: Add a customizable contact form to any post or page using the Jetpack Form Block.
@@ -17,6 +19,11 @@
  * Feature: Writing
  * Additional Search Queries: contact, form, grunion, feedback, submission, contact form, email, feedback, contact form plugin, custom form, custom form plugin, form builder, forms, form maker, survey, contact by jetpack, contact us, forms free
  */
+
+if ( defined( 'JETPACK_FORMS_PACKAGE_ENABLED' ) && JETPACK_FORMS_PACKAGE_ENABLED ) {
+	Jetpack_Forms::load_contact_form();
+	return true; // Not returning true will cause the module to become deactivated.
+}
 
 require_once __DIR__ . '/contact-form/grunion-contact-form.php';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #28405.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

This patch adds the dependency on `automattic/jetpack-forms` to the Jetpack plugin, ~and puts it behind a dedicated `JETPACK_FORMS_PACKAGE_ENABLED` flag~.  
The package code can be enabled by defining a filter for `jetpack_contact_form_use_package` to return `true`.

Having this in place first, will make it easier to test the contact form code once it's relocated into the new package.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pcsBup-N3-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Run `jetpack install packages/forms && jetpack install plugins/jetpack`.
- There should be no functional changes at all to any contact form features.
- ~Set JETPACK_FORMS_PACKAGE_ENABLED to `true` in your wp-config.php.~ Add  a filter for `jetpack_contact_form_use_package` and make it return `true`.
- Right now, this should effectively disable the contact form module and the relevant content should no longer load. This is just to make sure the switch works.
- ~Set JETPACK_FORMS_PACKAGE_ENABLED to false or remove it.~ Remove the filter.
- Everything should work as usual again.
