### PR TITLE
post-build: Check out PR commit as well as trunk for plugin upgrade test

### DIFF
--- a/.github/files/test-plugin-update/prepare-zips.sh
+++ b/.github/files/test-plugin-update/prepare-zips.sh
@@ -16,7 +16,7 @@ while IFS=$'\t' read -r SRC MIRROR SLUG; do
 	echo "::endgroup::"
 
 	echo "::group::Fetching $SLUG-trunk.zip..."
-	BETASLUG="$(jq -r '.extra["beta-plugin-slug"] // .extra["wp-plugin-slug"] // ""' "monorepo/$SRC/composer.json")"
+	BETASLUG="$(jq -r '.extra["beta-plugin-slug"] // .extra["wp-plugin-slug"] // ""' "commit/$SRC/composer.json")"
 	if [[ -z "$BETASLUG" ]]; then
 		echo "No beta-plugin-slug or wp-plugin-slug in composer.json, skipping"
 	else

--- a/.github/files/test-plugin-update/setup.sh
+++ b/.github/files/test-plugin-update/setup.sh
@@ -28,5 +28,5 @@ echo "::group::Install WordPress"
 wp --allow-root core install --url="$WP_DOMAIN" --title="$WP_TITLE" --admin_user="$WP_ADMIN_USER" --admin_password="$WP_ADMIN_PASSWORD" --admin_email="$WP_ADMIN_EMAIL" --skip-email
 rm -f index.html
 mkdir -p wp-content/mu-plugins
-cp "$GITHUB_WORKSPACE/monorepo/.github/files/test-plugin-update/mu-plugin.php" wp-content/mu-plugins/hack.php
+cp "$GITHUB_WORKSPACE/trunk/.github/files/test-plugin-update/mu-plugin.php" wp-content/mu-plugins/hack.php
 echo "::endgroup::"

--- a/.github/files/test-plugin-update/test.sh
+++ b/.github/files/test-plugin-update/test.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-source "$GITHUB_WORKSPACE/monorepo/.github/files/gh-funcs.sh"
+source "$GITHUB_WORKSPACE/trunk/.github/files/gh-funcs.sh"
 
 ZIPDIR="$GITHUB_WORKSPACE/zips"
 EXIT=0

--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -208,11 +208,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          path: monorepo
+          path: trunk
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.workflow_run.head_commit.id }}
+          path: commit
 
       - name: Get token
         id: get_token
-        uses: ./monorepo/.github/actions/gh-app-token
+        uses: ./trunk/.github/actions/gh-app-token
         env:
           # Work around a weird node 16/openssl 3 issue in the docker env
           OPENSSL_CONF: '/dev/null'
@@ -221,7 +225,7 @@ jobs:
           private_key: ${{ secrets.JP_LAUNCH_CONTROL_KEY }}
 
       - name: Notify check in progress
-        uses: ./monorepo/.github/actions/check-run
+        uses: ./trunk/.github/actions/check-run
         with:
           id: ${{ needs.setup.outputs.upgrade_check }}
           status: in_progress
@@ -255,19 +259,19 @@ jobs:
           tar --xz -xvvf build.tar.xz
 
       - name: Setup WordPress
-        run: monorepo/.github/files/test-plugin-update/setup.sh
+        run: trunk/.github/files/test-plugin-update/setup.sh
 
       - name: Prepare plugin zips
         id: zips
-        run: monorepo/.github/files/test-plugin-update/prepare-zips.sh
+        run: trunk/.github/files/test-plugin-update/prepare-zips.sh
 
       - name: Test upgrades
         id: tests
-        run: monorepo/.github/files/test-plugin-update/test.sh
+        run: trunk/.github/files/test-plugin-update/test.sh
 
       - name: Notify final status
         if: always()
-        uses: ./monorepo/.github/actions/check-run
+        uses: ./trunk/.github/actions/check-run
         with:
           id: ${{ needs.setup.outputs.upgrade_check }}
           conclusion: ${{ job.status }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
There was a subtle change in the plugin upgrade test in the move from the Build to the Post-Build workflow: since the latter runs via `workflow_run`, the "current" branch is trunk rather than the PR commit, so that's what gets checked out.

Mostly that works fine, but at one point we look in the checkout for the plugin's `wp-plugin-slug`. For that one check, we need a copy of the PR commit rather than trunk. But we want to keep everything else running off of trunk to avoid potential security issues (the same ones that led GitHub to introduce the "pull_request_target" event).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/28479#issuecomment-1405302517

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* I guess merge this in a forked repo, then make a copy of #28479 in that repo and see if it works.
