### PR TITLE
Update "Official buttons" styles

### DIFF
--- a/projects/plugins/jetpack/changelog/update-official-button-styles
+++ b/projects/plugins/jetpack/changelog/update-official-button-styles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Updating look and feel of sharing buttons when in "official" mode

--- a/projects/plugins/jetpack/modules/sharedaddy/admin-sharing.css
+++ b/projects/plugins/jetpack/modules/sharedaddy/admin-sharing.css
@@ -64,7 +64,6 @@ body.settings_page_sharing .services {
 }
 
 body.settings_page_sharing .services ul li {
-	float: left;
 	cursor: move;
 }
 
@@ -172,8 +171,9 @@ li.service.share-skype span:before {
  */
 
 body.settings_page_sharing ul.preview {
+	display: flex;
+	flex-wrap: wrap;
 	float: left;
-	margin: 0px;
 }
 
 body.settings_page_sharing ul.preview li.preview-item, body.settings_page_sharing ul.preview li.preview-item a {
@@ -314,6 +314,7 @@ body.settings_page_sharing .advanced input[type=submit] {
 	background-size: 85px 20px;
 	width:85px;
 	height:20px;
+	margin-left: -4px;
 }
 
 .preview-twitter .option-smart-on {

--- a/projects/plugins/jetpack/modules/sharedaddy/admin-sharing.js
+++ b/projects/plugins/jetpack/modules/sharedaddy/admin-sharing.js
@@ -95,6 +95,15 @@
 		function update_preview() {
 			var button_style = $( '#button_style' ).val();
 
+			// Toggle .sd-social-official class
+			var sharedaddy = $('.sharedaddy');
+			var oficialClass = 'sd-social-official';
+			if ( 'official' === button_style ) {
+				sharedaddy.addClass(oficialClass);
+			} else {
+				sharedaddy.removeClass(oficialClass);
+			}
+
 			// Clear the live preview
 			$( '#live-preview ul.preview li' ).remove();
 

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.css
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.css
@@ -26,15 +26,6 @@ div.sharedaddy h3.sd-title {
 	font-weight: bold;
 }
 
-div.sharedaddy h3.sd-title:before {
-	content: "";
-	display: block;
-	width: 100%;
-	min-width: 30px;
-	border-top: 1px solid #dcdcde;
-	margin-bottom: 1em;
-}
-
 body.highlander-light h3.sd-title:before {
 	border-top: 1px solid rgba(0,0,0,.2);
 }
@@ -110,7 +101,22 @@ body.highlander-dark h3.sd-title:before {
 	padding: 5px 11px 4px 9px;
 }
 
-.sd-social-text .sd-content ul li a.sd-button span,
+.sd-social-official .sd-content ul li a.sd-button,
+.sd-social-official .sd-content ul li.preview-item div.option.option-smart-off a {
+	align-items: center;
+	display: flex;
+	font-size: 12px;
+	line-height: 12px;
+	padding: 1px 6px 0px 5px;
+	min-height: 20px;
+}
+
+.sd-social-official .sd-content ul.preview li a.sd-button,
+.sd-social-official .sd-content ul.preview li.preview-item div.option.option-smart-off a {
+	position: relative;
+	top: 2px;
+}
+
 .sd-content ul li a.sd-button>span,
 .sd-content ul li .option a.share-ustom span,	/* Ugh. */
 .sd-content ul li.preview-item div.option.option-smart-off a span,
@@ -119,23 +125,20 @@ body.highlander-dark h3.sd-title:before {
 .sd-social-official .sd-content>ul>li>a.sd-button span,
 .sd-social-official .sd-content>ul>li .digg_button >a span {		/* official Digg button no longer works, needs cleaning */
 	line-height: 23px;
+	margin-left: 6px;
+}
+
+.sd-social-text .sd-content ul li a.sd-button span {
+	margin-left: 3px;
+}
+
+.sd-social-official .sd-content ul li a.sd-button>span,
+.sd-social-official .sd-content ul li.preview-item div.option.option-smart-off a span {
+	line-height: 12px;
+	margin-left: 3px;
 }
 
 
-
-/* Our gray buttons should be smaller when seen with the official ones */
-.sd-social-official .sd-content>ul>li>a.sd-button,
-.sd-social-official .sd-content .sharing-hidden .inner>ul>li>a.sd-button,
-.sd-social-official .sd-content>ul>li .digg_button>a,
-.sd-social-official .sd-content .sharing-hidden .inner>ul>li .digg_button>a {
-	line-height: 17px;
-	box-shadow: none; /* No shadow on gray buttons between the official ones */
-	vertical-align: top;
-}
-
-.sd-social-official .sd-content ul li a.sd-button>span {
-	line-height: 17px;
-}
 .sd-social-official .sd-content>ul>li>a.sd-button:before,
 .sd-social-official .sd-content>ul>li .digg_button>a:before,
 .sd-social-official .sd-content .sharing-hidden .inner>ul>li>a.sd-button:before,
@@ -199,19 +202,12 @@ body.highlander-dark h3.sd-title:before {
 }
 
 .sd-content ul li {
-	margin: 0 8px 8px 0;
+	margin: 0 8px 12px 0;
 	padding: 0;
 }
 /* Add more pading on touch devices */
 .jp-sharing-input-touch .sd-content ul li { padding-left: 10px; }
 
-/* Text + icon & Official */
-.sd-social-icon-text .sd-content ul li a span,
-.sd-social-official .sd-content ul li a.sd-button span,
-.sd-content ul li.preview-item a.sd-button span,
-.sd-content ul li.advanced .share-more span {
-	margin-left: 6px;
-}
 .sd-content ul li.preview-item.no-icon a.sd-button span {
 	margin-left: 0;
 }
@@ -386,14 +382,13 @@ body .sd-content ul li.share-custom.no-icon a span {
 	line-height: 1;
 }
 
-
-/* Official buttons */
-.sd-social-official .sd-content ul, .sd-social-official .sd-content ul li {
-	line-height: 25px !important;
-}
-
 .sd-social-official .sd-content>ul>li>a.sd-button span {
 	line-height: 1;
+}
+
+.sd-social-official .sd-content ul {
+	display: flex;
+	flex-wrap: wrap;
 }
 
 .sd-social-official .sd-content ul:after {
@@ -409,10 +404,12 @@ body .sd-content ul li.share-custom.no-icon a span {
 }
 
 .sd-social-official .sd-content ul>li {
-	display: block;
-	float: left;
-	margin: 0 10px 5px 0 !important;
-	height: 25px;
+	display: flex;
+	max-height: 18px;
+}
+
+.sd-social-official .sd-content ul>li .option-smart-off {
+	margin-right: 8px;
 }
 
 .sd-social-official .fb-share-button > span {
@@ -438,7 +435,7 @@ body .sd-content ul li.share-custom.no-icon a span {
 }
 
 .sd-social-official .sd-content .share-skype {
-	width: 55px;
+	min-width: 55px;
 }
 
 body .sd-social-official li.share-print ,
@@ -554,6 +551,7 @@ body .sd-social-icon .sd-content li.share-custom a span {
 	width: auto;
 	height: auto;
 	margin-bottom: 0;
+	max-width: 32px;
 }
 
 .sd-social-icon .sd-content ul li[class*='share-'] a.sd-button>span,
@@ -698,7 +696,7 @@ body .sd-social-icon .sd-content li.share-custom a span {
 }
 
 .sd-content .share-customize-link {
-	margin-top: 0em;
+	margin-top: 8px;
 	line-height: 11px;
 }
 

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -455,7 +455,7 @@ class Sharing_Admin {
 					</td>
 					<td class="services">
 						<h2 <?php echo ( count( $enabled['all'] ) > 0 ) ? ' style="display: none"' : ''; ?>><?php esc_html_e( 'Sharing is off. Add services above to enable.', 'jetpack' ); ?></h2>
-						<div class="sharedaddy sd-sharing-enabled <?php if ( $global['button_style'] === 'official' ) { echo ''; } ?>">
+						<div class="sharedaddy sd-sharing-enabled">
 							<?php if ( count( $enabled['all'] ) > 0 ) : ?>
 							<h3 class="sd-title"><?php echo esc_html( $global['sharing_label'] ); ?></h3>
 							<?php endif; ?>

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -455,7 +455,7 @@ class Sharing_Admin {
 					</td>
 					<td class="services">
 						<h2 <?php echo ( count( $enabled['all'] ) > 0 ) ? ' style="display: none"' : ''; ?>><?php esc_html_e( 'Sharing is off. Add services above to enable.', 'jetpack' ); ?></h2>
-						<div class="sharedaddy sd-sharing-enabled">
+						<div class="sharedaddy sd-sharing-enabled <?php if ( $global['button_style'] === 'official' ) { echo ''; } ?>">
 							<?php if ( count( $enabled['all'] ) > 0 ) : ?>
 							<h3 class="sd-title"><?php echo esc_html( $global['sharing_label'] ); ?></h3>
 							<?php endif; ?>


### PR DESCRIPTION
## Proposed changes:

This PR is one of several steps that we'll take to update the look and feel of the sharing icons. You can see a full list of updates that need to be made [here](https://github.com/Automattic/jetpack/issues/27817). In this PR we're updating the "Official buttons" styles.

## Front-end

### Before

<img width="606" alt="front-end-before" src="https://user-images.githubusercontent.com/5634774/218893517-d3427a19-af71-4f6a-912e-4f1a7c4f6c0a.png">

### After

<img width="611" alt="front-end-after" src="https://user-images.githubusercontent.com/5634774/218893528-8fdd75d0-c455-47be-a913-8dab3a34edd8.png">

## Preview

### Before

<img width="1056" alt="preview-before" src="https://user-images.githubusercontent.com/5634774/218893547-3e13f801-41a8-4285-a4f6-e6d8d6961a3b.png">

### After

<img width="1055" alt="preview-after" src="https://user-images.githubusercontent.com/5634774/218893588-fbd410cf-042c-422c-833b-d6a6ba751194.png">

## Jetpack product discussion
- #27817
- pe7F0s-i3-p2
- pe7F0s-qg-p2

## Does this pull request change what data or activity we track or use?
Nope.

## Testing instructions:
- Follow instructions to [set up JP locally](https://github.com/Automattic/jetpack/blob/trunk/docs/quick-start.md) (with jurassic.tube proxy), or use jurassic ninja
- Ensure that you have sharing buttons activated
- Select "Official buttons" sharing option
- Ensure that you have at least one published blog post
- Visit the blog post

## Related
- #27817
- #28876
- #28874
- https://github.com/Automattic/wp-calypso/pull/73126
- D101354-code