### PR TITLE
Jetpack: do not add block transform to v6 when video is not a VideoPress video

### DIFF
--- a/projects/plugins/jetpack/changelog/update-videopress-do-not-transfomr-not-videopress-videos
+++ b/projects/plugins/jetpack/changelog/update-videopress-do-not-transfomr-not-videopress-videos
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack: do not add block transform to v6 when video is not a VideoPress video

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -426,6 +426,11 @@ function addVideoPressCoreVideoTransform( settings, name ) {
 				{
 					type: 'block',
 					blocks: [ 'core/video' ],
+					isMatch: attrs => {
+						const { src, guid } = attrs;
+						const guidFromSrc = pickGUIDFromUrl( src );
+						return guid || guidFromSrc;
+					},
 					transform: attrs => createBlock( 'videopress/video', attrs ),
 				},
 			],

--- a/projects/plugins/jetpack/extensions/blocks/videopress/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/utils.js
@@ -70,7 +70,7 @@ export const pickGUIDFromUrl = url => {
 	}
 
 	const urlParts = url.match(
-		/^https?:\/\/(?<host>video(?:\.word)?press\.com)\/(?:v|embed)\/(?<guid>[a-zA-Z\d]{8})/
+		/^https?:\/\/(?<host>video(?:\.word|s\.files\.word)?press\.com)(?:\/v|\/embed)?\/(?<guid>[a-zA-Z\d]{8})/
 	);
 
 	if ( ! urlParts?.groups?.guid ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Jetpack: do not add block transform to v6 when video is not a VideoPress video

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Deactivate Jetpack plugin
* Go to the block editor
* Create a new core/video block (it is not v5, Jetpack is deactivated). The video is uploaded to the hosting.
* Activate Jetpack plugin
* Enable the VideoPress module
* Hard refresh in the block editor
* Confirm the core video block doesn't have a transform to v6

<img width="627" alt="image" src="https://user-images.githubusercontent.com/77539/213542993-25bb4d93-db86-4100-96c7-926071d8a1fb.png">

* Create another core/video block instance (v5)
* Upload a video
* Confirm now the block provides a transform to v6

<img width="634" alt="image" src="https://user-images.githubusercontent.com/77539/213543088-ff500199-64c5-418b-bfca-fb5169ff3604.png">


