### PR TITLE
Common Mappings: Add a mapping for `options-reading.php` based on the `calypso_use_modernized_reading_settings` feature flag

### DIFF
--- a/projects/plugins/jetpack/changelog/update-common-mappings-with-options-reading-php
+++ b/projects/plugins/jetpack/changelog/update-common-mappings-with-options-reading-php
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Common Mappings: Add a mapping for `options-reading.php` based on a `calypso_use_modernized_reading_settings` feature flag

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/menu-mappings.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/menu-mappings.php
@@ -24,14 +24,7 @@ $common_mappings = array(
 );
 
 if (
-	/**
-	 * Filter to enable the modernized Reading Settings in Calypso UI.
-	 *
-	 * @since $$next-version$$
-	 * @module masterbar
-	 *
-	 * @param bool false Should the modernized Reading Settings be enabled? Default to false.
-	 */
+	 /** This filter is documented in modules/masterbar/admin-menu/class-admin-menu.php */
 	apply_filters( 'calypso_use_modernized_reading_settings', false )
 ) {
 	$common_mappings['options-reading.php'] = 'https://wordpress.com/settings/reading/';

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/menu-mappings.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/menu-mappings.php
@@ -24,7 +24,7 @@ $common_mappings = array(
 );
 
 if (
-	 /** This filter is documented in modules/masterbar/admin-menu/class-admin-menu.php */
+	/** This filter is documented in modules/masterbar/admin-menu/class-admin-menu.php */
 	apply_filters( 'calypso_use_modernized_reading_settings', false )
 ) {
 	$common_mappings['options-reading.php'] = 'https://wordpress.com/settings/reading/';

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/menu-mappings.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/menu-mappings.php
@@ -23,6 +23,20 @@ $common_mappings = array(
 	'edit.php?post_type=jetpack-testimonial' => 'https://wordpress.com/types/jetpack-testimonial/',
 );
 
+if (
+	/**
+	 * Filter to enable the modernized Reading Settings in Calypso UI.
+	 *
+	 * @since $$next-version$$
+	 * @module masterbar
+	 *
+	 * @param bool false Should the modernized Reading Settings be enabled? Default to false.
+	 */
+	apply_filters( 'calypso_use_modernized_reading_settings', false )
+) {
+	$common_mappings['options-reading.php'] = 'https://wordpress.com/settings/reading/';
+}
+
 if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 	// WPCOM Specific mappings.
 	$common_mappings['export.php'] = 'https://wordpress.com/export/';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/71087

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a mapping for `options-reading.php` based on the `calypso_use_modernized_reading_settings` feature flag
  * This will result in the Reading Settings page displaying the **View ▼** component when viewed in the **Classic View** (wp-admin). The component allows to switch back to Calypso's **Default View**

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
The PR should be tested in particular with Simple and Atomic sites. Jetpack sites, in Calypso, do not display the **Settings —> Reading** admin menu item.

###  Test - Simple Sites
1. Test for no regressions:
  * Apply the PR to your sandbox
  * Sandbox your test site's domain
  * Go to https://your-test-site.wordpress.com/wp-admin/options-reading.php
  * You should not see the **View ▼** button

2. Test a case where the "feature flag" hook would return true:
  * Checkout the PR branch
  * At [the line](https://github.com/Automattic/jetpack/blob/bd23478d2ffc0f36e6399017095566df99d9e989/projects/plugins/jetpack/modules/masterbar/admin-menu/menu-mappings.php#L35) change the default hook value from `false` to `true`
  * Build the jetpack plugin locally
  * Using `jetpack rsync` apply the changes to your sandbox
  * Sandbox your test site's domain
  * Go to https://your-test-site.wordpress.com/wp-admin/options-reading.php
  * The **View ▼** button should be displayed and functional
![Screen Shot 2023-01-24 at 13 27 12](https://user-images.githubusercontent.com/2019970/214291652-19437669-2766-4665-8035-2fe52e7c0fd7.png)

### Test - Atomic Site
Here are some resources to help you out with setting up Jetpack Atomic site test environment: pb5gDS-1rQ-p2

Once your atomic site environment is ready we can do similar test cases as for the Simple sites above.

1. Test for no regressions:
  * Checkout the PR branch, build it and apply it to your Atomic test-site
  * Go to https://your-atomic-test-site.com/wp-admin/options-reading.php
  * You should not see the **View ▼** button

2. Test a case where the "feature flag" hook would return true:
  * Checkout the PR branch 
  * At [the line](https://github.com/Automattic/jetpack/blob/bd23478d2ffc0f36e6399017095566df99d9e989/projects/plugins/jetpack/modules/masterbar/admin-menu/menu-mappings.php#L35) change the default hook value from `false` to `true`
  * Build Jetpack plugin and apply it to your Atomic test-site
  * Go to https://your-test-site.wordpress.com/wp-admin/options-reading.php
  * The **View ▼** button should be displayed and functional
![Screen Shot 2023-01-24 at 13 27 12](https://user-images.githubusercontent.com/2019970/214291652-19437669-2766-4665-8035-2fe52e7c0fd7.png)


