### PR TITLE
Blaze: display action links in page list as well

### DIFF
--- a/projects/packages/blaze/changelog/update-blaze-action-links-pages
+++ b/projects/packages/blaze/changelog/update-blaze-action-links-pages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Display "Blaze" links in page list too.

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -53,6 +53,7 @@ class Blaze {
 	public static function add_post_links_actions() {
 		if ( self::should_initialize() ) {
 			add_filter( 'post_row_actions', array( __CLASS__, 'jetpack_blaze_row_action' ), 10, 2 );
+			add_filter( 'page_row_actions', array( __CLASS__, 'jetpack_blaze_row_action' ), 10, 2 );
 		}
 	}
 


### PR DESCRIPTION
## Proposed changes:

This is a follow-up to #27906 and #28671.

Blaze currently supports posts, pages, and products. In the Calypso UI, we display a "Promote with Blaze" link next to the Edit link for all those post types.

In wp-admin, we currently only display that link for posts and supported custom types (currently only product) since they rely on the same `post_row_actions` hook).
Let's extend that to pages as well, thanks to the `page_row_actions` hook.

<img width="562" alt="image" src="https://user-images.githubusercontent.com/426388/216304030-d04788ea-cc46-498f-9066-afa1a3721250.png">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* 1386-gh-dotcom-forge

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Blaze is now enabled for all Jetpack sites, so you can test this on any site, including Jurassic Ninja. The site has to be public though.

* Go to the Posts Menu -> notice the "Blaze" link when you move your mouse over published posts.
* Go to the Pages menu -> same thing should happen.
