### PR TITLE
VideoPress: Fix token bridge issue in development environment

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-service-worker
+++ b/projects/packages/videopress/changelog/fix-videopress-service-worker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fix token bridge issue in development environment

--- a/projects/packages/videopress/src/client/lib/token-bridge/index.ts
+++ b/projects/packages/videopress/src/client/lib/token-bridge/index.ts
@@ -91,7 +91,7 @@ export async function tokenBridgeHandler(
 			guid,
 			requestId,
 		},
-		'*'
+		{ targetOrigin: '*' }
 	);
 
 	const tokenData = await getMediaToken( 'playback', {
@@ -108,7 +108,7 @@ export async function tokenBridgeHandler(
 				guid: event.data.guid,
 				requestId,
 			} as VideopressAjaxPostMessageEventProps,
-			'*'
+			{ targetOrigin: '*' }
 		);
 		return;
 	}
@@ -121,7 +121,7 @@ export async function tokenBridgeHandler(
 			jwt: tokenData.token,
 			requestId,
 		} as VideopressAjaxPostMessageEventProps,
-		'*'
+		{ targetOrigin: '*' }
 	);
 }
 

--- a/projects/packages/videopress/src/client/lib/token-bridge/index.ts
+++ b/projects/packages/videopress/src/client/lib/token-bridge/index.ts
@@ -68,7 +68,10 @@ export async function tokenBridgeHandler(
 
 	const { source: tokenRequester } = event;
 	// Check the source of the message
-	if ( tokenRequester instanceof MessagePort || tokenRequester instanceof ServiceWorker ) {
+	if (
+		tokenRequester instanceof MessagePort ||
+		( typeof ServiceWorker !== 'undefined' && tokenRequester instanceof ServiceWorker )
+	) {
 		debug( '(%s) Invalid source', context );
 		return;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #28785

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Checks if `ServiceWorker` is defined before checking against its type
* Also changes the calls to `postMessage` making the `targetOrigin` explicit to avoid Typescript warnings

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test locally
* Go to the block editor
* Add a VideoPress block
* Set the video's privacy level to `private`
* Change some other property, like `loop` to force a token request
* Check that the video is loaded correctly and there is no error in the dev console