### PR TITLE
Jetpack/subscriptions view fix

### DIFF
--- a/projects/plugins/jetpack/changelog/jetpack-subscriptions-view-fix
+++ b/projects/plugins/jetpack/changelog/jetpack-subscriptions-view-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Add appropriate fix for the $post being null

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -331,8 +331,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 	 */
 	protected static function get_post_access_level() {
 		require_once __DIR__ . '/../../extensions/blocks/subscriptions/constants.php';
-		global $post;
-		$meta = get_post_meta( $post->ID, META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS, true );
+		$meta = get_post_meta( get_the_ID(), META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS, true );
 		if ( empty( $meta ) ) {
 			$meta = 'everybody';
 		}

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -330,8 +330,12 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 	 * @return string the actaul post access level (see projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js for the values).
 	 */
 	protected static function get_post_access_level() {
+		$post_id = get_the_ID();
+		if ( ! $post_id ) {
+			return 'everybody';
+		}
 		require_once __DIR__ . '/../../extensions/blocks/subscriptions/constants.php';
-		$meta = get_post_meta( get_the_ID(), META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS, true );
+		$meta = get_post_meta( $post_id, META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS, true );
 		if ( empty( $meta ) ) {
 			$meta = 'everybody';
 		}


### PR DESCRIPTION
More context in p1674830085351189-slack-CBG1CP4EN


Fixes the call where we would read the global $post without any protection against it being null

## Proposed changes:
* use `get_the_ID()` instead of the `$post` global



## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

Same as https://github.com/Automattic/jetpack/pull/28170