### PR TITLE
General: update wrong return types

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-docblocks
+++ b/projects/plugins/jetpack/changelog/fix-docblocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+General: update wrong return types and deprecate function.

--- a/projects/plugins/jetpack/changelog/fix-docblocks
+++ b/projects/plugins/jetpack/changelog/fix-docblocks
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-General: update wrong return types and deprecate function.
+General: update wrong return types

--- a/projects/plugins/jetpack/modules/comments/admin.php
+++ b/projects/plugins/jetpack/modules/comments/admin.php
@@ -29,7 +29,7 @@ class Jetpack_Comments_Settings {
 	/**
 	 * The default comment form color scheme - an empty array to start with
 	 *
-	 * @var string
+	 * @var array
 	 */
 	public $color_schemes = array();
 

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -506,7 +506,7 @@ EOT;
 		 * @param array $related_posts Array of related posts.
 		 * @param array $block_attributes Array of Block attributes.
 		 */
-		return apply_filters( 'jetpack_related_posts_display_markup', $display_markup, $post_id, $related_posts, $block_attributes );
+		return (string) apply_filters( 'jetpack_related_posts_display_markup', $display_markup, $post_id, $related_posts, $block_attributes );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/shortcodes.php
+++ b/projects/plugins/jetpack/modules/shortcodes.php
@@ -134,9 +134,12 @@ if ( ! function_exists( 'jetpack_shortcode_get_wpvideo_id' ) ) {
 	 * Get VideoPress ID from wpvideo shortcode attributes.
 	 *
 	 * @param array $atts Shortcode attributes.
-	 * @return int  $id   VideoPress ID.
+	 *
+	 * @return mixed $id VideoPress ID.
 	 */
 	function jetpack_shortcode_get_wpvideo_id( $atts ) {
+		// This is not used anywhere in Jetpack nor on WordPress.com anymore.
+		_deprecated_function( __FUNCTION__, 'jetpack-11.9' );
 		if ( isset( $atts[0] ) ) {
 			return $atts[0];
 		} else {

--- a/projects/plugins/jetpack/modules/shortcodes.php
+++ b/projects/plugins/jetpack/modules/shortcodes.php
@@ -135,11 +135,9 @@ if ( ! function_exists( 'jetpack_shortcode_get_wpvideo_id' ) ) {
 	 *
 	 * @param array $atts Shortcode attributes.
 	 *
-	 * @return mixed $id VideoPress ID.
+	 * @return string|int $id VideoPress ID.
 	 */
 	function jetpack_shortcode_get_wpvideo_id( $atts ) {
-		// This is not used anywhere in Jetpack nor on WordPress.com anymore.
-		_deprecated_function( __FUNCTION__, 'jetpack-11.9' );
 		if ( isset( $atts[0] ) ) {
 			return $atts[0];
 		} else {


### PR DESCRIPTION
## Proposed changes:

- The types were not appropriate, or could be modified via a filter.
- ~~The function doesn't appear to be used anywhere on WordPress.com Simple or in Jetpack anymore.~~ Turns out we still use it :) 
https://github.com/Automattic/jetpack/blob/5463f2e0284ca8a634f75deee22db0c1bf1de984/projects/plugins/jetpack/_inc/lib/class.media-extractor.php#L193

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* pdWQjU-e6-p2

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Not much to test here
