### PR TITLE
Migration: Add a REST API for getting migration status

### DIFF
--- a/projects/plugins/migration/changelog/add-migration-rest-routes
+++ b/projects/plugins/migration/changelog/add-migration-rest-routes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Adds a REST route for Migration plugin to fetch status from source site.

--- a/projects/plugins/migration/jetpack-migration.php
+++ b/projects/plugins/migration/jetpack-migration.php
@@ -115,7 +115,7 @@ add_filter(
 	}
 );
 
-register_deactivation_hook( __FILE__, array( 'Jetpack_Migration', 'plugin_deactivation' ) );
+register_deactivation_hook( __FILE__, array( \Automattic\Jetpack\Migration\Jetpack_Migration::class, 'plugin_deactivation' ) );
 
 // Main plugin class.
-new Jetpack_Migration();
+new \Automattic\Jetpack\Migration\Jetpack_Migration();

--- a/projects/plugins/migration/src/class-jetpack-migration.php
+++ b/projects/plugins/migration/src/class-jetpack-migration.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
 use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
@@ -100,7 +101,7 @@ class Jetpack_Migration {
 		);
 		Assets::enqueue_script( 'jetpack-migration' );
 		// Initial JS state including JP Connection data.
-		wp_add_inline_script( 'jetpack-migration', \Connection_Initial_State::render(), 'before' );
+		wp_add_inline_script( 'jetpack-migration', Connection_Initial_State::render(), 'before' );
 		wp_add_inline_script( 'jetpack-migration', $this->render_initial_state(), 'before' );
 	}
 

--- a/projects/plugins/migration/src/class-jetpack-migration.php
+++ b/projects/plugins/migration/src/class-jetpack-migration.php
@@ -5,12 +5,13 @@
  * @package automattic/jetpack-migration-plugin
  */
 
+namespace Automattic\Jetpack\Migration;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 use Automattic\Jetpack\Assets;
-use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
 use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
@@ -28,6 +29,9 @@ class Jetpack_Migration {
 		// Set up the REST authentication hooks.
 		Connection_Rest_Authentication::init();
 
+		// Set up the REST API routes.
+		new REST_Controller();
+
 		// Set up the top-level menu
 		add_action( 'admin_menu', array( $this, 'admin_menu_hook_callback' ), 1000 ); // Jetpack uses 998.
 
@@ -35,7 +39,7 @@ class Jetpack_Migration {
 		add_action(
 			'plugins_loaded',
 			function () {
-				$config = new Automattic\Jetpack\Config();
+				$config = new \Automattic\Jetpack\Config();
 				// Connection package.
 				$config->ensure(
 					'connection',
@@ -96,7 +100,7 @@ class Jetpack_Migration {
 		);
 		Assets::enqueue_script( 'jetpack-migration' );
 		// Initial JS state including JP Connection data.
-		wp_add_inline_script( 'jetpack-migration', Connection_Initial_State::render(), 'before' );
+		wp_add_inline_script( 'jetpack-migration', \Connection_Initial_State::render(), 'before' );
 		wp_add_inline_script( 'jetpack-migration', $this->render_initial_state(), 'before' );
 	}
 

--- a/projects/plugins/migration/src/class-rest-controller.php
+++ b/projects/plugins/migration/src/class-rest-controller.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * REST API Endpoints
+ *
+ * @package automattic/jetpack-migration-plugin
+ */
+
+namespace Automattic\Jetpack\Migration;
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * Makes REST API Endpoints for Migration
+ *
+ * @package Automattic\Jetpack\Migration
+ */
+class REST_Controller {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		// Set up REST API routes.
+		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
+	}
+
+	/**
+	 * Register REST API
+	 */
+	public function register_rest_routes() {
+		// Get migration status from source site.
+		register_rest_route(
+			'jetpack/v4',
+			'/migration/status',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_migration' ),
+				'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
+			)
+		);
+	}
+
+	/**
+	 * Gets the current migration for this source site.
+	 *
+	 * GET `jetpack/v4/migration/status`
+	 */
+	public function get_migration() {
+		$blog_id  = $this->get_blog_id();
+		$path     = sprintf( '/migrations/from-source/%d', absint( $blog_id ) );
+		$response = Client::wpcom_json_api_request_as_user( $path, '2', array(), null, 'wpcom' );
+		return rest_ensure_response( $this->make_proper_response( $response ) );
+	}
+
+	/**
+	 * Only administrators can access the API.
+	 *
+	 * @return bool|WP_Error True if current user can manage options, WP_Error otherwise.
+	 */
+	public function require_admin_privilege_callback() {
+		if ( current_user_can( 'manage_options' ) ) {
+			return true;
+		}
+
+		$error_msg = esc_html__(
+			'You are not allowed to perform this action.',
+			'jetpack-migration'
+		);
+
+		return new \WP_Error( 'rest_forbidden', $error_msg, array( 'status' => rest_authorization_required_code() ) );
+	}
+
+	/**
+	 * Forward remote response to client with error handling.
+	 *
+	 * @param array|WP_Error $response - Response from WPCOM.
+	 */
+	private function make_proper_response( $response ) {
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
+		$status_code = wp_remote_retrieve_response_code( $response );
+
+		if ( 200 === $status_code ) {
+			return $body;
+		}
+
+		return new \WP_Error(
+			isset( $body['error'] ) ? 'remote-error-' . $body['error'] : 'remote-error',
+			isset( $body['message'] ) ? $body['message'] : 'unknown remote error',
+			array( 'status' => $status_code )
+		);
+	}
+
+	/**
+	 * Get blog id
+	 */
+	protected function get_blog_id() {
+		$is_wpcom = defined( 'IS_WPCOM' ) && IS_WPCOM;
+		return $is_wpcom ? get_current_blog_id() : \Jetpack_Options::get_option( 'id' );
+	}
+}

--- a/projects/plugins/migration/src/class-rest-controller.php
+++ b/projects/plugins/migration/src/class-rest-controller.php
@@ -46,7 +46,11 @@ class REST_Controller {
 	 * GET `jetpack/v4/migration/status`
 	 */
 	public function get_migration() {
-		$blog_id  = $this->get_blog_id();
+		$blog_id = \Automattic\Jetpack\Connection\Manager::get_site_id();
+		if ( is_wp_error( $blog_id ) ) {
+			return $blog_id;
+		}
+
 		$path     = sprintf( '/migrations/from-source/%d', absint( $blog_id ) );
 		$response = Client::wpcom_json_api_request_as_user( $path, '2', array(), null, 'wpcom' );
 		return rest_ensure_response( $this->make_proper_response( $response ) );
@@ -92,13 +96,5 @@ class REST_Controller {
 			isset( $body['message'] ) ? $body['message'] : 'unknown remote error',
 			array( 'status' => $status_code )
 		);
-	}
-
-	/**
-	 * Get blog id
-	 */
-	protected function get_blog_id() {
-		$is_wpcom = defined( 'IS_WPCOM' ) && IS_WPCOM;
-		return $is_wpcom ? get_current_blog_id() : \Jetpack_Options::get_option( 'id' );
 	}
 }


### PR DESCRIPTION
This adds a REST API to get migration status from the source site.

## Proposed changes:
*  Adds a REST API `/jetpack/v4/migration/status` that calls the corresponding WPCOM API developed in this diff: D98822-code
* Namespaces the plugin under `Automattic\Jetpack\Migration`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

Since the client-side implementation has not been implemented, we can test this with the browser console:

* Get this plugin branch working locally.
* Make sure you do `jetpack watch` and select this migration plugin.
* Make sure to proxy via Jurassic Tube and access the Jetpack settings in the browser.
* Open the network console and `Copy as Fetch` any request that goes to a `jetpack/v4` endpoint.

<img width="1009" alt="CleanShot 2023-01-24 at 14 33 23@2x" src="https://user-images.githubusercontent.com/533/214250887-fc3cc922-5ba2-4c8b-a421-dc588497e475.png">


* Please make sure that D99157-code is applied on the WPCOM API sandbox as there is a small bug currently.
* Change the fetch URL to `http://<domain>.jurassic.tube/jetpack/v4/migration/status`
* Suffix `.then(c => c.json()).then(d => console.log(d));` to see the response, an example complete request is:

```
fetch("https://vishnugopal-test.jurassic.tube/wp-json/jetpack/v4/migration/status", {
  "headers": {
    "accept": "*/*",
    "accept-language": "en-US,en;q=0.9",
    "sec-ch-ua": "\"Not_A Brand\";v=\"99\", \"Microsoft Edge\";v=\"109\", \"Chromium\";v=\"109\"",
    "sec-ch-ua-mobile": "?0",
    "sec-ch-ua-platform": "\"macOS\"",
    "sec-fetch-dest": "empty",
    "sec-fetch-mode": "cors",
    "sec-fetch-site": "same-origin",
    "x-wp-nonce": "d6a591ce2d"
  },
  "referrer": "https://vishnugopal-test.jurassic.tube/wp-admin/admin.php?page=jetpack",
  "referrerPolicy": "strict-origin-when-cross-origin",
  "body": null,
  "method": "GET",
  "mode": "cors",
  "credentials": "include"
}).then(c => c.json()).then(d => console.log(d));
```

(note this exact request will not work because of different URL & nonce)


* You should see this response when Jetpack is not connected:

```
{
    "code": "unavailable_site_id",
    "message": "Sorry, something is wrong with your Jetpack connection.",
    "data": 403
}
```

or this:

```
{code: 'missing_token', message: '', data: null}
```

* If your Jetpack account is connected to a different user, you should see something like this:

```
{code: 'rest_forbidden', message: 'You are not allowed to perform this action.', data: {…}}
```

* Now in a new tab open the Migration Tab (`/wp-admin/admin.php?page=jetpack-migration`) and click `Get Started`. Tip: if you want to reset Jetpack connection state, [you can use this link](https://wordpress.com/wp-admin/network/admin.php?page=jetpack).

* You should see this response when a valid migration is going on:

```
{
    "source_blog_id": "214480316",
    "target_blog_id": "214749311",
    "status": "backing-up",
    "percent": 10,
    "created": "2023-01-24 09:22:43",
    "last_modified": "2023-01-24 09:22:45",
    "is_atomic": true
}
```

* You should see this response when no migration has completed:

```
{status: 'inactive'}
```
