### PR TITLE
VideoPress: do not request video data when user is not connected

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-do-not-perform-video-request-when-not-connected
+++ b/projects/packages/videopress/changelog/update-videopress-do-not-perform-video-request-when-not-connected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: do not request video data when user is not connected

--- a/projects/packages/videopress/src/class-block-editor-extensions.php
+++ b/projects/packages/videopress/src/class-block-editor-extensions.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\VideoPress;
 
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Status\Host;
 
@@ -138,5 +139,7 @@ class Block_Editor_Extensions {
 		);
 
 		Assets::enqueue_script( $handle );
+
+		wp_add_inline_script( $handle, Connection_Initial_State::render(), 'before' );
 	}
 }

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/index.ts
@@ -1,9 +1,11 @@
 /**
  * External dependencies
  */
+import { useConnection } from '@automattic/jetpack-connection';
 import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
+import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
@@ -16,6 +18,8 @@ import {
 	WPCOMRestAPIVideosGetEndpointResponseProps,
 } from '../../../types';
 import { UseVideoDataProps, UseVideoDataArgumentsProps, VideoDataProps } from './types';
+
+const debug = debugFactory( 'videopress:video:use-video-data' );
 
 /**
  * React hook to fetch the video data from the media library.
@@ -30,8 +34,14 @@ export default function useVideoData( {
 }: UseVideoDataArgumentsProps ): UseVideoDataProps {
 	const [ videoData, setVideoData ] = useState< VideoDataProps >( {} );
 	const [ isRequestingVideoData, setIsRequestingVideoData ] = useState( false );
+	const { isUserConnected } = useConnection();
 
 	useEffect( () => {
+		if ( ! isUserConnected ) {
+			debug( 'User is not connected ❌' );
+			return;
+		}
+
 		/**
 		 * Fetches the video videoData from the API.
 		 */
@@ -90,7 +100,7 @@ export default function useVideoData( {
 			setIsRequestingVideoData( true );
 			fetchVideoItem();
 		}
-	}, [ id, guid ] );
+	}, [ id, guid, isUserConnected ] );
 
 	return { videoData, isRequestingVideoData };
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR  checked if the user is connected with dotcom before performing a data request for the VideoPress video block.
Also, it logs via debug() the disconnected state.

Part of https://github.com/Automattic/jetpack/issues/27451

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: do not perform data requests when the user is not connected

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Block editor
* Ensure the post has a video block
* Disconnected the site
* Hard refresh in the block editor post
* The block should show the `Private` black screen (going to be addressed in a [follow-up](https://github.com/Automattic/jetpack/issues/27451))
* Confirm there is a log about the connection state:

<img width="443" alt="Screen Shot 2023-01-20 at 14 05 20" src="https://user-images.githubusercontent.com/77539/213716237-348baab3-4dd0-49b7-935d-a9479c86066b.png">

* Confirm the client doesn't perform the async request.
 
**Before**:

<img width="682" alt="image" src="https://user-images.githubusercontent.com/77539/213716421-6a1f4269-0dea-4a89-9b0c-f4dd2dd911cd.png">
