### PR TITLE
Boost: Fix compile warnings

### DIFF
--- a/projects/js-packages/components/changelog/fix-circular-dependency
+++ b/projects/js-packages/components/changelog/fix-circular-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed a circular dependency reference

--- a/projects/js-packages/components/components/pricing-table/index.tsx
+++ b/projects/js-packages/components/components/pricing-table/index.tsx
@@ -11,7 +11,7 @@ import {
 	ReactElement,
 } from 'react';
 import React, { CSSProperties } from 'react';
-import { getRedirectUrl } from '../../../components';
+import getRedirectUrl from '../../../components/tools/jp-redirect';
 import IconTooltip from '../icon-tooltip';
 import useBreakpointMatch from '../layout/use-breakpoint-match';
 import Text from '../text';

--- a/projects/plugins/boost/app/assets/src/css/components/critical-css.scss
+++ b/projects/plugins/boost/app/assets/src/css/components/critical-css.scss
@@ -168,6 +168,7 @@
 }
 
 .jb-premium-cta {
+	width: 100%;
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
@@ -175,6 +176,7 @@
 	margin: 32px 0;
 	border: 2px solid $jetpack-green;
 	border-radius: $border-radius;
+	background-color: #ffffff;
 	cursor: pointer;
 
 	p {

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssErrorDescription.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssErrorDescription.svelte
@@ -71,7 +71,7 @@
 	</span>
 
 	<MoreList let:entry entries={displayUrls}>
-		<a href={entry.href} target="_blank">
+		<a href={entry.href} target="_blank" rel="noreferrer">
 			{entry.label}
 		</a>
 	</MoreList>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssShowStopperError.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssShowStopperError.svelte
@@ -63,7 +63,7 @@
 
 	<div slot="actionButton">
 		{#if $criticalCssStatus.retried_show_stopper}
-			<a class="button button-secondary" href={supportLink} target="_blank">
+			<a class="button button-secondary" href={supportLink} target="_blank" rel="noreferrer">
 				{__( 'Contact Support', 'jetpack-boost' )}
 			</a>
 		{:else}

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PopOut.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PopOut.svelte
@@ -36,6 +36,7 @@
 				class="jb-button--primary"
 				href={ctaLink}
 				target="_blank"
+				rel="noreferrer"
 				on:click={() => {
 					disablePrompt();
 				}}
@@ -47,6 +48,7 @@
 				class="jb-link"
 				href={ctaLink}
 				target="_blank"
+				rel="noreferrer"
 				on:click|preventDefault={() => {
 					disablePrompt();
 				}}

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PremiumCTA.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PremiumCTA.svelte
@@ -19,7 +19,7 @@
 	}
 </script>
 
-<div class="jb-premium-cta" on:click={showBenefits}>
+<button class="jb-premium-cta" on:click={showBenefits}>
 	<div class="jb-premium-cta__content">
 		<p>{__( 'Save time by automatically regenerating critical CSS', 'jetpack-boost' )}</p>
 		<p class="jb-premium-cta__action-line">{__( 'Upgrade Jetpack Boost', 'jetpack-boost' )}</p>
@@ -27,4 +27,4 @@
 	<div class="jb-premium-cta__icon">
 		<RightArrow />
 	</div>
-</div>
+</button>

--- a/projects/plugins/boost/app/features/image-guide/src/ui/Bubble.svelte
+++ b/projects/plugins/boost/app/features/image-guide/src/ui/Bubble.svelte
@@ -95,7 +95,7 @@
 		text-align: center;
 
 		border: 1px solid hsl( 0deg 0% 100% / 0.05 );
-		text-shadow: 0 0 1px hsl( 0, 0%, 0% / 0.15 );
+		text-shadow: 0 0 1px hsl( 0, 0%, 0%, 0.15 );
 		cursor: default;
 		transition: background-color 300ms ease;
 

--- a/projects/plugins/boost/app/features/image-guide/src/ui/Popup.svelte
+++ b/projects/plugins/boost/app/features/image-guide/src/ui/Popup.svelte
@@ -275,11 +275,5 @@
 		.preview {
 			gap: 8px;
 		}
-
-		.details {
-			max-width: 300px;
-			min-width: 200px;
-			padding: 15px;
-		}
 	}
 </style>

--- a/projects/plugins/boost/changelog/fix-compile-warnings
+++ b/projects/plugins/boost/changelog/fix-compile-warnings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed compiler warnings for typescript
+
+

--- a/projects/plugins/boost/rollup-tsconfig.json
+++ b/projects/plugins/boost/rollup-tsconfig.json
@@ -1,8 +1,8 @@
 {
 	"extends": "./tsconfig.json",
 	"include": [
-		"app/assets/src/js/**/*",
 		"../../js-packages/components/**/*",
+		"app/assets/src/js/**/*",
 		"app/features/image-guide/src/**/*"
 	],
 	"compilerOptions": {

--- a/projects/plugins/boost/tsconfig.json
+++ b/projects/plugins/boost/tsconfig.json
@@ -10,7 +10,6 @@
 		 * Values from "@tsconfig/svelte/tsconfig.json"
 		 */
 		"sourceMap": true,
-		"forceConsistentCasingInFileNames": true,
-		"rootDir": "."
+		"forceConsistentCasingInFileNames": true
 	}
 }


### PR DESCRIPTION
## Proposed changes:
* Fixed a few compiler warnings in Boost
* Fixed circular dependency in js-packages/components

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
None
