### PR TITLE
VideoPress: remove undesired border of video player

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-player-border-visual-issue
+++ b/projects/packages/videopress/changelog/update-videopress-player-border-visual-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: remove undesired border of the video player

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/editor.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/editor.scss
@@ -25,6 +25,7 @@
 		iframe.components-sandbox {
 			position: relative;
 			z-index: 2;
+			border: 0;
 		}
 
 		.jetpack-videopress-player__loading {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: remove undesired border of the video player

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a new VideoPress video block
* Ensure the block has a video
* Confirm the light grey border is not there anymore

Before | After
-----|------
<img width="675" alt="Screen Shot 2023-01-20 at 10 09 57" src="https://user-images.githubusercontent.com/77539/213673108-55cc132e-7f58-435a-86c7-599a0013e775.png"> | <img width="679" alt="Screen Shot 2023-01-20 at 10 20 18" src="https://user-images.githubusercontent.com/77539/213673102-5b0f5516-12e9-4fbc-8605-dab6ec6fbae5.png">



