### PR TITLE
Add Import Package

### DIFF
--- a/projects/packages/import/.gitattributes
+++ b/projects/packages/import/.gitattributes
@@ -1,0 +1,17 @@
+# Files not needed to be distributed in the package.
+.gitattributes    export-ignore
+.github/          export-ignore
+package.json      export-ignore
+
+# Files to include in the mirror repo, but excluded via gitignore
+# Remember to end all directories with `/**` to properly tag every file.
+# /src/js/example.min.js  production-include
+
+# Files to exclude from the mirror repo, but included in the monorepo.
+# Remember to end all directories with `/**` to properly tag every file.
+.gitignore        production-exclude
+changelog/**      production-exclude
+phpunit.xml.dist  production-exclude
+.phpcs.dir.xml    production-exclude
+tests/**          production-exclude
+.phpcsignore      production-exclude

--- a/projects/packages/import/.gitignore
+++ b/projects/packages/import/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+node_modules/
+wordpress/

--- a/projects/packages/import/.phpcs.dir.xml
+++ b/projects/packages/import/.phpcs.dir.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="jetpack-import" />
+			</property>
+		</properties>
+	</rule>
+	<rule ref="Jetpack.Functions.I18n">
+		<properties>
+			<property name="text_domain" value="jetpack-import" />
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.Utils.I18nTextDomainFixer">
+		<properties>
+			<property name="old_text_domain" type="array" />
+			<property name="new_text_domain" value="jetpack-import" />
+		</properties>
+	</rule>
+
+</ruleset>

--- a/projects/packages/import/.phpcsignore
+++ b/projects/packages/import/.phpcsignore
@@ -1,0 +1,1 @@
+src/class-example.php

--- a/projects/packages/import/CHANGELOG.md
+++ b/projects/packages/import/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+

--- a/projects/packages/import/README.md
+++ b/projects/packages/import/README.md
@@ -1,0 +1,20 @@
+# Jetpack Import
+
+Set of REST API routes used in WPCOM Unified Importer.
+
+## How to install Jetpack Import
+
+### Installation From Git Repo
+
+## Contribute
+
+## Get Help
+
+## Security
+
+Need to report a security vulnerability? Go to [https://automattic.com/security/](https://automattic.com/security/) or directly to our security bug bounty site [https://hackerone.com/automattic](https://hackerone.com/automattic).
+
+## License
+
+Jetpack Import is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt)
+

--- a/projects/packages/import/changelog/add-import-package
+++ b/projects/packages/import/changelog/add-import-package
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add new Jetpack Import package.

--- a/projects/packages/import/composer.json
+++ b/projects/packages/import/composer.json
@@ -1,0 +1,62 @@
+{
+	"name": "automattic/jetpack-import",
+	"description": "Set of REST API routes used in WPCOM Unified Importer.",
+	"type": "jetpack-library",
+	"license": "GPL-2.0-or-later",
+	"require": {},
+	"require-dev": {
+		"yoast/phpunit-polyfills": "1.0.4",
+		"automattic/jetpack-changelogger": "@dev",
+		"automattic/wordbless": "dev-master"
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"scripts": {
+		"phpunit": [
+			"./vendor/phpunit/phpunit/phpunit --colors=always"
+		],
+		"test-coverage": [
+			"php -dpcov.directory=. ./vendor/bin/phpunit --coverage-clover \"$COVERAGE_DIR/clover.xml\""
+		],
+		"test-php": [
+			"@composer phpunit"
+		],
+		"build-production": "echo 'Add your build step to composer.json, please!'",
+		"build-development": "echo 'Add your build step to composer.json, please!'",
+		"post-install-cmd": "WorDBless\\Composer\\InstallDropin::copy",
+		"post-update-cmd": "WorDBless\\Composer\\InstallDropin::copy"
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../../packages/*",
+			"options": {
+				"monorepo": true
+			}
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"config": {
+		"allow-plugins": {
+			"roots/wordpress-core-installer": true
+		}
+	},
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-import",
+		"changelogger": {
+			"link-template": "https://github.com/Automattic/jetpack-import/compare/v${old}...v${new}"
+		},
+		"autotagger": true,
+		"branch-alias": {
+			"dev-trunk": "0.1.x-dev"
+		},
+		"textdomain": "jetpack-import",
+		"version-constants": {
+			"::PACKAGE_VERSION": "src/class-import.php"
+		}
+	}
+}

--- a/projects/packages/import/package.json
+++ b/projects/packages/import/package.json
@@ -1,0 +1,29 @@
+{
+	"private": true,
+	"name": "@automattic/jetpack-import",
+	"version": "0.1.0-alpha",
+	"description": "Set of REST API routes used in WPCOM Unified Importer.",
+	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/import/#readme",
+	"bugs": {
+		"url": "https://github.com/Automattic/jetpack/labels/[Package] Import"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Automattic/jetpack.git",
+		"directory": "projects/packages/import"
+	},
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic",
+	"scripts": {
+		"build": "echo 'Not implemented.'",
+		"build-js": "echo 'Not implemented.'",
+		"build-production": "echo 'Not implemented.'",
+		"build-production-js": "echo 'Not implemented.'",
+		"clean": "true"
+	},
+	"devDependencies": {},
+	"engines": {
+		"node": "^18.13.0",
+		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
+	}
+}

--- a/projects/packages/import/phpunit.xml.dist
+++ b/projects/packages/import/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
+	<testsuites>
+		<testsuite name="main">
+			<directory prefix="test" suffix=".php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+	<filter>
+		<whitelist processUncoveredFilesFromWhitelist="false">
+			<!-- Better to only include "src" than to add "." and then exclude "tests", "vendor", and so on, as PHPUnit still scans the excluded directories. -->
+			<!-- Add additional lines for any files or directories outside of src/ that need coverage. -->
+			<directory suffix=".php">src</directory>
+		</whitelist>
+	</filter>
+</phpunit>

--- a/projects/packages/import/src/class-import.php
+++ b/projects/packages/import/src/class-import.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Set of REST API routes used in WPCOM Unified Importer.
+ *
+ * @package automattic/jetpack-import
+ */
+
+namespace Automattic\Jetpack;
+
+/**
+ * This class will provide endpoint for the Unified Importer.
+ */
+class Import {
+	/**
+	 * Package version.
+	 *
+	 * @var string
+	 */
+	const PACKAGE_VERSION = '0.1.0-alpha';
+
+	/**
+	 * REST API prefix.
+	 *
+	 * @var string
+	 */
+	const REST_PREFIX = 'import/';
+}

--- a/projects/packages/import/tests/php/bootstrap.php
+++ b/projects/packages/import/tests/php/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Bootstrap.
+ *
+ * @package automattic/
+ */
+
+/**
+ * Include the composer autoloader.
+ */
+require_once __DIR__ . '/../../vendor/autoload.php';


### PR DESCRIPTION
This is the first barebone structure of the new Jetpack Import package.

In this conversation p1675062364389839-slack-CDLH4C1UZ, we decided that it is better to move [previous plugin codebase](https://github.com/Automattic/jetpack/tree/add/import-plugin) to a composer package and to create a first PR with just the barebone structure created with `jetpack generate`.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add the first empty structure of a new composer package used by the Unified Importer

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Project details: pcmemI-1ro-p2
Additional details: pcmemI-1Dn-p2

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
No tests.