### PR TITLE
Blaze: do not display links in non-supported CPT post lists.

### DIFF
--- a/projects/packages/blaze/changelog/fix-blaze-action-items-cpt
+++ b/projects/packages/blaze/changelog/fix-blaze-action-items-cpt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Do not display Blaze links in non-supported CPT pages.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.5.0",
+	"version": "0.5.1-alpha",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -17,7 +17,7 @@ use Automattic\Jetpack\Sync\Settings as Sync_Settings;
  */
 class Blaze {
 
-	const PACKAGE_VERSION = '0.5.0';
+	const PACKAGE_VERSION = '0.5.1-alpha';
 
 	/**
 	 * Script handle for the JS file we enqueue in the post editor.

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -172,6 +172,12 @@ class Blaze {
 	public static function jetpack_blaze_row_action( $post_actions, $post ) {
 		$post_id = $post->ID;
 
+		// Bail if we are not looking at one of the supported post types (post, page, or product).
+		if ( ! in_array( $post->post_type, array( 'post', 'page', 'product' ), true ) ) {
+			return $post_actions;
+		}
+
+		// Bail if the post is not published.
 		if ( $post->post_status !== 'publish' ) {
 			return $post_actions;
 		}


### PR DESCRIPTION
## Proposed changes:

* Avoid displaying "Blaze" links on non-supported CPT pages.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?
* No

## Testing instructions:

* On a WoA site, go to Jetpack > Settings and ensure the contact form module is active. Your site must also be public.
* If you've never submitted test feedback forms on that site in the past, create a new post and add a form block to it. Publish your post, and submit a test feedback.
* Go to the feedback menu in wp-admin. You should see the feedback you just submitted.
* Move your mouse over your entry; you should see the "Blaze" item.
* Now apply this branch; the "Blaze" link should be gone.
* Go to the Posts menu, still in wp-admin; you should see the "Blaze" link when moving your mouse over published posts there. 
