### PR TITLE
Update dependency social-logos to v2.5.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1755,7 +1755,7 @@ importers:
       sass: 1.38.1
       sass-loader: 12.4.0
       semver: 7.3.5
-      social-logos: 2.5.1
+      social-logos: 2.5.2
       swiper: 6.7.0
       tinycolor2: 1.4.2
       tus-js-client: 2.3.0
@@ -1819,7 +1819,7 @@ importers:
       resize-observer-polyfill: 1.5.1
       sass: 1.38.1
       semver: 7.3.5
-      social-logos: 2.5.1_react@17.0.2
+      social-logos: 2.5.2_react@17.0.2
       swiper: 6.7.0
       tinycolor2: 1.4.2
       tus-js-client: 2.3.0
@@ -1942,6 +1942,9 @@ importers:
       allure-playwright: 2.0.0-beta.19
       config: 3.3.7
       jetpack-e2e-commons: link:../../../../../tools/e2e-commons
+
+  projects/plugins/mu-wpcom-plugin:
+    specifiers: {}
 
   projects/plugins/protect:
     specifiers:
@@ -21516,8 +21519,8 @@ packages:
       - supports-color
     dev: true
 
-  /social-logos/2.5.1_react@17.0.2:
-    resolution: {integrity: sha512-d3iCMJHqFOLHae+KqgW/sH2w1QKIL0hHLjnNpIIAURdi27olMVdG79x7Vu8gfkT2QPFOWRtUkO8rXeqF4ZaxMw==}
+  /social-logos/2.5.2_react@17.0.2:
+    resolution: {integrity: sha512-cEucM1RY+dnILiU+vpce7AIMJ4L3e06rfYKVq8FQlNRZsG+MI4nMbXkIyuULoqO8mciNQ3kfQm47R+DsKzzeLA==}
     peerDependencies:
       react: 15 - 18
     dependencies:

--- a/projects/plugins/jetpack/changelog/update-social-logos
+++ b/projects/plugins/jetpack/changelog/update-social-logos
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Social Logos: update dependency

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -100,7 +100,7 @@
 		"resize-observer-polyfill": "1.5.1",
 		"sass": "1.38.1",
 		"semver": "7.3.5",
-		"social-logos": "2.5.1",
+		"social-logos": "2.5.2",
 		"swiper": "6.7.0",
 		"tinycolor2": "1.4.2",
 		"tus-js-client": "2.3.0",


### PR DESCRIPTION
## Proposed changes:

This manual update brings in changes from this PR:
https://github.com/Automattic/social-logos/pull/115

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* pewaj1-3x-p2

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Not much to test here, since we are not using the new icon yet. You can try checking that the existing icons still work:

* Connect your site to WordPress.com.
* Go to Jetpack > Settings > Traffic
* Enable the SEO tools
* Expand the SEO Tools section, and open the previews section
* You should see the Facebook, Google, and Twitter icons.