### PR TITLE
Admin Menu: Route to new Reading Settings page with feature flag

### DIFF
--- a/projects/plugins/jetpack/changelog/update-admin-menu-route-to-new-reading-settings
+++ b/projects/plugins/jetpack/changelog/update-admin-menu-route-to-new-reading-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Admin Menu: Route to new Reading Settings page (internal ATM - behind a feature flag)

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -375,6 +375,10 @@ class Admin_Menu extends Base_Admin_Menu {
 			$submenus_to_update['options-writing.php'] = 'https://wordpress.com/settings/writing/' . $this->domain;
 		}
 
+		if ( apply_filters( 'calypso_use_modernized_reading_settings', false ) && self::DEFAULT_VIEW === $this->get_preferred_view( 'options-reading.php' ) ) {
+			$submenus_to_update['options-reading.php'] = 'https://wordpress.com/settings/reading/' . $this->domain;
+		}
+
 		if ( self::DEFAULT_VIEW === $this->get_preferred_view( 'options-discussion.php' ) ) {
 			$submenus_to_update['options-discussion.php'] = 'https://wordpress.com/settings/discussion/' . $this->domain;
 		}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -375,7 +375,18 @@ class Admin_Menu extends Base_Admin_Menu {
 			$submenus_to_update['options-writing.php'] = 'https://wordpress.com/settings/writing/' . $this->domain;
 		}
 
-		if ( apply_filters( 'calypso_use_modernized_reading_settings', false ) && self::DEFAULT_VIEW === $this->get_preferred_view( 'options-reading.php' ) ) {
+		if (
+			/**
+			 * Filter to enable the modernized Reading Settings in Calypso UI.
+			 *
+			 * @since $$next-version$$
+			 * @module masterbar
+			 *
+			 * @param bool false Should the modernized Reading Settings be enabled? Default to false.
+			 */
+			apply_filters( 'calypso_use_modernized_reading_settings', false )
+			&& self::DEFAULT_VIEW === $this->get_preferred_view( 'options-reading.php' )
+		) {
 			$submenus_to_update['options-reading.php'] = 'https://wordpress.com/settings/reading/' . $this->domain;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/70421

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Override **Settings —> Reading** route to point to the new Reading Settings page in Calypso
  * Only if `calypso_use_modernized_reading_settings` filter resolves to `true`
* Feature flag: Implemented via `calypso_use_modernized_reading_settings` filter with a default value of `false`
  * Any environment  running the plugin can define their filter implementation and return `true` if they wish the Reading Settings page override route to apply
  * PR's will follow up to implement filter callbacks to enable it, for simple and atomic sites, in horizon environment
  * The feature flag is only to be used for the CfT period. Once the CfT is over and the new Reading Settings page is released the feature flag should be cleaned up.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1673961453638839-slack-C02TCEHP3HA
p1673963795054929-slack-C02TCEHP3HA
p1673982400836619-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
The PR should be tested in particular with Simple and Atomic sites. Jetpack sites, in Calypso, do not display the **Settings —> Reading** admin menu item.

###  Test - Simple Sites
1. Test for no regressions:
  * Apply the PR to your sandbox
  * Sandbox `public-api.wordpress.com`
  * Go to Calypso and switch to your test site (must be simple site)
  * Click on **Settings -> Reading**
  * You should be taken to the wp-admin Reading Settings page, i.e. no regression should be observed
  ![Screen Shot 2023-01-18 at 12 03 31](https://user-images.githubusercontent.com/2019970/213155401-a4be256b-4d43-4dbc-9081-a34358583d7d.png)

2. Test a case where the "feature flag" hook would return true:
  * Checkout the PR branch
  * At [the line](https://github.com/Automattic/jetpack/pull/28430/files#diff-f28ed4934935881a801bf44892fea5a11c9bad4f4ffaa1c7bc1c297669a1a567R378) change the default hook value from `false` to `true`
  * Build the jetpack plugin locally
  * Using `jetpack rsync` apply the changes to your sandbox
  * Sandbox `public-api.wordpress.com`
  * Go to Calypso and switch to your test site (must be simple site)
  * Click on **Settings -> Reading**
  * You should be taken to the new Reading Settings page
  ![Screen Shot 2023-01-18 at 12 02 58](https://user-images.githubusercontent.com/2019970/213155309-f71aa002-01cd-402f-96a0-9ad1b454d091.png)

### Test - Atomic Site
Here are some resources to help you out with setting up Jetpack Atomic site test environment: pb5gDS-1rQ-p2

Once your atomic site environment is ready we can do similar test cases as for the Simple sites above.

1. Test for no regressions:
  * Checkout the PR branch, build it and apply it to your Atomic test-site
  * Go to Calypso and switch to your Atomic test-site
  * Click on **Settings -> Reading**
  * You should be taken to the wp-admin Reading Settings page, i.e. no regression should be observed
  ![Screen Shot 2023-01-18 at 12 03 31](https://user-images.githubusercontent.com/2019970/213155401-a4be256b-4d43-4dbc-9081-a34358583d7d.png)

2. Test a case where the "feature flag" hook would return true:
  * Checkout the PR branch 
  * At [the line](https://github.com/Automattic/jetpack/pull/28430/files#diff-f28ed4934935881a801bf44892fea5a11c9bad4f4ffaa1c7bc1c297669a1a567R378) change the default hook value from `false` to `true`
  * Build Jetpack plugin and apply it to your Atomic test-site
  * Go to Calypso and switch to your Atomic test-site
  * Click on **Settings -> Reading**
  * You should be taken to the new Reading Settings page
  ![Screen Shot 2023-01-18 at 12 02 58](https://user-images.githubusercontent.com/2019970/213155309-f71aa002-01cd-402f-96a0-9ad1b454d091.png)
