### PR TITLE
Fix Goodreads' custom widget not finding target element

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-goodreads-custom-widget
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-goodreads-custom-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix goodreads custom widget not finding the target HTML element and appending another after its script tag.

--- a/projects/plugins/jetpack/modules/widgets/goodreads.php
+++ b/projects/plugins/jetpack/modules/widgets/goodreads.php
@@ -105,6 +105,7 @@ class WPCOM_Widget_Goodreads extends WP_Widget {
 
 		// Set widget ID based on shelf.
 		$this->goodreads_widget_id = $instance['user_id'] . '_' . $instance['shelf'];
+		$this->goodreads_widget_id = str_replace( '-', '_', $this->goodreads_widget_id ); // Goodread's custom widget does not like dashes.
 
 		if ( empty( $title ) ) {
 			$title = esc_html__( 'Goodreads', 'jetpack' );

--- a/projects/plugins/jetpack/modules/widgets/goodreads.php
+++ b/projects/plugins/jetpack/modules/widgets/goodreads.php
@@ -105,7 +105,7 @@ class WPCOM_Widget_Goodreads extends WP_Widget {
 
 		// Set widget ID based on shelf.
 		$this->goodreads_widget_id = $instance['user_id'] . '_' . $instance['shelf'];
-		$this->goodreads_widget_id = str_replace( '-', '_', $this->goodreads_widget_id ); // Goodread's custom widget does not like dashes.
+		$this->goodreads_widget_id = str_replace( '-', '_', $this->goodreads_widget_id ); // Goodreads' custom widget does not like dashes.
 
 		if ( empty( $title ) ) {
 			$title = esc_html__( 'Goodreads', 'jetpack' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jpop-issues/issues/8071

Goodreads' [custom widget script](https://github.com/Automattic/jetpack/blob/e231356cd3308fea237ad856df0abf5f99ba4ff3/projects/plugins/jetpack/modules/widgets/goodreads.php#L117) doesn't target [the element](https://github.com/Automattic/jetpack/blob/e231356cd3308fea237ad856df0abf5f99ba4ff3/projects/plugins/jetpack/modules/widgets/goodreads.php#L119) printed on the page by Jetpack.

If there's a plugin that moves scripts around (for example Jetpack Boost's defer JS feature, which moves scripts to the footer), the markup of the widget will get added right after the script tag.

## Explanation

It appears, that the Goodreads Custom Widget script replaces dashes with underscores in the provided `widget_id`. For example, looking at this URL:
`
https://www.goodreads.com/review/custom_widget/162760418.Goodreads:%20to-read?cover_position=&cover_size=small&num_books=5&order=d&shelf=to-read&sort=date_added&widget_bg_transparent=&widget_id=162760418_to-read
`
the provided `widget_id` param is `162760418_to-read` (note the dash, which is part of the shelf `To Read`, slugged). However, if you view the contents of [the script](https://www.goodreads.com/review/custom_widget/162760418.Goodreads:%20to-read?cover_position=&cover_size=small&num_books=5&order=d&shelf=to-read&sort=date_added&widget_bg_transparent=&widget_id=162760418_to-read), you can see that the generated id is `gr_custom_widget_162760418_to_read ` and not `gr_custom_widget_162760418_to-read` which is what the target element printed by Jetpack uses.

![image](https://user-images.githubusercontent.com/11799079/218779444-a42accff-4fab-4dc3-ad7a-5029dfd8719e.png)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Replace dashes with underscores, so Goodreads' custom widget script can properly target the HTML element and append the markup to it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jpop-issues/issues/8071

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Test that it works properly:

* Setup a website with this version of Jetpack and use a theme that supports widgets (I tested with Twenty Twenty);
* Enable Jetpack's `Make extra widgets available for use on your site including subscription forms and Twitter streams` option from `WP-Admin -> Jetpack -> Settings -> Writing` to enable the widget;
* Add the `Goodreads (Jetpack)` widget to a page (easiest would be to use `WP-Admin -> Appearance -> Customize -> Widgets` then a widget group), and add your Goodreads account id (If you don't have a Goodreads account, you can use my id `162760418`);
* Open a page with the widget and inspect the widget and make sure there's no HTML element after the goodreads custom widget script (note the HTML structure from the screenshot has no div after the script tag);

![image](https://user-images.githubusercontent.com/11799079/218785436-e1abc1f4-f6ae-465d-9ba2-67b8610f92c6.png)

### Test that it works properly with Jetpack Boost defer JS feature turned on

* Install the latest version of Jetpack Boost;
* Enable the `Defer Non-Essential JavaScript` option from `WP-Admin -> Jetpack -> Boost`;
* Open the page and inspect the widget. The script should not be inside the widget (it should be in the footer) and the widget should display in the correct place (not the footer).

![image](https://user-images.githubusercontent.com/11799079/218787318-e19de6e0-0c30-4fda-9cee-500215fa0596.png)

### Test that it does not work properly:

* On the same website, comment out [the fix](https://github.com/Automattic/jetpack/blob/e02a182b86bca62baf6b62e72bd8716434e56374/projects/plugins/jetpack/modules/widgets/goodreads.php#L108);
* Disable Jetpack Boost's `Defer Non-Essential JavaScript` feature;
* Refresh the page and inspect the widget. Note the HTML structure. There should be an additional div after the script.

![image](https://user-images.githubusercontent.com/11799079/218785458-0444123b-ca42-4773-8555-bcb6bb7d08e5.png)

