### PR TITLE
E2E tests: increase api response timeout for subscribe and simple payment blocks

### DIFF
--- a/tools/e2e-commons/pages/wp-admin/blocks/simple-payments.js
+++ b/tools/e2e-commons/pages/wp-admin/blocks/simple-payments.js
@@ -36,10 +36,11 @@ export default class SimplePaymentBlock extends EditorCanvas {
 	}
 
 	async waitForResponse() {
-		const response = await this.page.waitForResponse( r =>
-			decodeURIComponent( r.url() ).match( /jp_pay_product/ )
+		const response = await this.page.waitForResponse(
+			r => decodeURIComponent( r.url() ).match( /jp_pay_product/ ),
+			{ timeout: 30000 }
 		);
-		expect( [ 200, 201 ], 'Response status should be 200' ).toContain( response.status() );
+		expect( [ 200, 201 ], 'Response status should be 200 or 201' ).toContain( response.status() );
 	}
 
 	getSelector( selector ) {

--- a/tools/e2e-commons/pages/wp-admin/blocks/subscribe.js
+++ b/tools/e2e-commons/pages/wp-admin/blocks/subscribe.js
@@ -1,4 +1,5 @@
 import EditorCanvas from './editor-canvas.js';
+import { expect } from '@playwright/test';
 export default class SubscribeBlock extends EditorCanvas {
 	constructor( blockId, page ) {
 		super( page, 'Subscribe' );
@@ -14,11 +15,11 @@ export default class SubscribeBlock extends EditorCanvas {
 		return 'Subscribe';
 	}
 	async checkBlock() {
-		await this.page.waitForResponse(
-			r =>
-				decodeURIComponent( r.url() ).match( /wpcom\/v2\/subscribers\/counts/ ) &&
-				r.status() === 200
+		const response = await this.page.waitForResponse(
+			r => decodeURIComponent( r.url() ).match( /wpcom\/v2\/subscribers\/counts/ ),
+			{ timeout: 30000 }
 		);
+		expect( response.status(), 'Response status should be 200' ).toBe( 200 );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

Increase the time waiting for a successful api response for subscribe and simple payment blocks to 30s. This is an attempt to stop recent failures of the 2 tests cause by waiting for response timeout.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1674830243595909-slack-C03QNBQKG73

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* e2e tests pass