### PR TITLE
E2E tests: improve susbscribe block tests

### DIFF
--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -41,18 +41,6 @@ const projects = [
 		suite: '',
 	},
 	{ project: 'Social', path: 'projects/plugins/social/tests/e2e', testArgs: [], suite: '' },
-	{
-		project: 'Blocks with latest Gutenberg',
-		path: 'projects/plugins/jetpack/tests/e2e',
-		testArgs: [ 'blocks', '--retries=1' ],
-		suite: 'gutenberg-test',
-	},
-	{
-		project: 'Subscribe block on WoA',
-		path: 'projects/plugins/jetpack/tests/e2e',
-		testArgs: [ '-g subscribe', '--repeat-each=50' ],
-		suite: 'atomic-subscribe-test',
-	},
 ];
 
 const matrix = [];

--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -41,6 +41,18 @@ const projects = [
 		suite: '',
 	},
 	{ project: 'Social', path: 'projects/plugins/social/tests/e2e', testArgs: [], suite: '' },
+	{
+		project: 'Blocks with latest Gutenberg',
+		path: 'projects/plugins/jetpack/tests/e2e',
+		testArgs: [ 'blocks', '--retries=1' ],
+		suite: 'gutenberg-test',
+	},
+	{
+		project: 'Subscribe block on WoA',
+		path: 'projects/plugins/jetpack/tests/e2e',
+		testArgs: [ '-g subscribe', '--repeat-each=50' ],
+		suite: 'atomic-subscribe-test',
+	},
 ];
 
 const matrix = [];

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -49,7 +49,7 @@ jobs:
     name: "${{ matrix.project }} e2e tests"
     runs-on: ubuntu-latest
     needs: create-test-matrix
-    timeout-minutes: 40
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/projects/plugins/jetpack/changelog/e2e-improve-subscribe-block-test
+++ b/projects/plugins/jetpack/changelog/e2e-improve-subscribe-block-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+

--- a/projects/plugins/jetpack/tests/e2e/specs/blocks/free-blocks.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/blocks/free-blocks.test.js
@@ -146,15 +146,10 @@ test.describe( 'Free blocks', () => {
 
 		test( 'Subscribe block', async ( { page } ) => {
 			await prerequisitesBuilder( page ).withActiveModules( [ 'subscriptions' ] ).build();
-			let block;
+			const block = new SubscribeBlock( null, page );
 
-			await test.step( 'Can visit the block editor and add a Subscribe block', async () => {
-				const blockId = await blockEditor.insertBlock(
-					SubscribeBlock.name(),
-					SubscribeBlock.title()
-				);
-				block = new SubscribeBlock( blockId, page );
-				await block.checkBlock();
+			await test.step( 'Insert a Subscribe block', async () => {
+				await block.insertBlock( new BlockEditorPage( page ) );
 			} );
 
 			await test.step( 'Can publish a post with a Subscribe block', async () => {
@@ -192,15 +187,10 @@ test.describe( 'Free blocks', () => {
 
 		test( 'Subscribe block', async ( { page } ) => {
 			await prerequisitesBuilder( page ).withActiveModules( [ 'subscriptions' ] ).build();
-			let block;
+			const block = new SubscribeBlock( null, page );
 
 			await test.step( 'Can insert a Subscribe block', async () => {
-				const blockId = await siteEditor.insertBlock(
-					SubscribeBlock.name(),
-					SubscribeBlock.title()
-				);
-				block = new SubscribeBlock( blockId, page );
-				await block.checkBlock();
+				await block.insertBlock( new SiteEditorPage( page ) );
 			} );
 
 			let newTab;

--- a/tools/e2e-commons/pages/wp-admin/blocks/simple-payments.js
+++ b/tools/e2e-commons/pages/wp-admin/blocks/simple-payments.js
@@ -23,7 +23,8 @@ export default class SimplePaymentBlock extends EditorCanvas {
 		const responsePromise = this.page.waitForResponse(
 			r =>
 				decodeURIComponent( decodeURIComponent( r.url() ) ).match( /jp_pay_product/ ) &&
-				r.request().method() === 'POST'
+				r.request().method() === 'POST',
+			{ timeout: 30000 }
 		);
 		const blockId = await blockEditor.insertBlock(
 			SimplePaymentBlock.name(),

--- a/tools/e2e-commons/pages/wp-admin/blocks/subscribe.js
+++ b/tools/e2e-commons/pages/wp-admin/blocks/subscribe.js
@@ -5,7 +5,6 @@ export default class SubscribeBlock extends EditorCanvas {
 		super( page, 'Subscribe' );
 		this.blockTitle = SubscribeBlock.title();
 		this.page = page;
-		this.blockSelector = '#block-' + blockId;
 	}
 	static name() {
 		return 'subscriptions';
@@ -14,12 +13,21 @@ export default class SubscribeBlock extends EditorCanvas {
 	static title() {
 		return 'Subscribe';
 	}
-	async checkBlock() {
-		const response = await this.page.waitForResponse(
-			r => decodeURIComponent( r.url() ).match( /wpcom\/v2\/subscribers\/counts/ ),
+	async insertBlock( editorPage ) {
+		const responsePromise = this.page.waitForResponse(
+			r =>
+				decodeURIComponent( decodeURIComponent( r.url() ) ).match(
+					/wpcom\/v2\/subscribers\/counts/
+				),
 			{ timeout: 30000 }
 		);
-		expect( response.status(), 'Response status should be 200' ).toBe( 200 );
+		const blockId = await editorPage.insertBlock( SubscribeBlock.name(), SubscribeBlock.title() );
+		const response = await responsePromise;
+
+		expect( response.ok(), 'Response status should be ok' ).toBeTruthy();
+
+		this.blockId = blockId;
+		return blockId;
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

 Following example of #28703, refactor the insert block logic for Subscribe block to fix the tests failing mostly against WoA, in CI.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Tested with a suite that runs 50 iterations of each of the subscribe block tests, all passed: [#1](https://github.com/Automattic/jetpack/actions/runs/4084030681/jobs/7040269984#step:11:178), [#2](https://github.com/Automattic/jetpack/actions/runs/4084030681/jobs/7041023019#step:11:178)

