### PR TITLE
Tooling: Wording addition to deploy-to-svn script

### DIFF
--- a/tools/deploy-to-svn.sh
+++ b/tools/deploy-to-svn.sh
@@ -190,7 +190,7 @@ info "Tagging $SVNTAG"
 svn cp ^/$WPSLUG/trunk ^/$WPSLUG/tags/$SVNTAG -m "Creating the $SVNTAG tag"
 success "Done!"
 if [[ "$SVNTAG" =~ ^[0-9]+(\.[0-9]+)+$ ]]; then
-	info "Updating stable tag in readme.txt in SVN tags/$SVNTAG (this does not make $SVNTAG the live version, the stable tag in trunk/readme.txt is what is changed when ready, later."
+	info "Updating stable tag in readme.txt in SVN tags/$SVNTAG (this does not make $SVNTAG the live version, the stable tag in trunk/readme.txt is what is changed when ready, later)"
 	svn up tags/$SVNTAG | while IFS= read -r LINE; do printf "\r\e[K%s" $LINE; done
 	printf "\r\e[K"
 	sed -i.bak -e "s/Stable tag: .*/Stable tag: $SVNTAG/" "tags/$SVNTAG/readme.txt"

--- a/tools/deploy-to-svn.sh
+++ b/tools/deploy-to-svn.sh
@@ -190,7 +190,7 @@ info "Tagging $SVNTAG"
 svn cp ^/$WPSLUG/trunk ^/$WPSLUG/tags/$SVNTAG -m "Creating the $SVNTAG tag"
 success "Done!"
 if [[ "$SVNTAG" =~ ^[0-9]+(\.[0-9]+)+$ ]]; then
-	info "Updating stable tag in readme.txt in SVN tags/$SVNTAG"
+	info "Updating stable tag in readme.txt in SVN tags/$SVNTAG (this does not make $SVNTAG the live version, the stable tag in trunk/readme.txt is what is changed when ready, later."
 	svn up tags/$SVNTAG | while IFS= read -r LINE; do printf "\r\e[K%s" $LINE; done
 	printf "\r\e[K"
 	sed -i.bak -e "s/Stable tag: .*/Stable tag: $SVNTAG/" "tags/$SVNTAG/readme.txt"


### PR DESCRIPTION


## Proposed changes:

* This PR adds some additional wording to one of the deploy to SVN script outputs, to help add clarity (prevent panic...) when in the middle of running the script. In more detail it clarifies that updating the stable tag in readme.txt in the tags directory is not what makes the new version being released the live version.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Proof-read. 

