### PR TITLE
CRM: Migrate Fix script tag not being properly opened

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm_form_shows_js_code
+++ b/projects/plugins/crm/changelog/fix-crm_form_shows_js_code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+CRM: add a missing < which prevented a <script> tag from being opened.

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Forms.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Forms.php
@@ -107,7 +107,7 @@
 
                 ?>
 
-               script type="text/javascript">var zbscrmjs_secToken = '<?php echo esc_js( wp_create_nonce( 'zbscrmjs-ajax-nonce' ) ); ?>';</script>
+				<script type="text/javascript">var zbscrmjs_secToken = '<?php echo esc_js( wp_create_nonce( 'zbscrmjs-ajax-nonce' ) ); ?>';</script>
                 
                 <table class="form-table wh-metatab wptbp">
                 <?php foreach ($zbsFormFields as $fieldK => $fieldV){


### PR DESCRIPTION
Migrated from Jetpack CRM repo https://github.com/Automattic/zero-bs-crm/pull/2823

## Proposed changes:

* From the PR:

> This is a simple PR that just adds a missing < which prevented a <script> tag from being opened.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* See https://github.com/Automattic/zero-bs-crm/pull/2823
* To test in the Jetpack monorepo, on a Jurassic Ninja Site include the Jetpack Beta tester plugin, and under Jetpack CRM enable this branch.
* To test a build using a local development installation, with this PR checked out run `jetpack build plugins/crm`, or `jetpack build --production plugins/crm` to test the build as if it were running in production.

