### PR TITLE
build: Disable `execa` buffering when not needed

### DIFF
--- a/tools/cli/helpers/list-project-files.js
+++ b/tools/cli/helpers/list-project-files.js
@@ -19,21 +19,30 @@ export async function* listProjectFiles( src, spawn, output = undefined ) {
 	const lsFiles = spawn( 'git', [ '-c', 'core.quotepath=off', 'ls-files' ], {
 		cwd: src,
 		stdio: [ 'ignore', 'pipe', null ],
+		buffer: false,
 	} );
 	const lsIgnoredFiles = spawn(
 		'git',
 		[ '-c', 'core.quotepath=off', 'ls-files', '--others', '--ignored', '--exclude-standard' ],
-		{ cwd: src, stdio: [ 'ignore', 'pipe', null ] }
+		{ cwd: src, stdio: [ 'ignore', 'pipe', null ], buffer: false }
 	);
 	const checkAttrInclude = spawn(
 		'git',
 		[ '-c', 'core.quotepath=off', 'check-attr', '--stdin', 'production-include' ],
-		{ cwd: src, stdio: [ lsIgnoredFiles.stdout, 'pipe', null ] }
+		{
+			cwd: src,
+			stdio: [ lsIgnoredFiles.stdout, 'pipe', null ],
+			buffer: false,
+		}
 	);
 	const checkAttrExclude = spawn(
 		'git',
 		[ '-c', 'core.quotepath=off', 'check-attr', '--stdin', 'production-exclude' ],
-		{ cwd: src, stdio: [ 'pipe', 'pipe', null ] }
+		{
+			cwd: src,
+			stdio: [ 'pipe', 'pipe', null ],
+			buffer: false,
+		}
 	);
 	const filterProductionInclude = new FilterStream(
 		s => s.match( /^(.*): production-include: (?!unspecified|unset)/ )?.[ 1 ]
@@ -62,7 +71,7 @@ export async function* listProjectFiles( src, spawn, output = undefined ) {
 	yield* rl;
 
 	if ( output ) {
-		output( 'D: Awaiting processes\n' );
+		output( `D: Awaiting processes.\n` );
 	}
 	await Promise.all( [ lsFiles, lsIgnoredFiles, checkAttrInclude, checkAttrExclude ] );
 	if ( output ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Remove some of the debugging statements added in previous PRs. The problem seems to be that we're getting into a state where the promises returned by `execa` are not settled even though all the underlying processes have been reaped and no IO is pending. For the moment we'll leave only the debug statements around there.

Now, by default `execa` will buffer the stdout and stderr streams so it can return them as strings when the process is finished. Mostly in the build we don't need that, and maybe the combination of the buffering plus the piping to other processes is getting node confused. So let's pass `buffer: false` except in the cases where we actually do need the buffering and see if that makes a difference.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Build still works?
* Merge and observe.