### PR TITLE
VideoPress: do not depend on window.wp.media in getMediaToken() lib

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-do-not-use-wp-data
+++ b/projects/packages/videopress/changelog/update-videopress-do-not-use-wp-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: do not depend on window.wp.media in getMediaToken() lib

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.10.8",
+	"version": "0.10.9-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.10.8';
+	const PACKAGE_VERSION = '0.10.9-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/client/lib/get-media-token/index.ts
+++ b/projects/packages/videopress/src/client/lib/get-media-token/index.ts
@@ -22,10 +22,10 @@ const getMediaToken = function (
 	scope: MediaTokenScopeProps,
 	args: GetMediaTokenArgsProps = {}
 ): Promise< MediaTokenProps > {
-	const { id, guid, adminAjaxAPI: adminAjaxAPIArggument } = args;
+	const { id, guid, adminAjaxAPI: adminAjaxAPIArgument } = args;
 	return new Promise( function ( resolve, reject ) {
 		const adminAjaxAPI =
-			adminAjaxAPIArggument ||
+			adminAjaxAPIArgument ||
 			window.videopressAjax?.ajaxUrl ||
 			window?.ajaxurl ||
 			'/wp-admin/admin-ajax.php';

--- a/projects/packages/videopress/src/client/lib/get-media-token/index.ts
+++ b/projects/packages/videopress/src/client/lib/get-media-token/index.ts
@@ -22,12 +22,13 @@ const getMediaToken = function (
 	scope: MediaTokenScopeProps,
 	args: GetMediaTokenArgsProps = {}
 ): Promise< MediaTokenProps > {
-	const { id, guid, adminAjaxAPI: adminAjaxAPIArgument } = args;
+	const { id, guid, adminAjaxAPI: adminAjaxAPIArggument } = args;
 	return new Promise( function ( resolve, reject ) {
-		const adminAjaxAPI = adminAjaxAPIArgument || window.videopressAjax?.ajaxUrl;
-		if ( ! adminAjaxAPI ) {
-			return reject( 'adminAjaxAPI is not accesible' );
-		}
+		const adminAjaxAPI =
+			adminAjaxAPIArggument ||
+			window.videopressAjax?.ajaxUrl ||
+			window?.ajaxurl ||
+			'/wp-admin/admin-ajax.php';
 
 		if ( ! MEDIA_TOKEN_SCOPES.includes( scope ) ) {
 			return reject( 'Invalid scope' );

--- a/projects/packages/videopress/src/client/lib/get-media-token/index.ts
+++ b/projects/packages/videopress/src/client/lib/get-media-token/index.ts
@@ -24,7 +24,7 @@ const getMediaToken = function (
 ): Promise< MediaTokenProps > {
 	const { id, guid, adminAjaxAPI: adminAjaxAPIArgument } = args;
 	return new Promise( function ( resolve, reject ) {
-		const adminAjaxAPI = adminAjaxAPIArggument || window.videopressAjax?.ajaxUrl;
+		const adminAjaxAPI = adminAjaxAPIArgument || window.videopressAjax?.ajaxUrl;
 		if ( ! adminAjaxAPI ) {
 			return reject( 'adminAjaxAPI is not accesible' );
 		}

--- a/projects/packages/videopress/src/client/lib/get-media-token/index.ts
+++ b/projects/packages/videopress/src/client/lib/get-media-token/index.ts
@@ -22,7 +22,7 @@ const getMediaToken = function (
 	scope: MediaTokenScopeProps,
 	args: GetMediaTokenArgsProps = {}
 ): Promise< MediaTokenProps > {
-	const { id, guid, adminAjaxAPI: adminAjaxAPIArggument } = args;
+	const { id, guid, adminAjaxAPI: adminAjaxAPIArgument } = args;
 	return new Promise( function ( resolve, reject ) {
 		const adminAjaxAPI = adminAjaxAPIArggument || window.videopressAjax?.ajaxUrl;
 		if ( ! adminAjaxAPI ) {

--- a/projects/packages/videopress/src/client/lib/get-media-token/types.ts
+++ b/projects/packages/videopress/src/client/lib/get-media-token/types.ts
@@ -18,15 +18,19 @@ type AdminAjaxTokensProps = typeof TOKEN_ADMIN_AJAX_TYPES;
 export type GetMediaTokenArgsProps = {
 	id?: VideoId;
 	guid?: VideoGUID;
+	adminAjaxAPI?: string;
 };
 
 export type AdminAjaxTokenProps = AdminAjaxTokensProps[ number ];
 
 export type MediaTokenScopeAdminAjaxResponseBodyProps = {
-	upload_token: string;
-	upload_blog_id: string;
-	upload_action_url: string;
-	jwt: string;
+	success: boolean;
+	data: {
+		upload_token: string;
+		upload_blog_id: string;
+		upload_action_url: string;
+		jwt: string;
+	};
 };
 
 export type MediaTokenProps = {
@@ -34,3 +38,10 @@ export type MediaTokenProps = {
 	blogId?: string;
 	url?: string;
 };
+declare global {
+	interface Window {
+		videopressAjax: {
+			ajaxUrl: string;
+		};
+	}
+}

--- a/projects/packages/videopress/src/client/lib/get-media-token/types.ts
+++ b/projects/packages/videopress/src/client/lib/get-media-token/types.ts
@@ -43,5 +43,6 @@ declare global {
 		videopressAjax: {
 			ajaxUrl: string;
 		};
+		ajaxurl?: string;
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR gets rid of the `window.wp.media` dependency to request the media token in the `getMediaToken()` library, in favor of the fetch() native-lib usage.
It makes the getMediaLibrary() independent, allowing it to be used in other contexts.
Spoiler alert: Follow-up tasks are coming up to address video privacy issues.

Related with https://github.com/Automattic/jetpack/issues/28399

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: do not depend on window.wp.media in getMediaToken() lib

### Other information:

- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Nothing should change in terms of functionality. `getMediaToken()` is used in several places where we need to deal with uploading, updating, and deleting video data. For this:

* Go to the block editor
* Create a new video block
* Upload a file
* Confirm it gets uploaded
* Add a track. You can use the video description.
* Confirm the app uploads the track file correctly.
* Delete the track.
* Confirm it's deleted.

The getMediaToken() hits the admin-ajax endpoint. So you'd like to take a look at these request in the network tab tool of your browser:


https://user-images.githubusercontent.com/77539/215706280-8ac6fba2-e483-43cc-b8d4-f19c1c884eb7.mov


