### PR TITLE
E2E tests: remove GitHub annotations

### DIFF
--- a/tools/e2e-commons/config/playwright.config.default.cjs
+++ b/tools/e2e-commons/config/playwright.config.default.cjs
@@ -9,10 +9,6 @@ const reporter = [
 	[ `${ path.resolve( __dirname, '../', config.get( 'dirs.reporters' ) ) }/reporter.cjs` ],
 ];
 
-if ( process.env.CI ) {
-	reporter.push( [ 'github' ] );
-}
-
 // Fail early if the required test site config is not defined
 // Let config lib throw by using get function on an undefined property
 if ( process.env.TEST_SITE ) {


### PR DESCRIPTION
## Proposed changes:

Remove the Playwright's Github reporter. It provides automatic failure annotations, but it can be confusing for some folks, without bringing too much value instead.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
- e2e tests pass. 

