### PR TITLE
Subscription Block: Update block description

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-block-description
+++ b/projects/plugins/jetpack/changelog/update-subscribe-block-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Update subscribe block description

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/index.js
@@ -23,16 +23,11 @@ export const settings = {
 	title: __( 'Subscribe', 'jetpack' ),
 	description: (
 		<>
-			<p>
-				{ __(
-					'Allow readers to receive a newsletter with future posts in their inbox.',
-					'jetpack'
-				) }
-			</p>
+			<p>{ __( "Let readers subscribe to this blog's posts as a newsletter.", 'jetpack' ) }</p>
 			<p>
 				{ createInterpolateElement(
 					__(
-						'Subscribers can get notifications through email or <ExternalLink>the Reader app</ExternalLink>.',
+						'Subscribers can read the posts in their email inbox or <ExternalLink>the Reader app</ExternalLink>.',
 						'jetpack'
 					),
 					{ ExternalLink: <ExternalLink href={ 'https://wordpress.com/read' } /> }


### PR DESCRIPTION
Addresses https://github.com/Automattic/wp-calypso/issues/72647#issuecomment-1415623571 partially until we get to remove the Editor Toolkit _Learn More_ link. Otherwise it would be redundant to have to Learn more links

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates block description copy

### After

<img width="286" alt="image" src="https://user-images.githubusercontent.com/746152/216617320-8b10bf82-c648-4810-981b-6df2455657e9.png">


### Before

<img width="290" alt="image" src="https://user-images.githubusercontent.com/746152/216617398-0007f0cb-dcaa-4079-ae19-b9b27231cc04.png">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
NO

## Testing instructions:
* Checkout this branch or launch
* Connect the site, enable subscriptions from the Jetpack settings page
* Create a post
* Insert a subscribe block
* Select it, and confirm the description is updated on the insepector panel (right sidebar)
