### PR TITLE
Subscribe block: Fix button to behave the same as in the frontend with regards to white-space and min-width rules

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-block-button-test-wrapping
+++ b/projects/plugins/jetpack/changelog/update-subscribe-block-button-test-wrapping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix subscribe-block button to behave the same as in the fronted with regards to white-space and min-width rules applied to RichText by Gutenberg with the useDefaultStyles hook

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
@@ -19,8 +19,8 @@
 
 	.wp-block-jetpack-subscriptions__form-container {
 		display: flex;
-		flex-direction: column;	
-	}	
+		flex-direction: column;
+	}
 
 	.wp-block-jetpack-subscriptions__form,
 	form {
@@ -33,7 +33,13 @@
 		button {
 			line-height: 1.3;
 			box-sizing: border-box;
-			white-space: nowrap;
+			/*
+			 * These next two rules override the default styles for RichText component
+			 * which is used for the button label coming from
+			 * https://github.com/WordPress/gutenberg/blob/b9232527214cd3d523badc4a66b529b7efe615ca/packages/rich-text/src/component/use-default-style.js.
+			 */
+			white-space: nowrap !important;
+			min-width: auto !important;
 		}
 
 		input[type="email"]::placeholder {
@@ -65,7 +71,7 @@
 		}
 	}
 
-	&.wp-block-jetpack-subscriptions__show-subs {		
+	&.wp-block-jetpack-subscriptions__show-subs {
 		.wp-block-jetpack-subscriptions__subscount {
 			margin: 8px 0;
 			font-size: 16px;


### PR DESCRIPTION
Brings back the default values for `white-space` and `min-width` so the button does not wrap its text in narrow environments

We do this by overriding those CSS rules with `! important` to overcome the default styles applied to RichText with
[useDefault()](https://github.com/WordPress/gutenberg/blob/b9232527214cd3d523badc4a66b529b7efe615ca/packages/rich-text/src/component/use-default-style.js)<!--- Provide a general summary of your changes in the Title above -->

**Note that these two values updated here make the element carry the default values for these elements. It was also the intention of the frontend to have these styles set like this**


<table>
<tr>
	<td><img width="490" alt="image" src="https://user-images.githubusercontent.com/746152/218532545-cb5d7111-7b90-46b2-808c-aec28b0f3746.png">
	<td><img width="545" alt="image" src="https://user-images.githubusercontent.com/746152/218532470-3dc46001-f596-4154-afc6-0115981b11f4.png">
<tr>
<td>Before
<td>After
</table>






## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates the block's `view.css` file to use `! important` for`white-space` and `min-width` so the button does not wrap its text in narrow environments

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
no
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch
* Use the Lettre theme
* Visit the Editor (Site Editor) with Safari
* Confirm that you don't see the word `Subscribe` wrapped in the next line.

