### PR TITLE
VideoPress: check if the Media item is actually a VideoPress video

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-set-video-from-media-library
+++ b/projects/packages/videopress/changelog/fix-videopress-set-video-from-media-library
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: check if the Media item is actually a VideoPress video

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
@@ -193,45 +193,6 @@ const VideoPressUploader = ( {
 
 		// Handle selection of Media Library regular attachment
 		if ( media.id ) {
-			/*
-			 * Check if the selected media is hosted in VideoPress,
-			 * based on the media URL.
-			 * Dotcom Media Library doesn't provide the guid.
-			 */
-			const isVideoPressUrl = media.url?.includes( 'files.wordpress.com' );
-			if ( isVideoPressUrl ) {
-				apiFetch( {
-					path: `wp/v2/media/${ media.id }`,
-				} )
-					.then( ( mediaItem = {} ) => {
-						const { jetpack_videopress: videopressDetails } = mediaItem;
-						if ( ! videopressDetails || Object.keys( videopressDetails ).length === 0 ) {
-							return;
-						}
-
-						const blockAttributes = {
-							id: media.id,
-							guid: videopressDetails.guid,
-							allowDownload: !! videopressDetails.allow_download,
-							title: videopressDetails.title,
-							description: videopressDetails.description,
-							displayEmbed: !! videopressDetails.display_embed,
-							privacySetting: videopressDetails.privacy_setting,
-							rating: videopressDetails.rating,
-						};
-
-						setAttributes( blockAttributes );
-
-						const { url } = buildVideoPressURL( videopressDetails.guid, blockAttributes );
-						onSelectURL( url, media.id );
-					} )
-					.catch( error => {
-						// ToDo" Better error handling
-						console.error( error ); // eslint-disable-line no-console
-					} );
-				return;
-			}
-
 			if ( isSimpleSite() ) {
 				// It should not try to move the file in Simple sites.
 				return;

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
@@ -186,7 +186,7 @@ const VideoPressUploader = ( {
 				? media.videopress_guid[ 0 ] // <- pick the first item when it's an array
 				: media.videopress_guid;
 
-			const videoUrl = `https://videopress.com/v/${ videoGuid }`;
+			const { url: videoUrl } = buildVideoPressURL( videoGuid );
 			onSelectURL( videoUrl, media?.id );
 			return;
 		}
@@ -196,6 +196,7 @@ const VideoPressUploader = ( {
 			/*
 			 * Check if the selected media is hosted in VideoPress,
 			 * based on the media URL.
+			 * Dotcom Media Library doesn't provide the guid.
 			 */
 			const isVideoPressUrl = media.url?.includes( 'files.wordpress.com' );
 			if ( isVideoPressUrl ) {

--- a/projects/packages/videopress/src/client/lib/url/README.md
+++ b/projects/packages/videopress/src/client/lib/url/README.md
@@ -7,3 +7,9 @@
 ```es6
 const guid = pickGUIDFromUrl( 'https://videopress.com/v/SEhvBzm2?loop=1' ); // -> SEhvBzm2
 ```
+
+## buildVideoPressURL( guid, attributes )
+
+```es6
+const { guid, url } = buildVideoPressURL( 'guid-id', { autoplay: true } );
+```

--- a/projects/packages/videopress/src/client/lib/url/index.ts
+++ b/projects/packages/videopress/src/client/lib/url/index.ts
@@ -97,18 +97,23 @@ export function isVideoPressGuid( value: string ): boolean | VideoGUID {
 	return guid[ 0 ];
 }
 
+type BuildVideoPressURL = {
+	url?: string;
+	guid?: VideoGUID;
+};
+
 /**
  * Build a VideoPress URL from a VideoPress GUID or a VideoPress URL.
  * The function returns an { url, guid } object, or false.
  *
- * @param {string | VideoGUID} value        - The VideoPress GUID or URL.
+ * @param {string|VideoGUID} value          - The VideoPress GUID or URL.
  * @param {VideoPressUrlOptions} attributes - The VideoPress URL options.
- * @returns {false | string}                  VideoPress URL if the string is valid, false otherwise.
+ * @returns {BuildVideoPressURL}              VideoPress URL if the string is valid, false otherwise.
  */
 export function buildVideoPressURL(
 	value: string | VideoGUID,
 	attributes?: VideoPressUrlOptions
-): false | { url: string; guid: VideoGUID } {
+): BuildVideoPressURL {
 	const isGuidValue = isVideoPressGuid( value );
 	if ( isGuidValue ) {
 		if ( ! attributes ) {
@@ -123,7 +128,7 @@ export function buildVideoPressURL(
 		return { url: value, guid: isGuidFromUrl };
 	}
 
-	return false;
+	return {};
 }
 
 export const removeFileNameExtension = ( name: string ) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

TBD...
Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: check if the Media item is actually a VideoPress video

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* TBD...
*

