### PR TITLE
Remove calls to `parent::setUp()` from test `set_up()` methods

### DIFF
--- a/projects/packages/connection/changelog/fix-wrong-parent-setup-call
+++ b/projects/packages/connection/changelog/fix-wrong-parent-setup-call
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix tests calling `parent::setUp()` from `set_up()`, which will crash with latest WorDBless that picks up yoast-polyfill's TestCase class that calls `set_up()` from `setUp()`.
+
+

--- a/projects/packages/connection/tests/php/test_jetpack_xmlrpc_server.php
+++ b/projects/packages/connection/tests/php/test_jetpack_xmlrpc_server.php
@@ -26,7 +26,6 @@ class Jetpack_XMLRPC_Server_Test extends BaseTestCase {
 	 * @before
 	 */
 	protected function set_up() {
-		parent::setUp();
 		$user_id = wp_insert_user(
 			array(
 				'user_login' => 'admin',

--- a/projects/packages/stats/changelog/fix-wrong-parent-setup-call
+++ b/projects/packages/stats/changelog/fix-wrong-parent-setup-call
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix tests calling `parent::setUp()` from `set_up()`, which will crash with latest WorDBless that picks up yoast-polyfill's TestCase class that calls `set_up()` from `setUp()`.
+
+

--- a/projects/packages/stats/tests/php/test-base.php
+++ b/projects/packages/stats/tests/php/test-base.php
@@ -24,7 +24,6 @@ abstract class StatsBaseTestCase extends BaseTestCase {
 	 * @before
 	 */
 	protected function set_up() {
-		parent::setUp();
 		// Mock Jetpack Connection.
 		Jetpack_Options::update_option( 'id', 1234 );
 		Jetpack_Options::update_option( 'blog_token', 'blog_token.secret' );

--- a/projects/packages/videopress/changelog/fix-wrong-parent-setup-call
+++ b/projects/packages/videopress/changelog/fix-wrong-parent-setup-call
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix tests calling `parent::setUp()` from `set_up()`, which will crash with latest WorDBless that picks up yoast-polyfill's TestCase class that calls `set_up()` from `setUp()`.
+
+

--- a/projects/packages/videopress/tests/php/test-uploader.php
+++ b/projects/packages/videopress/tests/php/test-uploader.php
@@ -75,7 +75,6 @@ class Test_Uploader extends BaseTestCase {
 	 * @before
 	 */
 	protected function set_up() {
-		parent::setUp();
 		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
 		$user_id = wp_insert_user(
 			array(

--- a/projects/plugins/protect/changelog/fix-wrong-parent-setup-call
+++ b/projects/plugins/protect/changelog/fix-wrong-parent-setup-call
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix tests calling `parent::setUp()` from `set_up()`, which will crash with latest WorDBless that picks up yoast-polyfill's TestCase class that calls `set_up()` from `setUp()`.
+
+

--- a/projects/plugins/protect/tests/php/models/test-extension-model.php
+++ b/projects/plugins/protect/tests/php/models/test-extension-model.php
@@ -12,15 +12,6 @@ use WorDBless\BaseTestCase;
 class Test_Extension_Model extends BaseTestCase {
 
 	/**
-	 * Set up before each test
-	 *
-	 * @before
-	 */
-	protected function set_up() {
-		parent::setUp();
-	}
-
-	/**
 	 * Get a sample threat
 	 *
 	 * @param int|string $id The sample threat's unique identifier.

--- a/projects/plugins/protect/tests/php/models/test-threat-model.php
+++ b/projects/plugins/protect/tests/php/models/test-threat-model.php
@@ -12,15 +12,6 @@ use WorDBless\BaseTestCase;
 class Test_Threat_Model extends BaseTestCase {
 
 	/**
-	 * Set up before each test
-	 *
-	 * @before
-	 */
-	protected function set_up() {
-		parent::setUp();
-	}
-
-	/**
 	 * Tests for threat model's __construct() method.
 	 */
 	public function test_threat_model_construct() {

--- a/projects/plugins/protect/tests/php/test-scan-status.php
+++ b/projects/plugins/protect/tests/php/test-scan-status.php
@@ -24,7 +24,6 @@ class Test_Scan_Status extends BaseTestCase {
 	 * @before
 	 */
 	protected function set_up() {
-		parent::setUp();
 		Scan_Status::$status = null;
 	}
 

--- a/projects/plugins/protect/tests/php/test-status.php
+++ b/projects/plugins/protect/tests/php/test-status.php
@@ -25,7 +25,6 @@ class Test_Status extends BaseTestCase {
 	 * @before
 	 */
 	protected function set_up() {
-		parent::setUp();
 		Protect_Status::$status = null;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This is never necessary, but doesn't break with normal PHPUnit.

With Automattic/wordbless#61, however, now that parent `setUp()` itself calls `set_up()`, leading to infinite loops and stack exhaustion.

To fix this, we remove the bogus parent calls.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1675777301734439-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure stats package tests are completing successfully in CI.