### PR TITLE
Image Guide: Release v0.2.0

### DIFF
--- a/projects/js-packages/image-guide/CHANGELOG.md
+++ b/projects/js-packages/image-guide/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2023-01-19
+### Changed
+- Bundle the package to make it easy to consume [#28429]
+
+### Fixed
+- Clean up JavaScript eslint issues. [#28441]
+
 ## [0.1.2] - 2023-01-17
 ### Added
 - Fixed an issue that would break the release process [#28186]
@@ -26,5 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Minor package.json change - removing private entry.
 
+[0.2.0]: https://github.com/Automattic/jetpack-image-guide/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/Automattic/jetpack-image-guide/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/Automattic/jetpack-image-guide/compare/v0.1.0...v0.1.1

--- a/projects/js-packages/image-guide/changelog/renovate-major-eslint-packages
+++ b/projects/js-packages/image-guide/changelog/renovate-major-eslint-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Clean up JavaScript eslint issues.

--- a/projects/js-packages/image-guide/changelog/update-bundle-image-guide
+++ b/projects/js-packages/image-guide/changelog/update-bundle-image-guide
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Bundle the package to make it easy to consume

--- a/projects/js-packages/image-guide/package.json
+++ b/projects/js-packages/image-guide/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-image-guide",
-	"version": "0.2.0-alpha",
+	"version": "0.2.0",
 	"description": "Go through the dom to analyze image size on screen vs actual file size.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/image-guide/#readme",
 	"type": "module",


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Created this prerelease branch release Image Guide package version 0.2.0. This version bundles the image-guide using webpack into a single file which can be consumed by both Boost and Boost-Cloud.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
None

