### PR TITLE
Backup and Social plugins: update the release branch prefix

### DIFF
--- a/projects/plugins/backup/changelog/update-backup-social-release-branch-prefix
+++ b/projects/plugins/backup/changelog/update-backup-social-release-branch-prefix
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update release branch prefix to 'jetpack'
+
+

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -46,7 +46,7 @@
 		"autotagger": {
 			"v": false
 		},
-		"release-branch-prefix": "backup",
+		"release-branch-prefix": "jetpack",
 		"wp-plugin-slug": "jetpack-backup",
 		"wp-svn-autopublish": true
 	},

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "91a7e302876c8b13534259db0440f38c",
+    "content-hash": "17713a49a048dad36b8a2cec52db481f",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/social/changelog/update-backup-social-release-branch-prefix
+++ b/projects/plugins/social/changelog/update-backup-social-release-branch-prefix
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update release branch prefix to 'jetpack'
+
+

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -71,7 +71,7 @@
 			"v": false
 		},
 		"mirror-repo": "Automattic/jetpack-social-plugin",
-		"release-branch-prefix": "social",
+		"release-branch-prefix": "jetpack",
 		"wp-plugin-slug": "jetpack-social",
 		"wp-svn-autopublish": true
 	},

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5043cd885627f71f43998b37df4cbadc",
+    "content-hash": "3870fba0a0a82a649a90e144b71a9423",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",


### PR DESCRIPTION
## Proposed changes:

Backup and Social plugins: update the release branch prefix to 'jetpack'. This will allow the Jetpack release lead to release all three plugins from one `prerelease` branch cut.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Internal: p9dueE-6ak-p2#comment-8842

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

Proofread, we can give it a try for next release.