### PR TITLE
adds a notification task to notify KitKat for high and blocker bugs

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -3,7 +3,7 @@ on:
   pull_request_target: # When a PR is opened, edited, updated, closed, or a label is added.
     types: [opened, reopened, synchronize, edited, labeled, closed ]
   issues: # For auto-triage of issues.
-    types: [opened, reopened, edited, closed]
+    types: [opened, reopened, labeled, edited, closed]
   issue_comment: # To gather support references in issue comments.
     types: [created]
   push:

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -78,3 +78,4 @@ jobs:
           slack_editorial_channel: ${{ secrets.SLACK_EDITORIAL_CHANNEL }}
           slack_he_triage_channel: ${{ secrets.SLACK_HE_TRIAGE_CHANNEL }}
           slack_quality_channel: ${{ secrets.SLACK_QUALITY_CHANNEL }}
+          slack_kitkat_channel: ${{ secrets.SLACK_KITKAT_CHANNEL }}

--- a/projects/github-actions/repo-gardening/README.md
+++ b/projects/github-actions/repo-gardening/README.md
@@ -14,6 +14,7 @@ Here is the current list of tasks handled by this action:
 - WordPress.com Commit Reminder (`wpcomCommitReminder`): Posts a comment on merged PRs to remind Automatticians to commit the matching WordPress.com change.
 - Notify Design (`notifyDesign`): Sends a Slack Notification to the Design team to request feedback, based on labels applied to a PR.
 - Notify Editorial (`notifyEditorial`): Sends a Slack Notification to the Editorial team to request feedback, based on labels applied to a PR.
+- Notify Kitkat (`notifyKitKat`): Sends a Slack Notification to the Kitkat team to warn them of high or Blocker issues (based on labels assigned to the issues).
 - Flag OSS (`flagOss`): flags entries by external contributors, adds an "OSS Citizen" label to the PR, and sends a Slack message.
 - Triage New Issues (`triageNewIssues`): Adds labels to new issues based on issue content.
 - Gather support references (`gatherSupportReferences`): Adds a new comment with a list of all support references on the issue, and escalates that issue via a Slack message if needed.

--- a/projects/github-actions/repo-gardening/action.yml
+++ b/projects/github-actions/repo-gardening/action.yml
@@ -36,6 +36,10 @@ inputs:
     description: "Slack channel ID where issues needing extra triage / escalation will be sent"
     required: false
     default: ""
+  slack_kitkat_channel:
+    description: "Slack channel ID where issues needing the attention of the WordPress.com Quality team will be sent"
+    required: false
+    default: ""
   tasks:
     description: "Comma-separated selection of task names (function name, camelCase) this action should run. e.g. addLabels,cleanLabels"
     required: false

--- a/projects/github-actions/repo-gardening/changelog/add-notify-kitkat-for-high-and-blocker-bugs
+++ b/projects/github-actions/repo-gardening/changelog/add-notify-kitkat-for-high-and-blocker-bugs
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add new task to notify Quality team of important issues

--- a/projects/github-actions/repo-gardening/package.json
+++ b/projects/github-actions/repo-gardening/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "repo-gardening",
-	"version": "3.1.2-alpha",
+	"version": "3.2.0-alpha",
 	"description": "Manage Pull Requests and issues in your Open Source project (automate labelling, milestones, feedback to PR authors, ...)",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/github-actions/repo-gardening/src/index.js
+++ b/projects/github-actions/repo-gardening/src/index.js
@@ -56,7 +56,7 @@ const automations = [
 	{
 		event: 'issues',
 		action: [ 'labeled' ],
-		task: ifNotClosed( notifyKitKat ),
+		task: notifyKitKat,
 	},
 	{
 		event: 'push',

--- a/projects/github-actions/repo-gardening/src/index.js
+++ b/projects/github-actions/repo-gardening/src/index.js
@@ -9,6 +9,7 @@ const flagOss = require( './tasks/flag-oss' );
 const gatherSupportReferences = require( './tasks/gather-support-references' );
 const notifyDesign = require( './tasks/notify-design' );
 const notifyEditorial = require( './tasks/notify-editorial' );
+const notifyKitKat = require( './tasks/notify-kitkat' );
 const replyToCustomersReminder = require( './tasks/reply-to-customers-reminder' );
 const triageNewIssues = require( './tasks/triage-new-issues' );
 const wpcomCommitReminder = require( './tasks/wpcom-commit-reminder' );
@@ -51,6 +52,11 @@ const automations = [
 		event: 'pull_request_target',
 		action: [ 'labeled' ],
 		task: ifNotClosed( notifyEditorial ),
+	},
+	{
+		event: 'issues',
+		action: [ 'labeled' ],
+		task: ifNotClosed( notifyKitKat ),
 	},
 	{
 		event: 'push',

--- a/projects/github-actions/repo-gardening/src/tasks/notify-kitkat/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/notify-kitkat/index.js
@@ -16,8 +16,8 @@ const sendSlackMessage = require( '../../utils/send-slack-message' );
  */
 async function hasHighPrioLabel( octokit, owner, repo, number ) {
 	const labels = await getLabels( octokit, owner, repo, number );
-	// We're only interested in the [Prio] High label.
-	return labels.includes( '[Prio] High' );
+	// We're only interested in the [Pri] High label.
+	return labels.includes( '[Pri] High' );
 }
 
 /**
@@ -31,15 +31,15 @@ async function hasHighPrioLabel( octokit, owner, repo, number ) {
  */
 async function hasBlockerPrioLabel( octokit, owner, repo, number ) {
 	const labels = await getLabels( octokit, owner, repo, number );
-	// We're only interested in the [Prio] BLOCKER label.
-	return labels.includes( '[Prio] BLOCKER' );
+	// We're only interested in the [Pri] BLOCKER label.
+	return labels.includes( '[Pri] BLOCKER' );
 }
 
 /**
  * Send a Slack notification about a label to Team KitKat.
  *
  * @param {WebhookPayloadIssue} payload - Issue event payload.
- * @param {GitHub}                    octokit - Initialized Octokit REST client.
+ * @param {GitHub}              octokit - Initialized Octokit REST client.
  */
 async function notifyKitKat( payload, octokit ) {
 	const { number, repository } = payload;
@@ -54,23 +54,21 @@ async function notifyKitKat( payload, octokit ) {
 
 	const channel = getInput( 'slack_kitkat_channel' );
 	if ( ! channel ) {
-		setFailed(
-			'notify-kitkat: Input slack_kitkat_channel is required but missing. Aborting.'
-		);
+		setFailed( 'notify-kitkat: Input slack_kitkat_channel is required but missing. Aborting.' );
 		return;
 	}
 
-	// Check for a [Prio] High label.
+	// Check for a [Pri] High label.
 	const isLabeledHighPriority = await hasHighPrioLabel( octokit, ownerLogin, repo, number );
 	if ( isLabeledHighPriority ) {
 		debug(
-			'notify-kitkat: Found a [Prio] High label on issue #${ number }. Sending in Slack message.'
+			'notify-kitkat: Found a [Pri] High label on issue #${ number }. Sending in Slack message.'
 		);
 		await sendSlackMessage(
 			'New High priority bug! Please take a moment to triage this bug.',
-		    channel,
-		    slackToken,
-		    payload
+			channel,
+			slackToken,
+			payload
 		);
 	}
 
@@ -81,10 +79,10 @@ async function notifyKitKat( payload, octokit ) {
 			'notify-kitkat: Found a [Pri] BLOCKER label on issue #${ number }. Sending in Slack message.'
 		);
 		await sendSlackMessage(
-		    'New Blocker bug!  Please take a moment to triage this bug.',
-		    channel,
-		    slackToken,
-		    payload
+			'New Blocker bug!  Please take a moment to triage this bug.',
+			channel,
+			slackToken,
+			payload
 		);
 	}
 }

--- a/projects/github-actions/repo-gardening/src/tasks/notify-kitkat/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/notify-kitkat/index.js
@@ -36,12 +36,12 @@ async function hasBlockerPrioLabel( octokit, owner, repo, number ) {
 }
 
 /**
- * Check for a Kitkat Input Requested label on a PR.
+ * Check for a Kitkat Input Requested label on an issue.
  *
  * @param {GitHub} octokit - Initialized Octokit REST client.
  * @param {string} owner   - Repository owner.
  * @param {string} repo    - Repository name.
- * @param {string} number  - PR number.
+ * @param {string} number  - Issue number.
  * @returns {Promise<boolean>} Promise resolving to boolean.
  */
 async function hasKitkatSignalLabel( octokit, owner, repo, number ) {
@@ -57,7 +57,10 @@ async function hasKitkatSignalLabel( octokit, owner, repo, number ) {
  * @param {GitHub}              octokit - Initialized Octokit REST client.
  */
 async function notifyKitKat( payload, octokit ) {
-	const { number, repository } = payload;
+	const {
+		issue: { number },
+		repository,
+	} = payload;
 	const { owner, name: repo } = repository;
 	const ownerLogin = owner.login;
 

--- a/projects/github-actions/repo-gardening/src/tasks/notify-kitkat/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/notify-kitkat/index.js
@@ -79,7 +79,7 @@ function formatSlackMessage( payload, channel, message ) {
 				type: 'section',
 				text: {
 					type: 'mrkdwn',
-					text: `Could you take a look at it, triage, ping, and escalate to the right team if you think that's necessary. Once you've done so, please mark this message as :done:. Thank you!`,
+					text: `@kitkat-team please mark this message as :done: once the issue has been triaged. Thank you!`,
 				},
 			},
 			{
@@ -150,7 +150,7 @@ async function notifyKitKat( payload, octokit ) {
 		debug(
 			`notify-kitkat: Found a [Pri] High label on issue #${ number }. Sending in Slack message.`
 		);
-		const message = `:warning: New High priority bug! Please take a moment to triage this bug.`;
+		const message = `:bug_police: New High priority bug! Please take a moment to triage this bug.`;
 		const slackMessageFormat = formatSlackMessage( payload, channel, message );
 		await sendSlackMessage( message, channel, slackToken, payload, slackMessageFormat );
 	}
@@ -161,7 +161,7 @@ async function notifyKitKat( payload, octokit ) {
 		debug(
 			`notify-kitkat: Found a [Pri] BLOCKER label on issue #${ number }. Sending in Slack message.`
 		);
-		const message = `:warning: New Blocker bug!  Please take a moment to triage this bug.`;
+		const message = `:bug_police: New Blocker bug!  Please take a moment to triage this bug.`;
 		const slackMessageFormat = formatSlackMessage( payload, channel, message );
 		await sendSlackMessage( message, channel, slackToken, payload, slackMessageFormat );
 	}

--- a/projects/github-actions/repo-gardening/src/tasks/notify-kitkat/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/notify-kitkat/index.js
@@ -62,7 +62,7 @@ async function notifyKitKat( payload, octokit ) {
 	const isLabeledHighPriority = await hasHighPrioLabel( octokit, ownerLogin, repo, number );
 	if ( isLabeledHighPriority ) {
 		debug(
-			'notify-kitkat: Found a [Pri] High label on issue #${ number }. Sending in Slack message.'
+			`notify-kitkat: Found a [Pri] High label on issue #${ number }. Sending in Slack message.`
 		);
 		await sendSlackMessage(
 			'New High priority bug! Please take a moment to triage this bug.',
@@ -76,7 +76,7 @@ async function notifyKitKat( payload, octokit ) {
 	const isLabeledBlocker = await hasBlockerPrioLabel( octokit, ownerLogin, repo, number );
 	if ( isLabeledBlocker ) {
 		debug(
-			'notify-kitkat: Found a [Pri] BLOCKER label on issue #${ number }. Sending in Slack message.'
+			`notify-kitkat: Found a [Pri] BLOCKER label on issue #${ number }. Sending in Slack message.`
 		);
 		await sendSlackMessage(
 			'New Blocker bug!  Please take a moment to triage this bug.',

--- a/projects/github-actions/repo-gardening/src/tasks/notify-kitkat/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/notify-kitkat/index.js
@@ -1,0 +1,94 @@
+const { getInput, setFailed } = require( '@actions/core' );
+const debug = require( '../../utils/debug' );
+const getLabels = require( '../../utils/get-labels' );
+const sendSlackMessage = require( '../../utils/send-slack-message' );
+
+/* global GitHub, WebhookPayloadIssue */
+
+/**
+ * Check for a high priority label on an issue.
+ *
+ * @param {GitHub} octokit - Initialized Octokit REST client.
+ * @param {string} owner   - Repository owner.
+ * @param {string} repo    - Repository name.
+ * @param {string} number  - Issue number.
+ * @returns {Promise<boolean>} Promise resolving to boolean.
+ */
+async function hasHighPrioLabel( octokit, owner, repo, number ) {
+	const labels = await getLabels( octokit, owner, repo, number );
+	// We're only interested in the [Prio] High label.
+	return labels.includes( '[Prio] High' );
+}
+
+/**
+ * Check for a BLOCKER priority label on an issue.
+ *
+ * @param {GitHub} octokit - Initialized Octokit REST client.
+ * @param {string} owner   - Repository owner.
+ * @param {string} repo    - Repository name.
+ * @param {string} number  - Issue number.
+ * @returns {Promise<boolean>} Promise resolving to boolean.
+ */
+async function hasBlockerPrioLabel( octokit, owner, repo, number ) {
+	const labels = await getLabels( octokit, owner, repo, number );
+	// We're only interested in the [Prio] BLOCKER label.
+	return labels.includes( '[Prio] BLOCKER' );
+}
+
+
+/**
+ * Send a Slack notification about a label to Team KitKat.
+ *
+ * @param {WebhookPayloadIssue} payload - Issue event payload.
+ * @param {GitHub}                    octokit - Initialized Octokit REST client.
+ */
+async function notifyKitKat( payload, octokit ) {
+	const { number, repository } = payload;
+	const { owner, name: repo } = repository;
+	const ownerLogin = owner.login;
+
+	const slackToken = getInput( 'slack_token' );
+	if ( ! slackToken ) {
+		setFailed( `notify-kitkat: Input slack_token is required but missing. Aborting.` );
+		return;
+	}
+
+	const channel = getInput( 'slack_kitkat_channel' );
+	if ( ! channel ) {
+		setFailed(
+			`notify-editorial: Input slack_kitkat_channel is required but missing. Aborting.`
+		);
+		return;
+	}
+
+
+	// Check for a [Prio] High label.
+	const isLabeledHighPriority = await hasHighPrioLabel( octokit, ownerLogin, repo, number );
+	if ( isLabeledHighPriority ) {
+		debug(
+			`notify-kitkat: Found a [Prio] High label on issue #${ number }. Sending in Slack message.`
+		);
+		await sendSlackMessage(
+			`New High priority bug.`,
+			channel,
+			slackToken,
+			payload
+		);
+	}
+
+	// Check for a BLOCKER priority label.
+	const isLabeledBlocker = await hasLabel( octokit, ownerLogin, repo, number );
+	if ( isLabeledBlocker ) {
+		debug(
+			`notify-editorial: Found a [Pri] BLOCKER label on issue #${ number }. Sending in Slack message.`
+		);
+		await sendSlackMessage(
+			`New Blocker bug!.`,
+			channel,
+			slackToken,
+			payload
+		);
+	}
+}
+
+module.exports = notifyKitKat;

--- a/projects/github-actions/repo-gardening/src/tasks/notify-kitkat/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/notify-kitkat/index.js
@@ -35,7 +35,6 @@ async function hasBlockerPrioLabel( octokit, owner, repo, number ) {
 	return labels.includes( '[Prio] BLOCKER' );
 }
 
-
 /**
  * Send a Slack notification about a label to Team KitKat.
  *
@@ -49,44 +48,43 @@ async function notifyKitKat( payload, octokit ) {
 
 	const slackToken = getInput( 'slack_token' );
 	if ( ! slackToken ) {
-		setFailed( `notify-kitkat: Input slack_token is required but missing. Aborting.` );
+		setFailed( 'notify-kitkat: Input slack_token is required but missing. Aborting.' );
 		return;
 	}
 
 	const channel = getInput( 'slack_kitkat_channel' );
 	if ( ! channel ) {
 		setFailed(
-			`notify-editorial: Input slack_kitkat_channel is required but missing. Aborting.`
+			'notify-kitkat: Input slack_kitkat_channel is required but missing. Aborting.'
 		);
 		return;
 	}
-
 
 	// Check for a [Prio] High label.
 	const isLabeledHighPriority = await hasHighPrioLabel( octokit, ownerLogin, repo, number );
 	if ( isLabeledHighPriority ) {
 		debug(
-			`notify-kitkat: Found a [Prio] High label on issue #${ number }. Sending in Slack message.`
+			'notify-kitkat: Found a [Prio] High label on issue #${ number }. Sending in Slack message.'
 		);
 		await sendSlackMessage(
-			`New High priority bug.`,
-			channel,
-			slackToken,
-			payload
+			'New High priority bug! Please take a moment to triage this bug.',
+		    channel,
+		    slackToken,
+		    payload
 		);
 	}
 
 	// Check for a BLOCKER priority label.
-	const isLabeledBlocker = await hasLabel( octokit, ownerLogin, repo, number );
+	const isLabeledBlocker = await hasBlockerPrioLabel( octokit, ownerLogin, repo, number );
 	if ( isLabeledBlocker ) {
 		debug(
-			`notify-editorial: Found a [Pri] BLOCKER label on issue #${ number }. Sending in Slack message.`
+			'notify-kitkat: Found a [Pri] BLOCKER label on issue #${ number }. Sending in Slack message.'
 		);
 		await sendSlackMessage(
-			`New Blocker bug!.`,
-			channel,
-			slackToken,
-			payload
+		    'New Blocker bug!  Please take a moment to triage this bug.',
+		    channel,
+		    slackToken,
+		    payload
 		);
 	}
 }

--- a/projects/github-actions/repo-gardening/src/tasks/notify-kitkat/readme.md
+++ b/projects/github-actions/repo-gardening/src/tasks/notify-kitkat/readme.md
@@ -1,5 +1,7 @@
 # Notify KitKat
 
+**Kitkat is the WordPress.com Quality team. If your quality team is named differently, you can still use this task! :)**
+
 Send a Slack notification to KitKat when there is a high or blocker priority bug, or a bug with no priority label.
 
 This task responds to the following labels:

--- a/projects/github-actions/repo-gardening/src/tasks/notify-kitkat/readme.md
+++ b/projects/github-actions/repo-gardening/src/tasks/notify-kitkat/readme.md
@@ -1,0 +1,14 @@
+# Notify KitKat
+
+Send a Slack notification to KitKat when there is a high or blocker priority bug, or a bug with no priority label.
+
+This task responds to the following labels:
+
+- "[Pri] BLOCKER"
+- "[Pri] High"
+
+When one of the labels above is added to an issue, a Slack message will be sent to channel of your choice.
+
+## Rationale
+
+This alert will help improve triage times which should then improve MTTR.

--- a/projects/github-actions/repo-gardening/src/utils/send-slack-message.js
+++ b/projects/github-actions/repo-gardening/src/utils/send-slack-message.js
@@ -1,15 +1,15 @@
 const fetch = require( 'node-fetch' );
 
-/* global WebhookPayloadPullRequest */
+/* global WebhookPayloadPullRequest, WebhookPayloadIssue */
 
 /**
  * Send a message to a Slack channel using the Slack API.
  *
- * @param {string}                    message             - Message to post to Slack
- * @param {string}                    channel             - Slack channel ID.
- * @param {string}                    token               - Slack token.
- * @param {WebhookPayloadPullRequest} payload             - Pull request event payload.
- * @param {object}                    customMessageFormat - Custom message formatting. If defined, takes over from message completely.
+ * @param {string}                                        message             - Message to post to Slack
+ * @param {string}                                        channel             - Slack channel ID.
+ * @param {string}                                        token               - Slack token.
+ * @param {WebhookPayloadPullRequest|WebhookPayloadIssue} payload             - Pull request event payload.
+ * @param {object}                                        customMessageFormat - Custom message formatting. If defined, takes over from message completely.
  * @returns {Promise<boolean>} Promise resolving to a boolean, whether message was successfully posted or not.
  */
 async function sendSlackMessage( message, channel, token, payload, customMessageFormat = {} ) {
@@ -19,8 +19,8 @@ async function sendSlackMessage( message, channel, token, payload, customMessage
 	if ( Object.keys( customMessageFormat ).length > 0 ) {
 		slackMessage = customMessageFormat;
 	} else {
-		const { pull_request, repository } = payload;
-		const { html_url, title, user } = pull_request;
+		const { repository } = payload;
+		const { html_url, title, user } = payload?.pull_request ?? payload.issue;
 
 		slackMessage = {
 			channel,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

- This is WIP to add notifications to #kitkat-daily for high and blocker bugs.
- I have mostly copied from notify-editorial, and I'm sure I've made some mistakes. 😎
- I have not added the channel id as a secret (yet)
- ifNotClosed might need to be updated (or a new function added) to handle issues, as the existing function is geared towards PRs.
- This is my first time working with GitHub actions. I'm unsure if this will fire a notification when any label is added to a bug with the specified labels or only when the specified labels are added. For example, if a bug is labeled [Prio] High, and the notification is sent, and later, someone adds another label such as "Atomic", will this trigger another notification? I ask because notify-editorial has a check on "hasBeenRequested". If this is the case, I can add a check for the presence of the "needs triage" label, so that we don't send the notification if that label is not present. We will then need to ensure that new bugs start with that label and that we remove it consistently during triage.
- Also, I do not know how to test this, so advice would be greatly appreciated!

### Other information:

Since this is for GitHub Actions, there should be no impact on e2e tests or WP.com.

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


