### PR TITLE
Blaze Tests: only create new users once

### DIFF
--- a/projects/packages/blaze/changelog/update-blaze-test
+++ b/projects/packages/blaze/changelog/update-blaze-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Tests: add author test & only create users once

--- a/projects/packages/blaze/tests/php/test-blaze.php
+++ b/projects/packages/blaze/tests/php/test-blaze.php
@@ -29,6 +29,13 @@ class Test_Blaze extends BaseTestCase {
 	protected $editor_id;
 
 	/**
+	 * Author user id
+	 *
+	 * @var int
+	 */
+	protected $author_id;
+
+	/**
 	 * Set up before each test.
 	 *
 	 * @before
@@ -43,6 +50,14 @@ class Test_Blaze extends BaseTestCase {
 		);
 
 		$this->editor_id = wp_insert_user(
+			array(
+				'user_login' => 'dummy_user_2',
+				'user_pass'  => 'dummy_pass_2',
+				'role'       => 'editor',
+			)
+		);
+
+		$this->author_id = wp_insert_user(
 			array(
 				'user_login' => 'dummy_user_2',
 				'user_pass'  => 'dummy_pass_2',
@@ -103,6 +118,16 @@ class Test_Blaze extends BaseTestCase {
 	 */
 	public function test_editor_not_eligible() {
 		wp_set_current_user( $this->editor_id );
+		$this->assertFalse( Blaze::should_initialize() );
+	}
+
+	/**
+	 * Test that Blaze is not available to authors.
+	 *
+	 * @covers Automattic\Jetpack\Blaze::should_initialize
+	 */
+	public function test_author_not_eligible() {
+		wp_set_current_user( $this->author_id );
 		$this->assertFalse( Blaze::should_initialize() );
 	}
 

--- a/projects/packages/blaze/tests/php/test-blaze.php
+++ b/projects/packages/blaze/tests/php/test-blaze.php
@@ -15,6 +15,13 @@ use WorDBless\BaseTestCase;
  */
 class Test_Blaze extends BaseTestCase {
 	/**
+	 * Has the class been initialized already?
+	 *
+	 * @var bool
+	 */
+	protected static $initialized = false;
+
+	/**
 	 * Admin user id
 	 *
 	 * @var int
@@ -41,29 +48,34 @@ class Test_Blaze extends BaseTestCase {
 	 * @before
 	 */
 	public function set_up() {
-		$this->admin_id = wp_insert_user(
-			array(
-				'user_login' => 'dummy_user',
-				'user_pass'  => 'dummy_pass',
-				'role'       => 'administrator',
-			)
-		);
+		if ( ! self::$initialized ) {
+			$this->admin_id = wp_insert_user(
+				array(
+					'user_login' => 'dummy_user',
+					'user_pass'  => 'dummy_pass',
+					'role'       => 'administrator',
+				)
+			);
 
-		$this->editor_id = wp_insert_user(
-			array(
-				'user_login' => 'dummy_user_2',
-				'user_pass'  => 'dummy_pass_2',
-				'role'       => 'editor',
-			)
-		);
+			$this->editor_id = wp_insert_user(
+				array(
+					'user_login' => 'dummy_user_2',
+					'user_pass'  => 'dummy_pass_2',
+					'role'       => 'editor',
+				)
+			);
 
-		$this->author_id = wp_insert_user(
-			array(
-				'user_login' => 'dummy_user_2',
-				'user_pass'  => 'dummy_pass_2',
-				'role'       => 'editor',
-			)
-		);
+			$this->author_id = wp_insert_user(
+				array(
+					'user_login' => 'dummy_user_2',
+					'user_pass'  => 'dummy_pass_2',
+					'role'       => 'editor',
+				)
+			);
+
+			self::$initialized = true;
+		}
+
 		wp_set_current_user( 0 );
 
 		Blaze::$script_path = 'js/editor.js';


### PR DESCRIPTION
- Tests: add author test
- Tests: only create new users once

Follow-up to #22874828748

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Only attempts to create the new users once to be a little more efficient.
* Adds a filter test—which is currently false—in the event we want to change this in the future.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

