### PR TITLE
WAF: Fix uncaught exceptions

### DIFF
--- a/projects/packages/waf/changelog/fix-waf-throws
+++ b/projects/packages/waf/changelog/fix-waf-throws
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed uncaught exceptions.
+
+

--- a/projects/packages/waf/src/class-waf-initializer.php
+++ b/projects/packages/waf/src/class-waf-initializer.php
@@ -132,14 +132,14 @@ class Waf_Initializer {
 				try {
 					( new Waf_Standalone_Bootstrap() )->generate();
 				} catch ( \Exception $e ) {
-					return;
+					return new WP_Error( 'waf_update_failed', $e->getMessage() );
 				}
-				return;
+				return true;
 			}
 
 			Waf_Constants::define_mode();
 			if ( ! Waf_Runner::is_allowed_mode( JETPACK_WAF_MODE ) ) {
-				return;
+				return new WP_Error( 'waf_update_failed', 'Invalid firewall mode.' );
 			}
 
 			try {

--- a/projects/packages/waf/src/class-waf-initializer.php
+++ b/projects/packages/waf/src/class-waf-initializer.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Waf;
 
+use WP_Error;
+
 /**
  * Initializes the module
  */
@@ -48,12 +50,25 @@ class Waf_Initializer {
 
 	/**
 	 * On module activation set up waf mode
+	 *
+	 * @return bool|WP_Error True of the WAF activation was successful, WP_Error otherwise.
 	 */
 	public static function on_activation() {
 		update_option( Waf_Runner::MODE_OPTION_NAME, 'normal' );
 		add_option( Waf_Rules_Manager::AUTOMATIC_RULES_ENABLED_OPTION_NAME, false );
-		Waf_Runner::activate();
-		( new Waf_Standalone_Bootstrap() )->generate();
+
+		$waf_activated = Waf_Runner::activate();
+		if ( is_wp_error( $waf_activated ) ) {
+			return $waf_activated;
+		}
+
+		try {
+			( new Waf_Standalone_Bootstrap() )->generate();
+		} catch ( \Exception $e ) {
+			return new WP_Error( 'waf_activation_failed', $e->getMessage() );
+		}
+
+		return true;
 	}
 
 	/**
@@ -107,14 +122,18 @@ class Waf_Initializer {
 	 *
 	 * Updates the WAF when the "needs update" option is enabled.
 	 *
-	 * @return void
+	 * @return bool|WP_Error True if the WAF is up-to-date or was sucessfully updated, WP_Error if the update failed.
 	 */
 	public static function check_for_waf_update() {
 		if ( get_option( self::NEEDS_UPDATE_OPTION_NAME ) ) {
 			// Compatiblity patch for cases where an outdated WAF_Constants class has been
 			// autoloaded by the standalone bootstrap execution at the beginning of the current request.
 			if ( ! method_exists( Waf_Constants::class, 'define_mode' ) ) {
-				( new Waf_Standalone_Bootstrap() )->generate();
+				try {
+					( new Waf_Standalone_Bootstrap() )->generate();
+				} catch ( \Exception $e ) {
+					return;
+				}
 				return;
 			}
 
@@ -123,12 +142,17 @@ class Waf_Initializer {
 				return;
 			}
 
-			Waf_Rules_Manager::generate_ip_rules();
-			Waf_Rules_Manager::generate_rules();
-			( new Waf_Standalone_Bootstrap() )->generate();
-
-			update_option( self::NEEDS_UPDATE_OPTION_NAME, 0 );
+			try {
+				Waf_Rules_Manager::generate_ip_rules();
+				Waf_Rules_Manager::generate_rules();
+				( new Waf_Standalone_Bootstrap() )->generate();
+			} catch ( \Exception $e ) {
+				return new WP_Error( 'waf_update_failed', $e->getMessage() );
+			}
 		}
+
+		update_option( self::NEEDS_UPDATE_OPTION_NAME, 0 );
+		return true;
 	}
 
 	/**

--- a/projects/packages/waf/src/class-waf-rules-manager.php
+++ b/projects/packages/waf/src/class-waf-rules-manager.php
@@ -91,12 +91,12 @@ class Waf_Rules_Manager {
 	/**
 	 * Updates the rule set if rules version has changed
 	 *
-	 * @return void
+	 * @return bool|WP_Error True if rules update is successful, WP_Error on failure.
 	 */
 	public static function update_rules_if_changed() {
 		Waf_Constants::define_mode();
 		if ( ! Waf_Runner::is_allowed_mode( JETPACK_WAF_MODE ) ) {
-			return;
+			return new WP_Error( 'waf_update_failed', 'Invalid firewall mode.' );
 		}
 		$version = get_option( self::VERSION_OPTION_NAME );
 		if ( self::RULES_VERSION !== $version ) {
@@ -110,6 +110,8 @@ class Waf_Rules_Manager {
 				return new WP_Error( 'waf_update_failed', $e->getMessage() );
 			}
 		}
+
+		return true;
 	}
 
 	/**

--- a/projects/packages/waf/src/class-waf-rules-manager.php
+++ b/projects/packages/waf/src/class-waf-rules-manager.php
@@ -73,7 +73,7 @@ class Waf_Rules_Manager {
 	public static function update_rules_cron() {
 		Waf_Constants::define_mode();
 		if ( ! Waf_Runner::is_allowed_mode( JETPACK_WAF_MODE ) ) {
-			return;
+			return new WP_Error( 'waf_cron_update_failed', 'Invalid firewall mode.' );
 		}
 
 		try {

--- a/projects/packages/waf/src/class-waf-rules-manager.php
+++ b/projects/packages/waf/src/class-waf-rules-manager.php
@@ -137,7 +137,7 @@ class Waf_Rules_Manager {
 		$response_code = wp_remote_retrieve_response_code( $response );
 
 		if ( 200 !== $response_code ) {
-			throw new \Exception( 'API connection failed.', $response_code );
+			throw new \Exception( 'API connection failed.', (int) $response_code );
 		}
 
 		$rules_json = wp_remote_retrieve_body( $response );

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -271,8 +271,9 @@ class Waf_Runner {
 	public static function activate() {
 		Waf_Constants::define_mode();
 		if ( ! self::is_allowed_mode( JETPACK_WAF_MODE ) ) {
-			return;
+			new WP_Error( 'waf_activation_failed', 'Invalid firewall mode.' );
 		}
+
 		$version = get_option( Waf_Rules_Manager::VERSION_OPTION_NAME );
 		if ( ! $version ) {
 			add_option( Waf_Rules_Manager::VERSION_OPTION_NAME, Waf_Rules_Manager::RULES_VERSION );

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -265,7 +265,7 @@ class Waf_Runner {
 	/**
 	 * Activates the WAF by generating the rules script and setting the version
 	 *
-	 * @return void
+	 * @return bool|WP_Error True if the WAF was activated sucessfully, WP_Error if not.
 	 */
 	public static function activate() {
 		Waf_Constants::define_mode();
@@ -279,11 +279,17 @@ class Waf_Runner {
 
 		add_option( self::SHARE_DATA_OPTION_NAME, true );
 
-		self::initialize_filesystem();
-		Waf_Rules_Manager::generate_automatic_rules();
-		Waf_Rules_Manager::generate_ip_rules();
-		self::create_blocklog_table();
-		Waf_Rules_Manager::generate_rules();
+		try {
+			self::initialize_filesystem();
+			Waf_Rules_Manager::generate_automatic_rules();
+			Waf_Rules_Manager::generate_ip_rules();
+			self::create_blocklog_table();
+			Waf_Rules_Manager::generate_rules();
+		} catch ( \Exception $e ) {
+			return new WP_Error( 'waf_activation_failed', $e->getMessage() );
+		}
+
+		return true;
 	}
 
 	/**
@@ -364,7 +370,13 @@ class Waf_Runner {
 		Waf_Rules_Manager::update_rules_if_changed();
 		// Re-generate the standalone bootstrap file on every update
 		// TODO: We may consider only doing this when the WAF version changes
-		( new Waf_Standalone_Bootstrap() )->generate();
+		try {
+			( new Waf_Standalone_Bootstrap() )->generate();
+		} catch ( \Exception $e ) {
+			return new WP_Error( 'waf_update_failed', $e->getMessage() );
+		}
+
+		return true;
 	}
 
 	/**
@@ -382,7 +394,13 @@ class Waf_Runner {
 
 		// Validate that the automatic rules file exists and is not empty.
 		global $wp_filesystem;
-		self::initialize_filesystem();
+
+		try {
+			self::initialize_filesystem();
+		} catch ( \Exception $e ) {
+			return false;
+		}
+
 		$automatic_rules_file_contents = $wp_filesystem->get_contents( self::get_waf_file_path( Waf_Rules_Manager::AUTOMATIC_RULES_FILE ) );
 
 		// If the automatic rules file was removed or is now empty, return false.

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Waf;
 
 use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Status\Host;
+use WP_Error;
 
 /**
  * Executes the WAF.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR addresses unsafe usage of methods in the WAF package that potentially throw Exceptions.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Wrap all uses of methods that throw with a try/catch
* Gracefully return a `WP_Error` with the exception information, instead of blowing up.
* This patch only prevents the exceptions from going uncaught, but does not introduce new handling of the exceptions beyond converting them into a `WP_Error` returned by the method.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1675981016445109-slack-CDD9LQRSN

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Proof read changes.

Using the monorepo docker environment:
* Destroy the entire `jetpack-waf` content directory: `rm -rf tools/docker/wordpress/wp-content/jetpack-waf`
* Remove write permissions on your `wp-content` directory with `chmod -w tools/docker/wordpress/wp-content`.
* Run `jetpack docker wp jetpack-waf generate_rules` and validate no fatals or crashes - errors message will be displayed in the CLI.
* Restore file write permissions: `chmod +w tools/docker/wordpress/wp-content`.
* Run `jetpack docker wp jetpack-waf generate_rules` again and validate the rules are generated.

<img width="900" alt="Screenshot 2023-02-10 at 12 00 15 PM" src="https://user-images.githubusercontent.com/10933065/218175522-6cb49d67-e109-412b-a633-9659c3d352a0.png">
