### PR TITLE
Include "Recycle content" feature in all of the Social plans

### DIFF
--- a/projects/plugins/social/changelog/update-social-resharing-free
+++ b/projects/plugins/social/changelog/update-social-resharing-free
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Moved resharing to be available in the free plan

--- a/projects/plugins/social/src/js/components/pricing-page/index.js
+++ b/projects/plugins/social/src/js/components/pricing-page/index.js
@@ -60,16 +60,16 @@ const PricingPage = () => {
 				{ name: __( 'Twitter, Facebook, LinkedIn & Tumblr', 'jetpack-social' ) },
 				{ name: __( 'Customize publications', 'jetpack-social' ) },
 				{
-					name: __( 'Engagement optimizer', 'jetpack-social' ),
+					name: __( 'Recycle content', 'jetpack-social' ),
 					tooltipInfo: __(
-						'Enhance social media engagement with personalized posts.',
+						'Repurpose, reuse or republish already published content.',
 						'jetpack-social'
 					),
 				},
 				{
-					name: __( 'Recycle content', 'jetpack-social' ),
+					name: __( 'Engagement optimizer', 'jetpack-social' ),
 					tooltipInfo: __(
-						'Repurpose, reuse or republish already published content.',
+						'Enhance social media engagement with personalized posts.',
 						'jetpack-social'
 					),
 				},
@@ -150,7 +150,7 @@ const PricingPage = () => {
 				<PricingTableItem isIncluded />
 				<PricingTableItem isIncluded />
 				<PricingTableItem isIncluded />
-				<PricingTableItem />
+				<PricingTableItem isIncluded />
 				<PricingTableItem />
 				<PricingTableItem />
 				<PricingTableItem />
@@ -176,7 +176,7 @@ const PricingPage = () => {
 				<PricingTableItem isIncluded />
 				<PricingTableItem isIncluded />
 				<PricingTableItem isIncluded />
-				<PricingTableItem />
+				<PricingTableItem isIncluded />
 				<PricingTableItem />
 				<PricingTableItem />
 				<PricingTableItem />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

These small changes make the resharing feature appear in the free plan in the pricing table. This is needed, because we made resharing free

### Other information:

- [X] Have you written new tests for your changes, if applicable?
- [X] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [X] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

1203640801049718-as-1203785068344373

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Open the Social pricing page on the Social admin panel. Recycle content should be included in all of our 3 plans.

<img width="1131" alt="CleanShot 2023-01-31 at 10 04 24@2x" src="https://user-images.githubusercontent.com/36671565/215715847-ea20da60-4b7c-46f0-98cd-ecab44d81221.png">
