### PR TITLE
Boost: Add prompts for regenerating Critical CSS under some conditions

### DIFF
--- a/projects/plugins/boost/app/admin/class-regenerate-admin-notice.php
+++ b/projects/plugins/boost/app/admin/class-regenerate-admin-notice.php
@@ -48,6 +48,7 @@ class Regenerate_Admin_Notice {
 		return add_query_arg(
 			array(
 				self::$dismissal_key => '',
+				'nonce'              => wp_create_nonce( 'jb_dismiss_notice' ),
 			)
 		);
 	}
@@ -55,7 +56,7 @@ class Regenerate_Admin_Notice {
 	public static function maybe_handle_dismissal() {
 		// We're okay dismissing the notice without nonce verification.
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		if ( ! is_admin() || ! current_user_can( 'manage_options' ) || ! isset( $_GET[ self::$dismissal_key ] ) ) {
+		if ( ! is_admin() || ! current_user_can( 'manage_options' ) || ! isset( $_GET[ self::$dismissal_key ], $_GET['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['nonce'] ) ), 'jb_dismiss_notice' ) ) {
 			return;
 		}
 
@@ -65,7 +66,7 @@ class Regenerate_Admin_Notice {
 		// Dismiss the notice that shows up for major changes.
 		static::dismiss();
 
-		wp_safe_redirect( remove_query_arg( self::$dismissal_key ) );
+		wp_safe_redirect( remove_query_arg( array( self::$dismissal_key, 'nonce' ) ) );
 	}
 
 	public static function init() {

--- a/projects/plugins/boost/app/admin/class-regenerate-admin-notice.php
+++ b/projects/plugins/boost/app/admin/class-regenerate-admin-notice.php
@@ -54,8 +54,6 @@ class Regenerate_Admin_Notice {
 	}
 
 	public static function maybe_handle_dismissal() {
-		// We're okay dismissing the notice without nonce verification.
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( ! is_admin()
 			|| ! current_user_can( 'manage_options' )
 			|| ! isset( $_GET[ self::$dismissal_key ], $_GET['nonce'] )

--- a/projects/plugins/boost/app/admin/class-regenerate-admin-notice.php
+++ b/projects/plugins/boost/app/admin/class-regenerate-admin-notice.php
@@ -56,7 +56,11 @@ class Regenerate_Admin_Notice {
 	public static function maybe_handle_dismissal() {
 		// We're okay dismissing the notice without nonce verification.
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		if ( ! is_admin() || ! current_user_can( 'manage_options' ) || ! isset( $_GET[ self::$dismissal_key ], $_GET['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['nonce'] ) ), 'jb_dismiss_notice' ) ) {
+		if ( ! is_admin()
+			|| ! current_user_can( 'manage_options' )
+			|| ! isset( $_GET[ self::$dismissal_key ], $_GET['nonce'] )
+			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['nonce'] ) ), 'jb_dismiss_notice' )
+		) {
 			return;
 		}
 

--- a/projects/plugins/boost/app/admin/class-regenerate-admin-notice.php
+++ b/projects/plugins/boost/app/admin/class-regenerate-admin-notice.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack_Boost\Admin;
 
+use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_State;
 use Automattic\Jetpack_Boost\Lib\Transient;
 
 /**
@@ -21,11 +22,23 @@ class Regenerate_Admin_Notice {
 	}
 
 	public static function dismiss() {
-		Transient::delete( 'regenerate_admin_notice', false );
+		Transient::delete( 'regenerate_admin_notice' );
 	}
 
 	public static function is_enabled() {
 		return Transient::get( 'regenerate_admin_notice', false );
+	}
+
+	public static function enable_suggestion() {
+		Transient::set( 'regenerate_admin_suggestion', true );
+	}
+
+	public static function dismiss_suggestion() {
+		Transient::delete( 'regenerate_admin_suggestion' );
+	}
+
+	public static function is_suggestion_enabled() {
+		return Transient::get( 'regenerate_admin_suggestion', false );
 	}
 
 	/**
@@ -46,29 +59,33 @@ class Regenerate_Admin_Notice {
 			return;
 		}
 		static::dismiss();
+		static::dismiss_suggestion();
 		wp_safe_redirect( remove_query_arg( self::$dismissal_key ) );
 	}
 
 	public static function init() {
 		add_action( 'admin_notices', array( static::class, 'maybe_render' ) );
-		if ( static::is_enabled() ) {
+		if ( static::is_enabled() || static::is_suggestion_enabled() ) {
 			static::maybe_handle_dismissal();
 		}
 	}
 
 	public static function maybe_render() {
-		if ( static::is_enabled() && current_user_can( 'manage_options' ) ) {
-			static::render();
-		}
-	}
-
-	public static function render() {
 		// We're not actually using the GET parameter here, it's only used to find out what page we're on.
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		$on_settings_page = is_admin() && isset( $_GET['page'] ) && Admin::MENU_SLUG === $_GET['page'];
-		if ( $on_settings_page ) {
+		if ( $on_settings_page || ! current_user_can( 'manage_options' ) ) {
 			return;
 		}
+
+		if ( static::is_enabled() ) {
+			static::render_notice();
+		} elseif ( static::is_suggestion_enabled() && ! Critical_CSS_State::is_fresh() ) {
+			static::render_suggestion();
+		}
+	}
+
+	public static function render_notice() {
 		?>
 		<div id="jetpack-boost-notice-critical-css-regenerate" class="notice notice-warning is-dismissible">
 			<h3>
@@ -79,6 +96,35 @@ class Regenerate_Admin_Notice {
 			</p>
 			<p>
 				<?php esc_html_e( 'You can go to the Jetpack Boost settings page to have it re-generated automatically.', 'jetpack-boost' ); ?>
+			</p>
+
+			<p>
+				<a class='button button-primary' href="<?php echo esc_url( admin_url( 'admin.php?page=' . Admin::MENU_SLUG ) ); ?>">
+					<strong>
+						<?php esc_html_e( 'Go to Jetpack Boost', 'jetpack-boost' ); ?>
+					</strong>
+				</a>
+				<a class="jb-dismiss-notice" href="<?php echo esc_url( static::get_dismiss_url() ); ?>">
+					<strong>
+						<?php esc_html_e( 'Dismiss notice', 'jetpack-boost' ); ?>
+					</strong>
+				</a>
+			</p>
+		</div>
+		<?php
+	}
+
+	public static function render_suggestion() {
+		?>
+		<div id="jetpack-boost-notice-critical-css-regenerate" class="notice notice-info is-dismissible">
+			<h3>
+				<?php esc_html_e( 'Jetpack Boost - Regenerate Critical CSS', 'jetpack-boost' ); ?>
+			</h3>
+			<p>
+				<?php esc_html_e( 'We noticed some updates to your site that may have changed your HTML/CSS structure.', 'jetpack-boost' ); ?>
+			</p>
+			<p>
+				<?php esc_html_e( 'Please regenerate your Critical CSS to maintain optimal site performance.', 'jetpack-boost' ); ?>
 			</p>
 
 			<p>

--- a/projects/plugins/boost/app/admin/class-regenerate-admin-notice.php
+++ b/projects/plugins/boost/app/admin/class-regenerate-admin-notice.php
@@ -58,8 +58,13 @@ class Regenerate_Admin_Notice {
 		if ( ! is_admin() || ! current_user_can( 'manage_options' ) || ! isset( $_GET[ self::$dismissal_key ] ) ) {
 			return;
 		}
+
+		// Mark the critical CSS as fresh so we don't show the suggestion again in a period of time.
+		Critical_CSS_State::set_fresh( true );
+
+		// Dismiss the notice that shows up for major changes.
 		static::dismiss();
-		static::dismiss_suggestion();
+
 		wp_safe_redirect( remove_query_arg( self::$dismissal_key ) );
 	}
 

--- a/projects/plugins/boost/app/assets/src/js/global.d.ts
+++ b/projects/plugins/boost/app/assets/src/js/global.d.ts
@@ -29,7 +29,10 @@ declare global {
 		};
 		connectionIframeOriginUrl: string;
 		connection: ConnectionStatus;
-		criticalCssStatus?: CriticalCssStatus;
+		criticalCSS?: {
+			status: CriticalCssStatus;
+			suggestRegenerate: boolean;
+		};
 		showRatingPromptNonce?: string;
 		showScorePromptNonce?: string;
 		criticalCssDismissedRecommendations: string[];

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/Module.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/Module.svelte
@@ -74,6 +74,8 @@
 				{#if $isEnabled}
 					<slot name="meta" />
 				{/if}
+
+				<slot name="notice" />
 			</div>
 		</div>
 	</div>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -3,7 +3,8 @@
 	import { __ } from '@wordpress/i18n';
 	import ReactComponent from '../../../elements/ReactComponent.svelte';
 	import TemplatedString from '../../../elements/TemplatedString.svelte';
-	import { RegenerateCriticalCssNotice } from '../../../react-components/RegenerateCriticalCssNotice';
+	import { RegenerateCriticalCssSuggestion } from '../../../react-components/RegenerateCriticalCssSuggestion';
+	import config from '../../../stores/config';
 	import { modules } from '../../../stores/modules';
 	import {
 		requestCloudCss,
@@ -57,7 +58,10 @@
 		</div>
 
 		<div slot="notice">
-			<ReactComponent this={RegenerateCriticalCssNotice} />
+			<ReactComponent
+				this={RegenerateCriticalCssSuggestion}
+				show={$config.criticalCSS.suggestRegenerate}
+			/>
 		</div>
 	</Module>
 

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import { getRedirectUrl } from '@automattic/jetpack-components';
 	import { __ } from '@wordpress/i18n';
+	import ReactComponent from '../../../elements/ReactComponent.svelte';
 	import TemplatedString from '../../../elements/TemplatedString.svelte';
+	import { RegenerateCriticalCssNotice } from '../../../react-components/RegenerateCriticalCssNotice';
 	import { modules } from '../../../stores/modules';
 	import {
 		requestCloudCss,
@@ -52,6 +54,10 @@
 
 		<div slot="meta">
 			<CriticalCssMeta />
+		</div>
+
+		<div slot="notice">
+			<ReactComponent this={RegenerateCriticalCssNotice} />
 		</div>
 	</Module>
 
@@ -140,5 +146,9 @@
 		margin-left: 10px;
 		transform: translateY( -4.5px );
 		display: inline-block;
+	}
+
+	[slot='notice'] {
+		margin-top: 1rem;
 	}
 </style>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -60,7 +60,7 @@
 		<div slot="notice">
 			<ReactComponent
 				this={RegenerateCriticalCssSuggestion}
-				show={$config.criticalCSS.suggestRegenerate}
+				show={$config.criticalCSS?.suggestRegenerate}
 			/>
 		</div>
 	</Module>

--- a/projects/plugins/boost/app/assets/src/js/react-components/RegenerateCriticalCssNotice.tsx
+++ b/projects/plugins/boost/app/assets/src/js/react-components/RegenerateCriticalCssNotice.tsx
@@ -1,9 +1,22 @@
 import { Notice } from '@automattic/jetpack-components';
+import { useState } from 'react';
 import { __ } from '@wordpress/i18n';
 
 export const RegenerateCriticalCssNotice = () => {
+	const [ isDismissed, setIsDismissed ] = useState( false );
+
+	if ( isDismissed ) {
+		return null;
+	}
+
 	return (
-		<Notice level="info" title={ __( 'Regenerate Critical CSS', 'jetpack-boost' ) }>
+		<Notice
+			level="info"
+			title={ __( 'Regenerate Critical CSS', 'jetpack-boost' ) }
+			onClose={ () => {
+				setIsDismissed( true );
+			} }
+		>
 			<p>
 				{ __(
 					'We noticed some updates to your site that may have changed your HTML/CSS structure.',

--- a/projects/plugins/boost/app/assets/src/js/react-components/RegenerateCriticalCssNotice.tsx
+++ b/projects/plugins/boost/app/assets/src/js/react-components/RegenerateCriticalCssNotice.tsx
@@ -1,0 +1,21 @@
+import { Notice } from '@automattic/jetpack-components';
+import { __ } from '@wordpress/i18n';
+
+export const RegenerateCriticalCssNotice = () => {
+	return (
+		<Notice level="info" title={ __( 'Regenerate Critical CSS', 'jetpack-boost' ) }>
+			<p>
+				{ __(
+					'We noticed some updates to your site that may have changed your HTML/CSS structure.',
+					'jetpack-boost'
+				) }
+			</p>
+			<p>
+				{ __(
+					'Please regenerate your Critical CSS to maintain optimal site performance.',
+					'jetpack-boost'
+				) }
+			</p>
+		</Notice>
+	);
+};

--- a/projects/plugins/boost/app/assets/src/js/react-components/RegenerateCriticalCssSuggestion.tsx
+++ b/projects/plugins/boost/app/assets/src/js/react-components/RegenerateCriticalCssSuggestion.tsx
@@ -1,11 +1,9 @@
 import { Notice } from '@automattic/jetpack-components';
-import { useState } from 'react';
 import { __ } from '@wordpress/i18n';
+import { hideRegenerateCriticalCssSuggestion } from '../stores/config';
 
-export const RegenerateCriticalCssNotice = () => {
-	const [ isDismissed, setIsDismissed ] = useState( false );
-
-	if ( isDismissed ) {
+export const RegenerateCriticalCssSuggestion = ( { show } ) => {
+	if ( ! show ) {
 		return null;
 	}
 
@@ -14,7 +12,7 @@ export const RegenerateCriticalCssNotice = () => {
 			level="info"
 			title={ __( 'Regenerate Critical CSS', 'jetpack-boost' ) }
 			onClose={ () => {
-				setIsDismissed( true );
+				hideRegenerateCriticalCssSuggestion();
 			} }
 		>
 			<p>

--- a/projects/plugins/boost/app/assets/src/js/react-components/RegenerateCriticalCssSuggestion.tsx
+++ b/projects/plugins/boost/app/assets/src/js/react-components/RegenerateCriticalCssSuggestion.tsx
@@ -14,6 +14,7 @@ export const RegenerateCriticalCssSuggestion = ( { show } ) => {
 			onClose={ () => {
 				hideRegenerateCriticalCssSuggestion();
 			} }
+			hideCloseButton={ true }
 		>
 			<p>
 				{ __(

--- a/projects/plugins/boost/app/assets/src/js/stores/config.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/config.ts
@@ -39,6 +39,16 @@ export const markGetStartedComplete = () => {
 	} ) );
 };
 
+export const hideRegenerateCriticalCssSuggestion = () => {
+	update( store => ( {
+		...store,
+		criticalCSS: {
+			...store.criticalCSS,
+			suggestRegenerate: false,
+		},
+	} ) );
+};
+
 export default {
 	subscribe,
 	refresh,

--- a/projects/plugins/boost/app/assets/src/js/stores/critical-css-status.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/critical-css-status.ts
@@ -46,7 +46,7 @@ const resetState = {
 	status: 'not_generated',
 };
 
-const initialState = Jetpack_Boost.criticalCssStatus || resetState;
+const initialState = Jetpack_Boost.criticalCSS?.status || resetState;
 
 const store = writable< CriticalCssStatus >( initialState );
 const { subscribe, update } = store;

--- a/projects/plugins/boost/app/assets/src/js/utils/generate-critical-css.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/generate-critical-css.ts
@@ -1,5 +1,6 @@
 import { get } from 'svelte/store';
 import { __ } from '@wordpress/i18n';
+import { hideRegenerateCriticalCssSuggestion } from '../stores/config';
 import { clearDismissedRecommendations } from '../stores/critical-css-recommendations';
 import {
 	requestGeneration,
@@ -74,6 +75,7 @@ export default async function generateCriticalCss(
 		if ( reset ) {
 			await clearDismissedRecommendations();
 			updateGenerateStatus( { status: 'requesting', progress: 0 } );
+			hideRegenerateCriticalCssSuggestion();
 		}
 
 		// Fetch a list of provider keys and URLs while loading the Critical CSS lib.

--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -191,8 +191,12 @@ class Jetpack_Boost {
 	 * This is done here so even if the Critical CSS module is switched off we can
 	 * still capture the change of environment event and flag Critical CSS for a rebuild.
 	 */
-	public function handle_environment_change() {
-		Regenerate_Admin_Notice::enable();
+	public function handle_environment_change( $is_major_change ) {
+		if ( $is_major_change ) {
+			Regenerate_Admin_Notice::enable();
+		} else {
+			Regenerate_Admin_Notice::enable_suggestion();
+		}
 	}
 
 	/**

--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -22,6 +22,7 @@ use Automattic\Jetpack_Boost\Features\Setup_Prompt\Setup_Prompt;
 use Automattic\Jetpack_Boost\Lib\Analytics;
 use Automattic\Jetpack_Boost\Lib\CLI;
 use Automattic\Jetpack_Boost\Lib\Connection;
+use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_State;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Storage;
 use Automattic\Jetpack_Boost\Lib\Setup;
 use Automattic\Jetpack_Boost\Lib\Transient;
@@ -195,7 +196,7 @@ class Jetpack_Boost {
 		if ( $is_major_change ) {
 			Regenerate_Admin_Notice::enable();
 		} else {
-			Regenerate_Admin_Notice::enable_suggestion();
+			Critical_CSS_State::set_fresh( false );
 		}
 	}
 

--- a/projects/plugins/boost/app/features/optimizations/critical-css/Critical_CSS.php
+++ b/projects/plugins/boost/app/features/optimizations/critical-css/Critical_CSS.php
@@ -143,8 +143,11 @@ class Critical_CSS implements Feature, Has_Endpoints {
 	 */
 	public function add_critical_css_constants( $constants ) {
 		// Information about the current status of Critical CSS / generation.
-		$generator                      = new Generator();
-		$constants['criticalCssStatus'] = $generator->get_local_critical_css_generation_info();
+		$generator                = new Generator();
+		$constants['criticalCSS'] = array(
+			'status'            => $generator->get_local_critical_css_generation_info(),
+			'suggestRegenerate' => Regenerate_Admin_Notice::is_suggestion_enabled(),
+		);
 
 		return $constants;
 	}

--- a/projects/plugins/boost/app/features/optimizations/critical-css/Critical_CSS.php
+++ b/projects/plugins/boost/app/features/optimizations/critical-css/Critical_CSS.php
@@ -6,6 +6,7 @@ use Automattic\Jetpack_Boost\Admin\Regenerate_Admin_Notice;
 use Automattic\Jetpack_Boost\Contracts\Feature;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Admin_Bar_Compatibility;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Invalidator;
+use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_State;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Storage;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Display_Critical_CSS;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Recommendations;
@@ -146,7 +147,7 @@ class Critical_CSS implements Feature, Has_Endpoints {
 		$generator                = new Generator();
 		$constants['criticalCSS'] = array(
 			'status'            => $generator->get_local_critical_css_generation_info(),
-			'suggestRegenerate' => Regenerate_Admin_Notice::is_suggestion_enabled(),
+			'suggestRegenerate' => ! Critical_CSS_State::is_fresh(),
 		);
 
 		return $constants;

--- a/projects/plugins/boost/app/lib/Environment_Change_Detector.php
+++ b/projects/plugins/boost/app/lib/Environment_Change_Detector.php
@@ -31,7 +31,7 @@ class Environment_Change_Detector {
 
 	public function handle_post_change( $post_id, $post ) {
 		$post_types = get_post_types( array( 'name' => $post->post_type ), 'objects' );
-		if ( empty( $post_types ) || $post_types[0]->public !== true ) {
+		if ( empty( $post_types ) || $post_types['post']->public !== true ) {
 			return;
 		}
 

--- a/projects/plugins/boost/app/lib/Environment_Change_Detector.php
+++ b/projects/plugins/boost/app/lib/Environment_Change_Detector.php
@@ -43,7 +43,7 @@ class Environment_Change_Detector {
 	}
 
 	public function handle_plugin_change() {
-		$this->do_action( true, 'plugin_change' );
+		$this->do_action( false, 'plugin_change' );
 	}
 
 	/**

--- a/projects/plugins/boost/app/lib/critical-css/Critical_CSS_Invalidator.php
+++ b/projects/plugins/boost/app/lib/critical-css/Critical_CSS_Invalidator.php
@@ -32,9 +32,11 @@ class Critical_CSS_Invalidator {
 	/**
 	 * Clear cached data and trigger side effects.
 	 */
-	public static function handle_clear_cache() {
-		self::clear_data();
-		do_action( 'jetpack_boost_after_clear_cache' );
+	public static function handle_clear_cache( $is_major_change ) {
+		if ( $is_major_change ) {
+			self::clear_data();
+			do_action( 'jetpack_boost_after_clear_cache' );
+		}
 	}
 
 }

--- a/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
+++ b/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
@@ -386,6 +386,14 @@ class Critical_CSS_State {
 		return self::FAIL === $this->state;
 	}
 
+	public static function is_fresh() {
+		return Transient::get( 'ccss_is_fresh', false );
+	}
+
+	public static function set_fresh( $is_fresh = true ) {
+		Transient::set( 'ccss_is_fresh', $is_fresh, WEEK_IN_SECONDS );
+	}
+
 	/**
 	 * Given a column, collate all provider sources returning the specified
 	 * column for each one.

--- a/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
+++ b/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
@@ -386,12 +386,15 @@ class Critical_CSS_State {
 		return self::FAIL === $this->state;
 	}
 
+	/**
+	 * Has there been any HTML/CSS structure changes since the last Critical CSS generation?
+	 */
 	public static function is_fresh() {
-		return Transient::get( 'ccss_is_fresh', false );
+		return Transient::get( 'is_ccss_fresh', false );
 	}
 
 	public static function set_fresh( $is_fresh = true ) {
-		Transient::set( 'ccss_is_fresh', $is_fresh, WEEK_IN_SECONDS );
+		Transient::set( 'is_ccss_fresh', $is_fresh );
 	}
 
 	/**

--- a/projects/plugins/boost/app/rest-api/endpoints/Generator_Success.php
+++ b/projects/plugins/boost/app/rest-api/endpoints/Generator_Success.php
@@ -4,6 +4,7 @@ namespace Automattic\Jetpack_Boost\REST_API\Endpoints;
 
 use Automattic\Jetpack_Boost\Admin\Regenerate_Admin_Notice;
 use Automattic\Jetpack_Boost\Features\Optimizations\Critical_CSS\Generator;
+use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_State;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Storage;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Recommendations;
 use Automattic\Jetpack_Boost\Lib\Nonce;
@@ -78,6 +79,8 @@ class Generator_Success implements Endpoint {
 		$recommendations->reset();
 
 		Regenerate_Admin_Notice::dismiss();
+		Regenerate_Admin_Notice::dismiss_suggestion();
+		Critical_CSS_State::set_fresh();
 
 		// Set status to success to indicate the critical CSS data has been stored on the server.
 		return rest_ensure_response(

--- a/projects/plugins/boost/app/rest-api/endpoints/Generator_Success.php
+++ b/projects/plugins/boost/app/rest-api/endpoints/Generator_Success.php
@@ -79,7 +79,8 @@ class Generator_Success implements Endpoint {
 		$recommendations->reset();
 
 		Regenerate_Admin_Notice::dismiss();
-		Regenerate_Admin_Notice::dismiss_suggestion();
+		// Prevent the notice from showing again for a while.
+		Regenerate_Admin_Notice::snooze_suggestion();
 		Critical_CSS_State::set_fresh();
 
 		// Set status to success to indicate the critical CSS data has been stored on the server.

--- a/projects/plugins/boost/changelog/add-regerate-prompts
+++ b/projects/plugins/boost/changelog/add-regerate-prompts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added notices to regenerate Critical CSS when applicable

--- a/projects/plugins/boost/rollup.config.js
+++ b/projects/plugins/boost/rollup.config.js
@@ -14,7 +14,9 @@ import { terser } from 'rollup-plugin-terser';
 import sveltePreprocess from 'svelte-preprocess';
 import tsconfig from './rollup-tsconfig.json';
 
-const cssGenPath = path.dirname( require.resolve( 'jetpack-boost-critical-css-gen' ) );
+const cssGenPath = path.dirname(
+	path.dirname( require.resolve( 'jetpack-boost-critical-css-gen' ) )
+);
 
 const production = ! process.env.ROLLUP_WATCH;
 const runServer = !! process.env.SERVE;


### PR DESCRIPTION
Fixes Automattic/boost-cloud#194

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Show admin notice to regenerate Critical CSS if
  * Post from any post type is updated/added
  * Plugin activated
  * Plugin deactivated
* And, if the last time C.CSS was generated was more than a week ago
* Show a notice on Boost dashboard below C.CSS module

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pbNhbs-54S-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Generate Critical CSS
* Check database to see if there is an option named `jb_transient_is_css_fresh`, delete it
* Update, create posts from any post type, activate or deactivate a plugin
* Check wp-admin/ and check if there is a notice suggesting to regenerate critical CSS
* Click dismiss to check if the prompt goes away
* Check boost dashboard, there should be a notice under the critical CSS module as well
* The notice in Boost Dashboard is not dismissable, it will come back if the page is reloaded

![image](https://user-images.githubusercontent.com/3737780/216297558-1dc2ff13-4ca5-43ec-b524-afcedeac0b66.png)

![image](https://user-images.githubusercontent.com/3737780/216297619-e0bcd649-fbe1-4461-a4a0-e6ab1f8d98d5.png)
