### PR TITLE
Jetpack: convert v6 to v5 in case it is not registered

### DIFF
--- a/projects/plugins/jetpack/changelog/update-videopress-convert-v6-to-v5
+++ b/projects/plugins/jetpack/changelog/update-videopress-convert-v6-to-v5
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack: convert v6 to v5 in case it is not registered

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
@@ -847,7 +847,7 @@ const VideoPressEdit = CoreVideoEdit =>
 				saveEditorData();
 			};
 
-			const isResumableUploading = null !== fileForUpload && fileForUpload.name;
+			const isResumableUploading = null != fileForUpload && fileForUpload.name;
 
 			if ( isResumableUploading || this.state.isEditingWhileUploading ) {
 				const title = this.state.title ?? filename;

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -507,9 +507,6 @@ function mapV6AttributesToV5( attributes ) {
 		delete newAttributes.classNames;
 	}
 
-	// Set default value of fileForImmediateUpload to null.
-	newAttributes.fileForImmediateUpload = null;
-
 	// Clean the rest of the attributes.
 	delete newAttributes.title;
 	delete newAttributes.description;

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -639,6 +639,10 @@ const convertV6toV5 = createHigherOrderComponent( BlockListBlock => {
 				return;
 			}
 
+			if ( attributes?.originalName !== 'videopress/video' ) {
+				return;
+			}
+
 			try {
 				const parsedData = parse( attributes.originalContent );
 				const originalBlock = parsedData?.[ 0 ];

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -507,6 +507,9 @@ function mapV6AttributesToV5( attributes ) {
 		delete newAttributes.classNames;
 	}
 
+	// Set default value of fileForImmediateUpload to null.
+	newAttributes.fileForImmediateUpload = null;
+
 	// Clean the rest of the attributes.
 	delete newAttributes.title;
 	delete newAttributes.description;

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -9,6 +9,7 @@ import {
 } from '@automattic/jetpack-shared-extension-utils';
 import { createBlobURL } from '@wordpress/blob';
 import { useBlockEditContext, store as blockEditorStore } from '@wordpress/block-editor';
+import { parse } from '@wordpress/block-serialization-default-parser';
 import { createBlock, getBlockType } from '@wordpress/blocks';
 import { Button } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -489,8 +490,39 @@ function getVideoPressVideoBlockAttributes( attributes, defaultAttributes ) {
 	return attrs;
 }
 
+function mapV6AttributesToV5( attributes ) {
+	const newAttributes = { ...attributes };
+	if ( attributes?.tracks ) {
+		newAttributes.videoPressTracks = attributes.tracks;
+		delete newAttributes.tracks;
+	}
+
+	if ( attributes?.isExample ) {
+		newAttributes.isVideoPressExample = attributes.isExample;
+		delete newAttributes.isExample;
+	}
+
+	if ( attributes?.classNames ) {
+		newAttributes.videoPressClassNames = attributes.classNames;
+		delete newAttributes.classNames;
+	}
+
+	// Clean the rest of the attributes.
+	delete newAttributes.title;
+	delete newAttributes.description;
+	delete newAttributes.cacheHtml;
+	delete newAttributes.videoRatio;
+	delete newAttributes.privacySetting;
+	delete newAttributes.allowDownload;
+	delete newAttributes.displayEmbed;
+	delete newAttributes.rating;
+	delete newAttributes.isPrivate;
+
+	return newAttributes;
+}
+
 /**
- * Convert some video blocks to VideoPress video blocks,
+ * Convert video blocks to VideoPress video blocks,
  * when the app detects that the block is a VideoPress block instance.
  *
  * Blocks list:
@@ -591,3 +623,39 @@ addFilter(
 	'videopress/jetpack-convert-to-videopress-video-block',
 	convertVideoBlockToVideoPressVideoBlock
 );
+
+const convertV6toV5 = createHigherOrderComponent( BlockListBlock => {
+	return props => {
+		const { block } = props;
+		const { name, attributes, clientId } = block;
+		const { replaceBlock } = useDispatch( blockEditorStore );
+
+		/*
+		 * Detect missing videopress/video (v6) block,
+		 * and try to convert it to extended core/video (v5)
+		 */
+		useEffect( () => {
+			if ( name !== 'core/missing' ) {
+				return;
+			}
+
+			try {
+				const parsedData = parse( attributes.originalContent );
+				const originalBlock = parsedData?.[ 0 ];
+				if ( ! originalBlock ) {
+					return;
+				}
+
+				const { attrs } = originalBlock;
+				replaceBlock( clientId, createBlock( 'core/video', mapV6AttributesToV5( attrs ) ) );
+			} catch ( e ) {
+				// eslint-disable-next-line no-console
+				console.error( 'Error converting VideoPress block to core/video', e );
+			}
+		}, [ name, clientId, attributes, replaceBlock ] );
+
+		return <BlockListBlock { ...props } />;
+	};
+}, 'convertV6toV5' );
+
+addFilter( 'editor.BlockListBlock', 'videopress/jetpack-convert-from-v6-to-v5', convertV6toV5 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The VideoPress video block, aka `v6`, is a beta extension that will be moved to production soon. 
This new block allows, among many things, to transform the current instances of the VideoPress blocks (v5) to this new one.

Ideally, we'd like to leave behind the v5 implementation.

However, unexpected issues could arise, some of which could be addressed by working on v6, or if the severity of the issue is significant, we might need to roll back the feature to the beta state.

For this scenario, the user may get broken video block instances (since v6 will be unregistered for them again). This PR will try to recover the (now unregistered) v6 instances to v5.

Fixes https://github.com/Automattic/jetpack/issues/28919

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Jetpack: convert v6 to v5 in case it is not registered

### Other information:

- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

testing

* Activate Jetpack plugin
* Enable Beta extensions
* Go to the block editor
* Create a VideoPress video block (v6)
* Set block attributes by using the block sidebar
<img width="942" alt="Screen Shot 2023-02-14 at 14 02 05" src="https://user-images.githubusercontent.com/77539/218806604-d68be514-184d-4690-b44e-98827685d97f.png">

* Save the post
* Disable Beta extensions
* Hard refresh

**BEFORE**

* Confirm the video block is not rendered (block is not registered)

<img width="615" alt="image" src="https://user-images.githubusercontent.com/77539/218806934-0381c9aa-dab8-4406-97a2-734639ab2db1.png">


**AFTER**

* Confirm the editor converts the block to v5, automatically
* Confirm the block settings have been recovered

<img width="942" alt="Screen Shot 2023-02-14 at 14 07 05" src="https://user-images.githubusercontent.com/77539/218807599-c0c07913-add7-4e6e-a5e6-2f87efb34b5e.png">


