### PR TITLE
General: add External link icon to external links

### DIFF
--- a/projects/js-packages/components/changelog/fix-missing-external-links
+++ b/projects/js-packages/components/changelog/fix-missing-external-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use External Link icons for external links

--- a/projects/js-packages/components/components/pricing-table/index.tsx
+++ b/projects/js-packages/components/components/pricing-table/index.tsx
@@ -1,3 +1,4 @@
+import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, check, closeSmall } from '@wordpress/icons';
@@ -29,13 +30,9 @@ const ToS = createInterpolateElement(
 		'jetpack'
 	),
 	{
-		tosLink: <a href={ getRedirectUrl( 'wpcom-tos' ) } rel="noopener noreferrer" target="_blank" />,
+		tosLink: <ExternalLink href={ getRedirectUrl( 'wpcom-tos' ) } />,
 		shareDetailsLink: (
-			<a
-				href={ getRedirectUrl( 'jetpack-support-what-data-does-jetpack-sync' ) }
-				rel="noopener noreferrer"
-				target="_blank"
-			/>
+			<ExternalLink href={ getRedirectUrl( 'jetpack-support-what-data-does-jetpack-sync' ) } />
 		),
 	}
 );

--- a/projects/js-packages/connection/changelog/fix-missing-external-links
+++ b/projects/js-packages/connection/changelog/fix-missing-external-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add External link icon to links at the bottom of the disconnect modal.

--- a/projects/js-packages/connection/components/connect-screen/basic/test/component.jsx
+++ b/projects/js-packages/connection/components/connect-screen/basic/test/component.jsx
@@ -32,14 +32,14 @@ describe( 'ConnectScreen', () => {
 
 	it( 'applies correct href to terms of service', () => {
 		render( <ConnectScreen { ...requiredProps } /> );
-		const terms = screen.getByRole( 'link', { name: 'Terms of Service' } );
+		const terms = screen.getByRole( 'link', { name: 'Terms of Service (opens in a new tab)' } );
 		expect( terms ).toHaveAttribute( 'href', 'https://jetpack.com/redirect/?source=wpcom-tos' );
 		expect( terms ).toHaveAttribute( 'target', '_blank' );
 	} );
 
 	it( 'applies correct href to share', () => {
 		render( <ConnectScreen { ...requiredProps } /> );
-		const share = screen.getByRole( 'link', { name: 'share details' } );
+		const share = screen.getByRole( 'link', { name: 'share details (opens in a new tab)' } );
 		expect( share ).toHaveAttribute(
 			'href',
 			'https://jetpack.com/redirect/?source=jetpack-support-what-data-does-jetpack-sync'

--- a/projects/js-packages/connection/components/connect-screen/basic/visual.jsx
+++ b/projects/js-packages/connection/components/connect-screen/basic/visual.jsx
@@ -1,4 +1,5 @@
 import { getRedirectUrl, ActionButton } from '@automattic/jetpack-components';
+import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
@@ -12,13 +13,9 @@ export const ToS = createInterpolateElement(
 		'jetpack'
 	),
 	{
-		tosLink: <a href={ getRedirectUrl( 'wpcom-tos' ) } rel="noopener noreferrer" target="_blank" />,
+		tosLink: <ExternalLink href={ getRedirectUrl( 'wpcom-tos' ) } />,
 		shareDetailsLink: (
-			<a
-				href={ getRedirectUrl( 'jetpack-support-what-data-does-jetpack-sync' ) }
-				rel="noopener noreferrer"
-				target="_blank"
-			/>
+			<ExternalLink href={ getRedirectUrl( 'jetpack-support-what-data-does-jetpack-sync' ) } />
 		),
 	}
 );

--- a/projects/js-packages/connection/components/connect-screen/required-plan/test/component.jsx
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/test/component.jsx
@@ -37,14 +37,14 @@ describe( 'ConnectScreenRequiredPlan', () => {
 
 	it( 'applies correct href to terms of service', () => {
 		render( <ConnectScreenRequiredPlan { ...requiredProps } /> );
-		const terms = screen.getByRole( 'link', { name: 'Terms of Service' } );
+		const terms = screen.getByRole( 'link', { name: 'Terms of Service (opens in a new tab)' } );
 		expect( terms ).toHaveAttribute( 'href', 'https://jetpack.com/redirect/?source=wpcom-tos' );
 		expect( terms ).toHaveAttribute( 'target', '_blank' );
 	} );
 
 	it( 'applies correct href to share', () => {
 		render( <ConnectScreenRequiredPlan { ...requiredProps } /> );
-		const share = screen.getByRole( 'link', { name: 'share details' } );
+		const share = screen.getByRole( 'link', { name: 'share details (opens in a new tab)' } );
 		expect( share ).toHaveAttribute(
 			'href',
 			'https://jetpack.com/redirect/?source=jetpack-support-what-data-does-jetpack-sync'

--- a/projects/js-packages/connection/components/connect-screen/required-plan/visual.jsx
+++ b/projects/js-packages/connection/components/connect-screen/required-plan/visual.jsx
@@ -1,4 +1,5 @@
 import { getRedirectUrl, PricingCard, ActionButton } from '@automattic/jetpack-components';
+import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
@@ -36,15 +37,9 @@ const ConnectScreenRequiredPlanVisual = props => {
 			'jetpack'
 		),
 		{
-			tosLink: (
-				<a href={ getRedirectUrl( 'wpcom-tos' ) } rel="noopener noreferrer" target="_blank" />
-			),
+			tosLink: <ExternalLink href={ getRedirectUrl( 'wpcom-tos' ) } />,
 			shareDetailsLink: (
-				<a
-					href={ getRedirectUrl( 'jetpack-support-what-data-does-jetpack-sync' ) }
-					rel="noopener noreferrer"
-					target="_blank"
-				/>
+				<ExternalLink href={ getRedirectUrl( 'jetpack-support-what-data-does-jetpack-sync' ) } />
 			),
 		}
 	);

--- a/projects/js-packages/connection/components/disconnect-dialog/steps/step-disconnect.jsx
+++ b/projects/js-packages/connection/components/disconnect-dialog/steps/step-disconnect.jsx
@@ -1,5 +1,5 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { Button } from '@wordpress/components';
+import { Button, ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
@@ -129,7 +129,7 @@ const StepDisconnect = props => {
 
 			<div className="jp-connection__disconnect-dialog__actions">
 				<div className="jp-row">
-					<div className="lg-col-span-7 md-col-span-8 sm-col-span-4">
+					<div className="lg-col-span-8 md-col-span-9 sm-col-span-4">
 						<p>
 							{ createInterpolateElement(
 								__(
@@ -139,21 +139,17 @@ const StepDisconnect = props => {
 								{
 									strong: <strong></strong>,
 									jpConnectionInfoLink: (
-										<a
+										<ExternalLink
 											href={ getRedirectUrl(
 												'why-the-wordpress-com-connection-is-important-for-jetpack'
 											) }
-											rel="noopener noreferrer"
-											target="_blank"
 											className="jp-connection__disconnect-dialog__link"
 											onClick={ trackLearnClick }
 										/>
 									),
 									jpSupportLink: (
-										<a
+										<ExternalLink
 											href={ getRedirectUrl( 'jetpack-support' ) }
-											rel="noopener noreferrer"
-											target="_blank"
 											className="jp-connection__disconnect-dialog__link"
 											onClick={ trackSupportClick }
 										/>
@@ -162,7 +158,7 @@ const StepDisconnect = props => {
 							) }
 						</p>
 					</div>
-					<div className="jp-connection__disconnect-dialog__button-wrap lg-col-span-5 md-col-span-8 sm-col-span-4">
+					<div className="jp-connection__disconnect-dialog__button-wrap lg-col-span-4 md-col-span-7 sm-col-span-4">
 						<Button
 							variant="primary"
 							disabled={ isDisconnecting }

--- a/projects/js-packages/connection/components/disconnect-dialog/test/step-disconnect.jsx
+++ b/projects/js-packages/connection/components/disconnect-dialog/test/step-disconnect.jsx
@@ -67,8 +67,8 @@ describe( 'StepDisconnect', () => {
 
 	describe( 'When help links are clicked', () => {
 		const links = [
-			[ 'Jetpack connection', 'jetpack_disconnect_dialog_click_learn_about' ],
-			[ 'contact Jetpack support', 'jetpack_disconnect_dialog_click_support' ],
+			[ 'Jetpack connection (opens in a new tab)', 'jetpack_disconnect_dialog_click_learn_about' ],
+			[ 'contact Jetpack support (opens in a new tab)', 'jetpack_disconnect_dialog_click_support' ],
 		];
 		it.each( links )( `should track the "%s" click with %s`, async ( text, event ) => {
 			const user = userEvent.setup();

--- a/projects/js-packages/connection/components/manage-connection-dialog/index.jsx
+++ b/projects/js-packages/connection/components/manage-connection-dialog/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Button, getRedirectUrl, Text } from '@automattic/jetpack-components';
-import { Modal } from '@wordpress/components';
+import { ExternalLink, Modal } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronRight, external } from '@wordpress/icons';
@@ -143,7 +143,7 @@ const ManageConnectionActionCard = ( { title, onClick = () => null, link = '#', 
 const HelpFooter = ( { onClose } ) => {
 	return (
 		<div className="jp-row jp-connection__manage-dialog__actions">
-			<div className="jp-connection__manage-dialog__text-wrap lg-col-span-8 md-col-span-6 sm-col-span-3">
+			<div className="jp-connection__manage-dialog__text-wrap lg-col-span-9 md-col-span-7 sm-col-span-3">
 				<Text>
 					{ createInterpolateElement(
 						__(
@@ -153,21 +153,17 @@ const HelpFooter = ( { onClose } ) => {
 						{
 							strong: <strong></strong>,
 							connectionInfoLink: (
-								<a
+								<ExternalLink
 									href={ getRedirectUrl(
 										'why-the-wordpress-com-connection-is-important-for-jetpack'
 									) }
-									rel="noopener noreferrer"
-									target="_blank"
 									className="jp-connection__manage-dialog__link"
 									// TODO add click track
 								/>
 							),
 							supportLink: (
-								<a
+								<ExternalLink
 									href={ getRedirectUrl( 'jetpack-support' ) }
-									rel="noopener noreferrer"
-									target="_blank"
 									className="jp-connection__manage-dialog__link"
 									// TODO add click track
 								/>
@@ -176,7 +172,7 @@ const HelpFooter = ( { onClose } ) => {
 					) }
 				</Text>
 			</div>
-			<div className="jp-connection__manage-dialog__button-wrap lg-col-span-4 md-col-span-2 sm-col-span-1">
+			<div className="jp-connection__manage-dialog__button-wrap lg-col-span-3 md-col-span-1 sm-col-span-1">
 				<Button
 					weight="regular"
 					variant="secondary"

--- a/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
@@ -1,5 +1,6 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { DisconnectDialog } from '@automattic/jetpack-connection';
+import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getFragment } from '@wordpress/url';
@@ -214,18 +215,10 @@ export class ConnectButton extends React.Component {
 								'jetpack'
 							),
 							{
-								tosLink: (
-									<a
-										href={ getRedirectUrl( 'wpcom-tos' ) }
-										rel="noopener noreferrer"
-										target="_blank"
-									/>
-								),
+								tosLink: <ExternalLink href={ getRedirectUrl( 'wpcom-tos' ) } />,
 								shareDetailsLink: (
-									<a
+									<ExternalLink
 										href={ getRedirectUrl( 'jetpack-support-what-data-does-jetpack-sync' ) }
-										rel="noopener noreferrer"
-										target="_blank"
 									/>
 								),
 							}

--- a/projects/plugins/jetpack/_inc/client/components/footer/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/footer/index.jsx
@@ -1,5 +1,5 @@
 import { getRedirectUrl, JetpackFooter } from '@automattic/jetpack-components';
-import { ExternalLink } from '@wordpress/components';
+import { Dashicon } from '@wordpress/components';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import classNames from 'classnames';
 import DevCard from 'components/dev-card';
@@ -175,9 +175,11 @@ export class Footer extends React.Component {
 			if ( ! this.props.isAtomicPlatform ) {
 				return (
 					<li className="jp-footer__link-item">
-						<ExternalLink
+						<a
 							onClick={ this.trackVersionClick }
 							href={ getRedirectUrl( 'jetpack' ) }
+							target="_blank"
+							rel="noopener noreferrer"
 							className="jp-footer__link"
 							title={ __( 'Jetpack version', 'jetpack' ) }
 						>
@@ -188,7 +190,8 @@ export class Footer extends React.Component {
 										version
 								  )
 								: 'Jetpack' }
-						</ExternalLink>
+							{ <Dashicon icon="external" /> }
+						</a>
 					</li>
 				);
 			}
@@ -210,31 +213,40 @@ export class Footer extends React.Component {
 						<a
 							onClick={ this.trackAboutClick }
 							href={ aboutPageUrl }
+							target={ this.props.siteConnectionStatus ? '_self' : '_blank' }
+							rel="noopener noreferrer"
 							className="jp-footer__link"
 							title={ __( 'About Jetpack', 'jetpack' ) }
 						>
 							{ _x( 'About', 'Link to learn more about Jetpack.', 'jetpack' ) }
+							{ ! this.props.siteConnectionStatus && <Dashicon icon="external" /> }
 						</a>
 					</li>
 					<li className="jp-footer__link-item">
-						<ExternalLink
+						<a
 							onClick={ this.trackTermsClick }
 							href={ getRedirectUrl( 'wpcom-tos' ) }
+							target="_blank"
+							rel="noopener noreferrer"
 							title={ __( 'WordPress.com Terms of Service', 'jetpack' ) }
 							className="jp-footer__link"
 						>
 							{ _x( 'Terms', 'Shorthand for Terms of Service.', 'jetpack' ) }
-						</ExternalLink>
+							{ <Dashicon icon="external" /> }
+						</a>
 					</li>
 					<li className="jp-footer__link-item">
-						<ExternalLink
+						<a
 							onClick={ this.trackPrivacyClick }
 							href={ privacyUrl }
+							target={ this.props.siteConnectionStatus ? '_self' : '_blank' }
+							rel="noopener noreferrer"
 							title={ __( "Automattic's Privacy Policy", 'jetpack' ) }
 							className="jp-footer__link"
 						>
 							{ _x( 'Privacy', 'Shorthand for Privacy Policy.', 'jetpack' ) }
-						</ExternalLink>
+							{ ! this.props.siteConnectionStatus && <Dashicon icon="external" /> }
+						</a>
 					</li>
 					{ maybeShowModules() }
 					{ maybeShowDebug() }

--- a/projects/plugins/jetpack/_inc/client/components/footer/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/footer/index.jsx
@@ -1,4 +1,5 @@
 import { getRedirectUrl, JetpackFooter } from '@automattic/jetpack-components';
+import { ExternalLink } from '@wordpress/components';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import classNames from 'classnames';
 import DevCard from 'components/dev-card';
@@ -174,11 +175,9 @@ export class Footer extends React.Component {
 			if ( ! this.props.isAtomicPlatform ) {
 				return (
 					<li className="jp-footer__link-item">
-						<a
+						<ExternalLink
 							onClick={ this.trackVersionClick }
 							href={ getRedirectUrl( 'jetpack' ) }
-							target="_blank"
-							rel="noopener noreferrer"
 							className="jp-footer__link"
 							title={ __( 'Jetpack version', 'jetpack' ) }
 						>
@@ -189,7 +188,7 @@ export class Footer extends React.Component {
 										version
 								  )
 								: 'Jetpack' }
-						</a>
+						</ExternalLink>
 					</li>
 				);
 			}
@@ -218,27 +217,24 @@ export class Footer extends React.Component {
 						</a>
 					</li>
 					<li className="jp-footer__link-item">
-						<a
+						<ExternalLink
 							onClick={ this.trackTermsClick }
 							href={ getRedirectUrl( 'wpcom-tos' ) }
-							target="_blank"
-							rel="noopener noreferrer"
 							title={ __( 'WordPress.com Terms of Service', 'jetpack' ) }
 							className="jp-footer__link"
 						>
 							{ _x( 'Terms', 'Shorthand for Terms of Service.', 'jetpack' ) }
-						</a>
+						</ExternalLink>
 					</li>
 					<li className="jp-footer__link-item">
-						<a
+						<ExternalLink
 							onClick={ this.trackPrivacyClick }
 							href={ privacyUrl }
-							rel="noopener noreferrer"
 							title={ __( "Automattic's Privacy Policy", 'jetpack' ) }
 							className="jp-footer__link"
 						>
 							{ _x( 'Privacy', 'Shorthand for Privacy Policy.', 'jetpack' ) }
-						</a>
+						</ExternalLink>
 					</li>
 					{ maybeShowModules() }
 					{ maybeShowDebug() }

--- a/projects/plugins/jetpack/_inc/client/components/footer/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/footer/style.scss
@@ -73,6 +73,10 @@
 			border-bottom: none;
 		}
 	}
+
+	span {
+		padding: 0 0.1em;
+	}
 }
 
 .jp-footer__link__recommended {

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -1,4 +1,5 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import SimpleNotice from 'components/notice';
@@ -84,9 +85,7 @@ class JetpackStateNotices extends React.Component {
 						'jetpack'
 					),
 					{
-						a: (
-							<a href={ getRedirectUrl( 'wpcom-tos' ) } rel="noopener noreferrer" target="_blank" />
-						),
+						a: <ExternalLink href={ getRedirectUrl( 'wpcom-tos' ) } />,
 					}
 				);
 				break;

--- a/projects/plugins/jetpack/_inc/client/traffic/ads.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/ads.jsx
@@ -1,4 +1,5 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import Card from 'components/card';
@@ -175,7 +176,7 @@ export const Ads = withModuleSettingsFormHelpers(
 									),
 									{
 										link: (
-											<a
+											<ExternalLink
 												href={ getRedirectUrl( 'wpcom-automattic-ads-tos' ) }
 												target="_blank"
 												rel="noopener noreferrer"

--- a/projects/plugins/jetpack/changelog/fix-missing-external-links
+++ b/projects/plugins/jetpack/changelog/fix-missing-external-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+General: use external link icons for external links

--- a/projects/plugins/social/changelog/fix-missing-external-links
+++ b/projects/plugins/social/changelog/fix-missing-external-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use External Link icons for external links

--- a/projects/plugins/social/src/js/components/connection-screen/index.js
+++ b/projects/plugins/social/src/js/components/connection-screen/index.js
@@ -1,5 +1,6 @@
 import { Dialog, ProductOffer, Text, getRedirectUrl } from '@automattic/jetpack-components';
 import { useConnection } from '@automattic/jetpack-connection';
+import { ExternalLink } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -15,13 +16,9 @@ const tos = createInterpolateElement(
 		'jetpack-social'
 	),
 	{
-		tosLink: <a href={ getRedirectUrl( 'wpcom-tos' ) } rel="noopener noreferrer" target="_blank" />,
+		tosLink: <ExternalLink href={ getRedirectUrl( 'wpcom-tos' ) } />,
 		shareDetailsLink: (
-			<a
-				href={ getRedirectUrl( 'jetpack-support-what-data-does-jetpack-sync' ) }
-				rel="noopener noreferrer"
-				target="_blank"
-			/>
+			<ExternalLink href={ getRedirectUrl( 'jetpack-support-what-data-does-jetpack-sync' ) } />
 		),
 	}
 );


### PR DESCRIPTION
## Proposed changes:

* Add missing external link icons to external links:

<img width="1206" alt="Screenshot 2023-02-13 at 18 24 40" src="https://user-images.githubusercontent.com/426388/218529464-a5fe90ce-ca0d-4d7a-a275-7d218257fc3c.png">
<img width="1155" alt="Screenshot 2023-02-13 at 18 25 02" src="https://user-images.githubusercontent.com/426388/218529484-6f327788-a7a2-4c3b-96b2-1b8b36faf412.png">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* See 1202858161751496-as-1203957611988671/f and 1202858161751496-as-1203957611988695/f

## Does this pull request change what data or activity we track or use?
* No

## Testing instructions:

In your development environment, with a connected Jetpack;

* Go to the Plugins menu and click on "Deactivate" under the Jetpack plugin.
* Ensure the dialog window that pops has external link icons in the footer links.
* Go to Jetpack > Dashboard, scroll to the bottom of the page, and click "Manage site connection"
* Ensure the dialog window that pops has external link icons in the footer links.

You can also test the look of other external links in the dashboard, for all the plugins modified by this PR.