### PR TITLE
Forms: Update package with latest contact-form changes

### DIFF
--- a/projects/packages/forms/changelog/update-forms-from-trunk
+++ b/projects/packages/forms/changelog/update-forms-from-trunk
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Update Form package with latest contact-form changes from trunk

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -207,6 +207,7 @@ const EditTextarea = props => {
 
 	return (
 		<JetpackFieldTextarea
+			clientId={ props.clientId }
 			label={ props.attributes.label }
 			required={ props.attributes.required }
 			requiredText={ props.attributes.requiredText }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-dropdown.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-dropdown.js
@@ -1,9 +1,10 @@
 import { RichText } from '@wordpress/block-editor';
 import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 import { isEmpty, isNil, noop, split, trim } from 'lodash';
 import { setFocus } from '../util/focus';
-import { useFormWrapper } from '../util/form';
+import { useFormStyle, useFormWrapper } from '../util/form';
 import JetpackFieldControls from './jetpack-field-controls';
 import JetpackFieldLabel from './jetpack-field-label';
 import { useJetpackFieldStyles } from './use-jetpack-field-styles';
@@ -17,6 +18,12 @@ export const JetpackDropdownEdit = ( {
 } ) => {
 	const { id, label, options, required, requiredText, toggleLabel, width } = attributes;
 	const optionsWrapper = useRef();
+	const formStyle = useFormStyle( clientId );
+
+	const classes = classnames( 'jetpack-field jetpack-field-dropdown', {
+		'is-selected': isSelected,
+		'has-placeholder': ! isEmpty( toggleLabel ),
+	} );
 
 	useFormWrapper( { attributes, clientId, name } );
 
@@ -100,17 +107,18 @@ export const JetpackDropdownEdit = ( {
 	const { blockStyle } = useJetpackFieldStyles( attributes );
 
 	return (
-		<div style={ blockStyle }>
-			<JetpackFieldLabel
-				required={ required }
-				requiredText={ requiredText }
-				label={ label }
-				attributes={ attributes }
-				setAttributes={ setAttributes }
-				isSelected={ isSelected }
-			/>
-			<div className="jetpack-field-dropdown">
-				<div style={ blockStyle } className="jetpack-field-dropdown__toggle">
+		<div className={ classes } style={ blockStyle }>
+			<div className="jetpack-field-dropdown__wrapper">
+				<JetpackFieldLabel
+					required={ required }
+					requiredText={ requiredText }
+					label={ label }
+					attributes={ attributes }
+					setAttributes={ setAttributes }
+					isSelected={ isSelected }
+					style={ formStyle }
+				/>
+				<div className="jetpack-field-dropdown__toggle">
 					<RichText
 						value={ toggleLabel }
 						onChange={ value => {
@@ -121,25 +129,24 @@ export const JetpackDropdownEdit = ( {
 					/>
 					<span className="jetpack-field-dropdown__icon" />
 				</div>
-
-				{ isSelected && (
-					<div className="jetpack-field-dropdown__popover" ref={ optionsWrapper }>
-						{ options.map( ( option, index ) => (
-							<RichText
-								key={ index }
-								value={ option }
-								onChange={ handleChangeOption( index ) }
-								onSplit={ handleSplitOption( index ) }
-								onRemove={ handleDeleteOption( index ) }
-								onReplace={ noop }
-								placeholder={ __( 'Add option…', 'jetpack-forms' ) }
-								__unstableDisableFormats
-							/>
-						) ) }
-					</div>
-				) }
 			</div>
 
+			{ isSelected && (
+				<div className="jetpack-field-dropdown__popover" ref={ optionsWrapper }>
+					{ options.map( ( option, index ) => (
+						<RichText
+							key={ index }
+							value={ option }
+							onChange={ handleChangeOption( index ) }
+							onSplit={ handleSplitOption( index ) }
+							onRemove={ handleDeleteOption( index ) }
+							onReplace={ noop }
+							placeholder={ __( 'Add option…', 'jetpack-forms' ) }
+							__unstableDisableFormats
+						/>
+					) ) }
+				</div>
+			) }
 			<JetpackFieldControls
 				id={ id }
 				required={ required }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-label.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-label.js
@@ -1,19 +1,67 @@
 import { RichText } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 import { isNil } from 'lodash';
+import { FORM_STYLE } from '../util/form';
 import { useJetpackFieldStyles } from './use-jetpack-field-styles';
 
-const JetpackFieldLabel = ( {
-	setAttributes,
+const FieldLabel = ( {
+	attributes,
+	className,
 	label,
 	labelFieldName,
 	placeholder,
 	resetFocus,
 	required,
 	requiredText,
-	attributes,
+	setAttributes,
 } ) => {
+	const { labelStyle } = useJetpackFieldStyles( attributes );
+
+	return (
+		<div className={ classnames( className, 'jetpack-field-label' ) } style={ labelStyle }>
+			<RichText
+				tagName="label"
+				value={ label }
+				className="jetpack-field-label__input"
+				onChange={ value => {
+					resetFocus && resetFocus();
+					if ( labelFieldName ) {
+						setAttributes( { [ labelFieldName ]: value } );
+						return;
+					}
+					setAttributes( { label: value } );
+				} }
+				placeholder={ placeholder ?? __( 'Add label…', 'jetpack-forms' ) }
+				withoutInteractiveFormatting
+				allowedFormats={ [ 'core/bold', 'core/italic' ] }
+			/>
+			{ required && (
+				<RichText
+					tagName="span"
+					value={ requiredText }
+					className="required"
+					onChange={ value => {
+						setAttributes( { requiredText: value } );
+					} }
+					withoutInteractiveFormatting
+					allowedFormats={ [ 'core/bold', 'core/italic' ] }
+				/>
+			) }
+		</div>
+	);
+};
+
+const JetpackFieldLabel = props => {
+	const { setAttributes, requiredText, style } = props;
+
+	const classes = classnames( {
+		'notched-label__label': style === FORM_STYLE.OUTLINED,
+		'animated-label__label': style === FORM_STYLE.ANIMATED,
+		'below-label__label': style === FORM_STYLE.BELOW,
+	} );
+
 	useEffect( () => {
 		if ( isNil( requiredText ) ) {
 			setAttributes( { requiredText: __( '(required)', 'jetpack-forms' ) } );
@@ -21,42 +69,19 @@ const JetpackFieldLabel = ( {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
-	const { labelStyle } = useJetpackFieldStyles( attributes );
-
-	return (
-		<div className="jetpack-field-label">
-			<div style={ labelStyle }>
-				<RichText
-					tagName="label"
-					value={ label }
-					className="jetpack-field-label__input"
-					onChange={ value => {
-						resetFocus && resetFocus();
-						if ( labelFieldName ) {
-							setAttributes( { [ labelFieldName ]: value } );
-							return;
-						}
-						setAttributes( { label: value } );
-					} }
-					placeholder={ placeholder ?? __( 'Add label…', 'jetpack-forms' ) }
-					withoutInteractiveFormatting
-					allowedFormats={ [ 'core/bold', 'core/italic' ] }
-				/>
-				{ required && (
-					<RichText
-						tagName="span"
-						value={ requiredText }
-						className="required"
-						onChange={ value => {
-							setAttributes( { requiredText: value } );
-						} }
-						withoutInteractiveFormatting
-						allowedFormats={ [ 'core/bold', 'core/italic' ] }
-					/>
-				) }
+	if ( style === FORM_STYLE.OUTLINED ) {
+		return (
+			<div className="notched-label">
+				<div className="notched-label__leading" />
+				<div className="notched-label__notch">
+					<FieldLabel className={ classes } { ...props } />
+				</div>
+				<div className="notched-label__trailing" />
 			</div>
-		</div>
-	);
+		);
+	}
+
+	return <FieldLabel className={ classes } { ...props } />;
 };
 
 export default JetpackFieldLabel;

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-multiple.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-multiple.js
@@ -2,6 +2,8 @@ import { Button } from '@wordpress/components';
 import { withInstanceId } from '@wordpress/compose';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
+import { useFormStyle } from '../util/form';
 import JetpackFieldControls from './jetpack-field-controls';
 import JetpackFieldLabel from './jetpack-field-label';
 import JetpackOption from './jetpack-option';
@@ -9,6 +11,7 @@ import { useJetpackFieldStyles } from './use-jetpack-field-styles';
 
 function JetpackFieldMultiple( props ) {
 	const {
+		clientId,
 		id,
 		type,
 		instanceId,
@@ -21,6 +24,12 @@ function JetpackFieldMultiple( props ) {
 		options,
 		attributes,
 	} = props;
+	const formStyle = useFormStyle( clientId );
+
+	const classes = classnames( 'jetpack-field jetpack-field-multiple', {
+		'is-selected': isSelected,
+		'has-placeholder': options.length,
+	} );
 
 	const [ inFocus, setInFocus ] = useState( null );
 
@@ -60,10 +69,11 @@ function JetpackFieldMultiple( props ) {
 	const { blockStyle, fieldStyle } = useJetpackFieldStyles( attributes );
 
 	return (
-		<div style={ blockStyle }>
+		<>
 			<div
 				id={ `jetpack-field-multiple-${ instanceId }` }
-				className="jetpack-field jetpack-field-multiple"
+				className={ classes }
+				style={ blockStyle }
 			>
 				<JetpackFieldLabel
 					required={ required }
@@ -73,6 +83,7 @@ function JetpackFieldMultiple( props ) {
 					isSelected={ isSelected }
 					resetFocus={ () => setInFocus( null ) }
 					attributes={ attributes }
+					style={ formStyle }
 				/>
 				<ol
 					className="jetpack-field-multiple__list"
@@ -112,7 +123,7 @@ function JetpackFieldMultiple( props ) {
 				type={ type }
 				width={ width }
 			/>
-		</div>
+		</>
 	);
 }
 

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-textarea.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-textarea.js
@@ -1,22 +1,31 @@
-import { TextareaControl, Disabled } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
-import { isNil } from 'lodash';
+import classnames from 'classnames';
+import { isEmpty, isNil } from 'lodash';
+import { useFormStyle } from '../util/form';
 import JetpackFieldControls from './jetpack-field-controls';
 import JetpackFieldLabel from './jetpack-field-label';
 import { useJetpackFieldStyles } from './use-jetpack-field-styles';
 
 export default function JetpackFieldTextarea( props ) {
 	const {
+		attributes,
+		clientId,
 		id,
+		isSelected,
 		required,
 		requiredText,
 		label,
 		setAttributes,
 		placeholder,
 		width,
-		attributes,
 	} = props;
+	const formStyle = useFormStyle( clientId );
+	const { blockStyle, fieldStyle } = useJetpackFieldStyles( attributes );
+
+	const classes = classnames( 'jetpack-field jetpack-field-textarea', {
+		'is-selected': isSelected,
+		'has-placeholder': ! isEmpty( placeholder ),
+	} );
 
 	useEffect( () => {
 		if ( isNil( label ) ) {
@@ -25,27 +34,24 @@ export default function JetpackFieldTextarea( props ) {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
-	const { blockStyle, fieldStyle } = useJetpackFieldStyles( attributes );
-
 	return (
 		<>
-			<div style={ blockStyle } className="jetpack-field">
+			<div className={ classes } style={ blockStyle }>
 				<JetpackFieldLabel
+					clientId={ clientId }
 					required={ required }
 					requiredText={ requiredText }
 					label={ label }
 					setAttributes={ setAttributes }
 					attributes={ attributes }
+					style={ formStyle }
 				/>
-				<Disabled>
-					<TextareaControl
-						placeholder={ placeholder }
-						value={ placeholder }
-						onChange={ value => setAttributes( { placeholder: value } ) }
-						title={ __( 'Set the placeholder text', 'jetpack-forms' ) }
-						style={ fieldStyle }
-					/>
-				</Disabled>
+				<textarea
+					className="jetpack-field__textarea"
+					value={ placeholder }
+					onChange={ e => setAttributes( { placeholder: e.target.value } ) }
+					style={ fieldStyle }
+				/>
 			</div>
 
 			<JetpackFieldControls

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
@@ -1,46 +1,52 @@
-import { TextControl, Disabled } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
-import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
+import { isEmpty } from 'lodash';
+import { useFormStyle } from '../util/form';
 import JetpackFieldControls from './jetpack-field-controls';
 import JetpackFieldLabel from './jetpack-field-label';
 import { useJetpackFieldStyles } from './use-jetpack-field-styles';
 
 export default function JetpackField( props ) {
 	const {
+		attributes,
+		clientId,
 		id,
-		type,
+		isSelected,
 		required,
 		requiredText,
 		label,
 		setAttributes,
 		placeholder,
 		width,
-		attributes,
 	} = props;
 
 	const { blockStyle, fieldStyle } = useJetpackFieldStyles( attributes );
+	const formStyle = useFormStyle( clientId );
+
+	const classes = classnames( 'jetpack-field', {
+		'is-selected': isSelected,
+		'has-placeholder': ! isEmpty( placeholder ),
+	} );
 
 	return (
 		<>
-			<div className="jetpack-field" style={ blockStyle }>
+			<div className={ classes } style={ blockStyle }>
 				<JetpackFieldLabel
+					attributes={ attributes }
+					label={ label }
 					required={ required }
 					requiredText={ requiredText }
-					label={ label }
 					setAttributes={ setAttributes }
-					attributes={ attributes }
+					style={ formStyle }
 				/>
-				<Disabled>
-					<TextControl
-						type={ type }
-						placeholder={ placeholder }
-						value={ placeholder }
-						onChange={ value => setAttributes( { placeholder: value } ) }
-						title={ __( 'Set the placeholder text', 'jetpack-forms' ) }
-						style={ fieldStyle }
-					/>
-				</Disabled>
+				<input
+					className="jetpack-field__input"
+					onChange={ e => setAttributes( { placeholder: e.target.value } ) }
+					style={ fieldStyle }
+					type="text"
+					value={ placeholder }
+				/>
 			</div>
 
 			<JetpackFieldControls

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-option.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-option.js
@@ -50,7 +50,7 @@ class JetpackOption extends Component {
 		return (
 			<li className="jetpack-option">
 				{ type && type !== 'select' && (
-					<input style={ style } className="jetpack-option__type" type={ type } disabled />
+					<input className="jetpack-option__type" style={ style } type={ type } readOnly />
 				) }
 				<input
 					type="text"

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -260,7 +260,6 @@
 
 	.rich-text.jetpack-field-label__input {
 		cursor: text;
-		padding-right: 8px;
 		font-weight: bold;
 	}
 
@@ -268,7 +267,9 @@
 		word-break: normal;
 		color: unset;
 		opacity: 0.45;
-		font-size: 15px;
+		font-size: 85%;
+		margin-left: 0.25em;
+		font-weight: normal;
 	}
 
 	.components-toggle-control .components-base-control__field {
@@ -281,42 +282,31 @@
 	padding: 0;
 }
 
-input.components-text-control__input {
-	line-height: 16px;
-}
-
-/*
-	Gutenberg adds some default styling to the TextControl component
-	(https://github.com/WordPress/gutenberg/blob/trunk/packages/base-styles/_mixins.scss#L130)
-	For the TextareaControl, since the base styles are added to the StyledComponent,
-	(https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/textarea-control/styles/textarea-control-styles.ts#L13)
-	The output CSS has a lower specificity and it's being overridden on themes like
-	Twenty Twenty-One and Twenty Twenty-Two.
-	Adding this to normalize the styles between the TextControl and TextareaControl
- */
-:where(.jetpack-field) textarea.components-textarea-control__input {
-	border: 1px solid #757575;
+.jetpack-field__textarea {
+	min-height: 200px;
 }
 
 .jetpack-field {
-	// done to increase elevate specificity in order to overwrite calypso styles
-	.components-text-control__input.components-text-control__input {
+	.jetpack-field__input, .jetpack-field__textarea {
 		width: 100%;
-	}
-	input.components-text-control__input,
-	textarea.components-textarea-control__input {
-		color: #787c82;
-		padding: 12px 8px;
+		font: inherit;
+		box-sizing: border-box;
 		box-shadow: unset;
-		width: 100%;
+		border: 1px solid #8c8f94;
+		border-radius: 0;
+		padding: 16px;
+		margin: 0;
+	}
+
+	.jetpack-field__textarea {
+		border: var(--jetpack--contact-form--border);
+		border-color: var(--jetpack--contact-form--border-color);
+		border-style: var(--jetpack--contact-form--border-style);
+		border-width: var(--jetpack--contact-form--border-size);
 	}
 
 	.components-base-control__field {
 		margin-bottom: 0;
-	}
-
-	textarea.components-textarea-control__input {
-		min-height: 150px;
 	}
 
 	&.jetpack-field-checkbox .jetpack-field-checkbox__checkbox,
@@ -327,9 +317,36 @@ input.components-text-control__input {
 	}
 
 	.jetpack-option__type.jetpack-option__type {
+		width: 1rem;
+		height: 1rem;
 		border-color: currentColor;
 		opacity: 1;
+		margin: 0 0.75rem 0 0
 	}
+
+	&.jetpack-field-multiple {
+		.jetpack-field-multiple__add-option {
+			margin: 0;
+			padding: 0;
+
+			.dashicon {
+				width: 1rem;
+				height: 1rem;
+				display: flex;
+				margin-left: 0;
+				margin-right: 0.75rem;
+
+				&:before {
+					font-size: 1rem;
+				}
+			}
+
+			svg {
+				margin-right: 12px;
+			}
+		}
+	}
+
 
 	.jetpack-field-consent__checkbox + .jetpack-field-label {
 		line-height: normal;
@@ -351,6 +368,9 @@ input.components-text-control__input {
 	list-style-type: none;
 	margin: 0;
 	padding-left: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.25em;
 
 	&:empty {
 		display: none;
@@ -377,12 +397,13 @@ input.components-text-control__input {
 // Duplicated to elevate specificity in order to overwrite core styles
 .jetpack-option__input.jetpack-option__input.jetpack-option__input {
 	color: inherit;
-	border-color: transparent;
 	background: transparent;
+	border: none;
 	border-radius: 0;
 	flex-grow: 1;
-	line-height: normal;
+	line-height: 1.5;
 	font-size: inherit;
+	padding: 0;
 
 	&:hover {
 		border-color: #357cb5;
@@ -403,16 +424,6 @@ input.components-text-control__input {
 .jetpack-option__remove.jetpack-option__remove {
 	padding: 6px;
 	vertical-align: bottom;
-}
-
-.jetpack-field-multiple__add-option {
-	margin-left: -6px;
-	padding: 4px;
-	padding-right: 8px;
-
-	svg {
-		margin-right: 12px;
-	}
 }
 
 .jetpack-field .components-base-control__label {
@@ -496,6 +507,10 @@ input.components-text-control__input {
 	flex-direction: column;
 	font-family: var(--jetpack--contact-form--font-family);
 
+	&__wrapper {
+		position: relative;
+	}
+
 	&__toggle {
 		border: var(--jetpack--contact-form--border);
 		border-color: var(--jetpack--contact-form--border-color);
@@ -555,6 +570,248 @@ input.components-text-control__input {
 
 		.rich-text {
 			padding: var(--jetpack--contact-form--input-padding);
+		}
+	}
+}
+
+.jetpack-contact-form {
+	.jetpack-field {
+		.jetpack-field__input, .jetpack-field__textarea {
+			color: #787c82; //Simulates a placeholder color
+		}
+	}
+
+	&.is-style-outlined, &.is-style-animated {
+		.jetpack-field {
+			position: relative;
+		}
+	}
+
+	&.is-style-outlined {
+		.block-editor-block-list__block:not([contenteditable]):focus:after {
+			top: -10px;
+			left: -10px;
+			bottom: -10px;
+			right: -10px;
+		}
+
+		.jetpack-field {
+			--notch-width: max(var(--jetpack--contact-form--input-padding-left, 16px), var(--jetpack--contact-form--border-radius));
+			margin-top: 8px;
+			display: flex;
+
+			.notched-label {
+				position: absolute;
+				top: 0;
+				left: 0;
+				width: 100%;
+				max-width: 100%;
+				height: 100%;
+				display: flex;
+				box-sizing: border-box;
+				text-align: left;
+				z-index: 1;
+			}
+
+			.notched-label__leading {
+				width: var(--notch-width);
+				border: var(--jetpack--contact-form--border);
+				border-color: var(--jetpack--contact-form--border-color);
+				border-style: var(--jetpack--contact-form--border-style);
+				border-width: var(--jetpack--contact-form--border-size);
+				border-right: none;
+				border-radius: var(--jetpack--contact-form--border-radius);
+				border-top-right-radius: unset;
+				border-bottom-right-radius: unset;
+			}
+
+			.notched-label__notch {
+				border-radius: unset;
+				border: var(--jetpack--contact-form--border);
+				border-color: var(--jetpack--contact-form--border-color);
+				border-style: var(--jetpack--contact-form--border-style);
+				border-width: var(--jetpack--contact-form--border-size);
+				padding: 0 4px;
+				transition: border 150ms linear;
+			}
+
+			// For some reason, when keeping the rule below together with the above selector,
+			// on production builds, the attributes are being reordered, causing side-effects
+			.notched-label__notch {
+				border-left: none;
+				border-right: none;
+			}
+
+			.notched-label__label {
+				position: relative;
+				top: 50%;
+				transform: translateY(-50%);
+				will-change: transform;
+				transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
+				margin: 0;
+
+				label {
+					font-weight: 300;
+				}
+			}
+
+			.notched-label__trailing {
+				flex-grow: 1;
+				border: var(--jetpack--contact-form--border);
+				border-color: var(--jetpack--contact-form--border-color);
+				border-style: var(--jetpack--contact-form--border-style);
+				border-width: var(--jetpack--contact-form--border-size);
+				border-left: none;
+				border-radius: var(--jetpack--contact-form--border-radius);
+				border-top-left-radius: unset;
+				border-bottom-left-radius: unset;
+			}
+
+			&.jetpack-field-textarea .notched-label__label {
+				top: var(--jetpack--contact-form--input-padding-top, 16px);
+				transform: unset;
+			}
+
+			&.is-selected, &.has-placeholder {
+				.notched-label__notch {
+					border-top-color: transparent;
+				}
+
+				.notched-label__label,
+				{
+					top: calc(var(--jetpack--contact-form--border-size) * -1);
+					transform: translateY(-50%);
+					font-size: 0.8em;
+				}
+
+				&.jetpack-field-dropdown {
+					.jetpack-field-dropdown__toggle {
+						border-color: transparent;
+						padding-left: calc(var(--notch-width) + 4px);
+						padding-right: calc(var(--notch-width) + 4px);
+					}
+				}
+			}
+
+			&.jetpack-field-multiple {
+				background-color: var(--jetpack--contact-form--input-background);
+				border-radius: var(--jetpack--contact-form--border-radius);
+				border: var(--jetpack--contact-form--border);
+				border-color: var(--jetpack--contact-form--border-color);
+				border-style: var(--jetpack--contact-form--border-style);
+				border-width: var(--jetpack--contact-form--border-size);
+				padding: var(--jetpack--contact-form--input-padding, 16px);
+				padding-top: calc(var(--jetpack--contact-form--input-padding, 16px) + 4px);
+				border-top: none;
+
+				.notched-label {
+					height: unset;
+
+					&__leading, &__notch, &__trailing {
+						border-bottom: none;
+						border-left: none;
+						border-right: none;
+					}
+				}
+			}
+
+			.jetpack-field-dropdown {
+				&__popover .rich-text {
+					padding-left: calc(var(--notch-width) + 4px);
+					padding-right: calc(var(--notch-width) + 4px);
+				}
+
+				&__icon {
+					margin-right: 0;
+				}
+			}
+
+			.jetpack-field__input, .jetpack-field__textarea {
+				display: flex;
+				border-top-color: transparent !important; //Need to override styles coming from the style attribute
+				outline: none;
+				padding-left: calc(var(--notch-width) + 4px);
+				padding-right: calc(var(--notch-width) + 4px);
+			}
+		}
+	}
+
+	&.is-style-animated {
+		.jetpack-field {
+			--left-offset: calc(var(--jetpack--contact-form--input-padding-left, 16px) + var(--jetpack--contact-form--border-size));
+			--label-left: max(var(--left-offset), var(--jetpack--contact-form--border-radius));
+			--field-padding: calc(var(--label-left) - var(--jetpack--contact-form--border-size));
+
+			.jetpack-field__input {
+				outline: none;
+			}
+
+			.jetpack-field__textarea {
+				padding: var(--jetpack--contact-form--input-padding, 16px);
+				outline: none;
+			}
+
+			.jetpack-field__input,
+			.jetpack-field__textarea,
+			.jetpack-field-dropdown__toggle
+			{
+				padding-top: 1.4em;
+				padding-left: var(--field-padding);
+				padding-right: var(--field-padding);
+			}
+
+			&.jetpack-field-dropdown {
+				.jetpack-field-dropdown__popover {
+					.rich-text {
+						padding-left: var(--field-padding);
+						padding-right: var(--field-padding);
+					}
+				}
+			}
+
+			&.jetpack-field-multiple {
+				background-color: var(--jetpack--contact-form--input-background);
+				padding: var(--jetpack--contact-form--input-padding, 16px);
+				padding-top: 1.7em;
+				border-radius: var(--jetpack--contact-form--border-radius);
+				border: var(--jetpack--contact-form--border);
+				border-color: var(--jetpack--contact-form--border-color);
+				border-style: var(--jetpack--contact-form--border-style);
+				border-width: var(--jetpack--contact-form--border-size);
+			}
+
+			.animated-label__label {
+				position: absolute;
+				z-index: 1;
+				top: 50%;
+				left: var(--label-left);
+				width: 100%;
+				max-width: 100%;
+				box-sizing: border-box;
+				margin: 0;
+				transform: translateY(-50%);
+				transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
+			}
+
+			&.jetpack-field-textarea .animated-label__label {
+				transform: unset;
+				top: var(--jetpack--contact-form--input-padding-top, 16px);
+			}
+
+			&.is-selected, &.has-placeholder {
+				.animated-label__label {
+					font-size: 0.75em;
+					transform: translateY(0);
+					top: calc(2px + var(--jetpack--contact-form--border-size));
+				}
+			}
+		}
+	}
+
+	&.is-style-below {
+		.jetpack-field:not(.jetpack-field-checkbox) {
+			display: flex;
+			flex-direction: column-reverse;
 		}
 	}
 }

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -295,6 +295,8 @@
 		border: 1px solid #8c8f94;
 		border-radius: 0;
 		padding: 16px;
+		padding-left: max(var(--jetpack--contact-form--input-padding-left, 16px), var(--jetpack--contact-form--border-radius));
+		padding-right: max(var(--jetpack--contact-form--input-padding-left, 16px), var(--jetpack--contact-form--border-radius));
 		margin: 0;
 	}
 

--- a/projects/packages/forms/src/blocks/contact-form/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/index.js
@@ -76,6 +76,14 @@ export const settings = {
 			</div>
 		);
 	},
+	example: {},
+	styles: [
+		{ name: 'default', label: 'Default', isDefault: true },
+		{ name: 'animated', label: 'Animated' },
+		{ name: 'outlined', label: 'Outlined' },
+		// Need to figure out some details. Putting on hold for now
+		// { name: 'below', label: 'Below' },
+	],
 	variations,
 	category: 'contact-form',
 	transforms,

--- a/projects/packages/forms/src/blocks/contact-form/util/form.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/form.js
@@ -4,8 +4,16 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
+const FORM_BLOCK_NAME = 'jetpack/contact-form';
+
+export const FORM_STYLE = {
+	ANIMATED: 'animated',
+	BELOW: 'below',
+	DEFAULT: 'default',
+	OUTLINED: 'outlined',
+};
+
 export const useFormWrapper = ( { attributes, clientId, name } ) => {
-	const FORM_BLOCK_NAME = 'jetpack/contact-form';
 	const BUTTON_BLOCK_NAME = 'jetpack/button';
 	const SUBMIT_BUTTON_ATTR = {
 		text: __( 'Submit', 'jetpack-forms' ),
@@ -31,4 +39,22 @@ export const useFormWrapper = ( { attributes, clientId, name } ) => {
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
+};
+
+export const getBlockStyle = className => {
+	const styleClass = className && className.match( /is-style-([^\s]+)/i );
+	return styleClass ? styleClass[ 1 ] : '';
+};
+
+export const useFormStyle = clientId => {
+	const formBlockAttributes = useSelect( select => {
+		const [ formBlockClientId ] = select( blockEditorStore ).getBlockParentsByBlockName(
+			clientId,
+			FORM_BLOCK_NAME
+		);
+
+		return select( blockEditorStore ).getBlockAttributes( formBlockClientId );
+	} );
+
+	return getBlockStyle( formBlockAttributes?.className ) || FORM_STYLE.DEFAULT;
 };

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -45,6 +45,27 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	public $error = false;
 
 	/**
+	 * Styles to be applied to the field
+	 *
+	 * @var string
+	 */
+	public $block_styles = '';
+
+	/**
+	 * Styles to be applied to the field
+	 *
+	 * @var string
+	 */
+	public $field_styles = '';
+
+	/**
+	 * Styles to be applied to the field
+	 *
+	 * @var string
+	 */
+	public $label_styles = '';
+
+	/**
 	 * Constructor function.
 	 *
 	 * @param array                $attributes An associative array of shortcode attributes.  @see shortcode_atts().
@@ -61,6 +82,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				'requiredtext'           => null,
 				'options'                => array(),
 				'id'                     => null,
+				'style'                  => null,
+				'fieldbackgroundcolor'   => null,
+				'textcolor'              => null,
 				'default'                => null,
 				'values'                 => null,
 				'placeholder'            => null,
@@ -69,6 +93,15 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				'consenttype'            => null,
 				'implicitconsentmessage' => null,
 				'explicitconsentmessage' => null,
+				'borderradius'           => null,
+				'borderwidth'            => null,
+				'lineheight'             => null,
+				'labellineheight'        => null,
+				'bordercolor'            => null,
+				'inputcolor'             => null,
+				'labelcolor'             => null,
+				'labelfontsize'          => null,
+				'fieldfontsize'          => null,
 			),
 			$attributes,
 			'contact-field'
@@ -246,6 +279,45 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$field_width         = $this->get_attribute( 'width' );
 		$class               = 'date' === $field_type ? 'jp-contact-form-date' : $this->get_attribute( 'class' );
 
+		if ( is_numeric( $this->get_attribute( 'borderradius' ) ) ) {
+			$this->block_styles .= '--jetpack--contact-form--border-radius: ' . esc_attr( $this->get_attribute( 'borderradius' ) ) . 'px;';
+			$this->field_styles .= 'border-radius: ' . (int) $this->get_attribute( 'borderradius' ) . 'px;';
+		}
+		if ( is_numeric( $this->get_attribute( 'borderwidth' ) ) ) {
+			$this->block_styles .= '--jetpack--contact-form--border-size: ' . esc_attr( $this->get_attribute( 'borderwidth' ) ) . 'px;';
+			$this->field_styles .= 'border-width: ' . (int) $this->get_attribute( 'borderwidth' ) . 'px;';
+		}
+		if ( is_numeric( $this->get_attribute( 'lineheight' ) ) ) {
+			$this->block_styles .= '--jetpack--contact-form--line-height: ' . esc_attr( $this->get_attribute( 'lineheight' ) ) . ';';
+			$this->field_styles .= 'line-height: ' . (int) $this->get_attribute( 'lineheight' ) . ';';
+		}
+		if ( ! empty( $this->get_attribute( 'bordercolor' ) ) ) {
+			$this->block_styles .= '--jetpack--contact-form--border-color: ' . esc_attr( $this->get_attribute( 'bordercolor' ) ) . ';';
+			$this->field_styles .= 'border-color: ' . esc_attr( $this->get_attribute( 'bordercolor' ) ) . ';';
+		}
+		if ( ! empty( $this->get_attribute( 'inputcolor' ) ) ) {
+			$this->block_styles .= '--jetpack--contact-form--text-color: ' . esc_attr( $this->get_attribute( 'inputcolor' ) ) . ';';
+			$this->field_styles .= 'color: ' . esc_attr( $this->get_attribute( 'inputcolor' ) ) . ';';
+		}
+		if ( ! empty( $this->get_attribute( 'fieldbackgroundcolor' ) ) ) {
+			$this->block_styles .= '--jetpack--contact-form--input-background: ' . esc_attr( $this->get_attribute( 'fieldbackgroundcolor' ) ) . ';';
+			$this->field_styles .= 'background-color: ' . esc_attr( $this->get_attribute( 'fieldbackgroundcolor' ) ) . ';';
+		}
+		if ( ! empty( $this->get_attribute( 'fieldfontsize' ) ) ) {
+			$this->block_styles .= '--jetpack--contact-form--font-size: ' . esc_attr( $this->get_attribute( 'fieldfontsize' ) ) . ';';
+			$this->field_styles .= 'font-size: ' . esc_attr( $this->get_attribute( 'fieldfontsize' ) ) . ';';
+		}
+
+		if ( ! empty( $this->get_attribute( 'labelcolor' ) ) ) {
+			$this->label_styles .= 'color: ' . esc_attr( $this->get_attribute( 'labelcolor' ) ) . ';';
+		}
+		if ( ! empty( $this->get_attribute( 'labelfontsize' ) ) ) {
+			$this->label_styles .= 'font-size: ' . esc_attr( $this->get_attribute( 'labelfontsize' ) ) . ';';
+		}
+		if ( is_numeric( $this->get_attribute( 'labellineheight' ) ) ) {
+			$this->label_styles .= 'line-height: ' . (int) $this->get_attribute( 'labellineheight' ) . ';';
+		}
+
 		if ( ! empty( $field_width ) ) {
 			$class .= ' grunion-field-width-' . $field_width;
 		}
@@ -329,19 +401,37 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @param string $label - the label.
 	 * @param bool   $required - if the field is marked as required.
 	 * @param string $required_field_text - the text in the required text field.
+	 * @param array  $extra_attrs Array of key/value pairs to append as attributes to the element.
 	 *
 	 * @return string HTML
 	 */
-	public function render_label( $type, $id, $label, $required, $required_field_text ) {
+	public function render_label( $type, $id, $label, $required, $required_field_text, $extra_attrs = array() ) {
+		$form_style = $this->get_form_style();
+
+		if ( ! empty( $form_style ) && $form_style !== 'default' ) {
+			return '';
+		}
+
+		if ( ! empty( $this->label_styles ) ) {
+			$extra_attrs['style'] = $this->label_styles;
+		}
+
+		$extra_attrs_string = '';
+		if ( is_array( $extra_attrs ) && ! empty( $extra_attrs ) ) {
+			foreach ( $extra_attrs as $attr => $val ) {
+				$extra_attrs_string .= sprintf( '%s="%s" ', esc_attr( $attr ), esc_attr( $val ) );
+			}
+		}
 
 		$type_class = $type ? ' ' . $type : '';
 		return "<label
 				for='" . esc_attr( $id ) . "'
-				class='grunion-field-label{$type_class}" . ( $this->is_error() ? ' form-error' : '' ) . "'
-				>"
+				class='grunion-field-label{$type_class}" . ( $this->is_error() ? ' form-error' : '' ) . "'"
+				. $extra_attrs_string
+				. '>'
 				. esc_html( $label )
 				. ( $required ? '<span>' . $required_field_text . '</span>' : '' )
-			. "</label>\n";
+				. "</label>\n";
 	}
 
 	/**
@@ -359,6 +449,11 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 */
 	public function render_input_field( $type, $id, $value, $class, $placeholder, $required, $extra_attrs = array() ) {
 		$extra_attrs_string = '';
+
+		if ( ! empty( $this->field_styles ) ) {
+			$extra_attrs['style'] = $this->field_styles;
+		}
+
 		if ( is_array( $extra_attrs ) && ! empty( $extra_attrs ) ) {
 			foreach ( $extra_attrs as $attr => $val ) {
 				$extra_attrs_string .= sprintf( '%s="%s" ', esc_attr( $attr ), esc_attr( $val ) );
@@ -457,6 +552,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	public function render_textarea_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
 		$field  = $this->render_label( 'textarea', 'contact-form-comment-' . $id, $label, $required, $required_field_text );
 		$field .= "<textarea
+		                style='" . $this->field_styles . "'
 		                name='" . esc_attr( $id ) . "'
 		                id='contact-form-comment-" . esc_attr( $id ) . "'
 		                rows='20' "
@@ -481,11 +577,15 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_radio_field( $id, $label, $value, $class, $required, $required_field_text ) {
-		$field = $this->render_label( '', $id, $label, $required, $required_field_text );
+		$field  = $this->render_label( '', $id, $label, $required, $required_field_text );
+		$field .= '<div class="grunion-radio-options">';
+
+		$field_style = 'style="' . $this->field_styles . '"';
+
 		foreach ( (array) $this->get_attribute( 'options' ) as $option_index => $option ) {
 			$option = Contact_Form_Plugin::strip_tags( $option );
 			if ( is_string( $option ) && $option !== '' ) {
-				$field .= "\t\t<label class='grunion-radio-label radio" . ( $this->is_error() ? ' form-error' : '' ) . "'>";
+				$field .= "\t\t<label {$field_style} class='grunion-radio-label radio" . ( $this->is_error() ? ' form-error' : '' ) . "'>";
 				$field .= "<input
 									type='radio'
 									name='" . esc_attr( $id ) . "'
@@ -495,9 +595,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 									. ( $required ? "required aria-required='true'" : '' )
 									. '/> ';
 				$field .= esc_html( $option ) . "</label>\n";
-				$field .= "\t\t<div class='clear-form'></div>\n";
 			}
 		}
+		$field .= '</div>';
 		return $field;
 	}
 
@@ -514,11 +614,11 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_checkbox_field( $id, $label, $value, $class, $required, $required_field_text ) {
-		$field      = "<label class='grunion-field-label checkbox" . ( $this->is_error() ? ' form-error' : '' ) . "'>";
-			$field .= "\t\t<input type='checkbox' name='" . esc_attr( $id ) . "' value='" . esc_attr__( 'Yes', 'jetpack-forms' ) . "' " . $class . checked( (bool) $value, true, false ) . ' ' . ( $required ? "required aria-required='true'" : '' ) . "/> \n";
-			$field .= "\t\t" . esc_html( $label ) . ( $required ? '<span>' . $required_field_text . '</span>' : '' );
-		$field     .= "</label>\n";
-		$field     .= "<div class='clear-form'></div>\n";
+		$field  = "<label class='grunion-field-label checkbox" . ( $this->is_error() ? ' form-error' : '' ) . "' style='" . $this->label_styles . "'>";
+		$field .= "\t\t<input type='checkbox' name='" . esc_attr( $id ) . "' value='" . esc_attr__( 'Yes', 'jetpack-forms' ) . "' " . $class . checked( (bool) $value, true, false ) . ' ' . ( $required ? "required aria-required='true'" : '' ) . "/> \n";
+		$field .= "\t\t" . esc_html( $label ) . ( $required ? '<span>' . $required_field_text . '</span>' : '' );
+		$field .= "</label>\n";
+		$field .= "<div class='clear-form'></div>\n";
 		return $field;
 	}
 
@@ -558,16 +658,20 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_checkbox_multiple_field( $id, $label, $value, $class, $required, $required_field_text ) {
-		$field = $this->render_label( '', $id, $label, $required, $required_field_text );
+		$field  = $this->render_label( '', $id, $label, $required, $required_field_text );
+		$field .= '<div class="grunion-checkbox-multiple-options">';
+
+		$field_style = 'style="' . $this->field_styles . '"';
+
 		foreach ( (array) $this->get_attribute( 'options' ) as $option_index => $option ) {
 			$option = Contact_Form_Plugin::strip_tags( $option );
 			if ( is_string( $option ) && $option !== '' ) {
-				$field .= "\t\t<label class='grunion-checkbox-multiple-label checkbox-multiple" . ( $this->is_error() ? ' form-error' : '' ) . "'>";
+				$field .= "\t\t<label {$field_style} class='grunion-checkbox-multiple-label checkbox-multiple " . ( $this->is_error() ? ' form-error' : '' ) . "'>";
 				$field .= "<input type='checkbox' name='" . esc_attr( $id ) . "[]' value='" . esc_attr( $this->get_option_value( $this->get_attribute( 'values' ), $option_index, $option ) ) . "' " . $class . checked( in_array( $option, (array) $value, true ), true, false ) . ' /> ';
 				$field .= esc_html( $option ) . "</label>\n";
-				$field .= "\t\t<div class='clear-form'></div>\n";
 			}
 		}
+		$field .= '</div>';
 
 		return $field;
 	}
@@ -690,6 +794,77 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	}
 
 	/**
+	 * Return the HTML for the outlined label.
+	 *
+	 * @param int    $id - the ID.
+	 * @param string $label - the label.
+	 * @param bool   $required - if the field is marked as required.
+	 * @param string $required_field_text - the text in the required text field.
+	 *
+	 * @return string HTML
+	 */
+	public function render_outline_label( $id, $label, $required, $required_field_text ) {
+		return '
+			<div class="notched-label">
+				<div class="notched-label__leading"></div>
+				<div class="notched-label__notch">
+					<label
+						for="' . esc_attr( $id ) . '"
+						class="notched-label__label ' . ( $this->is_error() ? ' form-error' : '' ) . '"
+						style="' . $this->label_styles . '"
+					>'
+			. esc_html( $label )
+			. ( $required ? '<span>' . $required_field_text . '</span>' : '' ) .
+			'</label>
+				</div>
+				<div class="notched-label__trailing"></div>
+			</div>';
+	}
+
+	/**
+	 * Return the HTML for the animated label.
+	 *
+	 * @param int    $id - the ID.
+	 * @param string $label - the label.
+	 * @param bool   $required - if the field is marked as required.
+	 * @param string $required_field_text - the text in the required text field.
+	 *
+	 * @return string HTML
+	 */
+	public function render_animated_label( $id, $label, $required, $required_field_text ) {
+		return '
+			<label
+				for="' . esc_attr( $id ) . '"
+				class="animated-label__label ' . ( $this->is_error() ? ' form-error' : '' ) . '"
+				style="' . $this->label_styles . '"
+			>'
+			. esc_html( $label )
+			. ( $required ? '<span>' . $required_field_text . '</span>' : '' ) .
+			'</label>';
+	}
+
+	/**
+	 * Return the HTML for the below label.
+	 *
+	 * @param int    $id - the ID.
+	 * @param string $label - the label.
+	 * @param bool   $required - if the field is marked as required.
+	 * @param string $required_field_text - the text in the required text field.
+	 *
+	 * @return string HTML
+	 */
+	public function render_below_label( $id, $label, $required, $required_field_text ) {
+		return '
+			<label
+				for="' . esc_attr( $id ) . '"
+				class="below-label__label ' . ( $this->is_error() ? ' form-error' : '' ) . '"
+			>'
+			. esc_html( $label )
+			. ( $required ? '<span>' . $required_field_text . '</span>' : '' ) .
+			'</label>';
+	}
+
+	/**
 	 * Return the HTML for the email field.
 	 *
 	 * @param string $type - the type.
@@ -704,8 +879,19 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_field( $type, $id, $label, $value, $class, $placeholder, $required, $required_field_text ) {
+		$class .= ' grunion-field';
+
 		if ( $type === 'select' ) {
 			$class .= ' contact-form-dropdown';
+		}
+
+		$form_style = $this->get_form_style();
+		if ( ! empty( $form_style ) && $form_style !== 'default' ) {
+			if ( empty( $placeholder ) ) {
+				$placeholder .= ' ';
+			} else {
+				$class .= ' has-placeholder';
+			}
 		}
 
 		$field_placeholder = ( ! empty( $placeholder ) ) ? "placeholder='" . esc_attr( $placeholder ) . "'" : '';
@@ -716,7 +902,11 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			$wrap_classes .= ' ui-front';
 		}
 
-		$shell_field_class = "class='grunion-field-wrap grunion-field-" . trim( esc_attr( $type ) . '-wrap ' . esc_attr( $wrap_classes ) ) . "' ";
+		if ( empty( $label ) ) {
+			$wrap_classes .= ' no-label';
+		}
+
+		$shell_field_class = "class='grunion-field-" . trim( esc_attr( $type ) . '-wrap ' . esc_attr( $wrap_classes ) ) . "' ";
 
 		/**
 		 * Filter the Contact Form required field text
@@ -729,11 +919,19 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		 */
 		$required_field_text = esc_html( apply_filters( 'jetpack_required_field_text', $required_field_text ) );
 
-		$field = "\n<div {$shell_field_class} >\n"; // new in Jetpack 6.8.0
+		$block_style = 'style="';
+		if ( $type === 'select' || in_array( $form_style, array( 'outlined', 'animated' ), true ) ) {
+			$block_style .= $this->block_styles;
+		}
+		$block_style .= '"';
+
+		$field = "\n<div {$block_style} {$shell_field_class} >\n"; // new in Jetpack 6.8.0
+
 		// If they are logged in, and this is their site, don't pre-populate fields
 		if ( current_user_can( 'manage_options' ) ) {
 			$value = '';
 		}
+
 		switch ( $type ) {
 			case 'email':
 				$field .= $this->render_email_field( $id, $label, $value, $field_class, $required, $required_field_text, $field_placeholder );
@@ -769,6 +967,21 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				$field .= $this->render_default_field( $id, $label, $value, $field_class, $required, $required_field_text, $field_placeholder, $type );
 				break;
 		}
+
+		if ( ! empty( $form_style ) && $form_style !== 'default' && ! in_array( $type, array( 'checkbox', 'consent' ), true ) ) {
+			switch ( $form_style ) {
+				case 'outlined':
+					$field .= $this->render_outline_label( $id, $label, $required, $required_field_text );
+					break;
+				case 'animated':
+					$field .= $this->render_animated_label( $id, $label, $required, $required_field_text );
+					break;
+				case 'below':
+					$field .= $this->render_below_label( $id, $label, $required, $required_field_text );
+					break;
+			}
+		}
+
 		$field .= "\t</div>\n";
 		return $field;
 	}
@@ -802,5 +1015,16 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		}
 
 		return $type;
+	}
+
+	/**
+	 * Gets the form style based on its CSS class.
+	 *
+	 * @return string The form style type.
+	 */
+	private function get_form_style() {
+		$class_name = $this->form->get_attribute( 'className' );
+		preg_match( '/is-style-([^\s]+)/i', $class_name, $matches );
+		return count( $matches ) >= 2 ? $matches[1] : null;
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -919,11 +919,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		 */
 		$required_field_text = esc_html( apply_filters( 'jetpack_required_field_text', $required_field_text ) );
 
-		$block_style = 'style="';
-		if ( $type === 'select' || in_array( $form_style, array( 'outlined', 'animated' ), true ) ) {
-			$block_style .= $this->block_styles;
-		}
-		$block_style .= '"';
+		$block_style = 'style="' . $this->block_styles . '"';
 
 		$field = "\n<div {$block_style} {$shell_field_class} >\n"; // new in Jetpack 6.8.0
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -137,6 +137,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'customThankyouMessage'  => __( 'Thank you for your submission!', 'jetpack-forms' ), // The message to show when customThankyou is set to 'message'.
 			'customThankyouRedirect' => '', // The URL to redirect to when customThankyou is set to 'redirect'.
 			'jetpackCRM'             => true, // Whether Jetpack CRM should store the form submission.
+			'className'              => null,
 		);
 
 		$attributes = shortcode_atts( $this->defaults, $attributes, 'contact-form' );

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -35,6 +35,11 @@
 	height: 200px;
 }
 
+.contact-form .grunion-field {
+	padding-left: max(var(--jetpack--contact-form--input-padding-left, 16px), var(--jetpack--contact-form--border-radius));
+	padding-right: max(var(--jetpack--contact-form--input-padding-left, 16px), var(--jetpack--contact-form--border-radius));
+}
+
 .contact-form .grunion-field-wrap input,
 .contact-form .grunion-field-wrap textarea {
 	margin: 0;

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -2,10 +2,6 @@
 	clear: both;
 }
 
-.contact-form input {
-	font: inherit;
-}
-
 .contact-form input::placeholder {
 	transition: opacity 0.3s ease-out;
 }
@@ -24,27 +20,29 @@
 	.contact-form input[type='text'],
 	.contact-form input[type='email'],
 	.contact-form input[type='tel'],
-	.contact-form input[type='url']
+	.contact-form input[type='url'],
+	.contact-form textarea
 ) {
 	box-sizing: border-box;
 	width: 100%;
-	padding: 12px 8px;
-	border-width: 1px;
-	line-height: normal;
+	padding: 16px;
+	font: inherit;
+	border: 1px solid #8c8f94;
+	border-radius: 0;
+}
+
+:where(.contact-form textarea) {
+	height: 200px;
+}
+
+.contact-form .grunion-field-wrap input,
+.contact-form .grunion-field-wrap textarea {
+	margin: 0;
 }
 
 .contact-form select {
 	padding: 14px 7px;
 	min-width: 150px;
-}
-
-.contact-form textarea {
-	box-sizing: border-box;
-	float: none;
-	height: 200px;
-	width: 100%;
-	padding: 7px;
-	font: inherit;
 }
 
 .contact-form input[type='radio'],
@@ -82,11 +80,19 @@
 .contact-form label.checkbox,
 .contact-form label.checkbox-multiple,
 .contact-form label.radio {
-	margin-bottom: 0.25em;
+	margin-bottom: 0;
 	float: none;
 	font-weight: normal;
 	display: inline-flex;
 	align-items: center;
+	line-height: 1.5;
+}
+
+.contact-form .grunion-checkbox-multiple-options,
+.contact-form .grunion-radio-options {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25em
 }
 
 .contact-form label span {
@@ -246,10 +252,6 @@
 	width: 100%;
 }
 
-.contact-form-dropdown-wrap {
-	z-index: unset;
-}
-
 .contact-form .contact-form-dropdown__button.ui-button {
 	width: 100%;
 	box-sizing: border-box;
@@ -258,6 +260,9 @@
 	flex-direction: row-reverse;
 	justify-content: space-between;
 	border: var(--jetpack--contact-form--border);
+	border-color: var(--jetpack--contact-form--border-color);
+	border-style: var(--jetpack--contact-form--border-style);
+	border-width: var(--jetpack--contact-form--border-size);
 	border-radius: var(--jetpack--contact-form--border-radius);
 	background-color: var(--jetpack--contact-form--input-background);
 	color: var(--jetpack--contact-form--text-color);
@@ -302,9 +307,15 @@
 	transform: rotate(225deg);
 	margin-top: 8px;
 }
+.contact-form .contact-form-dropdown__menu {
+	z-index: 1;
+}
 
 .contact-form .contact-form-dropdown__menu ul.ui-menu {
 	border: var(--jetpack--contact-form--border);
+	border-color: var(--jetpack--contact-form--border-color);
+	border-style: var(--jetpack--contact-form--border-style);
+	border-width: var(--jetpack--contact-form--border-size);
 	border-radius: var(--jetpack--contact-form--border-radius);
 	background-color: var(--jetpack--contact-form--input-background);
 	color: var(--jetpack--contact-form--text-color);
@@ -329,5 +340,231 @@
 	position: relative;
 	border: none;
 	color: var(--jetpack--contact-form--input-background);
-	background-color: var(--jetpack--contact-form--primary-color);
+	background-color: var(--jetpack--contact-form--text-color);
+}
+
+
+.contact-form .is-style-outlined .grunion-field-wrap:not(.grunion-field-checkbox-wrap):not(.grunion-field-consent-wrap),
+.contact-form .is-style-animated .grunion-field-wrap:not(.grunion-field-checkbox-wrap):not(.grunion-field-consent-wrap) {
+	--notch-width: max(var(--jetpack--contact-form--input-padding-left, 16px), var(--jetpack--contact-form--border-radius));
+	position: relative;
+	display: flex;
+	flex-direction: row-reverse;
+}
+
+.contact-form .is-style-outlined .grunion-field-checkbox-multiple-wrap,
+.contact-form .is-style-outlined .grunion-field-radio-wrap {
+	background-color: var(--jetpack--contact-form--input-background);
+}
+
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-checkbox-multiple-options,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-radio-options,
+.contact-form .is-style-animated .grunion-field-wrap .grunion-checkbox-multiple-options,
+.contact-form .is-style-animated .grunion-field-wrap .grunion-radio-options
+{
+	padding: var(--jetpack--contact-form--input-padding, 16px);
+	padding-top: calc(var(--jetpack--contact-form--input-padding, 16px) + 4px);
+	flex-grow: 1;
+}
+
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label {
+	position: absolute;
+	right: 0;
+	left: 0;
+	width: 100%;
+	max-width: 100%;
+	height: 100%;
+	display: flex;
+	box-sizing: border-box;
+	text-align: left;
+	pointer-events: none;
+}
+
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label .notched-label__leading {
+	width: var(--notch-width);
+	border-radius: var(--jetpack--contact-form--border-radius);
+	border: var(--jetpack--contact-form--border);
+	border-color: var(--jetpack--contact-form--border-color);
+	border-style: var(--jetpack--contact-form--border-style);
+	border-width: var(--jetpack--contact-form--border-size);
+	border-right: none;
+	border-top-right-radius: unset;
+	border-bottom-right-radius: unset;
+}
+
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label .notched-label__notch {
+	border-radius: unset;
+	border: var(--jetpack--contact-form--border);
+	border-color: var(--jetpack--contact-form--border-color);
+	border-style: var(--jetpack--contact-form--border-style);
+	border-width: var(--jetpack--contact-form--border-size);
+	padding: 0 4px;
+	transition: border 150ms linear;
+}
+
+/*
+For some reason, when keeping the rule below together with the above selector,
+on production builds, the attributes are being reordered, causing side-effects
+*/
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label .notched-label__notch {
+	border-left: none;
+	border-right: none;
+}
+
+.contact-form .is-style-outlined .grunion-field-wrap.no-label .notched-label__notch {
+	padding: 0;
+}
+
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label .notched-label__label {
+	position: relative;
+	top: 50%;
+	transform: translateY(-50%);
+	pointer-events: none;
+	will-change: transform;
+	transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
+	margin: 0;
+	font-weight: 300;
+}
+
+.contact-form .is-style-outlined .grunion-field-textarea-wrap .notched-label .notched-label__label {
+	top: var(--jetpack--contact-form--input-padding-top, 16px);
+	transform: unset;
+}
+
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label .notched-label__trailing {
+	flex-grow: 1;
+	border-radius: var(--jetpack--contact-form--border-radius);
+	border: var(--jetpack--contact-form--border);
+	border-color: var(--jetpack--contact-form--border-color);
+	border-style: var(--jetpack--contact-form--border-style);
+	border-width: var(--jetpack--contact-form--border-size);
+	border-left: none;
+	border-top-left-radius: unset;
+	border-bottom-left-radius: unset;
+}
+
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:focus ~ .notched-label .notched-label__notch,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:not(:placeholder-shown) ~ .notched-label .notched-label__notch,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-field.has-placeholder ~ .notched-label .notched-label__notch,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-checkbox-multiple-options ~ .notched-label .notched-label__notch,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-radio-options ~ .notched-label .notched-label__notch
+{
+	border-top-color: transparent;
+}
+
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:focus ~ .notched-label .notched-label__label,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-field:not(:placeholder-shown) ~ .notched-label .notched-label__label,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-field.has-placeholder ~ .notched-label .notched-label__label,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-checkbox-multiple-options ~ .notched-label .notched-label__label,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-radio-options ~ .notched-label .notched-label__label
+{
+	top: calc(var(--jetpack--contact-form--border-size) * -1);
+	transform: translateY(-50%);
+	font-size: 0.8em;
+}
+
+.contact-form .is-style-outlined .grunion-field-wrap > input,
+.contact-form .is-style-outlined .grunion-field-wrap > textarea,
+.contact-form .is-style-outlined .grunion-field-wrap .contact-form-dropdown__button
+{
+	border-color: transparent !important; /* Need to override styles coming from the style attribute*/
+	outline: none;
+	padding-left: calc(var(--notch-width) + 4px);
+	padding-right: calc(var(--notch-width) + 4px);
+}
+
+.contact-form .is-style-outlined .grunion-field-wrap textarea {
+	padding: var(--jetpack--contact-form--input-padding, 16px);
+	padding-left: calc(var(--notch-width) + 4px);
+	padding-right: calc(var(--notch-width) + 4px);
+}
+
+.contact-form .is-style-outlined .contact-form-dropdown__menu .ui-menu-item-wrapper {
+	padding-left: calc(var(--notch-width) + 4px);
+	padding-right: calc(var(--notch-width) + 4px);
+}
+
+.contact-form .is-style-animated .grunion-field-wrap {
+	--left-offset: calc(var(--jetpack--contact-form--input-padding-left, 16px) + var(--jetpack--contact-form--border-size));
+	--label-left: max(var(--left-offset), var(--jetpack--contact-form--border-radius));
+	--field-padding: calc(var(--label-left) - var(--jetpack--contact-form--border-size));
+}
+
+.contact-form .is-style-animated .grunion-field-wrap input {
+	outline: none;
+}
+
+.contact-form .is-style-animated .grunion-field-wrap textarea {
+	padding: var(--jetpack--contact-form--input-padding, 16px);
+	outline: none;
+}
+
+.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) > input,
+.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) > textarea,
+.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) .contact-form-dropdown__button
+{
+	padding-top: 1.4em;
+	padding-left: var(--field-padding);
+	padding-right: var(--field-padding);
+}
+
+.contact-form .is-style-animated .grunion-field-wrap .contact-form-dropdown__menu .ui-menu-item-wrapper {
+	padding-left: var(--field-padding);
+	padding-right: var(--field-padding);
+}
+
+.contact-form .is-style-animated .grunion-field-checkbox-multiple-wrap,
+.contact-form .is-style-animated .grunion-field-radio-wrap {
+	background-color: var(--jetpack--contact-form--input-background);
+	border-radius: var(--jetpack--contact-form--border-radius);
+	border: var(--jetpack--contact-form--border);
+	border-color: var(--jetpack--contact-form--border-color);
+	border-style: var(--jetpack--contact-form--border-style);
+	border-width: var(--jetpack--contact-form--border-size);
+}
+
+.contact-form .is-style-animated .grunion-field-checkbox-multiple-wrap .grunion-checkbox-multiple-options,
+.contact-form .is-style-animated .grunion-field-radio-wrap .grunion-radio-options {
+	padding-top: 1.7em;
+}
+
+.contact-form .is-style-animated .grunion-field-wrap .animated-label__label {
+	position: absolute;
+	top: 50%;
+	left: var(--label-left);
+	width: 100%;
+	max-width: 100%;
+	box-sizing: border-box;
+	pointer-events: none;
+	margin: 0;
+	transform: translateY(-50%);
+	transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.contact-form .is-style-animated .grunion-field-textarea-wrap .animated-label__label {
+	transform: unset;
+	top: var(--jetpack--contact-form--input-padding-top, 16px);
+}
+
+.contact-form .is-style-animated .grunion-field-wrap .grunion-field:focus ~ .animated-label__label,
+.contact-form .is-style-animated .grunion-field-wrap .grunion-field:not(:placeholder-shown) ~ .animated-label__label,
+.contact-form .is-style-animated .grunion-field-wrap .grunion-field.has-placeholder ~ .animated-label__label,
+.contact-form .is-style-animated .grunion-field-wrap .grunion-checkbox-multiple-options ~ .animated-label__label,
+.contact-form .is-style-animated .grunion-field-wrap .grunion-radio-options ~ .animated-label__label
+{
+	font-size: 0.75em;
+	transform: translateY(0);
+	top: calc(2px + var(--jetpack--contact-form--border-size));
+}
+
+.contact-form .is-style-below .grunion-field-wrap .below-label__label {
+	margin-left: var(--jetpack--contact-form--border-size);
+}
+
+.wp-block-jetpack-contact-form-container {
+	filter: blur(10px);
+}
+
+.contact-form-styles-loaded .wp-block-jetpack-contact-form-container {
+	filter: blur(0px);
 }

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
@@ -946,7 +946,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 			$attributes['class'] = 'jp-contact-form-date';
 		}
 
-		$css_class = "grunion-field-wrap grunion-field-{$attributes['type']}-wrap {$attributes['class']}-wrap";
+		$css_class = "grunion-field-{$attributes['type']}-wrap {$attributes['class']}-wrap grunion-field-wrap";
 
 		if ( 'select' === $attributes['type'] ) {
 			$css_class .= ' contact-form-dropdown-wrap ui-front';
@@ -981,7 +981,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 
 		// Input.
 		$input = (
-			'textarea' === $attributes['type']
+		'textarea' === $attributes['type']
 			? $this->getFirstElement( $wrapper_div, 'textarea' )
 			: $this->getFirstElement( $wrapper_div, 'input' )
 		);
@@ -1016,13 +1016,13 @@ class WP_Test_Contact_Form extends BaseTestCase {
 		if ( 'date' === $attributes['type'] ) {
 			$this->assertEquals(
 				$input->getAttribute( 'class' ),
-				"{$attributes['type']} jp-contact-form-date",
+				"{$attributes['type']} jp-contact-form-date grunion-field",
 				'input class attribute doesn\'t match'
 			);
 		} else {
 			$this->assertEquals(
 				$input->getAttribute( 'class' ),
-				"{$attributes['type']} {$attributes['class']}",
+				"{$attributes['type']} {$attributes['class']} grunion-field",
 				'input class attribute doesn\'t match'
 			);
 		}
@@ -1051,7 +1051,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 			$this->assertEquals( 'checked', $input->getAttribute( 'checked' ), 'Input checked doesn\'t match' );
 		}
 
-		$this->assertEquals( $input->getAttribute( 'class' ), $attributes['type'] . ' ' . $attributes['class'], 'Input class doesn\'t match' );
+		$this->assertEquals( $input->getAttribute( 'class' ), $attributes['type'] . ' ' . $attributes['class'] . ' grunion-field', 'Input class doesn\'t match' );
 	}
 
 	/**
@@ -1085,7 +1085,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 				'label for does not equal input name!'
 			);
 
-			$this->assertEquals( $select->getAttribute( 'class' ), 'select ' . $attributes['class'] . ' contact-form-dropdown', ' select class does not match expected' );
+			$this->assertEquals( $select->getAttribute( 'class' ), 'select ' . $attributes['class'] . ' grunion-field contact-form-dropdown', ' select class does not match expected' );
 
 			// Options.
 			$options = $select->getElementsByTagName( 'option' );
@@ -1123,7 +1123,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 					$this->assertEquals( $input->getAttribute( 'name' ), $attributes['id'] . '[]', 'Input name doesn\'t match' );
 				}
 				$this->assertEquals( $input->getAttribute( 'value' ), $attributes['values'][ $i ], 'Input value doesn\'t match' );
-				$this->assertEquals( $input->getAttribute( 'class' ), $attributes['type'] . ' ' . $attributes['class'], 'Input class doesn\'t match' );
+				$this->assertEquals( $input->getAttribute( 'class' ), $attributes['type'] . ' ' . $attributes['class'] . ' grunion-field', 'Input class doesn\'t match' );
 				if ( 0 === $i ) {
 					$this->assertEquals( 'checked', $input->getAttribute( 'checked' ), 'Input checked doesn\'t match' );
 				} else {

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
@@ -981,7 +981,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 
 		// Input.
 		$input = (
-		'textarea' === $attributes['type']
+			'textarea' === $attributes['type']
 			? $this->getFirstElement( $wrapper_div, 'textarea' )
 			: $this->getFirstElement( $wrapper_div, 'input' )
 		);


### PR DESCRIPTION
Part of #28405

## Proposed changes:

* Updates package with latest contact-form changes from trunk

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pcsBup-N3-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

Enable the Forms package on your jetpack install by making sure the filter below is added before the contact form module is loaded:

```
add_filter( 'jetpack_contact_form_use_package', '__return_true' );
```

Make sure the package is installed with `jetpack install packages/forms && jetpack install plugins/jetpack`, and build the JS bundle with `jetpack build packages/forms`. 
You can also test the watch functionality with `jetpack watch packages/forms`.

Play with the Form block and check if it works as expected.
Make sure to test the latest style changes: #28212 - #27837
