### PR TITLE
Backup: fix to load Tracks when no user is connected

### DIFF
--- a/projects/packages/backup/changelog/fix-load-tracks-user-not-connected
+++ b/projects/packages/backup/changelog/fix-load-tracks-user-not-connected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix to add jp-tracks when no user is connected

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -138,8 +138,7 @@ class Jetpack_Backup {
 	 * Enqueue plugin admin scripts and styles.
 	 */
 	public static function enqueue_admin_scripts() {
-		$status  = new Status();
-		$manager = new Connection_Manager( 'jetpack-backup' );
+		$status = new Status();
 
 		Assets::register_script(
 			'jetpack-backup',
@@ -156,7 +155,7 @@ class Jetpack_Backup {
 		wp_add_inline_script( 'jetpack-backup', Connection_Initial_State::render(), 'before' );
 
 		// Load script for analytics.
-		if ( ! $status->is_offline_mode() && $manager->is_connected() ) {
+		if ( ! $status->is_offline_mode() ) {
 			wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Currently, backup package loads analytics script only when a manager is connected (and the site is not in maintenance mode). Loading the script when no user is connected is helpful to track when a user visits the main page of the Backup plugin.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix to load analytics script when no user is connected

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
* 1202586245449203-as-1203758786856450/f

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a Jurassic Ninja site with Jetpack Beta, using Backup branch `fix/backup-tracks-events`, ideally without Jetpack plugin (you can deactivate it and ensure you are not connected).
* Open your Chrome Developer Tools (or the one you use in your browsers) in Network tab.
* Visit Jetpack > VaultPress Backup.
* Ensure `w.js` is loaded and also you have a `t.gif` tracking pixel for `jetpack_backup_admin_page_view` event.