### PR TITLE
Widgets: Fix jQuery deps on Twitter timeline

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jquery-dependency-on-twitter-timeline
+++ b/projects/plugins/jetpack/changelog/update-jquery-dependency-on-twitter-timeline
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Twitter timeline shortcode: remove jQuery dependency for non-admin pages, and add it for admin pages

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -1196,7 +1196,7 @@ class Jetpack {
 			wp_register_script(
 				'jetpack-twitter-timeline',
 				Assets::get_file_url_for_environment( '_inc/build/twitter-timeline.min.js', '_inc/twitter-timeline.js' ),
-				array( 'jquery' ),
+				array(),
 				'4.0.0',
 				true
 			);

--- a/projects/plugins/jetpack/modules/widgets/twitter-timeline.php
+++ b/projects/plugins/jetpack/modules/widgets/twitter-timeline.php
@@ -85,7 +85,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 					'_inc/build/widgets/twitter-timeline-admin.min.js',
 					'modules/widgets/twitter-timeline-admin.js'
 				),
-				array(),
+				array( 'jquery' ),
 				JETPACK__VERSION,
 				true
 			);


### PR DESCRIPTION
The Twitter timeline shortcode currently lists jQuery as a dependency, when neither the loader script nor the script being loaded make use of it.

On the other hand, the scripts for the admin page do make use of jQuery, and are not  listing it as a dependency.

This PR fixes both issues.

Note: I added @Automattic/jetpack-crew as a reviewer, as I don't think this code is currently being maintained by a specific team. Please feel free to reassign if that's incorrect!

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove jQuery as a dependency from the timeline shortcode script
* Add jQuery as a dependency to the timeline shortcode admin script

### Other information:

- N/A Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None; this is a simple bugfix.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
* Pick a theme and a set of plugins that don't load jQuery (e.g. a block theme like twentytwentytwo, Jetpack default settings, and no other plugins)
* Verify that a simple page (e.g. the homepage) does not load jQuery
* Add a page with twitter timeline shortcode, e.g. `[twitter-timeline username=automattic]`
* Load the page
* Ensure that the embedded timeline works correctly
* Ensure that jQuery was not loaded

