### PR TITLE
CRM: Custom Fields: Escape placeholder field value

### DIFF
--- a/projects/plugins/crm/changelog/fix-minor-xss-custom-field-placeholder
+++ b/projects/plugins/crm/changelog/fix-minor-xss-custom-field-placeholder
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+CRM: Fixing minor admin only issue on placeholder fields.

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.settings.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.settings.js
@@ -230,14 +230,7 @@ function zbscrmJS_customFields_buildLine( area, typestr, namestr, placeholder, s
 	html += '<div class="zbscrm-cf-settings-wrap">';
 	html += '<div class="zbs-placeholder-text"></div>';
 
-	html +=
-		'<input type="text" class="form-control zbs-generic-hide zbs-generic" name="wpzbscrm_cf[' +
-		area +
-		'][placeholder][]" value="' +
-		placeholder +
-		'" placeholder="' +
-		zeroBSCRMJS_settingsLang( 'fieldplacehold', 'Field Placeholder Text' ) +
-		'" />';
+	html += '<input type="text" class="form-control zbs-generic-hide zbs-generic" name="wpzbscrm_cf[' + area + '][placeholder][]" value="' + jpcrm.esc_attr( placeholder ) + '" placeholder="' + zeroBSCRMJS_settingsLang('fieldplacehold','Field Placeholder Text') + '" />';
 
 	// encrypted (only shows if )
 	// Removed encrypted (for now), see JIRA-ZBS-738


### PR DESCRIPTION
Migrated from Jetpack CRM repo https://github.com/Automattic/zero-bs-crm/pull/2833

## Proposed changes:

* This PR fixes a potential issue using the placeholder field on the Custom Fields settings. The placeholder value was not escaped so that it could contain Javascript code. This PR is a minor one because that section is intended only for admin.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* See https://github.com/Automattic/zero-bs-crm/pull/2833
* To test in the Jetpack monorepo, on a Jurassic Ninja Site include the Jetpack Beta tester plugin, and under Jetpack CRM enable this branch.
* To test a build using a local development installation, run` jetpack build plugins/crm`, or `jetpack build --production plugins/crm` to test the build as if it were running in production.

