### PR TITLE
Repo experience: update report template & automated triage task

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,15 +1,21 @@
 name: Bug Report
 description: Report issues with one of our products.
-labels: [ 'Needs triage', '[Type] Bug' ]
+labels: [ 'Needs triage', '[Type] Bug', 'User Report' ]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for contributing to Jetpack!
-        Pick a clear title ("Sharing: Facebook button missing") and proceed.
+        ### Thanks for contributing to Jetpack!
 
-        __Avoid using image hosting services such as Cloudup, Droplr, Imgur, etc., to link to media.__
-        Instead, attach screenshot(s) or recording(s) directly in any of the text areas below: click, then drag and drop.
+        Please write a clear title, then fill in the fields below and submit.
+
+        Please **do not** link to image hosting services such as Cloudup, Droplr, Imgur, etc…
+        Instead, directly embed screenshot(s) or recording(s) in any of the text areas below: click, then drag and drop.
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ## Core Information
   - type: dropdown
     id: plugin-type
     attributes:
@@ -32,14 +38,18 @@ body:
     validations:
       required: true
   - type: textarea
+    id: summary
+    attributes:
+        label: Quick summary
+  - type: textarea
     id: steps
     attributes:
-      label: Steps to Reproduce
+      label: Steps to reproduce
       placeholder: |
-        1. Go to '...'
-        2. Click on '....'
-        3. Scroll down to '....'
-        ...
+        1. Start at `site-domain.com/blog`.
+        2. Click on any blog post.
+        3. Click on the 'Like' button.
+        4. ...
     validations:
       required: true
   - type: textarea
@@ -55,66 +65,17 @@ body:
       placeholder: |
         eg. Clicking the button does nothing visibly.
   - type: dropdown
-    id: browser
-    attributes:
-      label: Browser
-      description: (You may select more than one)
-      options:
-        - Google Chrome/Chromium
-        - Mozilla Firefox
-        - Microsoft Edge
-        - Apple Safari
-        - iOS Safari
-        - Android Chrome
-      multiple: true
-  - type: textarea
-    id: other
-    attributes:
-      label: Other information
-      placeholder: Screenshots, additional logs, notes, etc.
-  - type: markdown
-    attributes:
-      value: |
-        ---
-        ## Additional context
-
-        The following section is optional. If you're an Automattician, you should be able to fill it in. If not, please scroll to the bottom and submit the issue.
-  - type: dropdown
-    id: site-type
-    attributes:
-      label: Platform (Simple, Atomic, or both?)
-      description: (You may select more than one)
-      options:
-        - Simple
-        - Atomic
-        - Self-hosted
-      multiple: true
-  - type: markdown
-    attributes:
-      value: |
-        ## Issue severity
-
-        Please provide details around how often the issue is reproducible & how many users are affected.
-  - type: dropdown
-    id: reproducibility
-    attributes:
-      label: Reproducibility
-      options:
-        - Consistent
-        - Intermittent
-        - Once
-    validations:
-      required: true
-  - type: dropdown
     id: users-affected
     attributes:
-      label: Severity
-      description: How many users are impacted? A guess is fine.
+      label: Impact
+      description: Approximately how many users are impacted?
       options:
         - One
         - Some (< 50%)
         - Most (> 50%)
         - All
+    validations:
+      required: true
   - type: dropdown
     id: workarounds
     attributes:
@@ -125,10 +86,31 @@ body:
         - Yes, difficult to implement
         - Yes, easy to implement
         - There is no user impact
-  - type: textarea
-    id: workarounds-detail
+    validations:
+      required: true
+  - type: markdown
     attributes:
-      label: Workaround details
-      description: If you are aware of a workaround, please describe it below.
+      value: |
+        <br>
+
+        ## Optional Information
+        The following section is optional.
+  - type: dropdown
+    id: site-type
+    attributes:
+      label: Platform (Simple and/or Atomic)
+      description: (You may select more than one)
+      options:
+        - Simple
+        - Atomic
+        - Self-hosted
+      multiple: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or notes
       placeholder: |
-        e.g. There is an alternative way to access this setting in the sidebar, but it's not readily apparent.
+        Add any information that may be relevant, such as:
+          - Browser/Platform
+          - Theme
+          - Logs/Errors

--- a/projects/github-actions/repo-gardening/changelog/update-bug-report-format
+++ b/projects/github-actions/repo-gardening/changelog/update-bug-report-format
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update triage task to match new bug report template format.

--- a/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/index.js
@@ -44,7 +44,7 @@ function findPlugins( body ) {
  * @returns {Array} Platforms impacted by issue.
  */
 function findPlatforms( body ) {
-	const regex = /###\sPlatform\s\(Simple,\sAtomic,\sor\sboth\?\)\n\n([a-zA-Z ,-]*)\n\n/gm;
+	const regex = /###\sPlatform\s\(Simple\sand\/or Atomic\)\n\n([a-zA-Z ,-]*)\n\n/gm;
 
 	const match = regex.exec( body );
 	if ( match ) {
@@ -67,23 +67,23 @@ function findPlatforms( body ) {
  */
 function findPriority( body ) {
 	// Look for priority indicators in body.
-	const priorityRegex = /###\sSeverity\n\n(?<severity>.*)\n\n###\sAvailable\sworkarounds\?\n\n(?<blocking>.*)\n/gm;
+	const priorityRegex = /###\sImpact\n\n(?<impact>.*)\n\n###\sAvailable\sworkarounds\?\n\n(?<blocking>.*)\n/gm;
 	let match;
 	while ( ( match = priorityRegex.exec( body ) ) ) {
-		const [ , severity = '', blocking = '' ] = match;
+		const [ , impact = '', blocking = '' ] = match;
 
 		debug(
-			`triage-new-issues: Reported priority indicators for issue: "${ severity }" / "${ blocking }"`
+			`triage-new-issues: Reported priority indicators for issue: "${ impact }" / "${ blocking }"`
 		);
 
 		if ( blocking === 'No and the platform is unusable' ) {
-			return severity === 'One' ? 'High' : 'BLOCKER';
+			return impact === 'One' ? 'High' : 'BLOCKER';
 		} else if ( blocking === 'No but the platform is still usable' ) {
 			return 'High';
 		} else if ( blocking === 'Yes, difficult to implement' ) {
-			return severity === 'All' ? 'High' : 'Normal';
+			return impact === 'All' ? 'High' : 'Normal';
 		} else if ( blocking !== '' && blocking !== '_No response_' ) {
-			return severity === 'All' || severity === 'Most (> 50%)' ? 'Normal' : 'Low';
+			return impact === 'All' || impact === 'Most (> 50%)' ? 'Normal' : 'Low';
 		}
 		return null;
 	}


### PR DESCRIPTION
## Proposed changes:

The GitHub issue template is updated in Calypso in https://github.com/Automattic/wp-calypso/pull/71827/

Let's update ours to match and provide a consistent experience. We should also update our GitHub action that looks for key content in GitHub issues, so it knows where to find info about impacted platform and priority indicators in the updated bug report format.

> **Note**
> This needs to be merged in coordination with the matching Calypso PR.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* pciE2j-1Hh-p2
* p1673895559301559-slack-CQD1HH4MA

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This can probably be tested on a fork of this repo where you'll merge this branch to `trunk`. Then open a new issue there using the bug report template. [Here is a repo where you can test that](https://github.com/jeherve/jetpack/issues/).

* You will then be able to see the update template.
* You should see the priority and platform labels be automatically enabled based on your selection.

Here is an issue where I've tested things: https://github.com/jeherve/jetpack/issues/61 
Here is the result triage run: https://github.com/jeherve/jetpack/actions/runs/3952250285/jobs/6767096251

<img width="939" alt="image" src="https://user-images.githubusercontent.com/426388/213276601-671ded95-eb64-490b-a7fe-c4bd17d1089f.png">

