### PR TITLE
[Super Cache] Add a hook to allow users to control cache clearing on post edit

### DIFF
--- a/projects/plugins/super-cache/changelog/super-cache-post-edit-hook
+++ b/projects/plugins/super-cache/changelog/super-cache-post-edit-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added a filter to allow users to control post-editing cache-clearing behavior

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -3096,6 +3096,11 @@ function wp_cache_post_edit( $post_id ) {
 		return $post_id;
 	}
 
+	// Allow plugins to reject cache clears for specific posts.
+	if ( ! apply_filters( 'wp_super_cache_clear_post_cache', true, $post ) ) {
+		return $post_id;
+	}
+
 	// Some users are inexplicibly seeing this error on scheduled posts.
 	// define this constant to disable the post status check.
 	if ( ! defined( 'WPSCFORCEUPDATE' ) && ! in_array( get_post_status( $post ), array( 'publish', 'private' ), true ) ) {


### PR DESCRIPTION
This PR adds a hook that is called when a post has been edited, allowing users to skip clearing the cache on some post edits.

## Proposed changes:
* Add a filter to control which posts will trigger cache clears.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Add the following snippet to your test site:
```
add_filter( 'wp_super_cache_clear_post_cache', function( $clear, $post ) {
    $exclude = [
        'post',
        'revision',
    ];

    if ( in_array( $post->post_type, $exclude ) ) {
        return false;
    }

    return $clear;
}, 10, 2 );
```
* Enable the Advanced option " Clear all cache files when a post or page is published or updated."
* Edit a post and ensure the cache is not cleared
* Edit a page and ensure the cache is cleared.

