### PR TITLE
Connection: remove handling of the 'site_blacklisted' error code

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -77,7 +77,6 @@ class JetpackStateNotices extends React.Component {
 					key
 				);
 				break;
-			case 'site_blacklisted':
 			case 'connection_disabled':
 				message = createInterpolateElement(
 					__(

--- a/projects/plugins/jetpack/changelog/update-deprecate-site-blacklisted-2
+++ b/projects/plugins/jetpack/changelog/update-deprecate-site-blacklisted-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Remove handling for an error code that no longer exists.


### PR DESCRIPTION
## Proposed changes:
* Remove the error code `site_blacklisted` from the handler, as it's no longer being returned by WPCOM

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p9dueE-6oT-p2

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
_Rebuild `plugins/jetpack` if you're testing locally._

1. Activate the "Jetpack Debug" plugin, enable the "Cookie State Faker" tool.
2. Set the value `connection_disabled` for the "error" key. 
3. Go to Jetpack Dashboard and confirm that you see the error notice:
<img width="718" alt="Screen Shot 2023-01-18 at 11 14 32" src="https://user-images.githubusercontent.com/1341249/213231103-296076f5-fd75-4a6b-a88b-b861c590fafe.png">
