### PR TITLE
jetpack: Remove `build-color-schemes-wpcom` script

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-build-color-schemes-wpcom
+++ b/projects/plugins/jetpack/changelog/remove-build-color-schemes-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Remove Webpack config for no-longer-used `build-color-schemes-wpcom` script.

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -19,7 +19,6 @@
 		"build-asset-cdn-json": "php tools/build-asset-cdn-json.php",
 		"//": "# We set NODE_PATH here (and in other 'build-' scripts) so postcss-loader can find its plugins with pnpm 7. See https://github.com/pnpm/pnpm/discussions/3536#discussioncomment-2688984",
 		"build-client": "NODE_PATH=\"$PWD/node_modules\" concurrently --names js,css,masterbar,module-headings 'webpack --config ./tools/webpack.config.js' 'webpack --config ./tools/webpack.config.css.js' 'webpack --config ./tools/webpack.config.masterbar.js' 'php tools/build-module-headings-translations.php'",
-		"build-color-schemes-wpcom": "NODE_ENV=production MASTERBAR_ENV=wpcom webpack --config ./tools/webpack.config.masterbar.js",
 		"build-concurrently": "pnpm run clean && concurrently 'pnpm:compile-ts' 'pnpm:build-client' 'pnpm:build-extensions' 'pnpm:build-widget-visibility' && pnpm run build-asset-cdn-json",
 		"build-extensions": "NODE_PATH=\"$PWD/node_modules\" webpack --config ./tools/webpack.config.extensions.js",
 		"build-production": "pnpm run clean && pnpm run build-production-client && pnpm run build-production-extensions && pnpm run build-production-widget-visibility && pnpm run build-asset-cdn-json",

--- a/projects/plugins/jetpack/tools/webpack.config.masterbar.js
+++ b/projects/plugins/jetpack/tools/webpack.config.masterbar.js
@@ -2,25 +2,14 @@ const path = require( 'path' );
 const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
 const RemoveAssetWebpackPlugin = require( '@automattic/remove-asset-webpack-plugin' );
 const glob = require( 'glob' );
-const webpack = jetpackWebpackConfig.webpack;
 
 const masterbarCssEntries = {};
-if ( process.env.MASTERBAR_ENV === 'wpcom' ) {
-	// prettier-ignore
-	for ( const file of glob
-		.sync( '../masterbar/admin-color-schemes/colors/**/*.scss' )
-		.filter( n => ! path.basename( n ).startsWith( '_' ) )
-	) {
-		masterbarCssEntries[ file.substring( 13, file.length - 5 ) ] = file;
-	}
-} else {
-	// prettier-ignore
-	for ( const file of glob
-		.sync( 'modules/masterbar/admin-color-schemes/colors/**/*.scss' )
-		.filter( n => ! path.basename( n ).startsWith( '_' ) )
-	) {
-		masterbarCssEntries[ file.substring( 18, file.length - 5 ) ] = './' + file;
-	}
+// prettier-ignore
+for ( const file of glob
+	.sync( 'modules/masterbar/admin-color-schemes/colors/**/*.scss' )
+	.filter( n => ! path.basename( n ).startsWith( '_' ) )
+) {
+	masterbarCssEntries[ file.substring( 18, file.length - 5 ) ] = './' + file;
 }
 
 module.exports = {
@@ -29,27 +18,10 @@ module.exports = {
 	entry: masterbarCssEntries,
 	output: {
 		...jetpackWebpackConfig.output,
-		path: path.join(
-			__dirname,
-			process.env.MASTERBAR_ENV === 'wpcom' ? '../../masterbar' : '../_inc/build/masterbar'
-		),
+		path: path.join( __dirname, '../_inc/build/masterbar' ),
 	},
 	optimization: {
 		...jetpackWebpackConfig.optimization,
-		minimizer: [
-			jetpackWebpackConfig.CssMinimizerPlugin( {
-				minimizerOptions: {
-					preset: [
-						'default',
-						{
-							discardComments: {
-								remove: comment => comment !== 'NOAUTORTL' && ! comment.startsWith( '!' ),
-							},
-						},
-					],
-				},
-			} ),
-		],
 	},
 	module: {
 		strictExportPresence: true,
@@ -80,11 +52,6 @@ module.exports = {
 		// Delete the dummy JS files Webpack would otherwise create.
 		new RemoveAssetWebpackPlugin( {
 			assets: /\.js(\.map)?$/,
-		} ),
-		// Add wpcom's "NOAUTORTL" comment.
-		new webpack.BannerPlugin( {
-			banner: '/* NOAUTORTL */\n',
-			raw: true,
 		} ),
 	],
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This was previously used for the wpcom "Jetpack Blocks Build" job, which was removed in D88505. Let's simplify the webpack config by removing it.

We can also remove the stuff that was adding the `/* NOAUTORTL */` comments to all the files to avoid wpcom's autortl pre-commit hook, as all of Jetpack is excluded from that.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?
* The build output should be unchanged other than that the masterbar CSS files will no longer have the `/* NOAUTORTL */` comment at the start.