### PR TITLE
Boost: Remove regenerate suggestion banner

### DIFF
--- a/projects/plugins/boost/app/admin/class-regenerate-admin-notice.php
+++ b/projects/plugins/boost/app/admin/class-regenerate-admin-notice.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack_Boost\Admin;
 
-use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_State;
 use Automattic\Jetpack_Boost\Lib\Transient;
 
 /**
@@ -27,17 +26,6 @@ class Regenerate_Admin_Notice {
 
 	public static function is_enabled() {
 		return Transient::get( 'regenerate_admin_notice', false );
-	}
-
-	/**
-	 * Hide the admin notice for a week.
-	 */
-	public static function snooze_suggestion() {
-		Transient::set( 'snooze_regenerate_suggestion', true, WEEK_IN_SECONDS );
-	}
-
-	public static function is_suggestion_snoozed() {
-		return Transient::get( 'snooze_regenerate_suggestion', false );
 	}
 
 	/**
@@ -61,9 +49,6 @@ class Regenerate_Admin_Notice {
 			return;
 		}
 
-		// Temporarily snooze the suggestion
-		self::snooze_suggestion();
-
 		// Dismiss the notice that shows up for major changes.
 		static::dismiss();
 
@@ -72,7 +57,7 @@ class Regenerate_Admin_Notice {
 
 	public static function init() {
 		add_action( 'admin_notices', array( static::class, 'maybe_render' ) );
-		if ( static::is_enabled() || ! static::is_suggestion_snoozed() ) {
+		if ( static::is_enabled() ) {
 			static::maybe_handle_dismissal();
 		}
 	}
@@ -86,13 +71,11 @@ class Regenerate_Admin_Notice {
 		}
 
 		if ( static::is_enabled() ) {
-			static::render_notice();
-		} elseif ( ! static::is_suggestion_snoozed() && ! Critical_CSS_State::is_fresh() ) {
-			static::render_suggestion();
+			static::render();
 		}
 	}
 
-	public static function render_notice() {
+	public static function render() {
 		?>
 		<div id="jetpack-boost-notice-critical-css-regenerate" class="notice notice-warning is-dismissible">
 			<h3>
@@ -103,35 +86,6 @@ class Regenerate_Admin_Notice {
 			</p>
 			<p>
 				<?php esc_html_e( 'You can go to the Jetpack Boost settings page to have it re-generated automatically.', 'jetpack-boost' ); ?>
-			</p>
-
-			<p>
-				<a class='button button-primary' href="<?php echo esc_url( admin_url( 'admin.php?page=' . Admin::MENU_SLUG ) ); ?>">
-					<strong>
-						<?php esc_html_e( 'Go to Jetpack Boost', 'jetpack-boost' ); ?>
-					</strong>
-				</a>
-				<a class="jb-dismiss-notice" href="<?php echo esc_url( static::get_dismiss_url() ); ?>">
-					<strong>
-						<?php esc_html_e( 'Dismiss notice', 'jetpack-boost' ); ?>
-					</strong>
-				</a>
-			</p>
-		</div>
-		<?php
-	}
-
-	public static function render_suggestion() {
-		?>
-		<div id="jetpack-boost-notice-critical-css-regenerate" class="notice notice-info is-dismissible">
-			<h3>
-				<?php esc_html_e( 'Jetpack Boost - Regenerate Critical CSS', 'jetpack-boost' ); ?>
-			</h3>
-			<p>
-				<?php esc_html_e( 'We noticed some updates to your site that may have changed your HTML/CSS structure.', 'jetpack-boost' ); ?>
-			</p>
-			<p>
-				<?php esc_html_e( 'Please regenerate your Critical CSS to maintain optimal site performance.', 'jetpack-boost' ); ?>
 			</p>
 
 			<p>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -5,6 +5,7 @@
 	import TemplatedString from '../../../elements/TemplatedString.svelte';
 	import { RegenerateCriticalCssSuggestion } from '../../../react-components/RegenerateCriticalCssSuggestion';
 	import config from '../../../stores/config';
+	import { criticalCssStatus } from '../../../stores/critical-css-status';
 	import { modules } from '../../../stores/modules';
 	import {
 		requestCloudCss,
@@ -60,7 +61,7 @@
 		<div slot="notice">
 			<ReactComponent
 				this={RegenerateCriticalCssSuggestion}
-				show={$config.criticalCSS?.suggestRegenerate}
+				show={$config.criticalCSS?.suggestRegenerate && $criticalCssStatus.status !== 'requesting'}
 			/>
 		</div>
 	</Module>

--- a/projects/plugins/boost/app/rest-api/endpoints/Generator_Success.php
+++ b/projects/plugins/boost/app/rest-api/endpoints/Generator_Success.php
@@ -79,8 +79,6 @@ class Generator_Success implements Endpoint {
 		$recommendations->reset();
 
 		Regenerate_Admin_Notice::dismiss();
-		// Prevent the notice from showing again for a while.
-		Regenerate_Admin_Notice::snooze_suggestion();
 		Critical_CSS_State::set_fresh();
 
 		// Set status to success to indicate the critical CSS data has been stored on the server.

--- a/projects/plugins/boost/changelog/add-regerate-prompts
+++ b/projects/plugins/boost/changelog/add-regerate-prompts
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Added notices to regenerate Critical CSS when applicable
+Added notice to regenerate critical CSS on Boost dashboard


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removed regenerate suggestion admin notice that was recently added in #28714
* Hide the notice on Boost dashboard while regenerating 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
Make sure you do not see admin banner suggesting regenerate of C.CSS but, see a regenerate notice on Boost dashboard after making changes in regard to plugins,post,pages.