### PR TITLE
VideoPress: change the logic to enqueue video block scripts

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-register-and-enqueue-scripts
+++ b/projects/packages/videopress/changelog/update-videopress-register-and-enqueue-scripts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: change the logic to enqueue video block scripts

--- a/projects/packages/videopress/src/class-block-editor-extensions.php
+++ b/projects/packages/videopress/src/class-block-editor-extensions.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\VideoPress;
 
-use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Status\Host;
@@ -16,14 +15,6 @@ use Automattic\Jetpack\Status\Host;
  * VideoPress Extensions class.
  */
 class Block_Editor_Extensions {
-
-	/**
-	 * The handle used to enqueue the script
-	 *
-	 * @var string
-	 */
-	const SCRIPT_HANDLE = 'videopress-extensions';
-
 	/**
 	 * What version of the blocks we are loading.
 	 *
@@ -136,8 +127,6 @@ class Block_Editor_Extensions {
 	 * Enqueues the extensions script.
 	 */
 	public static function enqueue_extensions() {
-		self::enqueue_script();
-
 		$extensions_list = self::get_list();
 
 		$site_type = 'jetpack';
@@ -147,35 +136,22 @@ class Block_Editor_Extensions {
 			$site_type = 'atomic';
 		}
 
-		wp_localize_script(
-			self::SCRIPT_HANDLE,
-			'videoPressEditorState',
-			array(
-				'extensions'          => $extensions_list,
-				'siteType'            => $site_type,
-				'myJetpackConnectUrl' => admin_url( 'admin.php?page=my-jetpack#/connection' ),
-			)
-		);
-	}
-
-	/**
-	 * Enqueues only the JS script
-	 *
-	 * @param string $handle The script handle to identify the script.
-	 */
-	public static function enqueue_script( $handle = self::SCRIPT_HANDLE ) {
-		Assets::register_script(
-			$handle,
-			'../build/block-editor/index.js',
-			__FILE__,
-			array(
-				'in_footer'  => false,
-				'textdomain' => 'jetpack-videopress-pkg',
-			)
+		$videopress_editor_state = array(
+			'extensions'          => $extensions_list,
+			'siteType'            => $site_type,
+			'myJetpackConnectUrl' => admin_url( 'admin.php?page=my-jetpack#/connection' ),
 		);
 
-		Assets::enqueue_script( $handle );
+		/*
+		 * Use the videopress/video editor script handle to localize the script.
+		 * @see https://developer.wordpress.org/reference/functions/generate_block_asset_handle
+		 */
+		$handle = generate_block_asset_handle( 'videopress/video', 'editorScript' );
 
+		// Expose initital state of site connection
 		wp_add_inline_script( $handle, Connection_Initial_State::render(), 'before' );
+
+		// Expose initital state of videoPress editor
+		wp_localize_script( $handle, 'videoPressEditorState', $videopress_editor_state );
 	}
 }

--- a/projects/packages/videopress/src/class-block-editor-extensions.php
+++ b/projects/packages/videopress/src/class-block-editor-extensions.php
@@ -23,14 +23,30 @@ class Block_Editor_Extensions {
 	public static $blocks_variation = 'production';
 
 	/**
+	 * Script handle
+	 *
+	 * @var string
+	 */
+	public static $script_handle = '';
+
+	/**
 	 * Initializer
 	 *
-	 * This method should be called only once by the Initializer class. Do not call this method again.
+	 * This method should be called only once by the Block registrar.
+	 * Do not call this method again.
+	 *
+	 * @param array $block_metadata - The block metadata.
 	 */
-	public static function init() {
+	public static function init( $block_metadata ) {
 		if ( ! Status::is_active() ) {
 			return;
 		}
+
+		/*
+		 * Use the videopress/video editor script handle to localize enqueue scripts.
+		 * @see https://developer.wordpress.org/reference/functions/generate_block_asset_handle
+		 */
+		self::$script_handle = generate_block_asset_handle( $block_metadata->name, 'editorScript' );
 
 		/**
 		* Alternative to `JETPACK_BETA_BLOCKS`, set to `true` to load Beta Blocks.
@@ -142,16 +158,10 @@ class Block_Editor_Extensions {
 			'myJetpackConnectUrl' => admin_url( 'admin.php?page=my-jetpack#/connection' ),
 		);
 
-		/*
-		 * Use the videopress/video editor script handle to localize the script.
-		 * @see https://developer.wordpress.org/reference/functions/generate_block_asset_handle
-		 */
-		$handle = generate_block_asset_handle( 'videopress/video', 'editorScript' );
-
 		// Expose initital state of site connection
-		wp_add_inline_script( $handle, Connection_Initial_State::render(), 'before' );
+		wp_add_inline_script( self::$script_handle, Connection_Initial_State::render(), 'before' );
 
 		// Expose initital state of videoPress editor
-		wp_localize_script( $handle, 'videoPressEditorState', $videopress_editor_state );
+		wp_localize_script( self::$script_handle, 'videoPressEditorState', $videopress_editor_state );
 	}
 }

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -179,9 +179,6 @@ class Initializer {
 	 * @return void
 	 */
 	public static function register_videopress_video_block() {
-		// Register and enqueue scripts used by the VideoPress block.
-		Block_Editor_Extensions::init();
-
 		$videopress_video_metadata_file        = __DIR__ . '/../build/block-editor/blocks/video/block.json';
 		$videopress_video_metadata_file_exists = file_exists( $videopress_video_metadata_file );
 		if ( ! $videopress_video_metadata_file_exists ) {
@@ -195,6 +192,11 @@ class Initializer {
 
 		// Pick the block name straight from the block metadata .json file.
 		$videopress_video_block_name = $videopress_video_metadata->name;
+
+		// Register and enqueue scripts used by the VideoPress block.
+		Block_Editor_Extensions::init( $videopress_video_metadata );
+
+		// Do not register is the block is already registered.
 		if ( \WP_Block_Type_Registry::get_instance()->is_registered( $videopress_video_block_name ) ) {
 			return;
 		}

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -196,7 +196,7 @@ class Initializer {
 		// Register and enqueue scripts used by the VideoPress block.
 		Block_Editor_Extensions::init( $videopress_video_metadata );
 
-		// Do not register is the block is already registered.
+		// Do not register if the block is already registered.
 		if ( \WP_Block_Type_Registry::get_instance()->is_registered( $videopress_video_block_name ) ) {
 			return;
 		}

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -121,7 +121,6 @@ class Initializer {
 		VideoPress_Rest_Api_V1_Site::init();
 		VideoPress_Rest_Api_V1_Settings::init();
 		XMLRPC::init();
-		Block_Editor_Extensions::init();
 		Block_Editor_Content::init();
 		self::register_oembed_providers();
 		if ( self::should_initialize_admin_ui() ) {
@@ -180,6 +179,9 @@ class Initializer {
 	 * @return void
 	 */
 	public static function register_videopress_video_block() {
+		// Register and enqueue scripts used by the VideoPress block.
+		Block_Editor_Extensions::init();
+
 		$videopress_video_metadata_file        = __DIR__ . '/../build/block-editor/blocks/video/block.json';
 		$videopress_video_metadata_file_exists = file_exists( $videopress_video_metadata_file );
 		if ( ! $videopress_video_metadata_file_exists ) {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/style.scss
@@ -8,6 +8,7 @@
     padding: 0 16px;
 
     .block-banner__content {
+        color: #01283d;
         flex-grow: 2;
         margin: 0 8px;
     }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -45,7 +45,7 @@ import './editor.scss';
 const debug = debugFactory( 'videopress:video:edit' );
 
 // Get site type.
-const { siteType, myJetpackConnectUrl } = window.videoPressEditorState;
+const { siteType = '', myJetpackConnectUrl } = window?.videoPressEditorState || {};
 
 // Get connection intial state from the global window object.
 const initialState = window?.JP_CONNECTION_INITIAL_STATE;

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { useConnection } from '@automattic/jetpack-connection';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import {
 	BlockIcon,
@@ -45,7 +44,13 @@ import './editor.scss';
 
 const debug = debugFactory( 'videopress:video:edit' );
 
-const { myJetpackConnectUrl } = window.videoPressEditorState;
+// Get site type.
+const { siteType, myJetpackConnectUrl } = window.videoPressEditorState;
+
+// Get connection intial state from the global window object.
+const initialState = window?.JP_CONNECTION_INITIAL_STATE;
+// Set connection status based on site type and initial state, and the site type.
+const isUserConnected = siteType === 'simple' || initialState?.connectionStatus?.isUserConnected;
 
 const VIDEO_PREVIEW_ATTEMPTS_LIMIT = 10;
 
@@ -140,7 +145,6 @@ export default function VideoPressEdit( {
 	} );
 
 	// Get the redirect URI for the connection flow.
-	const { isUserConnected } = useConnection();
 	const [ isRedirectingToMyJetpack, setIsRedirectingToMyJetpack ] = useState( false );
 	/*
 	 * Request token when site is private

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -47,7 +47,7 @@ const debug = debugFactory( 'videopress:video:edit' );
 // Get site type.
 const { siteType = '', myJetpackConnectUrl } = window?.videoPressEditorState || {};
 
-// Get connection intial state from the global window object.
+// Get connection initial state from the global window object.
 const initialState = window?.JP_CONNECTION_INITIAL_STATE;
 // Set connection status based on site type and initial state, and the site type.
 const isUserConnected = siteType === 'simple' || initialState?.connectionStatus?.isUserConnected;

--- a/projects/packages/videopress/src/client/block-editor/global.d.ts
+++ b/projects/packages/videopress/src/client/block-editor/global.d.ts
@@ -9,5 +9,49 @@ declare global {
 			siteType: 'simple' | 'atomic' | 'jetpack';
 			myJetpackConnectUrl: string;
 		};
+
+		JP_CONNECTION_INITIAL_STATE: {
+			apiRoot: string;
+			apiNonce: string;
+			registrationNonce: string;
+			connectionStatus: {
+				isActive: boolean;
+				isStaging: boolean;
+				isRegistered: boolean;
+				isUserConnected: boolean;
+				hasConnectedOwner: boolean;
+				offlineMode: {
+					isActive: boolean;
+					constant: boolean;
+					url: boolean;
+					filter: boolean;
+					wpLocalConstant: boolean;
+				};
+				isPublic: boolean;
+			};
+			userConnectionData: {
+				currentUser: {
+					isConnected: boolean;
+					isMaster: boolean;
+					username: string;
+					id: number;
+					blogId: number;
+					wpcomUser: {
+						avatar: boolean;
+					};
+					gravatar: string;
+					permissions: {
+						connect: boolean;
+						connect_user: boolean;
+						disconnect: boolean;
+					};
+				};
+				connectionOwner: null;
+			};
+			connectedPlugins: object;
+			wpVersion: string;
+			siteSuffix: string;
+			connectionErrors: Array;
+		};
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR changes the logic to enqueue the relevant scripts used by the block editor to handle the behavior of the VideoPress video block, looking for:

* Ensure do not load scripts twice or more
* Use the same handle defined by the video block to enqueue the rest of them
* Ensure loading the scripts on all platforms

It fixes a bug that happens in Simple sites. The  `videoPressEditorState` is not provided by the server side to the client, generating an error when the client tries to destructure it:

![image](https://user-images.githubusercontent.com/77539/214809149-e2c5bf5a-1179-42e5-b0b5-6a292702139d.png)

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: change the logic to enqueue video block scripts

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Internal: p1674641635344319-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Ensure the `video/index` js file loads once (filter the files by `blocks/video`)
<img width="576" alt="image" src="https://user-images.githubusercontent.com/77539/214592515-261b12b8-f9e4-4ceb-8000-ca4aba25c041.png">

* Ensure the global `videoPressEditorState` var is defined
* Ensure the global `JP_CONNECTION_INITIAL_STATE` var is defined
* Test in all platforms