### PR TITLE
CDN: deprecated error fix

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-cdn-deprecated-error
+++ b/projects/plugins/jetpack/changelog/fix-cdn-deprecated-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Cleaning PHP deprecated error notice from the log

--- a/projects/plugins/jetpack/modules/photon-cdn.php
+++ b/projects/plugins/jetpack/modules/photon-cdn.php
@@ -77,6 +77,9 @@ class Jetpack_Photon_Static_Assets_CDN {
 				if ( wp_startswith( $thing->src, self::CDN ) ) {
 					continue;
 				}
+				if ( ! is_string( $thing->src ) ) {
+					continue;
+				}
 				$src = ltrim( str_replace( $site_url, '', $thing->src ), '/' );
 				if ( self::is_js_or_css_file( $src ) && in_array( substr( $src, 0, 9 ), array( 'wp-admin/', 'wp-includ' ), true ) ) {
 					$wp_scripts->registered[ $handle ]->src = sprintf( self::CDN . 'c/%1$s/%2$s', $version, $src );
@@ -85,6 +88,9 @@ class Jetpack_Photon_Static_Assets_CDN {
 			}
 			foreach ( $wp_styles->registered as $handle => $thing ) {
 				if ( wp_startswith( $thing->src, self::CDN ) ) {
+					continue;
+				}
+				if ( ! is_string( $thing->src ) ) {
 					continue;
 				}
 				$src = ltrim( str_replace( $site_url, '', $thing->src ), '/' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes PHP Deprecated: str_replace(): Passing null to parameter 3 ($subject) of type array|string is deprecated in 
/wordpress/plugins/jetpack/11.6-beta/modules/photon-cdn.php on line 80
PHP Warning: ltrim() expects parameter 1 to be string, array given in /wordpress/plugins/jetpack/11.6-beta/modules/photon-cdn.php on 
line 80

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* making sure we get string not a null or an array

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* none
*

