### PR TITLE
DNM: Testing WordBless with Yoast Polyfill

### DIFF
--- a/projects/packages/blaze/changelog/update-blaze-ui-admins
+++ b/projects/packages/blaze/changelog/update-blaze-ui-admins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Only display the Blaze UI to admins on a site.

--- a/projects/packages/blaze/composer.json
+++ b/projects/packages/blaze/composer.json
@@ -11,7 +11,7 @@
 		"yoast/phpunit-polyfills": "1.0.4",
 		"automattic/jetpack-assets": "@dev",
 		"automattic/jetpack-changelogger": "@dev",
-		"automattic/wordbless": "@dev"
+		"automattic/wordbless": "dev-add/yoast-polyfill"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -121,6 +121,11 @@ class Blaze {
 		$connection        = new Jetpack_Connection();
 		$site_id           = Jetpack_Connection::get_site_id();
 
+		// Only admins should be able to Blaze posts on a site.
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return false;
+		}
+
 		// On self-hosted sites, we must do some additional checks.
 		if ( ! $is_wpcom ) {
 			/*

--- a/projects/packages/blaze/tests/php/test-blaze.php
+++ b/projects/packages/blaze/tests/php/test-blaze.php
@@ -20,6 +20,16 @@ class Test_Blaze extends BaseTestCase {
 	 * @before
 	 */
 	public function set_up() {
+		// I don't like putting this here, but we can't use setUpBeforeClass with WorDBless at this time.
+		// https://github.com/Automattic/wordbless/issues/52
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'dummy_user',
+				'user_pass'  => 'dummy_pass',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $admin_id );
 		Blaze::$script_path = 'js/editor.js';
 	}
 

--- a/projects/packages/blaze/tests/php/test-blaze.php
+++ b/projects/packages/blaze/tests/php/test-blaze.php
@@ -15,13 +15,11 @@ use WorDBless\BaseTestCase;
  */
 class Test_Blaze extends BaseTestCase {
 	/**
-	 * Set up before each test.
-	 *
-	 * @before
+	 * Set up before the class.
+	 * This is run once before all tests.
 	 */
-	public function set_up() {
-		// I don't like putting this here, but we can't use setUpBeforeClass with WorDBless at this time.
-		// https://github.com/Automattic/wordbless/issues/52
+	public static function set_up_before_class() {
+		// Create a test admin user and set it as the current user.
 		$admin_id = wp_insert_user(
 			array(
 				'user_login' => 'dummy_user',
@@ -30,6 +28,14 @@ class Test_Blaze extends BaseTestCase {
 			)
 		);
 		wp_set_current_user( $admin_id );
+	}
+
+	/**
+	 * Set up before each test.
+	 *
+	 * @before
+	 */
+	public function set_up() {
 		Blaze::$script_path = 'js/editor.js';
 	}
 


### PR DESCRIPTION
- Blaze: only display UI to admins.
- Fix tests
- TEST: Showing wordbless with yoast polyfill

DO NOT MERGE. Just showing off WordBless while using Yoast polyfill in support of https://github.com/Automattic/wordbless/pull/61

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

