### PR TITLE
Blaze: move away from the singleton pattern

### DIFF
--- a/projects/packages/blaze/changelog/update-blaze-shoo-singleton
+++ b/projects/packages/blaze/changelog/update-blaze-shoo-singleton
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Move away from Singleton pattern to improve performance

--- a/projects/packages/blaze/composer.json
+++ b/projects/packages/blaze/composer.json
@@ -59,7 +59,7 @@
 			"link-template": "https://github.com/automattic/jetpack-blaze/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.4.x-dev"
+			"dev-trunk": "0.5.x-dev"
 		},
 		"textdomain": "jetpack-blaze",
 		"version-constants": {

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.4.1-alpha",
+	"version": "0.5.0-alpha",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -40,6 +40,7 @@ class Blaze {
 	/**
 	 * Check the WordPress.com REST API
 	 * to ensure that the site supports the Blaze feature.
+	 * Results are cached for a day.
 	 *
 	 * @param int $blog_id The blog ID to check.
 	 *
@@ -90,6 +91,7 @@ class Blaze {
 
 	/**
 	 * Determines if criteria is met to enable Blaze features.
+	 * Keep in mind that this makes remote requests, so we want to avoid calling it when unnecessary, like in the frontend.
 	 *
 	 * @return bool
 	 */

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -20,6 +20,13 @@ class Blaze {
 	const PACKAGE_VERSION = '0.5.0-alpha';
 
 	/**
+	 * Script handle for the JS file we enqueue in the post editor.
+	 *
+	 * @var string
+	 */
+	const SCRIPT_HANDLE = 'jetpack-promote-editor';
+
+	/**
 	 * The configuration method that is called from the jetpack-config package.
 	 *
 	 * @return void
@@ -206,7 +213,7 @@ class Blaze {
 		}
 
 		Assets::register_script(
-			'jetpack-promote-editor',
+			self::SCRIPT_HANDLE,
 			'../build/editor.js',
 			__FILE__,
 			array(
@@ -217,6 +224,6 @@ class Blaze {
 		);
 
 		// Adds Connection package initial state.
-		wp_add_inline_script( 'jetpack-promote-editor', Connection_Initial_State::render(), 'before' );
+		wp_add_inline_script( self::SCRIPT_HANDLE, Connection_Initial_State::render(), 'before' );
 	}
 }

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -27,6 +27,13 @@ class Blaze {
 	const SCRIPT_HANDLE = 'jetpack-promote-editor';
 
 	/**
+	 * Path of the JS file we enqueue in the post editor.
+	 *
+	 * @var string
+	 */
+	public static $script_path = '../build/editor.js';
+
+	/**
 	 * The configuration method that is called from the jetpack-config package.
 	 *
 	 * @return void
@@ -214,7 +221,7 @@ class Blaze {
 
 		Assets::register_script(
 			self::SCRIPT_HANDLE,
-			'../build/editor.js',
+			self::$script_path,
 			__FILE__,
 			array(
 				'enqueue'    => true,

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -21,19 +21,24 @@ class Blaze {
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.
+	 *
+	 * @return void
 	 */
 	public static function init() {
-		global $pagenow;
-
 		// On the edit screen, add a row action to promote the post.
-		if (
-			is_admin()
-			&& ! wp_doing_ajax()
-			&& 'edit.php' === $pagenow
-			&& self::should_initialize()
-		) {
+		add_action( 'load-edit.php', array( __CLASS__, 'add_post_links_actions' ) );
+		// In the post editor, add a post-publish panel to allow promoting the post.
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_block_editor_assets' ) );
+	}
+
+	/**
+	 * Add links under each published post in the wp-admin post list.
+	 *
+	 * @return void
+	 */
+	public static function add_post_links_actions() {
+		if ( self::should_initialize() ) {
 			add_filter( 'post_row_actions', array( __CLASS__, 'jetpack_blaze_row_action' ), 10, 2 );
-			add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_block_editor_assets' ) );
 		}
 	}
 
@@ -192,6 +197,11 @@ class Blaze {
 		 * See #20357 for more info.
 		 */
 		if ( ! in_array( $hook, array( 'post.php', 'post-new.php' ), true ) ) {
+			return;
+		}
+
+		// Bail if criteria is not met to enable Blaze features.
+		if ( ! self::should_initialize() ) {
 			return;
 		}
 

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -23,27 +23,9 @@ class Blaze {
 	 * The configuration method that is called from the jetpack-config package.
 	 */
 	public static function init() {
-		$blaze = self::get_instance();
-		$blaze->register();
-	}
-
-	/**
-	 * Initialize Blaze UIs.
-	 *
-	 * @return Blaze Blaze instance.
-	 */
-	public static function get_instance() {
-		return new Blaze();
-	}
-
-	/**
-	 * Sets up Post List action callbacks.
-	 */
-	public function register() {
-
 		if ( ! did_action( 'jetpack_on_blaze_init' ) ) {
-			add_filter( 'post_row_actions', array( $this, 'jetpack_blaze_row_action' ), 10, 2 );
-			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_block_editor_assets' ) );
+			add_filter( 'post_row_actions', array( __CLASS__, 'jetpack_blaze_row_action' ), 10, 2 );
+			add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_block_editor_assets' ) );
 
 			/**
 			 * Action called after initializing Blaze.
@@ -165,7 +147,7 @@ class Blaze {
 	 *
 	 * @return array
 	 */
-	public function jetpack_blaze_row_action( $post_actions, $post ) {
+	public static function jetpack_blaze_row_action( $post_actions, $post ) {
 		// Bail on sites that do not support Blaze.
 		if ( ! self::should_initialize() ) {
 			return $post_actions;
@@ -205,7 +187,7 @@ class Blaze {
 	 *
 	 * @param string $hook The current admin page.
 	 */
-	public function enqueue_block_editor_assets( $hook ) {
+	public static function enqueue_block_editor_assets( $hook ) {
 		/*
 		 * We do not want (nor need) Blaze in the site editor or the widget editor, only in the post editor.
 		 * Enqueueing the script in those editors would cause a fatal error.

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -17,7 +17,7 @@ use Automattic\Jetpack\Sync\Settings as Sync_Settings;
  */
 class Blaze {
 
-	const PACKAGE_VERSION = '0.4.1-alpha';
+	const PACKAGE_VERSION = '0.5.0-alpha';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -23,16 +23,17 @@ class Blaze {
 	 * The configuration method that is called from the jetpack-config package.
 	 */
 	public static function init() {
-		if ( ! did_action( 'jetpack_on_blaze_init' ) ) {
+		global $pagenow;
+
+		// On the edit screen, add a row action to promote the post.
+		if (
+			is_admin()
+			&& ! wp_doing_ajax()
+			&& 'edit.php' === $pagenow
+			&& self::should_initialize()
+		) {
 			add_filter( 'post_row_actions', array( __CLASS__, 'jetpack_blaze_row_action' ), 10, 2 );
 			add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_block_editor_assets' ) );
-
-			/**
-			 * Action called after initializing Blaze.
-			 *
-			 * @since 0.1.0
-			 */
-			do_action( 'jetpack_on_blaze_init' );
 		}
 	}
 
@@ -148,11 +149,6 @@ class Blaze {
 	 * @return array
 	 */
 	public static function jetpack_blaze_row_action( $post_actions, $post ) {
-		// Bail on sites that do not support Blaze.
-		if ( ! self::should_initialize() ) {
-			return $post_actions;
-		}
-
 		$post_id = $post->ID;
 
 		if ( $post->post_status !== 'publish' ) {
@@ -194,11 +190,6 @@ class Blaze {
 		 * See #20357 for more info.
 		 */
 		if ( ! in_array( $hook, array( 'post.php', 'post-new.php' ), true ) ) {
-			return;
-		}
-
-		// Bail on sites that do not support Blaze.
-		if ( ! self::should_initialize() ) {
 			return;
 		}
 

--- a/projects/packages/blaze/tests/php/test-blaze.php
+++ b/projects/packages/blaze/tests/php/test-blaze.php
@@ -22,6 +22,7 @@ class Test_Blaze extends BaseTestCase {
 	public function test_should_initialize() {
 		$this->assertFalse( has_action( 'post_row_actions', 'Blaze::jetpack_blaze_row_action' ), 'post_row_actions' );
 		$this->assertFalse( has_action( 'admin_enqueue_scripts', 'Blaze::enqueue_block_editor_assets' ), 'admin_enqueue_scripts' );
+		$this->assertFalse( has_filter( 'jetpack_blaze_enabled' ) );
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/test-blaze.php
+++ b/projects/packages/blaze/tests/php/test-blaze.php
@@ -30,8 +30,7 @@ class Test_Blaze extends BaseTestCase {
 	 * @covers Automattic\Jetpack\Blaze::init
 	 */
 	public function test_should_initialize() {
-		$this->assertFalse( has_action( 'post_row_actions', 'Blaze::jetpack_blaze_row_action' ), 'post_row_actions' );
-		$this->assertFalse( has_action( 'admin_enqueue_scripts', 'Blaze::enqueue_block_editor_assets' ), 'admin_enqueue_scripts' );
+		$this->assertFalse( has_action( 'post_row_actions' ) );
 		$this->assertFalse( has_filter( 'jetpack_blaze_enabled' ) );
 	}
 

--- a/projects/packages/blaze/tests/php/test-blaze.php
+++ b/projects/packages/blaze/tests/php/test-blaze.php
@@ -29,8 +29,16 @@ class Test_Blaze extends BaseTestCase {
 	 *
 	 * @covers Automattic\Jetpack\Blaze::init
 	 */
-	public function test_should_initialize() {
+	public function test_should_not_check_eligibility_by_defuault() {
+		/*
+		 *The post_row_actions action should not be available on init.
+		 * It only happens on a specific screen.
+		 */
 		$this->assertFalse( has_action( 'post_row_actions' ) );
+		/**
+		 * The jetpack_blaze_enabled filter should not be available on init.
+		 * It should only be available after you've made a remote request to WordPress.com.
+		 */
 		$this->assertFalse( has_filter( 'jetpack_blaze_enabled' ) );
 	}
 

--- a/projects/packages/blaze/tests/php/test-blaze.php
+++ b/projects/packages/blaze/tests/php/test-blaze.php
@@ -36,4 +36,25 @@ class Test_Blaze extends BaseTestCase {
 		$this->assertTrue( Blaze::should_initialize() );
 		add_filter( 'jetpack_blaze_enabled', '__return_false' );
 	}
+
+	/**
+	 * As a control when testing add_filters_and_actions_for_screen() make sure it always starts clean.
+	 */
+	private function confirm_add_filters_and_actions_for_screen_starts_clean() {
+		$this->assertFalse( has_action( 'post_row_actions' ) );
+	}
+
+	/**
+	 * Tests if the post_row action is added when we force Blaze to be enabled.
+	 *
+	 * @covers Automattic\Jetpack\Blaze::add_post_links_actions
+	 */
+	public function test_post_row_added() {
+		$this->confirm_add_filters_and_actions_for_screen_starts_clean();
+
+		add_filter( 'jetpack_blaze_enabled', '__return_true' );
+		Blaze::add_post_links_actions();
+
+		$this->assertNotFalse( has_action( 'post_row_actions' ) );
+	}
 }

--- a/projects/packages/blaze/tests/php/test-blaze.php
+++ b/projects/packages/blaze/tests/php/test-blaze.php
@@ -1,11 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 /**
- * This file contains PHPUnit tests for the Post_List class.
- * To run the package unit tests:
- * - go the post-list folder "cd projects/packages/post-list"
- * - run the command "composer test-php"
+ * This file contains PHPUnit tests for the Blaze class.
+ * To run the package unit tests, run jetpack test packages/blaze
  *
- * @package automattic/jetpack-post-list
+ * @package automattic/jetpack-blaze
  */
 
 namespace Automattic\Jetpack;
@@ -13,84 +11,17 @@ namespace Automattic\Jetpack;
 use WorDBless\BaseTestCase;
 
 /**
- * PHPUnit tests for the Post_List class.
- *
- * @package automattic/jetpack-post-list
+ * PHPUnit tests for the Blaze class.
  */
 class Test_Blaze extends BaseTestCase {
-
 	/**
-	 * Post_List::get_instance() should return and instance of the Post_List class.
+	 * Test that the jetpack_blaze_enabled filter overwrites eligibility.
+	 *
+	 * @covers Automattic\Jetpack\Blaze::should_initialize
 	 */
-	public function test_get_instance() {
-		$this->assertInstanceOf( Blaze::class, Blaze::get_instance() );
-	}
-
-	/**
-	 * Test the register() method.
-	 */
-	public function test_register() {
-		$blaze = Blaze::get_instance();
-
-		// did_action() Retrieves the number of times an action has been fired during the current request.
-		// Assert our action hasn't been fired yet.
-		$this->assertSame( 0, did_action( 'jetpack_on_blaze_init' ) );
-
-		// Set up our action callbacks using the register() method.
-		$blaze->register();
-
-		// Confirm it was only fired once even though we call it twice.
-		$blaze->register();
-
-		$this->assertSame( 1, did_action( 'jetpack_on_blaze_init' ) );
-	}
-
-	/**
-	 * As a control when testing add_filters_and_actions_for_screen() make sure it always starts clean.
-	 */
-	private function confirm_add_filters_and_actions_for_screen_starts_clean() {
-		$this->assertFalse( has_action( 'post_row_actions' ) );
-	}
-
-	/**
-	 * Test the jetpack_blaze_enabled filter overrides to true.
-	 */
-	public function test_jetpack_blaze_enabled_filter_override_should_initialize() {
-		$blaze = Blaze::get_instance();
-
-		// This filter should override everything, even if it's not connected.
+	public function test_filter_overwrites_eligibility() {
+		$this->assertFalse( Blaze::should_initialize() );
 		add_filter( 'jetpack_blaze_enabled', '__return_true' );
-
-		$blaze->register();
-
-		// The post_row_actions should be added.
-		$this->assertTrue( $blaze::should_initialize() );
-	}
-
-	/**
-	 * Test the jetpack_blaze_enabled overrides the should_initialize() method to false.
-	 */
-	public function test_jetpack_blaze_enabled_filter_override_should_not_initialize() {
-		$blaze = Blaze::get_instance();
-
-		// This filter should override everything, even if it's not connected.
-		add_filter( 'jetpack_blaze_enabled', '__return_false' );
-
-		$blaze->register();
-
-		// The post_row_actions should be added.
-		$this->assertFalse( $blaze::should_initialize() );
-	}
-
-	/**
-	 * Tests if the post_row action is added when the package is registered.
-	 */
-	public function test_post_row_added() {
-		$blaze = Blaze::get_instance();
-		$this->confirm_add_filters_and_actions_for_screen_starts_clean();
-
-		$blaze->register();
-
-		$this->assertNotFalse( has_action( 'post_row_actions' ) );
+		$this->assertTrue( Blaze::should_initialize() );
 	}
 }

--- a/projects/packages/blaze/tests/php/test-blaze.php
+++ b/projects/packages/blaze/tests/php/test-blaze.php
@@ -15,6 +15,16 @@ use WorDBless\BaseTestCase;
  */
 class Test_Blaze extends BaseTestCase {
 	/**
+	 * Test that Blaze::init() does not run everything by default.
+	 *
+	 * @covers Automattic\Jetpack\Blaze::init
+	 */
+	public function test_should_initialize() {
+		$this->assertFalse( has_action( 'post_row_actions', 'Blaze::jetpack_blaze_row_action' ), 'post_row_actions' );
+		$this->assertFalse( has_action( 'admin_enqueue_scripts', 'Blaze::enqueue_block_editor_assets' ), 'admin_enqueue_scripts' );
+	}
+
+	/**
 	 * Test that the jetpack_blaze_enabled filter overwrites eligibility.
 	 *
 	 * @covers Automattic\Jetpack\Blaze::should_initialize
@@ -23,5 +33,6 @@ class Test_Blaze extends BaseTestCase {
 		$this->assertFalse( Blaze::should_initialize() );
 		add_filter( 'jetpack_blaze_enabled', '__return_true' );
 		$this->assertTrue( Blaze::should_initialize() );
+		add_filter( 'jetpack_blaze_enabled', '__return_false' );
 	}
 }

--- a/projects/packages/blaze/tests/php/test-blaze.php
+++ b/projects/packages/blaze/tests/php/test-blaze.php
@@ -15,6 +15,15 @@ use WorDBless\BaseTestCase;
  */
 class Test_Blaze extends BaseTestCase {
 	/**
+	 * Set up before each test.
+	 *
+	 * @before
+	 */
+	public function set_up() {
+		Blaze::$script_path = 'js/editor.js';
+	}
+
+	/**
 	 * Tear down after each test.
 	 *
 	 * @after

--- a/projects/plugins/jetpack/changelog/update-blaze-shoo-singleton
+++ b/projects/plugins/jetpack/changelog/update-blaze-shoo-singleton
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -446,7 +446,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/blaze",
-                "reference": "fe763a3537f4a36cecda89a019600116ad551a4d"
+                "reference": "1c22a742cbab3a4d93b36924128c400685325bd5"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -466,7 +466,7 @@
                     "link-template": "https://github.com/automattic/jetpack-blaze/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.4.x-dev"
+                    "dev-trunk": "0.5.x-dev"
                 },
                 "textdomain": "jetpack-blaze",
                 "version-constants": {


### PR DESCRIPTION
Follow-up to #28568

## Proposed changes:

Let's move away from the singleton pattern, as discussed in p1674700231323229-slack-CBG1CP4EN.

I will also take the opportunity to improve performance by reducing the number of remote calls even more, and update the tests and add the regression test for the bug we fixed in #28568.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* 1386-gh-dotcom-forge
* p1674700231323229-slack-CBG1CP4EN
* p9o2xV-2L0-p2

## Does this pull request change what data or activity we track or use?
* No

## Testing instructions:

> **Note**
> For Blaze to work on your site, it should be in English and public.

* Is CI Happy?
* On a WoA site with the Jetpack Beta plugin, switch to this branch.
* Open an incognito window, and load the site's frontend. You should not see any Blaze request when clicking on the "Debug" button in the admin bar.
* Back logged in as admin, ensure the feature is still accessible in wp-admin/edit.php, when moving your mouse over the published posts. 
* Go to Posts > Add New, and publish a post; you should see the post-publish panel.

You can also test on your local instance, by setting the following filter: `add_filter( 'jetpack_blaze_enabled', '__return_true' );`
Once you've done that, you should see the Blaze interface for your published posts in wp-admin/edit.php.

You can also use something like the Query Monitor plugin, or add logging to `Blaze::should_initialize()` to ensure the method is only called once when you load wp-admin/edit.php, and is not called at all when loading your site's frontend, whether you are logged in or not.
