### PR TITLE
[Jetpack AI] Fix regression when loading the saved block editor 

### DIFF
--- a/projects/plugins/jetpack/changelog/jetpack-ai-fix-editor-reload
+++ b/projects/plugins/jetpack/changelog/jetpack-ai-fix-editor-reload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fixes a regression introduced when loading saved Jetpack AI block

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/edit.js
@@ -212,14 +212,14 @@ export default function Edit( { attributes, setAttributes } ) {
 					</Button>
 				</Placeholder>
 			) }
-			{ attributes.content && ! loadingCompletion && (
+			{ attributes.content && (
 				<div>
 					<div className="content">
 						<RawHTML>{ attributes.content.trim().replaceAll( '\n', '<br/>' ) }</RawHTML>
 					</div>
 				</div>
 			) }
-			{ loadingCompletion && (
+			{ loadingCompletion && ! attributes.content && (
 				<div style={ { padding: '10px', textAlign: 'center' } }>
 					<Spinner
 						style={ {


### PR DESCRIPTION
This fixes the regression when loading the saved Jetpack AI Paragraph content

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Build, sync, whatever floats your boat to get AI features operational
* Insert Jetpack AI block, make it generate content
* save post
* Reload post
* Observe content being there. ON trunk it erronously shows loading state for saved content

