### PR TITLE
Revert "Custom CSS: Scope Additional CSS submenu item to connected sites"

### DIFF
--- a/projects/plugins/jetpack/changelog/update-showadditional-css-submenus-when-connected
+++ b/projects/plugins/jetpack/changelog/update-showadditional-css-submenus-when-connected
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Scope Additional CSS submenus to site with a connected owner

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -102,9 +102,7 @@ class Jetpack_Admin {
 		}
 
 		// Ensure an Additional CSS menu item is added to the Appearance menu whenever Jetpack is connected.
-		if ( Jetpack::is_connection_ready() ) {
-			add_action( 'admin_menu', array( $this, 'additional_css_menu' ) );
-		}
+		add_action( 'admin_menu', array( $this, 'additional_css_menu' ) );
 
 		add_filter( 'jetpack_display_jitms_on_screen', array( $this, 'should_display_jitms_on_screen' ), 10, 2 );
 


### PR DESCRIPTION
Reverts Automattic/jetpack#28732

@oskosk This change seemed to cause a fatal on the Jetpack dashboard (and other pages) for WoA sites:

```
WordPress version 6.1.1
Active theme: Twenty Twenty-Three (version 1.0)
Current plugin: Jetpack (version 11.8-beta-4086507392-g50a8c434)
PHP version 8.0.27

Error Details
=============
An error of type E_ERROR was caused in line 782 of the file /srv/htdocs/wp-content/plugins/jetpack-dev/jetpack_vendor/automattic/jetpack-connection/src/class-manager.php. Error message: Uncaught Error: Call to undefined function Automattic\Jetpack\Connection\get_userdata() in /srv/htdocs/wp-content/plugins/jetpack-dev/jetpack_vendor/automattic/jetpack-connection/src/class-manager.php:782
Stack trace:
#0 /srv/htdocs/wp-content/plugins/jetpack-dev/jetpack_vendor/automattic/jetpack-connection/src/class-manager.php(718): Automattic\Jetpack\Connection\Manager->get_connection_owner()
#1 /srv/htdocs/wp-content/plugins/jetpack-dev/jetpack_vendor/automattic/jetpack-connection/src/class-manager.php(649): Automattic\Jetpack\Connection\Manager->get_connection_owner_id()
#2 /wordpress/plugins/wpcomsh/3.5.35/jetpack-require-connection-owner/class-wpcomsh-require-connection-owner.php(25): Automattic\Jetpack\Connection\Manager->has_connected_owner()
#3 /wordpress/core/6.1.1/wp-includes/class-wp-hook.php(308): WPCOMSH_Require_Connection_Owner::filter_is_connection_ready(true, Object(Automattic\Jetpack\Connection\Manager))
#4 /wordpress/core/6.1.1/wp-includes/plugin.php(205): WP_Hook->apply_filters(true, Array)
#5 /srv/htdocs/wp-content/plugins/jetpack-dev/class.jetpack.php(1614): apply_filters('jetpack_is_conn...', true, Object(Automattic\Jetpack\Connection\Manager))
#6 /srv/htdocs/wp-content/plugins/jetpack-dev/class.jetpack-admin.php(105): Jetpack::is_connection_ready()
#7 /srv/htdocs/wp-content/plugins/jetpack-dev/class.jetpack-admin.php(37): Jetpack_Admin->__construct()
#8 /srv/htdocs/wp-content/plugins/jetpack-dev/class.jetpack-admin.php(625): Jetpack_Admin::init()
#9 /srv/htdocs/wp-content/plugins/jetpack-dev/load-jetpack.php(79): require_once('/srv/htdocs/wp-...')
#10 /srv/htdocs/wp-content/plugins/jetpack-dev/jetpack.php(194): require_once('/srv/htdocs/wp-...')
#11 /wordpress/core/6.1.1/wp-settings.php(447): include_once('/srv/htdocs/wp-...')
#12 /srv/htdocs/wp-config.php(69): require_once('/wordpress/core...')
#13 /wordpress/core/6.1.1/wp-load.php(55): require_once('/srv/htdocs/wp-...')
#14 /wordpress/core/6.1.1/wp-blog-header.php(13): require_once('/wordpress/core...')
#15 /wordpress/core/6.1.1/index.php(17): require('/wordpress/core...')
#16 {main}
  thrown
```

I [reverted](https://github.com/Automattic/jetpack/commit/583275f7ea05a625049c6eeecfa0aa59e8db7e41) the PR on the `jetpack/11.8` release branch, and the new Jetpack build `Version 11.8-beta-4087103210-g583275f7` was able to load the Jetpack dashboard ok. To be clear, this was loading the version via the Jetpack Beta Tester plugin in case it helps with identifying the root cause here.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

n/a