### PR TITLE
WAF: Prevent errors when autoloaded classes are out of date

### DIFF
--- a/projects/packages/waf/changelog/patch-waf-update-fatal
+++ b/projects/packages/waf/changelog/patch-waf-update-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix an update error that impacted sites using the WAF in standalone mode.

--- a/projects/packages/waf/src/class-waf-constants.php
+++ b/projects/packages/waf/src/class-waf-constants.php
@@ -25,6 +25,14 @@ class Waf_Constants {
 	}
 
 	/**
+	 * Compatiblity patch for cases where an outdated Waf_Constants class has been autoloaded by
+	 * the standalone bootstrap execution at the beginning of the current request.
+	 */
+	public static function initialize_constants() {
+		self::initialize_bootstrap_constants();
+	}
+
+	/**
 	 * Set the path to the WAF directory if it has not been set.
 	 *
 	 * @return void

--- a/projects/packages/waf/src/class-waf-initializer.php
+++ b/projects/packages/waf/src/class-waf-initializer.php
@@ -111,6 +111,12 @@ class Waf_Initializer {
 	 */
 	public static function check_for_waf_update() {
 		if ( get_option( self::NEEDS_UPDATE_OPTION_NAME ) ) {
+			// Compatiblity patch for cases where an outdated WAF_Constants class has been
+			// autoloaded by the standalone bootstrap execution at the beginning of the current request.
+			if ( ! method_exists( Waf_Constants::class, 'define_mode' ) ) {
+				return;
+			}
+
 			Waf_Constants::define_mode();
 			if ( ! Waf_Runner::is_allowed_mode( JETPACK_WAF_MODE ) ) {
 				return;

--- a/projects/packages/waf/src/class-waf-initializer.php
+++ b/projects/packages/waf/src/class-waf-initializer.php
@@ -114,6 +114,7 @@ class Waf_Initializer {
 			// Compatiblity patch for cases where an outdated WAF_Constants class has been
 			// autoloaded by the standalone bootstrap execution at the beginning of the current request.
 			if ( ! method_exists( Waf_Constants::class, 'define_mode' ) ) {
+				( new Waf_Standalone_Bootstrap() )->generate();
 				return;
 			}
 

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -190,7 +190,7 @@ class Waf_Runner {
 			return;
 		}
 
-		Waf_Constants::initialize_bootstrap_constants();
+		Waf_Constants::initialize_constants();
 
 		// if ABSPATH is defined, then WordPress has already been instantiated,
 		// and we're running as a plugin (meh). Otherwise, we're running via something

--- a/projects/packages/waf/src/class-waf-standalone-bootstrap.php
+++ b/projects/packages/waf/src/class-waf-standalone-bootstrap.php
@@ -42,13 +42,7 @@ class Waf_Standalone_Bootstrap {
 	 * @return void
 	 */
 	private function initialize_constants() {
-		// Compatiblity patch for cases where an outdated Waf_Constants class has been
-		// autoloaded by the standalone bootstrap execution at the beginning of the current request.
-		if ( method_exists( Waf_Constants::class, 'initialize_bootstrap_constants' ) ) {
-			Waf_Constants::initialize_bootstrap_constants();
-		} elseif ( method_exists( Waf_Constants::class, 'initialize_constants' ) ) {
-			Waf_Constants::initialize_constants();
-		}
+		Waf_Constants::initialize_constants();
 	}
 
 	/**

--- a/projects/packages/waf/src/class-waf-standalone-bootstrap.php
+++ b/projects/packages/waf/src/class-waf-standalone-bootstrap.php
@@ -42,7 +42,13 @@ class Waf_Standalone_Bootstrap {
 	 * @return void
 	 */
 	private function initialize_constants() {
-		Waf_Constants::initialize_bootstrap_constants();
+		// Compatiblity patch for cases where an outdated Waf_Constants class has been
+		// autoloaded by the standalone bootstrap execution at the beginning of the current request.
+		if ( method_exists( Waf_Constants::class, 'initialize_bootstrap_constants' ) ) {
+			Waf_Constants::initialize_bootstrap_constants();
+		} elseif ( method_exists( Waf_Constants::class, 'initialize_constants' ) ) {
+			Waf_Constants::initialize_constants();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #28819

This PR patches potential errors that occur when a site has two versions of the WAF package installed via Jetpack and Jetpack Protect plugins, and has one of the package's classes autoloaded via the standalone mode bootstrap.php file at the beginning of each PHP request.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Prevents WAF update from running if the required `Waf_Constant::define_mode` methods are not available, and just updates the bootstrap file instead, so the update can run on the next request.
* Re-introduces the `initialize_constants` method to `Waf_Constants`, to prevent undefined method issues from the old package attempting to call the new `initialize_bootstrap_constants` method.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1675805859785799-slack-C029WFNV69M

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a Jurassic Ninja site
* Install Jetpack Protect
* Activate the WAF
* Set up standalone mode
  * Create a `.user.ini` file in the `public` directory with the following content: `auto_prepend_file = "/srv/users/USER/apps/USER/public/wp-content/jetpack-waf/bootstrap.php"`
* Install Jetpack 11.8
* Validate the fatal
* Update to this branch
* Validate the lack of fatal
* Test WAF execution on page loads, WAF settings updates, toggling on/off, etc.

## Demo

🎥 https://drive.google.com/file/d/16E85zemFhhtb-uyw0iDvskycosVDl0ND/view?usp=share_link