### PR TITLE
Backup: Update component to use custom backup retention days if set

### DIFF
--- a/projects/packages/backup/changelog/update-backup-storage-ui-to-use-custom-retention-period-if-set
+++ b/projects/packages/backup/changelog/update-backup-storage-ui-to-use-custom-retention-period-if-set
@@ -1,4 +1,3 @@
-Significance: minor
+Significance: patch
 Type: changed
-
-Updated backup storage UI to consider custom retention period
+Comment: Updated backup storage UI to consider custom retention period

--- a/projects/packages/backup/changelog/update-backup-storage-ui-to-use-custom-retention-period-if-set
+++ b/projects/packages/backup/changelog/update-backup-storage-ui-to-use-custom-retention-period-if-set
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Updated backup storage UI to consider custom retention period

--- a/projects/packages/backup/composer.json
+++ b/projects/packages/backup/composer.json
@@ -75,7 +75,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-backup/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "1.12.x-dev"
+			"dev-trunk": "1.13.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.12.3-alpha';
+	const PACKAGE_VERSION = '1.13.0-alpha';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/backup/src/js/actions/index.js
+++ b/projects/packages/backup/src/js/actions/index.js
@@ -25,6 +25,7 @@ const getSiteSize = () => ( { dispatch } ) => {
 				minDaysOfBackupsAllowed: res.min_days_of_backups_allowed,
 				daysOfBackupsAllowed: res.days_of_backups_allowed,
 				daysOfBackupsSaved: res.days_of_backups_saved,
+				retentionDays: res.retention_days,
 			};
 
 			dispatch( { type: SITE_BACKUP_SIZE_GET_SUCCESS, payload } );

--- a/projects/packages/backup/src/js/components/backup-storage-space/index.jsx
+++ b/projects/packages/backup/src/js/components/backup-storage-space/index.jsx
@@ -23,6 +23,8 @@ const BackupStorageSpace = () => {
 	const showComponent = storageSize !== null && storageLimit > 0;
 
 	const usageLevel = useSelect( select => select( STORE_ID ).getStorageUsageLevel() );
+	const backupRetentionDays = useSelect( select => select( STORE_ID ).getBackupRetentionDays() );
+	const retentionDays = backupRetentionDays || planRetentionDays;
 
 	const dispatch = useDispatch( STORE_ID );
 
@@ -56,7 +58,7 @@ const BackupStorageSpace = () => {
 				storageLimit,
 				minDaysOfBackupsAllowed,
 				daysOfBackupsAllowed,
-				planRetentionDays,
+				retentionDays,
 				daysOfBackupsSaved
 			)
 		);
@@ -66,7 +68,7 @@ const BackupStorageSpace = () => {
 		storageLimit,
 		minDaysOfBackupsAllowed,
 		daysOfBackupsAllowed,
-		planRetentionDays,
+		retentionDays,
 		daysOfBackupsSaved,
 	] );
 

--- a/projects/packages/backup/src/js/components/backup-storage-space/storage-usage-levels.ts
+++ b/projects/packages/backup/src/js/components/backup-storage-space/storage-usage-levels.ts
@@ -24,7 +24,7 @@ export const getUsageLevel = (
 	available: number | undefined,
 	minDaysOfBackupsAllowed: number,
 	daysOfBackupsAllowed: number,
-	planRetentionDays: number,
+	retentionDays: number,
 	daysOfBackupsSaved: number
 ): StorageUsageLevelName | null => {
 	if ( available === undefined || used === undefined ) {
@@ -34,7 +34,7 @@ export const getUsageLevel = (
 	if (
 		!! minDaysOfBackupsAllowed &&
 		!! daysOfBackupsAllowed &&
-		!! planRetentionDays &&
+		!! retentionDays &&
 		!! daysOfBackupsSaved
 	) {
 		// if current days of backups saved is less than or equal to the minimum and storage is overlimit.
@@ -49,7 +49,7 @@ export const getUsageLevel = (
 
 		// if current allowed days of backups is less than plan's retention days, that means
 		// we discarded some backups to make other fit in current storage limit.
-		if ( daysOfBackupsAllowed < planRetentionDays ) {
+		if ( daysOfBackupsAllowed < retentionDays ) {
 			return StorageUsageLevels.BackupsDiscarded;
 		}
 	}

--- a/projects/packages/backup/src/js/reducers/site-backup-size.js
+++ b/projects/packages/backup/src/js/reducers/site-backup-size.js
@@ -11,6 +11,7 @@ const initialState = {
 	minDaysOfBackupsAllowed: null,
 	daysOfBackupsAllowed: null,
 	daysOfBackupsSaved: null,
+	retentionDays: null,
 };
 
 const siteBackupSize = ( state = initialState, action ) => {

--- a/projects/packages/backup/src/js/reducers/site-backup-size.js
+++ b/projects/packages/backup/src/js/reducers/site-backup-size.js
@@ -32,6 +32,7 @@ const siteBackupSize = ( state = initialState, action ) => {
 				minDaysOfBackupsAllowed: action.payload?.minDaysOfBackupsAllowed,
 				daysOfBackupsAllowed: action.payload?.daysOfBackupsAllowed,
 				daysOfBackupsSaved: action.payload?.daysOfBackupsSaved,
+				retentionDays: action.payload?.retentionDays,
 			};
 		}
 		case SITE_BACKUP_SIZE_GET_FAILED: {

--- a/projects/packages/backup/src/js/reducers/test/site-backup-size.js
+++ b/projects/packages/backup/src/js/reducers/test/site-backup-size.js
@@ -15,6 +15,7 @@ describe( 'reducer', () => {
 			minDaysOfBackupsAllowed: null,
 			daysOfBackupsAllowed: null,
 			daysOfBackupsSaved: null,
+			retentionDays: null,
 		},
 		fetchingState: {
 			isFetching: true,
@@ -23,6 +24,7 @@ describe( 'reducer', () => {
 			minDaysOfBackupsAllowed: null,
 			daysOfBackupsAllowed: null,
 			daysOfBackupsSaved: null,
+			retentionDays: null,
 		},
 		failedState: {
 			isFetching: false,
@@ -31,6 +33,7 @@ describe( 'reducer', () => {
 			minDaysOfBackupsAllowed: null,
 			daysOfBackupsAllowed: null,
 			daysOfBackupsSaved: null,
+			retentionDays: null,
 		},
 	};
 
@@ -55,6 +58,7 @@ describe( 'reducer', () => {
 						minDaysOfBackupsAllowed: 7,
 						daysOfBackupsAllowed: 30,
 						daysOfBackupsSaved: 24,
+						retentionDays: 7,
 					},
 				},
 				expected: {
@@ -64,6 +68,7 @@ describe( 'reducer', () => {
 					minDaysOfBackupsAllowed: 7,
 					daysOfBackupsAllowed: 30,
 					daysOfBackupsSaved: 24,
+					retentionDays: 7,
 				},
 			},
 			{

--- a/projects/packages/backup/src/js/selectors/site-backup.js
+++ b/projects/packages/backup/src/js/selectors/site-backup.js
@@ -5,6 +5,7 @@ const siteBackupSelectors = {
 	getMinDaysOfBackupsAllowed: state => state.siteBackupSize.minDaysOfBackupsAllowed ?? null,
 	getDaysOfBackupsAllowed: state => state.siteBackupSize.daysOfBackupsAllowed ?? null,
 	getDaysOfBackupsSaved: state => state.siteBackupSize.daysOfBackupsSaved ?? null,
+	getBackupRetentionDays: state => state.siteBackupSize.retentionDays ?? null,
 
 	// Policies
 	isFetchingBackupPolicies: state => state.siteBackupPolicies.isFetching ?? null,

--- a/projects/packages/backup/src/js/selectors/test/site-backup-size.js
+++ b/projects/packages/backup/src/js/selectors/test/site-backup-size.js
@@ -14,6 +14,7 @@ describe( 'siteBackupSizeSelectors', () => {
 				minDaysOfBackupsAllowed: null,
 				daysOfBackupsAllowed: null,
 				daysOfBackupsSaved: null,
+				retentionDays: null,
 			},
 		},
 		fetchingState: {
@@ -24,6 +25,7 @@ describe( 'siteBackupSizeSelectors', () => {
 				minDaysOfBackupsAllowed: null,
 				daysOfBackupsAllowed: null,
 				daysOfBackupsSaved: null,
+				retentionDays: null,
 			},
 		},
 		failedState: {
@@ -34,6 +36,7 @@ describe( 'siteBackupSizeSelectors', () => {
 				minDaysOfBackupsAllowed: null,
 				daysOfBackupsAllowed: null,
 				daysOfBackupsSaved: null,
+				retentionDays: null,
 			},
 		},
 		successState: {
@@ -44,6 +47,7 @@ describe( 'siteBackupSizeSelectors', () => {
 				minDaysOfBackupsAllowed: 7,
 				daysOfBackupsAllowed: 30,
 				daysOfBackupsSaved: 24,
+				retentionDays: 7,
 			},
 		},
 	};
@@ -195,6 +199,37 @@ describe( 'siteBackupSizeSelectors', () => {
 			'should return getDaysOfBackupsSaved value if passed, null otherwise',
 			( { state, expected } ) => {
 				const output = selectors.getDaysOfBackupsSaved( state );
+				expect( output ).toBe( expected );
+			}
+		);
+	} );
+
+	describe( 'getBackupRetentionDays()', () => {
+		it.each( [
+			{
+				state: fixtures.emptyObject,
+				expected: null,
+			},
+			{
+				state: fixtures.initialState,
+				expected: null,
+			},
+			{
+				state: fixtures.fetchingState,
+				expected: null,
+			},
+			{
+				state: fixtures.failedState,
+				expected: null,
+			},
+			{
+				state: fixtures.successState,
+				expected: 7,
+			},
+		] )(
+			'should return getBackupRetentionDays value if passed, null otherwise',
+			( { state, expected } ) => {
+				const output = selectors.getBackupRetentionDays( state );
 				expect( output ).toBe( expected );
 			}
 		);

--- a/projects/plugins/backup/changelog/update-backup-storage-ui-to-use-custom-retention-period-if-set
+++ b/projects/plugins/backup/changelog/update-backup-storage-ui-to-use-custom-retention-period-if-set
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -238,7 +238,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "17a1ae562cf963aa86c453beca4b6fa1f708a885"
+                "reference": "d3e6b1a72d55ce864bc618ae5ed4f580ebb5f271"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -268,7 +268,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-backup/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.12.x-dev"
+                    "dev-trunk": "1.13.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/update-backup-storage-ui-to-use-custom-retention-period-if-set
+++ b/projects/plugins/jetpack/changelog/update-backup-storage-ui-to-use-custom-retention-period-if-set
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -361,7 +361,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/backup",
-                "reference": "17a1ae562cf963aa86c453beca4b6fa1f708a885"
+                "reference": "d3e6b1a72d55ce864bc618ae5ed4f580ebb5f271"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -391,7 +391,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-backup/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.12.x-dev"
+                    "dev-trunk": "1.13.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:

Update the component to make use of a custom backup retention period (in days) if set by the customer otherwise use the retention from the plan.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-jZR-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Take your own site whose backups are being discarded due to the storage limit having been reached and does not have a custom retention period set yet.
- Now set a custom retention period, specifically lower the retention period say from 30 days to 7 days via Jetpack Cloud or `vpshell`.
- Check that both the Jetpack cloud and Jetpack plugin show the same backup usage status i.e. under storage limit and normal. 

Similar to https://github.com/Automattic/wp-calypso/pull/73007 