### PR TITLE
WordPress.com reminder comment: add line breaks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,11 @@ jobs:
           script: |
             const { BRANCH_NAME, COMMENT_ID, TEST_COMMENT_INDICATOR } = process.env;
             const commentBody = `${ TEST_COMMENT_INDICATOR }
-            Are you an Automattician? You can now test your Pull Request on WordPress.com. On your sandbox, run \`bin/jetpack-downloader test jetpack ${ BRANCH_NAME }\` to get started. More details: p9dueE-5Nn-p2`;
+            Are you an Automattician? You can now test your Pull Request on WordPress.com. On your sandbox, run
+            \`\`\`
+            bin/jetpack-downloader test jetpack ${ BRANCH_NAME }
+            \`\`\`
+            to get started. More details: p9dueE-5Nn-p2`;
             await github.rest.issues.updateComment( {
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Proposed changes:

This should make it easier to copy the command from the GitHub comment.
See p1674724281751579-slack-CBG1CP4EN

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Not much to test here until this gets merged, I'm afraid.
