### PR TITLE
E2E tests: fix tiled gallery block test with GB 15.0.0

### DIFF
--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -48,13 +48,6 @@ const matrix = [];
 switch ( process.env.GITHUB_EVENT_NAME ) {
 	case 'pull_request':
 	case 'push': {
-		projects.push( {
-			project: 'Blocks with latest Gutenberg',
-			path: 'projects/plugins/jetpack/tests/e2e',
-			testArgs: [ 'blocks', '--retries=1' ],
-			suite: 'gutenberg',
-		} );
-
 		const changedProjects = JSON.parse(
 			execSync( '.github/files/list-changed-projects.sh' ).toString()
 		);

--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -48,6 +48,13 @@ const matrix = [];
 switch ( process.env.GITHUB_EVENT_NAME ) {
 	case 'pull_request':
 	case 'push': {
+		projects.push( {
+			project: 'Blocks with latest Gutenberg',
+			path: 'projects/plugins/jetpack/tests/e2e',
+			testArgs: [ 'blocks', '--retries=1' ],
+			suite: 'gutenberg',
+		} );
+
 		const changedProjects = JSON.parse(
 			execSync( '.github/files/list-changed-projects.sh' ).toString()
 		);

--- a/tools/e2e-commons/pages/wp-admin/blocks/tilled-gallery.js
+++ b/tools/e2e-commons/pages/wp-admin/blocks/tilled-gallery.js
@@ -39,6 +39,10 @@ export default class TiledGallery extends BlockEditorCanvas {
 	}
 
 	async linkToAttachment() {
+		const settingTabSelector = "button[role='tab'][aria-label='Settings']";
+		if ( await this.isElementVisible( settingTabSelector, 5000 ) ) {
+			await this.click( settingTabSelector );
+		}
 		await this.click( "button[data-label='Block']" );
 		await this.selectOption( 'select.components-select-control__input', 'Attachment Page' );
 	}


### PR DESCRIPTION
## Proposed changes:

Fix for Tiled Gallery block test. Open Setting tab if it exists.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1674073832600149-slack-C03QNBQKG73

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* [ran tests with latest Gutenberg and they passed](https://github.com/Automattic/jetpack/actions/runs/3953671832/jobs/6770227048)
* e2e tests should pass