### PR TITLE
CRM: Migrate Resolves 2738 - Show custom profile pictures on dashboard

### DIFF
--- a/projects/plugins/crm/admin/dashboard/main.page.php
+++ b/projects/plugins/crm/admin/dashboard/main.page.php
@@ -620,29 +620,19 @@ if (jQuery('#bar-chart').length){
 				<tbody>
 					<?php
 					foreach ( $latest_cust as $cust ) {
-						$avatar = '';
-						if ( isset( $cust ) && isset( $cust['email'] ) ) {
-							$avatar = zeroBSCRM_getGravatarURLfromEmail( $cust['email'], 25 );
-						}
-						$fname = '';
-						if ( isset( $cust ) && isset( $cust['fname'] ) ) {
-							$fname = $cust['fname'];
-						}
-						$lname = '';
-						if ( isset( $cust ) && isset( $cust['lname'] ) ) {
-							$lname = $cust['lname'];
-						}
-						$status = '';
-						if ( isset( $cust ) && isset( $cust['status'] ) ) {
-							$status = $cust['status'];
-						}
+						// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- to be refactored.
+						$avatar = ( isset( $cust ) && isset( $cust['id'] ) ) ? $zbs->DAL->contacts->getContactAvatar( $cust['id'] ) : '';
+						$fname  = ( isset( $cust ) && isset( $cust['fname'] ) ) ? $cust['fname'] : '';
+						$lname  = ( isset( $cust ) && isset( $cust['lname'] ) ) ? $cust['lname'] : '';
+						$status = ( isset( $cust ) && isset( $cust['status'] ) ) ? $cust['status'] : '';
+						// phpcs:enable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 						if ( empty( $status ) ) {
 							$status = __( 'None', 'zero-bs-crm' );
 						}
 						?>
 						<tr>
 						<td><?php echo esc_html( $cust['id'] ); ?></td>
-						<td><img class='img-rounded' alt='<?php esc_attr_e( 'Contact Image', 'zero-bs-crm', '' ); ?>' src='<?php echo esc_attr( $avatar ); ?>'/></td>
+						<td><img class='img-rounded jpcrm-avatar-small' alt='<?php esc_attr_e( 'Contact Image', 'zero-bs-crm' ); ?>' src='<?php echo esc_attr( $avatar ); ?>'/></td>
 						<td><div class='mar'><?php echo esc_html( $fname ); ?></div></td>
 						<td><div class='mar'><?php echo esc_html( $lname ); ?></div></td>
 						<td class='zbs-s <?php echo esc_attr( 'zbs-' . $zbs->DAL->makeSlug( $status ) ); ?>'><div><?php echo esc_html( $status ); ?></div></td>

--- a/projects/plugins/crm/changelog/fix-custom_profile_pictures_on_dashboard
+++ b/projects/plugins/crm/changelog/fix-custom_profile_pictures_on_dashboard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+CRM:  allows custom profile pictures to be shown in the dashboard.

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.homedash.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.homedash.scss
@@ -223,6 +223,10 @@ h1, h2, h3, h4, h5, h6 {
   margin-right:5px;
 }
 
+.jpcrm-avatar-small {
+  width: 25px;
+}
+
 .zbs-s div{
   background: #ddd;
   color:white;


### PR DESCRIPTION
Migrated from Jetpack CRM repo https://github.com/Automattic/zero-bs-crm/pull/2834

## Proposed changes:

From the PR:
```
* This PR allows custom profile pictures to be shown in the dashboard. Before this PR only gravatar pictures were allowed, and gravatars were being shown even when the image mode was set to "Custom Images".
* Note: There was just a small code cleanup, the indentation used was kept because it would involve too many changes.
Note 2: Be sure to force refresh the Dashboard while testing, to prevent using a cached CSS file.
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* See https://github.com/Automattic/zero-bs-crm/pull/2834
* To test in the Jetpack monorepo, on a Jurassic Ninja Site include the Jetpack Beta tester plugin, and under Jetpack CRM enable this branch.
* To test a build using a local development installation, run `jetpack build plugins/crm`, or `jetpack build --production plugins/crm` to test the build as if it were running in production.

