### PR TITLE
Blaze: add to Jetpack Social Plugin

### DIFF
--- a/projects/plugins/social/changelog/add-blaze-jetpack-social
+++ b/projects/plugins/social/changelog/add-blaze-jetpack-social
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Blaze: add Blaze feature to the Jetpack Social plugin.

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -7,6 +7,7 @@
 		"automattic/jetpack-admin-ui": "@dev",
 		"automattic/jetpack-assets": "@dev",
 		"automattic/jetpack-autoloader": "@dev",
+		"automattic/jetpack-blaze": "@dev",
 		"automattic/jetpack-composer-plugin": "@dev",
 		"automattic/jetpack-config": "@dev",
 		"automattic/jetpack-identity-crisis": "@dev",

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3870fba0a0a82a649a90e144b71a9423",
+    "content-hash": "6c011be1943e1f21a3267e5f66e098f7",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -228,6 +228,79 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-blaze",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/blaze",
+                "reference": "1c22a742cbab3a4d93b36924128c400685325bd5"
+            },
+            "require": {
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-sync": "@dev"
+            },
+            "require-dev": {
+                "automattic/jetpack-assets": "@dev",
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/wordbless": "@dev",
+                "yoast/phpunit-polyfills": "1.0.4"
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-blaze",
+                "changelogger": {
+                    "link-template": "https://github.com/automattic/jetpack-blaze/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.5.x-dev"
+                },
+                "textdomain": "jetpack-blaze",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-blaze.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
+                ],
+                "post-install-cmd": [
+                    "WorDBless\\Composer\\InstallDropin::copy"
+                ],
+                "post-update-cmd": [
+                    "WorDBless\\Composer\\InstallDropin::copy"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Attract high-quality traffic to your site using Blaze.",
             "transport-options": {
                 "relative": true
             }
@@ -4450,6 +4523,7 @@
         "automattic/jetpack-admin-ui": 20,
         "automattic/jetpack-assets": 20,
         "automattic/jetpack-autoloader": 20,
+        "automattic/jetpack-blaze": 20,
         "automattic/jetpack-composer-plugin": 20,
         "automattic/jetpack-config": 20,
         "automattic/jetpack-identity-crisis": 20,

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -87,6 +87,9 @@ class Jetpack_Social {
 						'force_refresh' => true,
 					)
 				);
+
+				// Blaze feature.
+				$config->ensure( 'blaze' );
 			},
 			1
 		);


### PR DESCRIPTION
## Proposed changes:

One should be able to promote their posts when using the Jetpack Social plugin only.

<img width="780" alt="image" src="https://user-images.githubusercontent.com/426388/216307878-6776a411-7a56-46a5-9b9e-a6bc78e8fc38.png">


> **Warning**
> While this PR itself currently works (it adds the interface in wp-admin), I'm noticing some issues in the Calypso UI. It seems that on sites running only the Jetpack Social plugin, Calypso isn't able to pull posts for some reason, and thus cannot display the content on the advertising screen.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* 1386-gh-dotcom-forge

## Does this pull request change what data or activity we track or use?

* Yes, it adds 2 new Tracks events on the post editor, when you publish a new post.

## Testing instructions:

Start with a site that runs only the Jetpack Social plugin, that's connected to WordPress.com. Your site must be public.

* Go to the Posts menu in wp-admin: you should see a "Blaze" link when moving your mouse over published posts.
* Go to Posts > Add New and write a new post.
* Upon publishing, you should see a post-publish panel in the post editor sidebar, inviting you to blaze your post.

