### PR TITLE
Stats: remove unnecessary params passed to wpcom

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-remove-unnecessary-params-passed-to-wpcom
+++ b/projects/packages/stats-admin/changelog/fix-remove-unnecessary-params-passed-to-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: remove unnecessary params that breaks wpcom API

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -519,11 +519,7 @@ class REST_Controller {
 		}
 
 		if ( 200 !== $response_code ) {
-			return new WP_Error(
-				isset( $response_body['error'] ) ? 'remote-error-' . $response_body['error'] : 'remote-error',
-				isset( $response_body['message'] ) ? $response_body['message'] : 'unknown remote error',
-				array( 'status' => $response_code )
-			);
+			return $this->get_wp_error( $response_body, $response_code );
 		}
 
 		// Cache the successful JSON response for 5 minutes.
@@ -562,5 +558,30 @@ class REST_Controller {
 			}
 		}
 		return http_build_query( $params );
+	}
+
+	/**
+	 * Build error object from remote response body and status code.
+	 *
+	 * @param array $response_body Remote response body.
+	 * @param int   $response_code Http response code.
+	 * @return WP_Error
+	 */
+	protected function get_wp_error( $response_body, $response_code = 500 ) {
+		$error_code = 'remote-error';
+		foreach ( array( 'code', 'error' ) as $error_code_key ) {
+			if ( isset( $response_body[ $error_code_key ] ) ) {
+				$error_code = $response_body[ $error_code_key ];
+				break;
+			}
+		}
+
+		$error_message = isset( $response_body['message'] ) ? $response_body['message'] : 'unknown remote error';
+
+		return new WP_Error(
+			$error_code,
+			$error_message,
+			array( 'status' => $response_code )
+		);
 	}
 }

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -554,9 +554,7 @@ class REST_Controller {
 		unset( $params['rest_route'] );
 		if ( ! empty( $keys_to_unset ) && is_array( $keys_to_unset ) ) {
 			foreach ( $keys_to_unset as $key ) {
-				if ( isset( $params[ $key ] ) ) {
-					unset( $params[ $key ] );
-				}
+				unset( $params[ $key ] );
 			}
 		}
 		return http_build_query( $params );

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -551,8 +551,10 @@ class REST_Controller {
 	 * @return string The filtered and built query string.
 	 */
 	protected function filter_and_build_query_string( $params, $keys_to_unset = array() ) {
+		if ( isset( $params['rest_route'] ) ) {
+			unset( $params['rest_route'] );
+		}
 		if ( ! empty( $keys_to_unset ) && is_array( $keys_to_unset ) ) {
-			$keys_to_unset[] = 'rest_route';
 			foreach ( $keys_to_unset as $key ) {
 				if ( isset( $params[ $key ] ) ) {
 					unset( $params[ $key ] );

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -290,8 +290,9 @@ class REST_Controller {
 				Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' ),
 				Jetpack_Options::get_option( 'id' ),
 				$req->get_param( 'resource_id' ),
-				http_build_query(
-					$req->get_params()
+				$this->filte_and_build_query_string(
+					$req->get_params(),
+					array( 'resource_id' )
 				)
 			),
 			array( 'timeout' => 5 )
@@ -385,7 +386,7 @@ class REST_Controller {
 				Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' ),
 				Jetpack_Options::get_option( 'id' ),
 				$req->get_param( 'resource_id' ),
-				http_build_query( $params )
+				$this->filte_and_build_query_string( $params, array( 'resource_id' ) )
 			),
 			array( 'timeout' => 5 )
 		);
@@ -419,7 +420,7 @@ class REST_Controller {
 			sprintf(
 				'/sites/%d/site-has-never-published-post?%s',
 				Jetpack_Options::get_option( 'id' ),
-				http_build_query(
+				$this->filte_and_build_query_string(
 					$req->get_params()
 				)
 			),
@@ -441,7 +442,7 @@ class REST_Controller {
 			sprintf(
 				'/sites/%d/wordads/earnings?%s',
 				Jetpack_Options::get_option( 'id' ),
-				http_build_query(
+				$this->filte_and_build_query_string(
 					$req->get_params()
 				)
 			),
@@ -461,7 +462,7 @@ class REST_Controller {
 			sprintf(
 				'/sites/%d/wordads/stats?%s',
 				Jetpack_Options::get_option( 'id' ),
-				http_build_query(
+				$this->filte_and_build_query_string(
 					$req->get_params()
 				)
 			),
@@ -540,5 +541,24 @@ class REST_Controller {
 		);
 
 		return new WP_Error( 'rest_forbidden', $error_msg, array( 'status' => rest_authorization_required_code() ) );
+	}
+
+	/**
+	 * Filter and build query string from all the requested params.
+	 *
+	 * @param array $params The params to filter.
+	 * @param array $keys_to_unset The keys to unset from the params array.
+	 * @return string The filtered and built query string.
+	 */
+	protected function filte_and_build_query_string( $params, $keys_to_unset = array() ) {
+		unset( $params['rest_route'] );
+		if ( ! empty( $keys_to_unset ) && is_array( $keys_to_unset ) ) {
+			foreach ( $keys_to_unset as $key ) {
+				if ( isset( $params[ $key ] ) ) {
+					unset( $params[ $key ] );
+				}
+			}
+		}
+		return http_build_query( $params );
 	}
 }

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -290,7 +290,7 @@ class REST_Controller {
 				Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' ),
 				Jetpack_Options::get_option( 'id' ),
 				$req->get_param( 'resource_id' ),
-				$this->filte_and_build_query_string(
+				$this->filter_and_build_query_string(
 					$req->get_params(),
 					array( 'resource_id' )
 				)
@@ -386,7 +386,7 @@ class REST_Controller {
 				Constants::get_constant( 'JETPACK__WPCOM_JSON_API_BASE' ),
 				Jetpack_Options::get_option( 'id' ),
 				$req->get_param( 'resource_id' ),
-				$this->filte_and_build_query_string( $params, array( 'resource_id' ) )
+				$this->filter_and_build_query_string( $params, array( 'resource_id' ) )
 			),
 			array( 'timeout' => 5 )
 		);
@@ -420,7 +420,7 @@ class REST_Controller {
 			sprintf(
 				'/sites/%d/site-has-never-published-post?%s',
 				Jetpack_Options::get_option( 'id' ),
-				$this->filte_and_build_query_string(
+				$this->filter_and_build_query_string(
 					$req->get_params()
 				)
 			),
@@ -442,7 +442,7 @@ class REST_Controller {
 			sprintf(
 				'/sites/%d/wordads/earnings?%s',
 				Jetpack_Options::get_option( 'id' ),
-				$this->filte_and_build_query_string(
+				$this->filter_and_build_query_string(
 					$req->get_params()
 				)
 			),
@@ -462,7 +462,7 @@ class REST_Controller {
 			sprintf(
 				'/sites/%d/wordads/stats?%s',
 				Jetpack_Options::get_option( 'id' ),
-				$this->filte_and_build_query_string(
+				$this->filter_and_build_query_string(
 					$req->get_params()
 				)
 			),
@@ -550,7 +550,7 @@ class REST_Controller {
 	 * @param array $keys_to_unset The keys to unset from the params array.
 	 * @return string The filtered and built query string.
 	 */
-	protected function filte_and_build_query_string( $params, $keys_to_unset = array() ) {
+	protected function filter_and_build_query_string( $params, $keys_to_unset = array() ) {
 		unset( $params['rest_route'] );
 		if ( ! empty( $keys_to_unset ) && is_array( $keys_to_unset ) ) {
 			foreach ( $keys_to_unset as $key ) {

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -551,10 +551,12 @@ class REST_Controller {
 	 * @return string The filtered and built query string.
 	 */
 	protected function filter_and_build_query_string( $params, $keys_to_unset = array() ) {
-		unset( $params['rest_route'] );
 		if ( ! empty( $keys_to_unset ) && is_array( $keys_to_unset ) ) {
+			$keys_to_unset[] = 'rest_route';
 			foreach ( $keys_to_unset as $key ) {
-				unset( $params[ $key ] );
+				if ( isset( $params[ $key ] ) ) {
+					unset( $params[ $key ] );
+				}
 			}
 		}
 		return http_build_query( $params );

--- a/projects/packages/stats-admin/tests/php/test-rest-controller.php
+++ b/projects/packages/stats-admin/tests/php/test-rest-controller.php
@@ -180,4 +180,45 @@ class Test_REST_Controller extends Stats_Test_Case {
 
 		$this->assertEquals( 400, $response->get_status() );
 	}
+
+	/**
+	 * Test filter_and_build_query_string.
+	 */
+	public function test_filter_and_build_query_string() {
+		$filter_and_build_query_string = new \ReflectionMethod( $this->rest_controller, 'filter_and_build_query_string' );
+		$filter_and_build_query_string->setAccessible( true );
+
+		$this->assertEquals(
+			'c=d&e=f',
+			$filter_and_build_query_string->invoke(
+				$this->rest_controller,
+				array(
+					'a'          => 'b',
+					'c'          => 'd',
+					'rest_route' => '/jetpack/v4/test-route',
+					'e'          => 'f',
+				),
+				array( 'a' )
+			)
+		);
+		$this->assertEquals(
+			'a=b&c=d&e=f',
+			$filter_and_build_query_string->invoke(
+				$this->rest_controller,
+				array(
+					'a'          => 'b',
+					'c'          => 'd',
+					'rest_route' => '/jetpack/v4/test-route',
+					'e'          => 'f',
+				)
+			)
+		);
+		$this->assertEquals(
+			'',
+			$filter_and_build_query_string->invoke(
+				$this->rest_controller,
+				array()
+			)
+		);
+	}
 }

--- a/projects/packages/stats-admin/tests/php/test-rest-controller.php
+++ b/projects/packages/stats-admin/tests/php/test-rest-controller.php
@@ -229,37 +229,42 @@ class Test_REST_Controller extends Stats_Test_Case {
 		$get_wp_error = new \ReflectionMethod( $this->rest_controller, 'get_wp_error' );
 		$get_wp_error->setAccessible( true );
 
+		$error = $get_wp_error->invoke(
+			$this->rest_controller,
+			array(
+				'error'   => 'err1',
+				'message' => 'msg1',
+			),
+			500
+		);
 		$this->assertEquals(
 			'err1',
-			( $get_wp_error->invoke(
-				$this->rest_controller,
-				array(
-					'error'   => 'err1',
-					'message' => 'msg1',
-				),
-				500
-			) )->get_error_code()
+			$error->get_error_code()
+		);
+
+		$error = $get_wp_error->invoke(
+			$this->rest_controller,
+			array(
+				'code'    => 'err2',
+				'message' => 'msg1',
+			),
+			500
 		);
 		$this->assertEquals(
 			'err2',
-			( $get_wp_error->invoke(
-				$this->rest_controller,
-				array(
-					'code'    => 'err2',
-					'message' => 'msg1',
-				),
-				500
-			) )->get_error_code()
+			$error->get_error_code()
+		);
+
+		$error = $get_wp_error->invoke(
+			$this->rest_controller,
+			array(
+				'code' => 'err2',
+			),
+			500
 		);
 		$this->assertEquals(
 			'unknown remote error',
-			( $get_wp_error->invoke(
-				$this->rest_controller,
-				array(
-					'code' => 'err2',
-				),
-				500
-			) )->get_error_message()
+			$error->get_error_message()
 		);
 	}
 }

--- a/projects/packages/stats-admin/tests/php/test-rest-controller.php
+++ b/projects/packages/stats-admin/tests/php/test-rest-controller.php
@@ -221,4 +221,45 @@ class Test_REST_Controller extends Stats_Test_Case {
 			)
 		);
 	}
+
+	/**
+	 * Test filter_and_build_query_string.
+	 */
+	public function test_get_wp_error() {
+		$get_wp_error = new \ReflectionMethod( $this->rest_controller, 'get_wp_error' );
+		$get_wp_error->setAccessible( true );
+
+		$this->assertEquals(
+			'err1',
+			( $get_wp_error->invoke(
+				$this->rest_controller,
+				array(
+					'error'   => 'err1',
+					'message' => 'msg1',
+				),
+				500
+			) )->get_error_code()
+		);
+		$this->assertEquals(
+			'err2',
+			( $get_wp_error->invoke(
+				$this->rest_controller,
+				array(
+					'code'    => 'err2',
+					'message' => 'msg1',
+				),
+				500
+			) )->get_error_code()
+		);
+		$this->assertEquals(
+			'unknown remote error',
+			( $get_wp_error->invoke(
+				$this->rest_controller,
+				array(
+					'code' => 'err2',
+				),
+				500
+			) )->get_error_message()
+		);
+	}
 }


### PR DESCRIPTION
## Proposed changes:
The PR add a general function to filter and build the query pass to WPCOM. The reason we are doing this is that, `rest_route` sometime breaks the WPCOM API. An example is `/jetpack/v4/stats-app/sites/{site-id}/site-has-never-published-post`.

The PR also takes the chance to add a method `get_wp_error` to unify remote error code and message.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Use branch of https://github.com/Automattic/wp-calypso/pull/73301 to build Odyssey Stats
* Choose `Plain` for Permanent Links `/wp-admin/options-permalink.php`
* Open `/wp-admin/admin.php?page=stats`
* Inspect network request
* Ensure no 404s for API requests. Requests should be like `https://jetpack.xxxx.com/index.php?rest_route=/jetpack/v4/stats-app/sites/{site-id}/site-has-never-published-post&include-pages=true`
* Ensure all tests pass

