### PR TITLE
Jetpack Search: longer filters caching

### DIFF
--- a/projects/packages/search/changelog/update-search-filters-longer-caching
+++ b/projects/packages/search/changelog/update-search-filters-longer-caching
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Increased Jetpack Search filters caching from one hour to four hours

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.31.5",
+	"version": "0.31.6-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.31.5';
+	const VERSION = '0.31.6-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/instant-search/class-instant-search.php
+++ b/projects/packages/search/src/instant-search/class-instant-search.php
@@ -305,7 +305,7 @@ class Instant_Search extends Classic_Search {
 		do_action( 'did_jetpack_search_query', $query );
 
 		// Update local cache.
-		set_transient( $transient_name, $response, 1 * HOUR_IN_SECONDS );
+		set_transient( $transient_name, $response, 4 * HOUR_IN_SECONDS );
 
 		return $response;
 	}


### PR DESCRIPTION
## Proposed changes:
Increase caching ttl when fetching search filters from 1 hour to 4 hours.

We had some internal discussions about this after some users reported higher than expected number of monthly search requests. It was mainly about simple sites hosted on wpcom, which have different implementation and caching, but there could be a problem here as well. The issue is that rendering old search widget with categories/tags/dates filters:

![image](https://user-images.githubusercontent.com/6437642/215255008-a8a3ac34-a073-4fb9-9474-474d4e30761e.png)

costs one query. If it has to be regenerated every hour, we can exceed the 500 limit granted to Jetpack Search Free even without a single search performed by visitors (24 * 31 = 744). By increasing cache to 4 hours, we'll only do at most 6 queries per day, 186 per month.

The downside is that filters rendered below search can have numbers that are a couple of hours old, but that seems like a reasonable trade-off.

Note that searches performed from the frontend don't go through the method I modified, instead they either go directly to public-api endoint, or through [this endpoint](https://github.com/Automattic/jetpack/blob/3f5bb9a0f41517641a693b99e98f08d6ca3cd49a/projects/packages/search/src/class-rest-controller.php#L328). This change should only affect fetching filters when rendering the page.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
 - D99470-code
 - p1674680711493919-slack-C02ME06LF

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Use older theme that has the legacy widget sidebar, I've used `twenty sixteen`. 
* Add Jetpack Search widget to the sidebar.
* Verify using xdebug or debug logging that the modified method is used for rendering the filters, but isn't for actual searches.