### PR TITLE
Fix blur on AMP renders for forms

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-blurry-thing-amp
+++ b/projects/plugins/jetpack/changelog/fix-blurry-thing-amp
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Inject an inline style to remove blurring from forms on AMP renders

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -387,6 +387,9 @@ class Grunion_Contact_Form_Plugin {
 		 *  add_action('wp_print_styles', 'remove_grunion_style');
 		 */
 		wp_register_style( 'grunion.css', GRUNION_PLUGIN_URL . 'css/grunion.css', array(), JETPACK__VERSION );
+		if ( function_exists( 'is_amp_request' ) && is_amp_request() ) {
+			wp_add_inline_style( 'grunion.css', '.wp-block-jetpack-contact-form-container {filter: blur(0px) !important;}' );
+		}
 		wp_style_add_data( 'grunion.css', 'rtl', 'replace' );
 
 		self::enqueue_contact_forms_style_script();


### PR DESCRIPTION

## Proposed changes:
While working on a better approach for dealing with forms on AMP pages, this patch injects a simple style override to remove the blur from forms.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Visit a form on an AMP render, it shouldn't be blurred