### PR TITLE
Forms: Fix persistent blur on amp pages

### DIFF
--- a/projects/packages/forms/changelog/fix-form-blur-amp-pages
+++ b/projects/packages/forms/changelog/fix-form-blur-amp-pages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent Forms blur effect on AMP pages

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -570,6 +570,10 @@ on production builds, the attributes are being reordered, causing side-effects
 	filter: blur(10px);
 }
 
-.contact-form-styles-loaded .wp-block-jetpack-contact-form-container {
+.contact-form-styles-loaded .wp-block-jetpack-contact-form-container,
+html[amp] body .wp-block-jetpack-contact-form-container,
+html[amp-version] body .wp-block-jetpack-contact-form-container,
+html[class*='amphtml'] body .wp-block-jetpack-contact-form-container
+{
 	filter: blur(0px);
 }

--- a/projects/plugins/jetpack/changelog/fix-form-blur-amp-pages
+++ b/projects/plugins/jetpack/changelog/fix-form-blur-amp-pages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Prevent Forms blur effect on AMP pages

--- a/projects/plugins/jetpack/modules/contact-form/css/grunion.css
+++ b/projects/plugins/jetpack/modules/contact-form/css/grunion.css
@@ -565,6 +565,10 @@ on production builds, the attributes are being reordered, causing side-effects
 	filter: blur(10px);
 }
 
-.contact-form-styles-loaded .wp-block-jetpack-contact-form-container {
+.contact-form-styles-loaded .wp-block-jetpack-contact-form-container,
+html[amp] body .wp-block-jetpack-contact-form-container,
+html[amp-version] body .wp-block-jetpack-contact-form-container,
+html[class*='amphtml'] body .wp-block-jetpack-contact-form-container
+{
 	filter: blur(0px);
 }


### PR DESCRIPTION
## Proposed changes:
* Prevent Forms blur effect on AMP pages

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Install and activate the AMP plugin
* Create a post, add a Form block, and publish the page
* Go to the public view and make sure you're seeing the AMP version
* The Form should appear on the page without the blur effect

