### PR TITLE
E2E tests: catch partner provisioning command failures

### DIFF
--- a/tools/e2e-commons/env/prerequisites.js
+++ b/tools/e2e-commons/env/prerequisites.js
@@ -4,9 +4,9 @@ import {
 	execWpCommand,
 	getDotComCredentials,
 	isLocalSite,
-	provisionJetpackStartConnection,
 	resetWordpressInstall,
 } from '../helpers/utils-helper.cjs';
+import { provisionJetpackStartConnection } from '../helpers/partner-provisioning.js';
 import fs from 'fs';
 import config from 'config';
 import assert from 'assert';
@@ -121,7 +121,7 @@ async function connect() {
 		provisionJetpackStartConnection( creds.userId, 'free' );
 	} catch ( error ) {
 		// Let's try to re-try the provisioning if it fails the first time.
-		if ( error.message.startsWith( 'Jetpack Start provision is failed' ) ) {
+		if ( error.message.startsWith( 'Jetpack Start provisioning failed' ) ) {
 			provisionJetpackStartConnection( creds.userId, 'free' );
 		} else {
 			throw error;

--- a/tools/e2e-commons/helpers/partner-provisioning.js
+++ b/tools/e2e-commons/helpers/partner-provisioning.js
@@ -1,0 +1,48 @@
+import config from 'config';
+import path from 'path';
+import shellescape from 'shell-escape';
+import logger from '../logger.cjs';
+import { execSyncShellCommand, execWpCommand, resolveSiteUrl } from './utils-helper.cjs';
+import * as url from 'url';
+
+/**
+ * Provisions Jetpack plan and connects the site through Jetpack Start flow
+ *
+ * @param {number} userId WPCOM user ID
+ * @param {string} plan   One of free, personal, premium, or professional.
+ * @param {string} user   Local user name, id, or e-mail
+ * @return {string} authentication URL
+ */
+export async function provisionJetpackStartConnection( userId, plan = 'free', user = 'wordpress' ) {
+	logger.info( `Provisioning Jetpack start connection [userId: ${ userId }, plan: ${ plan }]` );
+	const [ clientID, clientSecret ] = config.get( 'jetpackStartSecrets' );
+	const __dirname = url.fileURLToPath( new URL( '.', import.meta.url ) );
+	const cmd = `sh ${ path.resolve(
+		__dirname,
+		'../../partner-provision.sh'
+	) } --partner_id=${ clientID } --partner_secret=${ clientSecret } --user=${ user } --plan=${ plan } --url=${ resolveSiteUrl() } --wpcom_user_id=${ userId }`;
+
+	let response;
+	// catch a command failed error so that secrets are not logged
+	try {
+		response = execSyncShellCommand( cmd );
+	} catch ( error ) {
+		throw new Error( `Jetpack Start provisioning command failed.` );
+	}
+
+	const json = JSON.parse( response );
+
+	if ( json.success ) {
+		logger.cli( 'Successful provisioning' );
+	} else {
+		throw new Error( `'Jetpack Start provisioning failed: ${ json.error }` );
+	}
+
+	await execWpCommand(
+		`jetpack authorize_user --user=${ user } ` + shellescape( [ `--token=${ json.access_token }` ] )
+	);
+
+	await execWpCommand( 'jetpack status' );
+
+	return true;
+}


### PR DESCRIPTION
## Proposed changes:

* Catch partner provision script execution errors and don't log the command.
* Moved the partner provisioning function into its own file

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1675863693656559-slack-C03QNBQKG73

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* e2e tests should pass