### PR TITLE
CRM: Fix Client Portal not disabling access for contacts

### DIFF
--- a/projects/plugins/crm/changelog/crm-fix-client_portal_not_disabling_access
+++ b/projects/plugins/crm/changelog/crm-fix-client_portal_not_disabling_access
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Client Portal bug that prevented access from being disabled using the contact page was fixed

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -348,37 +348,32 @@ function zeroBS_searchCustomers($args=array(),$withMoneyData=false){
 	global $zbs; return $zbs->DAL->contacts->getContacts($args);
 }
 
-/*
- * Enables or disables the client portal access for a contact, by ID
+/**
+ * Enables or disables the client portal access for a contact, by ID.
+ *
+ * @param int    $contact_id The id of the CRM Contact to be enabled or disabled.
+ * @param string $enable_or_disable String indicating if the selected contact should be enabled or disabled. Use 'disable' to disable, otherwise the contact will be enabled.
+ *
+ * @return bool True in case of success, false otherwise.
  */
-function zeroBSCRM_customerPortalDisableEnable( $contact_id=-1, $enableOrDisable='disable' ) {
-
+function zeroBSCRM_customerPortalDisableEnable( $contact_id = -1, $enable_or_disable = 'disable' ) {
 	global $zbs;
 
-	if ( zeroBSCRM_permsCustomers() && !empty( $contact_id ) ) {
-
-			// Verify this user can be changed
-			// (Has to have singular role of `zerobs_customer`. This helps to avoid users changing each others accounts via crm)
+	if ( zeroBSCRM_permsCustomers() && ! empty( $contact_id ) ) {
+		// Verify this user can be changed.
+		// Has to have singular role of `zerobs_customer`. This helps to avoid users changing each others accounts via crm.
 		$wp_user_id  = zeroBSCRM_getClientPortalUserID( $contact_id );
 		$user_object = get_userdata( $wp_user_id );
-			if ( jpcrm_role_check( $user_object, array(), array(), array( 'zerobs_customer' ) ) ) {
-
-				if ( $enableOrDisable == 'disable' ) {
-
-					return $zbs->DAL->updateMeta( ZBS_TYPE_CONTACT, $contact_id, 'portal_disabled', true );
-
-				} else {
-
-					return $zbs->DAL->updateMeta( ZBS_TYPE_CONTACT, $contact_id, 'portal_disabled', false );
-
-				}
-
+		if ( jpcrm_role_check( $user_object, array(), array(), array( 'zerobs_customer' ) ) ) {
+			if ( $enable_or_disable === 'disable' ) {
+				return $zbs->DAL->updateMeta( ZBS_TYPE_CONTACT, $contact_id, 'portal_disabled', true ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			} else {
+				return $zbs->DAL->updateMeta( ZBS_TYPE_CONTACT, $contact_id, 'portal_disabled', false ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			}
-
+		}
 	}
 
 	return false;
-
 }
 
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -359,8 +359,8 @@ function zeroBSCRM_customerPortalDisableEnable( $contact_id=-1, $enableOrDisable
 
 			// Verify this user can be changed
 			// (Has to have singular role of `zerobs_customer`. This helps to avoid users changing each others accounts via crm)
-    	$contact_email = $zbs->DAL->contacts->getContactEmail( $contact_id );  
-      $user_object = get_userdata( $contact_email );
+		$wp_user_id  = zeroBSCRM_getClientPortalUserID( $contact_id );
+		$user_object = get_userdata( $wp_user_id );
 			if ( jpcrm_role_check( $user_object, array(), array(), array( 'zerobs_customer' ) ) ) {
 
 				if ( $enableOrDisable == 'disable' ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR fixes a bug when trying to disable Client Portal access for a contact.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a contact with a valid email (using `wp-admin/admin.php?page=zbs-add-edit&action=edit&zbstype=contact`)
* Edit this contact (e.g. `wp-admin/admin.php?page=zbs-add-edit&action=view&zbstype=contact&zbsid=CONTACT_ID`), and enable their Client Portal Access.
* Save the page
* Refresh the page
* Edit it again and try to disable it.
* Refresh the page

In `trunk` the button to Enable/Disable access changes when you click it, but after refreshing the page it goes back to its previous state. The contact's access will reflect the state you get when you refresh the page.

In `crm/fix/client_portal_not_disabling_access` the button's state does not change after the page being refreshed, as expected. The contact's access still works as expected.

**Note**: `JPCRM_PUBLIC_LOCALE_OPT_FOR_DATERANGEPICKER` was changed from `const` to `var` because it is being wrongly re-declared. Fixing this properly would involve more work and I decided to just change it to a `var` for the time being because our daterange picker has to be replaced and I don't feel like spending time to fix this is worth it. Changing it to `var` is not something that looks correct, but it works and will serve as a band-aid until we replace this input.
