### PR TITLE
Blaze: abort early if JP not connected and defensive coding re get_current_screen

### DIFF
--- a/projects/packages/blaze/changelog/fix-blaze-fatal-frontend
+++ b/projects/packages/blaze/changelog/fix-blaze-fatal-frontend
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Blaze: prevent fatals on frontend-loaded Gutenberg + bail early if Jetpack is not connected

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -215,10 +215,10 @@ class Blaze {
 	 */
 	public static function enqueue_block_editor_assets() {
 		/*
-		* We do not want (nor need) Blaze in the site editor, or the widget editor, or the classic editor.
-		* We only want it in the post editor.
-		* Enqueueing the script in those editors would cause a fatal error.
-		* See #20357 for more info.
+		 * We do not want (nor need) Blaze in the site editor, or the widget editor, or the classic editor.
+		 * We only want it in the post editor.
+		 * Enqueueing the script in those editors would cause a fatal error.
+		 * See #20357 for more info.
 		*/
 		if ( ! function_exists( 'get_current_screen' ) ) { // When Gutenberg is loaded in the frontend.
 			return;

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -214,23 +214,26 @@ class Blaze {
 	 * Enqueue block editor assets.
 	 */
 	public static function enqueue_block_editor_assets() {
+		// Bail if criteria is not met to enable Blaze features.
+		if ( ! self::should_initialize() ) {
+			return;
+		}
+
 		/*
 		 * We do not want (nor need) Blaze in the site editor, or the widget editor, or the classic editor.
 		 * We only want it in the post editor.
 		 * Enqueueing the script in those editors would cause a fatal error.
 		 * See #20357 for more info.
 		 */
+		if ( ! function_exists( 'get_current_screen' ) ) { // When Gutenberg is loaded in the frontend.
+			return;
+		}
 		$current_screen = get_current_screen();
 		if (
 			empty( $current_screen )
 			|| $current_screen->base !== 'post'
 			|| ! $current_screen->is_block_editor()
 		) {
-			return;
-		}
-
-		// Bail if criteria is not met to enable Blaze features.
-		if ( ! self::should_initialize() ) {
 			return;
 		}
 

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -214,17 +214,12 @@ class Blaze {
 	 * Enqueue block editor assets.
 	 */
 	public static function enqueue_block_editor_assets() {
-		// Bail if criteria is not met to enable Blaze features.
-		if ( ! self::should_initialize() ) {
-			return;
-		}
-
 		/*
-		 * We do not want (nor need) Blaze in the site editor, or the widget editor, or the classic editor.
-		 * We only want it in the post editor.
-		 * Enqueueing the script in those editors would cause a fatal error.
-		 * See #20357 for more info.
-		 */
+		* We do not want (nor need) Blaze in the site editor, or the widget editor, or the classic editor.
+		* We only want it in the post editor.
+		* Enqueueing the script in those editors would cause a fatal error.
+		* See #20357 for more info.
+		*/
 		if ( ! function_exists( 'get_current_screen' ) ) { // When Gutenberg is loaded in the frontend.
 			return;
 		}
@@ -234,6 +229,10 @@ class Blaze {
 			|| $current_screen->base !== 'post'
 			|| ! $current_screen->is_block_editor()
 		) {
+			return;
+		}
+		// Bail if criteria is not met to enable Blaze features.
+		if ( ! self::should_initialize() ) {
 			return;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes fatal issue on https://wordpress.org/gutenberg for Blaze assuming the editors will always be in the admin context.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move should_initialize earlier (the site impacted is not connected to Jetpack, simply installed by way of multisite), so Blaze was causing a fatal to the frontend of a disconnected site.
* Defensive check for get_current_screen. I don't know what we should expect for a frontend Gutenberg in terms of Blaze, but better to not fatal and miss Blaze on the edge case for now.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1676401831382259-slack-C01U2KGS2PQ
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Put Gutenberg on a page outside of wp-admin (use this theme: p1676403580324799-slack-C01U2KGS2PQ )
* Have an unconnected installed Jetpack
* Before patch: see fatal.
* After patch: no fatal