### PR TITLE
CRM: Migrate Fix avatar getting removed when saving a contact

### DIFF
--- a/projects/plugins/crm/changelog/fix-profile_picture_getting_removed
+++ b/projects/plugins/crm/changelog/fix-profile_picture_getting_removed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+CRM: Fix avatar getting removed when saving a contact

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
@@ -540,12 +540,13 @@
                     }
 
                 }
+				// phpcs:disable WordPress.NamingConventions.ValidVariableName -- to be refactored.
+				// We have to explicitly retrieve the avatar from the DB.
+				$dataArr['avatar'] = ( $contact_id !== -1 ) ? $zbs->DAL->contacts->getContactAvatar( $contact_id ) : '';
+				//phpcs:enable WordPress.NamingConventions.ValidVariableName
 
                 // make a copy for IA below (just fields)
                 $contactData = $dataArr;
-
-                #AVATARSAVE - save any avatar change if changed :)
-                if (isset($_POST['zbs-contact-avatar-custom-url']) && !empty($_POST['zbs-contact-avatar-custom-url'])) $dataArr['avatar'] = sanitize_text_field( $_POST['zbs-contact-avatar-custom-url'] );
                 
                 // Company assignment?
                 if (isset($_POST['zbs_company'])) $dataArr['companies'] = array((int)sanitize_text_field($_POST['zbs_company']));


### PR DESCRIPTION
Migrated from Jetpack CRM Repo https://github.com/Automattic/zero-bs-crm/pull/2826

## Proposed changes:

* From the PR:
```
This PR fixes the problem reported in https://github.com/Automattic/zero-bs-crm/issues/2736. The contact's avatar was removed when updating the contact.
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* See https://github.com/Automattic/zero-bs-crm/pull/2826
To test in the Jetpack monorepo, on a Jurassic Ninja Site include the Jetpack Beta tester plugin, and under Jetpack CRM enable this branch.
To test a build using a local development installation, run jetpack build plugins/crm, or jetpack build --production plugins/crm to test the build as if it were running in production.

