### PR TITLE
Lazy Images: Fix safar image loading

### DIFF
--- a/projects/packages/lazy-images/changelog/fix-safar-lazy-images
+++ b/projects/packages/lazy-images/changelog/fix-safar-lazy-images
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed  a bug that would occassionally skip loading some images on safari or cause jank

--- a/projects/packages/lazy-images/src/lazy-images.php
+++ b/projects/packages/lazy-images/src/lazy-images.php
@@ -449,7 +449,7 @@ class Jetpack_Lazy_Images {
 		 */
 		return apply_filters(
 			'lazyload_images_placeholder_image',
-			'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+			''
 		);
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #25284

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the default placeholder image

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pc9hqz-1Aw-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Launch a Jetpack+WooCommerce or Boost+WooCommerce site.
- Enable Lazy Loading on Jetpack or Boost, depending on which you have.
- Create a WooCommerce image, and include a Product image on it.
- Open the product image on Safari.
- Refresh it multiple times. The placeholder image should always load(as opposed to an occasional blank space).