### PR TITLE
Shortcodes: php warning fix

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-shortcode-warnings
+++ b/projects/plugins/jetpack/changelog/fix-shortcode-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Shortcodes: fix php warning

--- a/projects/plugins/jetpack/modules/shortcodes/presentations.php
+++ b/projects/plugins/jetpack/modules/shortcodes/presentations.php
@@ -106,10 +106,7 @@ if ( ! class_exists( 'Presentations' ) ) :
 			}
 
 			foreach ( $GLOBALS['posts'] as $p ) {
-				if ( ! $p ) {
-					continue;
-				}
-				if ( has_shortcode( $p->post_content, 'presentation' ) ) {
+				if ( isset( $p->post_content ) && has_shortcode( $p->post_content, 'presentation' ) ) {
 					$this->scripts_and_style_included = true;
 					break;
 				}

--- a/projects/plugins/jetpack/modules/shortcodes/presentations.php
+++ b/projects/plugins/jetpack/modules/shortcodes/presentations.php
@@ -106,6 +106,9 @@ if ( ! class_exists( 'Presentations' ) ) :
 			}
 
 			foreach ( $GLOBALS['posts'] as $p ) {
+				if ( ! $p ) {
+					continue;
+				}
 				if ( has_shortcode( $p->post_content, 'presentation' ) ) {
 					$this->scripts_and_style_included = true;
 					break;

--- a/projects/plugins/jetpack/modules/shortcodes/recipe.php
+++ b/projects/plugins/jetpack/modules/shortcodes/recipe.php
@@ -91,6 +91,9 @@ class Jetpack_Recipes {
 		}
 
 		foreach ( $GLOBALS['posts'] as $p ) {
+			if ( ! $p ) {
+				continue;
+			}
 			if ( has_shortcode( $p->post_content, 'recipe' ) ) {
 				$this->scripts_and_style_included = true;
 				break;

--- a/projects/plugins/jetpack/modules/shortcodes/recipe.php
+++ b/projects/plugins/jetpack/modules/shortcodes/recipe.php
@@ -91,10 +91,7 @@ class Jetpack_Recipes {
 		}
 
 		foreach ( $GLOBALS['posts'] as $p ) {
-			if ( ! $p ) {
-				continue;
-			}
-			if ( has_shortcode( $p->post_content, 'recipe' ) ) {
+			if ( isset( $p->post_content ) && has_shortcode( $p->post_content, 'recipe' ) ) {
 				$this->scripts_and_style_included = true;
 				break;
 			}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes
PHP Warning: Attempt to read property "post_content" on null in /wordpress/plugins/jetpack/11.8-a.13/modules/shortcodes/recipe.php 
on line 94
PHP Warning: Attempt to read property "post_content" on null in 
/wordpress/plugins/jetpack/11.8-a.13/modules/shortcodes/presentations.php on line 109

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Checking if array is not null

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* No tests
*

