### PR TITLE
Blaze: do not dispay UI for password-protected posts

### DIFF
--- a/projects/packages/blaze/changelog/fix-blaze-password-ui
+++ b/projects/packages/blaze/changelog/fix-blaze-password-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Do not display "Blaze" links in the post list for password-protected posts.

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -177,6 +177,11 @@ class Blaze {
 			return $post_actions;
 		}
 
+		// Bail if the post has a password.
+		if ( '' !== $post->post_password ) {
+			return $post_actions;
+		}
+
 		// Might be useful to wrap in a method call for general use without post_id.
 		$blaze_url = Redirect::get_url(
 			'jetpack-blaze',


### PR DESCRIPTION
## Proposed changes:

In the post-publish panel, we already choose not to display the option to Blaze for posts that are password-protected. Let's do the same in the post list.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* 1386-gh-dotcom-forge

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

On a public site, connected to WordPress.com:

* Go to Posts > Add New
* Add a password to your post (in the post sidebar)
* Publish your post
* Publish another post without password
* Go to the Posts list
    * You should see the Blaze link when moving your mouse over the post that's public, but not for the password-protected post.

