### PR TITLE
Allow Heart of Gold to manage their packages

### DIFF
--- a/.github/files/required-review.yaml
+++ b/.github/files/required-review.yaml
@@ -32,6 +32,8 @@
    - 'projects/plugins/jetpack/**'
    # Exclude packages managed by other teams, which are covered by other blocks below.
    - '!projects/js-packages/image-guide/**'
+   - '!projects/js-packages/svelte-data-sync-client/**'
+   - '!projects/packages/wp-js-data-sync/**'
    - '!projects/packages/backup/**'
    - '!projects/packages/search/**'
    - '!projects/packages/stats/**'


### PR DESCRIPTION
## Proposed changes:
`wp-js-sync` and `svelte-data-sync-client` packages are managed by @Automattic/heart-of-gold, this updates the GitHub permissions to not require a review by Crew.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
🦄