### PR TITLE
Protect: Fix status report caching

### DIFF
--- a/projects/plugins/protect/changelog/fix-protect-scan-status-caching
+++ b/projects/plugins/protect/changelog/fix-protect-scan-status-caching
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Protect scan status caching

--- a/projects/plugins/protect/changelog/fix-protect-scan-status-caching
+++ b/projects/plugins/protect/changelog/fix-protect-scan-status-caching
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix Protect scan status caching

--- a/projects/plugins/protect/changelog/fix-protect-status-caching
+++ b/projects/plugins/protect/changelog/fix-protect-status-caching
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Protect status report caching

--- a/projects/plugins/protect/src/class-protect-status.php
+++ b/projects/plugins/protect/src/class-protect-status.php
@@ -118,7 +118,7 @@ class Protect_Status extends Status {
 		}
 
 		$body = json_decode( wp_remote_retrieve_body( $response ) );
-		self::update_option( maybe_serialize( $body ) );
+		self::update_status_option( $body );
 		return $body;
 	}
 

--- a/projects/plugins/protect/src/class-scan-status.php
+++ b/projects/plugins/protect/src/class-scan-status.php
@@ -124,7 +124,7 @@ class Scan_Status extends Status {
 		}
 
 		$body = json_decode( wp_remote_retrieve_body( $response ) );
-		self::update_option( maybe_serialize( $body ) );
+		self::update_status_option( $body );
 		return $body;
 	}
 

--- a/projects/plugins/protect/src/class-status.php
+++ b/projects/plugins/protect/src/class-status.php
@@ -108,9 +108,9 @@ class Status {
 	 * @param array $status The new status to be cached.
 	 * @return void
 	 */
-	public static function update_option( $status ) {
+	public static function update_status_option( $status ) {
 		// TODO: Sanitize $status.
-		update_option( static::OPTION_NAME, $status );
+		update_option( static::OPTION_NAME, maybe_serialize( $status ) );
 		$end_date = self::get_cache_end_date_by_status( $status );
 		update_option( static::OPTION_TIMESTAMP_NAME, $end_date );
 	}

--- a/projects/plugins/protect/tests/php/test-scan-status.php
+++ b/projects/plugins/protect/tests/php/test-scan-status.php
@@ -457,13 +457,13 @@ class Test_Scan_Status extends BaseTestCase {
 				'initial',
 				null,
 			),
-			'invalid' => array(
-				'initial',
-				$this->get_sample_invalid_response(),
-			),
 			'empty'   => array(
 				'initial',
 				$this->get_sample_empty_response(),
+			),
+			'invalid' => array(
+				'initial',
+				$this->get_sample_invalid_response(),
 			),
 			'full'    => array(
 				'full',
@@ -481,14 +481,10 @@ class Test_Scan_Status extends BaseTestCase {
 	 */
 	public function test_get_cache_end_date_by_status( $check_type, $status ) {
 		$timestamp = Scan_Status::get_cache_end_date_by_status( $status );
-
-		if ( ! is_object( $status ) ) {
+		if ( ! is_object( $status ) || 'initial' === $check_type ) {
 			$this->assertSame( time() + Scan_Status::INITIAL_OPTION_EXPIRES_AFTER, $timestamp );
 		}
-		if ( 'initial' === $check_type ) {
-			$this->assertSame( time() + Scan_Status::INITIAL_OPTION_EXPIRES_AFTER, $timestamp );
-		}
-		if ( 'full' === $check_type ) {
+		if ( is_object( $status ) && 'full' === $check_type ) {
 			$this->assertSame( time() + Scan_Status::OPTION_EXPIRES_AFTER, $timestamp );
 		}
 	}

--- a/projects/plugins/protect/tests/php/test-scan-status.php
+++ b/projects/plugins/protect/tests/php/test-scan-status.php
@@ -42,6 +42,15 @@ class Test_Scan_Status extends BaseTestCase {
 	}
 
 	/**
+	 * Get a sample invalid response
+	 *
+	 * @return string
+	 */
+	public function get_sample_invalid_response() {
+		return 'Invalid response';
+	}
+
+	/**
 	 * Get a sample response
 	 *
 	 * @return object
@@ -444,15 +453,19 @@ class Test_Scan_Status extends BaseTestCase {
 	 */
 	public function get_cache_end_date_by_status_data() {
 		return array(
-			'null'  => array(
+			'null'    => array(
 				'initial',
 				null,
 			),
-			'empty' => array(
+			'invalid' => array(
+				'initial',
+				$this->get_sample_invalid_response(),
+			),
+			'empty'   => array(
 				'initial',
 				$this->get_sample_empty_response(),
 			),
-			'full'  => array(
+			'full'    => array(
 				'full',
 				$this->get_sample_status(),
 			),
@@ -469,6 +482,9 @@ class Test_Scan_Status extends BaseTestCase {
 	public function test_get_cache_end_date_by_status( $check_type, $status ) {
 		$timestamp = Scan_Status::get_cache_end_date_by_status( $status );
 
+		if ( ! is_object( $status ) ) {
+			$this->assertSame( time() + Scan_Status::INITIAL_OPTION_EXPIRES_AFTER, $timestamp );
+		}
 		if ( 'initial' === $check_type ) {
 			$this->assertSame( time() + Scan_Status::INITIAL_OPTION_EXPIRES_AFTER, $timestamp );
 		}

--- a/projects/plugins/protect/tests/php/test-status.php
+++ b/projects/plugins/protect/tests/php/test-status.php
@@ -422,13 +422,13 @@ class Test_Status extends BaseTestCase {
 				'initial',
 				null,
 			),
-			'invalid' => array(
-				'initial',
-				$this->get_sample_invalid_response(),
-			),
 			'empty'   => array(
 				'initial',
 				$this->get_sample_empty_response(),
+			),
+			'invalid' => array(
+				'initial',
+				$this->get_sample_invalid_response(),
 			),
 			'full'    => array(
 				'full',
@@ -446,13 +446,10 @@ class Test_Status extends BaseTestCase {
 	 */
 	public function test_get_cache_end_date_by_status( $check_type, $status ) {
 		$timestamp = Protect_Status::get_cache_end_date_by_status( $status );
-		if ( ! is_object( $status ) ) {
+		if ( ! is_object( $status ) || 'initial' === $check_type ) {
 			$this->assertSame( time() + Protect_Status::INITIAL_OPTION_EXPIRES_AFTER, $timestamp );
 		}
-		if ( 'initial' === $check_type ) {
-			$this->assertSame( time() + Protect_Status::INITIAL_OPTION_EXPIRES_AFTER, $timestamp );
-		}
-		if ( 'full' === $check_type ) {
+		if ( is_object( $status ) && 'full' === $check_type ) {
 			$this->assertSame( time() + Protect_Status::OPTION_EXPIRES_AFTER, $timestamp );
 		}
 	}

--- a/projects/plugins/protect/tests/php/test-status.php
+++ b/projects/plugins/protect/tests/php/test-status.php
@@ -141,6 +141,15 @@ class Test_Status extends BaseTestCase {
 	}
 
 	/**
+	 * Get a sample invalid response
+	 *
+	 * @return string
+	 */
+	public function get_sample_invalid_response() {
+		return 'Invalid response';
+	}
+
+	/**
 	 * Get a sample response
 	 *
 	 * @return object
@@ -409,15 +418,19 @@ class Test_Status extends BaseTestCase {
 	 */
 	public function get_cache_end_date_by_status_data() {
 		return array(
-			'null'  => array(
+			'null'    => array(
 				'initial',
 				null,
 			),
-			'empty' => array(
+			'invalid' => array(
+				'initial',
+				$this->get_sample_invalid_response(),
+			),
+			'empty'   => array(
 				'initial',
 				$this->get_sample_empty_response(),
 			),
-			'full'  => array(
+			'full'    => array(
 				'full',
 				$this->get_sample_response(),
 			),
@@ -433,6 +446,9 @@ class Test_Status extends BaseTestCase {
 	 */
 	public function test_get_cache_end_date_by_status( $check_type, $status ) {
 		$timestamp = Protect_Status::get_cache_end_date_by_status( $status );
+		if ( ! is_object( $status ) ) {
+			$this->assertSame( time() + Protect_Status::INITIAL_OPTION_EXPIRES_AFTER, $timestamp );
+		}
 		if ( 'initial' === $check_type ) {
 			$this->assertSame( time() + Protect_Status::INITIAL_OPTION_EXPIRES_AFTER, $timestamp );
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
At the moment, we serialize the scan status before passing it to the main `Status` class `update_option` method. The method uses the value to run the core `update_option` function to store the status and runs a method to determine the cache expiration. The `Status::get_cache_end_date_by_status` method expects the status in object form, when a non-object is found the expiration is always set to 1 minute.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
- Update the naming for the main `Status` class method responsible for updating the status option and setting the cache expiration
- Moves `maybe_serialize` to the core `update_option` call within the main `Status::update_status_option` so we serialize the data we store in the status option but continue to supply the object to `Status::get_cache_end_date_by_status` to determine cache expiration
- Adds/updates accompanying tests

### Other information:
- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- 1201069996155224-as-1203857869699589

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Startup Jurassic Ninja site with beta tester using this Protect branch
* Activate Protect and allow the initial status report to generate
   * Retrieve the value stored in the `jetpack_protect_status_time` option and verify that a 1-minute expiration on the initial report
   * Allow a second status report to run and verify that a 1-hour expiration is set
   * Manually supply a non-object value to `Status::get_cache_end_date_by_status` and ensure that a 1-minute expiration is set
   * Ensure that a properly serialized object is stored in `jetpack_protect_status` when applicable
* Upgrade to a Scan-level plan and perform the same tests for `jetpack_scan_status_timestamp` and `jetpack_scan_status`
* Ensure all Protect unit tests are passing

