### PR TITLE
Docs: Making the webpack-config setup link more obvious in development-environment.md

### DIFF
--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -156,7 +156,7 @@ The Jetpack Monorepo includes GitHub actions to build all projects, and optional
 A project must define `.scripts.build-development` and/or `.scripts.build-production` in `composer.json` to specify the commands needed to build.
 The build commands should assume that `pnpm install` and `composer install` have already been run, and _must not_ run them again.
 
-* If you're building JavaScript bundles with Webpack and [@automattic/jetpack-webpack-config](../projects/js-packages/webpack-config/README.md), note that your build-production command should set `NODE_ENV=production` and `BABEL_ENV=production`.
+* If you're building JavaScript bundles with Webpack and [@automattic/jetpack-webpack-config](../projects/js-packages/webpack-config/README.md) (more information on setup [in the README.md](../projects/js-packages/webpack-config/README.md)), note that your build-production command should set `NODE_ENV=production` and `BABEL_ENV=production`.
 * If you run into problems with Composer not recognizing the local git branch as being the right version, try setting `COMPOSER_ROOT_VERSION=dev-trunk` in the environment.
 * When building for the mirror repos, note that `COMPOSER_MIRROR_PATH_REPOS=1` will be set in the environment and the list of repositories in `composer.json` may be altered.
   This is not normally done in development environments, even with `jetpack build --production`.


### PR DESCRIPTION
## Proposed changes:

* This PR adds a more obvious link to the webpack-config README.md file at https://github.com/Automattic/jetpack/blob/trunk/projects/js-packages/webpack-config/README.md. The link exists already behind `@automattic/webpack-config` but at first glance that links look likes it links to another repository rather than a setup page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* There was confusion in finding the resource in this Slack thread - p1674690124965659-slack-C04J4UG3FLG

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Proof-read.