### PR TITLE
VideoPress dashboard: Disable local video upload for free plan after first upload

### DIFF
--- a/projects/packages/videopress/changelog/fix-disable-local-video-upload-free
+++ b/projects/packages/videopress/changelog/fix-disable-local-video-upload-free
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: disable upload button for local videos when it will not work
+
+

--- a/projects/packages/videopress/src/client/admin/components/video-list/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-list/index.tsx
@@ -7,14 +7,16 @@ import { __ } from '@wordpress/i18n';
 import { Icon, info, warning } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useState } from 'react';
-/**
- * Internal dependencies
- */
 import {
 	ERROR_MIME_TYPE_NOT_SUPPORTED,
 	VIDEO_PRIVACY_LEVELS,
 	VIDEO_PRIVACY_LEVEL_PRIVATE,
 } from '../../../state/constants';
+import { usePlan } from '../../hooks/use-plan';
+import useVideos from '../../hooks/use-videos';
+/**
+ * Internal dependencies
+ */
 import Checkbox from '../checkbox';
 import ConnectVideoRow, { LocalVideoRow, Stats } from '../video-row';
 import styles from './style.module.scss';
@@ -120,6 +122,9 @@ export const LocalVideoList = ( {
 	const [ isSmall ] = useBreakpointMatch( 'sm' );
 	const allSelected = selected?.length === videos?.length;
 	const showCheckbox = false; // TODO: implement bulk actions
+	const { hasVideoPressPurchase } = usePlan();
+	const { uploadedVideoCount, isFetching } = useVideos();
+	const hasVideos = uploadedVideoCount > 0 || isFetching || uploading?.length > 0;
 
 	const handleAll = checked => {
 		if ( checked ) {
@@ -205,7 +210,7 @@ export const LocalVideoList = ( {
 						onActionClick={ handleClickWithIndex( index ) }
 						actionButtonLabel={ __( 'Upload to VideoPress', 'jetpack-videopress-pkg' ) }
 						disabled={ video?.isUploadedToVideoPress || video?.readError != null }
-						disableActionButton={ uploading }
+						disableActionButton={ ( hasVideos && ! hasVideoPressPurchase ) || uploading }
 						titleAdornment={ getTitleAdornment( video ) }
 					/>
 				);

--- a/projects/packages/videopress/src/client/admin/components/video-list/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-list/index.tsx
@@ -7,6 +7,9 @@ import { __ } from '@wordpress/i18n';
 import { Icon, info, warning } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useState } from 'react';
+/**
+ * Internal dependencies
+ */
 import {
 	ERROR_MIME_TYPE_NOT_SUPPORTED,
 	VIDEO_PRIVACY_LEVELS,
@@ -14,9 +17,6 @@ import {
 } from '../../../state/constants';
 import { usePlan } from '../../hooks/use-plan';
 import useVideos from '../../hooks/use-videos';
-/**
- * Internal dependencies
- */
 import Checkbox from '../checkbox';
 import ConnectVideoRow, { LocalVideoRow, Stats } from '../video-row';
 import styles from './style.module.scss';


### PR DESCRIPTION
Fixes: https://github.com/Automattic/jetpack/issues/27561

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disable the local video upload button for sites on a free plan when a video has already been uploaded or is being uploaded:
 
<img width="1010" alt="Screenshot 2023-02-08 at 18 16 24" src="https://user-images.githubusercontent.com/16329583/217603663-1673fa6b-9df8-4859-a42d-a2cb560db58f.png">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No 
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Launch a  site with the VideoPress standalone plugin 
* Go to WordPress media and upload a local video
* Connect the site to Jetpack under a free plan
* Upload a video to VideoPress and confirm that the button is disabled
* Delete the VideoPress video or upgrade your plan and confirm that the button is enabled

