### PR TITLE
Repo Gardening: remove turnstyle recommendation from documentation

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-rm-deprecated-action
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-rm-deprecated-action
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update documentation and remove now-unnecessary action in job.


### PR DESCRIPTION
## Proposed changes:

This should no longer be necessary now that GitHub has better `concurrency`. It will also have the added benefit of removing deprecation warnings on repos that use that action, since it requires node 12 and GitHub doesn't want to support it anymore.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?
* No

## Testing instructions:

* Not much to test here, this is just a change in our documentation for others playing with our action.
