### PR TITLE
Components: Fix responsive across elements with box-sizing removal

### DIFF
--- a/projects/js-packages/components/changelog/fix-my-jetpack-responsive
+++ b/projects/js-packages/components/changelog/fix-my-jetpack-responsive
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Components: Fix usage of box-sizing across the elements

--- a/projects/js-packages/components/components/theme-provider/globals.module.scss
+++ b/projects/js-packages/components/components/theme-provider/globals.module.scss
@@ -1,0 +1,6 @@
+/* DO NOT USE THIS TO OVERRIDE STYLES */
+.theme {
+	& * {
+		box-sizing: border-box;
+	}
+}

--- a/projects/js-packages/components/components/theme-provider/globals.module.scss
+++ b/projects/js-packages/components/components/theme-provider/globals.module.scss
@@ -1,5 +1,5 @@
 /* DO NOT USE THIS TO OVERRIDE STYLES */
-.theme {
+.global {
 	& * {
 		box-sizing: border-box;
 	}

--- a/projects/js-packages/components/components/theme-provider/index.tsx
+++ b/projects/js-packages/components/components/theme-provider/index.tsx
@@ -1,4 +1,5 @@
 import React, { useLayoutEffect, useRef } from 'react';
+import styles from './globals.module.scss';
 import { ThemeInstance, ThemeProviderProps } from './types';
 
 export const typography = {
@@ -85,10 +86,14 @@ export const spacing = {
 
 const globalThemeInstances: Record< string, ThemeInstance > = {};
 
-const setup = ( root: HTMLElement, id: string ) => {
+const setup = ( root: HTMLElement, id: string, withGlobalStyles?: boolean ) => {
 	const tokens = { ...typography, ...colors, ...borders, ...spacing };
 	for ( const key in tokens ) {
 		root.style.setProperty( key, tokens[ key ] );
+	}
+
+	if ( withGlobalStyles ) {
+		root.classList.add( styles.theme );
 	}
 
 	if ( ! id ) {
@@ -108,7 +113,12 @@ const setup = ( root: HTMLElement, id: string ) => {
  * @param {ThemeProviderProps} props           - Component properties.
  * @returns {React.ReactNode}        ThemeProvider component.
  */
-const ThemeProvider: React.FC< ThemeProviderProps > = ( { children = null, targetDom, id } ) => {
+const ThemeProvider: React.FC< ThemeProviderProps > = ( {
+	children = null,
+	targetDom,
+	id,
+	withGlobalStyles = true,
+} ) => {
 	const themeWrapperRef = useRef< HTMLDivElement >();
 
 	// Check whether the theme provider instance is already registered.
@@ -120,15 +130,15 @@ const ThemeProvider: React.FC< ThemeProviderProps > = ( { children = null, targe
 		}
 
 		if ( targetDom ) {
-			return setup( targetDom, id );
+			return setup( targetDom, id, withGlobalStyles );
 		}
 
 		if ( ! themeWrapperRef?.current ) {
 			return;
 		}
 
-		setup( themeWrapperRef.current, id );
-	}, [ targetDom, themeWrapperRef, isAlreadyProvided, id ] );
+		setup( themeWrapperRef.current, id, withGlobalStyles );
+	}, [ targetDom, themeWrapperRef, isAlreadyProvided, id, withGlobalStyles ] );
 
 	// Do not wrap when the DOM element target is defined.
 	if ( targetDom ) {

--- a/projects/js-packages/components/components/theme-provider/index.tsx
+++ b/projects/js-packages/components/components/theme-provider/index.tsx
@@ -93,7 +93,7 @@ const setup = ( root: HTMLElement, id: string, withGlobalStyles?: boolean ) => {
 	}
 
 	if ( withGlobalStyles ) {
-		root.classList.add( styles.theme );
+		root.classList.add( styles.global );
 	}
 
 	if ( ! id ) {

--- a/projects/js-packages/components/components/theme-provider/types.ts
+++ b/projects/js-packages/components/components/theme-provider/types.ts
@@ -13,6 +13,10 @@ export type ThemeProviderProps = {
 	 * Content
 	 */
 	children?: React.ReactElement;
+	/**
+	 * Inser global/reset styles
+	 */
+	withGlobalStyles?: boolean;
 };
 
 export type ThemeInstance = {

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.27.0",
+	"version": "0.27.1-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
@@ -3,7 +3,6 @@
 }
 
 .notice {
-	box-sizing: border-box;
 	margin: 0;
     padding: calc( var( --spacing-base ) * 2 ) calc( var( --spacing-base ) * 3 ) calc( var( --spacing-base ) * 2 ) calc( var( --spacing-base ) * 3 ); // 16px | 24px | 16px | 24px
 	font-size: 16px;

--- a/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
@@ -10,7 +10,6 @@
 	display: flex;
 	flex-direction: column;
 	box-shadow: 0 0 0 1px var( --jp-gray-10 ) inset;
-	box-sizing: border-box;
 
 	&.is-link {
 		background: none;

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/style.module.scss
@@ -3,7 +3,6 @@
 	height: 100%;
 	padding: calc( var( --spacing-base ) * 8 );
 	position: relative;
-	box-sizing: border-box;
 }
 
 .container {
@@ -72,7 +71,7 @@
 		height: auto;
 		white-space: normal;
 	}
-	
+
 	&:global(.is-secondary):hover:not(:disabled) {
 		background-color: var( --jp-black );
 		color: var( --jp-white );

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-responsive
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-responsive
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Components: Fix usage of box-sizing across the elements

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "2.7.4",
+	"version": "2.7.5-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -30,7 +30,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '2.7.4';
+	const PACKAGE_VERSION = '2.7.5-alpha';
 
 	/**
 	 * Initialize My Jetpack


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

As we removed `box-sizing: border-box` from `base-styles` ( #28024 ), all elements got moved to `content-box` (the default rule) since we relied on `base-styles` for applying `border-box`. This rule (`content-box`) calculates the element size differently (not including borders/margins/padding). This movement completely broke our responsiveness across the pages.

This was happening in `My Jetpack`, `VideoPress` and all pages that uses our `Section/Layout` components.

Closes: #28485 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove local `box-sizing` from `My Jetpack`.
* Add `box-sizing: border-box` on `ThemeProvider` with support to include more global rules in the future.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-kcV-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Build `My Jetpack` and `VideoPress` or other plugin that uses `Section/Layout` component.
* Open it initial page.
* Reduce the page `width` manually.
* You should see that `padding` and/or `margins` are not outside the width count.
* Responsive should work normally.