### PR TITLE
Crm/fix/2641 disable frontend breaks jp connections

### DIFF
--- a/projects/plugins/crm/changelog/crm-fix-disable-frontend-breaks-jp-connections
+++ b/projects/plugins/crm/changelog/crm-fix-disable-frontend-breaks-jp-connections
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Before kill the fronend, check if the request is not XMLRPC or REST
+Before kill the frontend (when the option is enabled), skip it for XMLRPC or REST requests

--- a/projects/plugins/crm/changelog/crm-fix-disable-frontend-breaks-jp-connections
+++ b/projects/plugins/crm/changelog/crm-fix-disable-frontend-breaks-jp-connections
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Before kill the fronend, check if the request is not XMLRPC or REST

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -1821,8 +1821,6 @@ final class ZeroBSCRM {
 			if ( $this->settings->get( 'killfrontend' ) == 1 ) {
 				global $pagenow;
 
-				// http://wordpress.stackexchange.com/questions/12863/check-if-were-on-the-wp-login-page
-				// } 2.0.2 also allow /wild stuff (e.g. welcome wiz)
 				if ( ! zeroBSCRM_isLoginPage()
 					&& ! zeroBSCRM_isWelcomeWizPage()
 					&& ! zeroBSCRM_isAPIRequest()

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -1819,10 +1819,18 @@ final class ZeroBSCRM {
 
 			// } Catch front end loads :)
 			if ( $this->settings->get( 'killfrontend' ) == 1 ) {
+				global $pagenow;
 
 				// http://wordpress.stackexchange.com/questions/12863/check-if-were-on-the-wp-login-page
 				// } 2.0.2 also allow /wild stuff (e.g. welcome wiz)
-				if ( ! zeroBSCRM_isLoginPage() && ! zeroBSCRM_isWelcomeWizPage() && ! zeroBSCRM_isAPIRequest() ) {
+				if ( ! zeroBSCRM_isLoginPage()
+					&& ! zeroBSCRM_isWelcomeWizPage()
+					&& ! zeroBSCRM_isAPIRequest()
+					&& ! defined( 'XMLRPC_REQUEST' )
+					&& ! defined( 'REST_REQUEST' )
+					// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+					&& ! ( 'index.php' === $pagenow && ! empty( $_GET['rest_route'] ) )
+				) {
 
 					zeroBSCRM_stopFrontEnd();
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/zero-bs-crm/issues/2641

## Proposed changes:
This PR fixes an issue with Atomic sites when the user disables the Front-End (JPCRM General settings - WordPress Override Mode). When this option is on, any XML-RPC request is redirected to `wp-login.php` or `wp-admin`. The same happens with any REST request.

This PR checks that if the request is XML-RPC or REST, it skips the Front-End disabling. The standard functions to check it don't work because this code intercepts the request before the REST system is loaded, so we have to check if it is a REST request checking the URL query.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
<img width="1111" alt="image" src="https://user-images.githubusercontent.com/9832440/219030726-af75d72e-b19f-4801-b0da-78dcde0a1a9a.png">

- Locally, you can check it by turning on the `Disable Front-End` option
- Then go to `yoursite.example/xmlrpc.php`

In trunk, you will be redirected to` wp-login.php` if you are not logged in, or to `wp-admin` if you are logged.
In this branch, you will get a response `XML-RPC server accepts POST requests only.`

- Now go to `yoursite.example/?rest_route=test`

In trunk, will happen the same, you will be redirected
In this branch, you will get a response: `{"code":"rest_no_route","message":"No route was found matching the URL and request method.","data":{"status":404}}`
