### PR TITLE
Release Script: Double Check Version Matches Flag

### DIFF
--- a/tools/release-plugin.sh
+++ b/tools/release-plugin.sh
@@ -100,7 +100,7 @@ VERSION="$2"
 
 # Bail if we're passing an alpha or beta flag but not including it in the version number and vice versa.
 VERSION_AB=
-if VERSION_AB="$(grep -o '\-a\|\-beta' <<< "$VERSION")"; then
+if VERSION_AB="$(grep -o '-a\|-beta' <<< "$VERSION")"; then
 	VERSION_AB="-${VERSION_AB:1:1}"
 fi
 

--- a/tools/release-plugin.sh
+++ b/tools/release-plugin.sh
@@ -109,7 +109,7 @@ if [[ -n "$ALPHABETA" ]]; then
 		die "$ALPHABETA passed to script, but version number $VERSION does not contain the corresponding flag."
 	fi
 elif [[ -n "$VERSION_AB" && -z "$ALPHABETA" ]]; then
-	die "$VERSION contains alpha or beta flag, but corrosponding flag was not passed to the script, i.e. tools/release-plugin.sh -b plugins/jetpack 11.6-beta."
+	die "$VERSION contains alpha or beta flag, but corresponding flag was not passed to the script, i.e. tools/release-plugin.sh -b plugins/jetpack 11.6-beta."
 fi
 
 proceed_p "Releasing $PROJECT $VERSION" "Proceed?"

--- a/tools/release-plugin.sh
+++ b/tools/release-plugin.sh
@@ -98,6 +98,20 @@ if ! check_ver "$2"; then
 fi
 VERSION="$2"
 
+# Bail if we're passing an alpha or beta flag but not including it in the version number and vice versa.
+VERSION_AB=
+if VERSION_AB="$(grep -o '\-a\|\-beta' <<< "$VERSION")"; then
+	VERSION_AB="-${VERSION_AB:1:1}"
+fi
+
+if [[ -n "$ALPHABETA" ]]; then
+	if [[ "$VERSION_AB" != "$ALPHABETA" || ! "$VERSION_AB" ]]; then
+		die "$ALPHABETA passed to script, but version number $VERSION does not contain the corresponding flag."
+	fi
+elif [[ -n "$VERSION_AB" && -z "$ALPHABETA" ]]; then
+	die "$VERSION contains alpha or beta flag, but corrosponding flag was not passed to the script, i.e. tools/release-plugin.sh -b plugins/jetpack 11.6-beta."
+fi
+
 proceed_p "Releasing $PROJECT $VERSION" "Proceed?"
 
 # Make sure we're standing on trunk and working directory is clean


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Double check the version number to ensure it contains the appropriate flag, i.e if -a is passed, make sure the version is 11.6-a.5 etc.*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Throw an exit on line 116 or so and run a few commands:
tools/release-plugins.sh -a plugins/jetpack 11.9-beta -> should fail
tools/release-plugins.sh -a plugins/jetpack 11.9 -> should fail
tools/release-plugins.sh -a plugins/jetpack 11.9-a.1 -> should continue, etc.

