### PR TITLE
VideoPress: Add Preload control to the video block sidebar

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-preload-control
+++ b/projects/packages/videopress/changelog/add-videopress-preload-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add preload toggle to VideoPress block

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/index.tsx
@@ -94,7 +94,7 @@ export default function PlaybackPanel( { attributes, setAttributes }: VideoContr
 					'preload',
 					preload === 'metadata' ? 'none' : 'metadata'
 				) }
-				checked={ preload === 'metadata' ? true : false }
+				checked={ preload === 'metadata' }
 				help={ __(
 					'Preload the video metadata when the page is loaded.',
 					'jetpack-videopress-pkg'

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/index.tsx
@@ -21,12 +21,12 @@ import type React from 'react';
  * @returns {React.ReactElement}      Playback block sidebar panel
  */
 export default function PlaybackPanel( { attributes, setAttributes }: VideoControlProps ) {
-	const { autoplay, loop, muted, controls, playsinline } = attributes;
+	const { autoplay, loop, muted, controls, playsinline, preload } = attributes;
 
 	const handleAttributeChange = useCallback(
-		( attributeName: string ) => {
+		( attributeName: string, attributeValue?: string ) => {
 			return newValue => {
-				setAttributes( { [ attributeName ]: newValue } );
+				setAttributes( { [ attributeName ]: attributeValue ?? newValue } );
 			};
 		},
 		[ setAttributes ]
@@ -84,6 +84,19 @@ export default function PlaybackPanel( { attributes, setAttributes }: VideoContr
 				checked={ playsinline }
 				help={ __(
 					'Play the video inline instead of full-screen on mobile devices.',
+					'jetpack-videopress-pkg'
+				) }
+			/>
+
+			<ToggleControl
+				label={ __( 'Preload Metadata', 'jetpack-videopress-pkg' ) }
+				onChange={ handleAttributeChange(
+					'preload',
+					preload === 'metadata' ? 'none' : 'metadata'
+				) }
+				checked={ preload === 'metadata' ? true : false }
+				help={ __(
+					'Preload the video metadata when the page is loaded.',
 					'jetpack-videopress-pkg'
 				) }
 			/>

--- a/projects/packages/videopress/src/client/lib/url/index.ts
+++ b/projects/packages/videopress/src/client/lib/url/index.ts
@@ -57,7 +57,7 @@ export const getVideoPressUrl = (
 		...( muted && { muted: true, persistVolume: false } ),
 		...( playsinline && { playsinline: true } ),
 		...( poster && { posterUrl: poster } ),
-		...( preload !== 'none' && { preloadContent: preload } ),
+		...( preload !== '' && { preloadContent: preload } ),
 		...( seekbarColor !== '' && { sbc: seekbarColor } ),
 		...( seekbarPlayedColor !== '' && { sbpc: seekbarPlayedColor } ),
 		...( seekbarLoadingColor !== '' && { sblc: seekbarLoadingColor } ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #28670

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a modified control for the preload metadata option, only with the options 'metadata' and 'none' (on/off)

![image](https://user-images.githubusercontent.com/16329583/216142021-8dedc43d-bf7f-440f-9489-96f0e1200e69.png)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
* On a test site, connect Jetpack and add a VideoPress block
* Turn on / off the Preload Metadata option and confirm that the video loads with the chosen setting
* Confirm that the other options still work as expected

