### PR TITLE
[Super Cache] Ensure cron schedule is setup whenever the config changes

### DIFF
--- a/projects/plugins/super-cache/changelog/super-cache-fix-schedule
+++ b/projects/plugins/super-cache/changelog/super-cache-fix-schedule
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Reassert scheduled cron-job whenever the interval setting is updated

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -3598,13 +3598,16 @@ function wpsc_preload_settings( $min_refresh_interval = 'NA' ) {
 				if ( $wp_cache_preload_interval == 0 ) {
 					$return[] = "<p><strong>" . __( 'Scheduled preloading of cache cancelled.', 'wp-super-cache' ) . "</strong></p>";
 				}
-				if ( $_POST[ 'wp_cache_preload_interval' ] != 0 )
-					wp_schedule_single_event( time() + ( $_POST[ 'wp_cache_preload_interval' ] * 60 ), 'wp_cache_full_preload_hook' );
+			}
+
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing
+			$wp_cache_preload_interval = (int) $_POST['wp_cache_preload_interval'];
+			wp_cache_setting( 'wp_cache_preload_interval', $wp_cache_preload_interval );
+
+			if ( $wp_cache_preload_interval !== 0 ) {
+				wp_schedule_single_event( time() + ( $wp_cache_preload_interval * 60 ), 'wp_cache_full_preload_hook' );
 			}
 		}
-
-		$wp_cache_preload_interval = (int)$_POST[ 'wp_cache_preload_interval' ];
-		wp_cache_setting( "wp_cache_preload_interval", $wp_cache_preload_interval );
 	}
 
 	if ( $_POST[ 'wp_cache_preload_posts' ] == 'all' ) {

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -3586,28 +3586,19 @@ function wpsc_preload_settings( $min_refresh_interval = 'NA' ) {
 			$min_refresh_interval = 30;
 		}
 	}
+
+	// Set to true if the preload interval is changed, and a reschedule is required.
+	$force_preload_reschedule = false;
+
 	if ( isset( $_POST[ 'wp_cache_preload_interval' ] ) && ( $_POST[ 'wp_cache_preload_interval' ] == 0 || $_POST[ 'wp_cache_preload_interval' ] >= $min_refresh_interval ) ) {
-		// if preload interval changes than unschedule any preload jobs and schedule any new one.
 		$_POST[ 'wp_cache_preload_interval' ] = (int)$_POST[ 'wp_cache_preload_interval' ];
 		if ( $wp_cache_preload_interval != $_POST[ 'wp_cache_preload_interval' ] ) {
-			$next_preload = wp_next_scheduled( 'wp_cache_full_preload_hook' );
-			if ( $next_preload ) {
-				update_option( 'preload_cache_counter', array( 'c' => 0, 't' => time() ) );
-				add_option( 'preload_cache_stop', 1 );
-				wp_unschedule_event( $next_preload, 'wp_cache_full_preload_hook' );
-				if ( $wp_cache_preload_interval == 0 ) {
-					$return[] = "<p><strong>" . __( 'Scheduled preloading of cache cancelled.', 'wp-super-cache' ) . "</strong></p>";
-				}
-			}
-
-			// phpcs:ignore WordPress.Security.NonceVerification.Missing
-			$wp_cache_preload_interval = (int) $_POST['wp_cache_preload_interval'];
-			wp_cache_setting( 'wp_cache_preload_interval', $wp_cache_preload_interval );
-
-			if ( $wp_cache_preload_interval !== 0 ) {
-				wp_schedule_single_event( time() + ( $wp_cache_preload_interval * 60 ), 'wp_cache_full_preload_hook' );
-			}
+			$force_preload_reschedule = true;
 		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$wp_cache_preload_interval = (int) $_POST['wp_cache_preload_interval'];
+		wp_cache_setting( 'wp_cache_preload_interval', $wp_cache_preload_interval );
 	}
 
 	if ( $_POST[ 'wp_cache_preload_posts' ] == 'all' ) {
@@ -3642,6 +3633,33 @@ function wpsc_preload_settings( $min_refresh_interval = 'NA' ) {
 		$wp_cache_preload_on = 0;
 	}
 	wp_cache_setting( 'wp_cache_preload_on', $wp_cache_preload_on );
+
+	// Ensure that preload settings are applied to scheduled cron.
+	$next_preload    = wp_next_scheduled( 'wp_cache_full_preload_hook' );
+	$should_schedule = ( $wp_cache_preload_on === 1 && $wp_cache_preload_interval > 0 );
+
+	// If forcing a reschedule, or preload is disabled, clear the next scheduled event.
+	if ( $next_preload && ( ! $should_schedule || $force_preload_reschedule ) ) {
+		wp_cache_debug( 'Clearing old preload event' );
+		update_option(
+			'preload_cache_counter',
+			array(
+				'c' => 0,
+				't' => time(),
+			)
+		);
+
+		add_option( 'preload_cache_stop', 1 );
+		wp_unschedule_event( $next_preload, 'wp_cache_full_preload_hook' );
+
+		$next_preload = 0;
+	}
+
+	// Ensure a preload is scheduled if it should be.
+	if ( ! $next_preload && $should_schedule ) {
+		wp_cache_debug( 'Scheduling new preload event' );
+		wp_schedule_single_event( time() + ( $wp_cache_preload_interval * 60 ), 'wp_cache_full_preload_hook' );
+	}
 
 	return $return;
 }


### PR DESCRIPTION
Possibly related: https://wordpress.org/support/topic/empty-cache-directories/

When you set a preload schedule in wp-super-cache, the cron job was only being set up if _one was already scheduled_. If one wasn't for any reason, then it did not add one.

This PR changes the way that cronjobs are managed: Any time the settings are edited, it ensures that there is a cron if one should be there, and there isn't one if not. If the interval gets edited, then the cronjob gets destroyed (if it exists) and recreated.

Note: this will not schedule a cronjob if preload mode is not enabled. I wanted to verify with @donnchawp that's the correct / expected behaviour.

## Proposed changes:
* Ensure that preload crons are scheduled (or cancelled) on settings edit

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Try turning on preload mode, ensure a cron is appropriately scheduled
* Turn off preload mode, make sure there is no cron
* Turn on preload mode and edit the interval, ensure the correct interval gets set.

