### PR TITLE
google-fonts-provider: release v0.4.1

### DIFF
--- a/projects/packages/google-fonts-provider/CHANGELOG.md
+++ b/projects/packages/google-fonts-provider/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2023-01-17
+### Fixed
+- Use `wp_get_global_styles()` and fallback to `gutenberg_get_global_styles()` since the latter was removed from Gutenberg. [#28411]
+
 ## [0.4.0] - 2022-12-12
 ### Added
 - Added a way to filter the Google Fonts API url [#27719]
@@ -58,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Adds a provider for Google Fonts using the new Webfonts API in Gutenberg
 
+[0.4.1]: https://github.com/Automattic/jetpack-google-fonts-provider/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/Automattic/jetpack-google-fonts-provider/compare/v0.3.6...v0.4.0
 [0.3.6]: https://github.com/Automattic/jetpack-google-fonts-provider/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/Automattic/jetpack-google-fonts-provider/compare/v0.3.4...v0.3.5

--- a/projects/packages/google-fonts-provider/changelog/fix-global-styles-fonts
+++ b/projects/packages/google-fonts-provider/changelog/fix-global-styles-fonts
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Use wp_get_global_styles() and fallback to gutenberg_get_global_styles() since the latter was removed from Gutenberg

--- a/projects/packages/google-fonts-provider/package.json
+++ b/projects/packages/google-fonts-provider/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-google-fonts-provider",
-	"version": "0.4.1-alpha",
+	"version": "0.4.1",
 	"description": "WordPress Webfonts provider for Google Fonts",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/google-fonts-provider/#readme",
 	"bugs": {


### PR DESCRIPTION
## Proposed changes:

google-fonts-provider: release v0.4.1

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

#28411

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

See #28411

