### PR TITLE
Fix sending for email-only subscribers

### DIFF
--- a/projects/plugins/jetpack/changelog/paid-news-fix-async-mailer-check
+++ b/projects/plugins/jetpack/changelog/paid-news-fix-async-mailer-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix sending for email-only subscribers.

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-offline-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-offline-subscription-service.php
@@ -39,7 +39,12 @@ class WPCOM_Offline_Subscription_Service extends WPCOM_Online_Subscription_Servi
 	public function subscriber_can_receive_post_by_mail( $user_id, $post_id ) {
 		$is_blog_subscriber = true; // it is a subscriber as this is used in async job looping through subscribers...
 		$access_level       = get_post_meta( $post_id, '_jetpack_newsletter_access', true );
-		if ( in_array( $access_level, [ Token_Subscription_Service::POST_ACCESS_LEVEL_SUBSCRIBERS, Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY ], true ) ) {
+		$allowed            = array(
+			Token_Subscription_Service::POST_ACCESS_LEVEL_SUBSCRIBERS,
+			Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY,
+		);
+
+		if ( in_array( $access_level, $allowed, true ) ) {
 			return true;
 		}
 
@@ -51,8 +56,8 @@ class WPCOM_Offline_Subscription_Service extends WPCOM_Online_Subscription_Servi
 		$previous_user = wp_get_current_user();
 		wp_set_current_user( $user_id );
 
-		$valid_plan_ids     = \Jetpack_Memberships::get_all_plans_id_jetpack_recurring_payments();
-		$allowed            = $this->user_can_view_content( $valid_plan_ids, $access_level, $is_blog_subscriber, $post_id );
+		$valid_plan_ids = \Jetpack_Memberships::get_all_plans_id_jetpack_recurring_payments();
+		$allowed        = $this->user_can_view_content( $valid_plan_ids, $access_level, $is_blog_subscriber, $post_id );
 
 		wp_set_current_user( $previous_user->ID );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/72780. 

This was actually fixed by D99740-code on the WPCOM side, but we should include this for completeness.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds assumptions and explicit checks to function.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On WPCOM patch D99740-code, then run email-subscriptions tests.

