### PR TITLE
CRM: Refactor IntlDateFormatter dependency

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-format-task-dates-without-ext-dep
+++ b/projects/plugins/crm/changelog/fix-crm-format-task-dates-without-ext-dep
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: We used to depend on "strftime" before migrating into the monorepo which does not require ext-intl to be installed which we now match by using date instead of IntlDateFormatter
+
+

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.Localisation.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.Localisation.php
@@ -305,7 +305,6 @@ function zeroBSCRM_date_defaultFormat() {
 function zeroBSCRM_date_forceEN( $time = -1 ) {
 
 	if ( $time > 0 ) {
-
 		// Note: Because this continued to be use for task scheduler workaround (before we got to rewrite the locale timestamp saving)
 		// ... we functionised in Core.Localisation.php to keep it DRY
 
@@ -314,17 +313,18 @@ function zeroBSCRM_date_forceEN( $time = -1 ) {
 		// (Month names are localised, causing a mismatch here (Italian etc.))
 		// ... so we translate:
 		// d F Y H:i:s (date - not locale based)
-		// https://www.php.net/manual/en/function.date.php
 		// ... into
-		// dd MMMM yyyy HH:mm:ss (IntlDateFormatter - locale based date)
-		// (https://www.php.net/manual/en/class.intldateformatter.php)
+		// d F Y H:i:s (date - locale based date)
+		// (https://www.php.net/manual/en/function.date.php)
 
-		$fmt = new IntlDateFormatter( 'en_US', IntlDateFormatter::FULL, IntlDateFormatter::FULL );
-		$fmt->setPattern( 'dd MMMM yyyy HH:mm:ss' );
-		$r = $fmt->format( $time );
+		zeroBSCRM_locale_setServerLocale( 'en_US' );
+		// We specifically use "date" instead of "gmdate" because "date" is affected
+		// by runtime timezone changes.
+		// phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+		$r = date( 'd F Y H:i:s', $time );
+		zeroBSCRM_locale_resetServerLocale();
 
 		return $r;
-
 	}
 
 	return false;

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -1110,37 +1110,8 @@ function zeroBSCRM_getObjNav( $id = -1, $key = '', $type = ZBS_TYPE_CONTACT ) {
 
 
 	    } else {
-
-	    	// Note: Because this continued to be use for task scheduler workaround (before we got to rewrite the locale timestamp saving)
-	    	// ... we functionised in Core.Localisation.php to keep it DRY
-
-	        // temp pre v3.0 fix, forcing english en for this datepicker only. 
-	        // requires js mod: search #forcedlocaletasks
-	        // (Month names are localised, causing a mismatch here (Italian etc.)) 
-	        // ... so we translate:
-	        //      d F Y H:i:s (date - not locale based)
-	        // https://www.php.net/manual/en/function.date.php
-	        // ... into
-	        //      dd MMMM yyyy HH:mm:ss (IntlDateFormatter - locale based date)
-	        // (https://www.php.net/manual/en/class.intldateformatter.php)
-
-	        /*
-	        $start_d = zeroBSCRM_date_i18n('d F Y H:i:s', $taskObject['start']);
-	        $end_d = zeroBSCRM_date_i18n('d F Y H:i:s', $taskObject['end']);
-	        */
-
-	        /*
-
-	        $fmt = new IntlDateFormatter( 'en_US', IntlDateFormatter::FULL, IntlDateFormatter::FULL );
-	        $fmt->setPattern( 'dd MMMM yyyy HH:mm:ss' );
-	        $start_d = $fmt->format($task['start']);
-	        $end_d =  $fmt->format($task['end']);
-
-	        */
-
-	        $start_d = zeroBSCRM_date_forceEN($task['start']);
-	        $end_d = zeroBSCRM_date_forceEN($task['end']);
-
+			$start_d = zeroBSCRM_date_forceEN( $task['start'] );
+			$end_d   = zeroBSCRM_date_forceEN( $task['end'] );
 	    }
 
 	    return $start_d . ' - ' . $end_d;

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Events.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Events.php
@@ -726,51 +726,30 @@ function zeroBSCRM_task_ui_for_co($taskObject = array()){
 
 }
 
+/**
+ * The date picker UI
+ *
+ * @param array $task_object The task array that contains the date(s).
+ * @return string
+ */
+function zeroBSCRM_task_ui_date( $task_object = array() ) {
+	if ( ! isset( $task_object['start'] ) ) {
+		// starting date
+		// wh modified to now + 1hr - 2hr
+		// phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+		$start_d = date( 'd F Y H:i:s', ( time() + 3600 ) );
+		// phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+		$end_d = date( 'd F Y H:i:s', ( time() + 3600 + 3600 ) );
+	} else {
+		$start_d = zeroBSCRM_date_forceEN( $task_object['start'] );
+		$end_d   = zeroBSCRM_date_forceEN( $task_object['end'] );
+	}
 
-#} the date picker UI
-function zeroBSCRM_task_ui_date($taskObject = array()){
+	$html  = '<div class="no-task-date"><input type="text" id="daterange" class="form-control" name="daterange" value="' . $start_d . ' - ' . $end_d . '" autocomplete="zbs-' . time() . '-task-date" /></div>';
+	$html .= '<input type="hidden" id="zbs_from" name="zbse_start" value="' . $start_d . '"/>';
+	$html .= '<input type="hidden" id="zbs_to" name="zbse_end" value="' . $end_d . '"/>';
 
-    $html = "<div class='no-task-date'><i class='ui icon calendar outline'></i> ". __('Date','zero-bs-crm') ." </div>";
-
-    if (!isset($taskObject['start'])){
-
-        // starting date
-        //$start_d = date('m/d/Y H') . ":00:00";
-        //$end_d =  date('m/d/Y H') . ":00:00";
-        // wh modified to now + 1hr - 2hr
-        $start_d = date('d F Y H:i:s',(time()+3600));
-        $end_d =  date('d F Y H:i:s',(time()+3600+3600));
-
-
-    } else {
-
-
-        // temp pre v3.0 fix, forcing english en for this datepicker only. 
-        // requires js mod: search #forcedlocaletasks
-        // (Month names are localised, causing a mismatch here (Italian etc.)) 
-        // ... so we translate:
-        //      d F Y H:i:s (date - not locale based)
-        // https://www.php.net/manual/en/function.date.php
-        // ... into
-        //      dd MMMM yyyy HH:mm:ss (IntlDateFormatter - locale based date)
-        // (https://www.php.net/manual/en/class.intldateformatter.php)
-
-        /*
-        $start_d = zeroBSCRM_date_i18n('d F Y H:i:s', $taskObject['start']);
-        $end_d = zeroBSCRM_date_i18n('d F Y H:i:s', $taskObject['end']);
-        */
-
-        $fmt = new IntlDateFormatter( 'en_US', IntlDateFormatter::FULL, IntlDateFormatter::FULL );
-        $fmt->setPattern( 'dd MMMM yyyy HH:mm:ss' );
-        $start_d = $fmt->format($taskObject['start']);
-        $end_d =  $fmt->format($taskObject['end']);
-    }
-
-    $html = '<div class="no-task-date"><input type="text" id="daterange" class="form-control" name="daterange" value="' . $start_d . ' - ' . $end_d .'" autocomplete="zbs-'.time() . '-task-date" /></div>';
-    $html .= '<input type="hidden" id="zbs_from" name="zbse_start" value="' . $start_d .'"/>';
-    $html .= '<input type="hidden" id="zbs_to" name="zbse_end" value="' . $end_d . '"/>';
-    
-    return $html;
+	return $html;
 }
 
 #} save UI button


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We used to rely on `strftime` before migrating to the monorepo (https://github.com/Automattic/jetpack/pull/28314/), but `PHPCompatibility.FunctionUse.RemovedFunctions.strftimeDeprecated` revealed that it has been flagged as deprecated since PHP 8.1:

```
warning - Function strftime() is deprecated since PHP 8.1; Use date() or IntlDateFormatter::format() instead (PHPCompatibility.FunctionUse.RemovedFunctions.strftimeDeprecated)
```
We chose to refactor to use `IntlDateFormatter` in https://github.com/Automattic/jetpack/pull/28314/commits/dc36c7afdd08b992633793ab1d59043148b7dfe1 to satisfy PHPCS and be preventive in terms of `strftime` being removed but `IntlDateFormatter` requires the `intl` extension.
We might as well use `date()` and thereby keep same system requirements as before (which then also means that my local Jetpack Docker environment doesn't throw errors anymore 😄).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Switched from `IntlDateFormatter` to `date`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

* p1676069293714539-slack-C04J4UG3FLG

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Scenario 1: Create new task/event

* Spin up site locally
  * _(Make sure the `intl` extension is disabled if you want to reproduce the initial error before using this refactor)_
* Go to `/wp-admin/admin.php?page=zbs-add-edit&action=edit&zbstype=event`
* Create a new task and set a start & end date (remember the dates to compare with)
  * The rest of the data on the task doesn't matter and could just be `abcdefg`.
* Verify that the date was created and make check that the dates and times still match