### PR TITLE
Fix multiple choice parsing

### DIFF
--- a/projects/packages/forms/changelog/fix-multiple-choice-parsing
+++ b/projects/packages/forms/changelog/fix-multiple-choice-parsing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add new method to reverse print_r output as stored on the feedback posts. Use it to try and parse the form fields, fallback to old method.

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -61,7 +61,7 @@
 			"link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.3.x-dev"
+			"dev-trunk": "0.4.x-dev"
 		},
 		"textdomain": "jetpack-forms",
 		"version-constants": {

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.3.1-alpha",
+	"version": "0.4.0-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.3.1-alpha';
+	const PACKAGE_VERSION = '0.4.0-alpha';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -692,21 +692,38 @@ class Admin {
 	 * @return void
 	 */
 	public function grunion_manage_post_column_response( $post ) {
-		$content_fields = Contact_Form_Plugin::parse_fields_from_content( $post->ID );
-
-		$response_fields = array_diff_key(
-			isset( $content_fields['_feedback_all_fields'] ) ? $content_fields['_feedback_all_fields'] : array(),
-			array(
-				'email_marketing_consent' => '',
-				'entry_title'             => '',
-				'entry_permalink'         => '',
-				'feedback_id'             => '',
-			)
+		$non_printable_keys = array(
+			'email_marketing_consent',
+			'entry_title',
+			'entry_permalink',
+			'feedback_id',
 		);
+
+		$post_content = get_post_field( 'post_content', $post->ID );
+		$content      = explode( '<!--more-->', $post_content );
+		$content      = str_ireplace( array( '<br />', ')</p>' ), '', $content[1] );
+		$chunks       = explode( "\nArray", $content );
+		if ( $chunks[1] ) {
+			// re-construct the array string
+			$array = 'Array' . $chunks[1];
+			// re-construct the array
+			$rearray         = Contact_Form_Plugin::reverse_that_print( $array, true );
+			$response_fields = is_array( $rearray ) ? $rearray : array();
+		} else {
+			// couldn't reconstruct array, use the old method
+			$content_fields  = Contact_Form_Plugin::parse_fields_from_content( $post->ID );
+			$response_fields = isset( $content_fields['_feedback_all_fields'] ) ? $content_fields['_feedback_all_fields'] : array();
+		}
+
+		$response_fields = array_diff_key( $response_fields, array_flip( $non_printable_keys ) );
 
 		echo '<hr class="feedback_response__mobile-separator" />';
 		echo '<div class="feedback_response__item">';
 		foreach ( $response_fields as $key => $value ) {
+			if ( is_array( $value ) ) {
+				$value = implode( ', ', $value );
+			}
+
 			printf(
 				'<div class="feedback_response__item-key">%s</div><div class="feedback_response__item-value">%s</div>',
 				esc_html( preg_replace( '#^\d+_#', '', $key ) ),

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2061,4 +2061,79 @@ class Contact_Form_Plugin {
 	public function use_block_editor_for_post_type( $can_edit, $post_type ) {
 		return 'feedback' === $post_type ? false : $can_edit;
 	}
+
+	/**
+	 * Kludge method: reverses the output of a standard print_r( $array ).
+	 * Sort of what unserialize does to a serialized object.
+	 * This is here while we work on a better data storage inside the posts. See:
+	 * - https://a8c.slack.com/archives/C01CSBEN0QZ/p1675781140892129
+	 * - https://www.php.net/manual/en/function.print-r.php#93529
+	 *
+	 * @param string $print_r_output The array string to be reverted. Needs to being with 'Array'.
+	 * @param bool   $parse_html Whether to run html_entity_decode on each line.
+	 *                           As strings are stored right now, they are all escaped, so '=>' are '&gt;'.
+	 * @return array|string Array when succesfully reconstructed, string otherwise
+	 */
+	public static function reverse_that_print( $print_r_output, $parse_html = false ) {
+		$lines = explode( "\n", trim( $print_r_output ) );
+		if ( $parse_html ) {
+			$lines = array_map( 'html_entity_decode', $lines );
+		}
+
+		if ( trim( $lines[0] ) !== 'Array' ) {
+			// bottomed out to something that isn't an array, escape it and be done
+			return esc_html( $print_r_output );
+		} else {
+			// this is an array, lets parse it
+			if ( preg_match( '/(\s{5,})\(/', $lines[1], $match ) ) {
+				// this is a tested array/recursive call to this function
+				// take a set of spaces off the beginning
+				$spaces        = $match[1];
+				$spaces_length = strlen( $spaces );
+				$lines_total   = count( $lines );
+
+				for ( $i = 0; $i < $lines_total; $i++ ) {
+					if ( substr( $lines[ $i ], 0, $spaces_length ) === $spaces ) {
+						$lines[ $i ] = substr( $lines[ $i ], $spaces_length );
+					}
+				}
+			}
+
+			array_shift( $lines ); // Array
+			array_shift( $lines ); // (
+			array_pop( $lines ); // )
+			$print_r_output = implode( "\n", $lines );
+
+			// make sure we only match stuff with 4 preceding spaces (stuff for this array and not a nested one
+			preg_match_all( '/^\s{4}\[(.+?)\] \=\> /m', $print_r_output, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER );
+
+			$pos          = array();
+			$previous_key = '';
+			$in_length    = strlen( $print_r_output );
+
+			// store the following in $pos:
+			// array with key = key of the parsed array's item
+			// value = array(start position in $print_r_output, $end position in $print_r_output)
+			foreach ( $matches as $match ) {
+				$key         = $match[1][0];
+				$start       = $match[0][1] + strlen( $match[0][0] );
+				$pos[ $key ] = array( $start, $in_length );
+
+				if ( $previous_key !== '' ) {
+					$pos[ $previous_key ][1] = $match[0][1] - 1;
+				}
+
+				$previous_key = $key;
+			}
+
+			$ret = array();
+
+			foreach ( $pos as $key => $where ) {
+				// recursively see if the parsed out value is an array too
+				$ret[ $key ] = self::reverse_that_print( substr( $print_r_output, $where[0], $where[1] - $where[0] ), $parse_html );
+			}
+
+			return $ret;
+		}
+	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2066,7 +2066,7 @@ class Contact_Form_Plugin {
 	 * Kludge method: reverses the output of a standard print_r( $array ).
 	 * Sort of what unserialize does to a serialized object.
 	 * This is here while we work on a better data storage inside the posts. See:
-	 * - https://a8c.slack.com/archives/C01CSBEN0QZ/p1675781140892129
+	 * - p1675781140892129-slack-C01CSBEN0QZ
 	 * - https://www.php.net/manual/en/function.print-r.php#93529
 	 *
 	 * @param string $print_r_output The array string to be reverted. Needs to being with 'Array'.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2072,7 +2072,7 @@ class Contact_Form_Plugin {
 	 * @param string $print_r_output The array string to be reverted. Needs to being with 'Array'.
 	 * @param bool   $parse_html Whether to run html_entity_decode on each line.
 	 *                           As strings are stored right now, they are all escaped, so '=>' are '&gt;'.
-	 * @return array|string Array when succesfully reconstructed, string otherwise
+	 * @return array|string Array when succesfully reconstructed, string otherwise. Output will always be esc_html'd.
 	 */
 	public static function reverse_that_print( $print_r_output, $parse_html = false ) {
 		$lines = explode( "\n", trim( $print_r_output ) );

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form-plugin.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form-plugin.php
@@ -17,14 +17,34 @@ use \WorDBless\BaseTestCase;
 class WP_Test_Contact_Form_Plugin extends BaseTestCase {
 	/**
 	 * Test that ::revert_that_print works correctly
+	 *
+	 * @dataProvider arrayReversals
 	 */
-	public function testStaticPrintReversal() {
-		$array = array(
-			'some',
-			'array',
-			'with' => array( 'nested', 'arrays' ),
-		);
+	public function testStaticPrintReversal( $array, $decode_html ) {
 		$print = print_r( $array, true );
-		$this->assertSame( $array, Contact_Form_Plugin::reverse_that_print( $print ) );
+		$this->assertSame( $array, Contact_Form_Plugin::reverse_that_print( $print, $decode_html ) );
+	}
+
+	/**
+	 * Data provider for testStaticPrintReversal
+	 */
+	public function arrayReversals() {
+		return array(
+			'nested array' => array(
+				array(
+					'some',
+					'array',
+					'with' => array( 'nested', 'arrays' ),
+				),
+				false,
+			),
+			'multiline'    => array(
+				array(
+					'entry'        => "with\njumps",
+					'tricky entry' => "with\n[line] =&gt; jumps",
+				),
+				true,
+			),
+		);
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form-plugin.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form-plugin.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Unit Tests for Automattic\Jetpack\Forms\Contact_Form.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use \WorDBless\BaseTestCase;
+
+/**
+ * Test class for Contact_Form
+ *
+ * @covers Contact_Form_Plugin
+ */
+class WP_Test_Contact_Form_Plugin extends BaseTestCase {
+	/**
+	 * Test that ::revert_that_print works correctly
+	 */
+	public function testStaticPrintReversal() {
+		$array = array(
+			'some',
+			'array',
+			'with' => array( 'nested', 'arrays' ),
+		);
+		$print = print_r( $array, true );
+		$this->assertSame( $array, Contact_Form_Plugin::reverse_that_print( $print ) );
+	}
+}

--- a/projects/plugins/jetpack/changelog/fix-multiple-choice-parsing
+++ b/projects/plugins/jetpack/changelog/fix-multiple-choice-parsing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Add new method to reverse print_r output as stored on the feedback posts. Use it to try and parse the form fields, fallback to old method.

--- a/projects/plugins/jetpack/changelog/fix-multiple-choice-parsing#2
+++ b/projects/plugins/jetpack/changelog/fix-multiple-choice-parsing#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -919,7 +919,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/forms",
-                "reference": "a73f0123ceeebdd35b48b9b4df8dafbe971619cd"
+                "reference": "51b402cc8d32dd9f01032c34ef93293cc2904753"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -941,7 +941,7 @@
                     "link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.3.x-dev"
+                    "dev-trunk": "0.4.x-dev"
                 },
                 "textdomain": "jetpack-forms",
                 "version-constants": {

--- a/projects/plugins/jetpack/modules/contact-form/admin.php
+++ b/projects/plugins/jetpack/modules/contact-form/admin.php
@@ -313,21 +313,37 @@ function grunion_manage_post_column_from( $post ) {
  * @return void
  */
 function grunion_manage_post_column_response( $post ) {
-	$content_fields = Grunion_Contact_Form_Plugin::parse_fields_from_content( $post->ID );
-
-	$response_fields = array_diff_key(
-		isset( $content_fields['_feedback_all_fields'] ) ? $content_fields['_feedback_all_fields'] : array(),
-		array(
-			'email_marketing_consent' => '',
-			'entry_title'             => '',
-			'entry_permalink'         => '',
-			'feedback_id'             => '',
-		)
+	$non_printable_keys = array(
+		'email_marketing_consent',
+		'entry_title',
+		'entry_permalink',
+		'feedback_id',
 	);
+
+	$post_content = get_post_field( 'post_content', $post->ID );
+	$content      = explode( '<!--more-->', $post_content );
+	$content      = str_ireplace( array( '<br />', ')</p>' ), '', $content[1] );
+	$chunks       = explode( "\nArray", $content );
+	if ( $chunks[1] ) {
+		// re-construct the array string
+		$array = 'Array' . $chunks[1];
+		// re-construct the array
+		$rearray         = Grunion_Contact_Form_Plugin::reverse_that_print( $array, true );
+		$response_fields = is_array( $rearray ) ? $rearray : array();
+	} else {
+		// couldn't reconstruct array, use the old method
+		$content_fields  = Grunion_Contact_Form_Plugin::parse_fields_from_content( $post->ID );
+		$response_fields = isset( $content_fields['_feedback_all_fields'] ) ? $content_fields['_feedback_all_fields'] : array();
+	}
+
+	$response_fields = array_diff_key( $response_fields, array_flip( $non_printable_keys ) );
 
 	echo '<hr class="feedback_response__mobile-separator" />';
 	echo '<div class="feedback_response__item">';
 	foreach ( $response_fields as $key => $value ) {
+		if ( is_array( $value ) ) {
+			$value = implode( ', ', $value );
+		}
 		printf(
 			'<div class="feedback_response__item-key">%s</div><div class="feedback_response__item-value">%s</div>',
 			esc_html( preg_replace( '#^\d+_#', '', $key ) ),

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -2180,6 +2180,81 @@ class Grunion_Contact_Form_Plugin {
 	public function use_block_editor_for_post_type( $can_edit, $post_type ) {
 		return 'feedback' === $post_type ? false : $can_edit;
 	}
+
+	/**
+	 * Kludge method: reverses the output of a standard print_r( $array ).
+	 * Sort of what unserialize does to a serialized object.
+	 * This is here while we work on a better data storage inside the posts. See:
+	 * - https://a8c.slack.com/archives/C01CSBEN0QZ/p1675781140892129
+	 * - https://www.php.net/manual/en/function.print-r.php#93529
+	 *
+	 * @param string $print_r_output The array string to be reverted. Needs to being with 'Array'.
+	 * @param bool   $parse_html Whether to run html_entity_decode on each line.
+	 *                           As strings are stored right now, they are all escaped, so '=>' are '&gt;'.
+	 * @return array|string Array when succesfully reconstructed, string otherwise
+	 */
+	public static function reverse_that_print( $print_r_output, $parse_html = false ) {
+		$lines = explode( "\n", trim( $print_r_output ) );
+		if ( $parse_html ) {
+			$lines = array_map( 'html_entity_decode', $lines );
+		}
+
+		if ( trim( $lines[0] ) !== 'Array' ) {
+			// bottomed out to something that isn't an array, escape it and be done
+			return esc_html( $print_r_output );
+		} else {
+			// this is an array, lets parse it
+			if ( preg_match( '/(\s{5,})\(/', $lines[1], $match ) ) {
+				// this is a tested array/recursive call to this function
+				// take a set of spaces off the beginning
+				$spaces        = $match[1];
+				$spaces_length = strlen( $spaces );
+				$lines_total   = count( $lines );
+
+				for ( $i = 0; $i < $lines_total; $i++ ) {
+					if ( substr( $lines[ $i ], 0, $spaces_length ) === $spaces ) {
+						$lines[ $i ] = substr( $lines[ $i ], $spaces_length );
+					}
+				}
+			}
+
+			array_shift( $lines ); // Array
+			array_shift( $lines ); // (
+			array_pop( $lines ); // )
+			$print_r_output = implode( "\n", $lines );
+
+			// make sure we only match stuff with 4 preceding spaces (stuff for this array and not a nested one
+			preg_match_all( '/^\s{4}\[(.+?)\] \=\> /m', $print_r_output, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER );
+
+			$pos          = array();
+			$previous_key = '';
+			$in_length    = strlen( $print_r_output );
+
+			// store the following in $pos:
+			// array with key = key of the parsed array's item
+			// value = array(start position in $print_r_output, $end position in $print_r_output)
+			foreach ( $matches as $match ) {
+				$key         = $match[1][0];
+				$start       = $match[0][1] + strlen( $match[0][0] );
+				$pos[ $key ] = array( $start, $in_length );
+
+				if ( $previous_key !== '' ) {
+					$pos[ $previous_key ][1] = $match[0][1] - 1;
+				}
+
+				$previous_key = $key;
+			}
+
+			$ret = array();
+
+			foreach ( $pos as $key => $where ) {
+				// recursively see if the parsed out value is an array too
+				$ret[ $key ] = self::reverse_that_print( substr( $print_r_output, $where[0], $where[1] - $where[0] ), $parse_html );
+			}
+
+			return $ret;
+		}
+	}
 }
 
 /**

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -2191,7 +2191,7 @@ class Grunion_Contact_Form_Plugin {
 	 * @param string $print_r_output The array string to be reverted. Needs to being with 'Array'.
 	 * @param bool   $parse_html Whether to run html_entity_decode on each line.
 	 *                           As strings are stored right now, they are all escaped, so '=>' are '&gt;'.
-	 * @return array|string Array when succesfully reconstructed, string otherwise
+	 * @return array|string Array when succesfully reconstructed, string otherwise. Output will always be esc_html'd.
 	 */
 	public static function reverse_that_print( $print_r_output, $parse_html = false ) {
 		$lines = explode( "\n", trim( $print_r_output ) );

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -2185,7 +2185,7 @@ class Grunion_Contact_Form_Plugin {
 	 * Kludge method: reverses the output of a standard print_r( $array ).
 	 * Sort of what unserialize does to a serialized object.
 	 * This is here while we work on a better data storage inside the posts. See:
-	 * - https://a8c.slack.com/archives/C01CSBEN0QZ/p1675781140892129
+	 * - p1675781140892129-slack-C01CSBEN0QZ
 	 * - https://www.php.net/manual/en/function.print-r.php#93529
 	 *
 	 * @param string $print_r_output The array string to be reverted. Needs to being with 'Array'.


### PR DESCRIPTION

Fixes #28345, https://github.com/Automattic/wp-calypso/issues/72713

## Proposed changes:
This PR adds a new method on the Contact Form class to try and revert the output of a `print_r` command, used to store form fields.

The process will try to unparse the stored value and fallback to the old method.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Follow steps on #28345, value from multiple choice inputs should now be properly parsed.