### PR TITLE
Fix premium content block access level

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-premium-content-block-access-level
+++ b/projects/plugins/jetpack/changelog/fix-premium-content-block-access-level
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix premium content block where it would only allow access to site subscribers

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/access-check.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/access-check.php
@@ -94,7 +94,7 @@ function current_visitor_can_access( $attributes, $block ) {
 	}
 
 	$paywall      = subscription_service();
-	$access_level = Token_Subscription_Service::POST_ACCESS_LEVEL_SUBSCRIBERS; // Only subscribers should be granted access to the premium content
+	$access_level = Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS; // Only paid subscribers should be granted access to the premium content
 	$can_view     = $paywall->visitor_can_view_content( array( $selected_plan_id ), $access_level );
 
 	if ( $can_view ) {


### PR DESCRIPTION
This fixes a regression introduced in #28170 where people would have access to premium content block if they are site subscribers

Fixes #28911 

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:


1. build, sync this diff
2. Open incognito window, sign in as a test user, 
3. https://bestmemberships.wordpress.com/2020/02/17/premium-content/
4. Subscribe with your test user **as a follower** (bottom right menu)
5. you should NOT have access to the content
6. Subscribe as a paid subscriber
7. You should now have access
