### PR TITLE
VideoPress: address the whole connection/checkout flow from the VideoPress video block

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-video-connect-message
+++ b/projects/packages/videopress/changelog/update-videopress-video-connect-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: add connect banner when user is not connected

--- a/projects/packages/videopress/src/class-block-editor-extensions.php
+++ b/projects/packages/videopress/src/class-block-editor-extensions.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\VideoPress;
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Constants;
+// use Automattic\Jetpack\Status as Status;
 use Automattic\Jetpack\Status\Host;
 
 /**
@@ -153,7 +154,7 @@ class Block_Editor_Extensions {
 			array(
 				'extensions' => $extensions_list,
 				'siteType'   => $site_type,
-				'adminUrl'   => admin_url(),
+				'siteSuffix' => ( new \Automattic\Jetpack\Status() )->get_site_suffix(),
 			)
 		);
 	}

--- a/projects/packages/videopress/src/class-block-editor-extensions.php
+++ b/projects/packages/videopress/src/class-block-editor-extensions.php
@@ -153,6 +153,7 @@ class Block_Editor_Extensions {
 			array(
 				'extensions' => $extensions_list,
 				'siteType'   => $site_type,
+				'adminUrl'   => admin_url(),
 			)
 		);
 	}

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { Spinner } from '@wordpress/components';
 import { Icon, warning } from '@wordpress/icons';
 /**
  * Types
@@ -12,6 +13,7 @@ import './style.scss';
 type BlockBannerProps = {
 	icon?: React.ReactNode;
 	children: React.ReactNode;
+	isLoading?: boolean;
 };
 
 /**
@@ -25,11 +27,13 @@ type BlockBannerProps = {
 export default function BlockBanner( {
 	icon = warning,
 	children,
+	isLoading,
 }: BlockBannerProps ): React.ReactElement {
 	return (
 		<div className="block-banner">
 			<Icon icon={ icon } />
-			{ children }
+			<div className="block-banner__content">{ children }</div>
+			{ isLoading && <Spinner /> }
 		</div>
 	);
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/index.tsx
@@ -12,6 +12,7 @@ import './style.scss';
 
 type BlockBannerProps = {
 	icon?: React.ReactNode;
+	action?: React.ReactNode;
 	children: React.ReactNode;
 	isLoading?: boolean;
 };
@@ -20,12 +21,14 @@ type BlockBannerProps = {
  * React component to render a banner above a block.
  *
  * @param {BlockBannerProps} props         - Component props.
+ * @param {React.ReactNode} props.action   - Banner action button.
  * @param {React.ReactNode} props.children - Banner content.
  * @param {React.ReactNode} props.icon     - Banner icon.
  * @returns {React.ReactElement }            Banner component.
  */
 export default function BlockBanner( {
 	icon = warning,
+	action,
 	children,
 	isLoading,
 }: BlockBannerProps ): React.ReactElement {
@@ -34,6 +37,7 @@ export default function BlockBanner( {
 			<Icon icon={ icon } />
 			<div className="block-banner__content">{ children }</div>
 			{ isLoading && <Spinner /> }
+			{ action && <div className="block-banner__action">{ action }</div> }
 		</div>
 	);
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/index.tsx
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { Icon, warning } from '@wordpress/icons';
+/**
+ * Types
+ */
+import type React from 'react';
+
+import './style.scss';
+
+type BlockBannerProps = {
+	icon?: React.ReactNode;
+	children: React.ReactNode;
+};
+
+/**
+ * React component to render a banner above a block.
+ *
+ * @param {BlockBannerProps} props         - Component props.
+ * @param {React.ReactNode} props.children - Banner content.
+ * @param {React.ReactNode} props.icon     - Banner icon.
+ * @returns {React.ReactElement }            Banner component.
+ */
+export default function BlockBanner( {
+	icon = warning,
+	children,
+}: BlockBannerProps ): React.ReactElement {
+	return (
+		<div className="block-banner">
+			<Icon icon={ icon } />
+			{ children }
+		</div>
+	);
+}

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/style.scss
@@ -1,0 +1,17 @@
+.block-banner {
+	display: flex;
+    height: 48px;
+    font-size: 14px;
+    align-self: center;
+    align-items: center;
+    background: #F4F4F4;
+    padding: 0 16px;
+
+    .components-external-link {
+        margin: 0 4px;
+    }
+}
+
+.editor-styles-wrapper .wp-block-post-content .components-external-link {
+    color: var( --wp-components-color-accent,var( --wp-admin-theme-color, #007cba ) );
+}

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/style.scss
@@ -15,6 +15,12 @@
     .components-external-link {
         margin: 0 4px;
         cursor: pointer;
+
+        &.is-reconnecting {
+            opacity: 0.5;
+            cursor: default;
+            text-decoration: none;
+        }
     }
 }
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/style.scss
@@ -4,26 +4,11 @@
     font-size: 14px;
     align-self: center;
     align-items: center;
-    background: #F4F4F4;
+    background: #F6F7F7;
     padding: 0 16px;
 
     .block-banner__content {
         flex-grow: 2;
         margin: 0 8px;
     }
-
-    .components-external-link {
-        margin: 0 4px;
-        cursor: pointer;
-
-        &.is-reconnecting {
-            opacity: 0.5;
-            cursor: default;
-            text-decoration: none;
-        }
-    }
-}
-
-.editor-styles-wrapper .wp-block-post-content .components-external-link {
-    color: var( --wp-components-color-accent,var( --wp-admin-theme-color, #007cba ) );
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/style.scss
@@ -9,6 +9,7 @@
 
     .components-external-link {
         margin: 0 4px;
+        cursor: pointer;
     }
 }
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/style.scss
@@ -7,6 +7,11 @@
     background: #F4F4F4;
     padding: 0 16px;
 
+    .block-banner__content {
+        flex-grow: 2;
+        margin: 0 8px;
+    }
+
     .components-external-link {
         margin: 0 4px;
         cursor: pointer;

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -142,7 +142,12 @@ export default function VideoPressEdit( {
 
 	// Get the redirect URI for the connection flow.
 	const redirectUri = window.location.href.replace( adminUrl, '' );
-	const { isUserConnected, handleRegisterSite } = useConnection( {
+	const {
+		isUserConnected,
+		handleRegisterSite,
+		userIsConnecting,
+		siteIsRegistering,
+	} = useConnection( {
 		from: 'block-editor',
 		redirectUri,
 	} );
@@ -432,14 +437,19 @@ export default function VideoPressEdit( {
 			<div { ...blockProps } className={ blockMainClassName }>
 				<>
 					{ ! isUserConnected && (
-						<Banner>
+						<Banner isLoading={ siteIsRegistering || userIsConnecting }>
 							{ createInterpolateElement(
 								__(
 									'<link>Connect your account</link> to continue using VideoPress',
 									'jetpack-videopress-pkg'
 								),
 								{
-									link: <ExternalLink onClick={ handleRegisterSite } />,
+									link: (
+										<ExternalLink
+											disabled={ siteIsRegistering || userIsConnecting }
+											onClick={ handleRegisterSite }
+										/>
+									),
 								}
 							) }
 						</Banner>

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -46,6 +46,8 @@ import './editor.scss';
 
 const debug = debugFactory( 'videopress:video:edit' );
 
+const { adminUrl } = window.videoPressEditorState;
+
 const VIDEO_PREVIEW_ATTEMPTS_LIMIT = 10;
 
 export const PlaceholderWrapper = withNotices( function ( {
@@ -138,7 +140,12 @@ export default function VideoPressEdit( {
 		poster,
 	} );
 
-	const { isUserConnected } = useConnection();
+	// Get the redirect URI for the connection flow.
+	const redirectUri = window.location.href.replace( adminUrl, '' );
+	const { isUserConnected, handleRegisterSite } = useConnection( {
+		from: 'block-editor',
+		redirectUri,
+	} );
 
 	/*
 	 * Request token when site is private
@@ -432,7 +439,7 @@ export default function VideoPressEdit( {
 									'jetpack-videopress-pkg'
 								),
 								{
-									link: <ExternalLink href="#" />,
+									link: <ExternalLink onClick={ handleRegisterSite } />,
 								}
 							) }
 						</Banner>

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -10,10 +10,9 @@ import {
 	BlockControls,
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
-import { Spinner, Placeholder, Button, withNotices, ExternalLink } from '@wordpress/components';
+import { Spinner, Placeholder, Button, withNotices } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { createInterpolateElement } from '@wordpress/element';
 import { useEffect, useState, useCallback, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
@@ -438,20 +437,21 @@ export default function VideoPressEdit( {
 			<div { ...blockProps } className={ blockMainClassName }>
 				<>
 					{ ! isUserConnected && (
-						<Banner isLoading={ isReconnectingUser }>
-							{ createInterpolateElement(
-								__(
-									'<link>Connect your account</link> to continue using VideoPress',
-									'jetpack-videopress-pkg'
-								),
-								{
-									link: (
-										<ExternalLink
-											className={ isReconnectingUser ? 'is-reconnecting' : '' }
-											onClick={ handleRegisterSite }
-										/>
-									),
-								}
+						<Banner
+							action={
+								<Button
+									variant="primary"
+									onClick={ handleRegisterSite }
+									disabled={ isReconnectingUser }
+									isBusy={ isReconnectingUser }
+								>
+									{ __( 'Connect', 'jetpack-videopress-pkg' ) }
+								</Button>
+							}
+						>
+							{ __(
+								'Connect your account to continue using VideoPress',
+								'jetpack-videopress-pkg'
 							) }
 						</Banner>
 					) }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -433,11 +433,12 @@ export default function VideoPressEdit( {
 			setAttributes( { id: newVideoData.id, guid: newVideoData.guid, title: newVideoData.title } );
 		};
 
+		const isReconnectingUser = userIsConnecting || siteIsRegistering;
 		return (
 			<div { ...blockProps } className={ blockMainClassName }>
 				<>
 					{ ! isUserConnected && (
-						<Banner isLoading={ siteIsRegistering || userIsConnecting }>
+						<Banner isLoading={ isReconnectingUser }>
 							{ createInterpolateElement(
 								__(
 									'<link>Connect your account</link> to continue using VideoPress',
@@ -446,7 +447,7 @@ export default function VideoPressEdit( {
 								{
 									link: (
 										<ExternalLink
-											disabled={ siteIsRegistering || userIsConnecting }
+											className={ isReconnectingUser ? 'is-reconnecting' : '' }
 											onClick={ handleRegisterSite }
 										/>
 									),

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useConnection } from '@automattic/jetpack-connection';
+import { useProductCheckoutWorkflow } from '@automattic/jetpack-connection';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import {
 	BlockIcon,
@@ -45,7 +45,7 @@ import './editor.scss';
 
 const debug = debugFactory( 'videopress:video:edit' );
 
-const { adminUrl } = window.videoPressEditorState;
+const { siteSuffix } = window.videoPressEditorState;
 
 const VIDEO_PREVIEW_ATTEMPTS_LIMIT = 10;
 
@@ -140,15 +140,10 @@ export default function VideoPressEdit( {
 	} );
 
 	// Get the redirect URI for the connection flow.
-	const redirectUri = window.location.href.replace( adminUrl, '' );
-	const {
-		isUserConnected,
-		handleRegisterSite,
-		userIsConnecting,
-		siteIsRegistering,
-	} = useConnection( {
-		from: 'block-editor',
-		redirectUri,
+	const { run, hasCheckoutStarted, isRegistered } = useProductCheckoutWorkflow( {
+		siteSuffix,
+		productSlug: 'jetpack_videopress',
+		redirectUrl: window.location.href,
 	} );
 
 	/*
@@ -432,18 +427,17 @@ export default function VideoPressEdit( {
 			setAttributes( { id: newVideoData.id, guid: newVideoData.guid, title: newVideoData.title } );
 		};
 
-		const isReconnectingUser = userIsConnecting || siteIsRegistering;
 		return (
 			<div { ...blockProps } className={ blockMainClassName }>
 				<>
-					{ ! isUserConnected && (
+					{ ! isRegistered && (
 						<Banner
 							action={
 								<Button
 									variant="primary"
-									onClick={ handleRegisterSite }
-									disabled={ isReconnectingUser }
-									isBusy={ isReconnectingUser }
+									onClick={ run }
+									disabled={ hasCheckoutStarted }
+									isBusy={ hasCheckoutStarted }
 								>
 									{ __( 'Connect', 'jetpack-videopress-pkg' ) }
 								</Button>

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { useConnection } from '@automattic/jetpack-connection';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import {
 	BlockIcon,
@@ -9,9 +10,10 @@ import {
 	BlockControls,
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
-import { Spinner, Placeholder, Button, withNotices } from '@wordpress/components';
+import { Spinner, Placeholder, Button, withNotices, ExternalLink } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
 import { useEffect, useState, useCallback, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
@@ -22,6 +24,7 @@ import debugFactory from 'debug';
 import getMediaToken from '../../../lib/get-media-token';
 import { buildVideoPressURL, getVideoPressUrl } from '../../../lib/url';
 import { useSyncMedia } from '../../hooks/use-video-data-update';
+import Banner from './components/banner';
 import ColorPanel from './components/color-panel';
 import DetailsPanel from './components/details-panel';
 import { VideoPressIcon } from './components/icons';
@@ -134,6 +137,8 @@ export default function VideoPressEdit( {
 		useAverageColor,
 		poster,
 	} );
+
+	const { isUserConnected } = useConnection();
 
 	/*
 	 * Request token when site is private
@@ -418,14 +423,29 @@ export default function VideoPressEdit( {
 
 		return (
 			<div { ...blockProps } className={ blockMainClassName }>
-				<VideoPressUploader
-					setAttributes={ setAttributes }
-					attributes={ attributes }
-					handleDoneUpload={ handleDoneUpload }
-					fileToUpload={ fileToUpload }
-					isReplacing={ isReplacingFile?.isReplacing }
-					onReplaceCancel={ cancelReplacingVideoFile }
-				/>
+				<>
+					{ ! isUserConnected && (
+						<Banner>
+							{ createInterpolateElement(
+								__(
+									'<link>Connect your account</link> to continue using VideoPress',
+									'jetpack-videopress-pkg'
+								),
+								{
+									link: <ExternalLink href="#" />,
+								}
+							) }
+						</Banner>
+					) }
+					<VideoPressUploader
+						setAttributes={ setAttributes }
+						attributes={ attributes }
+						handleDoneUpload={ handleDoneUpload }
+						fileToUpload={ fileToUpload }
+						isReplacing={ isReplacingFile?.isReplacing }
+						onReplaceCancel={ cancelReplacingVideoFile }
+					/>
+				</>
 			</div>
 		);
 	}

--- a/projects/packages/videopress/src/client/block-editor/extensions/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/extensions/types.ts
@@ -2,7 +2,6 @@ export type VideoPressExtensionProps = {
 	name: string;
 	isEnabled: boolean;
 	isBeta: boolean;
-	adminUrl: string;
 };
 
 export type VideoPressExtensionsProps = Array< VideoPressExtensionProps >;

--- a/projects/packages/videopress/src/client/block-editor/extensions/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/extensions/types.ts
@@ -2,6 +2,7 @@ export type VideoPressExtensionProps = {
 	name: string;
 	isEnabled: boolean;
 	isBeta: boolean;
+	adminUrl: string;
 };
 
 export type VideoPressExtensionsProps = Array< VideoPressExtensionProps >;

--- a/projects/packages/videopress/src/client/block-editor/global.d.ts
+++ b/projects/packages/videopress/src/client/block-editor/global.d.ts
@@ -8,6 +8,8 @@ declare global {
 			extensions: VideoPressExtensionsProps;
 			siteType: 'simple' | 'atomic' | 'jetpack';
 			adminUrl: string;
+			myJetpackConnectUrl: string;
+			siteSuffix: string;
 		};
 	}
 }

--- a/projects/packages/videopress/src/client/block-editor/global.d.ts
+++ b/projects/packages/videopress/src/client/block-editor/global.d.ts
@@ -7,6 +7,7 @@ declare global {
 		videoPressEditorState: {
 			extensions: VideoPressExtensionsProps;
 			siteType: 'simple' | 'atomic' | 'jetpack';
+			adminUrl: string;
 		};
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/28525

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: address the whole connection/checkout flow from the VideoPress video block

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

