### PR TITLE
Slideshow block: Changing icons from URLEncoded to base64 encoded

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-slideshow-block-arrows
+++ b/projects/plugins/jetpack/changelog/fix-slideshow-block-arrows
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Changed previous and next icons to be base64 encoded vs. URLEncoded to fix a bug, which doesn't seem significant enough to add to the changelog
+
+

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/style.scss
@@ -147,7 +147,7 @@
 	.swiper-button-next.swiper-button-white,
 	.wp-block-jetpack-slideshow_button-next,
 	.amp-carousel-button-next {
-		background-image: url( "data:image/svg+xml,%3Csvg%20width%3D%2225%22%20height%3D%2224%22%20viewBox%3D%220%200%2025%2024%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cmask%20id%3D%22maskNext%22%20mask-type%3D%22alpha%22%20maskUnits%3D%22userSpaceOnUse%22%20x%3D%228%22%20y%3D%226%22%20width%3D%228%22%20height%3D%2212%22%3E%3Cpath%20d%3D%22M8.59814%2016.59L13.1557%2012L8.59814%207.41L10.0012%206L15.9718%2012L10.0012%2018L8.59814%2016.59Z%22%20fill%3D%22white%22%2F%3E%3C%2Fmask%3E%3Cg%20mask%3D%22url%28%23maskNext%29%22%3E%3Crect%20x%3D%220.34375%22%20width%3D%2223.8822%22%20height%3D%2224%22%20fill%3D%22%23000000%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E" );
+		background-image: url( "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjUiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNSAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48bWFzayBpZD0ibWFza05leHQiIG1hc2stdHlwZT0iYWxwaGEiIG1hc2tVbml0cz0idXNlclNwYWNlT25Vc2UiIHg9IjgiIHk9IjYiIHdpZHRoPSI4IiBoZWlnaHQ9IjEyIj48cGF0aCBkPSJNOC41OTgxNCAxNi41OUwxMy4xNTU3IDEyTDguNTk4MTQgNy40MUwxMC4wMDEyIDZMMTUuOTcxOCAxMkwxMC4wMDEyIDE4TDguNTk4MTQgMTYuNTlaIiBmaWxsPSJ3aGl0ZSIvPjwvbWFzaz48ZyBtYXNrPSJ1cmwoI21hc2tOZXh0KSI+PHJlY3QgeD0iMC4zNDM3NSIgd2lkdGg9IjIzLjg4MjIiIGhlaWdodD0iMjQiIGZpbGw9IiMwMDAwMDAiLz48L2c+PC9zdmc+" );
 	}
 
 	&.swiper-container-rtl .swiper-button-next.swiper-button-white,
@@ -155,7 +155,7 @@
 	.swiper-button-prev.swiper-button-white,
 	.wp-block-jetpack-slideshow_button-prev,
 	.amp-carousel-button-prev {
-		background-image: url( "data:image/svg+xml,%3Csvg%20width%3D%2225%22%20height%3D%2224%22%20viewBox%3D%220%200%2025%2024%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cmask%20id%3D%22maskPrev%22%20mask-type%3D%22alpha%22%20maskUnits%3D%22userSpaceOnUse%22%20x%3D%228%22%20y%3D%226%22%20width%3D%229%22%20height%3D%2212%22%3E%3Cpath%20d%3D%22M16.2072%2016.59L11.6496%2012L16.2072%207.41L14.8041%206L8.8335%2012L14.8041%2018L16.2072%2016.59Z%22%20fill%3D%22white%22%2F%3E%3C%2Fmask%3E%3Cg%20mask%3D%22url%28%23maskPrev%29%22%3E%3Crect%20x%3D%220.579102%22%20width%3D%2223.8823%22%20height%3D%2224%22%20fill%3D%22%23000000%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E" );
+		background-image: url( "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjUiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNSAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48bWFzayBpZD0ibWFza1ByZXYiIG1hc2stdHlwZT0iYWxwaGEiIG1hc2tVbml0cz0idXNlclNwYWNlT25Vc2UiIHg9IjgiIHk9IjYiIHdpZHRoPSI5IiBoZWlnaHQ9IjEyIj48cGF0aCBkPSJNMTYuMjA3MiAxNi41OUwxMS42NDk2IDEyTDE2LjIwNzIgNy40MUwxNC44MDQxIDZMOC44MzM1IDEyTDE0LjgwNDEgMThMMTYuMjA3MiAxNi41OVoiIGZpbGw9IndoaXRlIi8+PC9tYXNrPjxnIG1hc2s9InVybCgjbWFza1ByZXYpIj48cmVjdCB4PSIwLjU3OTEwMiIgd2lkdGg9IjIzLjg4MjMiIGhlaWdodD0iMjQiIGZpbGw9IiMwMDAwMDAiLz48L2c+PC9zdmc+" );
 	}
 
 	.wp-block-jetpack-slideshow_button-play,


### PR DESCRIPTION
## Description

An issue was [reported here](https://github.com/Automattic/wp-calypso/issues/71453) and it seems to be affecting quite a few WordPress.com customers.

@obenland highlighted [here](https://github.com/Automattic/wp-calypso/issues/71453#issuecomment-1409990686) that:

> CSS concatenation on Dotcom replaces relative URLs with absolute URLs in CSS url() functions

I noticed that the data strings had been updated to URLEncoded strings with [this PR](https://github.com/Automattic/jetpack/pull/27907). I believe that base64 encoding the images will fix the issue.

## Testing instructions:

1. On WP.com, pull up a testing site that uses Dara as the theme and has a static homepage.
2. Add a slideshow to the homepage.
3. Within the editor, you'll see the missing next/previous icons
4. View source and replace URLEncoded strings with new base64 encoded strings from this PR
5. You should see the next/prev icons now

### Before

![CleanShot 2023-01-31 at 14 07 17](https://user-images.githubusercontent.com/5634774/215858138-b97ad2ba-3e57-485d-b23d-bc2294e58460.gif)

### After

![CleanShot 2023-01-31 at 13 55 08](https://user-images.githubusercontent.com/5634774/215857958-62ac7aa8-5bbe-430b-baee-1bfc5bb1196c.gif)

### Note

I was unable to replicate the reported mobile issue from [the original issue](https://github.com/Automattic/wp-calypso/issues/71453), which said:

> When viewed on mobile the forward and back options are missing all together and there is a small transparent square which appears in the top right of the slideshow block

Here is what I see on mobile (no arrows), which is expected:

![CleanShot 2023-01-31 at 14 10 02](https://user-images.githubusercontent.com/5634774/215858898-5bc24356-f446-44cc-a4bc-4682d27df502.gif)

## Does this pull request change what data or activity we track or use?

No

## Related

https://github.com/Automattic/wp-calypso/issues/71453