### PR TITLE
Podcast player: remove wp-components frontend dependency

### DIFF
--- a/projects/plugins/jetpack/changelog/update-remove-wp-components-dep-from-podcast-player-frontend
+++ b/projects/plugins/jetpack/changelog/update-remove-wp-components-dep-from-podcast-player-frontend
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Podcast player block: remove dependency on wp-components from the frontend code

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/icons/link.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/icons/link.js
@@ -1,10 +1,7 @@
 /* eslint-disable jsdoc/check-tag-names */
 
-import { SVG, Path } from '@wordpress/components';
+import { SVG, Path } from '@wordpress/primitives';
 
-/**
- * @todo: Replace with `@wordpress/icons` when available
- */
 const link = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path d="M15.6 7.2H14v1.5h1.6c2 0 3.7 1.7 3.7 3.7s-1.7 3.7-3.7 3.7H14v1.5h1.6c2.8 0 5.2-2.3 5.2-5.2 0-2.9-2.3-5.2-5.2-5.2zM4.7 12.4c0-2 1.7-3.7 3.7-3.7H10V7.2H8.4c-2.9 0-5.2 2.3-5.2 5.2 0 2.9 2.3 5.2 5.2 5.2H10v-1.5H8.4c-2 0-3.7-1.7-3.7-3.7zm4.6.9h5.3v-1.5H9.3v1.5z" />

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/icons/queueMusic.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/icons/queueMusic.js
@@ -1,4 +1,4 @@
-import { G, Path, Rect, SVG } from '@wordpress/components';
+import { G, Path, Rect, SVG } from '@wordpress/primitives';
 
 export default (
 	<SVG height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/icons/track-icons.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/icons/track-icons.js
@@ -1,4 +1,4 @@
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 const sharedProps = {
 	height: '24',

--- a/projects/plugins/jetpack/tools/check-block-assets.php
+++ b/projects/plugins/jetpack/tools/check-block-assets.php
@@ -73,10 +73,10 @@ $allowed = array(
 		'lodash',
 		'react',
 		'react-dom',
-		'wp-components',
 		'wp-compose',
 		'wp-data',
 		'wp-element',
+		'wp-primitives',
 	),
 	'story'          => array(
 		'lodash',


### PR DESCRIPTION
The podcast player block frontend currently enqueues `wp-components`, which is an absolutely massive 200KB (compressed) dependency, and which comes with other large dependencies of its own.

It does this simply so that it can reuse some SVG-related components. While this is ripe for a deeper refactor, an immediate improvement we can apply is to use `wp-primitives` instead; it has the exact same components (`wp-components` reexports them), and `wp-primitives` has a massively smaller footprint.

Note: I added @Automattic/apex as a reviewer, as I believe that is the team responsible for this block. Please feel free to reassign if that's not the case!

This PR should save ~250KB compressed (!!) on pages with podcast player blocks.

## Proposed changes:
* Podcast player: remove dependency on `wp-components` by replacing it with a dependency on `wp-primitives`

### Other information:

- N/A Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None, this is a simple performance improvement with no functionality changes.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
- Create a page with a podcast player block
- Load the page and ensure that `wp-components` is not loaded
- Smoke-test the podcast player block and ensure it works correctly

