### PR TITLE
E2E tests: handle welcome guide modal in site editor

### DIFF
--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -48,12 +48,6 @@ const matrix = [];
 switch ( process.env.GITHUB_EVENT_NAME ) {
 	case 'pull_request':
 	case 'push': {
-		projects.push( {
-			project: 'Blocks with latest Gutenberg',
-			path: 'projects/plugins/jetpack/tests/e2e',
-			testArgs: [ 'blocks', '--retries=1' ],
-			suite: 'gutenberg-28673',
-		} );
 		const changedProjects = JSON.parse(
 			execSync( '.github/files/list-changed-projects.sh' ).toString()
 		);

--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -48,6 +48,12 @@ const matrix = [];
 switch ( process.env.GITHUB_EVENT_NAME ) {
 	case 'pull_request':
 	case 'push': {
+		projects.push( {
+			project: 'Blocks with latest Gutenberg',
+			path: 'projects/plugins/jetpack/tests/e2e',
+			testArgs: [ 'blocks', '--retries=1' ],
+			suite: 'gutenberg-28673',
+		} );
 		const changedProjects = JSON.parse(
 			execSync( '.github/files/list-changed-projects.sh' ).toString()
 		);

--- a/projects/plugins/jetpack/changelog/e2e-site_editor_welcome_modal
+++ b/projects/plugins/jetpack/changelog/e2e-site_editor_welcome_modal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+

--- a/projects/plugins/jetpack/tests/e2e/specs/blocks/free-blocks.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/blocks/free-blocks.test.js
@@ -179,6 +179,7 @@ test.describe( 'Free blocks', () => {
 			await test.step( 'Visit site editor page', async () => {
 				siteEditor = await SiteEditorPage.visit( page );
 				await siteEditor.edit();
+				await siteEditor.closeWelcomeGuide();
 				await siteEditor.clearCustomizations();
 			} );
 		} );

--- a/tools/e2e-commons/pages/wp-admin/site-editor.js
+++ b/tools/e2e-commons/pages/wp-admin/site-editor.js
@@ -32,6 +32,15 @@ export default class SiteEditorPage extends WpPage {
 		}
 	}
 
+	async closeWelcomeGuide() {
+		logger.step( 'Handling the welcome guide modal' );
+		const welcomeModal = "div[aria-label='Welcome to the site editor']";
+		if ( await this.isElementVisible( welcomeModal, 1000 ) ) {
+			logger.info( 'Closing the modal' );
+			await this.click( "button[aria-label='Close dialog']" );
+		}
+	}
+
 	async searchForBlock( searchTerm ) {
 		logger.step( `Search block: '${ searchTerm }'` );
 		await this.click( "button[aria-label='Toggle block inserter']" );


### PR DESCRIPTION
## Proposed changes:

Close the welcome guide modal in site editor if it's displayed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1675191150132429-slack-C03QNBQKG73

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* e2e tests pass