### PR TITLE
Contact form: php warning fix

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-grunion-error-warning
+++ b/projects/plugins/jetpack/changelog/fix-grunion-error-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+PHP error warning fix

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -2460,7 +2460,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		} elseif ( $post ) {
 			$attributes['id'] = $post->ID;
 			$post_author      = get_userdata( $post->post_author );
-			$default_to      .= $post_author->user_email;
+			$default_to      .= $post_author->user_email ? $post_author->user_email : '';
 		}
 
 		// Keep reference to $this for parsing form fields.

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -81,7 +81,8 @@ add_action( 'gutenberg_render_block_core_template_part_none', 'grunion_contact_f
  * @return string
  */
 function grunion_contact_form_unset_block_template_part_id_global( $content, $block ) {
-	if ( 'core/template-part' === $block['blockName']
+	if ( isset( $block['blockName'] )
+		&& 'core/template-part' === $block['blockName']
 		&& isset( $GLOBALS['grunion_block_template_part_id'] ) ) {
 		unset( $GLOBALS['grunion_block_template_part_id'] );
 	}

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -2460,7 +2460,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		} elseif ( $post ) {
 			$attributes['id'] = $post->ID;
 			$post_author      = get_userdata( $post->post_author );
-			$default_to      .= $post_author->user_email ? $post_author->user_email : '';
+			$default_to      .= isset( $post_author->user_email ) ? $post_author->user_email : '';
 		}
 
 		// Keep reference to $this for parsing form fields.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes 
PHP Warning: Trying to access array offset on value of type null in 
/wordpress/plugins/jetpack/11.8-a.13/modules/contact-form/grunion-contact-form.php on line 84
PHP Warning: Undefined array key "blockName" in /wordpress/plugins/jetpack/11.8-a.13/modules/contact-form/grunion-contact-form.php 
on line 84
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add isset check

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* No tests
*

