### PR TITLE
VideoPress: Disable local library item expansion when video is already uploaded (mobile)

### DIFF
--- a/projects/js-packages/components/changelog/fix-videopress-local-library-mobile
+++ b/projects/js-packages/components/changelog/fix-videopress-local-library-mobile
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Only a version bump required by CI
+
+

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.27.5",
+	"version": "0.27.6-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/packages/videopress/changelog/fix-videopress-local-library-mobile
+++ b/projects/packages/videopress/changelog/fix-videopress-local-library-mobile
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Disable local library upload button when video is already uploaded (mobile)

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.10.10",
+	"version": "0.10.11-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.10.10';
+	const PACKAGE_VERSION = '0.10.11-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/client/admin/components/video-row/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-row/index.tsx
@@ -142,6 +142,7 @@ export const VideoRow = ( {
 	const showBottom = ! loading && ( ! isSmall || ( isSmall && expanded ) );
 	const canExpand =
 		isSmall &&
+		showActions &&
 		! loading &&
 		( showActionButton ||
 			Boolean( duration ) ||

--- a/projects/packages/videopress/src/client/admin/components/video-row/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-row/index.tsx
@@ -6,7 +6,7 @@ import { dateI18n } from '@wordpress/date';
 import { sprintf, __ } from '@wordpress/i18n';
 import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 import classNames from 'classnames';
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 /**
  * Internal dependencies
  */
@@ -205,6 +205,12 @@ export const VideoRow = ( {
 			handleClick( e );
 		}
 	};
+
+	useEffect( () => {
+		if ( ! canExpand ) {
+			setExpanded( false );
+		}
+	}, [ canExpand ] );
 
 	return (
 		<div

--- a/projects/packages/videopress/src/client/admin/components/video-row/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-row/index.tsx
@@ -207,10 +207,10 @@ export const VideoRow = ( {
 	};
 
 	useEffect( () => {
-		if ( ! canExpand ) {
+		if ( disabled ) {
 			setExpanded( false );
 		}
-	}, [ canExpand ] );
+	}, [ disabled ] );
 
 	return (
 		<div

--- a/projects/packages/videopress/src/client/admin/components/video-row/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-row/index.tsx
@@ -312,7 +312,7 @@ export const VideoRow = ( {
 							loading={ loading }
 						/>
 
-						{ isSmall && (
+						{ isSmall && showActions && (
 							<div className={ styles[ 'mobile-actions' ] }>
 								{ showActionButton && actionButton }
 								{ showQuickActions && id && <ConnectVideoQuickActions videoId={ id } /> }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #28951

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Prevents expansion of the row when `showActions` is false, as the button is the only information there for local videos

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Media Library and upload some videos
* Connect Jetpack
* Go to the VideoPress dashboard and change the viewport to simulate a small screen (or test is on a smartphone)
* Using the local videos library, upload a video
* Check that after the video is uploaded, the row cannot be expanded anymore
* Change the VideoPress library to show rows instead of cards
* Check that the rows work as normal without regressions

![2023-02-14_18-02-53](https://user-images.githubusercontent.com/8486249/218863096-10bb8555-8e8e-430d-aede-9958fb93886e.png)
![2023-02-14_18-03-05](https://user-images.githubusercontent.com/8486249/218863091-1d4a3cd8-8637-47e8-99cc-bb7fddeae0d1.png)
