### PR TITLE
VideoPress: do not prompt to convert embed block to VideoPress video block

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-remove-prompt-to-convert-embed-block
+++ b/projects/packages/videopress/changelog/update-videopress-remove-prompt-to-convert-embed-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: do not prompt to convert embed block to VideoPress video block

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -114,6 +114,13 @@ export default function VideoPressEdit( {
 		isExample,
 	} = attributes;
 
+	/*
+	 * Force className cleanup.
+	 * It adds ` wp-embed-aspect-21-9 wp-has-aspect-ratio` classes
+	 * when transforming from embed block.
+	 */
+	delete attributes.className;
+
 	const videoPressUrl = getVideoPressUrl( guid, {
 		autoplay,
 		controls,

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/index.ts
@@ -1,15 +1,15 @@
 /**
  * WordPress dependencies
  */
-import { registerBlockType, createBlock } from '@wordpress/blocks';
+import { registerBlockType } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { getVideoPressUrl, pickGUIDFromUrl } from '../../../lib/url';
 import metadata from './block.json';
 import { VideoPressIcon as icon } from './components/icons';
 import Edit from './edit';
 import save from './save';
+import transforms from './transforms';
 import videoPressBlockExampleImage from './videopress-block-example-image.jpg';
 import './style.scss';
 
@@ -25,46 +25,5 @@ registerBlockType( name, {
 			isExample: true,
 		},
 	},
-	transforms: {
-		from: [
-			{
-				type: 'block',
-				blocks: [ 'core/embed' ],
-				isMatch: attrs => attrs.providerNameSlug === 'videopress' && pickGUIDFromUrl( attrs?.url ),
-				transform: attrs => {
-					const { url, providerNameSlug } = attrs;
-					const guid = pickGUIDFromUrl( url );
-					const isCoreEmbedVideoPressVariation = providerNameSlug === 'videopress' && !! guid;
-
-					/*
-					 * Do not add transform when the block
-					 * is not a core/embed VideoPress block variation
-					 */
-					if ( ! isCoreEmbedVideoPressVariation ) {
-						return createBlock( 'core/embed', attrs );
-					}
-
-					return createBlock( 'videopress/video', { ...attrs, guid, src: url } );
-				},
-			},
-		],
-		to: [
-			{
-				type: 'block',
-				blocks: [ 'core/embed' ],
-				isMatch: attrs => attrs?.src || getVideoPressUrl( attrs?.guid, attrs ),
-				transform: attrs => {
-					const { guid, src } = attrs;
-
-					// Build the source (URL) in case it isn't defined.
-					const url = src || getVideoPressUrl( guid, attrs );
-					if ( ! url ) {
-						return createBlock( 'core/embed' );
-					}
-
-					return createBlock( 'core/embed', { ...attrs, url } );
-				},
-			},
-		],
-	},
+	transforms,
 } );

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+/**
+ * Internal dependencies
+ */
+import { getVideoPressUrl, pickGUIDFromUrl } from '../../../../lib/url';
+
+const transfromFromCoreEmbed = {
+	type: 'block',
+	blocks: [ 'core/embed' ],
+	isMatch: attrs => attrs.providerNameSlug === 'videopress' && pickGUIDFromUrl( attrs?.url ),
+	transform: attrs => {
+		const { url, providerNameSlug } = attrs;
+		const guid = pickGUIDFromUrl( url );
+		const isCoreEmbedVideoPressVariation = providerNameSlug === 'videopress' && !! guid;
+
+		/*
+		 * Do not add transform when the block
+		 * is not a core/embed VideoPress block variation
+		 */
+		if ( ! isCoreEmbedVideoPressVariation ) {
+			return createBlock( 'core/embed', attrs );
+		}
+
+		return createBlock( 'videopress/video', { ...attrs, guid, src: url } );
+	},
+};
+
+const transfromToCoreEmbed = {
+	type: 'block',
+	blocks: [ 'core/embed' ],
+	isMatch: attrs => attrs?.src || getVideoPressUrl( attrs?.guid, attrs ),
+	transform: attrs => {
+		const { guid, src } = attrs;
+
+		// Build the source (URL) in case it isn't defined.
+		const url = src || getVideoPressUrl( guid, attrs );
+		if ( ! url ) {
+			return createBlock( 'core/embed' );
+		}
+
+		return createBlock( 'core/embed', { ...attrs, url } );
+	},
+};
+
+const from = [ transfromFromCoreEmbed ];
+const to = [ transfromToCoreEmbed ];
+
+export default { from, to };

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
@@ -5,7 +5,7 @@ import { createBlock } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { buildVideoPressURL, getVideoPressUrl, pickGUIDFromUrl } from '../../../../lib/url';
+import { buildVideoPressURL, pickGUIDFromUrl } from '../../../../lib/url';
 
 const transfromFromCoreEmbed = {
 	type: 'block',
@@ -31,13 +31,15 @@ const transfromFromCoreEmbed = {
 const transfromToCoreEmbed = {
 	type: 'block',
 	blocks: [ 'core/embed' ],
-	isMatch: attrs => attrs?.src || getVideoPressUrl( attrs?.guid, attrs ),
+	isMatch: attrs => attrs?.src || attrs?.guid,
 	transform: attrs => {
-		const { guid } = attrs;
+		const { guid, src: srcFromAttr } = attrs;
 
 		// Build the source (URL) in case it isn't defined.
 		const { url } = buildVideoPressURL( guid );
-		if ( ! url ) {
+
+		const src = srcFromAttr || url;
+		if ( ! src ) {
 			return createBlock( 'core/embed' );
 		}
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
@@ -12,11 +12,11 @@ const transfromFromCoreEmbed = {
 	blocks: [ 'core/embed' ],
 	isMatch: attrs => attrs.providerNameSlug === 'videopress' && pickGUIDFromUrl( attrs?.url ),
 	transform: attrs => {
-		const { url, providerNameSlug } = attrs;
-		const guid = pickGUIDFromUrl( url );
+		const { url: src, providerNameSlug } = attrs;
+		const guid = pickGUIDFromUrl( src );
 
 		/*
-		 * Do not add transform when the block
+		 * Do transform when the block
 		 * is not a core/embed VideoPress block variation
 		 */
 		const isCoreEmbedVideoPressVariation = providerNameSlug === 'videopress' && !! guid;
@@ -24,7 +24,7 @@ const transfromFromCoreEmbed = {
 			return createBlock( 'core/embed', attrs );
 		}
 
-		return createBlock( 'videopress/video', { ...attrs, guid, src: url } );
+		return createBlock( 'videopress/video', { guid, src } );
 	},
 };
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
@@ -5,7 +5,7 @@ import { createBlock } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { getVideoPressUrl, pickGUIDFromUrl } from '../../../../lib/url';
+import { buildVideoPressURL, getVideoPressUrl, pickGUIDFromUrl } from '../../../../lib/url';
 
 const transfromFromCoreEmbed = {
 	type: 'block',
@@ -33,15 +33,21 @@ const transfromToCoreEmbed = {
 	blocks: [ 'core/embed' ],
 	isMatch: attrs => attrs?.src || getVideoPressUrl( attrs?.guid, attrs ),
 	transform: attrs => {
-		const { guid, src } = attrs;
+		const { guid } = attrs;
 
 		// Build the source (URL) in case it isn't defined.
-		const url = src || getVideoPressUrl( guid, attrs );
+		const { url } = buildVideoPressURL( guid );
 		if ( ! url ) {
 			return createBlock( 'core/embed' );
 		}
 
-		return createBlock( 'core/embed', { ...attrs, url } );
+		return createBlock( 'core/embed', {
+			allowResponsive: true,
+			providerNameSlug: 'videopress',
+			responsive: true,
+			type: 'video',
+			url,
+		} );
 	},
 };
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
@@ -14,12 +14,12 @@ const transfromFromCoreEmbed = {
 	transform: attrs => {
 		const { url, providerNameSlug } = attrs;
 		const guid = pickGUIDFromUrl( url );
-		const isCoreEmbedVideoPressVariation = providerNameSlug === 'videopress' && !! guid;
 
 		/*
 		 * Do not add transform when the block
 		 * is not a core/embed VideoPress block variation
 		 */
+		const isCoreEmbedVideoPressVariation = providerNameSlug === 'videopress' && !! guid;
 		if ( ! isCoreEmbedVideoPressVariation ) {
 			return createBlock( 'core/embed', attrs );
 		}

--- a/projects/packages/videopress/src/client/block-editor/extend/index.js
+++ b/projects/packages/videopress/src/client/block-editor/extend/index.js
@@ -1,5 +1,5 @@
 /**
  * Internal dependencies
  */
-import './core-embed';
+// import './core-embed'; Let's keep here in case we'd like to extend the core/embed block in the future.
 import './core-video';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR updates the transform from/to Embed block:

* Remove the message that prompts the user to convert the embed block to video v6 block
* Re-organize the transforms code, creating a `transforms/` folder
* Fixes visual block height issue, cleaning up the CSS classes added in the transform process

Fixes https://github.com/Automattic/jetpack/issues/28461

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: do not prompt to convert embed block to VideoPress video block

### Other information:

- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to block editor
* Add a new embed block instance
* Fill with a VideoPress URL. Eg:`https://videopress.com/v/ezoR6kzb`
* Confirm the block does not prompt to convert the block to VideoPress video block

* Confirm, though, it's still possible to transform the block from/to VideoPress video block

From | To
------|------
<img width="684" alt="image" src="https://user-images.githubusercontent.com/77539/213520835-669ecacc-a99a-4acf-ac91-d1fc8d3278b1.png"> | <img width="674" alt="image" src="https://user-images.githubusercontent.com/77539/213520966-0e112b42-0981-4fae-aad4-2e49dbcea1bc.png">



