### PR TITLE
CRM: Reverting PHP compatibility changes related to IntDateFormatter

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-intl-date-formatter-revert
+++ b/projects/plugins/crm/changelog/fix-crm-intl-date-formatter-revert
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Reverting several IntDateFormatter related lines back to how they were pre monorepo move.
+
+

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.Localisation.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.Localisation.php
@@ -319,11 +319,11 @@ function zeroBSCRM_date_forceEN( $time = -1 ) {
 		// dd MMMM yyyy HH:mm:ss (IntlDateFormatter - locale based date)
 		// (https://www.php.net/manual/en/class.intldateformatter.php)
 
-		// phpcs:disable
-		zeroBSCRM_locale_setServerLocale('en_US');
-		$r = strftime("%d %B %Y %H:%M:%S",$time);
+		// @todo - this is to be refactored.
+		zeroBSCRM_locale_setServerLocale( 'en_US' );
+		$r = strftime( '%d %B %Y %H:%M:%S', $time );
 		zeroBSCRM_locale_resetServerLocale();
-		// phpcs:enable
+
 		return $r;
 
 	}

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.Localisation.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.Localisation.php
@@ -321,6 +321,7 @@ function zeroBSCRM_date_forceEN( $time = -1 ) {
 
 		// @todo - this is to be refactored.
 		zeroBSCRM_locale_setServerLocale( 'en_US' );
+		// phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.strftimeDeprecated
 		$r = strftime( '%d %B %Y %H:%M:%S', $time );
 		zeroBSCRM_locale_resetServerLocale();
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.Localisation.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.Localisation.php
@@ -319,10 +319,11 @@ function zeroBSCRM_date_forceEN( $time = -1 ) {
 		// dd MMMM yyyy HH:mm:ss (IntlDateFormatter - locale based date)
 		// (https://www.php.net/manual/en/class.intldateformatter.php)
 
-		$fmt = new IntlDateFormatter( 'en_US', IntlDateFormatter::FULL, IntlDateFormatter::FULL );
-		$fmt->setPattern( 'dd MMMM yyyy HH:mm:ss' );
-		$r = $fmt->format( $time );
-
+		// phpcs:disable
+		zeroBSCRM_locale_setServerLocale('en_US');
+		$r = strftime("%d %B %Y %H:%M:%S",$time);
+		zeroBSCRM_locale_resetServerLocale();
+		// phpcs:enable
 		return $r;
 
 	}

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -1111,32 +1111,34 @@ function zeroBSCRM_getObjNav( $id = -1, $key = '', $type = ZBS_TYPE_CONTACT ) {
 
 	    } else {
 
-	    	// Note: Because this continued to be use for task scheduler workaround (before we got to rewrite the locale timestamp saving)
-	    	// ... we functionised in Core.Localisation.php to keep it DRY
+			// Note: Because this continued to be use for task scheduler workaround (before we got to rewrite the locale timestamp saving)
+			// ... we functionised in Core.Localisation.php to keep it DRY
 
-	        // phpcs:disable
-	        // temp pre v3.0 fix, forcing english en for this datepicker only. 
-	        // requires js mod: search #forcedlocaletasks
-	        // (Month names are localised, causing a mismatch here (Italian etc.)) 
-	        // ... so we translate:
-	        //      d F Y H:i:s (date - not locale based)
-	        // https://www.php.net/manual/en/function.date.php
-	        // ... into
-	        //      %d %B %Y %H:%M:%S (strfttime - locale based date)
-	        // (https://www.php.net/manual/en/function.strftime.php)
+			// temp pre v3.0 fix, forcing english en for this datepicker only.
+			// requires js mod: search #forcedlocaletasks
+			// (Month names are localised, causing a mismatch here (Italian etc.))
+			// ... so we translate:
+			// d F Y H:i:s (date - not locale based)
+			// https://www.php.net/manual/en/function.date.php
+			// ... into
+			// %d %B %Y %H:%M:%S (strfttime - locale based date)
+			// (https://www.php.net/manual/en/function.strftime.php)
 
-	        /*
-	        $start_d = zeroBSCRM_date_i18n('d F Y H:i:s', $taskObject['start']);
-	        $end_d = zeroBSCRM_date_i18n('d F Y H:i:s', $taskObject['end']);
-	        */
+			// phpcs:disable Squiz.PHP.CommentedOutCode.Found, Squiz.Commenting.BlockComment.NoCapital
 
-	        /*
-	        zeroBSCRM_locale_setServerLocale('en_US');
-	        $start_d = strftime("%d %B %Y %H:%M:%S",$task['start']);
-	        $end_d =  strftime("%d %B %Y %H:%M:%S",$task['end']);
-	        zeroBSCRM_locale_resetServerLocale();
-	        // phpcs:enable
-	        */
+			/*
+			$start_d = zeroBSCRM_date_i18n('d F Y H:i:s', $taskObject['start']);
+			$end_d = zeroBSCRM_date_i18n('d F Y H:i:s', $taskObject['end']);
+			*/
+
+			/*
+			@todo - this is to be refactored.
+			zeroBSCRM_locale_setServerLocale('en_US');
+			$start_d = strftime("%d %B %Y %H:%M:%S",$task['start']);
+			$end_d =  strftime("%d %B %Y %H:%M:%S",$task['end']);
+			zeroBSCRM_locale_resetServerLocale();
+			*/
+			// phpcs:enable Squiz.PHP.CommentedOutCode.Found, Squiz.Commenting.BlockComment.NoCapital
 
 	        $start_d = zeroBSCRM_date_forceEN($task['start']);
 	        $end_d = zeroBSCRM_date_forceEN($task['end']);
@@ -1146,6 +1148,7 @@ function zeroBSCRM_getObjNav( $id = -1, $key = '', $type = ZBS_TYPE_CONTACT ) {
 	    return $start_d . ' - ' . $end_d;
 	}
 
+	// phpcs:disable
 /* ======================================================
   /	Tasks
    ====================================================== */
@@ -1957,3 +1960,4 @@ function zeroBSCRM_outputEmailHistory($userID = -1){
    		return $migrationName;
    		
    }
+// phpcs: enable

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -1122,7 +1122,7 @@ function zeroBSCRM_getObjNav( $id = -1, $key = '', $type = ZBS_TYPE_CONTACT ) {
 	        //      d F Y H:i:s (date - not locale based)
 	        // https://www.php.net/manual/en/function.date.php
 	        // ... into
-			//      %d %B %Y %H:%M:%S (strfttime - locale based date)
+            //      %d %B %Y %H:%M:%S (strfttime - locale based date)
 	        // (https://www.php.net/manual/en/function.strftime.php)
 
 	        /*

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -1114,6 +1114,7 @@ function zeroBSCRM_getObjNav( $id = -1, $key = '', $type = ZBS_TYPE_CONTACT ) {
 	    	// Note: Because this continued to be use for task scheduler workaround (before we got to rewrite the locale timestamp saving)
 	    	// ... we functionised in Core.Localisation.php to keep it DRY
 
+			// phpcs:disable
 	        // temp pre v3.0 fix, forcing english en for this datepicker only. 
 	        // requires js mod: search #forcedlocaletasks
 	        // (Month names are localised, causing a mismatch here (Italian etc.)) 
@@ -1121,8 +1122,8 @@ function zeroBSCRM_getObjNav( $id = -1, $key = '', $type = ZBS_TYPE_CONTACT ) {
 	        //      d F Y H:i:s (date - not locale based)
 	        // https://www.php.net/manual/en/function.date.php
 	        // ... into
-	        //      dd MMMM yyyy HH:mm:ss (IntlDateFormatter - locale based date)
-	        // (https://www.php.net/manual/en/class.intldateformatter.php)
+			//      %d %B %Y %H:%M:%S (strfttime - locale based date)
+	        // (https://www.php.net/manual/en/function.strftime.php)
 
 	        /*
 	        $start_d = zeroBSCRM_date_i18n('d F Y H:i:s', $taskObject['start']);
@@ -1130,12 +1131,11 @@ function zeroBSCRM_getObjNav( $id = -1, $key = '', $type = ZBS_TYPE_CONTACT ) {
 	        */
 
 	        /*
-
-	        $fmt = new IntlDateFormatter( 'en_US', IntlDateFormatter::FULL, IntlDateFormatter::FULL );
-	        $fmt->setPattern( 'dd MMMM yyyy HH:mm:ss' );
-	        $start_d = $fmt->format($task['start']);
-	        $end_d =  $fmt->format($task['end']);
-
+	        zeroBSCRM_locale_setServerLocale('en_US');
+	        $start_d = strftime("%d %B %Y %H:%M:%S",$task['start']);
+	        $end_d =  strftime("%d %B %Y %H:%M:%S",$task['end']);
+	        zeroBSCRM_locale_resetServerLocale();
+			// phpcs:enable
 	        */
 
 	        $start_d = zeroBSCRM_date_forceEN($task['start']);

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -1114,7 +1114,7 @@ function zeroBSCRM_getObjNav( $id = -1, $key = '', $type = ZBS_TYPE_CONTACT ) {
 	    	// Note: Because this continued to be use for task scheduler workaround (before we got to rewrite the locale timestamp saving)
 	    	// ... we functionised in Core.Localisation.php to keep it DRY
 
-			// phpcs:disable
+	        // phpcs:disable
 	        // temp pre v3.0 fix, forcing english en for this datepicker only. 
 	        // requires js mod: search #forcedlocaletasks
 	        // (Month names are localised, causing a mismatch here (Italian etc.)) 
@@ -1122,7 +1122,7 @@ function zeroBSCRM_getObjNav( $id = -1, $key = '', $type = ZBS_TYPE_CONTACT ) {
 	        //      d F Y H:i:s (date - not locale based)
 	        // https://www.php.net/manual/en/function.date.php
 	        // ... into
-            //      %d %B %Y %H:%M:%S (strfttime - locale based date)
+	        //      %d %B %Y %H:%M:%S (strfttime - locale based date)
 	        // (https://www.php.net/manual/en/function.strftime.php)
 
 	        /*
@@ -1135,7 +1135,7 @@ function zeroBSCRM_getObjNav( $id = -1, $key = '', $type = ZBS_TYPE_CONTACT ) {
 	        $start_d = strftime("%d %B %Y %H:%M:%S",$task['start']);
 	        $end_d =  strftime("%d %B %Y %H:%M:%S",$task['end']);
 	        zeroBSCRM_locale_resetServerLocale();
-			// phpcs:enable
+	        // phpcs:enable
 	        */
 
 	        $start_d = zeroBSCRM_date_forceEN($task['start']);

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Events.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Events.php
@@ -744,7 +744,7 @@ function zeroBSCRM_task_ui_date($taskObject = array()){
 
     } else {
 
-
+		// phpcs:disable
         // temp pre v3.0 fix, forcing english en for this datepicker only. 
         // requires js mod: search #forcedlocaletasks
         // (Month names are localised, causing a mismatch here (Italian etc.)) 
@@ -752,18 +752,19 @@ function zeroBSCRM_task_ui_date($taskObject = array()){
         //      d F Y H:i:s (date - not locale based)
         // https://www.php.net/manual/en/function.date.php
         // ... into
-        //      dd MMMM yyyy HH:mm:ss (IntlDateFormatter - locale based date)
-        // (https://www.php.net/manual/en/class.intldateformatter.php)
+		//      %d %B %Y %H:%M:%S (strfttime - locale based date)
+        // (https://www.php.net/manual/en/function.strftime.php)
 
         /*
         $start_d = zeroBSCRM_date_i18n('d F Y H:i:s', $taskObject['start']);
         $end_d = zeroBSCRM_date_i18n('d F Y H:i:s', $taskObject['end']);
         */
 
-        $fmt = new IntlDateFormatter( 'en_US', IntlDateFormatter::FULL, IntlDateFormatter::FULL );
-        $fmt->setPattern( 'dd MMMM yyyy HH:mm:ss' );
-        $start_d = $fmt->format($taskObject['start']);
-        $end_d =  $fmt->format($taskObject['end']);
+        zeroBSCRM_locale_setServerLocale('en_US');
+        $start_d = strftime("%d %B %Y %H:%M:%S",$taskObject['start']);
+        $end_d =  strftime("%d %B %Y %H:%M:%S",$taskObject['end']);
+        zeroBSCRM_locale_resetServerLocale();
+		// phpcs:enable
     }
 
     $html = '<div class="no-task-date"><input type="text" id="daterange" class="form-control" name="daterange" value="' . $start_d . ' - ' . $end_d .'" autocomplete="zbs-'.time() . '-task-date" /></div>';

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Events.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Events.php
@@ -761,12 +761,12 @@ function zeroBSCRM_task_ui_date($taskObject = array()){
 		$end_d = zeroBSCRM_date_i18n('d F Y H:i:s', $taskObject['end']);
 		*/
 		// @todo - this is to be refactored.
-		// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, PHPCompatibility.FunctionUse.RemovedFunctions.strftimeDeprecated
 		zeroBSCRM_locale_setServerLocale( 'en_US' );
 		$start_d = strftime( '%d %B %Y %H:%M:%S', $taskObject['start'] );
 		$end_d   = strftime( '%d %B %Y %H:%M:%S', $taskObject['end'] );
 		zeroBSCRM_locale_resetServerLocale();
-		// phps:enable Squiz.PHP.CommentedOutCode.Found, WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		// phps:enable Squiz.PHP.CommentedOutCode.Found, WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, PHPCompatibility.FunctionUse.RemovedFunctions.strftimeDeprecated
 	}
 
     $html = '<div class="no-task-date"><input type="text" id="daterange" class="form-control" name="daterange" value="' . $start_d . ' - ' . $end_d .'" autocomplete="zbs-'.time() . '-task-date" /></div>';

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Events.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Events.php
@@ -744,7 +744,7 @@ function zeroBSCRM_task_ui_date($taskObject = array()){
 
     } else {
 
-		// phpcs:disable
+        // phpcs:disable
         // temp pre v3.0 fix, forcing english en for this datepicker only. 
         // requires js mod: search #forcedlocaletasks
         // (Month names are localised, causing a mismatch here (Italian etc.)) 
@@ -752,7 +752,7 @@ function zeroBSCRM_task_ui_date($taskObject = array()){
         //      d F Y H:i:s (date - not locale based)
         // https://www.php.net/manual/en/function.date.php
         // ... into
-		//      %d %B %Y %H:%M:%S (strfttime - locale based date)
+        //      %d %B %Y %H:%M:%S (strfttime - locale based date)
         // (https://www.php.net/manual/en/function.strftime.php)
 
         /*
@@ -764,7 +764,7 @@ function zeroBSCRM_task_ui_date($taskObject = array()){
         $start_d = strftime("%d %B %Y %H:%M:%S",$taskObject['start']);
         $end_d =  strftime("%d %B %Y %H:%M:%S",$taskObject['end']);
         zeroBSCRM_locale_resetServerLocale();
-		// phpcs:enable
+        // phpcs:enable
     }
 
     $html = '<div class="no-task-date"><input type="text" id="daterange" class="form-control" name="daterange" value="' . $start_d . ' - ' . $end_d .'" autocomplete="zbs-'.time() . '-task-date" /></div>';

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Events.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Events.php
@@ -744,28 +744,30 @@ function zeroBSCRM_task_ui_date($taskObject = array()){
 
     } else {
 
-        // phpcs:disable
-        // temp pre v3.0 fix, forcing english en for this datepicker only. 
-        // requires js mod: search #forcedlocaletasks
-        // (Month names are localised, causing a mismatch here (Italian etc.)) 
-        // ... so we translate:
-        //      d F Y H:i:s (date - not locale based)
-        // https://www.php.net/manual/en/function.date.php
-        // ... into
-        //      %d %B %Y %H:%M:%S (strfttime - locale based date)
-        // (https://www.php.net/manual/en/function.strftime.php)
+		// temp pre v3.0 fix, forcing english en for this datepicker only.
+		// requires js mod: search #forcedlocaletasks
+		// (Month names are localised, causing a mismatch here (Italian etc.))
+		// ... so we translate:
+		// d F Y H:i:s (date - not locale based)
+		// https://www.php.net/manual/en/function.date.php
+		// ... into
+		// %d %B %Y %H:%M:%S (strfttime - locale based date)
+		// (https://www.php.net/manual/en/function.strftime.php)
 
-        /*
-        $start_d = zeroBSCRM_date_i18n('d F Y H:i:s', $taskObject['start']);
-        $end_d = zeroBSCRM_date_i18n('d F Y H:i:s', $taskObject['end']);
-        */
+		// phpcs:disable Squiz.PHP.CommentedOutCode.Found
 
-        zeroBSCRM_locale_setServerLocale('en_US');
-        $start_d = strftime("%d %B %Y %H:%M:%S",$taskObject['start']);
-        $end_d =  strftime("%d %B %Y %H:%M:%S",$taskObject['end']);
-        zeroBSCRM_locale_resetServerLocale();
-        // phpcs:enable
-    }
+		/*
+		$start_d = zeroBSCRM_date_i18n('d F Y H:i:s', $taskObject['start']);
+		$end_d = zeroBSCRM_date_i18n('d F Y H:i:s', $taskObject['end']);
+		*/
+		// @todo - this is to be refactored.
+		// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		zeroBSCRM_locale_setServerLocale( 'en_US' );
+		$start_d = strftime( '%d %B %Y %H:%M:%S', $taskObject['start'] );
+		$end_d   = strftime( '%d %B %Y %H:%M:%S', $taskObject['end'] );
+		zeroBSCRM_locale_resetServerLocale();
+		// phps:enable Squiz.PHP.CommentedOutCode.Found, WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	}
 
     $html = '<div class="no-task-date"><input type="text" id="daterange" class="form-control" name="daterange" value="' . $start_d . ' - ' . $end_d .'" autocomplete="zbs-'.time() . '-task-date" /></div>';
     $html .= '<input type="hidden" id="zbs_from" name="zbse_start" value="' . $start_d .'"/>';


### PR DESCRIPTION


## Proposed changes:

* On [one of the initial commits](https://github.com/Automattic/jetpack/pull/28314/commits/dc36c7afdd08b992633793ab1d59043148b7dfe1) when CRM was moved into the monorepo, in order to clean up some of the PHP the IntDateFormatter code was refactored. This resulted in a fatal error on some installations when the INTL PHP module was disabled, so this PR temporarily reverts that.
* We do have an issue to make sure to resolve this: https://github.com/Automattic/zero-bs-crm/issues/2884

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* The testing instructions from here should still apply: https://github.com/Automattic/jetpack/pull/28909

