### PR TITLE
Move dialogue and conversation blocks to beta

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-dialogue-and-conversation-block-from-experimental
+++ b/projects/plugins/jetpack/changelog/remove-dialogue-and-conversation-block-from-experimental
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Move dialogue and conversation editor extensions back to beta, as they were not released to wordpress.com users

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -46,6 +46,8 @@
 	],
 	"beta": [
 		"amazon",
+		"conversation",
+		"dialogue",
 		"google-docs-embed",
 		"launchpad-save-modal",
 		"post-publish-promote-post-panel",
@@ -58,9 +60,7 @@
 		"ai-paragraph",
 		"anchor-fm",
 		"blogging-prompts",
-		"premium-content",
-		"conversation",
-		"dialogue"
+		"premium-content"
 	],
 	"no-post-editor": [
 		"business-hours",


### PR DESCRIPTION
## Proposed changes:

Moves the dialogue and conversation editor extensions from the experimental build, back to beta. They remain behind a flag, and at this point, they are not going to be launched to users.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See pdWQjU-dR-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

- Verify that the editor extensions are available when `JETPACK_BETA_BLOCKS` is set, but not when `JETPACK_EXPERIMENTAL_BLOCKS` is set.