### PR TITLE
VideoPress: Prevent flash of initial state when there are search params

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-first-query
+++ b/projects/packages/videopress/changelog/fix-videopress-first-query
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: Prevent flash of initial state when there are search params

--- a/projects/packages/videopress/src/client/admin/components/admin-page/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/types.ts
@@ -1,6 +1,6 @@
 import {
 	productOriginalProps,
-	ProductPriceOriginalProps,
+	productPriceOriginalProps,
 	siteProductOriginalProps,
 } from '../../hooks/use-plan/types';
 import { LocalVideo, MetadataVideo, VideoPressVideo } from '../../types';
@@ -21,11 +21,16 @@ declare global {
 			};
 			siteProductData: siteProductOriginalProps;
 			productData?: productOriginalProps;
-			productPrice?: ProductPriceOriginalProps;
+			productPrice?: productPriceOriginalProps;
 			adminUrl: string;
 			adminUri: string;
 			siteSuffix: string;
 			contentNonce: string;
+			initialState: {
+				videos?: {
+					isFetching?: boolean;
+				};
+			};
 		};
 	}
 }

--- a/projects/packages/videopress/src/client/state/index.js
+++ b/projects/packages/videopress/src/client/state/index.js
@@ -17,7 +17,15 @@ import storeHolder from './store-holder';
  */
 export const stateDebug = debugFactory( 'videopress/media:state' );
 
-const initialState = window.jetpackVideoPressInitialState?.initialState || {};
+const initialState = window.jetpackVideoPressInitialState?.initialState || { videos: {} };
+
+const hash = window.location.hash.replace( /#\/\??/, '' );
+const hasSearchParams = new URLSearchParams( hash ).toString().replace( 'page=1', '' ).length > 0;
+
+if ( hasSearchParams ) {
+	// Avoid flash of initial data when we have a query
+	initialState.videos.isFetching = true;
+}
 
 /**
  * jetpack-videopress redux initializer


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #28259

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a check for URL hash params other than `page=1`, setting the `videos.isFetching` state to true early, avoiding the flash

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard with some videos
* Notice that, if there is no search/pagination URL parameter, there is no change in behavior, i.e. no loading
* Add a search/pagination query and hard-refresh
* Notice that the page initiates the loading screen immediately, without a flash of initial state
