### PR TITLE
Stats: Support opt-out notice for Odyssey Stats

### DIFF
--- a/projects/packages/stats-admin/changelog/add-opt-out-notice-for-odyssey
+++ b/projects/packages/stats-admin/changelog/add-opt-out-notice-for-odyssey
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: adds new Stats opt out notice

--- a/projects/packages/stats-admin/composer.json
+++ b/projects/packages/stats-admin/composer.json
@@ -8,7 +8,7 @@
 		"automattic/jetpack-options": "@dev",
 		"automattic/jetpack-stats": "@dev",
 		"automattic/jetpack-status": "@dev",
-		"automattic/jetpack-jitm": "2.2.x-dev"
+		"automattic/jetpack-jitm": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.0.4",

--- a/projects/packages/stats-admin/composer.json
+++ b/projects/packages/stats-admin/composer.json
@@ -7,7 +7,8 @@
 		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-options": "@dev",
 		"automattic/jetpack-stats": "@dev",
-		"automattic/jetpack-status": "@dev"
+		"automattic/jetpack-status": "@dev",
+		"automattic/jetpack-jitm": "2.2.x-dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.0.4",

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -238,18 +238,18 @@ class Dashboard {
 				'sites'       => array(
 					'items'    => array(
 						"$blog_id" => array(
-							'ID'                           => $blog_id,
-							'URL'                          => site_url(),
-							'jetpack'                      => true,
-							'visible'                      => true,
-							'capabilities'                 => $empty_object,
-							'products'                     => array(),
-							'plan'                         => $empty_object, // we need this empty object, otherwise the front end would crash on insight page.
-							'options'                      => array(
+							'ID'            => $blog_id,
+							'URL'           => site_url(),
+							'jetpack'       => true,
+							'visible'       => true,
+							'capabilities'  => $empty_object,
+							'products'      => array(),
+							'plan'          => $empty_object, // we need this empty object, otherwise the front end would crash on insight page.
+							'options'       => array(
 								'wordads'   => ( new Modules() )->is_active( 'wordads' ),
 								'admin_url' => admin_url(),
 							),
-							'has_opt_out_new_stats_notice' => self::has_opt_out_new_stats_notice(),
+							'stats_notices' => array( 'opt_out_new_stats' => self::has_opt_out_new_stats_notice() ),
 						),
 					),
 					'features' => array( "$blog_id" => array( 'data' => self::get_plan_features() ) ),

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\Stats_Admin;
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Modules;
+use Automattic\Jetpack\Stats\Options as Stats_Options;
 use Jetpack_Options;
 
 /**
@@ -19,8 +20,9 @@ use Jetpack_Options;
  */
 class Dashboard {
 	// This is a fixed list @see https://github.com/Automattic/wp-calypso/pull/71442/
-	const JS_DEPENDENCIES = array( 'lodash', 'react', 'react-dom', 'wp-api-fetch', 'wp-components', 'wp-compose', 'wp-element', 'wp-html-entities', 'wp-i18n', 'wp-is-shallow-equal', 'wp-polyfill', 'wp-primitives', 'wp-url', 'wp-warning' );
-	const ODYSSEY_CDN_URL = 'https://widgets.wp.com/odyssey-stats/%s/%s';
+	const JS_DEPENDENCIES                 = array( 'lodash', 'react', 'react-dom', 'wp-api-fetch', 'wp-components', 'wp-compose', 'wp-element', 'wp-html-entities', 'wp-i18n', 'wp-is-shallow-equal', 'wp-polyfill', 'wp-primitives', 'wp-url', 'wp-warning' );
+	const ODYSSEY_CDN_URL                 = 'https://widgets.wp.com/odyssey-stats/%s/%s';
+	const OPT_OUT_NEW_STATS_FEATURE_CLASS = 'opt-out-new-stats';
 	/**
 	 * We bump the asset version when the Jetpack back end is not compatible anymore.
 	 */
@@ -110,7 +112,7 @@ class Dashboard {
 				// we intercept on all anchor tags and change it to hashbang style.
 				$("#wpcom").on('click', 'a', function (e) {
 					const link = e && e.currentTarget && e.currentTarget.attributes && e.currentTarget.attributes.href && e.currentTarget.attributes.href.value;
-					if( link && ! link.startsWith( 'http' ) ) {
+					if( link && link.startsWith( '/stats' ) ) {
 						location.hash = `#!${link}`;
 						return false;
 					}
@@ -236,17 +238,18 @@ class Dashboard {
 				'sites'       => array(
 					'items'    => array(
 						"$blog_id" => array(
-							'ID'           => $blog_id,
-							'URL'          => site_url(),
-							'jetpack'      => true,
-							'visible'      => true,
-							'capabilities' => $empty_object,
-							'products'     => array(),
-							'plan'         => $empty_object, // we need this empty object, otherwise the front end would crash on insight page.
-							'options'      => array(
+							'ID'                 => $blog_id,
+							'URL'                => site_url(),
+							'jetpack'            => true,
+							'visible'            => true,
+							'capabilities'       => $empty_object,
+							'products'           => array(),
+							'plan'               => $empty_object, // we need this empty object, otherwise the front end would crash on insight page.
+							'options'            => array(
 								'wordads'   => ( new Modules() )->is_active( 'wordads' ),
 								'admin_url' => admin_url(),
 							),
+							'has_opt_out_notice' => self::has_opt_out_new_stats_notice(),
 						),
 					),
 					'features' => array( "$blog_id" => array( 'data' => self::get_plan_features() ) ),
@@ -293,7 +296,7 @@ class Dashboard {
 	/**
 	 * Get the features of the current plan.
 	 */
-	protected function get_plan_features() {
+	protected static function get_plan_features() {
 		if ( ! class_exists( 'Jetpack_Plan' ) ) {
 			return array();
 		}
@@ -309,12 +312,23 @@ class Dashboard {
 	 *
 	 * @return array An array of capabilities.
 	 */
-	protected function get_current_user_capabilities() {
+	protected static function get_current_user_capabilities() {
 		$user = wp_get_current_user();
 		if ( ! $user || is_wp_error( $user ) ) {
 			return array();
 		}
 		return $user->allcaps;
+	}
+
+	/**
+	 * Return ture if the opt-out notice should be shown.
+	 *
+	 * @return bool
+	 */
+	protected static function has_opt_out_new_stats_notice() {
+		$new_stats_enabled = Stats_Options::get_option( 'enable_calypso_stats' );
+		$hidden_jitms      = \Jetpack_Options::get_option( 'hide_jitm' );
+		return $new_stats_enabled && ! isset( $hidden_jitms[ self::OPT_OUT_NEW_STATS_FEATURE_CLASS ] );
 	}
 
 }

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -238,18 +238,18 @@ class Dashboard {
 				'sites'       => array(
 					'items'    => array(
 						"$blog_id" => array(
-							'ID'                 => $blog_id,
-							'URL'                => site_url(),
-							'jetpack'            => true,
-							'visible'            => true,
-							'capabilities'       => $empty_object,
-							'products'           => array(),
-							'plan'               => $empty_object, // we need this empty object, otherwise the front end would crash on insight page.
-							'options'            => array(
+							'ID'                           => $blog_id,
+							'URL'                          => site_url(),
+							'jetpack'                      => true,
+							'visible'                      => true,
+							'capabilities'                 => $empty_object,
+							'products'                     => array(),
+							'plan'                         => $empty_object, // we need this empty object, otherwise the front end would crash on insight page.
+							'options'                      => array(
 								'wordads'   => ( new Modules() )->is_active( 'wordads' ),
 								'admin_url' => admin_url(),
 							),
-							'has_opt_out_notice' => self::has_opt_out_new_stats_notice(),
+							'has_opt_out_new_stats_notice' => self::has_opt_out_new_stats_notice(),
 						),
 					),
 					'features' => array( "$blog_id" => array( 'data' => self::get_plan_features() ) ),

--- a/projects/plugins/jetpack/changelog/add-opt-out-notice-for-odyssey
+++ b/projects/plugins/jetpack/changelog/add-opt-out-notice-for-odyssey
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update composer lockfile

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2088,10 +2088,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "d013b764b41b21c50fee6f89da679a3bf60469e5"
+                "reference": "f86f8528b864500624df35217810f82dfb05f372"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-jitm": "@dev",
                 "automattic/jetpack-options": "@dev",
                 "automattic/jetpack-stats": "@dev",
                 "automattic/jetpack-status": "@dev"


### PR DESCRIPTION
## Proposed changes:
- Adds a key `has_opt_out_new_stats_notice` to flag whether the frontend should show the Opt-out notice
  - If Odyssey is turned on and the notice was not dismissed before, the notice would be shown
- Reused JITM `hide_jitm` API to remember the dismissed notice `jetpack/v4/jitm`
https://github.com/Automattic/jetpack/blob/0ec4b43a5925af778bec753528aea158768db925/projects/packages/jitm/src/class-rest-api-endpoints.php#L68

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Please follow test instructions in https://github.com/Automattic/wp-calypso/pull/72937

