### PR TITLE
Membership: user_can_view_post: Memoize results

### DIFF
--- a/projects/plugins/jetpack/changelog/update-user-can-view-post-cache
+++ b/projects/plugins/jetpack/changelog/update-user-can-view-post-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Membership: user_can_view_post: Memoize results

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -459,7 +459,7 @@ class Jetpack_Memberships {
 	 */
 	public static function user_can_view_post() {
 		$user_id   = get_current_user_id();
-		$post_id   = get_the_ID();
+		$post_id   = get_the_ID() || 0;
 		$cache_key = sprintf( '%d_%d', $user_id, $post_id );
 
 		if ( isset( self::$user_can_view_post_cache[ $cache_key ] ) ) {

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -77,6 +77,13 @@ class Jetpack_Memberships {
 	private static $instance;
 
 	/**
+	 * Cached results of user_can_view_post() method.
+	 *
+	 * @var array
+	 */
+	private static $user_can_view_post_cache = array();
+
+	/**
 	 * Currencies we support and Stripe's minimum amount for a transaction in that currency.
 	 *
 	 * @link https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
@@ -445,11 +452,31 @@ class Jetpack_Memberships {
 	}
 
 	/**
-	 * Determines whether the post can be viewed based on the newsletter access level
+	 * Determines whether the current user can view the post based on the newsletter access level
+	 * and caches the result.
 	 *
 	 * @return bool Whether the post can be viewed
 	 */
 	public static function user_can_view_post() {
+		$user_id   = get_current_user_id();
+		$post_id   = get_the_ID();
+		$cache_key = sprintf( '%d_%d', $user_id, $post_id );
+
+		if ( isset( self::$user_can_view_post_cache[ $cache_key ] ) ) {
+			return self::$user_can_view_post_cache[ $cache_key ];
+		}
+
+		$value                                        = self::user_can_view_post_nocache();
+		self::$user_can_view_post_cache[ $cache_key ] = $value;
+		return $value;
+	}
+
+	/**
+	 * Determines whether the post can be viewed based on the newsletter access level
+	 *
+	 * @return bool Whether the post can be viewed
+	 */
+	public static function user_can_view_post_nocache() {
 		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
 
 		$newsletter_access_level = self::get_newsletter_access_level();


### PR DESCRIPTION
### Summary

* The function `user_can_view_post()` will now memoize results per userid + postid combination and if possible, return the memorized result instead of recomputing.
  * Initial implementation of this is in #28170.

### Why

`user_can_view_post()` is hooked on `get_comment()`, which runs several times per comment. On a p2 post with ~500 comments, I see `user_can_view_post()` running ~11,700 times. It's generally a fast function, but anything times 12 thousand can have more of an impact than realized.

### Measurements

Apologies as this is from a WPCOM perspective and assumes you have a WPCOM sandbox and access to -pb.

Sandbox and view this post: 2f117-pb .

I used this diff on wpcom before:
```diff
diff --git a/wp-content/mu-plugins/jetpack-plugin/production/modules/memberships/class-jetpack-memberships.php b/wp-content/mu-plugins/jetpack-plugin/production/modules/memberships/class-jetpack-memberships.php
index 429cff680a..fc8cb53a8a 100644
--- a/wp-content/mu-plugins/jetpack-plugin/production/modules/memberships/class-jetpack-memberships.php
+++ b/wp-content/mu-plugins/jetpack-plugin/production/modules/memberships/class-jetpack-memberships.php
@@ -10,6 +10,22 @@ use Automattic\Jetpack\Blocks;
 
 require_once __DIR__ . '/../../extensions/blocks/subscriptions/constants.php';
 
+$GLOBALS['user_can_view_post__count'] = 0;
+$GLOBALS['user_can_view_post__time']  = 0;
+register_shutdown_function(
+       function() {
+               if ( $GLOBALS['user_can_view_post__count'] > 0 ) {
+                       $c = $GLOBALS['user_can_view_post__count'];
+                       $t = round( $GLOBALS['user_can_view_post__time'], 2 );
+
+                       $link = "$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
+                       if ( strpos( $link, '?' ) !== false ) {
+                               $link = substr( $link, 0, strpos( $link, '?' ) );
+                       }
+                       error_log("Spent $t ms calling user_can_view_post $c times. $link");
+               }
+       }
+);
 /**
  * Class Jetpack_Memberships
  * This class represents the Memberships functionality.
@@ -450,11 +466,19 @@ class Jetpack_Memberships {
         * @return bool Whether the post can be viewed
         */
        public static function user_can_view_post() {
+               $GLOBALS['user_can_view_post__count'] += 1;
+               $t1 = microtime( true );
+
                require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
 
                $newsletter_access_level = self::get_newsletter_access_level();
                $paywall                 = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
-               return $paywall->visitor_can_view_content( self::get_all_plans_id_jetpack_recurring_payments(), $newsletter_access_level );
+               $r = $paywall->visitor_can_view_content( self::get_all_plans_id_jetpack_recurring_payments(), $newsletter_access_level );
+
+               $t2 = microtime( true );
+               $e2 = ( $t2 - $t1 ) * 1000;
+               $GLOBALS['user_can_view_post__time'] += $e2;
+               return $r;
        }
 
        /**
```

And this PR + this diff for AFTER timings:
```diff
index 97545792f0..cc744c3b5c 100644
--- a/wp-content/mu-plugins/jetpack-plugin/production/modules/memberships/class-jetpack-memberships.php
+++ b/wp-content/mu-plugins/jetpack-plugin/production/modules/memberships/class-jetpack-memberships.php
@@ -10,6 +10,25 @@ use Automattic\Jetpack\Blocks;
 
 require_once __DIR__ . '/../../extensions/blocks/subscriptions/constants.php';
 
+$GLOBALS['user_can_view_post__count'] = 0;
+$GLOBALS['user_can_view_post__hits']  = 0;
+$GLOBALS['user_can_view_post__time']  = 0;
+register_shutdown_function(
+       function() {
+               if ( $GLOBALS['user_can_view_post__count'] > 0 ) {
+                       $c = $GLOBALS['user_can_view_post__count'];
+                       $t = round( $GLOBALS['user_can_view_post__time'], 2 );
+                       $h = $GLOBALS['user_can_view_post__hits'];
+
+                       $link = "$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
+                       if ( strpos( $link, '?' ) !== false ) {
+                               $link = substr( $link, 0, strpos( $link, '?' ) );
+                       }
+                       error_log("Spent $t ms calling user_can_view_post $c times. $h cache hits. $link");
+               }
+       }
+);
+
 /**
  * Class Jetpack_Memberships
  * This class represents the Memberships functionality.
@@ -452,16 +471,24 @@ class Jetpack_Memberships {
         * @return bool Whether the post can be viewed
         */
        public static function user_can_view_post() {
+               $GLOBALS['user_can_view_post__count'] += 1;
+               $t1 = microtime( true );
+
                $user_id = get_current_user_id();
                $post_id = get_the_ID();
                $cache_key = sprintf( '%d_%d', $user_id, $post_id );
 
                if ( isset( self::$user_can_view_post_cache[ $cache_key ] ) ) {
+                       $GLOBALS['user_can_view_post__hits'] += 1;
                        return self::$user_can_view_post_cache[ $cache_key ];
                }
 
                $value = self::user_can_view_post_nocache();
                self::$user_can_view_post_cache[ $cache_key ] = $value;
+
+               $t2 = microtime( true );
+               $e2 = ( $t2 - $t1 ) * 1000;
+               $GLOBALS['user_can_view_post__time'] += $e2;
                return $value;
        }

```

**Before results**

```
[09-Feb-2023 17:38:26 UTC] Spent 1773.56 ms calling user_can_view_post 11712 times. 
[09-Feb-2023 17:38:53 UTC] Spent 1821.24 ms calling user_can_view_post 11712 times.
[09-Feb-2023 17:39:21 UTC] Spent 2042.38 ms calling user_can_view_post 11712 times.
```

**After results**

```
[09-Feb-2023 17:45:25 UTC] Spent 4.94 ms calling user_can_view_post 11712 times. 11711 cache hits.
[09-Feb-2023 17:46:13 UTC] Spent 4.41 ms calling user_can_view_post 11712 times. 11711 cache hits.
```

The p2 itself still loads slowly - but this is a step in the right direction. However, I imagine any post with a handful of comments will show an improvement, just not so drastic.

## Proposed changes:

* The function `user_can_view_post()` will now memoize results per userid + postid combination and if possible, return the memorized result instead of recomputing.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Manually measure the time spent inside `user_can_view_post()`. See diffs above.
  * After the patch, when viewing a post with comments, less time should be spent in `user_can_view_post()`.
* The restrictions imposed by `user_can_view_post()` should continue to work.