### PR TITLE
VideoPress: show Connect banner above video player when the site is not connected 

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-show-connect-banner-in-player-too
+++ b/projects/packages/videopress/changelog/update-videopress-show-connect-banner-in-player-too
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: show Connect banner above video player when the site is not connected

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/connect-banner.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/connect-banner.tsx
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import Banner from './';
+/**
+ * Types
+ */
+import type React from 'react';
+
+type ConnectBannerProps = {
+	isConnected: boolean;
+	isConnecting: boolean;
+	onConnect: () => void;
+};
+
+/**
+ * Connect Banner component
+ *
+ * @param {ConnectBannerProps} props - component props
+ * @returns {React.ReactElement}       Connect banner component.
+ */
+export default function ConnectBanner( {
+	onConnect,
+	isConnected,
+	isConnecting,
+}: ConnectBannerProps ): React.ReactElement {
+	if ( isConnected ) {
+		return null;
+	}
+
+	let connectButtonText = __( 'Connect', 'jetpack-videopress-pkg' );
+	if ( isConnecting ) {
+		connectButtonText = __( 'Redirecting…', 'jetpack-videopress-pkg' );
+	}
+
+	return (
+		<Banner
+			action={
+				<Button
+					variant="primary"
+					onClick={ onConnect }
+					disabled={ isConnecting }
+					isBusy={ isConnecting }
+				>
+					{ connectButtonText }
+				</Button>
+			}
+		>
+			{ __( 'Connect your account to continue using VideoPress', 'jetpack-videopress-pkg' ) }
+		</Banner>
+	);
+}

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -22,7 +22,7 @@ import debugFactory from 'debug';
 import getMediaToken from '../../../lib/get-media-token';
 import { buildVideoPressURL, getVideoPressUrl } from '../../../lib/url';
 import { useSyncMedia } from '../../hooks/use-video-data-update';
-import Banner from './components/banner';
+import ConnectBanner from './components/banner/connect-banner';
 import ColorPanel from './components/color-panel';
 import DetailsPanel from './components/details-panel';
 import { VideoPressIcon } from './components/icons';
@@ -427,36 +427,18 @@ export default function VideoPressEdit( {
 			setAttributes( { id: newVideoData.id, guid: newVideoData.guid, title: newVideoData.title } );
 		};
 
-		let connectButtonText = __( 'Connect', 'jetpack-videopress-pkg' );
-		if ( isRedirectingToMyJetpack ) {
-			connectButtonText = __( 'Redirecting…', 'jetpack-videopress-pkg' );
-		}
-
 		return (
 			<div { ...blockProps } className={ blockMainClassName }>
 				<>
-					{ ! isUserConnected && (
-						<Banner
-							action={
-								<Button
-									variant="primary"
-									onClick={ () => {
-										setIsRedirectingToMyJetpack( true );
-										window.location.href = myJetpackConnectUrl;
-									} }
-									disabled={ isRedirectingToMyJetpack }
-									isBusy={ isRedirectingToMyJetpack }
-								>
-									{ connectButtonText }
-								</Button>
-							}
-						>
-							{ __(
-								'Connect your account to continue using VideoPress',
-								'jetpack-videopress-pkg'
-							) }
-						</Banner>
-					) }
+					<ConnectBanner
+						isConnected={ isUserConnected }
+						isConnecting={ isRedirectingToMyJetpack }
+						onConnect={ () => {
+							setIsRedirectingToMyJetpack( true );
+							window.location.href = myJetpackConnectUrl;
+						} }
+					/>
+
 					<VideoPressUploader
 						setAttributes={ setAttributes }
 						attributes={ attributes }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -584,6 +584,15 @@ export default function VideoPressEdit( {
 				<ColorPanel { ...{ attributes, setAttributes, isRequestingVideoData } } />
 			</InspectorControls>
 
+			<ConnectBanner
+				isConnected={ isUserConnected }
+				isConnecting={ isRedirectingToMyJetpack }
+				onConnect={ () => {
+					setIsRedirectingToMyJetpack( true );
+					window.location.href = myJetpackConnectUrl;
+				} }
+			/>
+
 			<VideoPressPlayer
 				html={ html }
 				isRequestingEmbedPreview={ isRequestingEmbedPreview }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -44,7 +44,6 @@ import './editor.scss';
 
 const debug = debugFactory( 'videopress:video:edit' );
 
-// Get site type.
 const { siteType = '', myJetpackConnectUrl } = window?.videoPressEditorState || {};
 
 // Get connection initial state from the global window object.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: show Connect banner above video player when the site is not connected 

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and add a VideoPress video block
* Disconnect the site
* Go back to the block editor (hard-refresh)
* Confirm the block shows the connect banner above the block

<img width="833" alt="image" src="https://user-images.githubusercontent.com/77539/214827848-59b90a5c-ac5f-46ef-b828-f6627d9b993a.png">


