### PR TITLE
VideoPress: set isPrivate attribute also based on private_enabled_for_site

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-fix-uploading-chapters-private-videos
+++ b/projects/packages/videopress/changelog/update-videopress-fix-uploading-chapters-private-videos
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: set isPravate attribute based also on private_enabled_for_site

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
@@ -308,7 +308,7 @@ export function useSyncMedia(
 				updateInitialState( dataToUpdate );
 
 				// Privacy settings attribute update
-				if ( dataToUpdate?.privacy_setting !== 2 ) {
+				if ( dataToUpdate.privacy_setting && dataToUpdate.privacy_setting !== 2 ) {
 					setAttributes( {
 						isPrivate: dataToUpdate.privacy_setting === 1,
 					} );

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
@@ -307,11 +307,21 @@ export function useSyncMedia(
 				// Update local state with fresh video data.
 				updateInitialState( dataToUpdate );
 
-				// Privacy settings attribute update
-				if ( dataToUpdate.privacy_setting && dataToUpdate.privacy_setting !== 2 ) {
-					setAttributes( {
-						isPrivate: dataToUpdate.privacy_setting === 1,
-					} );
+				/*
+				 * Update isPrivate attribute:
+				 * `is_private` is a read-only metadata field.
+				 * The VideoPress API provides its value
+				 * and depends on the `privacy_setting`
+				 * and `private_enabled_for_site` fields.
+				 */
+				if ( dataToUpdate.privacy_setting ) {
+					const isPrivateVideo =
+						dataToUpdate.privacy_setting !== 2
+							? dataToUpdate.privacy_setting === 1
+							: videoData.private_enabled_for_site;
+
+					debug( 'Updating isPrivate attribute: %o', isPrivateVideo );
+					setAttributes( { isPrivate: isPrivateVideo } );
 				}
 
 				// | Video Chapters feature |

--- a/projects/packages/videopress/src/client/lib/get-media-token/index.ts
+++ b/projects/packages/videopress/src/client/lib/get-media-token/index.ts
@@ -22,7 +22,7 @@ const getMediaToken = function (
 	scope: MediaTokenScopeProps,
 	args: GetMediaTokenArgsProps = {}
 ): Promise< MediaTokenProps > {
-	const { id, guid, adminAjaxAPI: adminAjaxAPIArgument } = args;
+	const { id, guid, adminAjaxAPI: adminAjaxAPIArgument, filename } = args;
 	return new Promise( function ( resolve, reject ) {
 		const adminAjaxAPI =
 			adminAjaxAPIArgument ||
@@ -38,11 +38,15 @@ const getMediaToken = function (
 			action: AdminAjaxTokenProps;
 			guid?: VideoGUID;
 			post_id?: string;
+			filename?: string;
 		} = { action: 'videopress-get-playback-jwt' };
 
 		switch ( scope ) {
 			case 'upload':
 				fetchData.action = 'videopress-get-upload-token';
+				if ( filename ) {
+					fetchData.filename = filename;
+				}
 				break;
 
 			case 'upload-jwt':

--- a/projects/packages/videopress/src/client/lib/get-media-token/types.ts
+++ b/projects/packages/videopress/src/client/lib/get-media-token/types.ts
@@ -19,6 +19,7 @@ export type GetMediaTokenArgsProps = {
 	id?: VideoId;
 	guid?: VideoGUID;
 	adminAjaxAPI?: string;
+	filename?: string;
 };
 
 export type AdminAjaxTokenProps = AdminAjaxTokensProps[ number ];

--- a/projects/packages/videopress/src/client/lib/video-tracks/index.ts
+++ b/projects/packages/videopress/src/client/lib/video-tracks/index.ts
@@ -23,7 +23,7 @@ const videoPressUploadTrack = function ( track: UploadTrackDataProps, guid: stri
 	return new Promise( function ( resolve, reject ) {
 		const { kind, srcLang, label, tmpFile: vttFile } = track;
 
-		getMediaToken( 'upload' ).then( ( { token, blogId } ) => {
+		getMediaToken( 'upload', { filename: vttFile.name } ).then( ( { token, blogId } ) => {
 			const body = new FormData();
 			body.append( 'kind', kind );
 			body.append( 'srclang', srcLang );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR iterates how the `useSyncMedia()` hook sets the `private` read-only value once the metadata saves, fixing the issue when saving chapters auto-generated by the video block description.

Fixes https://github.com/Automattic/jetpack/issues/28687

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: set isPravate attribute based also on private_enabled_for_site

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Tricky to test:

* Go to the block editor
* Create/edit a video block
* Set video private
* Generate chapters from the video description
* Save
* **(Before)** The app doesn't upload the chapters file. Error response `403`
<img width="941" alt="image" src="https://user-images.githubusercontent.com/77539/216947989-98e46b84-79dc-40d8-b9cd-5ae719c92749.png">
* **(After)** The app does upload the file.
* ...

