### PR TITLE
Blaze: avoid unnecessary requests for eligibility

### DIFF
--- a/projects/packages/blaze/changelog/fix-blaze-performance-request
+++ b/projects/packages/blaze/changelog/fix-blaze-performance-request
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid unnecessary requests for eligibility

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -166,7 +166,7 @@ class Blaze {
 	 * @return array
 	 */
 	public function jetpack_blaze_row_action( $post_actions, $post ) {
-		// no need on sites that do not support Blaze.
+		// Bail on sites that do not support Blaze.
 		if ( ! self::should_initialize() ) {
 			return $post_actions;
 		}
@@ -215,7 +215,7 @@ class Blaze {
 			return;
 		}
 
-		// No need on sites that do not support Blaze.
+		// Bail on sites that do not support Blaze.
 		if ( ! self::should_initialize() ) {
 			return;
 		}

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -42,10 +42,8 @@ class Blaze {
 	public function register() {
 
 		if ( ! did_action( 'jetpack_on_blaze_init' ) ) {
-			if ( self::should_initialize() ) {
-				add_filter( 'post_row_actions', array( $this, 'jetpack_blaze_row_action' ), 10, 2 );
-				add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_block_editor_assets' ) );
-			}
+			add_filter( 'post_row_actions', array( $this, 'jetpack_blaze_row_action' ), 10, 2 );
+			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_block_editor_assets' ) );
 
 			/**
 			 * Action called after initializing Blaze.
@@ -73,6 +71,11 @@ class Blaze {
 			return blaze_is_site_eligible( $blog_id );
 		}
 
+		$cached_result = get_transient( 'jetpack_blaze_site_supports_blaze_' . $blog_id );
+		if ( false !== $cached_result ) {
+			return $cached_result;
+		}
+
 		// Make the API request.
 		$url      = sprintf( '/sites/%d/blaze/status', $blog_id );
 		$response = Client::wpcom_json_api_request_as_blog(
@@ -95,6 +98,9 @@ class Blaze {
 		if ( ! is_array( $result ) || empty( $result['approved'] ) ) {
 			return false;
 		}
+
+		// Cache the result for 24 hours.
+		set_transient( 'jetpack_blaze_site_supports_blaze_' . $blog_id, (bool) $result['approved'], DAY_IN_SECONDS );
 
 		return (bool) $result['approved'];
 	}
@@ -160,6 +166,11 @@ class Blaze {
 	 * @return array
 	 */
 	public function jetpack_blaze_row_action( $post_actions, $post ) {
+		// no need on sites that do not support Blaze.
+		if ( ! self::should_initialize() ) {
+			return $post_actions;
+		}
+
 		$post_id = $post->ID;
 
 		if ( $post->post_status !== 'publish' ) {
@@ -201,6 +212,11 @@ class Blaze {
 		 * See #20357 for more info.
 		 */
 		if ( ! in_array( $hook, array( 'post.php', 'post-new.php' ), true ) ) {
+			return;
+		}
+
+		// No need on sites that do not support Blaze.
+		if ( ! self::should_initialize() ) {
 			return;
 		}
 

--- a/projects/packages/blaze/tests/php/test-blaze.php
+++ b/projects/packages/blaze/tests/php/test-blaze.php
@@ -83,16 +83,14 @@ class Test_Blaze extends BaseTestCase {
 	}
 
 	/**
-	 * Tests if the post_row action is added when the jetpack_blaze_enabled is overriding.
+	 * Tests if the post_row action is added when the package is registered.
 	 */
-	public function test_post_row_added_with_filter() {
+	public function test_post_row_added() {
 		$blaze = Blaze::get_instance();
 		$this->confirm_add_filters_and_actions_for_screen_starts_clean();
 
-		// This filter should override everything, even if it's not connected.
-		add_filter( 'jetpack_blaze_enabled', '__return_false' );
 		$blaze->register();
 
-		$this->assertFalse( has_action( 'post_row_actions' ) );
+		$this->assertNotFalse( has_action( 'post_row_actions' ) );
 	}
 }


### PR DESCRIPTION
## Proposed changes:

1. Do not make requests on the frontend by delaying when we check for eligibility.
2. Cache results for a day.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* 1557-gh-dotcom-forge

## Does this pull request change what data or activity we track or use?

* no

## Testing instructions:

* On a WoA site with the Jetpack Beta plugin, switch to this branch.
* Open an incognito window, and load the site's frontend. You should not see any Blaze request when clicking on the "Debug" button in the admin bar.
* Back logged in as admin, ensure the feature is still accessible in wp-admin/edit.php, when moving your mouse over the published posts. 

> **Note**
> For Blaze to work on your site, it should be in English and public.
