### PR TITLE
Custom CSS: Scope Additional CSS submenu item to connected sites

### DIFF
--- a/projects/plugins/jetpack/changelog/update-showadditional-css-submenus-when-connected
+++ b/projects/plugins/jetpack/changelog/update-showadditional-css-submenus-when-connected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Scope Additional CSS submenus to site with a connected owner

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -102,7 +102,9 @@ class Jetpack_Admin {
 		}
 
 		// Ensure an Additional CSS menu item is added to the Appearance menu whenever Jetpack is connected.
-		add_action( 'admin_menu', array( $this, 'additional_css_menu' ) );
+		if ( Jetpack::is_connection_ready() ) {
+			add_action( 'admin_menu', array( $this, 'additional_css_menu' ) );
+		}
 
 		add_filter( 'jetpack_display_jitms_on_screen', array( $this, 'should_display_jitms_on_screen' ), 10, 2 );
 


### PR DESCRIPTION
Makes it so the Additional CSS submenu item is shown only if the site is connected.

This behavior probably came from the refactor done in #23670 where the code was moved out from a module that was only loaded if Jetpack was connected

We currently show an Additional CSS submenu item under **Appearance** even when Jetpack is disconnected.



<img width="337" alt="image" src="https://user-images.githubusercontent.com/746152/216482368-1103c80c-7448-497f-90d1-3fd0168aee9b.png">

The expectations here get tampered with, given that WordPress already provides additional CSS functionality in the customizer. Still, we only link to it from that submenu if the site is connected. When disconnected instead, we force the user to connect to Jetpack.

The comment in the code that registers submenus even mentions `// Ensure an Additional CSS menu item is added to the Appearance menu whenever Jetpack is connected.` but there's no check for connection before it.

<img width="777" alt="image" src="https://user-images.githubusercontent.com/746152/216482068-1f1e8963-47a0-440d-b1b5-ba2ad4ccd809.png">

<table>
<tr>
	<td>
<img width="1548" alt="image" src="https://user-images.githubusercontent.com/746152/216482580-5e35cf15-4f99-44ca-8286-119d0cf9f363.png"></td>
	<td>
<img width="1546" alt="image" src="https://user-images.githubusercontent.com/746152/216482624-6fd039c9-4b72-453b-920c-b5d94d61402f.png"></td>
</tr>
<tr>
<td>
   When disconnected, we add a submenu item **Additional CSS**
</td>
<td>
  But it links to a Jetpack connection page
</td>
</tr>
</table>



Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Checks for the availability of a connection before attempting to register a submenu for Additional CSS.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:

* On a disconnected site, check this PR (Or [launch a JN site with it](https://jurassic.ninja/create?jetpack-beta&branches.jetpack=update/showadditional-css-submenus-when-connected&wp-debug-log))
* Confirm that there's no menu item **Appearance -> Additional CSS**
* Connect the site and confirm you now see **Appearance -> Additional CSS**

