### PR TITLE
CRM: Migrate Trailing comma breaking Php 7.2

### DIFF
--- a/projects/plugins/crm/changelog/fix-trailing_comma_breaking_php_7_2
+++ b/projects/plugins/crm/changelog/fix-trailing_comma_breaking_php_7_2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: In this case, just comments have been edited.
+
+

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Export.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Export.php
@@ -299,11 +299,11 @@ function jpcrm_export_process_file_export() {
 
 				} elseif ( $extraParams['segment'] ) {
 
-					// retrieve segment
+					// Retrieve segment.
 					$availObjs = $zbs->DAL->segments->getSegmentAudience(
 						$extraParams['segment']['id'],
-						-1, // all, no paging
-						-1 // all, no paging
+						-1, // All, no paging.
+						-1 // All, no paging.
 					);
 
 				} else {


### PR DESCRIPTION
Migrated from Jetpack CRM repo https://github.com/Automattic/zero-bs-crm/pull/2844

## Proposed changes:

* The original PR said:
> In our v5.5.2 we released a function with a trailing comma, which breaks the whole WordPress site for PHP 7.2.
This PR fixes this problem.
* In this case, only comments have been changed to match those in the original PR, as in the move over to the monorepo the trailing comma has actually been removed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* In this case testing isn't really required as it's just a few comments edited to match the original PR. Just proof-reading.

