### PR TITLE
jetpack-mu-wpcom: check array key exists before access

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/2023-02-13-20-37-22-243565
+++ b/projects/packages/jetpack-mu-wpcom/changelog/2023-02-13-20-37-22-243565
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Check array key exists before access.

--- a/projects/packages/jetpack-mu-wpcom/src/features/coming-soon/coming-soon.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/coming-soon/coming-soon.php
@@ -209,6 +209,7 @@ add_action( 'update_option_blog_public', __NAMESPACE__ . '\disable_coming_soon_o
  */
 function add_option_to_new_site( $blog_id, $user_id, $domain, $path, $network_id, $meta ) {
 	if ( 0 === $meta['public']
+		&& array_key_exists( 'options', $meta )
 		&& array_key_exists( 'wpcom_public_coming_soon', $meta['options'] )
 		&& 1 === (int) $meta['options']['wpcom_public_coming_soon']
 	) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/coming-soon/coming-soon.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/coming-soon/coming-soon.php
@@ -209,8 +209,7 @@ add_action( 'update_option_blog_public', __NAMESPACE__ . '\disable_coming_soon_o
  */
 function add_option_to_new_site( $blog_id, $user_id, $domain, $path, $network_id, $meta ) {
 	if ( 0 === $meta['public']
-		&& array_key_exists( 'options', $meta )
-		&& array_key_exists( 'wpcom_public_coming_soon', $meta['options'] )
+		&& isset( $meta['options']['wpcom_public_coming_soon'] )
 		&& 1 === (int) $meta['options']['wpcom_public_coming_soon']
 	) {
 		if ( function_exists( 'add_blog_option' ) ) {


### PR DESCRIPTION
## Proposed changes:

Make sure a nested array key exists before accessing it (undefined index error).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Reported in internal: p1676043136748709-slack-C4GAP2RHD

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

Proofread -- this change wouldn't throw off any existing logic (if `$meta['options']` didn't exist), just prevents the error.