### PR TITLE
CRM: Migrate Tag <strong> in the Client Portal Pro bundle notification

### DIFF
--- a/projects/plugins/crm/admin/contact/view.page.php
+++ b/projects/plugins/crm/admin/contact/view.page.php
@@ -1244,7 +1244,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 									<div style="margin-bottom:0;line-height: 1.8em;text-align:center" class="ui info segment">
 											<?php
 
-											esc_html_e( '<strong>Bundle holder:</strong> Please install the Client Portal Pro extension if you\'d like clients to view and upload their files via the Client Portal.', 'zero-bs-crm' );
+											echo wp_kses( __( '<strong>Bundle holder:</strong> Please install the Client Portal Pro extension if you\'d like clients to view and upload their files via the Client Portal.', 'zero-bs-crm' ), $zbs->acceptable_restricted_html );
 
 										}
 

--- a/projects/plugins/crm/changelog/fix-escape_client_portal_pro_notification
+++ b/projects/plugins/crm/changelog/fix-escape_client_portal_pro_notification
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+CRM:  fix the escape used in the "Bundle holder" notification when uploading files to a contact


### PR DESCRIPTION
Migrated from Jetpack CRM repo https://github.com/Automattic/zero-bs-crm/pull/2822

## Proposed changes:

* From the PR:
```
This PR fixes the escape used in the "Bundle holder" notification when uploading files to a contact
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* See https://github.com/Automattic/zero-bs-crm/pull/2822
* To test in the Jetpack monorepo, on a Jurassic Ninja Site include the Jetpack Beta tester plugin, and under Jetpack CRM enable this branch.
* To test a build using a local development installation, with this PR checked out run `jetpack build plugins/crm`, or `jetpack build --production plugins/crm` to test the build as if it were running in production.

