### PR TITLE
jetpack-mu-wpcom: add GH test reminder

### DIFF
--- a/.github/files/build-reminder-comment/check-test-reminder-comment.js
+++ b/.github/files/build-reminder-comment/check-test-reminder-comment.js
@@ -16,7 +16,7 @@ const getCheckComments = require( './get-check-comments.js' );
  * @param {Core}   core    - A reference to the @actions/core package
  * @returns {Promise} Promise resolving to an array of project strings needing testing.
  */
-async function isTouchingSomethingNeedingTesting( github, owner, repo, number, core ) {
+async function touchedProjectsNeedingTesting( github, owner, repo, number, core ) {
 	const changed = JSON.parse( process.env.CHANGED );
 	const projects = [];
 
@@ -57,18 +57,17 @@ async function checkTestReminderComment( github, context, core ) {
 	const data = {};
 
 	// Check if one of the files modified in this PR need testing on WordPress.com.
-	const touchesSomethingNeedingTesting = await isTouchingSomethingNeedingTesting(
+	data.projects = await touchedProjectsNeedingTesting(
 		github,
 		owner,
 		repoName,
 		issue.number,
 		core
 	);
-	data.projects = touchesSomethingNeedingTesting;
 
 	core.info(
 		`Build: This PR ${
-			touchesSomethingNeedingTesting ? 'touches' : 'does not touch'
+			data.projects.length ? 'touches' : 'does not touch'
 		} something that needs testing on WordPress.com.`
 	);
 
@@ -83,7 +82,7 @@ async function checkTestReminderComment( github, context, core ) {
 	);
 
 	// This PR does not touch files needing testing.
-	if ( ! touchesSomethingNeedingTesting.length ) {
+	if ( ! data.projects.length ) {
 		if ( testCommentIDs.length > 0 ) {
 			core.info(
 				`Build: this PR previously touched something that needs testing, but does not anymore. Deleting previous test reminder comments.`

--- a/.github/files/build-reminder-comment/check-test-reminder-comment.js
+++ b/.github/files/build-reminder-comment/check-test-reminder-comment.js
@@ -6,21 +6,32 @@ const getCheckComments = require( './get-check-comments.js' );
  * Does the PR touch anything that needs testing on WordPress.com.
  *
  * Currently we look whether process.env.CHANGED contains `plugins/jetpack`,
- * meaning that Jetpack is being built.
+ * meaning that Jetpack is being built. Or `packages/jetpack-mu-wpcom`,
+ * for the jetpack-mu-wpcom-plugin used on WordPress.com.
  *
  * @param {GitHub} github  - Initialized Octokit REST client.
  * @param {string} owner   - Repository owner.
  * @param {string} repo    - Repository name.
  * @param {string} number  - PR number.
  * @param {Core}   core    - A reference to the @actions/core package
- * @returns {Promise<boolean>} Promise resolving to a boolean if the PR touches something that needs testing.
+ * @returns {Promise} Promise resolving to an array of project strings needing testing, or false.
  */
 async function isTouchingSomethingNeedingTesting( github, owner, repo, number, core ) {
 	const changed = JSON.parse( process.env.CHANGED );
+	const projects = [];
 
 	if ( changed[ 'plugins/jetpack' ] ) {
 		core.info( 'Build: Jetpack is being built, testing needed' );
-		return true;
+		projects.push( 'jetpack' );
+	}
+
+	if ( changed[ 'packages/jetpack-mu-wpcom' ] ) {
+		core.info( 'Build: jetpack-mu-wpcom is being built, testing needed' );
+		projects.push( 'jetpack-mu-wpcom-plugin' );
+	}
+
+	if ( projects.length > 0 ) {
+		return projects;
 	}
 
 	core.info( 'Build: Nothing that needs testing was found' );
@@ -35,12 +46,15 @@ async function isTouchingSomethingNeedingTesting( github, owner, repo, number, c
  * @param {github} github  - Pre-authenticated octokit/rest.js client with pagination plugins
  * @param {object} context - Context of the workflow run
  * @param {core}   core    - A reference to the @actions/core package
- * @returns {Promise<number>} Promise resolving to a comment ID, or 0 if no comment is found.
+ * @returns {Promise} Promise resolving to an object with the following properties:
+ * - {commentId} - a comment ID, or 0 if no comment is found.
+ * - {projects} - an array of project strings needing testing, or false.
  */
 async function checkTestReminderComment( github, context, core ) {
 	const { repo, issue } = context;
 	const { owner, repo: repoName } = repo;
 	const { TEST_COMMENT_INDICATOR } = process.env;
+	const data = {};
 
 	// Check if one of the files modified in this PR has been de-fusioned,
 	// and thus must now be tested on WordPress.com.
@@ -51,6 +65,7 @@ async function checkTestReminderComment( github, context, core ) {
 		issue.number,
 		core
 	);
+	data.projects = touchesSomethingNeedingTesting;
 
 	core.info(
 		`Build: This PR ${
@@ -87,7 +102,8 @@ async function checkTestReminderComment( github, context, core ) {
 			);
 		}
 
-		return 0;
+		data.commentId = 0;
+		return data;
 	}
 
 	// If our PR needs testing, and there was previously a test reminder comment, return it.
@@ -97,7 +113,8 @@ async function checkTestReminderComment( github, context, core ) {
 		core.info(
 			`Build: this PR touches something that needs testing, and there was previously a test reminder comment, ${ testCommentIDs[ 0 ] }.`
 		);
-		return testCommentIDs[ 0 ];
+		data.commentId = testCommentIDs[ 0 ];
+		return data;
 	}
 
 	// If our PR touches something that needs testing, and there has been no test reminder comment yet, create one.
@@ -115,14 +132,16 @@ async function checkTestReminderComment( github, context, core ) {
 			body,
 		} );
 		core.info( `Build: created test reminder comment with ID ${ id }.` );
-		return id;
+		data.commentId = id;
+		return data;
 	}
 
 	// Fallback. No comment exists, or was created.
 	core.notice(
 		`Build: final fallback. No comment exists, or was created. We should not get here.`
 	);
-	return 0;
+	data.commentId = 0;
+	return data;
 }
 
 module.exports = checkTestReminderComment;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,11 +59,10 @@ jobs:
         env:
           CHANGED: ${{ steps.changed.outputs.projects }}
         with:
-          result-encoding: string
           script: |
             const checkTestReminderComment = require('.github/files/build-reminder-comment/check-test-reminder-comment.js')
-            const commentId = await checkTestReminderComment( github, context, core );
-            return commentId;
+            const data = await checkTestReminderComment( github, context, core );
+            return data;
 
       - name: Build changed projects
         id: build
@@ -116,24 +115,30 @@ jobs:
       - name: Update reminder with testing instructions
         id: update-reminder-comment
         uses: actions/github-script@v6
-        if: ${{ github.event_name == 'pull_request' && steps.check-test-reminder-comment.outputs.result != 0 && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
+        if: ${{ github.event_name == 'pull_request' && fromJSON(steps.check-test-reminder-comment.outputs.result)['commentId'] != 0 && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
         env:
           BRANCH_NAME: ${{ github.head_ref }}
-          COMMENT_ID: ${{ steps.check-test-reminder-comment.outputs.result }}
+          DATA: ${{ steps.check-test-reminder-comment.outputs.result }}
         with:
           script: |
-            const { BRANCH_NAME, COMMENT_ID, TEST_COMMENT_INDICATOR } = process.env;
+            const { BRANCH_NAME, TEST_COMMENT_INDICATOR } = process.env;
+            const data = JSON.parse( process.env.DATA );
+            const commands = data.projects.reduce( ( acc, cur ) => {
+              return acc += `
+              \`\`\`
+              bin/jetpack-downloader test ${ cur } ${ BRANCH_NAME }
+              \`\`\`
+              `;
+            }, '' );
             const commentBody = `${ TEST_COMMENT_INDICATOR }
             Are you an Automattician? You can now test your Pull Request on WordPress.com. On your sandbox, run
-            \`\`\`
-            bin/jetpack-downloader test jetpack ${ BRANCH_NAME }
-            \`\`\`
+            ${ commands }
             to get started. More details: p9dueE-5Nn-p2`;
             await github.rest.issues.updateComment( {
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: commentBody,
-              comment_id: +COMMENT_ID,
+              comment_id: +data.commentId,
             } );
 
   jetpack_beta:


### PR DESCRIPTION
## Proposed changes:

Adds test GH test reminder for when the `jetpack-mu-wpcom` package is being touched.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

It looks like the test reminder comment updated with both projects because looking at the Build action I see:

> Diff touches infrastructure file .github/workflows/build.yml, considering all projects as changed.

You can also delete the "Are you an Automattician?" comment and run the Build workflow again which should create a new comment.