### PR TITLE
[Paid Newsletters] Fix regression with comment box appearing everywhere

### DIFF
--- a/projects/plugins/jetpack/changelog/paid-newsletters-fix-comments-under-pages
+++ b/projects/plugins/jetpack/changelog/paid-newsletters-fix-comments-under-pages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix a bug where comments would be open under pages

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -82,8 +82,8 @@ function register_block() {
 	add_action( 'the_content', __NAMESPACE__ . '\maybe_get_locked_content' );
 
 	// Close comments on the front-end
-	add_filter( 'comments_open', __NAMESPACE__ . '\maybe_close_comments' );
-	add_filter( 'pings_open', __NAMESPACE__ . '\maybe_close_comments' );
+	add_filter( 'comments_open', __NAMESPACE__ . '\maybe_close_comments', 10, 2 );
+	add_filter( 'pings_open', __NAMESPACE__ . '\maybe_close_comments', 10, 2 );
 
 	// Hide existing comments
 	add_filter( 'get_comment', __NAMESPACE__ . '\maybe_gate_existing_comments' );
@@ -704,11 +704,17 @@ function maybe_get_locked_content( $the_content ) {
 }
 
 /**
- * Gate access to comments
+ * Gate access to comments. We want to close comments on private sites.
+ *
+ * @param bool $default_comments_open Default state of the comments_open filter.
+ * @param int  $post_id Current post id.
  *
  * @return bool
  */
-function maybe_close_comments() {
+function maybe_close_comments( $default_comments_open, $post_id ) {
+	if ( ! $default_comments_open || ! $post_id ) {
+		return $default_comments_open;
+	}
 	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
 	return Jetpack_Memberships::user_can_view_post();
 }


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/Automattic/jetpack/pull/28170 where comment box would start to appear on pages and other places where it isn't supposed to show.
This is happening only for proxied Automatticians at this moment, as they are the only ones running this code now

## Proposed changes:
* Respect the default value of the `comments_open` and `pings_open` filters


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Go to Pezvd2-9-p2
* Notice comments are open
* `pnpm jetpack build plugins/jetpack && pnpm jetpack rsync` to sync this branch to your sandbox
* Sandbox the domain of Pezvd2-9-p2
* Notice that comments are not open any more.
