### PR TITLE
Paid newsletters fix warnings

### DIFF
--- a/projects/plugins/jetpack/changelog/paid-newsletters-fix-warnings
+++ b/projects/plugins/jetpack/changelog/paid-newsletters-fix-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix warnings from the global reading of $post

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -430,8 +430,11 @@ function render_block( $attributes ) {
  * @return string the actual post access level (see projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js for the values).
  */
 function get_post_access_level() {
-	global $post;
-	$meta = get_post_meta( $post->ID, META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS, true );
+	$post_id = get_the_ID();
+	if ( ! $post_id ) {
+		return 'everybody';
+	}
+	$meta = get_post_meta( $post_id, META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS, true );
 	if ( empty( $meta ) ) {
 		$meta = 'everybody';
 	}


### PR DESCRIPTION
More context in p1674830085351189-slack-CBG1CP4EN

Fixes the call where we would read the global $post without any protection against it being null

## Proposed changes:

use get_the_ID() instead of the $post global

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

Same as https://github.com/Automattic/jetpack/pull/28170