### PR TITLE
[Boost] Fix speed score subsequent failures

### DIFF
--- a/projects/plugins/boost/app/features/speed-score/Speed_Score.php
+++ b/projects/plugins/boost/app/features/speed-score/Speed_Score.php
@@ -88,16 +88,13 @@ class Speed_Score {
 			return $url;
 		}
 
-		$score_request = $this->get_score_request_by_url( $url );
-		if ( empty( $score_request ) || ! $score_request->is_pending() ) {
-			// Create and store the Speed Score request.
-			$active_modules = array_keys( array_filter( $this->modules->get_status(), 'strlen' ) );
-			$score_request  = new Speed_Score_Request( $url, $active_modules );
-			$score_request->store( 1800 ); // Keep the request for 30 minutes even if no one access the results.
+		// Create and store the Speed Score request.
+		$active_modules = array_keys( array_filter( $this->modules->get_status(), 'strlen' ) );
+		$score_request  = new Speed_Score_Request( $url, $active_modules );
+		$score_request->store( 1800 ); // Keep the request for 30 minutes even if no one access the results.
 
-			// Send the request.
-			$score_request->execute();
-		}
+		// Send the request.
+		$score_request->execute();
 
 		$score_request_no_boost = $this->maybe_dispatch_no_boost_score_request( $url );
 

--- a/projects/plugins/boost/changelog/boost-fix-speed-score-subsequent-failure
+++ b/projects/plugins/boost/changelog/boost-fix-speed-score-subsequent-failure
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Update requesting a page speed refresh to force wpcom into making a new page speed request.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27285.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* These changes will force a new page speed request to be sent every time a refresh is invoked by the user.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Pre-requisites
* a sandboxed wp.com (public) that uses the staging version of boost cloud (otherwise requests would go to wp.com directly);
* a jurassic ninja site working with the sandboxed wp.com;
* this version of Boost on the website (easiest way to do it is the **Jetpack Beta Tester** plugin);

### Actual testing steps
* Request a new page score from the UI to make sure it works properly;
* Next, edit your wp.com sandbox (comment out this line fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Serfg%2Qncv%2Qcyhtvaf%2Sraqcbvagf%2Swrgcnpx%2Qobbfg%2Qfcrrq%2Qfpberf.cuc%3Se%3Qo5so0p85%23126-og), to prevent it from storing page speed results (this will simulate a failure to store the results);
* Now run make a page speed request and wait for it to timeout;
* Revert the change you did on the sandbox and click Refresh/Try Again;
* The page speed request should finish properly.