### PR TITLE
Jetpack: backport 11.8-a.11 release

### DIFF
--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## 0.27.3 - 2023-01-26
+### Changed
+- Use `flex-start` instead of `start` for better browser compatibility. [#28530]
+
 ## 0.27.2 - 2023-01-25
 ### Changed
 - Minor internal updates.

--- a/projects/js-packages/components/changelog/fix-css-warning-about-start
+++ b/projects/js-packages/components/changelog/fix-css-warning-about-start
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Use `flex-start` instead of `start` for better browser compatibility.

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.27.3-alpha",
+	"version": "0.27.3",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## 0.24.8 - 2023-01-26
+### Changed
+- Use `flex-start` instead of `start` for better browser compatibility. [#28530]
+
 ## 0.24.7 - 2023-01-25
 ### Changed
 - Minor internal updates.

--- a/projects/js-packages/connection/changelog/fix-css-warning-about-start
+++ b/projects/js-packages/connection/changelog/fix-css-warning-about-start
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Use `flex-start` instead of `start` for better browser compatibility.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.24.8-alpha",
+	"version": "0.24.8",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/licensing/CHANGELOG.md
+++ b/projects/js-packages/licensing/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.4 - 2023-01-26
+### Changed
+- Use `flex-start` instead of `start` for better browser compatibility. [#28530]
+
 ## 0.7.3 - 2023-01-25
 ### Changed
 - Minor internal updates.

--- a/projects/js-packages/licensing/changelog/fix-css-warning-about-start
+++ b/projects/js-packages/licensing/changelog/fix-css-warning-about-start
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Use `flex-start` instead of `start` for better browser compatibility.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.7.4-alpha",
+	"version": "0.7.4",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {

--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.37 - 2023-01-26
+### Changed
+- Minor internal updates.
+
 ## 0.2.36 - 2023-01-11
 ### Changed
 - Updated package dependencies.

--- a/projects/js-packages/partner-coupon/changelog/update-node-to-v18
+++ b/projects/js-packages/partner-coupon/changelog/update-node-to-v18
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update tooling node version to 18.13.0. Should be no change to the project.
-
-

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.37-alpha",
+	"version": "0.2.37",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2023-01-26
+### Changed
+- Update Media Picker UI in Jetpack Social sidebar to match new designs [#28527]
+
 ## [0.13.1] - 2023-01-23
 ### Fixed
 - Clean up JavaScript eslint issues. [#28441]
@@ -175,6 +179,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.14.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.13.1...v0.14.0
 [0.13.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.11.1...v0.12.0

--- a/projects/js-packages/publicize-components/changelog/change-jetpack-social-media-ui
+++ b/projects/js-packages/publicize-components/changelog/change-jetpack-social-media-ui
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Update Media Picker UI in Jetpack Social sidebar to match new designs

--- a/projects/js-packages/publicize-components/changelog/update-node-to-v18
+++ b/projects/js-packages/publicize-components/changelog/update-node-to-v18
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update tooling node version to 18.13.0. Should be no change to the project.
-
-

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.14.0-alpha",
+	"version": "0.14.0",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/remove-asset-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/remove-asset-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.16] - 2023-01-26
+### Changed
+- Minor internal updates.
+
 ## [1.0.15] - 2022-11-28
 ### Changed
 - Updated package dependencies. [#27043]
@@ -77,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[1.0.16]: https://github.com/Automattic/remove-asset-webpack-plugin/compare/v1.0.15...v1.0.16
 [1.0.15]: https://github.com/Automattic/remove-asset-webpack-plugin/compare/v1.0.14...v1.0.15
 [1.0.14]: https://github.com/Automattic/remove-asset-webpack-plugin/compare/v1.0.13...v1.0.14
 [1.0.13]: https://github.com/Automattic/remove-asset-webpack-plugin/compare/v1.0.12...v1.0.13

--- a/projects/js-packages/remove-asset-webpack-plugin/changelog/update-node-to-v18
+++ b/projects/js-packages/remove-asset-webpack-plugin/changelog/update-node-to-v18
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update tooling node version to 18.13.0. Should be no change to the project.
-
-

--- a/projects/js-packages/remove-asset-webpack-plugin/package.json
+++ b/projects/js-packages/remove-asset-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/remove-asset-webpack-plugin",
-	"version": "1.0.16-alpha",
+	"version": "1.0.16",
 	"description": "A Webpack plugin to remove assets from the build.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/remove-asset-webpack-plugin/README.md#readme",
 	"bugs": {

--- a/projects/packages/action-bar/CHANGELOG.md
+++ b/projects/packages/action-bar/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.9] - 2023-01-26
+### Changed
+- Minor internal updates.
+
 ## [0.1.8] - 2023-01-11
 ### Changed
 - Updated package dependencies. [#28127]
@@ -41,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Adds the Action Bar package and Jetpack plugin module for follows, likes, and comments. Just a scaffold to build on, for now. [#25447]
 
+[0.1.9]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.8...v0.1.9
 [0.1.8]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.5...v0.1.6

--- a/projects/packages/action-bar/changelog/update-node-to-v18
+++ b/projects/packages/action-bar/changelog/update-node-to-v18
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update tooling node version to 18.13.0. Should be no change to the project.
-
-

--- a/projects/packages/action-bar/package.json
+++ b/projects/packages/action-bar/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-action-bar",
-	"version": "0.1.9-alpha",
+	"version": "0.1.9",
 	"description": "An easy way for visitors to follow, like, and comment on your WordPress site.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/action-bar/#readme",
 	"bugs": {

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.0] - 2023-01-26
+### Added
+- Add backup storage UI on backup plugin [#28085]
+
 ## [1.10.8] - 2023-01-23
 ### Fixed
 - Clean up JavaScript eslint issues. [#28441]
@@ -321,6 +325,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[1.11.0]: https://github.com/Automattic/jetpack-backup/compare/v1.10.8...v1.11.0
 [1.10.8]: https://github.com/Automattic/jetpack-backup/compare/v1.10.7...v1.10.8
 [1.10.7]: https://github.com/Automattic/jetpack-backup/compare/v1.10.6...v1.10.7
 [1.10.6]: https://github.com/Automattic/jetpack-backup/compare/v1.10.5...v1.10.6

--- a/projects/packages/backup/changelog/add-backup-storage-ui
+++ b/projects/packages/backup/changelog/add-backup-storage-ui
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add backup storage UI on backup plugin

--- a/projects/packages/backup/changelog/update-node-to-v18
+++ b/projects/packages/backup/changelog/update-node-to-v18
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update tooling node version to 18.13.0. Should be no change to the project.
-
-

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.11.0-alpha';
+	const PACKAGE_VERSION = '1.11.0';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2023-01-26
+### Changed
+- Move away from Singleton pattern to improve performance [#28587]
+
+### Fixed
+- Avoid unnecessary requests for eligibility [#28568]
+
 ## [0.4.0] - 2023-01-23
 ### Added
 - Add new method to request eligibility to Blaze from WordPress.com. [#28353]
@@ -53,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.5.0]: https://github.com/automattic/jetpack-blaze/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/automattic/jetpack-blaze/compare/v0.3.4...v0.4.0
 [0.3.4]: https://github.com/automattic/jetpack-blaze/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/automattic/jetpack-blaze/compare/v0.3.2...v0.3.3

--- a/projects/packages/blaze/changelog/fix-blaze-performance-request
+++ b/projects/packages/blaze/changelog/fix-blaze-performance-request
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Avoid unnecessary requests for eligibility

--- a/projects/packages/blaze/changelog/update-blaze-shoo-singleton
+++ b/projects/packages/blaze/changelog/update-blaze-shoo-singleton
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Move away from Singleton pattern to improve performance

--- a/projects/packages/blaze/changelog/update-node-to-v18
+++ b/projects/packages/blaze/changelog/update-node-to-v18
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update tooling node version to 18.13.0. Should be no change to the project.
-
-

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.5.0-alpha",
+	"version": "0.5.0",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -17,7 +17,7 @@ use Automattic\Jetpack\Sync\Settings as Sync_Settings;
  */
 class Blaze {
 
-	const PACKAGE_VERSION = '0.5.0-alpha';
+	const PACKAGE_VERSION = '0.5.0';
 
 	/**
 	 * Script handle for the JS file we enqueue in the post editor.

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2023-01-26
+### Added
+- Moved contact form static files into the new forms package [#28417]
+
 ## 0.1.0 - 2023-01-23
 ### Added
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
+
+[0.2.0]: https://github.com/automattic/jetpack-forms/compare/v0.1.0...v0.2.0

--- a/projects/packages/forms/changelog/update-move-contact-form-static-assets
+++ b/projects/packages/forms/changelog/update-move-contact-form-static-assets
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Moved contact form static files into the new forms package

--- a/projects/packages/forms/changelog/update-node-to-v18
+++ b/projects/packages/forms/changelog/update-node-to-v18
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update tooling node version to 18.13.0. Should be no change to the project.
-
-

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.2.0-alpha",
+	"version": "0.2.0",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Forms;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.2.0-alpha';
+	const PACKAGE_VERSION = '0.2.0';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/google-fonts-provider/CHANGELOG.md
+++ b/projects/packages/google-fonts-provider/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2023-01-26
+### Changed
+- Minor internal updates.
+
 ## [0.4.1] - 2023-01-17
 ### Fixed
 - Use `wp_get_global_styles()` and fallback to `gutenberg_get_global_styles()` since the latter was removed from Gutenberg. [#28411]
@@ -62,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Adds a provider for Google Fonts using the new Webfonts API in Gutenberg
 
+[0.4.2]: https://github.com/Automattic/jetpack-google-fonts-provider/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/Automattic/jetpack-google-fonts-provider/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/Automattic/jetpack-google-fonts-provider/compare/v0.3.6...v0.4.0
 [0.3.6]: https://github.com/Automattic/jetpack-google-fonts-provider/compare/v0.3.5...v0.3.6

--- a/projects/packages/google-fonts-provider/changelog/update-node-to-v18
+++ b/projects/packages/google-fonts-provider/changelog/update-node-to-v18
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update tooling node version to 18.13.0. Should be no change to the project.
-
-

--- a/projects/packages/google-fonts-provider/package.json
+++ b/projects/packages/google-fonts-provider/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-google-fonts-provider",
-	"version": "0.4.2-alpha",
+	"version": "0.4.2",
 	"description": "WordPress Webfonts provider for Google Fonts",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/google-fonts-provider/#readme",
 	"bugs": {

--- a/projects/packages/lazy-images/CHANGELOG.md
+++ b/projects/packages/lazy-images/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.30] - 2023-01-26
+### Changed
+- Minor internal updates.
+
 ## [2.1.29] - 2022-12-06
 ### Changed
 - Updated package dependencies. [#27688, #27696]
@@ -281,6 +285,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Lazy Images: Move into a package
 
+[2.1.30]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.1.29...v2.1.30
 [2.1.29]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.1.28...v2.1.29
 [2.1.28]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.1.27...v2.1.28
 [2.1.27]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.1.26...v2.1.27

--- a/projects/packages/lazy-images/changelog/update-node-to-v18
+++ b/projects/packages/lazy-images/changelog/update-node-to-v18
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update tooling node version to 18.13.0. Should be no change to the project.
-
-

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.7] - 2023-01-26
+### Changed
+- Use `flex-start` instead of `start` for better browser compatibility. [#28530]
+
 ## [2.7.6] - 2023-01-25
 ### Changed
 - Minor internal updates.
@@ -734,6 +738,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[2.7.7]: https://github.com/Automattic/jetpack-my-jetpack/compare/2.7.6...2.7.7
 [2.7.6]: https://github.com/Automattic/jetpack-my-jetpack/compare/2.7.5...2.7.6
 [2.7.5]: https://github.com/Automattic/jetpack-my-jetpack/compare/2.7.4...2.7.5
 [2.7.4]: https://github.com/Automattic/jetpack-my-jetpack/compare/2.7.3...2.7.4

--- a/projects/packages/my-jetpack/changelog/fix-css-warning-about-start
+++ b/projects/packages/my-jetpack/changelog/fix-css-warning-about-start
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Use `flex-start` instead of `start` for better browser compatibility.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "2.7.7-alpha",
+	"version": "2.7.7",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -30,7 +30,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '2.7.7-alpha';
+	const PACKAGE_VERSION = '2.7.7';
 
 	/**
 	 * Initialize My Jetpack

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.2] - 2023-01-26
+### Changed
+- Minor internal updates.
+
 ## [0.19.1] - 2023-01-11
 ### Changed
 - Changed attached_media type [#27840]
@@ -211,6 +215,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.19.2]: https://github.com/Automattic/jetpack-publicize/compare/v0.19.1...v0.19.2
 [0.19.1]: https://github.com/Automattic/jetpack-publicize/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.18.4...v0.19.0
 [0.18.4]: https://github.com/Automattic/jetpack-publicize/compare/v0.18.3...v0.18.4

--- a/projects/packages/publicize/changelog/update-node-to-v18
+++ b/projects/packages/publicize/changelog/update-node-to-v18
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update tooling node version to 18.13.0. Should be no change to the project.
-
-

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.19.2-alpha",
+	"version": "0.19.2",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.31.5] - 2023-01-26
+### Changed
+- Minor internal updates.
+
 ## [0.31.4] - 2023-01-23
 ### Changed
 - Start using utilities from Status package to detect whether a site is private or "coming-soon" (unlaunched). [#28328]
@@ -643,6 +647,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.31.5]: https://github.com/Automattic/jetpack-search/compare/v0.31.4...v0.31.5
 [0.31.4]: https://github.com/Automattic/jetpack-search/compare/v0.31.3...v0.31.4
 [0.31.3]: https://github.com/Automattic/jetpack-search/compare/v0.31.2...v0.31.3
 [0.31.2]: https://github.com/Automattic/jetpack-search/compare/v0.31.1...v0.31.2

--- a/projects/packages/search/changelog/update-node-to-v18
+++ b/projects/packages/search/changelog/update-node-to-v18
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update tooling node version to 18.13.0. Should be no change to the project.
-
-

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.31.5-alpha",
+	"version": "0.31.5",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.31.5-alpha';
+	const VERSION = '0.31.5';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/stats-admin/CHANGELOG.md
+++ b/projects/packages/stats-admin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.1 - 2023-01-26
+### Fixed
+- Stats: fixed missing params to WPCOM API. [#28544]
+
 ## 0.4.0 - 2023-01-23
 ### Added
 - Stats: enable Ads page [#27791]

--- a/projects/packages/stats-admin/changelog/fix-ads-controller-params
+++ b/projects/packages/stats-admin/changelog/fix-ads-controller-params
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Stats: fixed missing params to WPCOM API

--- a/projects/packages/stats-admin/changelog/update-node-to-v18
+++ b/projects/packages/stats-admin/changelog/update-node-to-v18
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update tooling node version to 18.13.0. Should be no change to the project.
-
-

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.4.1-alpha",
+	"version": "0.4.1",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -18,7 +18,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.4.1-alpha';
+	const VERSION = '0.4.1';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.7] - 2023-01-26
+### Added
+- VideoPress: show Connect banner above video player when the site is not connected [#28585]
+
+### Changed
+- Use `flex-end` instead of `end` for better browser compatibility. [#28530]
+- VideoPress: change the logic to enqueue video block scripts [#28564]
+
 ## [0.10.6] - 2023-01-25
 ### Changed
 - VideoPress: Refactor video data check when populating block attributes [#28566]
@@ -655,6 +663,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.10.7]: https://github.com/Automattic/jetpack-videopress/compare/v0.10.6...v0.10.7
 [0.10.6]: https://github.com/Automattic/jetpack-videopress/compare/v0.10.5...v0.10.6
 [0.10.5]: https://github.com/Automattic/jetpack-videopress/compare/v0.10.4...v0.10.5
 [0.10.4]: https://github.com/Automattic/jetpack-videopress/compare/v0.10.3...v0.10.4

--- a/projects/packages/videopress/changelog/fix-css-warning-about-start
+++ b/projects/packages/videopress/changelog/fix-css-warning-about-start
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Use `flex-end` instead of `end` for better browser compatibility.

--- a/projects/packages/videopress/changelog/update-videopress-register-and-enqueue-scripts
+++ b/projects/packages/videopress/changelog/update-videopress-register-and-enqueue-scripts
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-VideoPress: change the logic to enqueue video block scripts

--- a/projects/packages/videopress/changelog/update-videopress-show-connect-banner-in-player-too
+++ b/projects/packages/videopress/changelog/update-videopress-show-connect-banner-in-player-too
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-VideoPress: show Connect banner above video player when the site is not connected

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.10.7-alpha",
+	"version": "0.10.7",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.10.7-alpha';
+	const PACKAGE_VERSION = '0.10.7';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/wordads/CHANGELOG.md
+++ b/projects/packages/wordads/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.29] - 2023-01-26
+### Changed
+- Minor internal updates.
+
 ## [0.2.28] - 2023-01-11
 ### Changed
 - Updated package dependencies.
@@ -145,6 +149,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`
 - Updated package dependencies.
 
+[0.2.29]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.28...v0.2.29
 [0.2.28]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.27...v0.2.28
 [0.2.27]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.26...v0.2.27
 [0.2.26]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.25...v0.2.26

--- a/projects/packages/wordads/changelog/update-node-to-v18
+++ b/projects/packages/wordads/changelog/update-node-to-v18
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update tooling node version to 18.13.0. Should be no change to the project.
-
-

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.2.29-alpha",
+	"version": "0.2.29",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.2.29-alpha';
+	const VERSION = '0.2.29';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 11.8-a.11 - 2023-01-26
+### Major Enhancements
+- add support for all Launchpad flows for the on save Post Editor modal [#28555]
+
+### Enhancements
+- Add the ability to toggle automatic and manual firewall rules independantly of each other. [#27726]
+- Release Jetpack AI to WPCOM Simple and Atomic users [#28552]
+- Sanitize AI endpoints input [#28583]
+- Update Form and variations icons [#28428]
+
+### Improved compatibility
+- Use `flex-start` instead of `start` for better browser compatibility. [#28530]
+
+### Bug fixes
+- Fix openAI paragraph. Refactor most of it. Added dynamic error when content length changes. [#28483]
+- Fix when categories are empty [#28604]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Admin Menu: Route to new Reading Settings page (internal ATM - behind a feature flag) [#28430]
+- Common Mappings: Add a mapping for `options-reading.php` based on a `calypso_use_modernized_reading_settings` feature flag [#28549]
+- e2e tests: update encryption [#28537]
+- Mark posts using Jetpack AI features. Introducing the _jetpack_ai_calls meta field to indicate that a post has performed AI calls. [#28487]
+
 ## 11.8-a.9 - 2023-01-23
 ### Enhancements
 - Contact Form: improve file naming when exporting form responses. [#28413]

--- a/projects/plugins/jetpack/changelog/add-backup-storage-ui
+++ b/projects/plugins/jetpack/changelog/add-backup-storage-ui
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-launchpad_save_modal_all_flows
+++ b/projects/plugins/jetpack/changelog/add-launchpad_save_modal_all_flows
@@ -1,4 +1,0 @@
-Significance: minor
-Type: major
-
-add support for all Launchpad flows for the on save Post Editor modal

--- a/projects/plugins/jetpack/changelog/add-open-ai-useselect
+++ b/projects/plugins/jetpack/changelog/add-open-ai-useselect
@@ -1,4 +1,0 @@
-Significance: minor
-Type: bugfix
-
-Fix openAI paragraph. Refactor most of it. Added dynamic error when content length changes.

--- a/projects/plugins/jetpack/changelog/add-sanitize-openai-input
+++ b/projects/plugins/jetpack/changelog/add-sanitize-openai-input
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Sanitize AI endpoints input

--- a/projects/plugins/jetpack/changelog/fix-categories-can-be-null
+++ b/projects/plugins/jetpack/changelog/fix-categories-can-be-null
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Fix when categories are empty

--- a/projects/plugins/jetpack/changelog/fix-css-warning-about-start
+++ b/projects/plugins/jetpack/changelog/fix-css-warning-about-start
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-Use `flex-start` instead of `start` for better browser compatibility.

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 11.8-a.10
-
-

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 11.8-a.12
+
+

--- a/projects/plugins/jetpack/changelog/jetpack-ai-release
+++ b/projects/plugins/jetpack/changelog/jetpack-ai-release
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Release Jetpack AI to WPCOM Simple and Atomic users

--- a/projects/plugins/jetpack/changelog/jetpack-ai-store-post-id
+++ b/projects/plugins/jetpack/changelog/jetpack-ai-store-post-id
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Mark posts using Jetpack AI features. Introducing the _jetpack_ai_calls meta field to indicate that a post has performed AI calls.

--- a/projects/plugins/jetpack/changelog/update-admin-menu-route-to-new-reading-settings
+++ b/projects/plugins/jetpack/changelog/update-admin-menu-route-to-new-reading-settings
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Admin Menu: Route to new Reading Settings page (internal ATM - behind a feature flag)

--- a/projects/plugins/jetpack/changelog/update-blaze-shoo-singleton
+++ b/projects/plugins/jetpack/changelog/update-blaze-shoo-singleton
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-common-mappings-with-options-reading-php
+++ b/projects/plugins/jetpack/changelog/update-common-mappings-with-options-reading-php
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Common Mappings: Add a mapping for `options-reading.php` based on a `calypso_use_modernized_reading_settings` feature flag

--- a/projects/plugins/jetpack/changelog/update-e2e-test-encryption
+++ b/projects/plugins/jetpack/changelog/update-e2e-test-encryption
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-e2e tests: update encryption

--- a/projects/plugins/jetpack/changelog/update-form-icons
+++ b/projects/plugins/jetpack/changelog/update-form-icons
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Update Form and variations icons

--- a/projects/plugins/jetpack/changelog/update-jetpack-editorial-11.8-a.9
+++ b/projects/plugins/jetpack/changelog/update-jetpack-editorial-11.8-a.9
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Jetpack: changelog edits for 11.8-a.9
-
-

--- a/projects/plugins/jetpack/changelog/update-jetpack-waf-settings-ui
+++ b/projects/plugins/jetpack/changelog/update-jetpack-waf-settings-ui
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Add the ability to toggle automatic and manual firewall rules independantly of each other.

--- a/projects/plugins/jetpack/changelog/update-move-contact-form-static-assets
+++ b/projects/plugins/jetpack/changelog/update-move-contact-form-static-assets
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-node-to-v18
+++ b/projects/plugins/jetpack/changelog/update-node-to-v18
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Update tooling node version to 18.13.0. Should be no change to the project.
-
-

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ11_8_a_11",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ11_8_a_12",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ11_8_a_10",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ11_8_a_11",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 11.8-a.11
+ * Version: 11.8-a.12
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -32,7 +32,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.0' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '11.8-a.11' );
+define( 'JETPACK__VERSION', '11.8-a.12' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 11.8-a.10
+ * Version: 11.8-a.11
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -32,7 +32,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.0' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '11.8-a.10' );
+define( 'JETPACK__VERSION', '11.8-a.11' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -379,7 +379,7 @@ class Admin_Menu extends Base_Admin_Menu {
 			/**
 			 * Filter to enable the modernized Reading Settings in Calypso UI.
 			 *
-			 * @since $$next-version$$
+			 * @since 11.8
 			 * @module masterbar
 			 *
 			 * @param bool false Should the modernized Reading Settings be enabled? Default to false.

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "11.8.0-a.10",
+	"version": "11.8.0-a.11",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "11.8.0-a.11",
+	"version": "11.8.0-a.12",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",


### PR DESCRIPTION
## Proposed changes:

Jetpack: backport 11.8-a.11 release

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

Proofread, changelog editorial to follow in additional PR.
