### PR TITLE
VideoPress: enqueue extensions when registrant plugin is active

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-fix-connect-url
+++ b/projects/packages/videopress/changelog/update-videopress-fix-connect-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: enqueue extensions when registrant plugin is active

--- a/projects/packages/videopress/src/class-block-editor-extensions.php
+++ b/projects/packages/videopress/src/class-block-editor-extensions.php
@@ -38,7 +38,7 @@ class Block_Editor_Extensions {
 	 * @param array $block_metadata - The block metadata.
 	 */
 	public static function init( $block_metadata ) {
-		if ( ! Status::is_active() ) {
+		if ( ! Status::is_registrant_plugin_active() ) {
 			return;
 		}
 

--- a/projects/packages/videopress/src/class-status.php
+++ b/projects/packages/videopress/src/class-status.php
@@ -15,20 +15,22 @@ use Jetpack;
 class Status {
 
 	/**
-	 * Returns whether VideoPress is active either as a Jetpack module or as a stand alone plugin
+	 * Returns whether VideoPress is active
+	 * either as a Jetpack module or as a stand alone plugin
 	 *
 	 * @return boolean
 	 */
 	public static function is_active() {
-		return self::is_jetpack_active() || self::is_standalone_plugin_active();
+		return self::is_jetpack_plugin_and_module_active() || self::is_standalone_plugin_active();
 	}
 
 	/**
-	 * Returns whether the Jetpack plugin and its VideoPress module are active
+	 * Returns whether the Jetpack plugin
+	 * and its VideoPress module are active.
 	 *
 	 * @return boolean
 	 */
-	public static function is_jetpack_active() {
+	public static function is_jetpack_plugin_and_module_active() {
 		return class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'videopress' );
 	}
 

--- a/projects/packages/videopress/src/class-status.php
+++ b/projects/packages/videopress/src/class-status.php
@@ -21,16 +21,23 @@ class Status {
 	 * @return boolean
 	 */
 	public static function is_active() {
-		return self::is_jetpack_plugin_and_module_active() || self::is_standalone_plugin_active();
+		return self::is_jetpack_plugin_and_videooress_module_active() || self::is_standalone_plugin_active();
 	}
 
 	/**
-	 * Returns whether the Jetpack plugin
+	 * Checks whether the Jetpack plugin is active
+	 */
+	public static function is_jetpack_plugin_active() {
+		return class_exists( 'Jetpack' );
+	}
+
+	/**
+	 * Checks whether the Jetpack plugin
 	 * and its VideoPress module are active.
 	 *
 	 * @return boolean
 	 */
-	public static function is_jetpack_plugin_and_module_active() {
+	public static function is_jetpack_plugin_and_videooress_module_active() {
 		return class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'videopress' );
 	}
 
@@ -41,5 +48,16 @@ class Status {
 	 */
 	public static function is_standalone_plugin_active() {
 		return class_exists( 'Jetpack_VideoPress_Plugin' );
+	}
+
+	/**
+	 * Checks whether the registrant plugin is active
+	 * either as a Jetpack module (via Jetpack plugin)
+	 * or as a stand-alone plugin.
+	 *
+	 * @return boolean True if the register plugin is active.
+	 */
+	public static function is_registrant_plugin_active() {
+		return self::is_jetpack_plugin_active() || self::is_standalone_plugin_active();
 	}
 }

--- a/projects/packages/videopress/src/class-status.php
+++ b/projects/packages/videopress/src/class-status.php
@@ -37,7 +37,7 @@ class Status {
 	 *
 	 * @return boolean
 	 */
-	public static function is_jetpack_plugin_and_videooress_module_active() {
+	public static function is_jetpack_plugin_and_videopress_module_active() {
 		return class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'videopress' );
 	}
 

--- a/projects/packages/videopress/src/class-status.php
+++ b/projects/packages/videopress/src/class-status.php
@@ -21,7 +21,7 @@ class Status {
 	 * @return boolean
 	 */
 	public static function is_active() {
-		return self::is_jetpack_plugin_and_videooress_module_active() || self::is_standalone_plugin_active();
+		return self::is_jetpack_plugin_and_videopress_module_active() || self::is_standalone_plugin_active();
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This plugin changes the condition when enqueuing the block extensions.
* It does not enqueue the extensions if the `Status->is_active()` is `False`. 
* `Status->is_active()` returns false when:
  * VideoPress standalone plugin is not active, or...
  * Jetpack plugin is not active, or...
  * Jetpack VideoPress module is not active

We want to enqueue the extensions when the plugin registrant is active (Jetpack or VideoPress standalone plugin) without considering whether the module is active.
The extension data is relevant (and needed) even when the module is inactive.

Fixes https://github.com/Automattic/jetpack/issues/28701

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: enqueue extensions when registrant plugin is active

### Other information:

- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Confirm the issue by following the steps described here: https://github.com/Automattic/jetpack/issues/28701
* With these changes, confirm that the `Connect` button leads properly to the connect screen

