### PR TITLE
API:admin menu php warning fix

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -430,21 +430,19 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	private function parse_menu_item( $title ) {
 		$item = array();
 
-		if ( false !== strpos( $title, 'count-' ) ) {
-			preg_match( '/<span class=".+\s?count-(\d*).+\s?<\/span><\/span>/', $title, $matches );
+		if ( false !== strpos( $title, 'count-' ) && preg_match( '/<span class=".+\s?count-(\d*).+\s?<\/span><\/span>/', $title, $matches ) ) {
 
-			$count = absint( $matches[1] );
+			$count = (int) ( $matches[1] ? $matches[1] : 0 );
 			if ( $count > 0 ) {
 				// Keep the counter in the item array.
 				$item['count'] = $count;
 			}
 
 			// Finally remove the markup.
-			$title = trim( str_replace( $matches[0], '', $title ) );
+			$title = trim( $matches[0] ? str_replace( $matches[0], '', $title ) : '' );
 		}
 
-		if ( false !== strpos( $title, 'inline-text' ) ) {
-			preg_match( '/<span class="inline-text".+\s?>(.+)<\/span>/', $title, $matches );
+		if ( false !== strpos( $title, 'inline-text' ) && preg_match( '/<span class="inline-text".+\s?>(.+)<\/span>/', $title, $matches ) ) {
 
 			$text = $matches[1];
 			if ( $text ) {
@@ -453,11 +451,10 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			}
 
 			// Finally remove the markup.
-			$title = trim( str_replace( $matches[0], '', $title ) );
+			$title = trim( $matches[0] ? str_replace( $matches[0], '', $title ) : '' );
 		}
 
-		if ( false !== strpos( $title, 'awaiting-mod' ) ) {
-			preg_match( '/<span class="awaiting-mod">(.+)<\/span>/', $title, $matches );
+		if ( false !== strpos( $title, 'awaiting-mod' ) && preg_match( '/<span class="awaiting-mod">(.+)<\/span>/', $title, $matches ) ) {
 
 			$text = $matches[1];
 			if ( $text ) {
@@ -466,11 +463,11 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			}
 
 			// Finally remove the markup.
-			$title = trim( str_replace( $matches[0], '', $title ) );
+			$title = trim( $matches[0] ? str_replace( $matches[0], '', $title ) : '' );
 		}
 
 		// It's important we sanitize the title after parsing data to remove any unexpected markup but keep the content.
-		// We are also capilizing the first letter in case there was a counter (now parsed) in front of the title.
+		// We are also capitalizing the first letter in case there was a counter (now parsed) in front of the title.
 		$item['title'] = ucfirst( wp_strip_all_tags( $title ) );
 
 		return $item;

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -430,19 +430,25 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	private function parse_menu_item( $title ) {
 		$item = array();
 
-		if ( false !== strpos( $title, 'count-' ) && preg_match( '/<span class=".+\s?count-(\d*).+\s?<\/span><\/span>/', $title, $matches ) ) {
+		if (
+			false !== strpos( $title, 'count-' )
+			&& preg_match( '/<span class=".+\s?count-(\d*).+\s?<\/span><\/span>/', $title, $matches )
+			) {
 
-			$count = (int) ( $matches[1] ? $matches[1] : 0 );
+			$count = (int) ( $matches[1] );
 			if ( $count > 0 ) {
 				// Keep the counter in the item array.
 				$item['count'] = $count;
 			}
 
 			// Finally remove the markup.
-			$title = trim( $matches[0] ? str_replace( $matches[0], '', $title ) : '' );
+			$title = trim( str_replace( $matches[0], '', $title ) );
 		}
 
-		if ( false !== strpos( $title, 'inline-text' ) && preg_match( '/<span class="inline-text".+\s?>(.+)<\/span>/', $title, $matches ) ) {
+		if (
+			false !== strpos( $title, 'inline-text' )
+			&& preg_match( '/<span class="inline-text".+\s?>(.+)<\/span>/', $title, $matches )
+			) {
 
 			$text = $matches[1];
 			if ( $text ) {
@@ -451,10 +457,13 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			}
 
 			// Finally remove the markup.
-			$title = trim( $matches[0] ? str_replace( $matches[0], '', $title ) : '' );
+			$title = trim( str_replace( $matches[0], '', $title ) );
 		}
 
-		if ( false !== strpos( $title, 'awaiting-mod' ) && preg_match( '/<span class="awaiting-mod">(.+)<\/span>/', $title, $matches ) ) {
+		if (
+			false !== strpos( $title, 'awaiting-mod' )
+			&& preg_match( '/<span class="awaiting-mod">(.+)<\/span>/', $title, $matches )
+			) {
 
 			$text = $matches[1];
 			if ( $text ) {
@@ -463,7 +472,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 			}
 
 			// Finally remove the markup.
-			$title = trim( $matches[0] ? str_replace( $matches[0], '', $title ) : '' );
+			$title = trim( str_replace( $matches[0], '', $title ) );
 		}
 
 		// It's important we sanitize the title after parsing data to remove any unexpected markup but keep the content.

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -433,7 +433,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		if (
 			false !== strpos( $title, 'count-' )
 			&& preg_match( '/<span class=".+\s?count-(\d*).+\s?<\/span><\/span>/', $title, $matches )
-			) {
+		) {
 
 			$count = (int) ( $matches[1] );
 			if ( $count > 0 ) {
@@ -448,7 +448,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		if (
 			false !== strpos( $title, 'inline-text' )
 			&& preg_match( '/<span class="inline-text".+\s?>(.+)<\/span>/', $title, $matches )
-			) {
+		) {
 
 			$text = $matches[1];
 			if ( $text ) {
@@ -463,7 +463,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 		if (
 			false !== strpos( $title, 'awaiting-mod' )
 			&& preg_match( '/<span class="awaiting-mod">(.+)<\/span>/', $title, $matches )
-			) {
+		) {
 
 			$text = $matches[1];
 			if ( $text ) {

--- a/projects/plugins/jetpack/changelog/fix-api-admin-menu
+++ b/projects/plugins/jetpack/changelog/fix-api-admin-menu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+API: Fix PHP warning


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes PHP Warning:  Undefined array key (0 or 1) in 
/wordpress/plugins/jetpack/11.8-beta/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php 
on line (436, 443, 462, 469)


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Sometimes plugins or themes modify wp-admin menu and we get unexpected response in $matches array. I'm 
checking if the response is what we need to build Calypso menu.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* None
*

