### PR TITLE
E2E tests: wait for editor canvas load

### DIFF
--- a/projects/plugins/jetpack/changelog/e2e-wait-for-editor
+++ b/projects/plugins/jetpack/changelog/e2e-wait-for-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+

--- a/projects/plugins/jetpack/tests/e2e/specs/blocks/free-blocks.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/blocks/free-blocks.test.js
@@ -29,6 +29,7 @@ test.describe.parallel( 'Free blocks', () => {
 		await test.step( 'Visit block editor page', async () => {
 			blockEditor = await BlockEditorPage.visit( page );
 			await blockEditor.resolveWelcomeGuide( false );
+			await blockEditor.waitForEditor();
 		} );
 	} );
 

--- a/projects/plugins/jetpack/tests/e2e/specs/blocks/pro-blocks.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/blocks/pro-blocks.test.js
@@ -27,6 +27,7 @@ test.describe( 'Paid blocks', () => {
 		await test.step( 'Visit block editor page', async () => {
 			blockEditor = await BlockEditorPage.visit( page );
 			await blockEditor.resolveWelcomeGuide( false );
+			await blockEditor.waitForEditor();
 		} );
 	} );
 

--- a/tools/e2e-commons/pages/wp-admin/block-editor.js
+++ b/tools/e2e-commons/pages/wp-admin/block-editor.js
@@ -150,4 +150,8 @@ export default class BlockEditorPage extends WpPage {
 			await this.click( settingsLocator );
 		}
 	}
+
+	async waitForEditor() {
+		await this.canvasPage.canvas().waitForSelector( "h1[aria-label='Add title']" );
+	}
 }


### PR DESCRIPTION
## Proposed changes:

This should improve the stability of blocks e2e tests. 
Sometimes, the editor canvas is not fully loaded before the test proceeds with searching for a block to insert. If the search panel is open, and the editor finishes loading focus will move to the post title, closing the search panel.
This happens more often since Gutenberg 15.0.0 release.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1674224651211299-slack-C03QNBQKG73

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* All e2e tests pass.