### PR TITLE
Add a top-level Move to WordPress.com menu

### DIFF
--- a/projects/plugins/migration/changelog/add-menu-for-migration
+++ b/projects/plugins/migration/changelog/add-menu-for-migration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Adds a top-level menu entry for Move to WordPress.com

--- a/projects/plugins/migration/src/class-jetpack-migration.php
+++ b/projects/plugins/migration/src/class-jetpack-migration.php
@@ -9,7 +9,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
@@ -29,15 +28,8 @@ class Jetpack_Migration {
 		// Set up the REST authentication hooks.
 		Connection_Rest_Authentication::init();
 
-		$page_suffix = Admin_Menu::add_menu(
-			__( 'Jetpack Migration', 'jetpack-migration' ),
-			_x( 'Migration', 'The Jetpack Migration product name, without the Jetpack prefix', 'jetpack-migration' ),
-			'manage_options',
-			'jetpack-migration',
-			array( $this, 'plugin_settings_page' ),
-			99
-		);
-		add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );
+		// Set up the top-level menu
+		add_action( 'admin_menu', array( $this, 'admin_menu_hook_callback' ), 1000 ); // Jetpack uses 998.
 
 		// Init Jetpack packages
 		add_action(
@@ -63,6 +55,23 @@ class Jetpack_Migration {
 		);
 
 		My_Jetpack_Initializer::init();
+	}
+
+	/**
+	 * Set up the admin menu.
+	 */
+	public function admin_menu_hook_callback() {
+		$page_suffix = add_menu_page(
+			'Move to WordPress.com',
+			'Move to WordPress.com',
+			'manage_options',
+			'jetpack-migration',
+			array( $this, 'plugin_settings_page' ),
+			'dashicons-admin-generic',
+			79 // right before the Settings menu (80)
+		);
+
+		add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );
 	}
 
 	/**


### PR DESCRIPTION
We've decided to not brand the jetpack-migration plugin under the Jetpack brand initially, see: pcmemI-1ti-p2#comment-1117

## Proposed changes:

* Removes the existing menu from under Jetpack
* Adds it in a top-level right above settings `Move to WordPress.com`

<img width="405" alt="CleanShot 2023-01-19 at 16 37 48@2x" src="https://user-images.githubusercontent.com/533/213427034-ef66a227-aa42-428f-9bf1-55cd93f35eb2.png">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
NA

## Does this pull request change what data or activity we track or use?
NA

## Testing instructions:

* Install plugin
* See that the top-level menu item appears
* Proxy via JN, and test the whole flow (pcmemI-1GG-p2), make sure it works.
* Note: the menu icon probably needs to be changed, but that can be done later.