### PR TITLE
CRM: Backporting 5.5.4-alpha release changelogs, and initializing 5.5.4-alpha2

### DIFF
--- a/projects/js-packages/components/changelog/prerelease
+++ b/projects/js-packages/components/changelog/prerelease
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Updated package dependencies.

--- a/projects/js-packages/components/changelog/prerelease
+++ b/projects/js-packages/components/changelog/prerelease
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Updated package dependencies.

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.27.5",
+	"version": "0.27.6-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/plugins/crm/CHANGELOG.md
+++ b/projects/plugins/crm/CHANGELOG.md
@@ -59,4 +59,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved: Security around phone numbers viewing
 - Improved: Added a migration to remove outdated AKA lines
 
-[5.5.4-beta]: https://github.com/Automattic/zero-bs-crm/compare/v5.5.3...v5.5.4-beta
+[5.5.4-alpha]: https://github.com/Automattic/zero-bs-crm/compare/v5.5.3...v5.5.4-alpha

--- a/projects/plugins/crm/CHANGELOG.md
+++ b/projects/plugins/crm/CHANGELOG.md
@@ -5,11 +5,39 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.5.4-alpha] - 2023-02-15
+### Added
+- adds the necessary migration to move all files that were inside the zbscrm-store folder with a flat struture to the new jpcrm-storage folder that uses a hierarchical structure [#28350]
+- Copy tests from old repo. [#28354]
+
+### Changed
+- Added webpack build step [#28578]
+- CRM: changing variable declarations back to var [#28872]
+- CRM: export vars that are referenced via window. [#28897]
+- Updated package dependencies. [#28910]
+
+### Fixed
+- Client Portal bug that prevented access from being disabled using the contact page was fixed [#28675]
+- CRM: add a missing < which prevented a <script> tag from being opened. [#28834]
+- CRM: Adding a JS function to a list of exports so that it can be called outside the bundle it was declared in. [#28827]
+- CRM: Adding exports to functions called externally, in all JS fiiles where it is needed. [#28860]
+- CRM:  allows custom profile pictures to be shown in the dashboard. [#28802]
+- CRM: Escaping an invoice ID in ZeroBSCRM.admin.invoicebuilder.js [#28830]
+- CRM: Fix avatar getting removed when saving a contact [#28829]
+- CRM: Fixes a contact fild issue when a Woo order subscription is updated. [#28800]
+- CRM: Fix escape in contact list filters [#28836]
+- CRM: Fixing minor admin only issue on placeholder fields. [#28811]
+- CRM: fix issue  where exporting contacts shows "County" when it should show "State". [#28868]
+- CRM:  fix the escape used in the "Bundle holder" notification when uploading files to a contact [#28831]
+- Fixed numeric fields, date fields, and textareas in the Client Portal [#28796]
+
 ## 5.5.3 - 2023-01-26
+
 - Fixed: CRM no longer breaks WordPress sites running on PHP 7.2
 - Fixed: HTML escaped code in contact list filters for segments
 
 ## 5.5.2 - 2023-01-25
+
 - Fixed: Custom profile images are now shown in the Latest Contacts dashboard
 - Fixed: Potential XSS in the Custom Fields setting page
 - Fixed: Custom profile pictures are no longer removed when updating contacts
@@ -30,3 +58,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed: Inline field editing no longer prevents listings from being displayed
 - Improved: Security around phone numbers viewing
 - Improved: Added a migration to remove outdated AKA lines
+
+[5.5.4-beta]: https://github.com/Automattic/zero-bs-crm/compare/v5.5.3...v5.5.4-beta

--- a/projects/plugins/crm/ZeroBSCRM.php
+++ b/projects/plugins/crm/ZeroBSCRM.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack CRM
  * Plugin URI: https://jetpackcrm.com
  * Description: Jetpack CRM is the simplest CRM for WordPress. Self host your own Customer Relationship Manager using WP.
- * Version: 5.5.4-alpha2
+ * Version: 5.5.5-alpha
  * Author: Automattic - Jetpack CRM team
  * Author URI: https://jetpackcrm.com
  * Text Domain: zero-bs-crm

--- a/projects/plugins/crm/ZeroBSCRM.php
+++ b/projects/plugins/crm/ZeroBSCRM.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack CRM
  * Plugin URI: https://jetpackcrm.com
  * Description: Jetpack CRM is the simplest CRM for WordPress. Self host your own Customer Relationship Manager using WP.
- * Version: 5.5.4-alpha
+ * Version: 5.5.4-alpha2
  * Author: Automattic - Jetpack CRM team
  * Author URI: https://jetpackcrm.com
  * Text Domain: zero-bs-crm

--- a/projects/plugins/crm/changelog/add-crm-add-watch-command
+++ b/projects/plugins/crm/changelog/add-crm-add-watch-command
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Adding build configuration which is not relevant for the end-user
-
-

--- a/projects/plugins/crm/changelog/add-crm-font-awesome
+++ b/projects/plugins/crm/changelog/add-crm-font-awesome
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Unminified a CSS file, so no actual changes.
-
-

--- a/projects/plugins/crm/changelog/add-crm-js-functions-module
+++ b/projects/plugins/crm/changelog/add-crm-js-functions-module
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-CRM: Adding a JS function to a list of exports so that it can be called outside the bundle it was declared in.

--- a/projects/plugins/crm/changelog/add-crm-plugin
+++ b/projects/plugins/crm/changelog/add-crm-plugin
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/crm/changelog/add-crm-tests
+++ b/projects/plugins/crm/changelog/add-crm-tests
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Copy tests from old repo.

--- a/projects/plugins/crm/changelog/crm-add-webpack_build_step
+++ b/projects/plugins/crm/changelog/crm-add-webpack_build_step
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Added webpack build step

--- a/projects/plugins/crm/changelog/crm-fix-client_portal_custom_fields_not_working
+++ b/projects/plugins/crm/changelog/crm-fix-client_portal_custom_fields_not_working
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed numeric fields, date fields, and textareas in the Client Portal

--- a/projects/plugins/crm/changelog/crm-fix-client_portal_not_disabling_access
+++ b/projects/plugins/crm/changelog/crm-fix-client_portal_not_disabling_access
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Client Portal bug that prevented access from being disabled using the contact page was fixed

--- a/projects/plugins/crm/changelog/fix-crm-escape-invoice-id
+++ b/projects/plugins/crm/changelog/fix-crm-escape-invoice-id
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-CRM: Escaping an invoice ID in ZeroBSCRM.admin.invoicebuilder.js

--- a/projects/plugins/crm/changelog/fix-crm-export-var
+++ b/projects/plugins/crm/changelog/fix-crm-export-var
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-CRM: export vars that are referenced via window.

--- a/projects/plugins/crm/changelog/fix-crm-intl-date-formatter-revert
+++ b/projects/plugins/crm/changelog/fix-crm-intl-date-formatter-revert
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Reverting several IntDateFormatter related lines back to how they were pre monorepo move.
-
-

--- a/projects/plugins/crm/changelog/fix-crm_form_shows_js_code
+++ b/projects/plugins/crm/changelog/fix-crm_form_shows_js_code
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-CRM: add a missing < which prevented a <script> tag from being opened.

--- a/projects/plugins/crm/changelog/fix-custom_profile_pictures_on_dashboard
+++ b/projects/plugins/crm/changelog/fix-custom_profile_pictures_on_dashboard
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-CRM:  allows custom profile pictures to be shown in the dashboard.

--- a/projects/plugins/crm/changelog/fix-esape_issue_on_contact_filter
+++ b/projects/plugins/crm/changelog/fix-esape_issue_on_contact_filter
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-CRM: Fix escape in contact list filters

--- a/projects/plugins/crm/changelog/fix-escape_client_portal_pro_notification
+++ b/projects/plugins/crm/changelog/fix-escape_client_portal_pro_notification
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-CRM:  fix the escape used in the "Bundle holder" notification when uploading files to a contact

--- a/projects/plugins/crm/changelog/fix-minor-xss-custom-field-placeholder
+++ b/projects/plugins/crm/changelog/fix-minor-xss-custom-field-placeholder
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-CRM: Fixing minor admin only issue on placeholder fields.

--- a/projects/plugins/crm/changelog/fix-new-folder-structure-migration
+++ b/projects/plugins/crm/changelog/fix-new-folder-structure-migration
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-adds the necessary migration to move all files that were inside the zbscrm-store folder with a flat struture to the new jpcrm-storage folder that uses a hierarchical structure

--- a/projects/plugins/crm/changelog/fix-profile_picture_getting_removed
+++ b/projects/plugins/crm/changelog/fix-profile_picture_getting_removed
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-CRM: Fix avatar getting removed when saving a contact

--- a/projects/plugins/crm/changelog/fix-top-crm-menu-broken-with-space
+++ b/projects/plugins/crm/changelog/fix-top-crm-menu-broken-with-space
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Removed some spaces that break the CSS class selector
-
-

--- a/projects/plugins/crm/changelog/fix-trailing_comma_breaking_php_7_2
+++ b/projects/plugins/crm/changelog/fix-trailing_comma_breaking_php_7_2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: In this case, just comments have been edited.
-
-

--- a/projects/plugins/crm/changelog/fix-translate-crm-field-labels
+++ b/projects/plugins/crm/changelog/fix-translate-crm-field-labels
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-CRM: fix issue  where exporting contacts shows "County" when it should show "State".

--- a/projects/plugins/crm/changelog/fix-woo-subscription-incorrectly-update-contact-date-added
+++ b/projects/plugins/crm/changelog/fix-woo-subscription-incorrectly-update-contact-date-added
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-CRM: Fixes a contact fild issue when a Woo order subscription is updated.

--- a/projects/plugins/crm/changelog/init-release-cycle
+++ b/projects/plugins/crm/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Init 5.5.4-alpha2
+
+

--- a/projects/plugins/crm/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/crm/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/crm/changelog/update-crm-autoload-dom-pdf
+++ b/projects/plugins/crm/changelog/update-crm-autoload-dom-pdf
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Changed the way we require Dompdf but it has no other impact on the UI
-
-

--- a/projects/plugins/crm/changelog/update-crm-const-to-vars
+++ b/projects/plugins/crm/changelog/update-crm-const-to-vars
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-CRM: changing variable declarations back to var

--- a/projects/plugins/crm/changelog/update-crm-wp-svn-autopublish-disable
+++ b/projects/plugins/crm/changelog/update-crm-wp-svn-autopublish-disable
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Temporary change of value for wp-svn-autopublish for one GitHub release.
-
-

--- a/projects/plugins/crm/changelog/update-js-files-export-functions
+++ b/projects/plugins/crm/changelog/update-js-files-export-functions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-CRM: Adding exports to functions called externally, in all JS fiiles where it is needed.

--- a/projects/plugins/crm/changelog/update-node-to-v18
+++ b/projects/plugins/crm/changelog/update-node-to-v18
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update tooling node version to 18.13.0. Should be no change to the project.
-
-

--- a/projects/plugins/crm/composer.json
+++ b/projects/plugins/crm/composer.json
@@ -37,7 +37,7 @@
 		"platform": {
 			"php": "7.3"
 		},
-		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ5_5_4_alpha",
+		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ5_5_5_alpha",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/crm/composer.json
+++ b/projects/plugins/crm/composer.json
@@ -37,7 +37,7 @@
 		"platform": {
 			"php": "7.3"
 		},
-		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ5_5_4_alpha2",
+		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ5_5_5_alpha",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/crm/composer.json
+++ b/projects/plugins/crm/composer.json
@@ -37,7 +37,7 @@
 		"platform": {
 			"php": "7.3"
 		},
-		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ5_5_5_alpha",
+		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ5_5_4_alpha2",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/crm/package.json
+++ b/projects/plugins/crm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-crm",
-	"version": "5.5.4-alpha2",
+	"version": "5.5.5-alpha",
 	"description": "The CRM for WordPress",
 	"author": "Automattic",
 	"license": "GPL-2.0",

--- a/projects/plugins/crm/package.json
+++ b/projects/plugins/crm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-crm",
-	"version": "5.5.4-alpha",
+	"version": "5.5.4-alpha2",
 	"description": "The CRM for WordPress",
 	"author": "Automattic",
 	"license": "GPL-2.0",

--- a/projects/plugins/crm/readme.txt
+++ b/projects/plugins/crm/readme.txt
@@ -399,7 +399,32 @@ We offer a full, no-hassle refund within 14 days. You can read more about that, 
 
 
 == Changelog ==
-v5.5.3 - 26 January 2023
+### 5.5.4-alpha - 2023-02-15
+#### Added
+- adds the necessary migration to move all files that were inside the zbscrm-store folder with a flat struture to the new jpcrm-storage folder that uses a hierarchical structure
+- Copy tests from old repo.
+
+#### Changed
+- Added webpack build step
+- CRM: changing variable declarations back to var
+- CRM: export vars that are referenced via window.
+- Updated package dependencies.
+
+#### Fixed
+- Client Portal bug that prevented access from being disabled using the contact page was fixed
+- CRM: add a missing < which prevented a <script> tag from being opened.
+- CRM: Adding a JS function to a list of exports so that it can be called outside the bundle it was declared in.
+- CRM: Adding exports to functions called externally, in all JS fiiles where it is needed.
+- CRM:  allows custom profile pictures to be shown in the dashboard.
+- CRM: Escaping an invoice ID in ZeroBSCRM.admin.invoicebuilder.js
+- CRM: Fix avatar getting removed when saving a contact
+- CRM: Fixes a contact fild issue when a Woo order subscription is updated.
+- CRM: Fix escape in contact list filters
+- CRM: Fixing minor admin only issue on placeholder fields.
+- CRM: fix issue  where exporting contacts shows "County" when it should show "State".
+- CRM:  fix the escape used in the "Bundle holder" notification when uploading files to a contact
+- Fixed numeric fields, date fields, and textareas in the Client Portal
+
 -------------------------
 * Fixed: CRM no longer breaks WordPress sites running on PHP 7.2
 * Fixed: HTML escaped code in contact list filters for segments


### PR DESCRIPTION

## Proposed changes:

* This PR backports CRM 5.5.4-alpha Changelog entries and initializes the next release version - ~5.5.4-alpha2~ 5.5.5-alpha.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Proof-read - versions should be up to date. This isn't going to be a public release so the changelog entries don't need editing.
* For comparison, here is the last Jetpack release PR: https://github.com/Automattic/jetpack/pull/28968

