### PR TITLE
CRM: Composer updates - preparing composer.json for the initial Github release

### DIFF
--- a/projects/plugins/crm/changelog/update-crm-wp-svn-autopublish-disable
+++ b/projects/plugins/crm/changelog/update-crm-wp-svn-autopublish-disable
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Temporary change of value for wp-svn-autopublish for one GitHub release.
+
+

--- a/projects/plugins/crm/composer.json
+++ b/projects/plugins/crm/composer.json
@@ -60,7 +60,9 @@
 	],
 	"minimum-stability": "dev",
 	"extra": {
-		"autotagger": true,
+		"autotagger": {
+			"v": false
+		},
 		"autorelease": true,
 		"mirror-repo": "Automattic/jetpack-crm",
 		"changelogger": {

--- a/projects/plugins/crm/composer.json
+++ b/projects/plugins/crm/composer.json
@@ -67,7 +67,6 @@
 			"link-template": "https://github.com/Automattic/zero-bs-crm/compare/v${old}...v${new}"
 		},
 		"release-branch-prefix": "crm",
-		"wp-plugin-slug": "zero-bs-crm",
-		"wp-svn-autopublish": true
+		"wp-plugin-slug": "zero-bs-crm"
 	}
 }

--- a/projects/plugins/crm/composer.lock
+++ b/projects/plugins/crm/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "953bb04dae7a71feaac037414c50a62f",
+    "content-hash": "d3b5eac9c6c956f2598747501c2b543e",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",

--- a/projects/plugins/crm/composer.lock
+++ b/projects/plugins/crm/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d3b5eac9c6c956f2598747501c2b543e",
+    "content-hash": "f453115233eaf904b276ec50a3912c23",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",


### PR DESCRIPTION
## Proposed changes:

* This PR removed 'wp-svn-autopublish' from `composer.json` in the CRM plugin, to prevent a Github release from auto-publishing to SVN. This is because the first release from the monorepo will be Github only. This will be added back afterwards.
* As an addition, it also sets the autotagger to v: false to be in line with other standalones and prevent 'v' being prefixed to tagged versions.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* No testing instructions - just proof-reading.

