### PR TITLE
VideoPress: handle VideoPress module connection from video block

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-handle-module-connection
+++ b/projects/packages/videopress/changelog/update-videopress-handle-module-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: handle VideoPress module connection from video block

--- a/projects/packages/videopress/src/class-block-editor-extensions.php
+++ b/projects/packages/videopress/src/class-block-editor-extensions.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\VideoPress;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Status\Host;
+use Jetpack;
 
 /**
  * VideoPress Extensions class.
@@ -153,9 +154,11 @@ class Block_Editor_Extensions {
 		}
 
 		$videopress_editor_state = array(
-			'extensions'          => $extensions_list,
-			'siteType'            => $site_type,
-			'myJetpackConnectUrl' => admin_url( 'admin.php?page=my-jetpack#/connection' ),
+			'extensions'                  => $extensions_list,
+			'siteType'                    => $site_type,
+			'myJetpackConnectUrl'         => admin_url( 'admin.php?page=my-jetpack#/connection' ),
+			'jetpackVideoPressSettingUrl' => admin_url( 'admin.php?page=jetpack#/settings?term=videopress' ),
+			'isVideoPressModuleActive'    => Jetpack::is_module_active( 'videopress' ),
 		);
 
 		// Expose initital state of site connection

--- a/projects/packages/videopress/src/class-block-editor-extensions.php
+++ b/projects/packages/videopress/src/class-block-editor-extensions.php
@@ -158,7 +158,7 @@ class Block_Editor_Extensions {
 			'myJetpackConnectUrl'         => admin_url( 'admin.php?page=my-jetpack#/connection' ),
 			'jetpackVideoPressSettingUrl' => admin_url( 'admin.php?page=jetpack#/settings?term=videopress' ),
 			'isVideoPressModuleActive'    => Status::is_jetpack_plugin_and_videopress_module_active(),
-			'isStandAloneActive'          => Status::is_standalone_plugin_active(),
+			'isStandaloneActive'          => Status::is_standalone_plugin_active(),
 		);
 
 		// Expose initital state of site connection

--- a/projects/packages/videopress/src/class-block-editor-extensions.php
+++ b/projects/packages/videopress/src/class-block-editor-extensions.php
@@ -158,6 +158,7 @@ class Block_Editor_Extensions {
 			'myJetpackConnectUrl'         => admin_url( 'admin.php?page=my-jetpack#/connection' ),
 			'jetpackVideoPressSettingUrl' => admin_url( 'admin.php?page=jetpack#/settings?term=videopress' ),
 			'isVideoPressModuleActive'    => Status::is_jetpack_plugin_and_videopress_module_active(),
+			'isStandAloneActive'          => Status::is_standalone_plugin_active(),
 		);
 
 		// Expose initital state of site connection

--- a/projects/packages/videopress/src/class-block-editor-extensions.php
+++ b/projects/packages/videopress/src/class-block-editor-extensions.php
@@ -10,7 +10,6 @@ namespace Automattic\Jetpack\VideoPress;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Status\Host;
-use Jetpack;
 
 /**
  * VideoPress Extensions class.
@@ -158,7 +157,7 @@ class Block_Editor_Extensions {
 			'siteType'                    => $site_type,
 			'myJetpackConnectUrl'         => admin_url( 'admin.php?page=my-jetpack#/connection' ),
 			'jetpackVideoPressSettingUrl' => admin_url( 'admin.php?page=jetpack#/settings?term=videopress' ),
-			'isVideoPressModuleActive'    => Jetpack::is_module_active( 'videopress' ),
+			'isVideoPressModuleActive'    => Status::is_jetpack_plugin_and_videopress_module_active(),
 		);
 
 		// Expose initital state of site connection

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -19,7 +19,10 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import { isUserConnected as getIsUserConnected } from '../../../lib/connection';
+import {
+	isUserConnected as getIsUserConnected,
+	isVideoPressModuleActive,
+} from '../../../lib/connection';
 import getMediaToken from '../../../lib/get-media-token';
 import { buildVideoPressURL, getVideoPressUrl } from '../../../lib/url';
 import { useSyncMedia } from '../../hooks/use-video-data-update';
@@ -44,8 +47,15 @@ import type React from 'react';
 import './editor.scss';
 
 const debug = debugFactory( 'videopress:video:edit' );
-const { myJetpackConnectUrl } = window?.videoPressEditorState || {};
+const { myJetpackConnectUrl, jetpackVideoPressSettingUrl } = window?.videoPressEditorState || {};
 const isUserConnected = getIsUserConnected();
+
+/**
+ * It considers VideoPress active
+ * if the user is connected and the module is active.
+ */
+const isModuleActive = isVideoPressModuleActive();
+const isVideoPressActive = isUserConnected && isModuleActive;
 
 const VIDEO_PREVIEW_ATTEMPTS_LIMIT = 10;
 
@@ -426,10 +436,13 @@ export default function VideoPressEdit( {
 			<div { ...blockProps } className={ blockMainClassName }>
 				<>
 					<ConnectBanner
-						isConnected={ isUserConnected }
+						isConnected={ isVideoPressActive }
 						isConnecting={ isRedirectingToMyJetpack }
 						onConnect={ () => {
 							setIsRedirectingToMyJetpack( true );
+							if ( ! isModuleActive ) {
+								return ( window.location.href = jetpackVideoPressSettingUrl );
+							}
 							window.location.href = myJetpackConnectUrl;
 						} }
 					/>
@@ -580,10 +593,14 @@ export default function VideoPressEdit( {
 			</InspectorControls>
 
 			<ConnectBanner
-				isConnected={ isUserConnected }
+				isConnected={ isVideoPressActive }
 				isConnecting={ isRedirectingToMyJetpack }
 				onConnect={ () => {
 					setIsRedirectingToMyJetpack( true );
+					if ( ! isModuleActive ) {
+						return ( window.location.href = jetpackVideoPressSettingUrl );
+					}
+
 					window.location.href = myJetpackConnectUrl;
 				} }
 			/>

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -19,7 +19,7 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import { isVideoPressActive, isVideoPressModuleActive } from '../../../lib/connection';
+import { isStandaloneActive, isVideoPressActive } from '../../../lib/connection';
 import getMediaToken from '../../../lib/get-media-token';
 import { buildVideoPressURL, getVideoPressUrl } from '../../../lib/url';
 import { useSyncMedia } from '../../hooks/use-video-data-update';
@@ -50,7 +50,7 @@ const { myJetpackConnectUrl, jetpackVideoPressSettingUrl } = window?.videoPressE
  * It considers VideoPress active
  * if the user is connected and the module is active.
  */
-const isModuleActive = isVideoPressModuleActive();
+const isStandalonePluginActive = isStandaloneActive();
 const isActive = isVideoPressActive();
 
 const VIDEO_PREVIEW_ATTEMPTS_LIMIT = 10;
@@ -436,7 +436,7 @@ export default function VideoPressEdit( {
 						isConnecting={ isRedirectingToMyJetpack }
 						onConnect={ () => {
 							setIsRedirectingToMyJetpack( true );
-							if ( ! isModuleActive ) {
+							if ( ! isStandalonePluginActive ) {
 								return ( window.location.href = jetpackVideoPressSettingUrl );
 							}
 							window.location.href = myJetpackConnectUrl;
@@ -593,7 +593,7 @@ export default function VideoPressEdit( {
 				isConnecting={ isRedirectingToMyJetpack }
 				onConnect={ () => {
 					setIsRedirectingToMyJetpack( true );
-					if ( ! isModuleActive ) {
+					if ( ! isStandalonePluginActive ) {
 						return ( window.location.href = jetpackVideoPressSettingUrl );
 					}
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -19,10 +19,7 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import {
-	isUserConnected as getIsUserConnected,
-	isVideoPressModuleActive,
-} from '../../../lib/connection';
+import { isVideoPressActive, isVideoPressModuleActive } from '../../../lib/connection';
 import getMediaToken from '../../../lib/get-media-token';
 import { buildVideoPressURL, getVideoPressUrl } from '../../../lib/url';
 import { useSyncMedia } from '../../hooks/use-video-data-update';
@@ -48,14 +45,13 @@ import './editor.scss';
 
 const debug = debugFactory( 'videopress:video:edit' );
 const { myJetpackConnectUrl, jetpackVideoPressSettingUrl } = window?.videoPressEditorState || {};
-const isUserConnected = getIsUserConnected();
 
 /**
  * It considers VideoPress active
  * if the user is connected and the module is active.
  */
 const isModuleActive = isVideoPressModuleActive();
-const isVideoPressActive = isUserConnected && isModuleActive;
+const isActive = isVideoPressActive();
 
 const VIDEO_PREVIEW_ATTEMPTS_LIMIT = 10;
 
@@ -436,7 +432,7 @@ export default function VideoPressEdit( {
 			<div { ...blockProps } className={ blockMainClassName }>
 				<>
 					<ConnectBanner
-						isConnected={ isVideoPressActive }
+						isConnected={ isActive }
 						isConnecting={ isRedirectingToMyJetpack }
 						onConnect={ () => {
 							setIsRedirectingToMyJetpack( true );
@@ -593,7 +589,7 @@ export default function VideoPressEdit( {
 			</InspectorControls>
 
 			<ConnectBanner
-				isConnected={ isVideoPressActive }
+				isConnected={ isActive }
 				isConnecting={ isRedirectingToMyJetpack }
 				onConnect={ () => {
 					setIsRedirectingToMyJetpack( true );

--- a/projects/packages/videopress/src/client/block-editor/global.d.ts
+++ b/projects/packages/videopress/src/client/block-editor/global.d.ts
@@ -9,7 +9,7 @@ declare global {
 			siteType: 'simple' | 'atomic' | 'jetpack';
 			myJetpackConnectUrl: string;
 			isVideoPressModuleActive: '' | '1';
-			isStandAloneActive: '' | '1';
+			isStandaloneActive: '' | '1';
 			jetpackVideoPressSettingUrl: string;
 		};
 

--- a/projects/packages/videopress/src/client/block-editor/global.d.ts
+++ b/projects/packages/videopress/src/client/block-editor/global.d.ts
@@ -8,6 +8,8 @@ declare global {
 			extensions: VideoPressExtensionsProps;
 			siteType: 'simple' | 'atomic' | 'jetpack';
 			myJetpackConnectUrl: string;
+			isVideoPressModuleActive: '' | '1';
+			jetpackVideoPressSettingUrl: string;
 		};
 
 		JP_CONNECTION_INITIAL_STATE: {

--- a/projects/packages/videopress/src/client/block-editor/global.d.ts
+++ b/projects/packages/videopress/src/client/block-editor/global.d.ts
@@ -9,6 +9,7 @@ declare global {
 			siteType: 'simple' | 'atomic' | 'jetpack';
 			myJetpackConnectUrl: string;
 			isVideoPressModuleActive: '' | '1';
+			isStandAloneActive: '' | '1';
 			jetpackVideoPressSettingUrl: string;
 		};
 

--- a/projects/packages/videopress/src/client/lib/connection/index.ts
+++ b/projects/packages/videopress/src/client/lib/connection/index.ts
@@ -42,3 +42,21 @@ export function isUserConnected(): boolean {
 export function isVideoPressModuleActive(): boolean {
 	return window?.videoPressEditorState?.isVideoPressModuleActive === '1';
 }
+
+/**
+ * Chek whether the VideoPress feature is active,
+ * considering the user connection status
+ * and also the module status.
+ *
+ * Note: It's possible to have the module active,
+ * but the user not connected.
+ *
+ * @returns {boolean} True if the feature is active, false otherwise.
+ */
+export function isVideoPressActive(): boolean {
+	if ( ! isUserConnected() ) {
+		return false;
+	}
+
+	return isVideoPressModuleActive();
+}

--- a/projects/packages/videopress/src/client/lib/connection/index.ts
+++ b/projects/packages/videopress/src/client/lib/connection/index.ts
@@ -62,7 +62,7 @@ export function isVideoPressActive(): boolean {
 }
 
 /**
- * Return whether the standalong plugin is active.
+ * Return whether the standalone plugin is active.
  *
  * @returns {boolean} True if the feature is active, false otherwise.
  */

--- a/projects/packages/videopress/src/client/lib/connection/index.ts
+++ b/projects/packages/videopress/src/client/lib/connection/index.ts
@@ -44,7 +44,7 @@ export function isVideoPressModuleActive(): boolean {
 }
 
 /**
- * Chek whether the VideoPress feature is active,
+ * Return whether the VideoPress feature is active,
  * considering the user connection status
  * and also the module status.
  *
@@ -59,4 +59,13 @@ export function isVideoPressActive(): boolean {
 	}
 
 	return isVideoPressModuleActive();
+}
+
+/**
+ * Return whether the standalong plugin is active.
+ *
+ * @returns {boolean} True if the feature is active, false otherwise.
+ */
+export function isStandaloneActive(): boolean {
+	return window?.videoPressEditorState?.isStandAloneActive === '1';
 }

--- a/projects/packages/videopress/src/client/lib/connection/index.ts
+++ b/projects/packages/videopress/src/client/lib/connection/index.ts
@@ -33,3 +33,12 @@ export function isUserConnected(): boolean {
 	debug( 'User is not connected ❌' );
 	return false;
 }
+
+/**
+ * Check whether the Jetpack VideoPress module is active.
+ *
+ * @returns {boolean} True if the module is active, false otherwise.
+ */
+export function isVideoPressModuleActive(): boolean {
+	return window?.videoPressEditorState?.isVideoPressModuleActive === '1';
+}

--- a/projects/packages/videopress/src/client/lib/connection/index.ts
+++ b/projects/packages/videopress/src/client/lib/connection/index.ts
@@ -58,7 +58,7 @@ export function isVideoPressActive(): boolean {
 		return false;
 	}
 
-	return isVideoPressModuleActive();
+	return isVideoPressModuleActive() || isStandaloneActive();
 }
 
 /**

--- a/projects/packages/videopress/src/client/lib/connection/index.ts
+++ b/projects/packages/videopress/src/client/lib/connection/index.ts
@@ -67,5 +67,5 @@ export function isVideoPressActive(): boolean {
  * @returns {boolean} True if the feature is active, false otherwise.
  */
 export function isStandaloneActive(): boolean {
-	return window?.videoPressEditorState?.isStandAloneActive === '1';
+	return window?.videoPressEditorState?.isStandaloneActive === '1';
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

> The block does not handle when the Jetpack VideoPress module is not active. The UI doesn't show any message about it. but when the user tries to upload a video, it fails silently.

This PR adds the Connect banner above the video block also when the Jetpack VideoPress module is inactive.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: handle VideoPress module connection from video block

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### VideoPress standalone plugin connection flow

* Go to the plugins page
* Deactivate the Jetpack plugin
* Activate the Standalone plugin
* Do not connect
* Go to the block editor
* Add a video block
* Confirm the block shows the Connect banner
* Confirm it leads to the Connect screen by clicking on the Connect button
<img width="300" alt="image" src="https://user-images.githubusercontent.com/77539/216627576-8b7cecc2-b25b-44a4-9628-6d8d163aad3d.png">

* Connect the user
* Go back to the block editor
* Hard refresh
* Confirm the connect banner goes away

### Jetpack plugin connection flow

* Go back to wp-admin. Disconnect the user.
* Go to the plugins page
* Deactivate the Standalone plugin
* Activate  the Jetpack plugin
* Connect
* Ensure the VideoPress module is not active
* Go to the block editor
* Add a video block
* Confirm the block shows the Connect banner
* Confirm it leads to the Jetpack Settings page, VideoPress section by clicking on the Connect button
<img width="300" alt="image" src="https://user-images.githubusercontent.com/77539/216626553-91ed16c9-dff5-4b02-a641-51317db5cf60.png">

* Active the module
* Go back to the block editor
* Hard refresh
* Confirm the connect banner goes away

