### PR TITLE
E2E tests: fix undefined page when waiting for blocks

### DIFF
--- a/tools/e2e-commons/helpers/blocks-helper.js
+++ b/tools/e2e-commons/helpers/blocks-helper.js
@@ -11,7 +11,7 @@ export async function waitForBlock( blockSlug, page ) {
 		// eslint-disable-next-line
 		await page.waitForTimeout( 1000 );
 		await page.reload( { waitUntil: 'domcontentloaded' } );
-		block = await findAvailableBlock( blockSlug );
+		block = await findAvailableBlock( blockSlug, page );
 		count += 1;
 	}
 }


### PR DESCRIPTION
## Proposed changes:

In the updates merged with #28805 I missed sending the page in a function call. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* e2e tests should pass

