### PR TITLE
build: Restore "Test plugin upgrades" in build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,6 +132,56 @@ jobs:
               comment_id: +COMMENT_ID,
             } );
 
+  upgrade_test:
+    name: Test plugin upgrades
+    runs-on: ubuntu-latest
+    needs: build
+    if: needs.build.outputs.any_plugins == 'true'
+    timeout-minutes: 10  # 2022-03-04: Successful runs seem to take about 3 minutes, but give some extra time for the downloads.
+    services:
+      db:
+        image: mariadb:latest
+        env:
+          MARIADB_ROOT_PASSWORD: wordpress
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
+    container:
+      image: ghcr.io/automattic/jetpack-wordpress-dev:latest
+      env:
+        WP_DOMAIN: localhost
+        WP_ADMIN_USER: wordpress
+        WP_ADMIN_EMAIL: wordpress@example.com
+        WP_ADMIN_PASSWORD: wordpress
+        WP_TITLE: Hello World
+        MYSQL_HOST: db:3306
+        MYSQL_DATABASE: wordpress
+        MYSQL_USER: root
+        MYSQL_PASSWORD: wordpress
+        HOST_PORT: 80
+      ports:
+        - 80:80
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: monorepo
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: jetpack-build
+      - name: Extract build archive
+        run: tar --xz -xvvf build.tar.xz
+
+      - name: Setup WordPress
+        run: monorepo/.github/files/test-plugin-update/setup.sh
+
+      - name: Prepare plugin zips
+        run: monorepo/.github/files/test-plugin-update/prepare-zips.sh
+
+      - name: Test upgrades
+        run: monorepo/.github/files/test-plugin-update/test.sh
+
   jetpack_beta:
     name: Create artifact for Jetpack Beta plugin
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Something is not working right yet with the post-build job. Let's keep it around for debugging, but restore the copy in the build job so peoples' PRs aren't blocked by it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Does the "Build / Test plugins upgrades" check run?
