### PR TITLE
VideoPress: Fix video library stuck on loading state

### DIFF
--- a/projects/packages/videopress/changelog/fix-video-library-stuck-on-loading-state
+++ b/projects/packages/videopress/changelog/fix-video-library-stuck-on-loading-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: fix loading state bug on VideoPress video library when the query string parameters are `page=1`

--- a/projects/packages/videopress/src/client/state/index.js
+++ b/projects/packages/videopress/src/client/state/index.js
@@ -21,8 +21,8 @@ const initialState = window.jetpackVideoPressInitialState?.initialState || { vid
 
 const hashPieces = window.location.hash.split( '?' );
 
-if ( hashPieces?.[ 0 ] === '#/' && hashPieces?.[ 1 ] ) {
-	// Avoid flash of initial data when we have a query on the main library page (#/)
+if ( hashPieces?.[ 0 ] === '#/' && hashPieces?.[ 1 ] && hashPieces?.[ 1 ] !== 'page=1' ) {
+	// Avoid flash of initial data when we have a query on the main library page (#/), different from a page=1 query
 	initialState.videos.isFetching = true;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #28593. Caused by #28611.

We fixed the bug that lead the Edit video details page to be stuck on a loading state, but the fix that we added made the video library hang on a loading state when it's accessed using `page=1` as a search param. The value is not reached by the application but can be typed by the user.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a specific test case to check for a `page=1` parameter present on the URL and prevent setting the loading state when that is the case

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `Jetpack > Videopress`
* Navigate to a second page of videos, so a `?page=2` parameter gets added to the URL
* Change the `page` parameter to `1`, setting it as `?page=1`
* Do a hard refresh on the page
* Before the fix, the application would be hanged on a loading state:

<img width="1000" alt="Screen Shot 2023-01-27 at 12 20 00" src="https://user-images.githubusercontent.com/6760046/215187292-8fc9e967-26af-4fc2-8204-46803b5ee886.png">

* After the fix, the application will show the first page of videos as expected:

<img width="1000" alt="Screen Shot 2023-01-27 at 17 09 41" src="https://user-images.githubusercontent.com/6760046/215187653-1cf93270-5d7e-4f63-98bc-00e12dd5abc1.png">
