### PR TITLE
jetpack-mu-wpcom: migrate Automattic/wp-calypso/pull/71541

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-mu-wpcom-coming-soon
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-mu-wpcom-coming-soon
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Migrate Calypso code for Coming Soon: Automattic/wp-calypso/pull/71541
+
+

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "0.2.0",
+	"version": "0.2.1-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '0.2.0';
+	const PACKAGE_VERSION = '0.2.1-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/coming-soon/coming-soon.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/coming-soon/coming-soon.php
@@ -223,15 +223,17 @@ function add_option_to_new_site( $blog_id, $user_id, $domain, $path, $network_id
 add_action( 'wpmu_new_blog', __NAMESPACE__ . '\add_option_to_new_site', 10, 6 );
 
 /**
- * Decides whether to redirect to the site's coming soon page and performs
- * the redirect.
+ * Decides whether to render to the site's coming soon page and performs
+ * the render.
+ *
+ * @param string $template The template to render.
  */
-function coming_soon_page() {
+function coming_soon_page( $template ) {
 	if ( ! should_show_coming_soon_page() ) {
-		return;
+		return $template;
 	}
 
 	render_fallback_coming_soon_page();
 	die();
 }
-add_action( 'template_redirect', __NAMESPACE__ . '\coming_soon_page' );
+add_filter( 'template_include', __NAMESPACE__ . '\coming_soon_page' );


### PR DESCRIPTION
## Proposed changes:

Migrates Automattic/wp-calypso/pull/71541 which happened after the initial move of coming-soon from ETK.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

Proofread.
