### PR TITLE
CRM: Migrate Fix escape in contact list filters

### DIFF
--- a/projects/plugins/crm/changelog/fix-esape_issue_on_contact_filter
+++ b/projects/plugins/crm/changelog/fix-esape_issue_on_contact_filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+CRM: Fix escape in contact list filters

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -532,9 +532,11 @@ class zeroBSCRM_list{
                                     <div id="zbs-list-view-filter-options-current" class="zbs-filter-manager-connected ui-sortable">
 
                                     <?php if (is_array($currentFilterButtons)) foreach ($currentFilterButtons as $filterButtonKey => $filterButton){
-
-                                        ?><div id="zbs-filter-manager-button-<?php echo esc_attr( $filterButtonKey ); ?>" class="ui basic button tiny zbs-filter-button-manager-button" data-key="<?php echo esc_attr( $filterButtonKey ); ?>"><?php echo esc_html( $filterButton[0] ); ?></div><?php
-
+										// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- to be refactored.
+										?>
+										<div id="zbs-filter-manager-button-<?php echo esc_attr( $filterButtonKey ); ?>" class="ui basic button tiny zbs-filter-button-manager-button" data-key="<?php echo esc_attr( $filterButtonKey ); ?>"><?php echo wp_kses( $filterButton[0], array( 'i' => array( 'class' => array() ) ) ); ?></div>
+										<?php
+										// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
                                     } ?>
 
 
@@ -553,7 +555,7 @@ class zeroBSCRM_list{
 										if ( ! array_key_exists( $filterButtonKey, $currentFilterButtons ) ) {
 
 											?>
-												<div id="zbs-filter-manager-button-<?php echo esc_attr( $filterButtonKey ); ?>" class="ui basic button tiny zbs-filter-button-manager-button" data-key="<?php echo esc_attr( $filterButtonKey ); ?>"><?php echo wp_kses( $filterButton[0], array( 'i' => array( 'class' ) ) ); ?></div>
+												<div id="zbs-filter-manager-button-<?php echo esc_attr( $filterButtonKey ); ?>" class="ui basic button tiny zbs-filter-button-manager-button" data-key="<?php echo esc_attr( $filterButtonKey ); ?>"><?php echo wp_kses( $filterButton[0], array( 'i' => array( 'class' => array() ) ) ); ?></div>
 												<?php
 
 										}
@@ -917,8 +919,14 @@ class zeroBSCRM_list{
 
                             if ($buttonCount > 0) echo ',';
                             
-                            #} Hard coded, lazy
-                            echo "{namestr:'". esc_html( zeroBSCRM_slashOut($button[0],true) ) ."',fieldstr:'". esc_html( $buttonKey ) ."'}";
+							// Hard coded, lazy
+							printf(
+								"{namestr:'%s',fieldstr:'%s'}",
+								wp_kses( $button[0], array( 'i' => array( 'class' => array() ) ) ),
+								// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- to be refactored.
+								esc_html( $buttonKey )
+								// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+							);
 
                             $buttonCount++;
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -549,12 +549,15 @@ class zeroBSCRM_list{
                                     <div id="zbs-list-view-filter-options-available" class="zbs-filter-manager-connected ui-sortable">
 
                                     <?php foreach ($allFilterButtons as $filterButtonKey => $filterButton){
+										// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- to be refactored.
+										if ( ! array_key_exists( $filterButtonKey, $currentFilterButtons ) ) {
 
-                                                if (!array_key_exists($filterButtonKey, $currentFilterButtons)){
+											?>
+												<div id="zbs-filter-manager-button-<?php echo esc_attr( $filterButtonKey ); ?>" class="ui basic button tiny zbs-filter-button-manager-button" data-key="<?php echo esc_attr( $filterButtonKey ); ?>"><?php echo wp_kses( $filterButton[0], array( 'i' => array( 'class' ) ) ); ?></div>
+												<?php
 
-                                                    ?><div id="zbs-filter-manager-button-<?php echo esc_attr( $filterButtonKey ); ?>" class="ui basic button tiny zbs-filter-button-manager-button" data-key="<?php echo esc_attr( $filterButtonKey ); ?>"><?php echo esc_html( $filterButton[0] ); ?></div><?php
-
-                                                }
+										}
+										// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
                                     } ?>
 


### PR DESCRIPTION
Migrated from Jetpack CRM repo https://github.com/Automattic/zero-bs-crm/pull/2821
This also includes the fix in https://github.com/Automattic/zero-bs-crm/pull/2845

## Proposed changes:

* From the PRs:

> Resolves https://github.com/Automattic/zero-bs-crm/issues/2748 - Fix escape in contact list filters
> This PR fixes a bug that makes `<i>` tags show (escaped) in the segment contact filter list.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* See https://github.com/Automattic/zero-bs-crm/pull/2821 and https://github.com/Automattic/zero-bs-crm/pull/2845
* To test in the Jetpack monorepo, on a Jurassic Ninja Site include the Jetpack Beta tester plugin, and under Jetpack CRM enable this branch.
* To test a build using a local development installation, with this PR checked out run `jetpack build plugins/crm`, or `jetpack build --production plugins/crm` to test the build as if it were running in production.

