### PR TITLE
Stats: Add notice status control endpoint

### DIFF
--- a/projects/packages/stats-admin/changelog/add-stats-notice-status-control
+++ b/projects/packages/stats-admin/changelog/add-stats-notice-status-control
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: Adds support for Notice control

--- a/projects/packages/stats-admin/composer.json
+++ b/projects/packages/stats-admin/composer.json
@@ -50,7 +50,7 @@
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-stats-admin",
 		"branch-alias": {
-			"dev-trunk": "0.5.x-dev"
+			"dev-trunk": "0.6.x-dev"
 		},
 		"textdomain": "jetpack-stats-admin",
 		"version-constants": {

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.5.1-alpha",
+	"version": "0.6.0-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -255,7 +255,7 @@ class Dashboard {
 								'wordads'   => ( new Modules() )->is_active( 'wordads' ),
 								'admin_url' => admin_url(),
 							),
-							'stats_notices' => Notices::get_notices_to_show(),
+							'stats_notices' => ( new Notices() )->get_notices_to_show(),
 						),
 					),
 					'features' => array( "$blog_id" => array( 'data' => self::get_plan_features() ) ),

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -86,6 +86,12 @@ class Dashboard {
 	 * Override render funtion
 	 */
 	public function render() {
+		// Record the number of views of the stats dashboard on the initial several loads for the purpose of showing feedback notice.
+		$views = intval( Stats_Options::get_option( 'views' ) ) + 1;
+		if ( $views <= Notices::VIEWS_TO_SHOW_FEEDBACK ) {
+			Stats_Options::set_option( 'views', $views );
+		}
+
 		?>
 		<div id="wpcom" class="jp-stats-dashboard" style="min-height: calc(100vh - 100px);">
 			<div class="hide-if-js"><?php esc_html_e( 'Your Jetpack Stats dashboard requires JavaScript to function properly.', 'jetpack-stats-admin' ); ?></div>
@@ -249,10 +255,7 @@ class Dashboard {
 								'wordads'   => ( new Modules() )->is_active( 'wordads' ),
 								'admin_url' => admin_url(),
 							),
-							'stats_notices' => array(
-								'opt_out_new_stats'  => self::has_opt_out_new_stats_notice(),
-								'new_stats_feedback' => true,
-							),
+							'stats_notices' => Notices::get_notices_to_show(),
 						),
 					),
 					'features' => array( "$blog_id" => array( 'data' => self::get_plan_features() ) ),

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -249,7 +249,10 @@ class Dashboard {
 								'wordads'   => ( new Modules() )->is_active( 'wordads' ),
 								'admin_url' => admin_url(),
 							),
-							'stats_notices' => array( 'opt_out_new_stats' => self::has_opt_out_new_stats_notice() ),
+							'stats_notices' => array(
+								'opt_out_new_stats'  => self::has_opt_out_new_stats_notice(),
+								'new_stats_feedback' => true,
+							),
 						),
 					),
 					'features' => array( "$blog_id" => array( 'data' => self::get_plan_features() ) ),

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -18,7 +18,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.5.1-alpha';
+	const VERSION = '0.6.0-alpha';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats-admin/src/class-notices.php
+++ b/projects/packages/stats-admin/src/class-notices.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * A class that handles the notices for the Stats Admin dashboard.
+ *
+ * @package automattic/jetpack-stats-admin
+ */
+
+namespace Automattic\Jetpack\Stats_Admin;
+
+use Automattic\Jetpack\Stats\Options as Stats_Options;
+
+/**
+ * The Notices class handles the notices for the Stats Admin dashboard.
+ *
+ * @package Automattic\Jetpack\Stats_Admin
+ */
+class Notices {
+	const OPT_OUT_NEW_STATS_NOTICE_ID  = 'opt_out_new_stats';
+	const NEW_STATS_FEEDBACK_NOTICE_ID = 'new_stats_feedback';
+	const OPT_IN_NEW_STATS_NOTICE_ID   = 'opt_in_new_stats';
+
+	const NOTICE_STATUS_DISMISSED = 'dismissed';
+	const NOTICE_STATUS_POSTPONED = 'postponed';
+
+	const VIEWS_TO_SHOW_FEEDBACK = 3;
+	const POSTPONE_FEEDBACK_DAYS = 30;
+
+	/**
+	 * Update the notice status.
+	 *
+	 * @param mixed $id ID of the notice.
+	 * @param mixed $status Status of the notice.
+	 * @return bool
+	 */
+	public static function update_notice( $id, $status ) {
+		$notices        = Stats_Options::get_option( 'notices' );
+		$notices[ $id ] = array(
+			'status'       => $status,
+			'id'           => $id,
+			'dismissed_at' => time(),
+			'next_show_at' => $status === self::NOTICE_STATUS_POSTPONED ? time() + self::POSTPONE_FEEDBACK_DAYS * DAY_IN_SECONDS : PHP_INT_MAX,
+		);
+		return Stats_Options::set_option( 'notices', $notices );
+	}
+
+	/**
+	 * For now, we support only one notice at a time.
+	 *
+	 * @return array
+	 */
+	public static function get_notices_to_show() {
+		$new_stats_enabled = Stats_Options::get_option( 'enable_odyssey_stats' );
+		if ( ! $new_stats_enabled ) {
+			return array();
+		}
+
+		// Views > 3 and not dismissed, we show the feedback notice.
+		if ( self::get_new_stats_views() >= self::VIEWS_TO_SHOW_FEEDBACK && ! self::is_notice_hidden( self::OPT_OUT_NEW_STATS_NOTICE_ID ) ) {
+			return array(
+				self::NEW_STATS_FEEDBACK_NOTICE_ID => true,
+			);
+		}
+
+		// If opt-out notice is not dismissed, we show it.
+		if ( ! self::is_notice_hidden( self::OPT_OUT_NEW_STATS_NOTICE_ID ) ) {
+			return array(
+				self::OPT_OUT_NEW_STATS_NOTICE_ID => true,
+			);
+		}
+		return array();
+	}
+
+	/**
+	 * Returns the array of hidden notice IDs.
+	 *
+	 * @return array Array of hidden notice IDs.
+	 */
+	public static function get_hidden_notice_ids() {
+		static $hidden_notice_ids;
+		$notices = Stats_Options::get_option( 'notices' );
+
+		$hidden_notice_ids = array_map(
+			function ( $notice, $id ) {
+				if ( ! isset( $notice['status'] ) ) {
+					return false;
+				}
+				switch ( $notice['status'] ) {
+					case 'dismissed':
+						return $id;
+					case 'postponed':
+						return $notice['next_show_at'] < time() ? $id : false;
+					default:
+						return false;
+				}
+			},
+			$notices
+		);
+		$hidden_notice_ids = array_filter( $hidden_notice_ids );
+		return $hidden_notice_ids;
+	}
+
+	/**
+	 * Checks if a notice is hidden.
+	 *
+	 * @param mixed $id ID of the notice.
+	 * @return bool
+	 */
+	public static function is_notice_hidden( $id ) {
+		return in_array( $id, self::get_hidden_notice_ids(), true );
+	}
+
+	/**
+	 * Returns the number of views of the new stats dashboard.
+	 */
+	public static function get_new_stats_views() {
+		return Stats_Options::get_option( 'views' );
+	}
+}

--- a/projects/packages/stats-admin/src/class-notices.php
+++ b/projects/packages/stats-admin/src/class-notices.php
@@ -50,8 +50,9 @@ class Notices {
 	 */
 	public function get_notices_to_show() {
 		$new_stats_enabled = Stats_Options::get_option( 'enable_odyssey_stats' );
-		if ( ! $new_stats_enabled ) {
-			return array();
+
+		if ( ! $new_stats_enabled && ! $this->is_notice_hidden( self::NEW_STATS_FEEDBACK_NOTICE_ID ) ) {
+			return array( self::OPT_IN_NEW_STATS_NOTICE_ID => true );
 		}
 
 		// Views > 3 and not dismissed, we show the feedback notice.

--- a/projects/packages/stats-admin/src/class-notices.php
+++ b/projects/packages/stats-admin/src/class-notices.php
@@ -39,8 +39,11 @@ class Notices {
 			'status'       => $status,
 			'id'           => $id,
 			'dismissed_at' => time(),
-			'next_show_at' => $status === self::NOTICE_STATUS_POSTPONED ? time() + $postponed_for : PHP_INT_MAX,
 		);
+		// Set the next show time if the notice is postponed.
+		if ( $status === self::NOTICE_STATUS_POSTPONED && $postponed_for > 0 ) {
+			$notices[ $id ]['next_show_at'] = time() + $postponed_for;
+		}
 		return Stats_Options::set_option( 'notices', $notices );
 	}
 
@@ -92,7 +95,7 @@ class Notices {
 					case 'dismissed':
 						return true;
 					case 'postponed':
-						return $notice['next_show_at'] > time();
+						return $notice['next_show_at'] === 0 || $notice['next_show_at'] > time();
 					default:
 						return false;
 				}

--- a/projects/packages/stats-admin/src/class-notices.php
+++ b/projects/packages/stats-admin/src/class-notices.php
@@ -71,7 +71,7 @@ class Notices {
 	public function get_hidden_notices() {
 		$notices = Stats_Options::get_option( 'notices' );
 
-		$hidden_notice_ids = array_filter(
+		$hidden_notices = array_filter(
 			$notices,
 			function ( $notice ) {
 				if ( ! isset( $notice['status'] ) ) {
@@ -89,7 +89,7 @@ class Notices {
 			ARRAY_FILTER_USE_BOTH
 		);
 
-		return $hidden_notice_ids;
+		return $hidden_notices;
 	}
 
 	/**

--- a/projects/packages/stats-admin/src/class-notices.php
+++ b/projects/packages/stats-admin/src/class-notices.php
@@ -54,26 +54,13 @@ class Notices {
 	 */
 	public function get_notices_to_show() {
 		$new_stats_enabled = Stats_Options::get_option( 'enable_odyssey_stats' );
+		$stats_views       = $this->get_new_stats_views();
 
-		// Show opt in notice shown on legacy stats if new stats is disabled.
-		if ( ! $new_stats_enabled && ! $this->is_notice_hidden( self::OPT_IN_NEW_STATS_NOTICE_ID ) ) {
-			return array( self::OPT_IN_NEW_STATS_NOTICE_ID => true );
-		}
-
-		// Views > 3 and not hidden, show the feedback notice.
-		if ( $this->get_new_stats_views() >= self::VIEWS_TO_SHOW_FEEDBACK && ! $this->is_notice_hidden( self::NEW_STATS_FEEDBACK_NOTICE_ID ) ) {
-			return array(
-				self::NEW_STATS_FEEDBACK_NOTICE_ID => true,
-			);
-		}
-
-		// If opt-out notice is not hidden, we show it.
-		if ( ! $this->is_notice_hidden( self::OPT_OUT_NEW_STATS_NOTICE_ID ) ) {
-			return array(
-				self::OPT_OUT_NEW_STATS_NOTICE_ID => true,
-			);
-		}
-		return array();
+		return array(
+			self::OPT_IN_NEW_STATS_NOTICE_ID   => ! $new_stats_enabled && ! $this->is_notice_hidden( self::OPT_IN_NEW_STATS_NOTICE_ID ),
+			self::NEW_STATS_FEEDBACK_NOTICE_ID => $new_stats_enabled && $stats_views >= self::VIEWS_TO_SHOW_FEEDBACK && ! $this->is_notice_hidden( self::NEW_STATS_FEEDBACK_NOTICE_ID ),
+			self::OPT_OUT_NEW_STATS_NOTICE_ID  => $new_stats_enabled && $stats_views < self::VIEWS_TO_SHOW_FEEDBACK && ! $this->is_notice_hidden( self::OPT_OUT_NEW_STATS_NOTICE_ID ),
+		);
 	}
 
 	/**

--- a/projects/packages/stats-admin/src/class-notices.php
+++ b/projects/packages/stats-admin/src/class-notices.php
@@ -48,7 +48,7 @@ class Notices {
 	}
 
 	/**
-	 * For now, we support only one notice at a time.
+	 * Return an array of notices IDs as keys and their value to flag whther to show them.
 	 *
 	 * @return array
 	 */
@@ -64,9 +64,9 @@ class Notices {
 	}
 
 	/**
-	 * Returns the array of hidden notice IDs.
+	 * Returns the array of hidden notices.
 	 *
-	 * @return array Array of hidden notice IDs.
+	 * @return array Array of hidden notices.
 	 */
 	public function get_hidden_notices() {
 		$notices = Stats_Options::get_option( 'notices' );

--- a/projects/packages/stats-admin/src/class-notices.php
+++ b/projects/packages/stats-admin/src/class-notices.php
@@ -52,18 +52,19 @@ class Notices {
 	public function get_notices_to_show() {
 		$new_stats_enabled = Stats_Options::get_option( 'enable_odyssey_stats' );
 
+		// Show opt in notice shown on legacy stats if new stats is disabled.
 		if ( ! $new_stats_enabled && ! $this->is_notice_hidden( self::OPT_IN_NEW_STATS_NOTICE_ID ) ) {
 			return array( self::OPT_IN_NEW_STATS_NOTICE_ID => true );
 		}
 
-		// Views > 3 and not dismissed, we show the feedback notice.
+		// Views > 3 and not hidden, show the feedback notice.
 		if ( $this->get_new_stats_views() >= self::VIEWS_TO_SHOW_FEEDBACK && ! $this->is_notice_hidden( self::NEW_STATS_FEEDBACK_NOTICE_ID ) ) {
 			return array(
 				self::NEW_STATS_FEEDBACK_NOTICE_ID => true,
 			);
 		}
 
-		// If opt-out notice is not dismissed, we show it.
+		// If opt-out notice is not hidden, we show it.
 		if ( ! $this->is_notice_hidden( self::OPT_OUT_NEW_STATS_NOTICE_ID ) ) {
 			return array(
 				self::OPT_OUT_NEW_STATS_NOTICE_ID => true,

--- a/projects/packages/stats-admin/src/class-notices.php
+++ b/projects/packages/stats-admin/src/class-notices.php
@@ -51,7 +51,7 @@ class Notices {
 	public function get_notices_to_show() {
 		$new_stats_enabled = Stats_Options::get_option( 'enable_odyssey_stats' );
 
-		if ( ! $new_stats_enabled && ! $this->is_notice_hidden( self::NEW_STATS_FEEDBACK_NOTICE_ID ) ) {
+		if ( ! $new_stats_enabled && ! $this->is_notice_hidden( self::OPT_IN_NEW_STATS_NOTICE_ID ) ) {
 			return array( self::OPT_IN_NEW_STATS_NOTICE_ID => true );
 		}
 

--- a/projects/packages/stats-admin/src/class-notices.php
+++ b/projects/packages/stats-admin/src/class-notices.php
@@ -32,7 +32,7 @@ class Notices {
 	 * @param mixed $status Status of the notice.
 	 * @return bool
 	 */
-	public static function update_notice( $id, $status ) {
+	public function update_notice( $id, $status ) {
 		$notices        = Stats_Options::get_option( 'notices' );
 		$notices[ $id ] = array(
 			'status'       => $status,
@@ -48,21 +48,21 @@ class Notices {
 	 *
 	 * @return array
 	 */
-	public static function get_notices_to_show() {
+	public function get_notices_to_show() {
 		$new_stats_enabled = Stats_Options::get_option( 'enable_odyssey_stats' );
 		if ( ! $new_stats_enabled ) {
 			return array();
 		}
 
 		// Views > 3 and not dismissed, we show the feedback notice.
-		if ( self::get_new_stats_views() >= self::VIEWS_TO_SHOW_FEEDBACK && ! self::is_notice_hidden( self::NEW_STATS_FEEDBACK_NOTICE_ID ) ) {
+		if ( $this->get_new_stats_views() >= self::VIEWS_TO_SHOW_FEEDBACK && ! $this->is_notice_hidden( self::NEW_STATS_FEEDBACK_NOTICE_ID ) ) {
 			return array(
 				self::NEW_STATS_FEEDBACK_NOTICE_ID => true,
 			);
 		}
 
 		// If opt-out notice is not dismissed, we show it.
-		if ( ! self::is_notice_hidden( self::OPT_OUT_NEW_STATS_NOTICE_ID ) ) {
+		if ( ! $this->is_notice_hidden( self::OPT_OUT_NEW_STATS_NOTICE_ID ) ) {
 			return array(
 				self::OPT_OUT_NEW_STATS_NOTICE_ID => true,
 			);
@@ -75,7 +75,7 @@ class Notices {
 	 *
 	 * @return array Array of hidden notice IDs.
 	 */
-	public static function get_hidden_notices() {
+	public function get_hidden_notices() {
 		static $hidden_notice_ids;
 		$notices = Stats_Options::get_option( 'notices' );
 
@@ -106,14 +106,14 @@ class Notices {
 	 * @param mixed $id ID of the notice.
 	 * @return bool
 	 */
-	public static function is_notice_hidden( $id ) {
-		return array_key_exists( $id, self::get_hidden_notices() );
+	public function is_notice_hidden( $id ) {
+		return array_key_exists( $id, $this->get_hidden_notices() );
 	}
 
 	/**
 	 * Returns the number of views of the new stats dashboard.
 	 */
-	public static function get_new_stats_views() {
+	public function get_new_stats_views() {
 		return Stats_Options::get_option( 'views' );
 	}
 }

--- a/projects/packages/stats-admin/src/class-notices.php
+++ b/projects/packages/stats-admin/src/class-notices.php
@@ -55,7 +55,7 @@ class Notices {
 		}
 
 		// Views > 3 and not dismissed, we show the feedback notice.
-		if ( self::get_new_stats_views() >= self::VIEWS_TO_SHOW_FEEDBACK && ! self::is_notice_hidden( self::OPT_OUT_NEW_STATS_NOTICE_ID ) ) {
+		if ( self::get_new_stats_views() >= self::VIEWS_TO_SHOW_FEEDBACK && ! self::is_notice_hidden( self::NEW_STATS_FEEDBACK_NOTICE_ID ) ) {
 			return array(
 				self::NEW_STATS_FEEDBACK_NOTICE_ID => true,
 			);
@@ -75,27 +75,28 @@ class Notices {
 	 *
 	 * @return array Array of hidden notice IDs.
 	 */
-	public static function get_hidden_notice_ids() {
+	public static function get_hidden_notices() {
 		static $hidden_notice_ids;
 		$notices = Stats_Options::get_option( 'notices' );
 
-		$hidden_notice_ids = array_map(
-			function ( $notice, $id ) {
+		$hidden_notice_ids = array_filter(
+			$notices,
+			function ( $notice ) {
 				if ( ! isset( $notice['status'] ) ) {
 					return false;
 				}
 				switch ( $notice['status'] ) {
 					case 'dismissed':
-						return $id;
+						return true;
 					case 'postponed':
-						return $notice['next_show_at'] < time() ? $id : false;
+						return $notice['next_show_at'] > time();
 					default:
 						return false;
 				}
 			},
-			$notices
+			ARRAY_FILTER_USE_BOTH
 		);
-		$hidden_notice_ids = array_filter( $hidden_notice_ids );
+
 		return $hidden_notice_ids;
 	}
 
@@ -106,7 +107,7 @@ class Notices {
 	 * @return bool
 	 */
 	public static function is_notice_hidden( $id ) {
-		return in_array( $id, self::get_hidden_notice_ids(), true );
+		return array_key_exists( $id, self::get_hidden_notices() );
 	}
 
 	/**

--- a/projects/packages/stats-admin/src/class-notices.php
+++ b/projects/packages/stats-admin/src/class-notices.php
@@ -30,15 +30,16 @@ class Notices {
 	 *
 	 * @param mixed $id ID of the notice.
 	 * @param mixed $status Status of the notice.
+	 * @param int   $postponed_for Postponed for how many seconds.
 	 * @return bool
 	 */
-	public function update_notice( $id, $status ) {
+	public function update_notice( $id, $status, $postponed_for = self::POSTPONE_FEEDBACK_DAYS * DAY_IN_SECONDS ) {
 		$notices        = Stats_Options::get_option( 'notices' );
 		$notices[ $id ] = array(
 			'status'       => $status,
 			'id'           => $id,
 			'dismissed_at' => time(),
-			'next_show_at' => $status === self::NOTICE_STATUS_POSTPONED ? time() + self::POSTPONE_FEEDBACK_DAYS * DAY_IN_SECONDS : PHP_INT_MAX,
+			'next_show_at' => $status === self::NOTICE_STATUS_POSTPONED ? time() + $postponed_for : PHP_INT_MAX,
 		);
 		return Stats_Options::set_option( 'notices', $notices );
 	}

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -161,7 +161,7 @@ class REST_Controller {
 				'args'                => array(
 					'id'     => array(
 						'required'    => true,
-						'type'        => 'number',
+						'type'        => 'string',
 						'description' => 'ID of the notice',
 						'enum'        => array(
 							Notices::OPT_IN_NEW_STATS_NOTICE_ID,
@@ -471,7 +471,7 @@ class REST_Controller {
 	 * @return array
 	 */
 	public function update_notice_status( $req ) {
-		return Notices::update_notice( $req->param['id'], $req->param['status'] );
+		return Notices::update_notice( $req->get_param( 'id' ), $req->get_param( 'status' ) );
 	}
 
 	/**

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -471,7 +471,7 @@ class REST_Controller {
 	 * @return array
 	 */
 	public function update_notice_status( $req ) {
-		return Notices::update_notice( $req->get_param( 'id' ), $req->get_param( 'status' ) );
+		return ( new Notices() )->update_notice( $req->get_param( 'id' ), $req->get_param( 'status' ) );
 	}
 
 	/**

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -159,7 +159,7 @@ class REST_Controller {
 				'callback'            => array( $this, 'update_notice_status' ),
 				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
 				'args'                => array(
-					'id'     => array(
+					'id'            => array(
 						'required'    => true,
 						'type'        => 'string',
 						'description' => 'ID of the notice',
@@ -169,7 +169,7 @@ class REST_Controller {
 							Notices::NEW_STATS_FEEDBACK_NOTICE_ID,
 						),
 					),
-					'status' => array(
+					'status'        => array(
 						'required'    => true,
 						'type'        => 'string',
 						'description' => 'Status of the notice',
@@ -177,6 +177,12 @@ class REST_Controller {
 							Notices::NOTICE_STATUS_DISMISSED,
 							Notices::NOTICE_STATUS_POSTPONED,
 						),
+					),
+					'postponed_for' => array(
+						'type'        => 'number',
+						'default'     => null,
+						'description' => 'Postponed for (in seconds)',
+						'minimum'     => 0,
 					),
 				),
 			)
@@ -471,7 +477,7 @@ class REST_Controller {
 	 * @return array
 	 */
 	public function update_notice_status( $req ) {
-		return ( new Notices() )->update_notice( $req->get_param( 'id' ), $req->get_param( 'status' ) );
+		return ( new Notices() )->update_notice( $req->get_param( 'id' ), $req->get_param( 'status' ), $req->get_param( 'postponed_for' ) );
 	}
 
 	/**

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -10,7 +10,6 @@ namespace Automattic\Jetpack\Stats_Admin;
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Constants;
-use Automattic\Jetpack\Stats\Options as Stats_Options;
 use Automattic\Jetpack\Stats\WPCOM_Stats;
 use Jetpack_Options;
 use WP_Error;
@@ -165,8 +164,9 @@ class REST_Controller {
 						'type'        => 'number',
 						'description' => 'ID of the notice',
 						'enum'        => array(
-							'new-stats-feedback',
-							'opt-out-new-stats',
+							Notices::OPT_IN_NEW_STATS_NOTICE_ID,
+							Notices::OPT_OUT_NEW_STATS_NOTICE_ID,
+							Notices::NEW_STATS_FEEDBACK_NOTICE_ID,
 						),
 					),
 					'status' => array(
@@ -174,8 +174,8 @@ class REST_Controller {
 						'type'        => 'string',
 						'description' => 'Status of the notice',
 						'enum'        => array(
-							'dismissed',
-							'postponed',
+							Notices::NOTICE_STATUS_DISMISSED,
+							Notices::NOTICE_STATUS_POSTPONED,
 						),
 					),
 				),
@@ -471,14 +471,7 @@ class REST_Controller {
 	 * @return array
 	 */
 	public function update_notice_status( $req ) {
-		$notices                            = Stats_Options::get_option( 'notices' );
-		$notices[ $req->get_param( 'id' ) ] = array(
-			'status'       => $req->get_param( 'status' ),
-			'id'           => $req->get_param( 'id' ),
-			'dismissed_at' => time(),
-			'next_show'    => $req->get_param( 'status' ) === 'postponed' ? time() + 30 * DAY_IN_SECONDS : 0,
-		);
-		return Stats_Options::set_option( 'notices', $notices );
+		return Notices::update_notice( $req->param['id'], $req->param['status'] );
 	}
 
 	/**

--- a/projects/packages/stats-admin/tests/php/test-rest-controller.php
+++ b/projects/packages/stats-admin/tests/php/test-rest-controller.php
@@ -146,4 +146,21 @@ class Test_REST_Controller extends Stats_Test_Case {
 
 		$this->assertNotTrue( $response );
 	}
+
+	/**
+	 * Test '/jetpack/v4/stats-app/stats/notices'
+	 */
+	public function test_stats_notices_exists() {
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/stats-app/stats/notices' );
+		$request->set_body_params(
+			array(
+				'id'     => 'new_stats_feedback',
+				'status' => 'dismissed',
+			)
+		);
+		$request->set_header( 'content-type', 'application/json' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertNotEquals( 200, $response->get_status() );
+	}
 }

--- a/projects/packages/stats-admin/tests/php/test-rest-controller.php
+++ b/projects/packages/stats-admin/tests/php/test-rest-controller.php
@@ -148,9 +148,10 @@ class Test_REST_Controller extends Stats_Test_Case {
 	}
 
 	/**
-	 * Test '/jetpack/v4/stats-app/stats/notices'
+	 * Test '/jetpack/v4/stats-app/stats/notices' succeed.
 	 */
-	public function test_stats_notices_exists() {
+	public function test_stats_notices_succeed() {
+		wp_set_current_user( $this->admin_id );
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/stats-app/stats/notices' );
 		$request->set_body_params(
 			array(
@@ -161,6 +162,22 @@ class Test_REST_Controller extends Stats_Test_Case {
 		$request->set_header( 'content-type', 'application/json' );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertNotEquals( 200, $response->get_status() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * Test '/jetpack/v4/stats-app/stats/notices' failed
+	 */
+	public function test_stats_notices_illegal_params() {
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/stats-app/stats/notices' );
+		$request->set_body_params(
+			array(
+				'id' => 'new_stats_feedback',
+			)
+		);
+		$request->set_header( 'content-type', 'application/json' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 400, $response->get_status() );
 	}
 }

--- a/projects/packages/stats-admin/tests/php/test-stats-notices.php
+++ b/projects/packages/stats-admin/tests/php/test-stats-notices.php
@@ -27,6 +27,7 @@ class Test_Notices extends Stats_Test_Case {
 		parent::set_up();
 		Stats_Options::set_option( 'enable_odyssey_stats', true );
 		Stats_Options::set_option( 'notices', array() );
+		Stats_Options::set_option( 'views', 0 );
 		self::$notices = new Notices();
 	}
 
@@ -34,10 +35,10 @@ class Test_Notices extends Stats_Test_Case {
 	 * Test opt out new stats show.
 	 */
 	public function test_opt_out_new_stats_show() {
-		$this->assertEquals( array( 'opt_out_new_stats' => true ), self::$notices->get_notices_to_show() );
+		$this->assertTrue( self::$notices->get_notices_to_show()['opt_out_new_stats'] );
 
 		Stats_Options::set_option( 'views', 2 );
-		$this->assertEquals( array( 'opt_out_new_stats' => true ), self::$notices->get_notices_to_show() );
+		$this->assertTrue( self::$notices->get_notices_to_show()['opt_out_new_stats'] );
 	}
 
 	/**
@@ -45,7 +46,7 @@ class Test_Notices extends Stats_Test_Case {
 	 */
 	public function test_opt_out_new_stats_notice_dismissed() {
 		self::$notices->update_notice( 'opt_out_new_stats', 'dismissed' );
-		$this->assertEmpty( self::$notices->get_notices_to_show() );
+		$this->assertFalse( self::$notices->get_notices_to_show()['opt_out_new_stats'] );
 	}
 
 	/**
@@ -53,7 +54,7 @@ class Test_Notices extends Stats_Test_Case {
 	 */
 	public function test_new_stats_feedback_notice_show() {
 		Stats_Options::set_option( 'views', 3 );
-		$this->assertEquals( array( 'new_stats_feedback' => true ), self::$notices->get_notices_to_show() );
+		$this->assertTrue( self::$notices->get_notices_to_show()['new_stats_feedback'] );
 	}
 
 	/**
@@ -62,34 +63,37 @@ class Test_Notices extends Stats_Test_Case {
 	public function test_new_stats_feedback_notice_dismissed() {
 		self::$notices->update_notice( 'new_stats_feedback', 'dismissed' );
 		self::$notices->update_notice( 'opt_out_new_stats', 'dismissed' );
-		$this->assertEmpty( self::$notices->get_notices_to_show() );
+		$this->assertFalse( self::$notices->get_notices_to_show()['new_stats_feedback'] );
+		$this->assertFalse( self::$notices->get_notices_to_show()['opt_out_new_stats'] );
 	}
 
 	/**
 	 * Test new stats feedback notice dismissed.
 	 */
 	public function test_new_stats_feedback_notice_postponed() {
-		self::$notices->update_notice( 'new_stats_feedback', 'postponed' );
+		self::$notices->update_notice( 'new_stats_feedback', 'postponed', 10000 );
 		self::$notices->update_notice( 'opt_out_new_stats', 'dismissed' );
 		$stored_notices = Stats_Options::get_option( 'notices' );
 
 		$this->assertGreaterThanOrEqual( time(), $stored_notices['new_stats_feedback']['next_show_at'] );
-		$this->assertEmpty( self::$notices->get_notices_to_show() );
+		$this->assertFalse( self::$notices->get_notices_to_show()['new_stats_feedback'] );
+		$this->assertFalse( self::$notices->get_notices_to_show()['opt_out_new_stats'] );
 	}
 
 	/**
 	 * Test new stats feedback notice postponed and show again.
 	 */
 	public function test_new_stats_feedback_notice_postponed_show_again() {
-		self::$notices->update_notice( 'new_stats_feedback', 'postponed' );
+		self::$notices->update_notice( 'new_stats_feedback', 'postponed', 10000 );
 		self::$notices->update_notice( 'opt_out_new_stats', 'dismissed' );
+		Stats_Options::set_option( 'views', 3 );
 
-		$stored_notices = Stats_Options::get_option( 'notices' );
-
+		$stored_notices                                       = Stats_Options::get_option( 'notices' );
 		$stored_notices['new_stats_feedback']['next_show_at'] = time() - 1;
 		Stats_Options::set_option( 'notices', $stored_notices );
 
-		$this->assertEquals( array( 'new_stats_feedback' => true ), self::$notices->get_notices_to_show() );
+		$this->assertTrue( self::$notices->get_notices_to_show()['new_stats_feedback'] );
+		$this->assertFalse( self::$notices->get_notices_to_show()['opt_out_new_stats'] );
 	}
 
 	/**
@@ -97,7 +101,7 @@ class Test_Notices extends Stats_Test_Case {
 	 */
 	public function test_opt_in_new_stats_notice_show() {
 		Stats_Options::set_option( 'enable_odyssey_stats', false );
-		$this->assertEquals( array( 'opt_in_new_stats' => true ), self::$notices->get_notices_to_show() );
+		$this->assertTrue( self::$notices->get_notices_to_show()['opt_in_new_stats'] );
 	}
 
 	/**

--- a/projects/packages/stats-admin/tests/php/test-stats-notices.php
+++ b/projects/packages/stats-admin/tests/php/test-stats-notices.php
@@ -100,4 +100,41 @@ class Test_Notices extends Stats_Test_Case {
 		$this->assertEquals( array( 'opt_in_new_stats' => true ), self::$notices->get_notices_to_show() );
 	}
 
+	/**
+	 * Test get views.
+	 */
+	public function test_get_new_stats_views() {
+		Stats_Options::set_option( 'views', 3 );
+		$this->assertEquals( 3, self::$notices->get_new_stats_views() );
+	}
+
+	/**
+	 * Test is notice hidden.
+	 */
+	public function test_is_notice_hidden() {
+		$this->assertFalse( self::$notices->is_notice_hidden( 'opt_in_new_stats' ) );
+		self::$notices->update_notice( 'opt_in_new_stats', 'dismissed' );
+		$this->assertTrue( self::$notices->is_notice_hidden( 'opt_in_new_stats' ) );
+		self::$notices->update_notice( 'opt_in_new_stats', 'postponed' );
+		$this->assertTrue( self::$notices->is_notice_hidden( 'opt_in_new_stats' ) );
+	}
+
+	/**
+	 * Test get hidden notices.
+	 */
+	public function test_get_hidden_notices() {
+		$this->assertEmpty( self::$notices->get_hidden_notices( 'opt_in_new_stats' ) );
+		self::$notices->update_notice( 'opt_in_new_stats', 'dismissed' );
+		self::$notices->update_notice( 'new_stats_feedback', 'postponed' );
+
+		$this->assertArrayHasKey( 'opt_in_new_stats', self::$notices->get_hidden_notices() );
+		$this->assertArrayHasKey( 'new_stats_feedback', self::$notices->get_hidden_notices() );
+
+		$stored_notices                                       = Stats_Options::get_option( 'notices' );
+		$stored_notices['new_stats_feedback']['next_show_at'] = time() - 1;
+		Stats_Options::set_option( 'notices', $stored_notices );
+
+		$this->assertArrayNotHasKey( 'new_stats_feedback', self::$notices->get_hidden_notices() );
+	}
+
 }

--- a/projects/packages/stats-admin/tests/php/test-stats-notices.php
+++ b/projects/packages/stats-admin/tests/php/test-stats-notices.php
@@ -1,0 +1,103 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Automattic\Jetpack\Stats_Admin;
+
+use Automattic\Jetpack\Stats\Options as Stats_Options;
+use Automattic\Jetpack\Stats_Admin\Test_Case as Stats_Test_Case;
+
+/**
+ * Unit tests for the Notice class.
+ *
+ * @package automattic/jetpack-stats-admin
+ */
+class Test_Notices extends Stats_Test_Case {
+	/**
+	 * Holds the Notices instance.
+	 *
+	 * @var Notices
+	 */
+	protected static $notices;
+
+	/**
+	 * Setting up the test.
+	 *
+	 * @before
+	 */
+	public function set_up() {
+		parent::set_up();
+		Stats_Options::set_option( 'enable_odyssey_stats', true );
+		Stats_Options::set_option( 'notices', array() );
+		self::$notices = new Notices();
+	}
+
+	/**
+	 * Test opt out new stats show.
+	 */
+	public function test_opt_out_new_stats_show() {
+		$this->assertEquals( array( 'opt_out_new_stats' => true ), self::$notices->get_notices_to_show() );
+
+		Stats_Options::set_option( 'views', 2 );
+		$this->assertEquals( array( 'opt_out_new_stats' => true ), self::$notices->get_notices_to_show() );
+	}
+
+	/**
+	 * Test opt out new stats notice dismissed.
+	 */
+	public function test_opt_out_new_stats_notice_dismissed() {
+		self::$notices->update_notice( 'opt_out_new_stats', 'dismissed' );
+		$this->assertEmpty( self::$notices->get_notices_to_show() );
+	}
+
+	/**
+	 * Test new stats feedback notice show.
+	 */
+	public function test_new_stats_feedback_notice_show() {
+		Stats_Options::set_option( 'views', 3 );
+		$this->assertEquals( array( 'new_stats_feedback' => true ), self::$notices->get_notices_to_show() );
+	}
+
+	/**
+	 * Test new stats feedback notice dismissed.
+	 */
+	public function test_new_stats_feedback_notice_dismissed() {
+		self::$notices->update_notice( 'new_stats_feedback', 'dismissed' );
+		self::$notices->update_notice( 'opt_out_new_stats', 'dismissed' );
+		$this->assertEmpty( self::$notices->get_notices_to_show() );
+	}
+
+	/**
+	 * Test new stats feedback notice dismissed.
+	 */
+	public function test_new_stats_feedback_notice_postponed() {
+		self::$notices->update_notice( 'new_stats_feedback', 'postponed' );
+		self::$notices->update_notice( 'opt_out_new_stats', 'dismissed' );
+		$stored_notices = Stats_Options::get_option( 'notices' );
+
+		$this->assertGreaterThanOrEqual( time(), $stored_notices['new_stats_feedback']['next_show_at'] );
+		$this->assertEmpty( self::$notices->get_notices_to_show() );
+	}
+
+	/**
+	 * Test new stats feedback notice postponed and show again.
+	 */
+	public function test_new_stats_feedback_notice_postponed_show_again() {
+		self::$notices->update_notice( 'new_stats_feedback', 'postponed' );
+		self::$notices->update_notice( 'opt_out_new_stats', 'dismissed' );
+
+		$stored_notices = Stats_Options::get_option( 'notices' );
+
+		$stored_notices['new_stats_feedback']['next_show_at'] = time() - 1;
+		Stats_Options::set_option( 'notices', $stored_notices );
+
+		$this->assertEquals( array( 'new_stats_feedback' => true ), self::$notices->get_notices_to_show() );
+	}
+
+	/**
+	 * Test opt in new stats notice show.
+	 */
+	public function test_opt_in_new_stats_notice_show() {
+		Stats_Options::set_option( 'enable_odyssey_stats', false );
+		$this->assertEquals( array( 'opt_in_new_stats' => true ), self::$notices->get_notices_to_show() );
+	}
+
+}

--- a/projects/packages/stats/changelog/add-stats-notice-status-control
+++ b/projects/packages/stats/changelog/add-stats-notice-status-control
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: Adds support for Notice control

--- a/projects/packages/stats/src/class-options.php
+++ b/projects/packages/stats/src/class-options.php
@@ -164,6 +164,7 @@ class Options {
 			'collapse_nudges'          => false,
 			'enable_odyssey_stats'     => true,
 			'odyssey_stats_changed_at' => 0,
+			'notices'                  => array(),
 		);
 	}
 }

--- a/projects/packages/stats/src/class-options.php
+++ b/projects/packages/stats/src/class-options.php
@@ -165,6 +165,7 @@ class Options {
 			'enable_odyssey_stats'     => true,
 			'odyssey_stats_changed_at' => 0,
 			'notices'                  => array(),
+			'views'                    => 0,
 		);
 	}
 }

--- a/projects/packages/stats/tests/php/test-options.php
+++ b/projects/packages/stats/tests/php/test-options.php
@@ -45,6 +45,7 @@ class Test_Options extends StatsBaseTestCase {
 			'enable_odyssey_stats'     => true,
 			'odyssey_stats_changed_at' => 0,
 			'notices'                  => array(),
+			'views'                    => 0,
 		);
 		$this->assertSame( $options_should_be, $options );
 	}
@@ -74,6 +75,7 @@ class Test_Options extends StatsBaseTestCase {
 			'enable_odyssey_stats'     => true,
 			'odyssey_stats_changed_at' => 0,
 			'notices'                  => array(),
+			'views'                    => 0,
 		);
 		$this->assertSame( $options_should_be, $options );
 	}
@@ -154,6 +156,7 @@ class Test_Options extends StatsBaseTestCase {
 					'enable_odyssey_stats'     => true,
 					'odyssey_stats_changed_at' => 0,
 					'notices'                  => array(),
+					'views'                    => 0,
 				),
 			),
 			'set version'          => array(
@@ -174,6 +177,7 @@ class Test_Options extends StatsBaseTestCase {
 					'enable_odyssey_stats'     => true,
 					'odyssey_stats_changed_at' => 0,
 					'notices'                  => array(),
+					'views'                    => 0,
 				),
 			),
 			'set blog blog_id'     => array(
@@ -194,6 +198,7 @@ class Test_Options extends StatsBaseTestCase {
 					'enable_odyssey_stats'     => true,
 					'odyssey_stats_changed_at' => 0,
 					'notices'                  => array(),
+					'views'                    => 0,
 				),
 			),
 			'multiple options'     => array(
@@ -225,6 +230,7 @@ class Test_Options extends StatsBaseTestCase {
 					'enable_odyssey_stats'     => true,
 					'odyssey_stats_changed_at' => 0,
 					'notices'                  => array(),
+					'views'                    => 0,
 				),
 			),
 		);
@@ -283,6 +289,7 @@ class Test_Options extends StatsBaseTestCase {
 			'enable_odyssey_stats'     => true,
 			'odyssey_stats_changed_at' => 0,
 			'notices'                  => array(),
+			'views'                    => 0,
 		);
 		$this->assertTrue( Options::set_options( $set_options ) );
 		$this->assertSame( $stored_options, get_option( 'stats_options' ) );
@@ -312,6 +319,7 @@ class Test_Options extends StatsBaseTestCase {
 					'enable_odyssey_stats'     => true,
 					'odyssey_stats_changed_at' => 0,
 					'notices'                  => array(),
+					'views'                    => 0,
 				),
 			),
 			'Roles'        => array(
@@ -331,6 +339,7 @@ class Test_Options extends StatsBaseTestCase {
 					'enable_odyssey_stats'     => true,
 					'odyssey_stats_changed_at' => 0,
 					'notices'                  => array(),
+					'views'                    => 0,
 				),
 			),
 			'Count Roles'  => array(
@@ -349,6 +358,7 @@ class Test_Options extends StatsBaseTestCase {
 					'enable_odyssey_stats'     => true,
 					'odyssey_stats_changed_at' => 0,
 					'notices'                  => array(),
+					'views'                    => 0,
 				),
 			),
 			'Version'      => array(
@@ -367,6 +377,7 @@ class Test_Options extends StatsBaseTestCase {
 					'enable_odyssey_stats'     => true,
 					'odyssey_stats_changed_at' => 0,
 					'notices'                  => array(),
+					'views'                    => 0,
 				),
 			),
 			'Honor DNT'    => array(
@@ -385,6 +396,7 @@ class Test_Options extends StatsBaseTestCase {
 					'enable_odyssey_stats'     => true,
 					'odyssey_stats_changed_at' => 0,
 					'notices'                  => array(),
+					'views'                    => 0,
 				),
 			),
 			'Dummy option' => array(
@@ -403,6 +415,7 @@ class Test_Options extends StatsBaseTestCase {
 					'enable_odyssey_stats'     => true,
 					'odyssey_stats_changed_at' => 0,
 					'notices'                  => array(),
+					'views'                    => 0,
 				),
 			),
 		);

--- a/projects/packages/stats/tests/php/test-options.php
+++ b/projects/packages/stats/tests/php/test-options.php
@@ -44,6 +44,7 @@ class Test_Options extends StatsBaseTestCase {
 			'collapse_nudges'          => false,
 			'enable_odyssey_stats'     => true,
 			'odyssey_stats_changed_at' => 0,
+			'notices'                  => array(),
 		);
 		$this->assertSame( $options_should_be, $options );
 	}
@@ -72,6 +73,7 @@ class Test_Options extends StatsBaseTestCase {
 			'collapse_nudges'          => false,
 			'enable_odyssey_stats'     => true,
 			'odyssey_stats_changed_at' => 0,
+			'notices'                  => array(),
 		);
 		$this->assertSame( $options_should_be, $options );
 	}
@@ -151,6 +153,7 @@ class Test_Options extends StatsBaseTestCase {
 					'collapse_nudges'          => false,
 					'enable_odyssey_stats'     => true,
 					'odyssey_stats_changed_at' => 0,
+					'notices'                  => array(),
 				),
 			),
 			'set version'          => array(
@@ -170,6 +173,7 @@ class Test_Options extends StatsBaseTestCase {
 					'collapse_nudges'          => false,
 					'enable_odyssey_stats'     => true,
 					'odyssey_stats_changed_at' => 0,
+					'notices'                  => array(),
 				),
 			),
 			'set blog blog_id'     => array(
@@ -189,6 +193,7 @@ class Test_Options extends StatsBaseTestCase {
 					'collapse_nudges'          => false,
 					'enable_odyssey_stats'     => true,
 					'odyssey_stats_changed_at' => 0,
+					'notices'                  => array(),
 				),
 			),
 			'multiple options'     => array(
@@ -219,6 +224,7 @@ class Test_Options extends StatsBaseTestCase {
 					'collapse_nudges'          => false,
 					'enable_odyssey_stats'     => true,
 					'odyssey_stats_changed_at' => 0,
+					'notices'                  => array(),
 				),
 			),
 		);
@@ -276,6 +282,7 @@ class Test_Options extends StatsBaseTestCase {
 			'collapse_nudges'          => false,
 			'enable_odyssey_stats'     => true,
 			'odyssey_stats_changed_at' => 0,
+			'notices'                  => array(),
 		);
 		$this->assertTrue( Options::set_options( $set_options ) );
 		$this->assertSame( $stored_options, get_option( 'stats_options' ) );
@@ -304,6 +311,7 @@ class Test_Options extends StatsBaseTestCase {
 					'collapse_nudges'          => false,
 					'enable_odyssey_stats'     => true,
 					'odyssey_stats_changed_at' => 0,
+					'notices'                  => array(),
 				),
 			),
 			'Roles'        => array(
@@ -322,6 +330,7 @@ class Test_Options extends StatsBaseTestCase {
 					'collapse_nudges'          => false,
 					'enable_odyssey_stats'     => true,
 					'odyssey_stats_changed_at' => 0,
+					'notices'                  => array(),
 				),
 			),
 			'Count Roles'  => array(
@@ -339,6 +348,7 @@ class Test_Options extends StatsBaseTestCase {
 					'collapse_nudges'          => false,
 					'enable_odyssey_stats'     => true,
 					'odyssey_stats_changed_at' => 0,
+					'notices'                  => array(),
 				),
 			),
 			'Version'      => array(
@@ -356,6 +366,7 @@ class Test_Options extends StatsBaseTestCase {
 					'collapse_nudges'          => false,
 					'enable_odyssey_stats'     => true,
 					'odyssey_stats_changed_at' => 0,
+					'notices'                  => array(),
 				),
 			),
 			'Honor DNT'    => array(
@@ -373,6 +384,7 @@ class Test_Options extends StatsBaseTestCase {
 					'collapse_nudges'          => false,
 					'enable_odyssey_stats'     => true,
 					'odyssey_stats_changed_at' => 0,
+					'notices'                  => array(),
 				),
 			),
 			'Dummy option' => array(
@@ -390,6 +402,7 @@ class Test_Options extends StatsBaseTestCase {
 					'collapse_nudges'          => false,
 					'enable_odyssey_stats'     => true,
 					'odyssey_stats_changed_at' => 0,
+					'notices'                  => array(),
 				),
 			),
 		);

--- a/projects/packages/stats/tests/php/test-xmlrpc-provider.php
+++ b/projects/packages/stats/tests/php/test-xmlrpc-provider.php
@@ -100,6 +100,7 @@ class Test_XMLRPC_Provider extends StatsBaseTestCase {
 			'enable_odyssey_stats'     => true,
 			'odyssey_stats_changed_at' => 0,
 			'notices'                  => array(),
+			'views'                    => 0,
 			'host'                     => 'example.org',
 			'path'                     => '/',
 			'blogname'                 => false,

--- a/projects/packages/stats/tests/php/test-xmlrpc-provider.php
+++ b/projects/packages/stats/tests/php/test-xmlrpc-provider.php
@@ -99,6 +99,7 @@ class Test_XMLRPC_Provider extends StatsBaseTestCase {
 			'collapse_nudges'          => false,
 			'enable_odyssey_stats'     => true,
 			'odyssey_stats_changed_at' => 0,
+			'notices'                  => array(),
 			'host'                     => 'example.org',
 			'path'                     => '/',
 			'blogname'                 => false,

--- a/projects/plugins/jetpack/changelog/add-stats-notice-status-control
+++ b/projects/plugins/jetpack/changelog/add-stats-notice-status-control
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2088,7 +2088,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "f86f8528b864500624df35217810f82dfb05f372"
+                "reference": "3ee9d58e654a2110285175c45123c0774d4a6f27"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -2107,7 +2107,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-stats-admin",
                 "branch-alias": {
-                    "dev-trunk": "0.5.x-dev"
+                    "dev-trunk": "0.6.x-dev"
                 },
                 "textdomain": "jetpack-stats-admin",
                 "version-constants": {


### PR DESCRIPTION
## Proposed changes:
The PR adds the ability to manage notice availability for new Stats. The supported notices include,

```PHP
	const OPT_OUT_NEW_STATS_NOTICE_ID  = 'opt_out_new_stats';
	const NEW_STATS_FEEDBACK_NOTICE_ID = 'new_stats_feedback';
	const OPT_IN_NEW_STATS_NOTICE_ID   = 'opt_in_new_stats';
```

- A `Automattic\Jetpack\Stats_Admin\Notices` is introduced to manage notice
- A new route `/jetpack/v4/stats-app/stats/notices` is added for front end to leverage
- Unit tests are added and updated accordingly
- Adds new `views` option to stats to track new Stats views

cc @a8ck3n 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Ensure all tests pass and code looks good

