### PR TITLE
Blaze: do not require JSON API module anymore.

### DIFF
--- a/projects/packages/blaze/changelog/rm-blaze-json-api-gate
+++ b/projects/packages/blaze/changelog/rm-blaze-json-api-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Do not require Jetpack's JSON API module to use feature.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.5.0",
+	"version": "0.5.1-alpha",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -17,7 +17,7 @@ use Automattic\Jetpack\Sync\Settings as Sync_Settings;
  */
 class Blaze {
 
-	const PACKAGE_VERSION = '0.5.0';
+	const PACKAGE_VERSION = '0.5.1-alpha';
 
 	/**
 	 * Script handle for the JS file we enqueue in the post editor.

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -138,12 +138,6 @@ class Blaze {
 			if ( ! Sync_Settings::is_sync_enabled() ) {
 				$should_initialize = false;
 			}
-
-			// The feature relies on this module for now.
-			// See 1386-gh-dotcom-forge
-			if ( ! ( new Modules() )->is_active( 'json-api' ) ) {
-				$should_initialize = false;
-			}
 		}
 
 		// Check if the site supports Blaze.


### PR DESCRIPTION
## Proposed changes:

This effectively reverts #28267. This check should no longer be necessary when D97667-code will be committed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* 1386-gh-dotcom-forge

## Does this pull request change what data or activity we track or use?
* No

## Testing instructions:

> **Note**
> You will not be able to test this until the above diff is committed.

* Test on a public WoA site
* Go to the Post list, in wp-admin: `wp-admin/edit.php?post_type=post`
* You should see the "Blaze" option when moving your mouse over a post row (if the post is published).
* Go to `https://yoursite.com/wp-admin/admin.php?page=jetpack_modules`
* Disable the JSON API module.
* Reload the post list in wp-admin.
* The Blaze option should still be there.
* Click on one of the links.
* Ensure the Calypso page loads fully.

