### PR TITLE
Slideshow: avoid loading editor on page view

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-slideshow-loads-editor-on-every-page-view
+++ b/projects/plugins/jetpack/changelog/fix-slideshow-loads-editor-on-every-page-view
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix slideshow loading excess dependencies on every page view

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/pagination.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/pagination.js
@@ -1,0 +1,33 @@
+import { __, sprintf } from '@wordpress/i18n';
+
+export function paginationCustomRender( swiper, current, total ) {
+	let markup = '';
+
+	// Print dots pagination when total slides are less than six.
+	if ( total <= 5 ) {
+		for ( let i = 1; i <= total; i++ ) {
+			const active = i === current ? ' swiper-pagination-bullet-active' : '';
+			const cssClass = `swiper-pagination-bullet${ active }`;
+			const ariaLabel = sprintf(
+				/* translators: placeholder is the the video number to navigate to */
+				__( 'Go to slide %s', 'jetpack' ),
+				i
+			);
+
+			markup +=
+				'<button ' +
+				'class="' +
+				cssClass +
+				'" ' +
+				'tab-index="0" ' +
+				'role="button" ' +
+				'aria-label="' +
+				ariaLabel +
+				'"></button>';
+		}
+	} else {
+		markup += `<div class="swiper-pagination-simple">${ current } / ${ total }</div>`;
+	}
+
+	return markup;
+}

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.js
@@ -5,7 +5,7 @@ import { isBlobURL } from '@wordpress/blob';
 import { RichText } from '@wordpress/block-editor';
 import { Spinner } from '@wordpress/components';
 import { Component, createRef } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { isEqual } from 'lodash';
 import ResizeObserver from 'resize-observer-polyfill';
@@ -13,6 +13,7 @@ import ResizeObserver from 'resize-observer-polyfill';
  * Internal dependencies
  */
 import createSwiper from './create-swiper';
+import { paginationCustomRender } from './pagination';
 import {
 	swiperApplyAria,
 	swiperInit,
@@ -20,37 +21,6 @@ import {
 	swiperResize,
 } from './swiper-callbacks';
 
-export function paginationCustomRender( swiper, current, total ) {
-	let markup = '';
-
-	// Print dots pagination when total slides are less than six.
-	if ( total <= 5 ) {
-		for ( let i = 1; i <= total; i++ ) {
-			const active = i === current ? ' swiper-pagination-bullet-active' : '';
-			const cssClass = `swiper-pagination-bullet${ active }`;
-			const ariaLabel = sprintf(
-				/* translators: placeholder is the the video number to navigate to */
-				__( 'Go to slide %s', 'jetpack' ),
-				i
-			);
-
-			markup +=
-				'<button ' +
-				'class="' +
-				cssClass +
-				'" ' +
-				'tab-index="0" ' +
-				'role="button" ' +
-				'aria-label="' +
-				ariaLabel +
-				'"></button>';
-		}
-	} else {
-		markup += `<div class="swiper-pagination-simple">${ current } / ${ total }</div>`;
-	}
-
-	return markup;
-}
 class Slideshow extends Component {
 	pendingRequestAnimationFrame = null;
 	resizeObserver = null;

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/view.js
@@ -2,7 +2,7 @@ import domReady from '@wordpress/dom-ready';
 import { forEach } from 'lodash';
 import ResizeObserver from 'resize-observer-polyfill';
 import createSwiper from './create-swiper';
-import { paginationCustomRender } from './slideshow';
+import { paginationCustomRender } from './pagination';
 import {
 	swiperApplyAria,
 	swiperInit,


### PR DESCRIPTION
As described in #28561,

> The Slideshow block currently loads the editor JS on every page view. This is a huge amount of JS, which severely affects page performance. The issue appears to have started with https://github.com/Automattic/jetpack/pull/27936, because `view.js` now imports from `slideshow.js`, which imports from the editor.
>
> This is a classic case of insufficient modularity; the function that `view.js` is importing from `slideshow.js` (`paginationCustomRender`) should be split into its own module, that doesn't depend on the editor.

This PR fixes the issue by moving the pagination code to its own module, instead of having it live in `slideshow.js`.

Fixes #28561

## Proposed changes:
* Move slideshow pagination code to its own module

### Other information:

- N/A Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None; this is a simple bugfix.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Create a simple page with a slideshow
2. Load the page on a browser, with DevTools open
3. Observe that the editor JS does not get loaded

