### PR TITLE
Rename Jetpack Migration plugin to "Move to WordPress.com"

### DIFF
--- a/projects/plugins/migration/.eslintrc.js
+++ b/projects/plugins/migration/.eslintrc.js
@@ -6,11 +6,11 @@ module.exports = {
 		},
 	},
 	rules: {
-		// Enforce the use of the jetpack-migration textdomain.
+		// Enforce the use of the wpcom-migration textdomain.
 		'@wordpress/i18n-text-domain': [
 			'error',
 			{
-				allowedTextDomain: 'jetpack-migration',
+				allowedTextDomain: 'wpcom-migration',
 			},
 		],
 	},

--- a/projects/plugins/migration/.phpcs.dir.xml
+++ b/projects/plugins/migration/.phpcs.dir.xml
@@ -4,20 +4,20 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array">
-				<element value="jetpack-migration" />
+				<element value="wpcom-migration" />
 			</property>
 		</properties>
 	</rule>
 	<rule ref="Jetpack.Functions.I18n">
 		<properties>
-			<property name="text_domain" value="jetpack-migration" />
+			<property name="text_domain" value="wpcom-migration" />
 		</properties>
 	</rule>
 
 	<rule ref="WordPress.Utils.I18nTextDomainFixer">
 		<properties>
 			<property name="old_text_domain" type="array" />
-			<property name="new_text_domain" value="jetpack-migration" />
+			<property name="new_text_domain" value="wpcom-migration" />
 		</properties>
 	</rule>
 

--- a/projects/plugins/migration/README.md
+++ b/projects/plugins/migration/README.md
@@ -1,8 +1,8 @@
-# Jetpack Migration
+# Move to WordPress.com
 
-Jetpack Migration plugin
+Move to WordPress.com plugin
 
-## How to install Jetpack Migration
+## How to install Move to WordPress.com
 
 ### Installation From Git Repo
 
@@ -16,5 +16,5 @@ Need to report a security vulnerability? Go to [https://automattic.com/security/
 
 ## License
 
-Jetpack Migration is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt)
+Move to WordPress.com is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt)
 

--- a/projects/plugins/migration/babel.config.js
+++ b/projects/plugins/migration/babel.config.js
@@ -2,7 +2,7 @@ const config = {
 	presets: [
 		[
 			'@automattic/jetpack-webpack-config/babel/preset',
-			{ pluginReplaceTextdomain: { textdomain: 'jetpack-migration' } },
+			{ pluginReplaceTextdomain: { textdomain: 'wpcom-migration' } },
 		],
 	],
 };

--- a/projects/plugins/migration/changelog/update-rename-migration-plugin
+++ b/projects/plugins/migration/changelog/update-rename-migration-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Rename Jetpack Migration to Move to WordPress.com and wpcom-migration

--- a/projects/plugins/migration/composer.json
+++ b/projects/plugins/migration/composer.json
@@ -1,6 +1,6 @@
 {
-	"name": "automattic/jetpack-migration",
-	"description": "A Jetpack plugin that helps users to migrate their sites to WordPress.com",
+	"name": "automattic/wpcom-migration",
+	"description": "A WordPress plugin that helps users to migrate their sites to WordPress.com",
 	"type": "wordpress-plugin",
 	"license": "GPL-2.0-or-later",
 	"require": {
@@ -59,9 +59,9 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"extra": {
-		"mirror-repo": "Automattic/jetpack-migration",
+		"mirror-repo": "Automattic/wpcom-migration",
 		"release-branch-prefix": "migration",
-		"wp-plugin-slug": "jetpack-migration"
+		"wp-plugin-slug": "wpcom-migration"
 	},
 	"config": {
 		"allow-plugins": {

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "867b4e02ffa189cc1006f75609474338",
+    "content-hash": "1ddcdf6c42199ee2e81f1e3125bff4f1",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/migration/package.json
+++ b/projects/plugins/migration/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"description": "A WordPress plugin that helps users to migrate their sites to WordPress.com.",
-	"homepage": "https://jetpack.com",
+	"homepage": "https://wordpress.com",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Migration"
 	},

--- a/projects/plugins/migration/package.json
+++ b/projects/plugins/migration/package.json
@@ -1,6 +1,6 @@
 {
 	"private": true,
-	"description": "A Jetpack plugin that helps users to migrate their sites to WordPress.com.",
+	"description": "A WordPress plugin that helps users to migrate their sites to WordPress.com.",
 	"homepage": "https://jetpack.com",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Migration"

--- a/projects/plugins/migration/readme.txt
+++ b/projects/plugins/migration/readme.txt
@@ -1,4 +1,4 @@
-=== Jetpack Migration ===
+=== Move to WordPress.com ===
 Contributors: automattic,
 Tags: jetpack, stuff
 Requires at least: 6.0
@@ -8,11 +8,11 @@ Stable tag: 0.1.0-alpha
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Jetpack Migration plugin
+Move to WordPress.com plugin
 
 == Description ==
 
-A Jetpack plugin that helps users to migrate their sites to WordPress.com
+A WordPress plugin that helps users to migrate their sites to WordPress.com
 
 == Installation ==
 

--- a/projects/plugins/migration/src/class-rest-controller.php
+++ b/projects/plugins/migration/src/class-rest-controller.php
@@ -2,7 +2,7 @@
 /**
  * REST API Endpoints
  *
- * @package automattic/jetpack-migration-plugin
+ * @package automattic/wpcom-migration-plugin
  */
 
 namespace Automattic\Jetpack\Migration;
@@ -68,7 +68,7 @@ class REST_Controller {
 
 		$error_msg = esc_html__(
 			'You are not allowed to perform this action.',
-			'jetpack-migration'
+			'wpcom-migration'
 		);
 
 		return new \WP_Error( 'rest_forbidden', $error_msg, array( 'status' => rest_authorization_required_code() ) );

--- a/projects/plugins/migration/src/class-wpcom-migration.php
+++ b/projects/plugins/migration/src/class-wpcom-migration.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Primary class file for the Jetpack Migration plugin.
+ * Primary class file for the Move to WordPress.com plugin.
  *
- * @package automattic/jetpack-migration-plugin
+ * @package automattic/wpcom-migration-plugin
  */
 
 namespace Automattic\Jetpack\Migration;
@@ -19,9 +19,9 @@ use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
 use Automattic\Jetpack\Sync\Data_Settings;
 
 /**
- * Class Jetpack_Migration
+ * Class WPCOM_Migration
  */
-class Jetpack_Migration {
+class WPCOM_Migration {
 
 	/**
 	 * Constructor.
@@ -45,9 +45,9 @@ class Jetpack_Migration {
 				$config->ensure(
 					'connection',
 					array(
-						'slug'     => JETPACK_MIGRATION_SLUG,
-						'name'     => JETPACK_MIGRATION_NAME,
-						'url_info' => JETPACK_MIGRATION_URI,
+						'slug'     => WPCOM_MIGRATION_SLUG,
+						'name'     => WPCOM_MIGRATION_NAME,
+						'url_info' => WPCOM_MIGRATION_URI,
 					)
 				);
 				// Sync package.
@@ -70,7 +70,7 @@ class Jetpack_Migration {
 			'Move to WordPress.com',
 			'Move to WordPress.com',
 			'manage_options',
-			'jetpack-migration',
+			'wpcom-migration',
 			array( $this, 'plugin_settings_page' ),
 			'dashicons-admin-generic',
 			79 // right before the Settings menu (80)
@@ -91,18 +91,18 @@ class Jetpack_Migration {
 	 */
 	public function enqueue_admin_scripts() {
 		Assets::register_script(
-			'jetpack-migration',
+			'wpcom-migration',
 			'build/index.js',
-			JETPACK_MIGRATION_ROOT_FILE,
+			WPCOM_MIGRATION_ROOT_FILE,
 			array(
 				'in_footer'  => true,
-				'textdomain' => 'jetpack-migration',
+				'textdomain' => 'wpcom-migration',
 			)
 		);
-		Assets::enqueue_script( 'jetpack-migration' );
+		Assets::enqueue_script( 'wpcom-migration' );
 		// Initial JS state including JP Connection data.
-		wp_add_inline_script( 'jetpack-migration', Connection_Initial_State::render(), 'before' );
-		wp_add_inline_script( 'jetpack-migration', $this->render_initial_state(), 'before' );
+		wp_add_inline_script( 'wpcom-migration', Connection_Initial_State::render(), 'before' );
+		wp_add_inline_script( 'wpcom-migration', $this->render_initial_state(), 'before' );
 	}
 
 	/**
@@ -111,7 +111,7 @@ class Jetpack_Migration {
 	 * @return string
 	 */
 	public function render_initial_state() {
-		return 'var jetpackMigrationInitialState=JSON.parse(decodeURIComponent("' . rawurlencode( wp_json_encode( $this->initial_state() ) ) . '"));';
+		return 'var wpcomMigrationInitialState=JSON.parse(decodeURIComponent("' . rawurlencode( wp_json_encode( $this->initial_state() ) ) . '"));';
 	}
 
 	/**
@@ -132,7 +132,7 @@ class Jetpack_Migration {
 	 */
 	public function plugin_settings_page() {
 		?>
-			<div id="jetpack-migration-root"></div>
+			<div id="wpcom-migration-root"></div>
 		<?php
 	}
 
@@ -144,7 +144,7 @@ class Jetpack_Migration {
 	 * @static
 	 */
 	public static function plugin_deactivation() {
-		$manager = new Connection_Manager( 'jetpack-migration' );
+		$manager = new Connection_Manager( 'wpcom-migration' );
 		$manager->remove_connection();
 	}
 }

--- a/projects/plugins/migration/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/migration/src/js/components/admin-page/index.jsx
@@ -7,7 +7,7 @@ import { Migration, MigrationError, MigrationLoading, MigrationProgress } from '
 
 const Admin = () => {
 	const sourceSiteSlug = window?.location?.host;
-	const { apiNonce, apiRoot, registrationNonce } = window.jetpackMigrationInitialState;
+	const { apiNonce, apiRoot, registrationNonce } = window.wpcomMigrationInitialState;
 
 	const configureApi = useCallback( () => {
 		restApi.setApiRoot( apiRoot );
@@ -43,7 +43,7 @@ const Admin = () => {
 
 	return (
 		<AdminPage
-			moduleName={ __( `Move to WordPress.com`, 'jetpack-migration' ) }
+			moduleName={ __( `Move to WordPress.com`, 'wpcom-migration' ) }
 			showBackground={ false }
 			showHeader={ false }
 			showFooter={ false }

--- a/projects/plugins/migration/src/js/components/migration/error.tsx
+++ b/projects/plugins/migration/src/js/components/migration/error.tsx
@@ -20,18 +20,18 @@ export function MigrationError( props: Props ) {
 		if ( message ) {
 			return sprintf(
 				/* translators: %s: Message from the server e.g: "There's a problem getting your import's status." */
-				__( 'Error: %s', 'jetpack-migration' ),
+				__( 'Error: %s', 'wpcom-migration' ),
 				message
 			);
 		}
-		return __( "Sorry, there's a problem getting your import's status.", 'jetpack-migration' );
+		return __( "Sorry, there's a problem getting your import's status.", 'wpcom-migration' );
 	};
 
 	return (
 		<ConnectScreenLayout
 			className={ 'wordpress-branding' }
 			logo={ <WordPressLogo /> }
-			title={ __( 'Oops, something went wrong…', 'jetpack-migration' ) }
+			title={ __( 'Oops, something went wrong…', 'wpcom-migration' ) }
 			images={ [ migrationImage1 ] }
 		>
 			<p> { renderErrorMessages() } </p>

--- a/projects/plugins/migration/src/js/components/migration/index.tsx
+++ b/projects/plugins/migration/src/js/components/migration/index.tsx
@@ -17,7 +17,7 @@ export * from './progress';
 export const ToS = createInterpolateElement(
 	__(
 		'By clicking "Get started", you agree to our <tosLink>Terms of Service</tosLink> and to <shareDetailsLink>share details</shareDetailsLink> with WordPress.com.',
-		'jetpack-migration'
+		'wpcom-migration'
 	),
 	{
 		tosLink: <a href={ getRedirectUrl( 'wpcom-tos' ) } rel="noopener noreferrer" target="_blank" />,
@@ -44,9 +44,9 @@ interface Props {
  * @returns {React.ReactElement} - JSX Element
  */
 export function Migration( props: Props ) {
-	const pluginName = 'jetpack-migration';
+	const pluginName = 'wpcom-migration';
 	const { apiRoot, apiNonce, registrationNonce, sourceSiteSlug } = props;
-	const redirectUri = 'admin.php?page=jetpack-migration';
+	const redirectUri = 'admin.php?page=wpcom-migration';
 	const autoTrigger = false;
 	const skipUserConnection = false;
 
@@ -84,7 +84,7 @@ export function Migration( props: Props ) {
 		<ConnectScreenLayout
 			className={ 'wordpress-branding' }
 			logo={ <WordPressLogo /> }
-			title={ __( 'WordPress.com Migration', 'jetpack-migration' ) }
+			title={ __( 'Move to WordPress.com', 'wpcom-migration' ) }
 			images={ [ migrationImage1 ] }
 		>
 			<p>
@@ -93,24 +93,24 @@ export function Migration( props: Props ) {
 						"migrating your site to WordPress.com shouldn't be hard. That's our job! " +
 						'Migrate your site now and get managed by experienced, dedicated and specailists on ' +
 						'WordPress professionals.',
-					'jetpack-migration'
+					'wpcom-migration'
 				) }
 			</p>
 			<ul>
 				<li className={ 'bullet-1' }>
 					{ __(
 						'No need to worry about budget - this is a free migration service offically provided by WordPress.com.',
-						'jetpack-migration'
+						'wpcom-migration'
 					) }
 				</li>
 				<li className={ 'bullet-2' }>
 					{ __(
 						'This is seamless and automated process. It takes one click to back-up and migrate your entire site to WordPress.com',
-						'jetpack-migration'
+						'wpcom-migration'
 					) }
 				</li>
 				<li className={ 'bullet-3' }>
-					{ __( 'WordPress.com Migration provides low to zero downtime.', 'jetpack-migration' ) }
+					{ __( 'Move to WordPress.com provides low to zero downtime.', 'wpcom-migration' ) }
 				</li>
 			</ul>
 			<div className={ 'action-buttons' }>
@@ -122,7 +122,7 @@ export function Migration( props: Props ) {
 					href={ `${ MIGRATION_HANDLER_ROUTE }?from=${ sourceSiteSlug }` }
 					onClick={ onGetStartedClick }
 				>
-					{ __( 'Get started', 'jetpack-migration' ) }
+					{ __( 'Get started', 'wpcom-migration' ) }
 				</Button>
 				<Button
 					isSecondary={ true }
@@ -131,19 +131,19 @@ export function Migration( props: Props ) {
 						'https://wordpress.com/support/import/import-an-entire-wordpress-site/'
 					) }
 				>
-					{ createInterpolateElement( __( 'Learn more <ExternalLink />', 'jetpack-migration' ), {
+					{ createInterpolateElement( __( 'Learn more <ExternalLink />', 'wpcom-migration' ), {
 						ExternalLink: <ExternalLink size={ 20 } />,
 					} ) }
 				</Button>
 				{ registrationError && (
 					<Notice status="warning" isDismissible={ false }>
-						{ __( 'An error occurred. Please try again.', 'jetpack-migration' ) }
+						{ __( 'An error occurred. Please try again.', 'wpcom-migration' ) }
 					</Notice>
 				) }
 			</div>
 			<p className={ 'get-started-help' }>
 				{ createInterpolateElement(
-					__( 'Do you need help? <Button>Contact us.</Button>', 'jetpack-migration' ),
+					__( 'Do you need help? <Button>Contact us.</Button>', 'wpcom-migration' ),
 					{
 						Button: (
 							<Button

--- a/projects/plugins/migration/src/js/components/migration/loading.tsx
+++ b/projects/plugins/migration/src/js/components/migration/loading.tsx
@@ -15,10 +15,10 @@ export function MigrationLoading() {
 		<ConnectScreenLayout
 			className={ 'wordpress-branding' }
 			logo={ <WordPressLogo /> }
-			title={ __( 'WordPress.com Migration', 'jetpack-migration' ) }
+			title={ __( 'Move to WordPress.com', 'wpcom-migration' ) }
 			images={ [ migrationImage1 ] }
 		>
-			<p>{ __( 'Loading…', 'jetpack-migration' ) }</p>
+			<p>{ __( 'Loading…', 'wpcom-migration' ) }</p>
 		</ConnectScreenLayout>
 	);
 }

--- a/projects/plugins/migration/src/js/components/migration/progress.tsx
+++ b/projects/plugins/migration/src/js/components/migration/progress.tsx
@@ -33,13 +33,13 @@ export function MigrationProgress( props: Props ) {
 		<ConnectScreenLayout
 			className={ 'wordpress-branding' }
 			logo={ <WordPressLogo /> }
-			title={ __( 'Migrating your site..', 'jetpack-migration' ) }
+			title={ __( 'Migrating your site..', 'wpcom-migration' ) }
 			images={ [ migrationImage2 ] }
 		>
 			<p>
 				{ __(
 					"We're safely gathering your data, which can take a few minutes to a few hours. Once the migration is done, we'll notify you, and you can visit your brand-new WordPress.com Dashboard!",
-					'jetpack-migration'
+					'wpcom-migration'
 				) }
 			</p>
 
@@ -49,12 +49,12 @@ export function MigrationProgress( props: Props ) {
 					target={ '_blank' }
 					href={ `${ MIGRATION_HANDLER_ROUTE }?from=${ sourceSiteSlug }` }
 				>
-					{ __( 'Check your migration progress', 'jetpack-migration' ) }
+					{ __( 'Check your migration progress', 'wpcom-migration' ) }
 				</Button>
 			</div>
 			<p className={ 'get-started-help' }>
 				{ createInterpolateElement(
-					__( 'Do you need help? <Button>Contact us.</Button>', 'jetpack-migration' ),
+					__( 'Do you need help? <Button>Contact us.</Button>', 'wpcom-migration' ),
 					{
 						Button: (
 							<Button

--- a/projects/plugins/migration/src/js/components/migration/styles.module.scss
+++ b/projects/plugins/migration/src/js/components/migration/styles.module.scss
@@ -1,5 +1,5 @@
 :global {
-	#jetpack-migration-root {
+	#wpcom-migration-root {
 		.jp-connection__connect-screen-layout ul li {
 			background-size: 27px 27px;
 			background-repeat: no-repeat;

--- a/projects/plugins/migration/src/js/index.js
+++ b/projects/plugins/migration/src/js/index.js
@@ -7,7 +7,7 @@ import AdminPage from './components/admin-page';
  * Initial render function.
  */
 function render() {
-	const container = document.getElementById( 'jetpack-migration-root' );
+	const container = document.getElementById( 'wpcom-migration-root' );
 
 	if ( null === container ) {
 		return;

--- a/projects/plugins/migration/tests/e2e/package.json
+++ b/projects/plugins/migration/tests/e2e/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "jetpack-migration-e2e-tests",
+	"name": "wpcom-migration-e2e-tests",
 	"private": true,
 	"type": "module",
-	"description": "A Jetpack plugin that helps users to migrate their sites to WordPress.com.",
+	"description": "A WordPress plugin that helps users to migrate their sites to WordPress.com.",
 	"homepage": "https://jetpack.com",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Migration"
@@ -46,6 +46,6 @@
 			"tools/e2e-commons"
 		],
 		"pluginSlug": "migration",
-		"mirrorName": "jetpack-migration"
+		"mirrorName": "wpcom-migration"
 	}
 }

--- a/projects/plugins/migration/webpack.config.js
+++ b/projects/plugins/migration/webpack.config.js
@@ -50,7 +50,7 @@ module.exports = [
 		externals: {
 			...jetpackWebpackConfig.externals,
 			jetpackConfig: JSON.stringify( {
-				consumer_slug: 'jetpack-migration',
+				consumer_slug: 'wpcom-migration',
 			} ),
 		},
 	},

--- a/projects/plugins/migration/wpcom-migration.php
+++ b/projects/plugins/migration/wpcom-migration.php
@@ -6,7 +6,7 @@
  * Description: A WordPress plugin that helps users to migrate their sites to WordPress.com.
  * Version: 0.1.0-alpha
  * Author: Automattic
- * Author URI: https://jetpack.com/
+ * Author URI: https://wordpress.com/
  * License: GPLv2 or later
  * Text Domain: wpcom-migration
  *
@@ -38,7 +38,7 @@ define( 'WPCOM_MIGRATION_ROOT_FILE', __FILE__ );
 define( 'WPCOM_MIGRATION_ROOT_FILE_RELATIVE_PATH', plugin_basename( __FILE__ ) );
 define( 'WPCOM_MIGRATION_SLUG', 'wpcom-migration' );
 define( 'WPCOM_MIGRATION_NAME', 'Move to WordPress.com' );
-define( 'WPCOM_MIGRATION_URI', 'https://jetpack.com/wpcom-migration' );
+define( 'WPCOM_MIGRATION_URI', 'https://wordpress.com/wpcom-migration' );
 define( 'WPCOM_MIGRATION_FOLDER', dirname( plugin_basename( __FILE__ ) ) );
 
 // Jetpack Autoloader.

--- a/projects/plugins/migration/wpcom-migration.php
+++ b/projects/plugins/migration/wpcom-migration.php
@@ -1,16 +1,16 @@
 <?php
 /**
  *
- * Plugin Name: Jetpack Migration
- * Plugin URI: https://wordpress.org/plugins/jetpack-migration
- * Description: A Jetpack plugin that helps users to migrate their sites to WordPress.com.
+ * Plugin Name: Move to WordPress.com
+ * Plugin URI: https://wordpress.org/plugins/wpcom-migration
+ * Description: A WordPress plugin that helps users to migrate their sites to WordPress.com.
  * Version: 0.1.0-alpha
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later
- * Text Domain: jetpack-migration
+ * Text Domain: wpcom-migration
  *
- * @package automattic/jetpack-migration
+ * @package automattic/wpcom-migration
  */
 
 /*
@@ -33,25 +33,25 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'JETPACK_MIGRATION_DIR', plugin_dir_path( __FILE__ ) );
-define( 'JETPACK_MIGRATION_ROOT_FILE', __FILE__ );
-define( 'JETPACK_MIGRATION_ROOT_FILE_RELATIVE_PATH', plugin_basename( __FILE__ ) );
-define( 'JETPACK_MIGRATION_SLUG', 'jetpack-migration' );
-define( 'JETPACK_MIGRATION_NAME', 'Jetpack Migration' );
-define( 'JETPACK_MIGRATION_URI', 'https://jetpack.com/jetpack-migration' );
-define( 'JETPACK_MIGRATION_FOLDER', dirname( plugin_basename( __FILE__ ) ) );
+define( 'WPCOM_MIGRATION_DIR', plugin_dir_path( __FILE__ ) );
+define( 'WPCOM_MIGRATION_ROOT_FILE', __FILE__ );
+define( 'WPCOM_MIGRATION_ROOT_FILE_RELATIVE_PATH', plugin_basename( __FILE__ ) );
+define( 'WPCOM_MIGRATION_SLUG', 'wpcom-migration' );
+define( 'WPCOM_MIGRATION_NAME', 'Move to WordPress.com' );
+define( 'WPCOM_MIGRATION_URI', 'https://jetpack.com/wpcom-migration' );
+define( 'WPCOM_MIGRATION_FOLDER', dirname( plugin_basename( __FILE__ ) ) );
 
 // Jetpack Autoloader.
-$jetpack_autoloader = JETPACK_MIGRATION_DIR . 'vendor/autoload_packages.php';
+$jetpack_autoloader = WPCOM_MIGRATION_DIR . 'vendor/autoload_packages.php';
 if ( is_readable( $jetpack_autoloader ) ) {
 	require_once $jetpack_autoloader;
 	if ( method_exists( \Automattic\Jetpack\Assets::class, 'alias_textdomains_from_file' ) ) {
-		\Automattic\Jetpack\Assets::alias_textdomains_from_file( JETPACK_MIGRATION_DIR . 'jetpack_vendor/i18n-map.php' );
+		\Automattic\Jetpack\Assets::alias_textdomains_from_file( WPCOM_MIGRATION_DIR . 'jetpack_vendor/i18n-map.php' );
 	}
 } else { // Something very unexpected. Error out gently with an admin_notice and exit loading.
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			__( 'Error loading autoloader file for Jetpack Migration plugin', 'jetpack-migration' )
+			__( 'Error loading autoloader file for Move to WordPress.com plugin', 'wpcom-migration' )
 		);
 	}
 
@@ -65,7 +65,7 @@ if ( is_readable( $jetpack_autoloader ) ) {
 				printf(
 					wp_kses(
 						/* translators: Placeholder is a link to a support document. */
-						__( 'Your installation of Jetpack Migration is incomplete. If you installed Jetpack Migration from GitHub, please refer to <a href="%1$s" target="_blank" rel="noopener noreferrer">this document</a> to set up your development environment. Jetpack Migration must have Composer dependencies installed and built via the build command.', 'jetpack-migration' ),
+						__( 'Your installation of Move to WordPress.com is incomplete. If you installed Move to WordPress.com from GitHub, please refer to <a href="%1$s" target="_blank" rel="noopener noreferrer">this document</a> to set up your development environment. Move to WordPress.com must have Composer dependencies installed and built via the build command.', 'wpcom-migration' ),
 						array(
 							'a' => array(
 								'href'   => array(),
@@ -87,35 +87,35 @@ if ( is_readable( $jetpack_autoloader ) ) {
 }
 
 // Redirect to plugin page when the plugin is activated.
-add_action( 'activated_plugin', 'jetpack_migration_activation' );
+add_action( 'activated_plugin', 'wpcom_migration_activation' );
 
 /**
  * Redirects to plugin page when the plugin is activated
  *
  * @param string $plugin Path to the plugin file relative to the plugins directory.
  */
-function jetpack_migration_activation( $plugin ) {
+function wpcom_migration_activation( $plugin ) {
 	if (
-		JETPACK_MIGRATION_ROOT_FILE_RELATIVE_PATH === $plugin &&
-		\Automattic\Jetpack\Plugins_Installer::is_current_request_activating_plugin_from_plugins_screen( JETPACK_MIGRATION_ROOT_FILE_RELATIVE_PATH )
+		WPCOM_MIGRATION_ROOT_FILE_RELATIVE_PATH === $plugin &&
+		\Automattic\Jetpack\Plugins_Installer::is_current_request_activating_plugin_from_plugins_screen( WPCOM_MIGRATION_ROOT_FILE_RELATIVE_PATH )
 	) {
-		wp_safe_redirect( esc_url( admin_url( 'admin.php?page=jetpack-migration' ) ) );
+		wp_safe_redirect( esc_url( admin_url( 'admin.php?page=wpcom-migration' ) ) );
 		exit;
 	}
 }
 
 // Add "Settings" link to plugins page.
 add_filter(
-	'plugin_action_links_' . JETPACK_MIGRATION_FOLDER . '/jetpack-migration.php',
+	'plugin_action_links_' . WPCOM_MIGRATION_FOLDER . '/wpcom-migration.php',
 	function ( $actions ) {
-		$settings_link = '<a href="' . esc_url( admin_url( 'admin.php?page=jetpack-migration' ) ) . '">' . __( 'Settings', 'jetpack-migration' ) . '</a>';
+		$settings_link = '<a href="' . esc_url( admin_url( 'admin.php?page=wpcom-migration' ) ) . '">' . __( 'Settings', 'wpcom-migration' ) . '</a>';
 		array_unshift( $actions, $settings_link );
 
 		return $actions;
 	}
 );
 
-register_deactivation_hook( __FILE__, array( \Automattic\Jetpack\Migration\Jetpack_Migration::class, 'plugin_deactivation' ) );
+register_deactivation_hook( __FILE__, array( \Automattic\Jetpack\Migration\WPCOM_Migration::class, 'plugin_deactivation' ) );
 
 // Main plugin class.
-new \Automattic\Jetpack\Migration\Jetpack_Migration();
+new \Automattic\Jetpack\Migration\WPCOM_Migration();

--- a/projects/plugins/migration/wpcom-migration.php
+++ b/projects/plugins/migration/wpcom-migration.php
@@ -38,7 +38,7 @@ define( 'WPCOM_MIGRATION_ROOT_FILE', __FILE__ );
 define( 'WPCOM_MIGRATION_ROOT_FILE_RELATIVE_PATH', plugin_basename( __FILE__ ) );
 define( 'WPCOM_MIGRATION_SLUG', 'wpcom-migration' );
 define( 'WPCOM_MIGRATION_NAME', 'Move to WordPress.com' );
-define( 'WPCOM_MIGRATION_URI', 'https://wordpress.com/wpcom-migration' );
+define( 'WPCOM_MIGRATION_URI', 'https://wordpress.com/' );
 define( 'WPCOM_MIGRATION_FOLDER', dirname( plugin_basename( __FILE__ ) ) );
 
 // Jetpack Autoloader.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #28736 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Rename Jetpack Migration plugin to "Move to WordPress.com".
* Rename slug from `jetpack-migration` to `wpcom-migration`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
P2 discussion: p9dueE-6Cx-p2
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* jetpack build -> plugins -> migration and spin up your local WordPress.
* Use jurassic tube to make the site public
* Navigate to the plugin page main page, Installed plugin page and try to connect and disconnect Jetpack to see if the functionality is fine and the wording are correct.
* There shouldn't be anything like `Jetpack Migration` or slug like `jetpack-migration`.