### PR TITLE
Adds post categories as classnames to search results

### DIFF
--- a/projects/packages/search/changelog/update-search-add-category-classnames
+++ b/projects/packages/search/changelog/update-search-add-category-classnames
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search: Adds assigned post categories as classnames to search results

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -70,7 +70,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.31.x-dev"
+			"dev-trunk": "0.32.x-dev"
 		},
 		"version-constants": {
 			"::VERSION": "src/class-package.php"

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.31.8-alpha",
+	"version": "0.32.0-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.31.8-alpha';
+	const VERSION = '0.32.0-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/instant-search/components/search-result-expanded.jsx
+++ b/projects/packages/search/src/instant-search/components/search-result-expanded.jsx
@@ -1,3 +1,4 @@
+import { cleanForSlug } from '@wordpress/url';
 import React from 'react';
 import PathBreadcrumbs from './path-breadcrumbs';
 import PhotonImage from './photon-image';
@@ -19,6 +20,20 @@ export default function SearchResultExpanded( props ) {
 		return null;
 	}
 
+	const getCategories = () => {
+		let cats = fields[ 'category.name.default' ];
+
+		if ( ! cats ) {
+			return [];
+		}
+
+		if ( ! Array.isArray( cats ) ) {
+			cats = [ cats ];
+		}
+
+		return cats;
+	};
+
 	const firstImage = Array.isArray( fields[ 'image.url.raw' ] )
 		? fields[ 'image.url.raw' ][ 0 ]
 		: fields[ 'image.url.raw' ];
@@ -30,6 +45,9 @@ export default function SearchResultExpanded( props ) {
 				`jetpack-instant-search__search-result-expanded--${ fields.post_type }`,
 				! firstImage ? 'jetpack-instant-search__search-result-expanded--no-image' : '',
 				isMultiSite ? 'is-multisite' : '',
+				getCategories()
+					.map( cat => 'jetpack-instant-search__search-result-category--' + cleanForSlug( cat ) )
+					.join( ' ' ),
 			].join( ' ' ) }
 		>
 			<div className="jetpack-instant-search__search-result-expanded__content-container">

--- a/projects/packages/search/src/instant-search/components/search-result-minimal.jsx
+++ b/projects/packages/search/src/instant-search/components/search-result-minimal.jsx
@@ -1,3 +1,4 @@
+import { cleanForSlug } from '@wordpress/url';
 import React, { Component } from 'react';
 import Gridicon from './gridicon';
 import PathBreadcrumbs from './path-breadcrumbs';
@@ -25,7 +26,7 @@ class SearchResultMinimal extends Component {
 		return tags.slice( 0, MAX_TAGS_OR_CATEGORIES );
 	}
 
-	getCategories() {
+	getCategories( returnAll = false ) {
 		let cats = this.props.result.fields[ 'category.name.default' ];
 
 		if ( ! cats ) {
@@ -34,6 +35,10 @@ class SearchResultMinimal extends Component {
 
 		if ( ! Array.isArray( cats ) ) {
 			cats = [ cats ];
+		}
+
+		if ( returnAll ) {
+			return cats;
 		}
 
 		return cats.slice( 0, MAX_TAGS_OR_CATEGORIES );
@@ -96,7 +101,15 @@ class SearchResultMinimal extends Component {
 		const noMatchingContent = ! highlight.content || highlight.content[ 0 ] === '';
 
 		return (
-			<li className="jetpack-instant-search__search-result jetpack-instant-search__search-result-minimal">
+			<li
+				className={ [
+					'jetpack-instant-search__search-result',
+					'jetpack-instant-search__search-result-minimal',
+					this.getCategories( true )
+						.map( cat => 'jetpack-instant-search__search-result-category--' + cleanForSlug( cat ) )
+						.join( ' ' ),
+				].join( ' ' ) }
+			>
 				<h3 className="jetpack-instant-search__search-result-title jetpack-instant-search__search-result-minimal-title">
 					<PostTypeIcon postType={ fields.post_type } shortcodeTypes={ fields.shortcode_types } />
 					<a

--- a/projects/packages/search/src/instant-search/components/search-result-product.jsx
+++ b/projects/packages/search/src/instant-search/components/search-result-product.jsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { cleanForSlug } from '@wordpress/url';
 import React, { Component } from 'react';
 import Gridicon from './gridicon';
 import PhotonImage from './photon-image';
@@ -13,6 +14,20 @@ class SearchResultProduct extends Component {
 		if ( result_type !== 'post' ) {
 			return null;
 		}
+
+		const getCategories = () => {
+			let cats = fields[ 'category.name.default' ];
+
+			if ( ! cats ) {
+				return [];
+			}
+
+			if ( ! Array.isArray( cats ) ) {
+				cats = [ cats ];
+			}
+
+			return cats;
+		};
 
 		const firstImage = Array.isArray( fields[ 'image.url.raw' ] )
 			? fields[ 'image.url.raw' ][ 0 ]
@@ -34,7 +49,15 @@ class SearchResultProduct extends Component {
 			highlight.content[ 0 ]?.length > 0;
 
 		return (
-			<li className="jetpack-instant-search__search-result jetpack-instant-search__search-result-product">
+			<li
+				className={ [
+					'jetpack-instant-search__search-result',
+					'jetpack-instant-search__search-result-product',
+					getCategories()
+						.map( cat => 'jetpack-instant-search__search-result-category--' + cleanForSlug( cat ) )
+						.join( ' ' ),
+				].join( '' ) }
+			>
 				<a
 					className="jetpack-instant-search__search-result-product-img-link"
 					href={ `//${ fields[ 'permalink.url.raw' ] }` }

--- a/projects/plugins/jetpack/changelog/update-search-add-category-classnames
+++ b/projects/plugins/jetpack/changelog/update-search-add-category-classnames
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1945,7 +1945,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "2e89301b4063073eb8c2abc3110735e057b02b15"
+                "reference": "f2e34fe09e5988d20fe683e873766d9bfcdb924e"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1969,7 +1969,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.31.x-dev"
+                    "dev-trunk": "0.32.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"

--- a/projects/plugins/search/changelog/update-search-add-category-classnames
+++ b/projects/plugins/search/changelog/update-search-add-category-classnames
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1101,7 +1101,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "2e89301b4063073eb8c2abc3110735e057b02b15"
+                "reference": "f2e34fe09e5988d20fe683e873766d9bfcdb924e"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1125,7 +1125,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.31.x-dev"
+                    "dev-trunk": "0.32.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates Jetpack instant search results to include category taxonomy names as CSS classes
* Updates all 3 search result view options (expanded, minimal, product) to include this

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

I can't see any discussion of this via an MGS search, but the idea of this PR is to allow for category based styling of search results in the ES modal. 

Context: Team51 has a VVIP partner who is requesting results in a certain category have different styling than other search results.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup Jetpack instant search
* Fire off a search that returns results
* Ensure category names are attached to each search results `<li>` parent.
* TESTED: Results without categories are correctly handled.
* TESTED: Results with multiple categories are correctly handled.

![Screenshot 2023-02-07 at 18 38 42](https://user-images.githubusercontent.com/3149464/217335921-40749893-a7ef-4ebf-930c-2a526ce10827.png)
