### PR TITLE
CRM: Migrate Escape Invoice ID

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-escape-invoice-id
+++ b/projects/plugins/crm/changelog/fix-crm-escape-invoice-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+CRM: Escaping an invoice ID in ZeroBSCRM.admin.invoicebuilder.js

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.invoicebuilder.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.invoicebuilder.js
@@ -425,7 +425,7 @@ function zbscrm_JS_draw_invoice_top_right_form( res ) {
 	} else {
 		html +=
 			'<input type="text" name="zbsi_ref" id="ref" class="form-control widetext" placeholder="" value="' +
-			res.invoiceObj.id_override +
+			jpcrm.esc_attr( res.invoiceObj.id_override ) +
 			'" autocomplete="zbsinv" />';
 	}
 	html += '</td>';


### PR DESCRIPTION
Migrated from Jetpack CRM repo https://github.com/Automattic/zero-bs-crm/pull/2824

## Proposed changes:

* See the original PR: https://github.com/Automattic/zero-bs-crm/pull/2824

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* See https://github.com/Automattic/zero-bs-crm/pull/2824
* To test in the Jetpack monorepo, on a Jurassic Ninja Site include the Jetpack Beta tester plugin, and under Jetpack CRM enable this branch.
* To test a build using a local development installation, with this PR checked out run `jetpack build plugins/crm`, or `jetpack build --production plugins/crm` to test the build as if it were running in production.

