### PR TITLE
VideoPress: Fix custom CSS classes removal

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-block-custom-classnames
+++ b/projects/packages/videopress/changelog/fix-videopress-block-custom-classnames
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fix custom CSS classes removal

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -124,13 +124,6 @@ export default function VideoPressEdit( {
 		isExample,
 	} = attributes;
 
-	/*
-	 * Force className cleanup.
-	 * It adds ` wp-embed-aspect-21-9 wp-has-aspect-ratio` classes
-	 * when transforming from embed block.
-	 */
-	delete attributes.className;
-
 	const videoPressUrl = getVideoPressUrl( guid, {
 		autoplay,
 		controls,

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
@@ -7,7 +7,7 @@ import { createBlock } from '@wordpress/blocks';
  */
 import { buildVideoPressURL, pickGUIDFromUrl } from '../../../../lib/url';
 
-const transfromFromCoreEmbed = {
+const transformFromCoreEmbed = {
 	type: 'block',
 	blocks: [ 'core/embed' ],
 	isMatch: attrs => attrs.providerNameSlug === 'videopress' && pickGUIDFromUrl( attrs?.url ),
@@ -16,7 +16,7 @@ const transfromFromCoreEmbed = {
 		const guid = pickGUIDFromUrl( src );
 
 		/*
-		 * Do transform when the block
+		 * Don't transform when the block
 		 * is not a core/embed VideoPress block variation
 		 */
 		const isCoreEmbedVideoPressVariation = providerNameSlug === 'videopress' && !! guid;
@@ -24,11 +24,18 @@ const transfromFromCoreEmbed = {
 			return createBlock( 'core/embed', attrs );
 		}
 
+		/*
+		 * Force className cleanup.
+		 * It adds aspect ratio classes when transforming from embed block.
+		 */
+		const classRegex = /(wp-embed-aspect-\d+-\d+)|(wp-has-aspect-ratio)/g;
+		attrs.className = attrs.className?.replace( classRegex, '' ).trim();
+
 		return createBlock( 'videopress/video', { guid, src } );
 	},
 };
 
-const transfromToCoreEmbed = {
+const transformToCoreEmbed = {
 	type: 'block',
 	blocks: [ 'core/embed' ],
 	isMatch: attrs => attrs?.src || attrs?.guid,
@@ -53,7 +60,7 @@ const transfromToCoreEmbed = {
 	},
 };
 
-const from = [ transfromFromCoreEmbed ];
-const to = [ transfromToCoreEmbed ];
+const from = [ transformFromCoreEmbed ];
+const to = [ transformToCoreEmbed ];
 
 export default { from, to };

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
@@ -53,6 +53,9 @@ export type VideoBlockAttributes = VideoBlockColorAttributesProps & {
 	rating?: string;
 
 	isPrivate?: boolean;
+
+	// CSS classes
+	className?: string;
 };
 
 export type VideoBlockSetAttributesProps = ( attributes: VideoBlockAttributes ) => void;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #28780

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The custom classes were removed because a transformation from the embed block added some aspect-ration classes. This cleanup was moved to the embed transform function and reduced to remove only the aspect-ration classes.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Add an embed block with a VideoPress link (e.g. https://videopress.com/v/Ygmx4akX)
* Add a custom class to the embed block:
![2023-02-09_17-07-52](https://user-images.githubusercontent.com/8486249/217926349-d24124e1-c0a3-4f35-8b6e-e709890c4ee3.png)
* Transform the block to a VideoPress block:
![2023-02-09_17-09-37](https://user-images.githubusercontent.com/8486249/217926422-9c1ee5f3-24a1-4c8f-be8c-5e0af860bb2f.png)
* Check that the custom class is not removed, but the other classes are:
![2023-02-09_17-09-58](https://user-images.githubusercontent.com/8486249/217926530-2dd1c4f7-053f-411a-8038-cc651c107f2a.png)
* Publish the post and visit it
* Check that the custom class is added to the block (`figure` tag):
![2023-02-09_17-11-42](https://user-images.githubusercontent.com/8486249/217926640-f41c7133-e20a-4232-a04d-14e9a799f14f.png)


