### PR TITLE
E2E tests: update edit site button selector 

### DIFF
--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -41,6 +41,12 @@ const projects = [
 		suite: '',
 	},
 	{ project: 'Social', path: 'projects/plugins/social/tests/e2e', testArgs: [], suite: '' },
+	{
+		project: 'Blocks with latest Gutenberg',
+		path: 'projects/plugins/jetpack/tests/e2e',
+		testArgs: [ 'blocks', '--retries=1' ],
+		suite: 'gutenberg',
+	},
 ];
 
 const matrix = [];

--- a/tools/e2e-commons/pages/wp-admin/site-editor.js
+++ b/tools/e2e-commons/pages/wp-admin/site-editor.js
@@ -14,7 +14,7 @@ export default class SiteEditorPage extends WpPage {
 	}
 
 	async edit() {
-		const editBtnSelector = "button[aria-label='Open the editor']";
+		const editBtnSelector = 'button.edit-site-site-hub__edit-button';
 		if ( await this.isElementVisible( editBtnSelector, 2000 ) ) {
 			await this.click( editBtnSelector );
 		}


### PR DESCRIPTION
## Proposed changes:

Update sector for edit button in broken site editor flow. We were using the button's aria label removed by Gutenberg with https://github.com/WordPress/gutenberg/pull/47343

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1675896045693039-slack-C03QNBQKG73

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Subscribe block test passes with latest Gutenberg 