### PR TITLE
VideoPress: improve requesting video data

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-improve-requesting-token
+++ b/projects/packages/videopress/changelog/update-videopress-improve-requesting-token
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: improve requesting video data


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR iterates over the `useVideoData()` hook to improve the process when requesting video data by hitting the videos endpoint.

By default, the hook "supposes" the data is not private, so it hits the endpoint without taking concern of the token. If the response is successful, the hook stores and provides the data.

Otherwise, it will check the response error. If it's about an authentication issue, it will request a token and performs a new request but this time pass the token to the request. It tries three times as the maximum.

Related to https://github.com/Automattic/jetpack/issues/28399

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: improve requesting video data

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create/edit a video block
* Set video private
* Open the network tab
* Filter requests by `1.1/videos`
* Hard refresh
* Confirm the endpoint URL **does not** contain the token_metafata value
* Confirm the response fails the first time (auth)
* Confirm the app tries again, taking a look at the debug() lines
* Confirm the endpoint URL **does**  contain the token_metafata value
* Confirm the next time, the response is successful. It will try three times as the maximum.

logs:

<img width="992" alt="image" src="https://user-images.githubusercontent.com/77539/215846090-615549f5-9026-4356-827f-c523bc32bb7f.png">

* Set video public
* Confirm the endpoint URL **does not** contain the token_metafata value
* Confirm the response is successful.
