### PR TITLE
WAF: Ensure the jetpack-waf directory exists as part of filesystem initialization

### DIFF
--- a/projects/packages/waf/changelog/add-waf-ensure-content-directory
+++ b/projects/packages/waf/changelog/add-waf-ensure-content-directory
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed PHP fatal when the jetpack-waf directory has been deleted from the wp-content folder
+
+

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -245,7 +245,7 @@ class Waf_Runner {
 	}
 
 	/**
-	 * Initializes the WP filesystem.
+	 * Initializes the WP filesystem and WAF directory structure.
 	 *
 	 * @return void
 	 * @throws \Exception If filesystem is unavailable.
@@ -258,6 +258,8 @@ class Waf_Runner {
 		if ( ! \WP_Filesystem() ) {
 			throw new \Exception( 'No filesystem available.' );
 		}
+
+		self::initialize_waf_directory();
 	}
 
 	/**
@@ -278,7 +280,6 @@ class Waf_Runner {
 		add_option( self::SHARE_DATA_OPTION_NAME, true );
 
 		self::initialize_filesystem();
-		self::create_waf_directory();
 		Waf_Rules_Manager::generate_automatic_rules();
 		Waf_Rules_Manager::generate_ip_rules();
 		self::create_blocklog_table();
@@ -286,12 +287,12 @@ class Waf_Runner {
 	}
 
 	/**
-	 * Created the waf directory on activation.
+	 * Ensures that the waf directory is created.
 	 *
 	 * @return void
 	 * @throws \Exception In case there's a problem when creating the directory.
 	 */
-	public static function create_waf_directory() {
+	public static function initialize_waf_directory() {
 		WP_Filesystem();
 		Waf_Constants::define_waf_directory();
 
@@ -302,7 +303,7 @@ class Waf_Runner {
 
 		if ( ! $wp_filesystem->is_dir( JETPACK_WAF_DIR ) ) {
 			if ( ! $wp_filesystem->mkdir( JETPACK_WAF_DIR ) ) {
-				throw new \Exception( 'Failed creating WAF standalone bootstrap file directory: ' . JETPACK_WAF_DIR );
+				throw new \Exception( 'Failed creating WAF file directory: ' . JETPACK_WAF_DIR );
 			}
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes an uncaught PHP fatal that occurs when WAF attempts to generate rules when the `wp-content/jetpack-waf` directory does not exist (i.e. manually deleted).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Check for and create the WAF content directory as a part of `Waf_Runner::initialize_filesystem()`. This ensures that any time we are getting ready to use the filesystem, our directory structure will be available.
* Rename `create_waf_directory` to `initialize_waf_directory`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jetpack/pull/27726#discussion_r1092923749

https://twitter.com/saqksahm/status/1623336373225951232

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Reproducing the fatal:**
* Running `trunk`, enable the firewall and upgrade to a Jetpack Scan plan.
* Delete the `jetpack-waf` directory from `wp-content`.
* Run `jetpack docker wp jetpack-waf generate_rules`. 
* Behold the fatal error!

**Validating the fix:**
* Switch to this branch
* Run `jetpack docker wp jetpack-waf generate_rules` again.
* Behold the correctly generated rule files!

