### PR TITLE
Fix/sync close php session immediately

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-close-php-session-immediately
+++ b/projects/packages/sync/changelog/fix-sync-close-php-session-immediately
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Close PHP Session if it's active when running a Dedicated Sync request.


### PR DESCRIPTION
## Proposed changes:

* This PR adds function to close the PHP session if it's active when running a Dedicated Sync request. This should prevent some additional locking, that might slow down the site for a specific visitor.

## Jetpack product discussion

N/a

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Try adding a `sleep(30)` call somewhere in Sync. 
* Attempt to log in into WP-Admin and see if the request will stall for 30 seconds.
* Apply PR
* Try attempting logging in again and the request should finish immediately.
