### PR TITLE
Blaze: always enqueue Connection state info

### DIFF
--- a/projects/packages/blaze/changelog/fix-blaze-missing-connection-info
+++ b/projects/packages/blaze/changelog/fix-blaze-missing-connection-info
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Always enqueue Jetpack Connnection info when enqueuing Blaze script

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack;
 
+use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
 use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\Sync\Settings as Sync_Settings;
@@ -190,5 +191,8 @@ class Blaze {
 				'textdomain' => 'jetpack-blaze',
 			)
 		);
+
+		// Adds Connection package initial state.
+		wp_add_inline_script( 'jetpack-promote-editor', Connection_Initial_State::render(), 'before' );
 	}
 }


### PR DESCRIPTION
## Proposed changes:

We previously relied on the plugins that were enabling Blaze (i.e. Jetpack for now) to enqueue that info for us:
https://github.com/Automattic/jetpack/blob/e16722f28354c610c59e7a83ddb21c16d58d43a7/projects/plugins/jetpack/class.jetpack-gutenberg.php#L737-L738

However, in some scenarios, it would seem that this is not enqueued while the Blaze editor is. I'm not quite sure how exactly this happens yet, but I think we can alleviate such problems by ensuring we enqueue the Connection info every time we enqueue the Blaze editor.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1674116811088839/1674109103.627279-slack-C03TY6J1A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

On a WoA site:

* Go to Posts > Add New
* You should not see any errors related to Blaze in the browser console.
* Publish your post.
* The Blaze post-publish panel should appear if your site is public.

