### PR TITLE
Forms: Fix script concatenation

### DIFF
--- a/projects/packages/forms/changelog/fix-form-script-concatenation
+++ b/projects/packages/forms/changelog/fix-form-script-concatenation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add filter to prevent contact-form-styles script from being concatenated

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -277,6 +277,8 @@ class Contact_Form_Plugin {
 	 * Enqueue scripts responsible for handling contact form styles.
 	 */
 	private static function enqueue_contact_forms_style_script() {
+		add_filter( 'js_do_concat', array( __CLASS__, 'disable_forms_style_script_concat' ), 10, 3 );
+
 		wp_enqueue_script(
 			'contact-form-styles',
 			plugins_url( 'js/form-styles.js', __FILE__ ),
@@ -284,6 +286,19 @@ class Contact_Form_Plugin {
 			\JETPACK__VERSION,
 			true
 		);
+	}
+
+	/**
+	 * Prevent 'contact-form-styles' script from being concatenated.
+	 *
+	 * @param array  $do_concat - the concatenation flag.
+	 * @param string $handle - script name.
+	 */
+	public static function disable_forms_style_script_concat( $do_concat, $handle ) {
+		if ( 'contact-form-styles' === $handle ) {
+			$do_concat = false;
+		}
+		return $do_concat;
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-form-script-concatenation
+++ b/projects/plugins/jetpack/changelog/fix-form-script-concatenation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Add filter to prevent contact-form-styles script from being concatenated

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -397,6 +397,8 @@ class Grunion_Contact_Form_Plugin {
 	 * Enqueue scripts responsible for handling contact form styles.
 	 */
 	private static function enqueue_contact_forms_style_script() {
+		add_filter( 'js_do_concat', array( __CLASS__, 'disable_forms_style_script_concat' ), 10, 3 );
+
 		wp_enqueue_script(
 			'contact-form-styles',
 			plugins_url( 'js/form-styles.js', __FILE__ ),
@@ -404,6 +406,19 @@ class Grunion_Contact_Form_Plugin {
 			JETPACK__VERSION,
 			true
 		);
+	}
+
+	/**
+	 * Prevent 'contact-form-styles' script from being concatenated.
+	 *
+	 * @param array  $do_concat - the concatenation flag.
+	 * @param string $handle - script name.
+	 */
+	public static function disable_forms_style_script_concat( $do_concat, $handle ) {
+		if ( 'contact-form-styles' === $handle ) {
+			$do_concat = false;
+		}
+		return $do_concat;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #28883

## Proposed changes:

* Adds a filter to prevent the `contact-form-styles` script from being concatenated when the `Page Optimize` plugin is active.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Install the [Page Optimize plugin](https://wordpress.org/plugins/page-optimize/) and activate it
* Create a post and add a Form block
* Publish the page and visit the public view
* Inspect the page and search for `form-styles.js`
* You should find the JS file in its own `<script>` tag

