### PR TITLE
Blaze: do not load in the classic editor

### DIFF
--- a/projects/packages/blaze/changelog/fix-blaze-classic-editor
+++ b/projects/packages/blaze/changelog/fix-blaze-classic-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Do not load the Blaze script in the classic editor.

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -42,7 +42,7 @@ class Blaze {
 		// On the edit screen, add a row action to promote the post.
 		add_action( 'load-edit.php', array( __CLASS__, 'add_post_links_actions' ) );
 		// In the post editor, add a post-publish panel to allow promoting the post.
-		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_block_editor_assets' ) );
+		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_block_editor_assets' ) );
 	}
 
 	/**
@@ -212,23 +212,18 @@ class Blaze {
 
 	/**
 	 * Enqueue block editor assets.
-	 *
-	 * @param string $hook The current admin page.
 	 */
-	public static function enqueue_block_editor_assets( $hook ) {
+	public static function enqueue_block_editor_assets() {
 		/*
-		 * We do not want (nor need) Blaze in the site editor or the widget editor, only in the post editor.
+		 * We do not want (nor need) Blaze in the site editor, or the widget editor, or the classic editor.
+		 * We only want it in the post editor.
 		 * Enqueueing the script in those editors would cause a fatal error.
 		 * See #20357 for more info.
 		 */
-		if ( ! in_array( $hook, array( 'post.php', 'post-new.php' ), true ) ) {
-			return;
-		}
-
-		// We do not want (nor need) Blaze in the classic editor.
 		$current_screen = get_current_screen();
 		if (
 			empty( $current_screen )
+			|| $current_screen->base !== 'post'
 			|| ! $current_screen->is_block_editor()
 		) {
 			return;

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -225,6 +225,15 @@ class Blaze {
 			return;
 		}
 
+		// We do not want (nor need) Blaze in the classic editor.
+		$current_screen = get_current_screen();
+		if (
+			empty( $current_screen )
+			|| ! $current_screen->is_block_editor()
+		) {
+			return;
+		}
+
 		// Bail if criteria is not met to enable Blaze features.
 		if ( ! self::should_initialize() ) {
 			return;

--- a/projects/packages/blaze/tests/php/test-blaze.php
+++ b/projects/packages/blaze/tests/php/test-blaze.php
@@ -153,7 +153,10 @@ class Test_Blaze extends BaseTestCase {
 			add_filter( 'jetpack_blaze_enabled', '__return_true' );
 		}
 
-		Blaze::enqueue_block_editor_assets( $hook );
+		// Set the current admin page.
+		set_current_screen( $hook );
+
+		Blaze::enqueue_block_editor_assets();
 
 		// Assert that our style, filter, and action has been added.
 		if ( $should_enqueue ) {
@@ -175,31 +178,31 @@ class Test_Blaze extends BaseTestCase {
 	public function get_enqueue_scenarios() {
 		return array(
 			'In site editor, Blaze enabled, site admin'  => array(
-				'site-editor.php',
+				'site-editor',
 				true,
 				true,
 				false,
 			),
 			'In post editor, Blaze disabled, site admin' => array(
-				'post.php',
+				'post',
 				false,
 				true,
 				false,
 			),
 			'In post editor, Blaze enabled, site admin'  => array(
-				'post.php',
+				'post',
 				true,
 				true,
 				true,
 			),
 			'In random admin page, Blaze enabled, site admin' => array(
-				'tools.php',
+				'tools',
 				true,
 				true,
 				false,
 			),
 			'In post editor, Blaze enabled, editor role' => array(
-				'post.php',
+				'post',
 				true,
 				false,
 				false,


### PR DESCRIPTION
## Proposed changes:

We do not need the script to be enqueued in the classic editor, as we do not display anything there.
Moreover, loading this script in the classic editor can conflict with other plugins.

> **Note**
> This is a byproduct of this fix: #28187 
> When we stopped hooking into `enqueue_block_editor_assets` to decide when the script should be loaded, we started enqueuing it in the classic editor as well.

Here is an example of a conflict that came up:
https://github.com/Yoast/wordpress-seo/issues/19840

**To do**

- [ ] Update the tests to take this new use-case into account.
- [x] Consolidate with the existing check for the post editor page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1676050658080489-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Posts > Add New on a public site connected to WordPress.com. Use the Twenty Twenty Three theme.
* Write a new post and publish it.
* Upon publication, you should see an invitation to Blaze your post.
* Now go to Plugins > Add New, install and activate the Classic Editor plugin
* Go to Posts > Add New
* In your browser console, check the sources loaded on the page; you should find no script loaded from `wp-content/plugins/jetpack/jetpack_vendor/automattic/jetpack-blaze/`
* Go to Appearance > Site Editor
* Ensure the page loads just fine. 
* In your browser console, check the sources loaded on the page; you should find no script loaded from `wp-content/plugins/jetpack/jetpack_vendor/automattic/jetpack-blaze/`

You can also test that the following conflict is resolved:

* Go to Plugins > Add New and install the Yoast SEO plugin.
* Go to the Posts menu, and open the editor for a post that's already published.
* Scroll down to the Yoast SEO section, and look for the "slug" section.
* It should contain the post slug. 
* When not running this branch, you'll find that the field is empty.
