### PR TITLE
[AI] Add/sanitize openai input

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
@@ -56,8 +56,15 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 					'permission_callback' => array( 'Jetpack_AI_Helper', 'get_status_permission_check' ),
 				),
 				'args' => array(
-					'content' => array( 'required' => true ),
-					'post_id' => array( 'required' => false ),
+					'content' => array(
+						'type'              => 'string',
+						'required'          => true,
+						'sanitize_callback' => 'sanitize_textarea_field',
+					),
+					'post_id' => array(
+						'required' => false,
+						'type'     => 'integer',
+					),
 				),
 			)
 		);
@@ -71,8 +78,15 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 					'permission_callback' => array( 'Jetpack_AI_Helper', 'get_status_permission_check' ),
 				),
 				'args' => array(
-					'prompt'  => array( 'required' => true ),
-					'post_id' => array( 'required' => false ),
+					'prompt'  => array(
+						'type'              => 'string',
+						'required'          => true,
+						'sanitize_callback' => 'sanitize_textarea_field',
+					),
+					'post_id' => array(
+						'required' => false,
+						'type'     => 'integer',
+					),
 				),
 			)
 		);
@@ -84,7 +98,7 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 	 * @param  WP_REST_Request $request The request.
 	 */
 	public function request_gpt_completion( $request ) {
-		return Jetpack_AI_Helper::get_gpt_completion( sanitize_textarea_field( $request['content'] ), $request['post_id'] );
+		return Jetpack_AI_Helper::get_gpt_completion( $request['content'], $request['post_id'] );
 	}
 
 	/**
@@ -93,7 +107,7 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 	 * @param  WP_REST_Request $request The request.
 	 */
 	public function request_dalle_generation( $request ) {
-		return Jetpack_AI_Helper::get_dalle_generation( sanitize_textarea_field( $request['prompt'] ), $request['post_id'] );
+		return Jetpack_AI_Helper::get_dalle_generation( $request['prompt'], $request['post_id'] );
 	}
 }
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
@@ -84,7 +84,7 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 	 * @param  WP_REST_Request $request The request.
 	 */
 	public function request_gpt_completion( $request ) {
-		return Jetpack_AI_Helper::get_gpt_completion( $request['content'], $request['post_id'] );
+		return Jetpack_AI_Helper::get_gpt_completion( sanitize_textarea_field( $request['content'] ), $request['post_id'] );
 	}
 
 	/**
@@ -93,7 +93,7 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 	 * @param  WP_REST_Request $request The request.
 	 */
 	public function request_dalle_generation( $request ) {
-		return Jetpack_AI_Helper::get_dalle_generation( $request['prompt'], $request['post_id'] );
+		return Jetpack_AI_Helper::get_dalle_generation( sanitize_textarea_field( $request['prompt'] ), $request['post_id'] );
 	}
 }
 

--- a/projects/plugins/jetpack/changelog/add-sanitize-openai-input
+++ b/projects/plugins/jetpack/changelog/add-sanitize-openai-input
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Sanitize AI endpoints input


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes @fgiannar [comment](https://github.com/Automattic/jetpack/pull/28309#issuecomment-1387300514)

## Does this pull request change what data or activity we track or use?

No

## Proposed changes:

* Sanitize endpoints inputs

## Testing instructions

- Deploy to your WPCOM sandbox.
- Make sure the AI blocks are still working

<img width="858" alt="Screenshot 2023-01-26 at 11 16 36" src="https://user-images.githubusercontent.com/790558/214811347-7a1ea7f2-875a-498e-b78c-57f3ba8f5e23.png">
