### PR TITLE
Show ai content as regular blocks

### DIFF
--- a/projects/plugins/jetpack/changelog/ai-add-editable-paragraph
+++ b/projects/plugins/jetpack/changelog/ai-add-editable-paragraph
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add editable paragraphs to experimental ai-paragraph block.

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/attributes.js
@@ -1,17 +1,8 @@
-// Added state because with the way gutenberg works, replacing the inner blocks
-// doesn't mark the block as dirty, we need to update an attribute after the
-// inner blocks have been replaced.  This makes the preview button work after
-// the block is rendered.
-export const STATE = Object.freeze( {
-	DEFAULT: '',
-	PROCESSING: 'processing',
-	RENDERING: 'rendering',
-	DONE: 'done',
-} );
+import { STATE } from './state';
 
 export default {
 	state: {
-		enum: [ STATE.DEFAULT, STATE.PROCESSING, STATE.RENDERING, STATE.DONE ],
+		enum: [ ...Object.values( STATE ) ],
 		default: STATE.DEFAULT,
 	},
 };

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/attributes.js
@@ -1,6 +1,17 @@
+// Added state because with the way gutenberg works, replacing the inner blocks
+// doesn't mark the block as dirty, we need to update an attribute after the
+// inner blocks have been replaced.  This makes the preview button work after
+// the block is rendered.
+export const STATE = Object.freeze( {
+	DEFAULT: '',
+	PROCESSING: 'processing',
+	RENDERING: 'rendering',
+	DONE: 'done',
+} );
+
 export default {
-	triggered: {
-		type: 'boolean',
-		default: false,
+	state: {
+		enum: [ STATE.DEFAULT, STATE.PROCESSING, STATE.RENDERING, STATE.DONE ],
+		default: STATE.DEFAULT,
 	},
 };

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/attributes.js
@@ -3,8 +3,4 @@ export default {
 		type: 'boolean',
 		default: false,
 	},
-	animationDone: {
-		type: 'boolean',
-		default: false,
-	},
 };

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/attributes.js
@@ -1,7 +1,7 @@
 export default {
-	content: {
-		type: 'string',
-		source: 'html',
+	triggered: {
+		type: 'boolean',
+		default: false,
 	},
 	animationDone: {
 		type: 'boolean',

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/deprecated/v1.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/deprecated/v1.js
@@ -1,5 +1,6 @@
 import { useBlockProps } from '@wordpress/block-editor';
 import { pasteHandler } from '@wordpress/blocks';
+import { RawHTML } from '@wordpress/element';
 
 export default {
 	attributes: {
@@ -15,7 +16,7 @@ export default {
 	},
 	save: ( { attributes: { content } } ) => {
 		const blockProps = useBlockProps.save();
-		return <div { ...blockProps }>{ content }</div>;
+		return <RawHTML { ...blockProps }>{ content }</RawHTML>;
 	},
 	migrate: ( { content } ) => {
 		const parsedBlocks = pasteHandler( {

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/deprecated/v1.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/deprecated/v1.js
@@ -1,0 +1,45 @@
+import { useBlockProps } from '@wordpress/block-editor';
+import { pasteHandler } from '@wordpress/blocks';
+
+/**
+ * Example data to migrate:
+ * ```
+ * <!-- wp:paragraph -->
+ * <p>GPT generates a block for testing.  This block should be an interesting but somewhat obscure fact regarding pirates and their constant battles with ninjas.</p>
+ * <!-- /wp:paragraph -->
+ *
+ * <!-- wp:jetpack/ai-paragraph {"animationDone":true} -->
+ * <div class="wp-block-jetpack-ai-paragraph">Pirates and ninjas shared a common enemy during the Age of Exploration: samurai. Both pirates and ninjas were constantly engaged in a battle of wits to outsmart the samurai and escape their grip. The pirates and ninjas often ended up teaming up in order to evade the samurai, swapping knowledge and resources and even joining forces to achieve greater strength. This was a highly effective strategy, as the samurai were no match for the combined strength of the two groups.</div>
+ * <!-- /wp:jetpack/ai-paragraph -->
+ * ```
+ */
+export default {
+	attributes: {
+		content: {
+			type: 'string',
+			source: 'html',
+			selector: 'div',
+		},
+		animationDone: {
+			type: 'boolean',
+			default: false,
+		},
+	},
+	save: ( { attributes: { content } } ) => {
+		const blockProps = useBlockProps.save();
+		return <div { ...blockProps }>{ content }</div>;
+	},
+	migrate: ( { content } ) => {
+		const parsedBlocks = pasteHandler( {
+			HTML: '',
+			mode: 'BLOCKS',
+			plainText: content,
+		} );
+		return [
+			{
+				state: 'done',
+			},
+			parsedBlocks,
+		];
+	},
+};

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/deprecated/v1.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/deprecated/v1.js
@@ -1,18 +1,6 @@
 import { useBlockProps } from '@wordpress/block-editor';
 import { pasteHandler } from '@wordpress/blocks';
 
-/**
- * Example data to migrate:
- * ```
- * <!-- wp:paragraph -->
- * <p>GPT generates a block for testing.  This block should be an interesting but somewhat obscure fact regarding pirates and their constant battles with ninjas.</p>
- * <!-- /wp:paragraph -->
- *
- * <!-- wp:jetpack/ai-paragraph {"animationDone":true} -->
- * <div class="wp-block-jetpack-ai-paragraph">Pirates and ninjas shared a common enemy during the Age of Exploration: samurai. Both pirates and ninjas were constantly engaged in a battle of wits to outsmart the samurai and escape their grip. The pirates and ninjas often ended up teaming up in order to evade the samurai, swapping knowledge and resources and even joining forces to achieve greater strength. This was a highly effective strategy, as the samurai were no match for the combined strength of the two groups.</div>
- * <!-- /wp:jetpack/ai-paragraph -->
- * ```
- */
 export default {
 	attributes: {
 		content: {

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/edit.js
@@ -8,7 +8,6 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useEffect, useCallback } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import { pasteHandler } from '@wordpress/blocks';
-import MarkdownIt from 'markdown-it';
 import classNames from 'classnames';
 import { name as aiParagraphBlockName } from './index';
 
@@ -256,10 +255,9 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 
 	const updateInnerBlocks = useCallback(
 		source => {
-			const md = new MarkdownIt();
 			// Get a list of inner blocks
 			const newInnerBlocks = pasteHandler( {
-				HTML: md.render( source ),
+				HTML: '',
 				mode: 'BLOCKS',
 				plainText: source,
 			} );

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/edit.js
@@ -3,11 +3,11 @@ import './editor.scss';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import apiFetch from '@wordpress/api-fetch';
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+import { pasteHandler } from '@wordpress/blocks';
 import { Placeholder, Button, Spinner } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useEffect, useCallback } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
-import { pasteHandler } from '@wordpress/blocks';
 import classNames from 'classnames';
 import { name as aiParagraphBlockName } from './index';
 
@@ -270,7 +270,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 	// At this point this is an established pattern.
 	useEffect( () => {
 		// If the content is not loaded, we do nothing.
-		if ( ! content ) {
+		if ( ! content || ! triggered ) {
 			return;
 		}
 
@@ -286,10 +286,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 		setTimeout( () => {
 			updateInnerBlocks( content );
 		}, 50 * tokens.length );
-	}, [ triggered ] ); // eslint-disable-line react-hooks/exhaustive-deps
-
-	// Fix the inner blocks (they can only be of this type).
-	const TEMPLATE = [ [ 'jetpack/markdown', {} ] ];
+	}, [ triggered, content ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	// Used for styling the block in the editor.
 	const classes = classNames( {
@@ -301,7 +298,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 
 	return (
 		<div { ...blockProps }>
-			<InnerBlocks templateLock="all" />
+			<InnerBlocks />
 
 			{ ! isLoadingCompletion && ! isLoadingCategories && errorMessage && (
 				<Placeholder label={ __( 'AI Paragraph', 'jetpack' ) } instructions={ errorMessage }>

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/edit.js
@@ -154,8 +154,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 	};
 
 	const getSuggestionFromOpenAI = () => {
-		console.log( 'triggered', triggered );
-		if ( !! content || isLoadingCompletion || triggered) {
+		if ( !! content || isLoadingCompletion || triggered ) {
 			return;
 		}
 
@@ -253,12 +252,15 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 
 	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
 
-	const updateInnerBlocks = useCallback( content => {
-		const paragraph = innerBlocks[ 0 ];
-		if ( paragraph && content ) {
-			updateBlockAttributes( paragraph.clientId, { source: content } );
-		}
-	}, [ innerBlocks ] );
+	const updateInnerBlocks = useCallback(
+		source => {
+			const paragraph = innerBlocks[ 0 ];
+			if ( paragraph && source ) {
+				updateBlockAttributes( paragraph.clientId, { source } );
+			}
+		},
+		[ innerBlocks ] // eslint-disable-line react-hooks/exhaustive-deps
+	);
 
 	// This is to animate text input. This will give an idea of a "better" AI.
 	// At this point this is an established pattern.
@@ -280,7 +282,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 		setTimeout( () => {
 			updateInnerBlocks( content );
 		}, 50 * tokens.length );
-	}, [ triggered ] );
+	}, [ triggered ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	// Fix the inner blocks (they can only be of this type).
 	const TEMPLATE = [ [ 'jetpack/markdown', {} ] ];
@@ -295,9 +297,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 
 	return (
 		<div { ...blockProps }>
-			<InnerBlocks
-				template={ TEMPLATE }
-				templateLock="all"/>
+			<InnerBlocks template={ TEMPLATE } templateLock="all" />
 
 			{ ! isLoadingCompletion && ! isLoadingCategories && errorMessage && (
 				<Placeholder label={ __( 'AI Paragraph', 'jetpack' ) } instructions={ errorMessage }>

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/edit.js
@@ -103,9 +103,8 @@ export default function Edit( { attributes: { state }, setAttributes, clientId }
 	 * isWaitingForAI: if OpenAI request is in progress.
 	 * isReadyToRetry: if the block is in an error state and can be retried.
 	 */
-	const { isError, isTriggered, isDoneLoading, isWaitingForAI, isReadyToRetry } = deriveStates(
-		state
-	);
+	const { isError, isTriggered, isDoneLoading, isWaitingForAI, isReadyToRetry } =
+		deriveStates( state );
 
 	// Let's grab post data so that we can do something smart.
 	const currentPostTitle = useSelect( select =>

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/edit.js
@@ -260,28 +260,32 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 		}
 	}, [ innerBlocks ] );
 
+	// This is to animate text input. This will give an idea of a "better" AI.
+	// At this point this is an established pattern.
 	useEffect( () => {
+		// If the content is not loaded, we do nothing.
 		if ( ! content ) {
 			return;
 		}
 
-		// This is to animate text input. I think this will give an idea of a "better" AI.
-		// At this point this is an established pattern.
+		// Break the content into words
 		const tokens = content.split( ' ' );
+
+		// For each word, update the inner block content.
 		for ( let i = 1; i < tokens.length; i++ ) {
 			const output = tokens.slice( 0, i ).join( ' ' );
 			setTimeout( () => updateInnerBlocks( output ), 50 * i );
 		}
+		// Finally set the inner block to the full content.
 		setTimeout( () => {
 			updateInnerBlocks( content );
 		}, 50 * tokens.length );
 	}, [ triggered ] );
 
-	// Sets the inner blocks to a single paragraph block.
-
-	console.log( 'clientId', clientId );
+	// Fix the inner blocks (they can only be of this type).
 	const TEMPLATE = [ [ 'jetpack/markdown', {} ] ];
 
+	// Used for styling the block in the editor.
 	const classes = classNames( {
 		triggered,
 	} );

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/edit.js
@@ -178,7 +178,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 			data: data,
 		} )
 			.then( res => {
-				const result = res.prompts[ 0 ].text.trim().replaceAll( '\n', '<br/>' );
+				const result = res.prompts[ 0 ].text.trim();
 				setContent( result );
 				setAttributes( { triggered: true } );
 				setIsLoadingCompletion( false );
@@ -256,7 +256,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 	const updateInnerBlocks = useCallback( content => {
 		const paragraph = innerBlocks[ 0 ];
 		if ( paragraph && content ) {
-			updateBlockAttributes( paragraph.clientId, { content } );
+			updateBlockAttributes( paragraph.clientId, { source: content } );
 		}
 	}, [ innerBlocks ] );
 
@@ -280,7 +280,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 	// Sets the inner blocks to a single paragraph block.
 
 	console.log( 'clientId', clientId );
-	const TEMPLATE = [ [ 'core/paragraph', {} ] ];
+	const TEMPLATE = [ [ 'jetpack/markdown', {} ] ];
 
 	const classes = classNames( {
 		triggered,

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/editor.scss
@@ -2,9 +2,3 @@
  * Editor styles for Jetpack AI Paragraph
  */
 
- /* Hide the inner blocks until the AI paragraph is triggered */
-.wp-block-jetpack-ai-paragraph.state- .block-editor-inner-blocks,
-.wp-block-jetpack-ai-paragraph.state-processing .block-editor-inner-blocks
-{
-	display: none;
-}

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/editor.scss
@@ -2,18 +2,9 @@
  * Editor styles for Jetpack AI Paragraph
  */
 
-.wp-block-ai-generate-suggestion {
-	padding: 0;
+ /* Hide the inner blocks until the AI paragraph is triggered */
+.wp-block-jetpack-ai-paragraph.state- .block-editor-inner-blocks,
+.wp-block-jetpack-ai-paragraph.state-processing .block-editor-inner-blocks
+{
+	display: none;
 }
-
-.wp-block-ai-generate-suggestion .content {}
-
-.wp-block-ai-generate-suggestion .components-text-control__input {
-	margin: 10px;
-	width:80%;
-}
-
-.wp-block-ai-generate-suggestion .components-button.is-primary {
-	margin: 10px;
-}
-

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/editor.scss
@@ -16,3 +16,11 @@
 .wp-block-ai-generate-suggestion .components-button.is-primary {
 	margin: 10px;
 }
+
+/* Hide the inner blocks until the AI paragraph is triggered */
+.wp-block-jetpack-ai-paragraph:not(.triggered) .block-editor-inner-blocks {
+	display: none;
+}
+.triggered .block-editor-inner-blocks {
+	display: block;
+}

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/editor.scss
@@ -17,10 +17,3 @@
 	margin: 10px;
 }
 
-/* Hide the inner blocks until the AI paragraph is triggered */
-.wp-block-jetpack-ai-paragraph:not(.triggered) .block-editor-inner-blocks {
-	display: none;
-}
-.triggered .block-editor-inner-blocks {
-	display: block;
-}

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
@@ -2,7 +2,7 @@ import { getRedirectUrl } from '@automattic/jetpack-components';
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { ExternalLink } from '@wordpress/components';
-import { Fragment, RawHTML } from '@wordpress/element';
+import { Fragment } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { getIconColor } from '../../shared/block-icons';
 import attributes from './attributes';
@@ -71,7 +71,7 @@ export const settings = {
 		reusable: false,
 	},
 	edit,
-	save: attrs => {
+	save: () => {
 		const blockProps = useBlockProps.save();
 		return (
 			<div { ...blockProps }>

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
@@ -1,5 +1,5 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { useBlockProps } from '@wordpress/block-editor';
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { ExternalLink } from '@wordpress/components';
 import { Fragment, RawHTML } from '@wordpress/element';
@@ -73,7 +73,11 @@ export const settings = {
 	edit,
 	save: attrs => {
 		const blockProps = useBlockProps.save();
-		return <RawHTML { ...blockProps }>{ attrs.attributes.content }</RawHTML>;
+		return (
+			<div { ...blockProps }>
+				<InnerBlocks.Content />
+			</div>
+		);
 	},
 	attributes,
 	transforms: {

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
@@ -6,6 +6,7 @@ import { Fragment } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { getIconColor } from '../../shared/block-icons';
 import attributes from './attributes';
+import v1 from './deprecated/v1';
 import edit from './edit';
 
 /**
@@ -99,4 +100,5 @@ export const settings = {
 			content: __( "I'm afraid I can't do that, Dave.", 'jetpack' ),
 		},
 	},
+	deprecated: [ v1 ],
 };

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
@@ -94,9 +94,16 @@ export const settings = {
 	},
 	example: {
 		attributes: {
-			animationDone: false,
-			content: __( "I'm afraid I can't do that, Dave.", 'jetpack' ),
+			state: 'done',
 		},
+		innerBlocks: [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: "I'm afraid I can't do that, Dave.",
+				},
+			},
+		],
 	},
 	deprecated: [ v1 ],
 };

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
@@ -85,11 +85,9 @@ export const settings = {
 		to: [
 			{
 				type: 'block',
-				blocks: [ 'core/paragraph' ],
-				transform: ( { content } ) => {
-					return createBlock( 'core/paragraph', {
-						content,
-					} );
+				blocks: [ 'core/group' ],
+				transform: ( _attributes, innerBlocks ) => {
+					return createBlock( 'core/group', {}, innerBlocks );
 				},
 			},
 		],

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
@@ -1,5 +1,5 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { ExternalLink } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
@@ -73,11 +73,11 @@ export const settings = {
 	edit,
 	save: () => {
 		const blockProps = useBlockProps.save();
-		return (
-			<div { ...blockProps }>
-				<InnerBlocks.Content />
-			</div>
-		);
+		const innerBlockProps = useInnerBlocksProps.save( {
+			...blockProps,
+			className: 'wp-block-group__inner-container',
+		} );
+		return <div { ...innerBlockProps } />;
 	},
 	attributes,
 	transforms: {

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/state.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/state.js
@@ -1,0 +1,30 @@
+// Added state because with the way gutenberg works, replacing the inner blocks
+// doesn't mark the block as dirty, we need to update an attribute after the
+// inner blocks have been replaced.  This makes the preview button work after
+// the block is rendered.
+export const STATE = Object.freeze( {
+	DEFAULT: '',
+	PROCESSING: 'processing',
+	RENDERING: 'rendering',
+	DONE: 'done',
+	ERROR: 'error',
+	RETRY: 'retry',
+} );
+
+export const ERROR_STATES = [ STATE.ERROR, STATE.RETRY ];
+export const WAITING_STATES = [ STATE.PROCESSING ];
+export const TRIGGERED_STATES = [ STATE.PROCESSING, STATE.RENDERING, STATE.DONE ];
+export const UNTRIGGERED_STATES = [ STATE.DEFAULT, STATE.ERROR, STATE.RETRY ];
+export const DONE_LOADING_STATES = [ STATE.RENDERING, STATE.DONE ];
+export const READY_TO_RETRY_STATES = [ STATE.RETRY ];
+
+export function deriveStates( state ) {
+	return {
+		isError: ERROR_STATES.includes( state ),
+		isTriggered: TRIGGERED_STATES.includes( state ),
+		isUntriggered: UNTRIGGERED_STATES.includes( state ),
+		isDoneLoading: DONE_LOADING_STATES.includes( state ),
+		isWaitingForAI: WAITING_STATES.includes( state ),
+		isReadyToRetry: READY_TO_RETRY_STATES.includes( state ),
+	};
+}


### PR DESCRIPTION
Fixes #28384

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the content attribute for the ai-paragraph and use a paragraph block for storing the returned data from openAI.

## Testing instructions:
1. Apply to your sandbox with `bin/jetpack-downloader test jetpack ai/add-editable-paragraph`.
2. Load your sandboxed site and test the ai-paragraph block as outlined below.

## Does this pull request change what data or activity we track or use?

No

## Things to test:
- [x] Try creating an open ai block with no content (no title, no tags, no categories). You should see an error message without a retry box.  After you've added some content the retry should appear.
- [x] Force the block into an error state by using the code editor and changing state to "retry". This error state adds a generic message and shows the retry button.  Using "error" as state will not show the retry button.
- [x] Open an old ai-paragraph block.  The migration should work. (The new block will have a single `InnerBlock` of a paragraph). An example old ai-paragraph block can be found here: 2f768-pb - This can be pasted into the code editor.
- [x] Create a new ai-paragraph block. After it gets created you should be able to edit it like a normal post.
- [x] After the new block is created, the preview should display correctly.
- [x] The AI block now transforms itself into the group block correctly (just passes the `innerBlocks` into a new group block).