### PR TITLE
jetpack-mu-wpcom: updated checks for coming-soon

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-mu-wpcom-coming-soon-checks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-mu-wpcom-coming-soon-checks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated checks for loading the coming soon feature.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "0.2.2",
+	"version": "0.2.3-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -29,10 +29,9 @@ class Jetpack_Mu_Wpcom {
 
 		// Shared code for src/features
 		require_once self::PKG_DIR . 'src/common/index.php'; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
-		// Todo: once coming-soon is removed from ETK, we can remove the has_action check.
-		if ( has_action( 'plugins_loaded', 'A8C\FSE\load_coming_soon' ) === false ) {
-			add_action( 'plugins_loaded', array( __CLASS__, 'load_coming_soon' ) );
-		}
+
+		// Coming Soon feature.
+		add_action( 'plugins_loaded', array( __CLASS__, 'load_coming_soon' ) );
 
 		/**
 		 * Runs right after the Jetpack_Mu_Wpcom package is initialized.
@@ -46,6 +45,15 @@ class Jetpack_Mu_Wpcom {
 	 * Load the Coming Soon feature.
 	 */
 	public static function load_coming_soon() {
+		/**
+		 * On WoA sites, users may be using non-symlinked older versions of the FSE plugin.
+		 * If they are, check the active version to avoid redeclaration errors.
+		 */
+		$invalid_fse_version_active = is_plugin_active( 'full-site-editing/full-site-editing-plugin.php' ) && version_compare( get_plugin_data( WP_PLUGIN_DIR . '/full-site-editing/full-site-editing-plugin.php' )['Version'], '3.56084', '<' );
+		if ( $invalid_fse_version_active ) {
+			return;
+		}
+
 		if (
 			( defined( 'WPCOM_PUBLIC_COMING_SOON' ) && WPCOM_PUBLIC_COMING_SOON ) ||
 			apply_filters( 'a8c_enable_public_coming_soon', false )

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '0.2.2';
+	const PACKAGE_VERSION = '0.2.3-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**


### PR DESCRIPTION
## Proposed changes:

- Removes `has_action( 'plugins_loaded', 'A8C\FSE\load_coming_soon'` check since coming-soon has now been removed from the ETK plugin.
- Make sure WoA sites aren't using older FSE plugin versions that would conflict with jetpack-mu-wpcom

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Rollback the equivalent changes from wpcomsh done in: 1253-gh-Automattic/wpcomsh
* Patch in changes to the package directly from this PR to `class-jetpack-mu-wpcom.php`
* Continue testing on WoA dev blog with steps in 1253-gh-Automattic/wpcomsh

## Todo:

- [ ] Once merged/deployed, cleanup the similar code added to wpcomsh: 1253-gh-Automattic/wpcomsh