### PR TITLE
[Super Cache] Add missing action trigger

### DIFF
--- a/projects/plugins/super-cache/changelog/super-cache-missing-action
+++ b/projects/plugins/super-cache/changelog/super-cache-missing-action
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Trigger wp_cache_cleared when clearing the cache as a result of the "clear on post updated/published" option

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -3109,6 +3109,8 @@ function wp_cache_post_edit( $post_id ) {
 		wp_cache_debug( "wp_cache_post_edit: Clearing cache $blog_cache_dir and {$cache_path}supercache/ on post edit per config.", 2 );
 		prune_super_cache( $blog_cache_dir, true );
 		prune_super_cache( get_supercache_dir(), true );
+
+		do_action( 'wp_cache_cleared' );
 	} else {
 		$action = current_filter();
 		wp_cache_debug( "wp_cache_post_edit: Clearing cache for post $post_id on {$action}", 2 );


### PR DESCRIPTION
Fixes #28422

Trigger the `wp_cache_cleared` action when clearing the cache as a result of the "Clear all cache files when a post or page is published or updated" option.

## Proposed changes:
* Trigger the `wp_cache_cleared` action when clearing the cache after a post edit.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Turn on the Advanced option "Clear all cache files when a post or page is published or updated.”
* Update or create a post.
* Verify that the `wp_cache_cleared` action is appropriately triggered.