### PR TITLE
CRM: Encode textarea fields produce HTML entities on views

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-html-entities-for-special-characters-in-textareas
+++ b/projects/plugins/crm/changelog/fix-crm-html-entities-for-special-characters-in-textareas
@@ -1,3 +1,3 @@
 Significance: patch
 Type: fixed
-Comment: For textarea fields, we are encoding special characters into HTML entities before store it on the DB
+Comment: Special characters in textarea fields (contacts, transactions, quotes) produce visible HTML entities  

--- a/projects/plugins/crm/changelog/fix-crm-html-entities-for-special-characters-in-textareas
+++ b/projects/plugins/crm/changelog/fix-crm-html-entities-for-special-characters-in-textareas
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fixed
+Comment: For textarea fields, we are encoding special characters into HTML entities before store it on the DB

--- a/projects/plugins/crm/changelog/fix-crm-html-entities-for-special-characters-in-textareas
+++ b/projects/plugins/crm/changelog/fix-crm-html-entities-for-special-characters-in-textareas
@@ -1,3 +1,4 @@
 Significance: patch
 Type: fixed
-Comment: Special characters in textarea fields (contacts, transactions, quotes) produce visible HTML entities  
+
+Special characters in textarea fields (contacts, transactions, quotes) produce visible HTML entities

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -3112,6 +3112,11 @@ function zeroBS___________DAL30Helpers(){return;}
 		                        $retArray[$outputPrefix.$fK] = intval($retArray[$outputPrefix.$fK]);
 		                        break;
 
+						case 'textarea':
+							// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+							$retArray[ $outputPrefix . $fK ] = sanitize_textarea_field( $arraySource[ $fieldPrefix . $fK ] );
+							break;
+
 		                    case 'date':
 
 		                        $retArray[$outputPrefix.$fK] = sanitize_text_field($arraySource[$fieldPrefix.$fK]);

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -3112,13 +3112,6 @@ function zeroBS___________DAL30Helpers(){return;}
 		                        $retArray[$outputPrefix.$fK] = intval($retArray[$outputPrefix.$fK]);
 		                        break;
 
-
-		                    case 'textarea':
-
-		                        $retArray[$outputPrefix.$fK] = zeroBSCRM_textProcess($arraySource[$fieldPrefix.$fK]);
-
-		                        break;
-
 		                    case 'date':
 
 		                        $retArray[$outputPrefix.$fK] = sanitize_text_field($arraySource[$fieldPrefix.$fK]);


### PR DESCRIPTION
Fixes https://github.com/Automattic/zero-bs-crm/issues/2861 https://github.com/Automattic/zero-bs-crm/issues/2790

## Proposed changes:

This PR fixes an issue that happens with special characters (i.e. German characters) on any textarea for Quotes, Transactions, or custom fields for Contacts. It removes any HTML encoding for textarea before storing the value in the database, like the other text fields, simply using the `sanitize_text_field` function.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Create a new Transaction. Fill out the description with characters like: äüöß
- In trunk: Once you save it, you will see HTML entities instead of those characters.
- In this branch: You will see the correct characters
- The same happens for Quotes or any custom fields using textarea, for example, Contacts
- Repeat the test for those cases:
- Create a quote, and in the textarea Notes, add äüöß characters
- Create a custom field (textarea) for a contact. Create or edit an existing contact, and fill out that field with those characters.

