### PR TITLE
Fix node 18 compatibility

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1533,7 +1533,7 @@ importers:
       '@wordpress/i18n': 4.22.0
       concurrently: 6.0.2
       history: 5.3.0
-      jetpack-boost-critical-css-gen: github:automattic/jetpack-boost-critical-css-gen#release-0.0.4
+      jetpack-boost-critical-css-gen: github:automattic/jetpack-boost-critical-css-gen#release-0.0.6
       postcss: 8.4.21
       prettier: 2.6.2
       prettier-plugin-svelte: 2.8.1
@@ -1558,7 +1558,7 @@ importers:
       '@wordpress/components': 22.1.0_jc4nol2pc3xxtec3jthlyk5a5a
       '@wordpress/element': 4.20.0
       history: 5.3.0
-      jetpack-boost-critical-css-gen: github.com/automattic/jetpack-boost-critical-css-gen/91e0ed5e0cf6296fd06f525d1fc016d5d46af86f
+      jetpack-boost-critical-css-gen: github.com/automattic/jetpack-boost-critical-css-gen/799e6d78bbc14d51288ba929e59de0a624649e8b
       prettier: 2.6.2
       svelte-navigator: 3.1.5_blprp4ovaphqvsbuhbk2xnyjlu
     devDependencies:
@@ -12460,6 +12460,14 @@ packages:
       mdn-data: 2.0.14
       source-map: 0.6.1
 
+  /css-tree/2.3.1:
+    resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+    dependencies:
+      mdn-data: 2.0.30
+      source-map-js: 1.0.2
+    dev: false
+
   /css-what/6.1.0:
     resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
     engines: {node: '>= 6'}
@@ -15813,6 +15821,11 @@ packages:
       strip-ansi: 6.0.1
       through: 2.3.8
 
+  /install/0.13.0:
+    resolution: {integrity: sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA==}
+    engines: {node: '>= 0.10'}
+    dev: false
+
   /internal-slot/1.0.4:
     resolution: {integrity: sha512-tA8URYccNzMo94s5MQZgH8NB/XTa6HsOo0MLfXTKKEnHVVdegzaQoFZ7Jp44bdvLvY2waT5dc+j5ICEswhi7UQ==}
     engines: {node: '>= 0.4'}
@@ -17740,6 +17753,10 @@ packages:
   /mdn-data/2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
 
+  /mdn-data/2.0.30:
+    resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+    dev: false
+
   /mdurl/1.0.1:
     resolution: {integrity: sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==}
 
@@ -18144,6 +18161,86 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       path-key: 3.1.1
+
+  /npm/8.19.3:
+    resolution: {integrity: sha512-0QjmyPtDxSyMWWD8I91QGbrgx9KzbV6C9FK1liEb/K0zppiZkr5KxXc990G+LzPwBHDfRjUBlO9T1qZ08vl9mA==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    hasBin: true
+    dev: false
+    bundledDependencies:
+      - '@isaacs/string-locale-compare'
+      - '@npmcli/arborist'
+      - '@npmcli/ci-detect'
+      - '@npmcli/config'
+      - '@npmcli/fs'
+      - '@npmcli/map-workspaces'
+      - '@npmcli/package-json'
+      - '@npmcli/run-script'
+      - abbrev
+      - archy
+      - cacache
+      - chalk
+      - chownr
+      - cli-columns
+      - cli-table3
+      - columnify
+      - fastest-levenshtein
+      - fs-minipass
+      - glob
+      - graceful-fs
+      - hosted-git-info
+      - ini
+      - init-package-json
+      - is-cidr
+      - json-parse-even-better-errors
+      - libnpmaccess
+      - libnpmdiff
+      - libnpmexec
+      - libnpmfund
+      - libnpmhook
+      - libnpmorg
+      - libnpmpack
+      - libnpmpublish
+      - libnpmsearch
+      - libnpmteam
+      - libnpmversion
+      - make-fetch-happen
+      - minimatch
+      - minipass
+      - minipass-pipeline
+      - mkdirp
+      - mkdirp-infer-owner
+      - ms
+      - node-gyp
+      - nopt
+      - npm-audit-report
+      - npm-install-checks
+      - npm-package-arg
+      - npm-pick-manifest
+      - npm-profile
+      - npm-registry-fetch
+      - npm-user-validate
+      - npmlog
+      - opener
+      - p-map
+      - pacote
+      - parse-conflict-json
+      - proc-log
+      - qrcode-terminal
+      - read
+      - read-package-json
+      - read-package-json-fast
+      - readdir-scoped-modules
+      - rimraf
+      - semver
+      - ssri
+      - tar
+      - text-table
+      - tiny-relative-date
+      - treeverse
+      - validate-npm-package-name
+      - which
+      - write-file-atomic
 
   /npmlog/5.0.1:
     resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
@@ -23629,16 +23726,15 @@ packages:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
     dev: true
 
-  github.com/automattic/jetpack-boost-critical-css-gen/91e0ed5e0cf6296fd06f525d1fc016d5d46af86f:
-    resolution: {tarball: https://codeload.github.com/automattic/jetpack-boost-critical-css-gen/tar.gz/91e0ed5e0cf6296fd06f525d1fc016d5d46af86f}
+  github.com/automattic/jetpack-boost-critical-css-gen/799e6d78bbc14d51288ba929e59de0a624649e8b:
+    resolution: {tarball: https://codeload.github.com/automattic/jetpack-boost-critical-css-gen/tar.gz/799e6d78bbc14d51288ba929e59de0a624649e8b}
     name: jetpack-boost-critical-css-gen
-    version: 0.0.4
+    version: 0.0.6
     prepare: true
     requiresBuild: true
     dependencies:
       clean-css: 5.3.1
-      css-tree: 1.1.3
-      node-fetch: 2.6.7
-    transitivePeerDependencies:
-      - encoding
+      css-tree: 2.3.1
+      install: 0.13.0
+      npm: 8.19.3
     dev: false

--- a/projects/plugins/boost/changelog/boost-fix-node-18-compatibility
+++ b/projects/plugins/boost/changelog/boost-fix-node-18-compatibility
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Updated Jetpack Boost dependencies to support Node 18
+
+

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -10,7 +10,7 @@
 		"@wordpress/components": "22.1.0",
 		"@wordpress/element": "4.20.0",
 		"history": "5.3.0",
-		"jetpack-boost-critical-css-gen": "github:automattic/jetpack-boost-critical-css-gen#release-0.0.4",
+		"jetpack-boost-critical-css-gen": "github:automattic/jetpack-boost-critical-css-gen#release-0.0.6",
 		"prettier": "2.6.2",
 		"svelte-navigator": "3.1.5"
 	},


### PR DESCRIPTION
This fixes Node 18 compatibility issues that come up with a fresh monorepo install:

```
pnpm i
Scope: all 68 workspace projects
Lockfile is up to date, resolution step is skipped
Packages: +2439
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Packages are hard linked from the content-addressable store to the virtual store.
  Content-addressable store is at: /Users/a14/Library/pnpm/store/v3
  Virtual store is at:             node_modules/.pnpm
../../../Library/pnpm/store/v3/tmp/_tmp_5764_9532727db424d5de852132277deb98cc [jetpack-boost-critical-css-gen@0.0.4]: Running npm-install script, failed in 763ms
...5764_9532727db424d5de852132277deb98cc npm-install$ npm install
│ npm ERR! code EBADENGINE
│ npm ERR! engine Unsupported engine
│ npm ERR! engine Not compatible with your version of node/npm: @es-joy/jsdoccomment@0.10.8
│ npm ERR! notsup Not compatible with your version of node/npm: @es-joy/jsdoccomment@0.10.8
│ npm ERR! notsup Required: {"node":"^12 || ^14 || ^16"}
│ npm ERR! notsup Actual:   {"npm":"8.19.3","node":"v18.13.0"}
│ npm ERR! A complete log of this run can be found in:
│ npm ERR!     /Users/a14/.npm/_logs/2023-01-25T17_30_59_353Z-debug-0.log
└─ Failed in 763ms at /Users/a14/Library/pnpm/store/v3/tmp/_tmp_5764_9532727db424d5de852132277deb98cc
 ERR_PNPM_PREPARE_PACKAGE  Failed to prepare git-hosted package fetched from "https://codeload.github.com/automattic/jetpack-boost-critical-css-gen/tar.gz/91e0ed5e0cf6296fd06f525d1fc016d5d46af86f": jetpack-boost-critical-css-gen@0.0.4 npm-install: `npm install`
Exit status 1
Progress: resolved 2439, reused 2315, downloaded 0, added 144
```

Related:
https://github.com/Automattic/jetpack-boost-critical-css-gen/pull/35

## Proposed changes:
Updated `jetpack-boost-critical-css-gen` dependency version to support Node v18
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1674650430613589-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

Install Node 18

```
rm -rf node_modules
pnpm store prune
pnpm install
```