### PR TITLE
Jetpack: Fix registering VaultPress and Scan submenus on a new Jetpack connected site

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-backup-scan-submenu-visibility
+++ b/projects/plugins/jetpack/changelog/fix-backup-scan-submenu-visibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Do not register the VaultPress and Scan submenu items if we don't have the backups and scan state yet.

--- a/projects/plugins/jetpack/modules/scan/class-admin-sidebar-link.php
+++ b/projects/plugins/jetpack/modules/scan/class-admin-sidebar-link.php
@@ -162,7 +162,11 @@ class Admin_Sidebar_Link {
 	private function has_scan() {
 		$this->maybe_refresh_transient_cache();
 		$scan_state = get_transient( 'jetpack_scan_state' );
-		return ! $scan_state || 'unavailable' !== $scan_state->state;
+		if ( ! $scan_state ) {
+			return false;
+		}
+
+		return isset( $scan_state->state ) && 'unavailable' !== $scan_state->state;
 	}
 
 	/**
@@ -182,7 +186,11 @@ class Admin_Sidebar_Link {
 	private function has_backup() {
 		$this->maybe_refresh_transient_cache();
 		$rewind_state = get_transient( 'jetpack_rewind_state' );
-		return ! $rewind_state || 'unavailable' !== $rewind_state->state;
+		if ( ! $rewind_state ) {
+			return false;
+		}
+
+		return isset( $rewind_state->state ) && 'unavailable' !== $rewind_state->state;
 	}
 
 	/**


### PR DESCRIPTION
There may be scenarios when connecting a new site to Jetpack where we don't have a rewind or scan state yet and it will return `null`, given that [we use a cronjob to refresh the Scan and Rewind state](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/jetpack/modules/scan/class-admin-sidebar-link.php#L200). It seems [we were returning that the site has backup and scan when the state was null](https://github.com/Automattic/jetpack/blob/5463f2e0284ca8a634f75deee22db0c1bf1de984/projects/plugins/jetpack/modules/scan/class-admin-sidebar-link.php#L168).

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix to not registering VaultPress and Scan submenus on a new Jetpack connected site if the backups/scan state is null

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1675284525650069-slack-C03TA48NSUX

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Validate how it was working before
* Spin up a Jurassic Ninja site with Jetpack 11.7.1 without any backup or scan plan.
* Connect the site to Jetpack
* You should see `Backup & Scan`, `Backup` or `Scan` submenu with the external-link icon

### Validate this branch (fixed version)
* Spin up a Jurassic Ninja site with Jetpack plugin using this branch (`fix/vaultpress-scan-submenu-state`) without any backup or scan plan.
* Connect the site to Jetpack
* You should not see any `Backup & Scan`, `Backup`, `VaultPress` or `Scan` submenu with the external-link icon.

### Regression test: #28650
We implemented recently a change to display `VaultPress` and `Scan` external link submenu only when the user has those capabilities. Even though this change does not directly impact those changes, it would be ideal to do a regression test [using the same testing instructions](https://github.com/Automattic/jetpack/pull/28650).