### PR TITLE
mu-wpcom-plugin: conditionally load the package

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-mu-wpcom-loading
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-mu-wpcom-loading
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Bumping major package version past zero.

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -47,7 +47,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "0.1.x-dev"
+			"dev-trunk": "0.2.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "0.1.2",
+	"version": "0.2.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '0.1.2';
+	const PACKAGE_VERSION = '0.2.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-jetpack-mu-wpcom-loading
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-jetpack-mu-wpcom-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN to conditionally load the package.

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-jetpack-mu-wpcom-loading#2
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-jetpack-mu-wpcom-loading#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -45,6 +45,6 @@
 		"release-branch-prefix": "jetpack"
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_0_2"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_0_3_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "445dfef6aaf9011ac49815c54720ba4cf0a259eb"
+                "reference": "f4885e743f456cb0dc8b9de19393ce456b95a49e"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -27,7 +27,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.1.x-dev"
+                    "dev-trunk": "0.2.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -12,13 +12,13 @@
  */
 
 /**
- * Include the composer autoloader.
+ * Conditionally load the jetpack-mu-wpcom package.
+ *
+ * JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN=true will load the package via the Jetpack Beta Tester plugin, not wpcomsh.
  */
-require_once __DIR__ . '/vendor/autoload.php';
-
-/**
- * Jetpack_Mu_Wpcom initialization.
- */
-if ( class_exists( 'Automattic\Jetpack\Jetpack_Mu_Wpcom' ) ) {
-	Automattic\Jetpack\Jetpack_Mu_Wpcom::init();
+if ( defined( 'JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN' ) && JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN ) {
+	require_once __DIR__ . '/vendor/autoload.php';
+	if ( class_exists( 'Automattic\Jetpack\Jetpack_Mu_Wpcom' ) ) {
+		Automattic\Jetpack\Jetpack_Mu_Wpcom::init();
+	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.0.2
+ * Version: 1.0.3-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.0.2",
+	"version": "1.0.3-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
## Proposed changes:

Use JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN to conditionally load the package. If constant is false, then the package will load by default via the wpcomsh implementation on WoA sites.

Internal: see related 1241-gh-Automattic/wpcomsh

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

Would need to test alongside 1241-gh-Automattic/wpcomsh

From my testing, using JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN to switch between the two implementations works well.