### PR TITLE
Super Cache: Prevent a deprecation notice in PHP 8.1 and later

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-deprecation-warning-php-8-1
+++ b/projects/plugins/super-cache/changelog/fix-deprecation-warning-php-8-1
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed PHP 8.1 deprecation notice
+
+

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -28,6 +28,10 @@ function get_wp_cache_key( $url = false ) {
 	if ( ! $url ) {
 		$url = $wp_cache_request_uri;
 	}
+	// Prevent a PHP 8.1+ notice when passed into str_replace()
+	if ( null === $url ) {
+		$url = '';
+	}
 	$server_port = isset( $_SERVER['SERVER_PORT'] ) ? intval( $_SERVER['SERVER_PORT'] ) : 0;
 	return do_cacheaction( 'wp_cache_key', wp_cache_check_mobile( $WPSC_HTTP_HOST . $server_port . preg_replace( '/#.*$/', '', str_replace( '/index.php', '/', $url ) ) . $wp_cache_gzip_encoding . wp_cache_get_cookies_values() ) );
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/28847

## Proposed changes:

If `$url` is `null`, set to `''` before passing to `str_replace()`. This is effectively the same behavior — we get to fix the notice without worrying about any potential bugs.
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.
## Testing instructions:

1. Spin up a testing environment with PHP 8.1.
2. Observe the PHP notice when visiting `/wp-admin/plugins.php` with WP Super Cache active.
3. Apply this pull request.
4. Observe the PHP notice no longer appears.
