### PR TITLE
Update Release Script to Timeout if no Build ID Found

### DIFF
--- a/tools/release-plugin.sh
+++ b/tools/release-plugin.sh
@@ -27,8 +27,13 @@ function usage {
 
 # Make sure the GitHub CLI is installed.
 if ! command -v gh &> /dev/null; then
-	proceed_p "This tool requires the GitHub CLI, which was not found." "Install it?"
-	brew install gh
+	yellow "This tool requires the GitHub CLI, which was not found."
+	if command -v brew &> /dev/null; then
+		proceed_p "Install the GitHub CLI via brew?"
+		brew install gh
+	else
+		die "Please install the GitHub CLI before proceeding"
+	fi 
 fi
 
 # Get the options passed and parse them.

--- a/tools/release-plugin.sh
+++ b/tools/release-plugin.sh
@@ -25,6 +25,12 @@ function usage {
 	exit 1
 }
 
+# Make sure the GitHub CLI is installed.
+if ! command -v gh &> /dev/null; then
+	proceed_p "This tool requires the GitHub CLI, which was not found." "Install it?"
+	brew install gh
+fi
+
 # Get the options passed and parse them.
 ARGS=('-p')
 ALPHABETA=
@@ -100,8 +106,8 @@ if [[ -n "$(git status --porcelain)" ]]; then
 	die "Working directory not clean, make sure you're working from a clean checkout and try again."
 fi
 
+yellow "Checking out prerelease branch."
 # Check out and push pre-release branch
-BRANCHES="$( git branch )"
 if git rev-parse --verify prerelease &>/dev/null; then
 	proceed_p "Existing prerelease branch found." "Delete it?"
 	git branch -D prerelease
@@ -112,6 +118,7 @@ if ! git push -u origin HEAD; then
 	die "Branch push failed. Check #jetpack-releases and make sure no one is doing a release already, then delete the branch at https://github.com/Automattic/jetpack/branches"
 fi
 
+yellow "Updating the changelogs."
 # Run the changelogger release script
 tools/changelogger-release.sh "${ARGS[@]}" "$PROJECT"
 
@@ -119,22 +126,36 @@ tools/changelogger-release.sh "${ARGS[@]}" "$PROJECT"
 read -r -s -p $'Edit all the changelog entries you want (in a separate terminal or your text editor of choice (make sure to save)), then press enter when finished to continue the release process.'
 echo ""
 
-echo "Committing changes..."
+yellow "Committing changes."
 git add --all
 git commit -am "Changelog edits for $PROJECT"
 
 # If we're running a beta, amend the changelog
 if [[ "$PROJECT" == "projects/jetpack" && "$ALPHABETA" == "-b" ]]; then
-	echo "Releasing a beta, amending the readme.txt"
+	yellow "Releasing a beta, amending the readme.txt"
 	jetpack changelog squash plugins/jetpack readme
 	git commit -am "Amend readme.txt"
 fi
 
-# Push the changes, then tell the user to wait for the builds to complete and things to update.
+yellow "Pushing changes."
 git push -u origin prerelease
 
 yellow "Waiting for build to complete and push to mirror repos"
 BUILDID="$( gh run list --json headBranch,event,databaseId,workflowName --jq '.[] | select(.event=="push" and .headBranch=="prerelease" and .workflowName=="Build") | .databaseId' )"
+
+# If the build ID doesn't exist, try every five seconds until timeout after a minute.
+TIMEOUT=$((SECONDS+60))
+while [ $SECONDS -lt $TIMEOUT ] && [[ -z "$BUILDID" ]]; do
+    echo "Waiting for build to become available..."
+	sleep 5
+	BUILDID="$( gh run list --json headBranch,event,databaseId,workflowName --jq '.[] | select(.event=="push" and .headBranch=="prerelease" and .workflowName=="Build") | .databaseId' )"
+done
+
+if [[ -z "$BUILDID" ]]; then
+	die "Build ID not found. Check GitHub actions to see if build on prerelease branch is running, then continue with manual steps."
+fi 
+
+yellow "Build ID found, waiting for build to complete and push to mirror repos."
 if ! gh run watch "${BUILDID[0]}" --exit-status; then
 	echo "Build failed! Check for build errors on GitHub for more information." && die
 fi 
@@ -143,4 +164,4 @@ fi
 yellow "Build is complete. Creating a release branch."
 tools/create-release-branch.sh "$PROJECT" "$VERSION"
 
-echo "Release branch created!"
+yellow "Release branch created!"

--- a/tools/release-plugin.sh
+++ b/tools/release-plugin.sh
@@ -150,8 +150,8 @@ BUILDID="$( gh run list --json headBranch,event,databaseId,workflowName --jq '.[
 
 # If the build ID doesn't exist, try every five seconds until timeout after a minute.
 TIMEOUT=$((SECONDS+60))
-while [ $SECONDS -lt $TIMEOUT ] && [[ -z "$BUILDID" ]]; do
-    echo "Waiting for build to become available..."
+while [[ $SECONDS -lt $TIMEOUT &&  -z "$BUILDID" ]]; do
+	echo "Waiting for build to become available..."
 	sleep 5
 	BUILDID="$( gh run list --json headBranch,event,databaseId,workflowName --jq '.[] | select(.event=="push" and .headBranch=="prerelease" and .workflowName=="Build") | .databaseId' )"
 done


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
Adds a timeout to finding the BUILDID in case it takes GitHub a while to start the action. Also has more verbose output so release knows what step is being followed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Code look okay? Will test with release later today.

