### PR TITLE
Remove sharing buttons override styles on twentynineteen and twentysixteen themes

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sharing-buttons-twenty-themes
+++ b/projects/plugins/jetpack/changelog/fix-sharing-buttons-twenty-themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Theme Compatiblity: ensure redesigned sharing buttons look good in  default themes as well (Twenty Nineteen, Twenty Sixteen)

--- a/projects/plugins/jetpack/modules/theme-tools/compat/twentynineteen.css
+++ b/projects/plugins/jetpack/modules/theme-tools/compat/twentynineteen.css
@@ -117,20 +117,6 @@
 	margin-bottom: 0 !important;
 }
 
-.entry #sharing_email .sharing_send,
-.entry .sd-content ul li .option a.share-ustom,
-.entry .sd-content ul li a.sd-button,
-.entry .sd-content ul li.advanced a.share-more,
-.entry .sd-content ul li.preview-item div.option.option-smart-off a,
-.entry .sd-social-icon .sd-content ul li a.sd-button,
-.entry .sd-social-icon-text .sd-content ul li a.sd-button,
-.entry .sd-social-official .sd-content > ul > li .digg_button > a,
-.entry .sd-social-official .sd-content > ul > li > a.sd-button,
-.entry .sd-social-text .sd-content ul li a.sd-button {
-	box-shadow: none;
-}
-
-
 /**
  * Related Posts
  */

--- a/projects/plugins/jetpack/modules/theme-tools/compat/twentysixteen-rtl.css
+++ b/projects/plugins/jetpack/modules/theme-tools/compat/twentysixteen-rtl.css
@@ -716,19 +716,6 @@ iframe[src^="http://api.mixcloud.com/"] {
 	margin-bottom: -0.625em !important;
 }
 
-.hentry #sharing_email .sharing_send,
-.hentry .sd-content ul li .option a.share-ustom,
-.hentry .sd-content ul li a.sd-button,
-.hentry .sd-content ul li.advanced a.share-more,
-.hentry .sd-content ul li.preview-item div.option.option-smart-off a,
-.hentry .sd-social-icon .sd-content ul li a.sd-button,
-.hentry .sd-social-icon-text .sd-content ul li a.sd-button,
-.hentry .sd-social-official .sd-content > ul > li .digg_button > a,
-.hentry .sd-social-official .sd-content > ul > li > a.sd-button,
-.hentry .sd-social-text .sd-content ul li a.sd-button {
-	box-shadow: none;
-}
-
 
 /**
  * Stats

--- a/projects/plugins/jetpack/modules/theme-tools/compat/twentysixteen.css
+++ b/projects/plugins/jetpack/modules/theme-tools/compat/twentysixteen.css
@@ -711,19 +711,6 @@ iframe[src^="http://api.mixcloud.com/"] {
 	margin-bottom: -0.625em !important;
 }
 
-.hentry #sharing_email .sharing_send,
-.hentry .sd-content ul li .option a.share-ustom,
-.hentry .sd-content ul li a.sd-button,
-.hentry .sd-content ul li.advanced a.share-more,
-.hentry .sd-content ul li.preview-item div.option.option-smart-off a,
-.hentry .sd-social-icon .sd-content ul li a.sd-button,
-.hentry .sd-social-icon-text .sd-content ul li a.sd-button,
-.hentry .sd-social-official .sd-content > ul > li .digg_button > a,
-.hentry .sd-social-official .sd-content > ul > li > a.sd-button,
-.hentry .sd-social-text .sd-content ul li a.sd-button {
-	box-shadow: none;
-}
-
 
 /**
  * Stats


### PR DESCRIPTION
## Proposed changes:

This PR extends the work in #28874 to update the look and feel of the sharing icons. You can see a full list of updates that need to be made [here](https://github.com/Automattic/jetpack/issues/27817).

Previously there had been a border and a box-shadow. I suspect that whomever added these overrides disliked how chunky it looked with both a border and a box-shadow so they decided to override the styles and remove the box-shadow.  In #28874 I remove the border, which left the sharing buttons on these two themes without any sort of visual border. I've fixed this by removing these override styles for both themes.

## TwentyNineteen

### Before

![twentynineteen-before](https://user-images.githubusercontent.com/5634774/217896338-89eaf73c-998f-4edc-a24d-478d0af86203.png)

### After

![twentynineteen-after](https://user-images.githubusercontent.com/5634774/217896366-bf5763a9-e9e4-4fba-9161-5dfcba99abe8.png)

## TwentySixteen

### Before

![twentysixteen-before](https://user-images.githubusercontent.com/5634774/217896397-781a55d6-6c72-42b1-8e8a-ca2e4d48410a.png)

### After

![twentysixteen-after](https://user-images.githubusercontent.com/5634774/217896427-a1ffb145-bd31-4dcf-8156-f45fff6f0929.png)

## Jetpack product discussion
- #27817
- pe7F0s-i3-p2
- pe7F0s-qg-p2

## Does this pull request change what data or activity we track or use?
Nope.

## Testing instructions:
- Follow instructions to [set up JP locally](https://github.com/Automattic/jetpack/blob/trunk/docs/quick-start.md) (with jurassic.tube proxy), or use jurassic ninja
- Ensure that you have sharing buttons activated
- Ensure that you have at least one published blog post
- Set twentynineteen and then twentysixteen as your theme
- Visit the blog post

## Related
- Parent PR -> #28874
- #27817
- https://github.com/Automattic/wp-calypso/pull/73126