### PR TITLE
Stats: Dashboard - remove box around blocked numbers

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/dash-item/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/dash-item/style.scss
@@ -35,8 +35,6 @@
 	font-weight: 500;
 	font-size: rem( 32px );
 	display: inline-block;
-	border: 1px solid $light-gray-700;
-	border-radius: 4px;
 	padding: 0 4px;
 	min-width: 36px;
 	text-align: center;

--- a/projects/plugins/jetpack/_inc/client/dashboard-widget/style.scss
+++ b/projects/plugins/jetpack/_inc/client/dashboard-widget/style.scss
@@ -253,8 +253,6 @@
 			font-weight: 500;
 			font-size: 2rem;
 			display: inline-block;
-			border: 1px solid #c3c4c7;
-			border-radius: 4px;
 			padding: 0 4px;
 			min-width: 36px;
 			text-align: center;
@@ -274,7 +272,7 @@
 		.footer-links{
 			padding: 0.75em 0.75em 0.5em 0.75em;
 			border-top: 1px solid #f0f0f1;
-						
+
 			svg {
 				height: 20px;
 			}

--- a/projects/plugins/jetpack/changelog/remove-box-stats
+++ b/projects/plugins/jetpack/changelog/remove-box-stats
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Dashboard Admin: remove border around blocked numbers for anti-spam/protect blocks

--- a/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
@@ -116,7 +116,7 @@ class Jetpack_Stats_Dashboard_Widget {
 			</div>
 
 			<div class="akismet">
-				<h3><?php esc_html_e( 'Anti-spam', 'jetpack' ); ?></h3>
+				<h3><?php esc_html_e( 'Akismet Anti-spam', 'jetpack' ); ?></h3>
 				<?php if ( is_plugin_active( 'akismet/akismet.php' ) ) : ?>
 					<p class="blocked-count">
 						<?php echo esc_html( number_format_i18n( get_option( 'akismet_spam_count', 0 ) ) ); ?>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes user report from @m

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the errant border box from the wp-admin dashboard Stats widget.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
View wp-admin.
* Go to '..'
*

Before:

![2023-02-03 at 10 24 AM](https://user-images.githubusercontent.com/88897/216654848-83ab43d6-5a41-4dee-9c45-4145b3f01e0e.png)

After:
![2023-02-03 at 10 28 AM](https://user-images.githubusercontent.com/88897/216655765-90699bfb-a4c1-41dd-8282-47f75e3578e8.png)

[from different sites; disregard the data difference]

