### PR TITLE
JSON API: Fix the response format of the `GET /sites/$site/dropdown-pages/` endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-dropdown-pages-api
+++ b/projects/plugins/jetpack/changelog/fix-dropdown-pages-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Json API: Fix the response format for the "/sites/$site/dropdown-pages/". The endpoint is not used in production yet.

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -937,7 +937,6 @@ abstract class WPCOM_JSON_API_Endpoint {
 				);
 				$return[ $key ] = (array) $this->cast_and_filter( $value, $docs, false, $for_output );
 				break;
-
 			case 'visibility':
 				// This is needed to fix a bug in WPAndroid where `public: "PUBLIC"` is sent in place of `public: 1`.
 				if ( 'public' === strtolower( $value ) ) {
@@ -948,7 +947,9 @@ abstract class WPCOM_JSON_API_Endpoint {
 					$return[ $key ] = (int) $value;
 				}
 				break;
-
+			case 'dropdown_page':
+				$return[ $key ] = (array) $this->cast_and_filter( $value, $this->dropdown_page_object_format, false, $for_output );
+				break;
 			default:
 				$method_name = $type['type'] . '_docs';
 				if ( method_exists( 'WPCOM_JSON_API_Jetpack_Overrides', $method_name ) ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
@@ -30,14 +30,27 @@ new WPCOM_JSON_API_List_Dropdown_Pages_Endpoint(
  *
  * /sites/%s/dropdown-pages/ -> $blog_id
  */
-class WPCOM_JSON_API_List_Dropdown_Pages_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
+class WPCOM_JSON_API_List_Dropdown_Pages_Endpoint extends WPCOM_JSON_API_Endpoint {
+
+	/**
+	 * Page object format.
+	 *
+	 * @var array
+	 */
+	public $dropdown_page_object_format = array(
+		'ID'       => '(int) The page ID.',
+		'title'    => '(string) The page title.',
+		'children' => '(array:dropdown_page) An array of child pages.',
+	);
+
 	/**
 	 * The response format.
 	 *
 	 * @var array
 	 */
 	public $response_format = array(
-		'dropdown_pages' => '(array:page) An array of page objects.',
+		'found'          => '(int) The number of pages found.',
+		'dropdown_pages' => '(array:dropdown_page) An array of dropdown_page objects.',
 	);
 
 	/**
@@ -70,13 +83,19 @@ class WPCOM_JSON_API_List_Dropdown_Pages_Endpoint extends WPCOM_JSON_API_Post_En
 		$pages = get_pages();
 
 		if ( empty( $pages ) ) {
-			return array();
+			return array(
+				'found'          => 0,
+				'dropdown_pages' => array(),
+			);
 		}
 
 		$this->pages_by_id     = self::to_pages_by_id( $pages );
 		$this->pages_by_parent = self::to_pages_by_parent( $pages );
 		$dropdown_pages        = $this->create_dropdown_pages();
-		return $dropdown_pages;
+		return array(
+			'found'          => count( $dropdown_pages ),
+			'dropdown_pages' => $dropdown_pages,
+		);
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/72612

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix the response format for the `GET /sites/$site/dropdown-pages/` endpoint
  * Encapsulate the response (i.e. the array of pages) in an associative array. This is an implied expectation when an atomic site's Jetpack endpoint is called. Otherwise when we return an int indexed array, the call to the `public-api` for atomic sites fails with the 500 error code. 
* Match the actual endpoint's response to the updated response format
* Add type validation for `dropdown_page` object in WPCOM_JSON_API_Endpoint class

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Testing for Simple sites:
* Apply the PR to your sandbox ([how to](https://github.com/Automattic/jetpack/pull/28586#issuecomment-1404932340))
* Sandbox `public-api.wordpress.com`
* Go to WPCOM API developer console
* Select `WP.COM API`, `v1.1`, `GET`, `/sites/$site/dropdown-pages/` endpoint
  * Replace the `$site` with your test site domain 
* Execute the call and ensure the response has the expected format

### Testing for Atomic sites:
It is required to apply the PR to both the sandbox and the atomic test site. This is due to the fact that when we call the `public-api` endpoint for an atomic site, the call will be forwarded by the Jetpack XML-RPC client to the XML_RPC endpoint hosted by the atomic site itself. Once the XML response is received by the sandbox, it is decoded and its type is validated based on the endpoint's `response_format` definition. Once validated the sandbox will finally return the decoded JSON.

* Apply the PR to your sandbox ([how to](https://github.com/Automattic/jetpack/pull/28586#issuecomment-1404932340))
* Sandbox `public-api.wordpress.com`
* Apply the PR to your atomic test site (how to: pb5gDS-1rQ-p2)
* Go to WPCOM API developer console
* Select `WP.COM API`, `v1.1`, `GET`, `/sites/$site/dropdown-pages/` endpoint
  * Replace the `$site` with your atomic test site domain 
* Execute the call and ensure the response has the expected format
![Screen Shot 2023-01-26 at 13 45 29](https://user-images.githubusercontent.com/2019970/214839725-0b3de4cc-2928-4f34-b550-b3789a63b2fd.png)