### PR TITLE
VideoPress: anticipate privacy state of video

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-anticipate-video-privacy
+++ b/projects/packages/videopress/changelog/update-videopress-anticipate-video-privacy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: anticipate privacy state of the video

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/privacy-and-rating-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/privacy-and-rating-panel/index.tsx
@@ -15,10 +15,10 @@ import {
 	VIDEO_RATING_PG_13,
 	VIDEO_RATING_R_17,
 } from '../../../../../state/constants';
-import { VideoControlProps } from '../../types';
 /**
  * Types
  */
+import type { VideoControlProps } from '../../types';
 import type React from 'react';
 
 /**
@@ -31,7 +31,7 @@ export default function PrivacyAndRatingPanel( {
 	attributes,
 	setAttributes,
 	privateEnabledForSite,
-}: VideoControlProps ) {
+}: VideoControlProps ): React.ReactElement {
 	const { privacySetting, rating, allowDownload, displayEmbed } = attributes;
 
 	const privacyLabels = {
@@ -76,7 +76,17 @@ export default function PrivacyAndRatingPanel( {
 			<SelectControl
 				label={ __( 'Privacy', 'jetpack-videopress-pkg' ) }
 				onChange={ value => {
-					setAttributes( { privacySetting: Number( value ) } );
+					const attrsToUpdate: { privacySetting?: number; isPrivate?: boolean } = {};
+
+					// Anticipate the isPrivate attribute.
+					if ( value !== '2' ) {
+						attrsToUpdate.isPrivate = value === '1';
+					} else {
+						attrsToUpdate.isPrivate = privateEnabledForSite;
+					}
+
+					attrsToUpdate.privacySetting = Number( value );
+					setAttributes( attrsToUpdate );
 				} }
 				value={ String( privacySetting ) }
 				options={ [

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
@@ -307,6 +307,13 @@ export function useSyncMedia(
 				// Update local state with fresh video data.
 				updateInitialState( dataToUpdate );
 
+				// Privacy settings attribute update
+				if ( dataToUpdate?.privacy_setting !== 2 ) {
+					setAttributes( {
+						isPrivate: dataToUpdate.privacy_setting === 1,
+					} );
+				}
+
 				// | Video Chapters feature |
 				const chapters = extractVideoChapters( dataToUpdate?.description );
 

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
@@ -161,11 +161,12 @@ export function useSyncMedia(
 	setAttributes: VideoBlockSetAttributesProps,
 	options: UseSyncMediaOptionsProps
 ): UseSyncMediaProps {
-	const { id, guid } = attributes;
+	const { id, guid, isPrivate } = attributes;
 	const { videoData, isRequestingVideoData } = useVideoData( {
 		id,
 		guid,
 		skipRatingControl: true,
+		maybeIsPrivate: isPrivate,
 	} );
 
 	const isSaving = useSelect( select => select( editorStore ).isSavingPost(), [] );

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/index.ts
@@ -10,6 +10,7 @@ import debugFactory from 'debug';
  */
 import { isUserConnected as getIsUserConnected } from '../../../lib/connection';
 import getMediaToken from '../../../lib/get-media-token';
+import { MediaTokenProps } from '../../../lib/get-media-token/types';
 /**
  * Types
  */
@@ -32,6 +33,7 @@ export default function useVideoData( {
 	id,
 	guid,
 	skipRatingControl = false,
+	maybeIsPrivate = false,
 }: UseVideoDataArgumentsProps ): UseVideoDataProps {
 	const [ videoData, setVideoData ] = useState< VideoDataProps >( {} );
 	const [ isRequestingVideoData, setIsRequestingVideoData ] = useState( false );
@@ -53,9 +55,15 @@ export default function useVideoData( {
 			try {
 				const params: WPCOMRestAPIVideosGetEndpointRequestArguments = {};
 
+				// Try to anticipate the private requestin
+				let tokenData: MediaTokenProps;
+				if ( maybeIsPrivate ) {
+					tokenData = await getMediaToken( 'playback', { id, guid } );
+				}
+
 				// Add the token to the request if it exists.
-				if ( token ) {
-					params.metadata_token = token;
+				if ( token || tokenData?.token ) {
+					params.metadata_token = token || tokenData.token;
 				}
 
 				// Add the birthdate to skip the rating check if it's required.

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/types.ts
@@ -8,6 +8,7 @@ export type UseVideoDataArgumentsProps = {
 	id?: VideoId;
 	guid?: VideoGUID;
 	skipRatingControl: boolean;
+	maybeIsPrivate: boolean;
 };
 
 export type VideoDataProps = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR tries to anticipate the privacy state of the video, based on the block attributes.

The goal is to reduce as much as possible (ideally totally) the reattempt requests when the endpoint response is wrong because of Auth issues.

In other words, the app should know when to request and add, and when not, the token to get access to private data.

Related to https://github.com/Automattic/jetpack/issues/28399

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: anticipate privacy state of the video

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Add/edit a video block
* Set the video `public`
* Save the post 
* Hard refresh
* Pay attention to the `v1.1/videos/<guid>` endpoint.
  * There should be **only one** request made by the app.
  * The app should **not add** a token to the request URL.
Keep in mind that the route script hits the same endpoint. That is not the request that we want to check here.

<img width="918" alt="Screen Shot 2023-01-31 at 12 37 02" src="https://user-images.githubusercontent.com/77539/215761863-0c57361d-0a4b-498b-8941-fc63e6701bbc.png">

* Set video `private`
* Save the post 
* Hard refresh
* Pay attention to the `v1.1/videos/<guid>` endpoint.
  * There should be **only one** request made by the app.
  * The app should **add** a token to the request URL.


