### PR TITLE
Related Posts: Fix options saving in the endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-endpoint-related-posts-options-save
+++ b/projects/plugins/jetpack/changelog/fix-endpoint-related-posts-options-save
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+RAPI: Fix Related Posts options saving

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -1063,7 +1063,13 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 		if ( count( $jetpack_relatedposts_options ) ) {
 			// track new jetpack_relatedposts options against old.
 			$old_relatedposts_options = Jetpack_Options::get_option( 'relatedposts' );
-			if ( Jetpack_Options::update_option( 'relatedposts', $jetpack_relatedposts_options ) ) {
+
+			$jetpack_relatedposts_options_to_save = $old_relatedposts_options;
+			foreach ( $jetpack_relatedposts_options as $key => $value ) {
+				$jetpack_relatedposts_options_to_save[ $key ] = $value;
+			}
+
+			if ( Jetpack_Options::update_option( 'relatedposts', $jetpack_relatedposts_options_to_save ) ) {
 				foreach ( $jetpack_relatedposts_options as $key => $value ) {
 					if ( in_array( $key, array( 'show_context', 'show_date' ), true ) ) {
 						$has_initialized_option = ! isset( $old_relatedposts_options[ $key ] ) && $value;


### PR DESCRIPTION
The proposed changes fix a bug present in the POST request of the `/sites/%s/settings/` endpoint.

Without the fix, the `Jetpack_Options::update_option()` is called only with the options that are about to be updated. As a result, the other existing options that had been saved in the past, are being lost in the update process.

Fixes https://github.com/Automattic/wp-calypso/issues/72284

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Make sure the array passed to `Jetpack_Options::update_option()` includes **_all_** Related Posts' options - as opposed to the current state where it includes only the options that are about to be updated.
* The newly-introduced array to be saved (`$jetpack_relatedposts_options_to_save`) is based on the existing options and then updated to include the newest values passed to the endpoint.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No, it does not.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**General steps:**
1. Apply the PR to your sandbox.
2. Sandbox `public-api.wordpress.com`.
3. For testing with Atomic and Jetpack sites, the following resources may help: PCYsg-eg0-p2 (Jetpack) and pb5gDS-1rQ-p2 (Atomic). Jurassic Ninja can be used for emulating Jetpack-connected site.
4. The PR can be tested either through the Calypso UI or through the API Developer Console.

**Testing through the Calypso UI:**
1. Apply the following PR to your local Calypso and build it: https://github.com/Automattic/wp-calypso/pull/72220 (no worries if it is in the draft state).
2. Navigate to `http://calypso.localhost:3000/settings/reading/[site-address]` and experiment with changing and saving Related Posts settings.
3. All the changes you make should be correctly reflected on the Reading settings page in WP Admin (`/wp-admin/options-reading.php`).

| Calypso | WP Admin |
| ------------- | ------------- |
| ![Markup on 2023-01-18 at 17:13:18](https://user-images.githubusercontent.com/25105483/213230814-01b8776e-8b72-4941-91e0-79dd655e0bff.png) | ![Markup on 2023-01-18 at 17:13:38](https://user-images.githubusercontent.com/25105483/213230820-5e3164e1-393e-49fa-b44a-3e0abfdb9106.png) |

**Testing through the API Developer Console:**
1. Open the API Developer Console.
2. Make the GET `/sites/%s/settings/` request with your test site: 

![Markup on 2023-01-18 at 17:00:14](https://user-images.githubusercontent.com/25105483/213224983-8c6256e5-ddbe-415b-971b-f3b4bbab3779.png)

3. Note the values of the Related Posts options, e.g.:

```js
jetpack_relatedposts_enabled:true
jetpack_relatedposts_show_context:false
jetpack_relatedposts_show_date:false
jetpack_relatedposts_show_headline:false
jetpack_relatedposts_show_thumbnails:false
```

4. In a new tab, make a POST `/sites/%s/settings/` request with your test site that will be changing one or more Related Posts options from the example list above.
5. When you make another GET request, you should see only that one (or multiple) options being changed. Other options that haven't been touched by the POST request, should be intact.

For instance, if I changed `jetpack_relatedposts_show_thumbnails` to `true`, the subsequent GET request should return all the previous options as they were before with just the `jetpack_relatedposts_show_thumbnails` set to `true`.

6. Feel free to run other POST requests, trying to alter different Related Posts options. 🙂 