### PR TITLE
E2E tests: remove Gutenberg test suite from matrix

### DIFF
--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -41,12 +41,6 @@ const projects = [
 		suite: '',
 	},
 	{ project: 'Social', path: 'projects/plugins/social/tests/e2e', testArgs: [], suite: '' },
-	{
-		project: 'Blocks with latest Gutenberg',
-		path: 'projects/plugins/jetpack/tests/e2e',
-		testArgs: [ 'blocks', '--retries=1' ],
-		suite: 'gutenberg',
-	},
 ];
 
 const matrix = [];


### PR DESCRIPTION

## Proposed changes:

With #28862 I added the Gutenberg test suite in the e2e tests matrix as a temporary solution to validate the change against a site with latest Gutenberg, but forgot to remove it after the tests ran.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* e2e tests pass
* Gutenberg suite does not run

