### PR TITLE
Change responses export field names

### DIFF
--- a/projects/plugins/jetpack/changelog/change-response-export-field-names
+++ b/projects/plugins/jetpack/changelog/change-response-export-field-names
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Improve field/column name handling when exporting responses for proper "Date", "IP Address" and other column names.
+Contact Form: update the name of the columns used when exporting Contact Form responses to CSV. The file will now use clear and detailed column names.

--- a/projects/plugins/jetpack/changelog/change-response-export-field-names
+++ b/projects/plugins/jetpack/changelog/change-response-export-field-names
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Improve field/column name handling when exporting responses for proper "Date", "IP Address" and other column names.

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -1369,7 +1369,7 @@ class Grunion_Contact_Form_Plugin {
 			'_feedback_author_email' => '2_Email',
 			'_feedback_author_url'   => '3_Website',
 			'_feedback_main_comment' => '4_Comment',
-			'_feedback_author_ip'    => '5_IP',
+			'_feedback_ip'           => __( 'IP Address', 'jetpack' ),
 		);
 
 		foreach ( $field_mapping as $parsed_field_name => $field_name ) {

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -1324,12 +1324,12 @@ class Grunion_Contact_Form_Plugin {
 		$md[ __( 'IP Address', 'jetpack' ) ] = ( isset( $content_fields['_feedback_ip'] ) ) ? $content_fields['_feedback_ip'] : 0;
 
 		// add the email_marketing_consent to the post meta.
-		$md[ __( 'Consent', 'jetpack' ) ] = 0;
+		$md[ _x( 'Consent', 'noun', 'jetpack' ) ] = 0;
 		if ( isset( $content_fields['_feedback_all_fields'] ) ) {
 			$all_fields = $content_fields['_feedback_all_fields'];
 			// check if the email_marketing_consent field exists.
 			if ( isset( $all_fields['email_marketing_consent'] ) ) {
-				$md[ __( 'Consent', 'jetpack' ) ] = $all_fields['email_marketing_consent'];
+				$md[ _x( 'Consent', 'noun', 'jetpack' ) ] = $all_fields['email_marketing_consent'];
 			}
 		}
 

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -1921,6 +1921,7 @@ class Grunion_Contact_Form_Plugin {
 		}
 
 		fclose( $output ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fclose
+		exit();
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -1765,13 +1765,17 @@ class Grunion_Contact_Form_Plugin {
 			 * If it is not - add an empty string, which is just a placeholder in the CSV.
 			 */
 			foreach ( $field_names as $single_field_name ) {
+				/**
+				 * Remove the numeral prefix 1_, 2_, etc, only for export results
+				 */
+				$renamed_field = preg_replace( '/^(\d{1,2}_)/', '', $single_field_name );
 				if (
 					isset( $single_post_data[ $single_field_name ] )
 					&& ! empty( $single_post_data[ $single_field_name ] )
 				) {
-					$result[ $single_field_name ][] = trim( $single_post_data[ $single_field_name ] );
+					$result[ $renamed_field ][] = trim( $single_post_data[ $single_field_name ] );
 				} else {
-					$result[ $single_field_name ][] = '';
+					$result[ $renamed_field ][] = '';
 				}
 			}
 		}

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -1318,18 +1318,18 @@ class Grunion_Contact_Form_Plugin {
 	 * @return mixed
 	 */
 	public function get_post_meta_for_csv_export( $post_id ) {
-		$md                  = get_post_meta( $post_id, '_feedback_extra_fields', true );
-		$md['feedback_date'] = get_the_date( DATE_RFC3339, $post_id );
-		$content_fields      = self::parse_fields_from_content( $post_id );
-		$md['feedback_ip']   = ( isset( $content_fields['_feedback_ip'] ) ) ? $content_fields['_feedback_ip'] : 0;
+		$md                                  = get_post_meta( $post_id, '_feedback_extra_fields', true );
+		$md[ __( 'Date', 'jetpack' ) ]       = get_the_date( DATE_RFC3339, $post_id );
+		$content_fields                      = self::parse_fields_from_content( $post_id );
+		$md[ __( 'IP Address', 'jetpack' ) ] = ( isset( $content_fields['_feedback_ip'] ) ) ? $content_fields['_feedback_ip'] : 0;
 
 		// add the email_marketing_consent to the post meta.
-		$md['email_marketing_consent'] = 0;
+		$md[ __( 'Consent', 'jetpack' ) ] = 0;
 		if ( isset( $content_fields['_feedback_all_fields'] ) ) {
 			$all_fields = $content_fields['_feedback_all_fields'];
 			// check if the email_marketing_consent field exists.
 			if ( isset( $all_fields['email_marketing_consent'] ) ) {
-				$md['email_marketing_consent'] = $all_fields['email_marketing_consent'];
+				$md[ __( 'Consent', 'jetpack' ) ] = $all_fields['email_marketing_consent'];
 			}
 		}
 

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -1364,7 +1364,8 @@ class Grunion_Contact_Form_Plugin {
 		$mapped_fields = array();
 
 		$field_mapping = array(
-			'_feedback_subject'      => __( 'Contact Form', 'jetpack' ),
+			// TODO: Commented out since we'll be re-introducing this after some other changes
+			// '_feedback_subject'      => __( 'Contact Form', 'jetpack' ),
 			'_feedback_author'       => '1_Name',
 			'_feedback_author_email' => '2_Email',
 			'_feedback_author_url'   => '3_Website',

--- a/projects/plugins/jetpack/tests/php/modules/contact-form/test-class.grunion-contact-form.php
+++ b/projects/plugins/jetpack/tests/php/modules/contact-form/test-class.grunion-contact-form.php
@@ -1301,7 +1301,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 				),
 				array(
 					'Contact Form' => 'subj1',
-					'4_Comment'    => 'This is my test 15',
+					'Comment'      => 'This is my test 15',
 				),
 			),
 			array(
@@ -1311,7 +1311,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 				),
 				array(
 					'Contact Form' => 'subj2',
-					'4_Comment'    => 'This is my test 16',
+					'Comment'      => 'This is my test 16',
 				),
 			),
 		);
@@ -1342,7 +1342,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			'key4'         => array( '', 'value4' ),
 			'key5'         => array( '', 'value5' ),
 			'key6'         => array( '', 'value6' ),
-			'4_Comment'    => array( 'This is my test 15', 'This is my test 16' ),
+			'Comment'      => array( 'This is my test 15', 'This is my test 16' ),
 		);
 
 		$this->assertEquals( $expected_result, $result );
@@ -1395,7 +1395,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 				),
 				array(
 					'Contact Form' => 'subj1',
-					'4_Comment'    => 'This is my test 15',
+					'Comment'      => 'This is my test 15',
 				),
 			),
 			array(
@@ -1405,7 +1405,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 				),
 				array(
 					'Contact Form' => 'subj2',
-					'4_Comment'    => 'This is my test 16',
+					'Comment'      => 'This is my test 16',
 				),
 			),
 		);
@@ -1430,7 +1430,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 		$expected_result = array(
 			'Contact Form' => array( 'subj1', 'subj2' ),
-			'4_Comment'    => array( 'This is my test 15', 'This is my test 16' ),
+			'Comment'      => array( 'This is my test 15', 'This is my test 16' ),
 		);
 
 		$this->assertEquals( $expected_result, $result );
@@ -1500,7 +1500,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 				),
 				array(
 					'Contact Form' => 'subj1',
-					'4_Comment'    => 'This is my test 15',
+					'Comment'      => 'This is my test 15',
 				),
 			),
 			array(
@@ -1510,7 +1510,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 				),
 				array(
 					'Contact Form' => 'subj2',
-					'4_Comment'    => 'This is my test 16',
+					'Comment'      => 'This is my test 16',
 				),
 			),
 		);
@@ -1539,7 +1539,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			'key4'         => array( 'value4' ),
 			'key5'         => array( 'value5' ),
 			'key6'         => array( 'value6' ),
-			'4_Comment'    => array( 'This is my test 16' ),
+			'Comment'      => array( 'This is my test 16' ),
 		);
 
 		$this->assertEquals( $expected_result, $result );
@@ -1611,7 +1611,6 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$result = $plugin->map_parsed_field_contents_of_post_to_field_names( $input_data );
 
 		$expected_result = array(
-			// 'Contact Form' => 'This is my form', // TODO: we'll be getting this back in on next iteration
 			'1_Name'    => 'John Smith',
 			'3_Website' => 'http://example.com',
 			'4_Comment' => 'This is my comment!',

--- a/projects/plugins/jetpack/tests/php/modules/contact-form/test-class.grunion-contact-form.php
+++ b/projects/plugins/jetpack/tests/php/modules/contact-form/test-class.grunion-contact-form.php
@@ -1240,7 +1240,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			'key4'         => array( 'value4', 'value4' ),
 			'key5'         => array( '', 'value5' ),
 			'key6'         => array( '', 'value6' ),
-			'4_Comment'    => array( 'This is my test 15', 'This is my test 16' ),
+			'Comment'      => array( 'This is my test 15', 'This is my test 16' ),
 		);
 
 		$this->assertEquals( $expected_result, $result );
@@ -1611,10 +1611,10 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$result = $plugin->map_parsed_field_contents_of_post_to_field_names( $input_data );
 
 		$expected_result = array(
-			'Contact Form' => 'This is my form',
-			'1_Name'       => 'John Smith',
-			'3_Website'    => 'http://example.com',
-			'4_Comment'    => 'This is my comment!',
+			// 'Contact Form' => 'This is my form', // TODO: we'll be getting this back in on next iteration
+			'1_Name'    => 'John Smith',
+			'3_Website' => 'http://example.com',
+			'4_Comment' => 'This is my comment!',
 		);
 
 		$this->assertEquals( $expected_result, $result );
@@ -1666,7 +1666,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			$this->assertSame( 'feedback', $data['group_id'], 'group_id matches' );
 			$this->assertSame( 'Feedback', $data['group_label'], 'group_label matches' );
 			$this->assertSame( true, ! empty( $data['item_id'] ), 'has item_id key' );
-			$this->assertCount( 9, $data['data'], 'has total expected data keys' );
+			$this->assertCount( 8, $data['data'], 'has total expected data keys' );
 		}
 	}
 


### PR DESCRIPTION
See: pcsBup-K4-p2

Fixes #28421 
Fixes #28423

## Proposed changes:
This PR improves the field/column names at the time of export.

- Remove numeral (1_, 2_, etc) prefix from column names
- Provide literal values for "Date" and "IP Address" columns
- Remove the first column "Contact Form"

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
On a test site, export to CSV/Google drive some responses, see that column names comply with the PR description