### PR TITLE
mu-wpcom-plugin: backport v1.0.1 release

### DIFF
--- a/projects/js-packages/babel-plugin-replace-textdomain/CHANGELOG.md
+++ b/projects/js-packages/babel-plugin-replace-textdomain/CHANGELOG.md
@@ -7,8 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.22] - 2023-02-06
 ### Changed
-- Updated package dependencies. [#28682]
-- Updated package dependencies. [#28755]
+- Updated package dependencies.
 
 ## [1.0.21] - 2023-01-25
 

--- a/projects/js-packages/babel-plugin-replace-textdomain/CHANGELOG.md
+++ b/projects/js-packages/babel-plugin-replace-textdomain/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.22] - 2023-02-06
+### Changed
+- Updated package dependencies. [#28682]
+- Updated package dependencies. [#28755]
+
 ## [1.0.21] - 2023-01-25
+
 - Minor internal updates.
 
 ## [1.0.20] - 2023-01-11
@@ -97,6 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release.
 - Replace missing domains too.
 
+[1.0.22]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.21...v1.0.22
 [1.0.21]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.20...v1.0.21
 [1.0.20]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.19...v1.0.20
 [1.0.19]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.18...v1.0.19

--- a/projects/js-packages/babel-plugin-replace-textdomain/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/babel-plugin-replace-textdomain/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/babel-plugin-replace-textdomain/changelog/renovate-babel-plugin-tester-11.x
+++ b/projects/js-packages/babel-plugin-replace-textdomain/changelog/renovate-babel-plugin-tester-11.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/babel-plugin-replace-textdomain/package.json
+++ b/projects/js-packages/babel-plugin-replace-textdomain/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/babel-plugin-replace-textdomain",
-	"version": "1.0.22-alpha",
+	"version": "1.0.22",
 	"description": "A Babel plugin to replace the textdomain in gettext-style function calls.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/babel-plugin-replace-textdomain/#readme",
 	"bugs": {

--- a/projects/js-packages/i18n-check-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-check-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.28] - 2023-02-06
+### Changed
+- Updated package dependencies. [#28682]
+
 ## [1.0.27] - 2023-01-25
 ### Changed
 - Minor internal updates.
@@ -133,6 +137,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[1.0.28]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.0.27...v1.0.28
 [1.0.27]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.0.26...v1.0.27
 [1.0.26]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.0.25...v1.0.26
 [1.0.25]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.0.24...v1.0.25

--- a/projects/js-packages/i18n-check-webpack-plugin/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/i18n-check-webpack-plugin/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/i18n-check-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-check-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-check-webpack-plugin",
-	"version": "1.0.28-alpha",
+	"version": "1.0.28",
 	"description": "A Webpack plugin to check that WordPress i18n hasn't been mangled by Webpack optimizations.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/i18n-check-webpack-plugin/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.3.23 - 2023-02-06
+### Changed
+- Updated package dependencies. [#28682]
+- Updated package dependencies. [#28754]
+
 ## 1.3.22 - 2023-01-25
 ### Changed
 - Minor internal updates.

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -7,8 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 1.3.23 - 2023-02-06
 ### Changed
-- Updated package dependencies. [#28682]
-- Updated package dependencies. [#28754]
+- Updated package dependencies.
 
 ## 1.3.22 - 2023-01-25
 ### Changed

--- a/projects/js-packages/webpack-config/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/webpack-config/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/webpack-config/changelog/renovate-major-babel-monorepo
+++ b/projects/js-packages/webpack-config/changelog/renovate-major-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "1.3.23-alpha",
+	"version": "1.3.23",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2023-02-06
+
+- Migrate code from 'Automattic/jetpack/pull/27815'.
+
 ## 0.1.1 - 2023-01-27
 
 - Minor internal updates.
@@ -12,3 +16,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.1.0 - 2023-01-19
 
 - Testing initial package release.
+
+[0.1.2]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v0.1.1...v0.1.2

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-migrate-coming-soon-to-package
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-migrate-coming-soon-to-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Migrate code from Automattic/jetpack/pull/27815
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-node-to-v18
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-node-to-v18
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update tooling node version to 18.13.0. Should be no change to the project.
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-wordbless-composer-install
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-wordbless-composer-install
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Use correct WorDBless setup command. No user-visible change to package.
-
-

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "0.1.2-alpha",
+	"version": "0.1.2",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '0.1.2-alpha';
+	const PACKAGE_VERSION = '0.1.2';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**
@@ -37,7 +37,7 @@ class Jetpack_Mu_Wpcom {
 		/**
 		 * Runs right after the Jetpack_Mu_Wpcom package is initialized.
 		 *
-		 * @since $$next-version$$
+		 * @since 0.1.2
 		 */
 		do_action( 'jetpack_mu_wpcom_initialized' );
 	}

--- a/projects/packages/jitm/CHANGELOG.md
+++ b/projects/packages/jitm/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.41] - 2023-02-06
+### Fixed
+- JITM: minor fix for styles on Safari browser.
+
 ## [2.2.40] - 2023-01-30
 ### Changed
 - Updated styles for Just in Time Messages (notices) [#27515]
@@ -534,6 +538,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Jetpack to use new JITM package
 
+[2.2.41]: https://github.com/Automattic/jetpack-jitm/compare/v2.2.40...v2.2.41
 [2.2.40]: https://github.com/Automattic/jetpack-jitm/compare/v2.2.39...v2.2.40
 [2.2.39]: https://github.com/Automattic/jetpack-jitm/compare/v2.2.38...v2.2.39
 [2.2.38]: https://github.com/Automattic/jetpack-jitm/compare/v2.2.37...v2.2.38

--- a/projects/packages/jitm/changelog/fix-jitm-styles
+++ b/projects/packages/jitm/changelog/fix-jitm-styles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-JITM: Fix broken styles on Safari

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '2.2.41-alpha';
+	const PACKAGE_VERSION = '2.2.41';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.1 - 2023-02-06
+
+- Updated package dependencies.
+
 ## 1.0.0 - 2023-01-30
 
 - Initial plugin release.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-jetpack-mu-wpcom-plugin
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-jetpack-mu-wpcom-plugin
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Initial commit for jetpack-mu-wpcom-plugin
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/init-release-cycle
+++ b/projects/plugins/mu-wpcom-plugin/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Init 1.0.1-alpha
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/init-release-cycle
+++ b/projects/plugins/mu-wpcom-plugin/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Init 1.0.2-alpha
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -45,6 +45,6 @@
 		"release-branch-prefix": "jetpack"
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_0_1_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_0_1"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -45,6 +45,6 @@
 		"release-branch-prefix": "jetpack"
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_0_1"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_0_2_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.0.1-alpha
+ * Version: 1.0.1
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.0.1
+ * Version: 1.0.2-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.0.1-alpha",
+	"version": "1.0.1",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.0.1",
+	"version": "1.0.2-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
## Proposed changes:

* mu-wpcom-plugin: backport v1.0.1 release
* packages/jitm: backport v2.2.41 release

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

Proofread.