### PR TITLE
VideoPress: do not use JS template strings to build queryString of the chapter file to avoid concat_js=no issues

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-do-not-use-js-template-to-create-file-chapter-url
+++ b/projects/packages/videopress/changelog/update-videopress-do-not-use-js-template-to-create-file-chapter-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: do not use JS template to build queryString of the chapter file to avoid concat_js=no issues

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -170,11 +170,13 @@ export default function VideoPressEdit( {
 			return;
 		}
 
-		const queryString = token
-			? `?${ new URLSearchParams( { metadata_token: token } ).toString() }`
-			: '';
+		let queryString = '';
+		if ( token ) {
+			queryString = '?' + new URLSearchParams( { metadata_token: token } ).toString();
+		}
 
-		const chapterUrl = `https://videos.files.wordpress.com/${ guid }/${ chapter.src }${ queryString }`;
+		const chapterUrl =
+			'https://videos.files.wordpress.com/' + guid + '/' + chapter.src + queryString;
 
 		try {
 			fetch( chapterUrl )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We've been informed about an issue where the block editor breaks using the JS=on mode. Although I couldn't reproduce the issue in my dev environment, the system seems unhappy when using the [JS template string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) to build the query string of the video chapter.

This PR replaces the template string by using the classic string concatenation.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: do not use the JS template to build queryString of the chapter file to avoid concat_js=no issues

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test on Simple site
* Get sandboxed and proxied.
* Apply these changes to your sandbox
* Go to the block editor
* Add/edit a video block
* Set the video
* Set privacy private
* Add chapters by editing the video description
* save the post
* Everything should work as expected 
* You can inspect the network tab to get the generated `vtt` file. 
* Also, you can try to load it in a new tab (usually by doing a double click in the filename)

<img width="890" alt="Screen Shot 2023-02-13 at 10 01 52" src="https://user-images.githubusercontent.com/77539/218465306-448a0109-aee4-4301-beaa-32b2d04c639a.png">
