### PR TITLE
CRM: top menu is broken. Bad CSS class selector

### DIFF
--- a/projects/plugins/crm/changelog/fix-top-crm-menu-broken-with-space
+++ b/projects/plugins/crm/changelog/fix-top-crm-menu-broken-with-space
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Removed some spaces that break the CSS class selector
+
+

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
@@ -721,7 +721,7 @@ function zeroBSCRM_admin_top_menu( $branding = 'zero-bs-crm', $page = 'dash' ) {
 			<?php
 			// } Build pop-out
 
-			$popoutMenu = array(
+			$popout_menu = array(
 				'col1' => array(),
 				'col2' => array(),
 				'col3' => array(),
@@ -729,53 +729,53 @@ function zeroBSCRM_admin_top_menu( $branding = 'zero-bs-crm', $page = 'dash' ) {
 
 			// if admin, settings + datatools
 			if ( zeroBSCRM_isZBSAdminOrAdmin() ) {
-				$popoutMenu['col1'][] = '<a id="zbs-settings2-top-menu" href="' . zeroBSCRM_getAdminURL( $zbs->slugs['settings'] ) . '" class="item"><i class="settings icon"></i> ' . __( 'Settings', 'zero-bs-crm' ) . '</a>';
+				$popout_menu['col1'][] = '<a id="zbs-settings2-top-menu" href="' . zeroBSCRM_getAdminURL( $zbs->slugs['settings'] ) . '" class="item"><i class="settings icon"></i> ' . __( 'Settings', 'zero-bs-crm' ) . '</a>';
 				// WLREMOVE
-				$popoutMenu['col1'][] = '<a id="zbs-datatools-top-menu" href="' . zeroBSCRM_getAdminURL( $zbs->slugs['datatools'] ) . '" class="item"><i class="wrench icon"></i> ' . __( 'Data Tools', 'zero-bs-crm' ) . '</a>';
+				$popout_menu['col1'][] = '<a id="zbs-datatools-top-menu" href="' . zeroBSCRM_getAdminURL( $zbs->slugs['datatools'] ) . '" class="item"><i class="wrench icon"></i> ' . __( 'Data Tools', 'zero-bs-crm' ) . '</a>';
 				// /WLREMOVE
 			}
 			// teams page for WP Admin or Jetpack CRM Full Admin
 			if ( current_user_can( 'manage_options' ) ) {
-				$popoutMenu['col1'][] = '<a id="zbs-team-top-menu" href="' . zeroBSCRM_getAdminURL( $zbs->slugs['team'] ) . '" class="item"><i class="icon users"></i> ' . __( 'Team', 'zero-bs-crm' ) . '</a>';
+				$popout_menu['col1'][] = '<a id="zbs-team-top-menu" href="' . zeroBSCRM_getAdminURL( $zbs->slugs['team'] ) . '" class="item"><i class="icon users"></i> ' . __( 'Team', 'zero-bs-crm' ) . '</a>';
 			}
 
 			// if admin, system status + extensions
 			if ( zeroBSCRM_isZBSAdminOrAdmin() ) {
-				$popoutMenu['col1'][] = '<a class="item" href="' . zeroBSCRM_getAdminURL( $zbs->slugs['systemstatus'] ) . '"><i class="server icon" aria-hidden="true"></i> ' . __( 'System Assistant', 'zero-bs-crm' ) . '</a>';
-				$popoutMenu['col1'][] = '<a class="item" href="' . zeroBSCRM_getAdminURL( $zbs->slugs['emails'] ) . '"><i class="envelope icon" aria-hidden="true"></i> ' . __( 'Emails', 'zero-bs-crm' ) . '</a>';
-				$popoutMenu['col1'][] = '<a class="item" href="' . zeroBSCRM_getAdminURL( $zbs->slugs['modules'] ) . '"><i class="icon th" aria-hidden="true"></i> ' . __( 'Core Modules', 'zero-bs-crm' ) . '</a>';
+				$popout_menu['col1'][] = '<a class="item" href="' . zeroBSCRM_getAdminURL( $zbs->slugs['systemstatus'] ) . '"><i class="server icon" aria-hidden="true"></i> ' . __( 'System Assistant', 'zero-bs-crm' ) . '</a>';
+				$popout_menu['col1'][] = '<a class="item" href="' . zeroBSCRM_getAdminURL( $zbs->slugs['emails'] ) . '"><i class="envelope icon" aria-hidden="true"></i> ' . __( 'Emails', 'zero-bs-crm' ) . '</a>';
+				$popout_menu['col1'][] = '<a class="item" href="' . zeroBSCRM_getAdminURL( $zbs->slugs['modules'] ) . '"><i class="icon th" aria-hidden="true"></i> ' . __( 'Core Modules', 'zero-bs-crm' ) . '</a>';
 				// WLREMOVE
-				$popoutMenu['col1'][] = '<a class="item" href="' . zeroBSCRM_getAdminURL( $zbs->slugs['extensions'] ) . '"><i class="icon plug" aria-hidden="true"></i> ' . __( 'Extensions', 'zero-bs-crm' ) . '</a>';
+				$popout_menu['col1'][] = '<a class="item" href="' . zeroBSCRM_getAdminURL( $zbs->slugs['extensions'] ) . '"><i class="icon plug" aria-hidden="true"></i> ' . __( 'Extensions', 'zero-bs-crm' ) . '</a>';
 				// /WLREMOVE
 
 			}
 
 			// remove the col if nothing in there
-			if ( count( $popoutMenu['col1'] ) == 0 ) {
-				unset( $popoutMenu['col1'] );
+			if ( count( $popout_menu['col1'] ) == 0 ) {
+				unset( $popout_menu['col1'] );
 			}
 
 			?>
 			<div class="ui popup bottom left transition hidden" id="zbs-user-menu">
 				<?php
-					switch ( count( $popoutMenu ) ) {
-						case 3:
-							$menu_style = 'three';
-							break;
-						case 2:
-							$menu_style = 'two';
-							break;
-						default:
-							$menu_style = 'one';
-					}
+				switch ( count( $popout_menu ) ) {
+					case 3:
+						$menu_style = 'three';
+						break;
+					case 2:
+						$menu_style = 'two';
+						break;
+					default:
+						$menu_style = 'one';
+				}
 				?>
-				<div class="ui <?php echo $menu_style ?> column equal height divided grid">
-			<?php if ( isset( $popoutMenu['col1'] ) && count( $popoutMenu['col1'] ) > 0 ) { ?>
+				<div class="ui <?php echo esc_attr( $menu_style ); ?> column equal height divided grid">
+			<?php if ( isset( $popout_menu['col1'] ) && count( $popout_menu['col1'] ) > 0 ) { ?>
 				<div class="column">
 					<h4 class="ui header"><?php esc_html_e( 'CRM Admin', 'zero-bs-crm' ); ?></h4>
 					<div class="ui link list">
 					<?php
-					foreach ( $popoutMenu['col1'] as $link ) {
+					foreach ( $popout_menu['col1'] as $link ) {
 						echo $link; }
 					?>
 					</div>

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
@@ -757,17 +757,19 @@ function zeroBSCRM_admin_top_menu( $branding = 'zero-bs-crm', $page = 'dash' ) {
 
 			?>
 			<div class="ui popup bottom left transition hidden" id="zbs-user-menu">
-				<div class="ui 
 				<?php
-				if ( count( $popoutMenu ) == 3 ) {
-					echo 'three';
-				} elseif ( count( $popoutMenu ) == 2 ) {
-					echo 'two';
-				} else {
-					echo 'one';
-				}
+					switch ( count( $popoutMenu ) ) {
+						case 3:
+							$menu_style = 'three';
+							break;
+						case 2:
+							$menu_style = 'two';
+							break;
+						default:
+							$menu_style = 'one';
+					}
 				?>
-				column equal height divided grid">
+				<div class="ui <?php echo $menu_style ?> column equal height divided grid">
 			<?php if ( isset( $popoutMenu['col1'] ) && count( $popoutMenu['col1'] ) > 0 ) { ?>
 				<div class="column">
 					<h4 class="ui header"><?php esc_html_e( 'CRM Admin', 'zero-bs-crm' ); ?></h4>

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
@@ -751,7 +751,7 @@ function zeroBSCRM_admin_top_menu( $branding = 'zero-bs-crm', $page = 'dash' ) {
 			}
 
 			// remove the col if nothing in there
-			if ( count( $popout_menu['col1'] ) == 0 ) {
+			if ( count( $popout_menu['col1'] ) === 0 ) {
 				unset( $popout_menu['col1'] );
 			}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Some spaces added during the migration to the monorepo, interfere with the CSS class selector. That breaks the top-menu:

![image](https://user-images.githubusercontent.com/9832440/214884094-3851f7a6-a66e-4be3-8bd4-ff7ddcda0c41.png)

Fixes Automattic/zero-bs-crm#2812

## Proposed changes:

This PR fixes those spaces in the class attribute that was breaking the top-menu. After the fix, the top-menu should look like this:

<img width="556" alt="image" src="https://user-images.githubusercontent.com/9832440/215120015-a1253476-e2ee-4612-9afc-c1db9721f8f3.png">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Apply this patch and check that the top menu is not broken like the image above.

