### PR TITLE
Stats: Update/remove stats ads page lock

### DIFF
--- a/projects/packages/stats-admin/changelog/update-remove-stats-ads-page-lock
+++ b/projects/packages/stats-admin/changelog/update-remove-stats-ads-page-lock
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Stats: Remove feature lock for Ads page

--- a/projects/packages/stats-admin/composer.json
+++ b/projects/packages/stats-admin/composer.json
@@ -49,7 +49,7 @@
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-stats-admin",
 		"branch-alias": {
-			"dev-trunk": "0.4.x-dev"
+			"dev-trunk": "0.5.x-dev"
 		},
 		"textdomain": "jetpack-stats-admin",
 		"version-constants": {

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.4.1",
+	"version": "0.5.0-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -310,10 +310,6 @@ class Dashboard {
 	 * @return array An array of capabilities.
 	 */
 	protected function get_current_user_capabilities() {
-		// Feature lock.
-		if ( ! isset( $_GET['flags'] ) || $_GET['flags'] !== 'stats/ads-page' ) {// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			return array();
-		}
 		$user = wp_get_current_user();
 		if ( ! $user || is_wp_error( $user ) ) {
 			return array();

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -18,7 +18,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.4.1';
+	const VERSION = '0.5.0-alpha';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/plugins/jetpack/changelog/update-remove-stats-ads-page-lock
+++ b/projects/plugins/jetpack/changelog/update-remove-stats-ads-page-lock
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2077,7 +2077,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "1e063258c2df95b38a9eaa4cad153e2ab9ac3792"
+                "reference": "d013b764b41b21c50fee6f89da679a3bf60469e5"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -2095,7 +2095,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-stats-admin",
                 "branch-alias": {
-                    "dev-trunk": "0.4.x-dev"
+                    "dev-trunk": "0.5.x-dev"
                 },
                 "textdomain": "jetpack-stats-admin",
                 "version-constants": {


### PR DESCRIPTION
## Proposed changes:

Since Ads page is working okay, the PR proposes to remove feature lock.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Setup Odyssey with Option 1 in `PejTkB-3E-p2`
* Open `/wp-admin/admin.php?page=stats`
* Ensure Ads tab is showing
* Click Ads tab
* Ensure the page is working okay

