### PR TITLE
VideoPress: resend token when requester retries

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-read-and-support-is-retry-from-token-requester
+++ b/projects/packages/videopress/changelog/update-videopress-read-and-support-is-retry-from-token-requester
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: flish token when the requester retries

--- a/projects/packages/videopress/changelog/update-videopress-read-and-support-is-retry-from-token-requester
+++ b/projects/packages/videopress/changelog/update-videopress-read-and-support-is-retry-from-token-requester
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-VideoPress: flish token when the requester retries
+VideoPress: flush token when the requester retries

--- a/projects/packages/videopress/src/client/lib/token-bridge/index.ts
+++ b/projects/packages/videopress/src/client/lib/token-bridge/index.ts
@@ -95,6 +95,10 @@ export async function tokenBridgeHandler(
 		{ targetOrigin: '*' }
 	);
 
+	if ( isRetry ) {
+		debug( '(%s) client retrying request. Flush the token.', context );
+	}
+
 	const tokenData = await getMediaToken( 'playback', {
 		id: Number( postId ),
 		guid,

--- a/projects/packages/videopress/src/client/lib/token-bridge/index.ts
+++ b/projects/packages/videopress/src/client/lib/token-bridge/index.ts
@@ -26,6 +26,7 @@ type TokenBrigeEventProps = {
 	guid: VideoGUID;
 	requestId: string;
 	origin: Origin;
+	isRetry?: boolean;
 };
 
 /**
@@ -49,7 +50,7 @@ export async function tokenBridgeHandler(
 
 	const { context = 'main' } = videopressAjax;
 
-	const { guid, requestId } = event.data;
+	const { guid, requestId, isRetry } = event.data;
 	if ( ! guid || ! requestId ) {
 		debug( '(%s) Invalid request', context );
 		return;
@@ -98,6 +99,7 @@ export async function tokenBridgeHandler(
 		id: Number( postId ),
 		guid,
 		adminAjaxAPI: videopressAjax.ajaxUrl,
+		flushToken: isRetry, // flush the token if it's a retry
 	} );
 
 	if ( ! tokenData?.token ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR implements changes in the token bridge to be able to re-send a token when the requester retries the request.
This scenario happens when, for some reason, the requester things the sent token was invalid, proceeding to request it by adding `isRetry: true` into the event data object.

~# branched off from https://github.com/Automattic/jetpack/pull/28797~

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: resend token when requester retries

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


#### Go to the block editor

* Create/edit a video block
* Set privacy private
* Save the post
* Hard refresh
* From here, the client has stored the token.
-----------
* Go to the front-end
* Confirm the private video is properly shown.
* Confirm the client does not request the token (no admin-ajax requests)
* Confirm the token is provided by the storing layer
<img width="886" alt="Screen Shot 2023-02-16 at 08 10 30" src="https://user-images.githubusercontent.com/77539/219349555-ae829ae4-65c0-41ad-a14c-78408125f41a.png">

----------
* Check and identify the stored token by looking at the application tab / Local storage section (Chrome). The token has the `vpc-playback-<post-id>-<guid>` shape.

* Let's make the token invalid, running the following script, replacing the `<post-id>` and `<guid>` with your token.

```es6
let id = '<post-id>';
let guid = '<guid>';
let tokenBridgeKey = `vpc-playback-${id}-${guid}`;
localStorage.setItem( tokenBridgeKey, JSON.stringify( { ...JSON.parse( localStorage.getItem( tokenBridgeKey ) ), data: { ...JSON.parse( localStorage.getItem( tokenBridgeKey ) ).data, token: '12345' } } ) );
```

* Confirm the new invalid token value
<img width="424" alt="Screen Shot 2023-02-16 at 08 28 30" src="https://user-images.githubusercontent.com/77539/219353135-67cc2364-ccec-4e42-8ff2-485c8b748290.png">

* hard refresh
* Confirm the client doesn't get the data (network tab)
<img width="888" alt="image" src="https://user-images.githubusercontent.com/77539/219353479-3782571a-280b-4f97-85f4-bcee7ebaf9e9.png">
* Confirm the bridge identifies the re-attempt (flushing/storing/providing)
<img width="885" alt="Screen Shot 2023-02-16 at 08 31 49" src="https://user-images.githubusercontent.com/77539/219353679-c29b7f92-64c1-471b-91eb-668fd1c66a1e.png">
* new admin-ajax request to get the fresh token
<img width="888" alt="image" src="https://user-images.githubusercontent.com/77539/219353848-d2800547-da7d-4a57-95d6-b4a7730e6773.png">
* Confirm the video is properly shown
* Confirm the token has been stored
<img width="629" alt="image" src="https://user-images.githubusercontent.com/77539/219353971-20f9170d-9ad9-4de1-915a-96f7567074f4.png">
* Confirm, after a hard refresh, the token is provided by the storing layer. No additional admin-ajax requests for it.



