### PR TITLE
VideoPress: fix Edit video details page stuck on the loading state

### DIFF
--- a/projects/packages/videopress/changelog/fix-stuck-edit-page
+++ b/projects/packages/videopress/changelog/fix-stuck-edit-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: change how we detect search parameters on the home page to prevent the stuck edit video details page

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.10.7",
+	"version": "0.10.8-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.10.7';
+	const PACKAGE_VERSION = '0.10.8-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/client/state/index.js
+++ b/projects/packages/videopress/src/client/state/index.js
@@ -19,11 +19,10 @@ export const stateDebug = debugFactory( 'videopress/media:state' );
 
 const initialState = window.jetpackVideoPressInitialState?.initialState || { videos: {} };
 
-const hash = window.location.hash.replace( /#\/\??/, '' );
-const hasSearchParams = new URLSearchParams( hash ).toString().replace( 'page=1', '' ).length > 0;
+const hashPieces = window.location.hash.split( '?' );
 
-if ( hasSearchParams ) {
-	// Avoid flash of initial data when we have a query
+if ( hashPieces?.[ 0 ] === '#/' && hashPieces?.[ 1 ] ) {
+	// Avoid flash of initial data when we have a query on the main library page (#/)
 	initialState.videos.isFetching = true;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #28593.

The application was getting stuck on the loading state because we manually set the `isFetching` state var to `true` to fix the flash of initial state content on the library, on [this PR](https://github.com/Automattic/jetpack/pull/28528).

To decide between setting it or not, we were checking the content on the `location.hash` variable, but turns out that the Edit video details page was a false positive on the code that checked which we should set `isFetching = true`.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change how to detect search parameters on the home page by spliting the `location.hash`on the question mark `?`, getting two pieces of information: the route (we are interested in the `#/`, the home page route) and all the search parameters (we are interested in all the parameter list that is not empty); this way we can only apply the `isFetching = true` change on the home page route and detect search parameters on a more reliable way

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `Jetpack > VideoPress`, navigate to another page of videos (or search for some term) and hard refresh the page, to make sure the flash of initial state is still not present 
   * refer to the [original PR](https://github.com/Automattic/jetpack/pull/28528) testing instructions for more details
* On any page of videos, click the `Edit video details` button of some video to get to the details page, then copy the URL of the page and open it on a new tab
   * Before this fix, the page would be stuck on a loading state
   * After this fix, the page should load properly and you will be able to see the details of the video

