### PR TITLE
Fix when categories or tags are empty

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-categories-can-be-null
+++ b/projects/plugins/jetpack/changelog/fix-categories-can-be-null
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix when categories are empty

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/edit.js
@@ -122,9 +122,8 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 	const postId = useSelect( select => select( 'core/editor' ).getCurrentPostId() );
 
 	let loading = false;
-	const categories = useSelect( select =>
-		select( 'core/editor' ).getEditedPostAttribute( 'categories' )
-	);
+	const categories =
+		useSelect( select => select( 'core/editor' ).getEditedPostAttribute( 'categories' ) ) || [];
 
 	const categoryObjects = useSelect(
 		select => {
@@ -145,7 +144,8 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 		[ categories ]
 	);
 
-	const tags = useSelect( select => select( 'core/editor' ).getEditedPostAttribute( 'tags' ), [] );
+	const tags =
+		useSelect( select => select( 'core/editor' ).getEditedPostAttribute( 'tags' ), [] ) || [];
 
 	const tagObjects = useSelect(
 		select => {


### PR DESCRIPTION
Return [] if categories return empty. See  #28602

## Proposed changes:
* Return [] if categories return empty. See 

## Testing instructions:

See https://github.com/Automattic/jetpack/pull/28483

## Does this pull request change what data or activity we track or use?

no