### PR TITLE
Stats: Fix Ads Stats controller params

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-ads-controller-params
+++ b/projects/packages/stats-admin/changelog/fix-ads-controller-params
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: fixed missing params to WPCOM API

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -401,7 +401,7 @@ class REST_Controller {
 	public function get_wordads_earnings( $req ) {
 		return $this->request_as_blog_cached(
 			sprintf(
-				'/sites/%d/wordads/earnings',
+				'/sites/%d/wordads/earnings?%s',
 				Jetpack_Options::get_option( 'id' ),
 				http_build_query(
 					$req->get_params()
@@ -421,7 +421,7 @@ class REST_Controller {
 	public function get_wordads_stats( $req ) {
 		return $this->request_as_blog_cached(
 			sprintf(
-				'/sites/%d/wordads/stats',
+				'/sites/%d/wordads/stats?%s',
 				Jetpack_Options::get_option( 'id' ),
 				http_build_query(
 					$req->get_params()


### PR DESCRIPTION
## Proposed changes:
Fixed missing params to be passed to WPCOM API. This is a follow up for #27791.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable WordAds - `/wp-admin/admin.php?page=jetpack#/traffic?term=wordads`
* Open `/wp-admin/admin.php?page=stats&flags=stats%2Fads-page`
* Switch period for the bar chart on Ads page 
* Ensure data look okay 

