### PR TITLE
Protect: Improve connection button loading and disabled states

### DIFF
--- a/projects/plugins/protect/changelog/fix-protect-connection-buttons
+++ b/projects/plugins/protect/changelog/fix-protect-connection-buttons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix connection button loading indicators

--- a/projects/plugins/protect/src/js/components/pricing-table/index.jsx
+++ b/projects/plugins/protect/src/js/components/pricing-table/index.jsx
@@ -11,7 +11,7 @@ import {
 } from '@automattic/jetpack-components';
 import { useConnection } from '@automattic/jetpack-connection';
 import { __ } from '@wordpress/i18n';
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import useAnalyticsTracks from '../../hooks/use-analytics-tracks';
 import useProtectData from '../../hooks/use-protect-data';
 import useWafData from '../../hooks/use-waf-data';
@@ -25,9 +25,11 @@ import useWafData from '../../hooks/use-waf-data';
  * @returns {object}                ConnectedPricingTable react component.
  */
 const ConnectedPricingTable = ( { onScanAdd, scanJustAdded } ) => {
-	const { siteIsRegistering, handleRegisterSite, registrationError } = useConnection( {
+	const { handleRegisterSite, registrationError } = useConnection( {
 		skipUserConnection: true,
 	} );
+
+	const [ protectFreeIsRegistering, setProtectFreeIsRegistering ] = useState( false );
 
 	// Access paid protect product data
 	const { jetpackScan } = useProtectData();
@@ -42,14 +44,19 @@ const ConnectedPricingTable = ( { onScanAdd, scanJustAdded } ) => {
 		: null;
 
 	// Track free and paid click events
-	const { recordEventHandler } = useAnalyticsTracks();
+	const { recordEvent, recordEventHandler } = useAnalyticsTracks();
 	const getScan = recordEventHandler(
 		'jetpack_protect_pricing_table_get_scan_link_click',
 		onScanAdd
 	);
-	const getProtectFree = recordEventHandler( 'jetpack_protect_connected_product_activated', () =>
-		handleRegisterSite().then( refreshWaf )
-	);
+
+	const getProtectFree = useCallback( () => {
+		recordEvent( 'jetpack_protect_connected_product_activated' );
+		setProtectFreeIsRegistering( true );
+		handleRegisterSite()
+			.then( () => setProtectFreeIsRegistering( false ) )
+			.then( refreshWaf );
+	}, [ handleRegisterSite, recordEvent, refreshWaf ] );
 
 	const args = {
 		title: __( 'Stay one step ahead of threats', 'jetpack-protect' ),
@@ -87,7 +94,12 @@ const ConnectedPricingTable = ( { onScanAdd, scanJustAdded } ) => {
 							currency={ currency }
 							hideDiscountLabel={ false }
 						/>
-						<Button fullWidth onClick={ getScan } isLoading={ scanJustAdded }>
+						<Button
+							fullWidth
+							onClick={ getScan }
+							isLoading={ scanJustAdded }
+							disabled={ protectFreeIsRegistering || scanJustAdded }
+						>
 							{ __( 'Get Jetpack Protect', 'jetpack-protect' ) }
 						</Button>
 					</PricingTableHeader>
@@ -116,7 +128,8 @@ const ConnectedPricingTable = ( { onScanAdd, scanJustAdded } ) => {
 							fullWidth
 							variant="secondary"
 							onClick={ getProtectFree }
-							isLoading={ siteIsRegistering }
+							isLoading={ protectFreeIsRegistering }
+							disabled={ protectFreeIsRegistering || scanJustAdded }
 							error={
 								registrationError
 									? __( 'An error occurred. Please try again.', 'jetpack-protect' )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes the loading state logic for the "Start for free" button, so that it does not show as loading after the "Get Jetpack Protect" button is clicked.
* Adds a `disabled` state to the connection buttons, whenever one connection path is in progress. This prevents multiple registration requests from happening from users clicking the buttons multiple times, and further indicates to the user that a request is in progress.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

1201069996155224-as-1203685117934350

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to a `/wp-admin/admin.php?page=jetpack-protect` on an unconnected site.
* Try clicking each button, verifying that both buttons are disabled after each click, and that the loading indicator only appears on the button you clicked.

## Screenshots

<img width="1147" alt="Screenshot 2023-01-21 at 3 54 51 PM" src="https://user-images.githubusercontent.com/10933065/213890307-601ac227-da33-4f8b-b3b8-586b32e01fa9.png">
