### PR TITLE
Jetpack: backport 11.8-beta changelogs and stable tags

### DIFF
--- a/projects/plugins/backup/CHANGELOG.md
+++ b/projects/plugins/backup/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.4.4-beta - 2023-02-01
+## 1.4.4 - 2023-02-07
 ### Changed
 - Updated package dependencies. [#28218]
 

--- a/projects/plugins/backup/changelog/update-backport-jp-11.8-changelogs
+++ b/projects/plugins/backup/changelog/update-backport-jp-11.8-changelogs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Backport stable tag
+
+

--- a/projects/plugins/backup/readme.txt
+++ b/projects/plugins/backup/readme.txt
@@ -4,7 +4,7 @@ Tags: jetpack
 Requires at least: 6.0
 Requires PHP: 5.6
 Tested up to: 6.1
-Stable tag: 1.4.3
+Stable tag: 1.4.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -108,7 +108,7 @@ If you don’t have Backups as part of your Jetpack plan, [visit Jetpack.com to 
 
 As soon as you purchase Jetpack VaultPress Backup, it will be activated, and the first backup will be completed. There are barely any settings to configure, and you don’t need coding experience.
 
-For plans with daily backups, a new backup will take place approximately 24 hours from the previous backup. They occur automatically – you don’t need to create a specific time for backups to run. 
+For plans with daily backups, a new backup will take place approximately 24 hours from the previous backup. They occur automatically – you don’t need to create a specific time for backups to run.
 
 For plans with real-time backups, a new backup will be performed each time a change is made to WordPress core's database tables, WooCommerce database tables, and any associated file changes. All other changes are backed up daily.
 
@@ -160,7 +160,7 @@ No, Jetpack VaultPress Backup does not currently support split site or split hom
 2. Your site backups are stored in multiple locations on our world-class cloud infrastructure so you can recover them at any moment.
 
 == Changelog ==
-### 1.4.4-beta - 2023-02-01
+### 1.4.4 - 2023-02-07
 #### Changed
 - Updated package dependencies.
 

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
-## 11.8-beta - 2023-01-30
+## 11.8 - 2023-02-07
 ### Enhancements
 - Form block: add styling of input fields. [#27837]
 
@@ -11,13 +11,16 @@
 - Revue block: add a direct link to the WordPress.com subscriber import page. [#28538]
 
 ### Bug fixes
+- Backup: fix Backup submenu item not visible when the site has a VaultPress Backup plan but the VaultPress Backup plugin is not active. [#28650]
+- Dashboard: do not register the VaultPress and Scan submenu items without having Backups/Scan state. [#28711]
 - Slideshow: fix slideshow loading excessive dependencies on every page view. [#28562]
-- Masterbar: avoid PHP fatal on WoA sites due to a bad filter return. [#28622]
 - Twitter Timeline shortcode: remove jQuery dependency for non-admin pages, and add it for admin pages. [#28643]
 
 ### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
 - Contact Form: fix a PHP warning. [#28640]
+- Dashboard: remove border around counts for anti-spam/protect. [#28746]
 - JSON API: fix the response format for '/sites/$site/dropdown-pages/', the endpoint is not used in production yet. [#28586]
+- Masterbar: avoid PHP fatal on WoA sites due to a bad filter return. [#28622]
 - Reading settings: add 'Reading' link to the menu in Calypso for self-hosted Jetpack sites. [#28616]
 - Shortcodes: fix a PHP warning. [#28644]
 - Subscriptions: fix warnings from the global reading of '$post'. [#28639]

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
-## 11.8 - 2023-02-07
+## [11.8] - 2023-02-07
 ### Enhancements
 - Form block: add styling of input fields. [#27837]
 
@@ -7671,8 +7671,9 @@ Other bugfixes and enhancements at https://github.com/Automattic/jetpack/commits
 
 - Initial release
 
-[11.6]: https://wp.me/p1moTy-PLI
+[11.8]: https://wp.me/p1moTy-QEM
 [11.7]: https://wp.me/p1moTy-Q9t
+[11.6]: https://wp.me/p1moTy-PLI
 [11.5]: https://wp.me/p1moTy-Ppq
 [11.4]: https://wp.me/p1moTy-O5I
 [11.3]: https://wp.me/p1moTy-M5i

--- a/projects/plugins/jetpack/changelog/fix-backup-menu-item
+++ b/projects/plugins/jetpack/changelog/fix-backup-menu-item
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Fix Backup submenu item not visible when the site has a VaultPress Backup plan but the VaultPress Backup  plugin is not active.

--- a/projects/plugins/jetpack/changelog/fix-backup-scan-submenu-visibility
+++ b/projects/plugins/jetpack/changelog/fix-backup-scan-submenu-visibility
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Do not register the VaultPress and Scan submenu items if we don't have the backups and scan state yet.

--- a/projects/plugins/jetpack/changelog/remove-box-stats
+++ b/projects/plugins/jetpack/changelog/remove-box-stats
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Dashboard Admin: remove border around blocked numbers for anti-spam/protect blocks

--- a/projects/plugins/jetpack/changelog/update-jetpack-11.8-beta-changelog-editorial
+++ b/projects/plugins/jetpack/changelog/update-jetpack-11.8-beta-changelog-editorial
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Jetpack: 11.8-beta changelog editorial
-
-

--- a/projects/plugins/jetpack/changelog/update-jp-11.8-to-test
+++ b/projects/plugins/jetpack/changelog/update-jp-11.8-to-test
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Jetpack: 11.8 to-test items.
-
-

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack - WP Security, Backup, Speed, & Growth ===
 Contributors: automattic, adamkheckler, adrianmoldovanwp, aduth, akirk, allendav, alternatekev, andy, annamcphee, annezazu, apeatling, arcangelini, azaozz, batmoo, barry, beaulebens, biskobe, blobaugh, bjorsch, brbrr, cainm, cena, cfinke, chaselivingston, chellycat, clickysteve, csonnek, danielbachhuber, davoraltman, daniloercoli, delawski, designsimply, dllh, drawmyface, dsmart, dzver, ebinnion, egregor, eliorivero, enej, eoigal, erania-pinnera, ethitter, fgiannar, gcorne, georgestephanis, gibrown, goldsounds, hew, hugobaeta, hypertextranch, iammattthomas, iandunn, jblz, jasmussen, jeffgolenski, jeherve, jenhooks, jenia, jessefriedman, jgs, jkudish, jmdodd, joanrho, johnjamesjacoby, jshreve, kbrownkd, keoshi, koke, kraftbj, lancewillett, leogermani, lschuyler, macmanx, martinremy, matt, matveb, mattwiebe, maverick3x6, mcsf, mdawaffe, mdbitz, MichaelArestad, migueluy, mikeyarce, mkaz, nancythanki, nickmomrik, obenland, oskosk, pento, professor44, rachelsquirrel, rdcoll, ryancowles, richardmuscat, richardmtl, robertbpugh, roccotripaldi, samhotchkiss, samiff, scarstocea, scottsweb, sdixon194, sdquirk, sermitr, simison, stephdau, tmoorewp, tyxla, Viper007Bond, westi, yoavf, zinigor
 Tags: Security, backup, Woo, malware, scan, spam, CDN, search, social
-Stable tag: 11.7.1
+Stable tag: 11.8
 Requires at least: 6.0
 Requires PHP: 5.6
 Tested up to: 6.1

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -242,7 +242,7 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 4. Promote your newest posts, pages, and products across your social media channels.
 
 == Changelog ==
-### 11.8-beta - 2023-01-30
+### 11.8 - 2023-02-07
 #### Enhancements
 - Form block: add styling of input fields.
 
@@ -251,8 +251,17 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 - Revue block: add a direct link to the WordPress.com subscriber import page.
 
 #### Bug fixes
-- Slidedhow: fix slideshow loading excessive dependencies on every page view.
-- Masterbar: avoid PHP fatal on WoA sites due to a bad filter return.
+- Backup: fix Backup submenu item not visible when the site has a VaultPress Backup plan but the VaultPress Backup plugin is not active.
+- Dashboard: do not register the VaultPress and Scan submenu items without having Backup/Scan state.
+- Dashboard: fix the price display and description for products with intro offers for the first month.
+- Dashboard: show Boost in My Plans dashboard when added to a site.
+- Infinite Scroll: fix an AMP related bug.
+- Modules: allow for deactivating multiple plugins when activating a module.
+- Related Posts: fix Related Posts options saving.
+- Reverts PR #27958 as it conflicts with the way WooCommerce updates submenus.
+- Sharing: do not include the sharing buttons in REST API responses.
+- Slideshow: fix slideshow loading excessive dependencies on every page view.
+- Subscriptions: add a null check to a $post reference.
 - Twitter Timeline shortcode: remove jQuery dependency for non-admin pages, and add it for admin pages.
 
 --------

--- a/projects/plugins/social/CHANGELOG.md
+++ b/projects/plugins/social/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.7.0-beta - 2023-02-01
+## 1.7.0 - 2023-02-07
 ### Added
 - Added Advanced Social plan to pricing table [#28258]
 

--- a/projects/plugins/social/changelog/update-backport-jp-11.8-changelogs
+++ b/projects/plugins/social/changelog/update-backport-jp-11.8-changelogs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Backport stable tag
+
+

--- a/projects/plugins/social/readme.txt
+++ b/projects/plugins/social/readme.txt
@@ -4,7 +4,7 @@ Tags: social-media, publicize, social-media-manager, social-networking, social m
 Requires at least: 6.0
 Requires PHP: 5.6
 Tested up to: 6.1
-Stable tag: 1.6.0
+Stable tag: 1.7.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -91,7 +91,7 @@ The easiest way is to use the Custom Message option in the publishing options bo
 4. Manage your Jetpack Social and other Jetpack plugins from My Jetpack.
 
 == Changelog ==
-### 1.7.0-beta - 2023-02-01
+### 1.7.0 - 2023-02-07
 #### Added
 - Added Advanced Social plan to pricing table
 


### PR DESCRIPTION
## Proposed changes:

Backport Jetpack, Backup, and Social changelogs & stable tags from the beta period.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
Proofread.

