### PR TITLE
E2E tests: toggle welcomeGuide in site editor using wp data module

### DIFF
--- a/tools/e2e-commons/pages/wp-admin/site-editor.js
+++ b/tools/e2e-commons/pages/wp-admin/site-editor.js
@@ -33,11 +33,16 @@ export default class SiteEditorPage extends WpPage {
 	}
 
 	async closeWelcomeGuide() {
-		logger.step( 'Handling the welcome guide modal' );
-		const welcomeModal = "div[aria-label='Welcome to the site editor']";
-		if ( await this.isElementVisible( welcomeModal, 1000 ) ) {
-			logger.info( 'Closing the modal' );
-			await this.click( "button[aria-label='Close dialog']" );
+		const isWelcomeGuideActive = await this.page.evaluate( () =>
+			wp.data.select( 'core/edit-site' ).isFeatureActive( 'welcomeGuide' )
+		);
+
+		if ( isWelcomeGuideActive ) {
+			logger.step( 'Closing the welcome guide modal' );
+			await this.page.evaluate( () => {
+				wp.data.dispatch( 'core/edit-site' ).toggleFeature( 'welcomeGuide' );
+				wp.data.dispatch( 'core/edit-site' ).toggleFeature( 'welcomeGuideStyles' );
+			} );
 		}
 	}
 


### PR DESCRIPTION
## Proposed changes:

Closing the editor welcome guide modal through the UI is flaky, as sometimes the modal can show up later than expected.
This change adds toggling the modal by updating the application state via the wp.data module.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* e2e tests should pass

