### PR TITLE
CRM: Adding JS functions to the list of exported functions

### DIFF
--- a/projects/plugins/crm/changelog/add-crm-js-functions-module
+++ b/projects/plugins/crm/changelog/add-crm-js-functions-module
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+CRM: Adding a JS function to a list of exports so that it can be called outside the bundle it was declared in.

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
@@ -2777,5 +2777,5 @@ if ( module ) {
 		zbscrmjs_nl2br, zbscrmjs_reversenl2br, ucwords, jpcrm_abbreviate_str, empty, zeroBSCRMJS_telURLFromNo, zeroBSCRMJS_isArray, zeroBSCRMJS_ucwords,
 		jpcrm_strip_trailing_slashes, zeroBSCRMJS_formatCurrency, zeroBSCRMJS_extend, zeroBSCRMJS_retrieveURLS, jpcrm_looks_like_URL, 
 		zeroBSCRMJS_retrieveEmails, zeroBSCRMJS_genericLoaded, zeroBSCRMJS_genericPostData, jpcrm_sleep, zbsJS_updateScreenOptions,
-		zeroBSCRMJS_obj_viewLink, zeroBSCRMJS_obj_editLink, jpcrm_set_jpcrm_transient };
+		zeroBSCRMJS_obj_viewLink, zeroBSCRMJS_obj_editLink, jpcrm_set_jpcrm_transient, jpcrm_js_bind_daterangepicker };
 }

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
@@ -2777,5 +2777,5 @@ if ( module ) {
 		zbscrmjs_nl2br, zbscrmjs_reversenl2br, ucwords, jpcrm_abbreviate_str, empty, zeroBSCRMJS_telURLFromNo, zeroBSCRMJS_isArray, zeroBSCRMJS_ucwords,
 		jpcrm_strip_trailing_slashes, zeroBSCRMJS_formatCurrency, zeroBSCRMJS_extend, zeroBSCRMJS_retrieveURLS, jpcrm_looks_like_URL, 
 		zeroBSCRMJS_retrieveEmails, zeroBSCRMJS_genericLoaded, zeroBSCRMJS_genericPostData, jpcrm_sleep, zbsJS_updateScreenOptions,
-		zeroBSCRMJS_obj_viewLink, zeroBSCRMJS_obj_editLink, jpcrm_set_jpcrm_transient, jpcrm_js_bind_daterangepicker };
+		zeroBSCRMJS_obj_viewLink, zeroBSCRMJS_obj_editLink, jpcrm_set_jpcrm_transient, jpcrm_js_bind_daterangepicker, zeroBSCRMJS_globViewLang };
 }


### PR DESCRIPTION

## Proposed changes:

* This PR adds the functions `jpcrm_js_bind_daterangepicker` and `zeroBSCRMJS_globViewLang` to the module exports list in `ZeroBSCRM.admin.global.js`, so that they can be referenced outside of `ZeroBSCRM.admin.global.js` without generating console errors.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* This came up in testing here: https://github.com/Automattic/jetpack/pull/28798

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* To test, follow the testing instructions in this PR and those console errors should not appear: https://github.com/Automattic/jetpack/pull/28798. You may initially need to make sure you install the CRM plugin as well as just selecting this CRM branch to test (if testing using the Beta plugin).

