### PR TITLE
tools: Avoid double-tagging in wporg SVN

### DIFF
--- a/.github/files/gh-wp-svn-autopublish/files/wp-svn-autopublish.sh
+++ b/.github/files/gh-wp-svn-autopublish/files/wp-svn-autopublish.sh
@@ -37,8 +37,13 @@ svn up trunk
 echo '::endgroup::'
 
 echo "::group::Checking out SVN tags (shallowly)"
-svn up tags --depth=empty
+svn up tags --depth=immediates
 echo '::endgroup::'
+
+if [[ -e "tags/$TAG" ]]; then
+	echo "::error::Tag $TAG already exists in SVN. Aborting."
+	exit 1
+fi
 
 echo "::group::Deleting everything in trunk except for .svn directories"
 find trunk ! \( -path '*/.svn/*' -o -path "*/.svn" \) \( ! -type d -o -empty \) -delete

--- a/tools/deploy-to-svn.sh
+++ b/tools/deploy-to-svn.sh
@@ -84,6 +84,12 @@ if [[ -z "$WPSLUG" ]]; then
 fi
 $FAIL && exit 1
 
+if jq -e '.extra["wp-svn-autopublish"] // false' "$PLUGIN_DIR/composer.json" &>/dev/null; then
+	yellow "$PLUGIN_NAME is set up to automatically publish to WordPress.org via GitHub Actions."
+	yellow $'\e[1mIf you run this script in addition to the auto-publish, you\'ll likely wind up with a broken tag (see https://github.com/Automattic/jetpack/issues/28400).'
+	proceed_p '' 'Really publish to SVN manually?'
+fi
+
 # Check build dir.
 if [[ -z "$BUILD_DIR" ]]; then
 	TMPDIR="${TMPDIR:-/tmp}"
@@ -124,8 +130,12 @@ printf "\r\e[K"
 success "Done!"
 
 info "Checking out SVN tags shallowly to $DIR/tags"
-svn -q up tags --depth=empty
+svn -q up tags --depth=immediates
 success "Done!"
+
+if [[ -e "tags/$SVNTAG" ]]; then
+	die "Tag $SVNTAG already exists in SVN. Aborting."
+fi
 
 info "Deleting everything in trunk except for .svn directories"
 find trunk ! \( -path '*/.svn/*' -o -path "*/.svn" \) \( ! -type d -o -empty \) -delete


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The command used to tag a release in SVN has an unfortunate failure modde if the tag already exists: instead of simply failing, it will create a `trunk` directory inside the tag.

This PR does two things to try to avoid this situation:

* The manual `deploy-to-svn.sh` script will now confirm if someone tries to run it on a plugin that is set up for auto-publish.
* Both that and the auto-publish will abort if they detect the tag already exists (but note this check is subject to races).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Fixes #28414 (as far as we can on our own)

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try running `tools/deploy-to-svn.sh protect 1.2.3`, it should warn about the possibility of things breaking.
* Try running `tools/deploy-to-svn.sh jetpack 9.4`. It should (eventually) abort because that tag already exists in SVN.