### PR TITLE
VideoPress: Fix fatal error when local video cannot be read

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-fatal-local-videos
+++ b/projects/packages/videopress/changelog/fix-videopress-fatal-local-videos
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fix fatal error when local video cannot be read

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -241,9 +241,15 @@ class Data {
 				$media_details      = $video['media_details'];
 				$jetpack_videopress = $video['jetpack_videopress'];
 
-				// Check if video is already uploaded to VideoPress.
-				$uploader                  = new Uploader( $id );
-				$is_uploaded_to_videopress = $uploader->is_uploaded();
+				// Check if video is already uploaded to VideoPress or has some error.
+				try {
+					$uploader                  = new Uploader( $id );
+					$is_uploaded_to_videopress = $uploader->is_uploaded();
+					$read_error                = null;
+				} catch ( Upload_Exception $e ) {
+					$is_uploaded_to_videopress = false;
+					$read_error                = $e->getCode();
+				}
 
 				$upload_date = $video['date'];
 				$url         = $video['source_url'];
@@ -267,6 +273,7 @@ class Data {
 					'uploadDate'             => $upload_date,
 					'duration'               => $duration,
 					'isUploadedToVideoPress' => $is_uploaded_to_videopress,
+					'readError'              => $read_error,
 				);
 			},
 			$local_videos_data['videos']

--- a/projects/packages/videopress/src/class-upload-exception.php
+++ b/projects/packages/videopress/src/class-upload-exception.php
@@ -11,4 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * VideoPress Uploader Exception class
  */
 class Upload_Exception extends \Exception {
+	const ERROR_INVALID_ATTACHMENT_ID   = 0;
+	const ERROR_FILE_NOT_FOUND          = 1;
+	const ERROR_MIME_TYPE_NOT_SUPPORTED = 2;
 }

--- a/projects/packages/videopress/src/class-uploader.php
+++ b/projects/packages/videopress/src/class-uploader.php
@@ -72,13 +72,13 @@ class Uploader {
 	public function __construct( $attachment_id ) {
 		$this->attachment_id = $attachment_id;
 		if ( ! $this->get_file_path() ) {
-			throw new Upload_Exception( __( 'Invalid attachment ID', 'jetpack-videopress-pkg' ) );
+			throw new Upload_Exception( __( 'Invalid attachment ID', 'jetpack-videopress-pkg' ), Upload_Exception::ERROR_INVALID_ATTACHMENT_ID );
 		}
 		if ( ! is_readable( $this->get_file_path() ) ) {
-			throw new Upload_Exception( __( 'File not found', 'jetpack-videopress-pkg' ) );
+			throw new Upload_Exception( __( 'File not found', 'jetpack-videopress-pkg' ), Upload_Exception::ERROR_FILE_NOT_FOUND );
 		}
 		if ( ! $this->file_has_supported_mime_type() ) {
-			throw new Upload_Exception( __( 'Mime type not supported', 'jetpack-videopress-pkg' ) );
+			throw new Upload_Exception( __( 'Mime type not supported', 'jetpack-videopress-pkg' ), Upload_Exception::ERROR_MIME_TYPE_NOT_SUPPORTED );
 		}
 	}
 

--- a/projects/packages/videopress/src/client/admin/components/video-list/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/video-list/style.module.scss
@@ -1,27 +1,31 @@
 .list {
-	background-color: var(--jp-white);
+	background-color: var( --jp-white );
 }
 
 .header {
 	display: flex;
 	align-items: center;
-	padding: calc( var(--spacing-base) * 2 ) var(--spacing-base); // 16px | 8px
+	padding: calc( var( --spacing-base ) * 2 ) var( --spacing-base ); // 16px | 8px
 	justify-content: space-between;
-	gap: calc( var(--spacing-base) * 2 ); // 16px
-	border-bottom: 1px solid var(--jp-gray-5);
+	gap: calc( var( --spacing-base ) * 2 ); // 16px
+	border-bottom: 1px solid var( --jp-gray-5 );
 }
 
 .title-wrapper {
 	display: flex;
-	gap: calc( var(--spacing-base) * 2 ); // 16px
+	gap: calc( var( --spacing-base ) * 2 ); // 16px
 }
 
 .row {
-	border-bottom: 1px solid var(--jp-gray-5);
+	border-bottom: 1px solid var( --jp-gray-5 );
 }
 
 .title-adornment {
-	fill: var(--jp-gray-10);
-	margin-left: var(--spacing-base);
+	fill: var( --jp-gray-10 );
+	margin-left: var( --spacing-base );
 	display: inline-flex;
+
+	&.error {
+		fill: var( --jp-yellow-20 );
+	}
 }

--- a/projects/packages/videopress/src/client/admin/types/index.ts
+++ b/projects/packages/videopress/src/client/admin/types/index.ts
@@ -203,6 +203,10 @@ export type LocalVideo = {
 	 * Flag to indicate if the video is already uploaded or not to VideoPress.
 	 */
 	isUploadedToVideoPress: boolean;
+	/**
+	 * The video error, if any.
+	 */
+	readError?: 0 | 1 | 2;
 };
 
 export type MetadataVideo = {

--- a/projects/packages/videopress/src/client/state/constants.js
+++ b/projects/packages/videopress/src/client/state/constants.js
@@ -86,6 +86,13 @@ export const VIDEO_PRIVACY_LEVELS = [
 	VIDEO_PRIVACY_LEVEL_SITE_DEFAULT,
 ];
 
+/*
+ * Local video errors
+ */
+export const LOCAL_VIDEO_ERROR_INVALID_ATTACHMENT_ID = 0;
+export const LOCAL_VIDEO_ERROR_FILE_NOT_FOUND = 1;
+export const ERROR_MIME_TYPE_NOT_SUPPORTED = 2;
+
 export const VIDEO_RATING_G = 'G';
 export const VIDEO_RATING_PG_13 = 'PG-13';
 export const VIDEO_RATING_R_17 = 'R-17';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #28707

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Checks for thrown errors when checking local video files and marking the files instead of allowing a fatal error
* Adds error codes to be shown in the list via tooltips

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This one is tricky to test out of local environment.
* Force an error to be thrown by adding it [here](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/videopress/src/class-uploader.php#L73). For example: `throw new Upload_Exception( __( 'Invalid attachment ID', 'jetpack-videopress-pkg' ), Upload_Exception::ERROR_INVALID_ATTACHMENT_ID );`
* Go to the VideoPress dashboard with at least one local video
* Check that there is no fatal error
* Check that there is a yellow icon with a tooltip message

Before | After
-|-
![2023-02-07_15-51-08](https://user-images.githubusercontent.com/8486249/217338436-0a4b19ac-84d3-4158-bdb6-0f3262c67e7c.png) | ![2023-02-07_15-43-06](https://user-images.githubusercontent.com/8486249/217338455-aa3a7392-c95f-4112-a678-9098f60d9fd0.png)
