### PR TITLE
Subscribe block: Fix rendering of subscriber email in .com as default value for the subscribe block input in wpcom

### DIFF
--- a/projects/plugins/jetpack/changelog/add-render-user_email_to_input
+++ b/projects/plugins/jetpack/changelog/add-render-user_email_to_input
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix rendering of subscriber email in .com as default value for the subscribe block input in wpcom

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -501,8 +501,8 @@ function render_wpcom_subscribe_form( $data, $classes, $styles ) {
 							%1$s
 							style="%2$s"
 							placeholder="%3$s"
-							value=""
-							id="%4$s"
+							value="%4$s"
+							id="%5$s"
 						/>',
 						( ! empty( $classes['email_field'] )
 							? 'class="' . esc_attr( $classes['email_field'] ) . '"'
@@ -513,6 +513,7 @@ function render_wpcom_subscribe_form( $data, $classes, $styles ) {
 							: 'width: 95%; padding: 1px 10px'
 						),
 						esc_attr( $data['subscribe_placeholder'] ),
+						esc_attr( $data['subscribe_email'] ),
 						esc_attr( $email_field_id )
 					);
 					?>


### PR DESCRIPTION
Makes the subscribe block input in the frontend show the visitor's user email if logged in for wpcom sites.


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Makes the subscribe block input in the frontend show the visitor's user email if logged in for wpcom sites

<table>
<tr>
<td>After
<td>Before
</tr>
<tr>
<td>
<img width="852" alt="image" src="https://user-images.githubusercontent.com/746152/216742413-f23a0100-dfe6-4dd3-bed4-f62f660aea7a.png" />

</td>
	<td><img width="852" alt="image" src="https://user-images.githubusercontent.com/746152/216742491-12dd349b-8bb0-4688-8452-99a6599e218a.png" />
</td>
</tr>

</table>

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no
## Testing instructions:

* Checkout this branch in .com with `bin/jetpack-downloader test jetpack add/render-user_email_to_input`
* On a sandboxed simple site, create a new subscribe block on a post. Save the post
* Visit the post at the frontend
* Expect to see your .com email address pre-filled
* Visit the page incognito. 
* Expect to see no address and no PHP errors logged in the sandbox

